### PR TITLE
fix: validate type parameter bounds on type definitions

### DIFF
--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -263,6 +263,15 @@ impl<'r, 's> Checker<'r, 's> {
         }
     }
 
+    /// Validate that all bound annotations on generics refer to types that exist in scope.
+    pub(crate) fn validate_generic_bounds(&mut self, generics: &[Generic], span: &Span) {
+        for g in generics {
+            for b in &g.bounds {
+                self.convert_to_type(b, span);
+            }
+        }
+    }
+
     /// Resolve a simple name (e.g., "Sunday") to a public definition in an imported module.
     /// First tries direct match (`module_id.name`), then falls back to searching
     /// for nested definitions (e.g., `module_id.Weekday.Sunday`) preferring top-level

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -270,6 +270,7 @@ impl Checker<'_, '_> {
     ) {
         self.scopes.push();
         self.put_in_scope(generics);
+        self.validate_generic_bounds(generics, span);
 
         let new_parents = parents
             .iter()

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -26,6 +26,11 @@ impl Checker<'_, '_> {
             .expect("enum type must exist")
             .clone();
 
+        self.scopes.push();
+        self.put_in_scope(generics);
+        self.validate_generic_bounds(generics, span);
+        self.scopes.pop();
+
         let new_variants: Vec<_> = variants
             .iter()
             .map(|v| self.resolve_enum_variant_fields(v, generics, span))
@@ -383,6 +388,7 @@ impl Checker<'_, '_> {
 
         self.scopes.push();
         self.put_in_scope(generics);
+        self.validate_generic_bounds(generics, span);
 
         let new_fields: Vec<StructFieldDefinition> = fields
             .iter()
@@ -634,6 +640,7 @@ impl Checker<'_, '_> {
         self.scopes.push();
 
         self.put_in_scope(generics);
+        self.validate_generic_bounds(generics, span);
 
         let body_ty = self.convert_to_type(annotation, span);
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1074,6 +1074,42 @@ fn test() {
 }
 
 #[test]
+fn infer_type_not_found_struct_bound() {
+    let input = r#"
+struct Foo<T: Undefined> {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_not_found_enum_bound() {
+    let input = r#"
+enum Foo<T: Undefined> {
+  Bar(T)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_not_found_interface_bound() {
+    let input = r#"
+interface Foo<T: Undefined> {
+  fn get(self) -> T
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_not_found_type_alias_bound() {
+    let input = r#"
+type Foo<T: Undefined> = T
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_variable_not_found_no_suggestion() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_type_not_found_enum_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_enum_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type not found
+   ╭─[test.lis:2:13]
+ 1 │ 
+ 2 │ enum Foo<T: Undefined> {
+   ·             ────┬────
+   ·                 ╰── type not found in scope
+ 3 │   Bar(T)
+   ╰────
+  help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_interface_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_interface_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type not found
+   ╭─[test.lis:2:18]
+ 1 │ 
+ 2 │ interface Foo<T: Undefined> {
+   ·                  ────┬────
+   ·                      ╰── type not found in scope
+ 3 │   fn get(self) -> T
+   ╰────
+  help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_struct_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_struct_bound.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type not found
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ struct Foo<T: Undefined> {}
+   ·               ────┬────
+   ·                   ╰── type not found in scope
+   ╰────
+  help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_type_alias_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_type_alias_bound.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type not found
+   ╭─[test.lis:2:13]
+ 1 │ 
+ 2 │ type Foo<T: Undefined> = T
+   ·             ────┬────
+   ·                 ╰── type not found in scope
+   ╰────
+  help: Define or import this type · code: [resolve.type_not_found]


### PR DESCRIPTION
Type param bounds on structs, enums, interfaces, and type aliases were not validated during registration, allowing undefined constraint types to slip through to Go codegen where they would fail with a cryptic Go compiler error.

Fixes #42