### PR TITLE
fix: decouple diagnostic coloring from environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: just lint
 
       - name: Test
-        run: NO_COLOR=1 cargo test -p tests --test suite -- --format terse
+        run: cargo test -p tests --test suite -- --format terse
 
       - name: Build
         run: just build

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -178,13 +178,12 @@ pub struct LisetteDiagnostic {
     severity: Severity,
     code: Option<String>,
     file_id: Option<u32>,
+    use_color: bool,
 }
 
 impl fmt::Display for LisetteDiagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let use_color = std::env::var("NO_COLOR").is_err();
-
-        if use_color {
+        if self.use_color {
             let styled_message = match self.severity {
                 Severity::Error => {
                     format_with_backticks(&self.message, true, |s| format!("{}", s.red().bold()))
@@ -210,11 +209,12 @@ struct HelpText<'a> {
     help: Option<&'a str>,
     note: Option<&'a str>,
     diagnostic_code: Option<&'a str>,
+    use_color: bool,
 }
 
 impl fmt::Display for HelpText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let use_color = std::env::var("NO_COLOR").is_err();
+        let use_color = self.use_color;
         let has_code = self.diagnostic_code.is_some();
 
         let combined = match (self.help, self.note) {
@@ -264,11 +264,12 @@ impl Diagnostic for LisetteDiagnostic {
             help: self.help.as_deref(),
             note: self.note.as_deref(),
             diagnostic_code,
+            use_color: self.use_color,
         }))
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        let use_color = std::env::var("NO_COLOR").is_err();
+        let use_color = self.use_color;
         let severity = self.severity;
 
         let formatted_labels = self.labels.iter().map(move |span| {
@@ -323,6 +324,7 @@ impl LisetteDiagnostic {
             severity: Severity::Error,
             code: None,
             file_id: None,
+            use_color: false,
         }
     }
 
@@ -335,7 +337,13 @@ impl LisetteDiagnostic {
             severity: Severity::Warning,
             code: None,
             file_id: None,
+            use_color: false,
         }
+    }
+
+    pub fn with_color(mut self, use_color: bool) -> Self {
+        self.use_color = use_color;
+        self
     }
 
     pub fn with_span_label(mut self, span: &Span, text: impl Into<String>) -> Self {

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -110,9 +110,11 @@ fn render(
     diagnostic: &LisetteDiagnostic,
     source: &IndexedSource,
     filename: &str,
+    use_color: bool,
 ) {
     let report = diagnostic
         .clone()
+        .with_color(use_color)
         .with_source_code(source.clone(), filename.to_string());
     let mut output = String::new();
     if handler.render_report(&mut output, report.as_ref()).is_ok() {
@@ -182,7 +184,7 @@ pub fn render_all(
         };
         for error in &errors {
             let (src, name) = get_cached_source(error.file_id(), &mut source_cache);
-            render(&handler, error, &src, &name);
+            render(&handler, error, &src, &name, use_color);
         }
     }
 
@@ -194,7 +196,7 @@ pub fn render_all(
         };
         for warning in &warnings {
             let (src, name) = get_cached_source(warning.file_id(), &mut source_cache);
-            render(&handler, warning, &src, &name);
+            render(&handler, warning, &src, &name, use_color);
         }
     }
 

--- a/justfile
+++ b/justfile
@@ -18,14 +18,14 @@ build-debug:
     cargo build
 
 test:
-    NO_COLOR=1 cargo test -p tests --test suite
-    NO_COLOR=1 cargo test -p tests --test lsp
+    cargo test -p tests --test suite
+    cargo test -p tests --test lsp
 
 test-infer:
-    NO_COLOR=1 cargo test -p tests --test suite infer_tests
+    cargo test -p tests --test suite infer_tests
 
 test-watch:
-    NO_COLOR=1 cargo watch -x "test -p tests --test suite"
+    cargo watch -x "test -p tests --test suite"
 
 test-review:
     cargo insta review
@@ -34,7 +34,7 @@ test-accept:
     cargo insta accept --all
 
 test-e2e:
-    NO_COLOR=1 cargo test -p tests --test suite e2e
+    cargo test -p tests --test suite e2e
 
 test-cov:
     cargo llvm-cov -p tests --test suite --test lsp --html --open


### PR DESCRIPTION
Opt into coloring at the render call site rather than checking from the environment inside each diagnostic `Display` impl, so test snapshots are accurate regardless of environment.

Fixes #4