### PR TITLE
feat: compiler awareness of third-party Go deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,7 @@ dependencies = [
  "lisette-syntax",
  "owo-colors",
  "rustc-hash",
- "serde",
  "tokio",
- "toml",
  "tower-lsp",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 name = "lisette"
 version = "0.1.6"
 dependencies = [
+ "lisette-deps",
  "lisette-diagnostics",
  "lisette-emit",
  "lisette-format",
@@ -497,6 +498,15 @@ dependencies = [
  "tokio",
  "toml",
  "tower-lsp",
+]
+
+[[package]]
+name = "lisette-deps"
+version = "0.1.6"
+dependencies = [
+ "lisette-stdlib",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -533,6 +543,7 @@ version = "0.1.6"
 dependencies = [
  "dashmap 6.1.0",
  "ecow",
+ "lisette-deps",
  "lisette-diagnostics",
  "lisette-format",
  "lisette-semantics",
@@ -549,6 +560,7 @@ version = "0.1.6"
 dependencies = [
  "bincode",
  "ecow",
+ "lisette-deps",
  "lisette-diagnostics",
  "lisette-stdlib",
  "lisette-syntax",
@@ -980,6 +992,7 @@ dependencies = [
  "ecow",
  "futures",
  "insta",
+ "lisette-deps",
  "lisette-diagnostics",
  "lisette-emit",
  "lisette-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/format",
     "crates/emit",
     "crates/stdlib",
+    "crates/deps",
     "crates/lsp",
     "tests",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,5 +30,3 @@ tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 owo-colors.workspace = true
 rustc-hash.workspace = true
-toml = "0.9.10"
-serde = { workspace = true, features = ["derive"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,6 +24,7 @@ diagnostics = { package = "lisette-diagnostics", version = "0.1.6", path = "../d
 format = { package = "lisette-format", version = "0.1.6", path = "../format" }
 emit = { package = "lisette-emit", version = "0.1.6", path = "../emit" }
 stdlib = { package = "lisette-stdlib", version = "0.1.6", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.6", path = "../deps" }
 lsp = { package = "lisette-lsp", version = "0.1.6", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 include!(concat!(env!("OUT_DIR"), "/go_version.rs"));
 
+use deps::GoDepResolver;
 use emit::PRELUDE_IMPORT_PATH;
 
 pub fn require_go() -> Result<(), i32> {
@@ -97,14 +98,24 @@ pub fn go_fmt(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub fn write_go_mod(dir: &Path, module_name: &str) -> Result<(), String> {
+pub fn write_go_mod(
+    dir: &Path,
+    module_name: &str,
+    go_resolver: &GoDepResolver,
+) -> Result<(), String> {
     let prelude_version = env!("CARGO_PKG_VERSION");
+
+    let mut requires = vec![format!("\t{} v{}", PRELUDE_IMPORT_PATH, prelude_version)];
+
+    for (module_path, dep) in go_resolver.deps() {
+        requires.push(format!("\t{} {}", module_path, dep.version));
+    }
+
     let mut content = format!(
-        "module {}\n\ngo {}\n\nrequire {} v{}\n",
+        "module {}\n\ngo {}\n\nrequire (\n{}\n)\n",
         module_name,
         go_mod_version(),
-        PRELUDE_IMPORT_PATH,
-        prelude_version,
+        requires.join("\n"),
     );
 
     if cfg!(debug_assertions) {

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -2,24 +2,11 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
-use serde::Deserialize;
-
 use crate::cli_error;
 use crate::go_cli;
 use diagnostics::render::{self, Filter};
 use lisette::fs::LocalFileSystem;
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
-
-#[derive(Deserialize)]
-struct Manifest {
-    project: Project,
-}
-
-#[derive(Deserialize)]
-struct Project {
-    name: String,
-    version: String,
-}
 
 pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
     if let Err(code) = crate::go_cli::require_go() {
@@ -35,10 +22,18 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
         return 1;
     }
 
-    let manifest = match read_manifest(project_path) {
-        Ok(m) => m,
-        Err(()) => return 1,
-    };
+    let (manifest, go_resolver) =
+        match deps::GoDepResolver::from_project_with_manifest(project_path) {
+            Ok(pair) => pair,
+            Err(msg) => {
+                cli_error!(
+                    "Failed to compile Lisette project to Go",
+                    msg,
+                    "Run `lis new <name>` to create a project, or fix `lisette.toml`"
+                );
+                return 1;
+            }
+        };
 
     let main_lis = project_path.join("src/main.lis");
     let go_module_name = &manifest.project.name;
@@ -86,6 +81,7 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
         load_siblings: true,
         debug,
         project_root: Some(project_path.to_path_buf()),
+        go_resolver: go_resolver.clone(),
     };
 
     let source_dir = main_lis.parent().and_then(|p| p.to_str()).unwrap_or(".");
@@ -128,7 +124,7 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
         return 1;
     }
 
-    if let Err(e) = go_cli::write_go_mod(&target_dir, &compile_config.go_module) {
+    if let Err(e) = go_cli::write_go_mod(&target_dir, &compile_config.go_module, &go_resolver) {
         cli_error!(
             "Failed to compile Lisette project to Go",
             e,
@@ -236,28 +232,4 @@ fn validate_project(project_path: &Path) -> bool {
     }
 
     true
-}
-
-fn read_manifest(project_path: &Path) -> Result<Manifest, ()> {
-    let toml_path = project_path.join("lisette.toml");
-
-    let content = match fs::read_to_string(&toml_path) {
-        Ok(c) => c,
-        Err(_) => {
-            cli_error!(
-                "Failed to compile Lisette project to Go",
-                format!("No `lisette.toml` manifest in `{}`", project_path.display()),
-                "Run `lis new <name>` to create a project"
-            );
-            return Err(());
-        }
-    };
-
-    toml::from_str(&content).map_err(|e| {
-        cli_error!(
-            "Failed to compile Lisette project to Go",
-            format!("Invalid `lisette.toml` manifest: {}", e),
-            "Fix the TOML syntax in `lisette.toml`"
-        );
-    })
 }

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use deps::GoDepResolver;
 use diagnostics::render::{self, Filter};
 use lisette::fs::LocalFileSystem;
 use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
@@ -28,7 +29,7 @@ pub fn check(path: Option<String>, errors_only: bool, warnings_only: bool) -> i3
     };
 
     if !target_path.is_dir() {
-        return check_single_file(target_path, &filter, false);
+        return check_single_file(target_path, &filter, false, GoDepResolver::default());
     }
 
     if target_path.join("lisette.toml").exists() {
@@ -60,12 +61,27 @@ fn check_project(project_path: &Path, filter: &Filter) -> i32 {
         return 1;
     }
 
-    check_single_file(&src_main, filter, true)
+    let go_resolver = match GoDepResolver::from_project(project_path) {
+        Ok(r) => r,
+        Err(msg) => {
+            cli_error!("Failed to check project", msg, "Fix `lisette.toml`");
+            return 1;
+        }
+    };
+
+    check_single_file(&src_main, filter, true, go_resolver)
 }
 
-fn check_single_file(file_path: &Path, filter: &Filter, load_siblings: bool) -> i32 {
+fn check_single_file(
+    file_path: &Path,
+    filter: &Filter,
+    load_siblings: bool,
+    go_resolver: GoDepResolver,
+) -> i32 {
     let start = Instant::now();
-    let Some((result, source, filename)) = compile_single_file(file_path, load_siblings) else {
+    let Some((result, source, filename)) =
+        compile_single_file(file_path, load_siblings, go_resolver)
+    else {
         return 1; // Read error already reported by compile_single_file
     };
     let counts = render::render_all(
@@ -94,6 +110,7 @@ fn check_single_file(file_path: &Path, filter: &Filter, load_siblings: bool) -> 
 fn compile_single_file(
     file_path: &Path,
     load_siblings: bool,
+    go_resolver: GoDepResolver,
 ) -> Option<(CompileResult, String, String)> {
     let source = match fs::read_to_string(file_path) {
         Ok(s) => s,
@@ -118,7 +135,8 @@ fn compile_single_file(
         standalone_mode: !load_siblings,
         load_siblings,
         debug: false,
-        project_root: None,
+        project_root: go_resolver.project_root().map(|p| p.to_path_buf()),
+        go_resolver,
     };
 
     let working_dir = file_path.parent().and_then(|p| p.to_str()).unwrap_or(".");
@@ -163,7 +181,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
         let mut compiled = None;
         let mut dir_read_failures = 0;
         for file in dir_files {
-            if let Some(result) = compile_single_file(file, true) {
+            if let Some(result) = compile_single_file(file, true, GoDepResolver::default()) {
                 compiled = Some(result);
                 break;
             }

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -103,6 +103,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         load_siblings: false,
         debug,
         project_root: None,
+        go_resolver: deps::GoDepResolver::default(),
     };
 
     struct NoLoader;
@@ -139,7 +140,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         return 1;
     }
 
-    if let Err(e) = go_cli::write_go_mod(&temp_dir, "lis-standalone") {
+    if let Err(e) = go_cli::write_go_mod(&temp_dir, "lis-standalone", &compile_config.go_resolver) {
         cli_error!("Failed to run standalone file", e, "Check file permissions");
         return 1;
     }

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 use std::path::PathBuf;
 
+use deps::GoDepResolver;
 use diagnostics::LisetteDiagnostic;
 use emit::{EmitOptions, Emitter, OutputFile};
 
@@ -25,6 +26,7 @@ pub struct CompileConfig {
     pub load_siblings: bool,
     pub debug: bool,
     pub project_root: Option<PathBuf>,
+    pub go_resolver: GoDepResolver,
 }
 
 #[derive(Debug)]
@@ -72,6 +74,7 @@ pub fn compile(
         ast: syntax_result.ast,
         project_root: config.project_root.clone(),
         compile_phase: config.target_phase,
+        go_resolver: config.go_resolver.clone(),
     });
 
     let sources: HashMap<u32, SourceInfo> = semantic_result

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "lisette-deps"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+stdlib = { package = "lisette-stdlib", version = "0.1.6", path = "../stdlib" }
+toml = "0.9.10"
+serde = { workspace = true, features = ["derive"] }

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -1,0 +1,5 @@
+mod manifest;
+mod resolver;
+
+pub use manifest::{GoDependency, Manifest, check_toolchain_version, parse_manifest};
+pub use resolver::{GoDepResolver, GoTypedefResult, TypedefOrigin, typedef_cache_path};

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -2,4 +2,4 @@ mod manifest;
 mod resolver;
 
 pub use manifest::{GoDependency, Manifest, check_toolchain_version, parse_manifest};
-pub use resolver::{GoDepResolver, GoTypedefResult, TypedefOrigin, typedef_cache_path};
+pub use resolver::{GoDepResolver, GoTypedefResult, TypedefOrigin, has_domain, typedef_cache_path};

--- a/crates/deps/src/manifest.rs
+++ b/crates/deps/src/manifest.rs
@@ -1,0 +1,115 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    pub project: Project,
+    pub toolchain: Option<Toolchain>,
+    pub dependencies: Option<Dependencies>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Project {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Toolchain {
+    pub lis: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Dependencies {
+    #[serde(default)]
+    pub go: BTreeMap<String, GoDependency>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GoDependency {
+    pub version: String,
+    pub via: Option<Vec<String>>,
+}
+
+impl<'de> Deserialize<'de> for GoDependency {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct GoDependencyVisitor;
+
+        impl<'de> Visitor<'de> for GoDependencyVisitor {
+            type Value = GoDependency;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a version string or a table with `version` and optional `via`")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<GoDependency, E> {
+                Ok(GoDependency {
+                    version: v.to_string(),
+                    via: None,
+                })
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<GoDependency, M::Error> {
+                let mut version = None;
+                let mut via = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "version" => version = Some(map.next_value()?),
+                        "via" => via = Some(map.next_value()?),
+                        other => {
+                            return Err(de::Error::unknown_field(other, &["version", "via"]));
+                        }
+                    }
+                }
+
+                let version = version.ok_or_else(|| de::Error::missing_field("version"))?;
+
+                Ok(GoDependency { version, via })
+            }
+        }
+
+        deserializer.deserialize_any(GoDependencyVisitor)
+    }
+}
+
+impl Manifest {
+    pub fn go_deps(&self) -> BTreeMap<String, GoDependency> {
+        self.dependencies
+            .as_ref()
+            .map(|d| d.go.clone())
+            .unwrap_or_default()
+    }
+}
+
+pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
+    let toml_path = project_root.join("lisette.toml");
+
+    let content = fs::read_to_string(&toml_path)
+        .map_err(|_| format!("No `lisette.toml` manifest in `{}`", project_root.display()))?;
+
+    toml::from_str(&content).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))
+}
+
+pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
+    let Some(ref toolchain) = manifest.toolchain else {
+        return Ok(());
+    };
+
+    let running = env!("CARGO_PKG_VERSION");
+    if running != toolchain.lis {
+        return Err(format!(
+            "Toolchain mismatch: `lisette.toml` pins lis {} but running lis {}",
+            toolchain.lis, running,
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/deps/src/resolver.rs
+++ b/crates/deps/src/resolver.rs
@@ -1,0 +1,232 @@
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::manifest::GoDependency;
+
+/// Result of looking up a Go typedef.
+#[derive(Debug)]
+pub enum GoTypedefResult {
+    /// Found the typedef source.
+    Found {
+        source: Cow<'static, str>,
+        origin: TypedefOrigin,
+    },
+    /// Looks like a stdlib package but no stdlib typedef exists.
+    UnknownStdlib,
+    /// Has a domain-style path but is not declared in the manifest.
+    UndeclaredImport,
+    /// Declared in the manifest but no `.d.lis` file found on disk.
+    MissingTypedef { module: String, version: String },
+    /// Typedef file exists but could not be read.
+    UnreadableTypedef { path: PathBuf, error: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypedefOrigin {
+    Stdlib,
+    ProjectOverride,
+    Cache,
+}
+
+/// Resolves Go package import paths to their typedef sources.
+///
+/// Holds the dependency map from `lisette.toml`, the project root (for
+/// overrides), and the home directory (for the global cache).
+#[derive(Debug, Clone, Default)]
+pub struct GoDepResolver {
+    deps: BTreeMap<String, GoDependency>,
+    project_root: Option<PathBuf>,
+    home: Option<String>,
+}
+
+impl GoDepResolver {
+    pub fn new(
+        deps: BTreeMap<String, GoDependency>,
+        project_root: Option<PathBuf>,
+        home: Option<String>,
+    ) -> Self {
+        Self {
+            deps,
+            project_root,
+            home,
+        }
+    }
+
+    pub fn from_project(project_root: &Path) -> Result<Self, String> {
+        let (_, resolver) = Self::from_project_with_manifest(project_root)?;
+        Ok(resolver)
+    }
+
+    pub fn from_project_with_manifest(
+        project_root: &Path,
+    ) -> Result<(crate::Manifest, Self), String> {
+        let manifest = crate::parse_manifest(project_root)?;
+        crate::check_toolchain_version(&manifest)?;
+        let resolver = Self::new(
+            manifest.go_deps(),
+            Some(project_root.to_path_buf()),
+            std::env::var("HOME").ok(),
+        );
+        Ok((manifest, resolver))
+    }
+
+    pub fn project_root(&self) -> Option<&Path> {
+        self.project_root.as_deref()
+    }
+
+    pub fn deps(&self) -> &BTreeMap<String, GoDependency> {
+        &self.deps
+    }
+
+    pub fn has_deps(&self) -> bool {
+        !self.deps.is_empty()
+    }
+
+    /// Resolve a Go package path (without the `go:` prefix) to its typedef source.
+    pub fn resolve(&self, go_pkg: &str) -> GoTypedefResult {
+        if !has_domain(go_pkg) {
+            return match stdlib::get_go_stdlib_typedef(go_pkg) {
+                Some(source) => GoTypedefResult::Found {
+                    source: Cow::Borrowed(source),
+                    origin: TypedefOrigin::Stdlib,
+                },
+                None => GoTypedefResult::UnknownStdlib,
+            };
+        }
+
+        let Some((module_path, dep)) = self.resolve_package_to_module(go_pkg) else {
+            return GoTypedefResult::UndeclaredImport;
+        };
+
+        let version = &dep.version;
+
+        for (path, origin) in self.typedef_search_paths(module_path, version, go_pkg) {
+            match std::fs::read_to_string(&path) {
+                Ok(source) => {
+                    return GoTypedefResult::Found {
+                        source: Cow::Owned(source),
+                        origin,
+                    };
+                }
+                Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+                    return GoTypedefResult::UnreadableTypedef {
+                        path,
+                        error: e.to_string(),
+                    };
+                }
+                Err(_) => {} // NotFound — try next path
+            }
+        }
+
+        GoTypedefResult::MissingTypedef {
+            module: module_path.to_string(),
+            version: version.clone(),
+        }
+    }
+
+    /// Return the ordered list of paths to check for a third-party typedef.
+    fn typedef_search_paths(
+        &self,
+        module_path: &str,
+        version: &str,
+        go_pkg: &str,
+    ) -> Vec<(PathBuf, TypedefOrigin)> {
+        let mut paths = Vec::with_capacity(2);
+
+        if let Some(ref root) = self.project_root {
+            paths.push((
+                typedef_path_in(root.join(".lisette/deps/go"), module_path, version, go_pkg),
+                TypedefOrigin::ProjectOverride,
+            ));
+        }
+
+        if let Some(ref home) = self.home {
+            paths.push((
+                typedef_path_in(
+                    PathBuf::from(home).join(".lisette/cache/go"),
+                    module_path,
+                    version,
+                    go_pkg,
+                ),
+                TypedefOrigin::Cache,
+            ));
+        }
+
+        paths
+    }
+
+    /// Find the longest declared module path that is a prefix of the package path.
+    fn resolve_package_to_module(&self, package_path: &str) -> Option<(&str, &GoDependency)> {
+        let mut best: Option<(&str, &GoDependency)> = None;
+
+        for (module_path, dep) in &self.deps {
+            let is_match = package_path == module_path.as_str()
+                || (package_path.starts_with(module_path.as_str())
+                    && package_path.as_bytes().get(module_path.len()) == Some(&b'/'));
+
+            if is_match
+                && best
+                    .as_ref()
+                    .is_none_or(|(prev, _)| module_path.len() > prev.len())
+            {
+                best = Some((module_path.as_str(), dep));
+            }
+        }
+
+        best
+    }
+}
+
+/// Determine the cache/override path for a typedef file.
+///
+/// Given a base directory (e.g. `~/.lisette/cache/go`), a module path, version,
+/// and package path, return the full path to the `.d.lis` file.
+///
+/// Root package: `.../github.com/gorilla/mux@v1.8.0/mux.d.lis`
+/// Subpackage:   `.../github.com/gorilla/mux@v1.8.0/middleware/auth/auth.d.lis`
+pub fn typedef_path_in(
+    base: PathBuf,
+    module_path: &str,
+    version: &str,
+    package_path: &str,
+) -> PathBuf {
+    let module_dir = base.join(format!("{}@{}", module_path, version));
+
+    let relative = if package_path == module_path {
+        ""
+    } else {
+        package_path
+            .strip_prefix(module_path)
+            .and_then(|s| s.strip_prefix('/'))
+            .unwrap_or("")
+    };
+
+    let last_segment = package_path.rsplit('/').next().unwrap_or(package_path);
+
+    let filename = format!("{}.d.lis", last_segment);
+
+    if relative.is_empty() {
+        module_dir.join(filename)
+    } else {
+        module_dir.join(relative).join(&filename)
+    }
+}
+
+/// A Go package path has a domain if its first segment contains a dot.
+fn has_domain(pkg: &str) -> bool {
+    pkg.split('/')
+        .next()
+        .is_some_and(|first| first.contains('.'))
+}
+
+/// Compute the full cache path for a typedef. Convenience wrapper.
+pub fn typedef_cache_path(module_path: &str, version: &str, package_path: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    typedef_path_in(
+        Path::new(&home).join(".lisette/cache/go"),
+        module_path,
+        version,
+        package_path,
+    )
+}

--- a/crates/deps/src/resolver.rs
+++ b/crates/deps/src/resolver.rs
@@ -214,7 +214,10 @@ pub fn typedef_path_in(
 }
 
 /// A Go package path has a domain if its first segment contains a dot.
-fn has_domain(pkg: &str) -> bool {
+/// This is the canonical stdlib vs third-party distinction: stdlib paths
+/// like `net/http` or `fmt` never have dots in the first segment, while
+/// third-party paths like `github.com/gorilla/mux` always do.
+pub fn has_domain(pkg: &str) -> bool {
     pkg.split('/')
         .next()
         .is_some_and(|first| first.contains('.'))

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -44,6 +44,38 @@ pub fn test_file_not_supported(filename: &str) -> LisetteDiagnostic {
         .with_help("Files ending in `_test.lis` are reserved for future testing support. Rename this file to compile it.")
 }
 
+pub fn undeclared_go_import(go_pkg: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Undeclared Go dependency")
+        .with_resolve_code("undeclared_go_import")
+        .with_span_label(&span, "not in lisette.toml")
+        .with_help(format!(
+            "Run `lis add {}` to add this dependency, or add it manually to `[dependencies.go]` in `lisette.toml`",
+            go_pkg
+        ))
+}
+
+pub fn missing_go_typedef(
+    go_pkg: &str,
+    module: &str,
+    version: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Missing Go typedef")
+        .with_resolve_code("missing_go_typedef")
+        .with_span_label(&span, "no .d.lis file found")
+        .with_help(format!(
+            "Package `{}` is declared via `{}` {} but no typedef was found. Run `lis sync` to generate it.",
+            go_pkg, module, version
+        ))
+}
+
+pub fn unreadable_go_typedef(path: &std::path::Path, error: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Failed to read Go typedef")
+        .with_resolve_code("unreadable_go_typedef")
+        .with_span_label(&span, "typedef exists but could not be read")
+        .with_help(format!("Failed to read `{}`: {}", path.display(), error,))
+}
+
 pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
     let modules: Vec<_> = path[..path.len() - 1].to_vec();
 

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 syntax = { package = "lisette-syntax", version = "0.1.6", path = "../syntax" }
 semantics = { package = "lisette-semantics", version = "0.1.6", path = "../semantics" }
 diagnostics = { package = "lisette-diagnostics", version = "0.1.6", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.1.6", path = "../deps" }
 format = { package = "lisette-format", version = "0.1.6", path = "../format" }
 ecow.workspace = true
 tower-lsp = "0.20"

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use miette::Diagnostic as MietteDiagnostic;
 use tower_lsp::lsp_types::*;
 
+use deps::GoDepResolver;
 use diagnostics::LisetteDiagnostic;
 use semantics::analyze::{AnalyzeInput, CompilePhase, SemanticConfig, analyze};
 use syntax::desugar;
@@ -87,6 +88,15 @@ impl SharedState {
             .map(Into::into)
             .collect();
 
+        let (go_resolver, manifest_error) = if config.standalone_mode {
+            (GoDepResolver::default(), None)
+        } else {
+            match GoDepResolver::from_project(&config.root) {
+                Ok(r) => (r, None),
+                Err(msg) => (GoDepResolver::default(), Some(msg)),
+            }
+        };
+
         let (mut result, facts) = analyze(AnalyzeInput {
             config: SemanticConfig {
                 run_lints: !has_parse_errors,
@@ -103,12 +113,19 @@ impl SharedState {
                 Some(config.root.clone())
             },
             compile_phase: CompilePhase::Check,
+            go_resolver,
         });
 
         if has_parse_errors {
             let mut all_errors = parse_errors;
             all_errors.append(&mut result.errors);
             result.errors = all_errors;
+        }
+
+        if let Some(msg) = manifest_error {
+            result
+                .errors
+                .push(LisetteDiagnostic::error(msg).with_resolve_code("manifest_error"));
         }
 
         Ok(AnalysisSnapshot::new(
@@ -172,7 +189,10 @@ impl SharedState {
             .errors
             .iter()
             .chain(&snapshot.result.lints)
-            .filter(|d| d.file_id() == Some(file_id))
+            .filter(|d| {
+                let fid = d.file_id();
+                fid == Some(file_id) || fid.is_none()
+            })
             .map(|d| convert_diagnostic(d, line_index))
             .collect()
     }

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 syntax = { package = "lisette-syntax", version = "0.1.6", path = "../syntax", features = ["serde"] }
 diagnostics = { package = "lisette-diagnostics", version = "0.1.6", path = "../diagnostics" }
 stdlib = { package = "lisette-stdlib", version = "0.1.6", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.6", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -5,6 +5,8 @@ use diagnostics::{DiagnosticSink, SemanticResult};
 use syntax::ast::Expression;
 use syntax::program::{File, ModuleInfo, MutationInfo, UnusedInfo};
 
+use deps::GoDepResolver;
+
 use crate::cache::{
     CompiledModule, compute_module_hash, get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
@@ -20,7 +22,6 @@ use crate::module_graph::build_module_graph;
 use crate::pattern_analysis;
 use crate::prelude::parse_and_register_prelude;
 use crate::store::{ENTRY_MODULE_ID, Store};
-use stdlib::get_go_stdlib_typedef;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompilePhase {
@@ -44,6 +45,7 @@ pub struct AnalyzeInput<'a> {
     pub ast: Vec<Expression>,
     pub project_root: Option<PathBuf>,
     pub compile_phase: CompilePhase,
+    pub go_resolver: GoDepResolver,
 }
 
 pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
@@ -79,6 +81,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
         &entry_module,
         &sink,
         input.config.standalone_mode,
+        &input.go_resolver,
     );
 
     for cycle in &graph_result.cycles {
@@ -134,8 +137,10 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                     }
                 }
                 // Cache miss: parse and register
-                if let Some(typedef) = get_go_stdlib_typedef(go_pkg) {
-                    checker.parse_and_register_go_module(&module_id, typedef);
+                if let deps::GoTypedefResult::Found { source, .. } =
+                    input.go_resolver.resolve(go_pkg)
+                {
+                    checker.parse_and_register_go_module(&module_id, &source, &input.go_resolver);
                 }
                 continue;
             }

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -129,14 +129,15 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
 
         for module_id in order {
             if let Some(go_pkg) = module_id.strip_prefix("go:") {
-                if let Some(ref cache) = go_cache {
-                    // Load this module + transitive deps from cache
+                let is_third_party = deps::has_domain(go_pkg);
+
+                if !is_third_party && let Some(ref cache) = go_cache {
                     load_cached_go_module(checker.store, &module_id, cache);
                     if checker.store.is_visited(&module_id) {
                         continue;
                     }
                 }
-                // Cache miss: parse and register
+
                 if let deps::GoTypedefResult::Found { source, .. } =
                     input.go_resolver.resolve(go_pkg)
                 {
@@ -202,7 +203,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                 .store
                 .modules
                 .keys()
-                .filter(|id| id.starts_with("go:"))
+                .filter(|id| id.strip_prefix("go:").is_some_and(|p| !deps::has_domain(p)))
                 .cloned()
                 .collect();
             let needs_save = !all_go_modules.is_empty()

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -137,17 +137,18 @@ impl Checker<'_, '_> {
         let receiver_qualified_name = receiver_ty.get_qualified_name();
         let module_id = self.cursor.module_id.clone();
 
-        if let Some(dot_position) = receiver_qualified_name.find('.') {
-            let type_module = &receiver_qualified_name[..dot_position];
-            if type_module != module_id {
-                self.sink.push(diagnostics::infer::impl_on_foreign_type(
-                    type_name,
-                    type_module,
-                    *span,
-                ));
-                self.scopes.pop();
-                return;
-            }
+        if let Some(type_module) = self
+            .store
+            .module_for_qualified_name(&receiver_qualified_name)
+            && type_module != module_id
+        {
+            self.sink.push(diagnostics::infer::impl_on_foreign_type(
+                type_name,
+                type_module,
+                *span,
+            ));
+            self.scopes.pop();
+            return;
         }
 
         let mut impl_bounds: Vec<syntax::types::Bound> = Vec::new();

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -5,7 +5,7 @@ mod types;
 
 use rustc_hash::FxHashMap as HashMap;
 
-use stdlib::get_go_stdlib_typedef;
+use deps::GoDepResolver;
 use syntax::ast::{
     Annotation, Attribute, AttributeArg, EnumVariant, Expression, FunctionDefinition, Generic,
     Span, StructKind, Visibility as SyntacticVisibility,
@@ -145,10 +145,15 @@ impl Checker<'_, '_> {
         self.ufcs_methods.extend(ufcs_entries);
     }
 
-    /// Register a Go stdlib module. Unlike regular modules, Go modules:
-    /// - Export everything as public
-    /// - Don't put their own module in scope (no self-references like `MyModule.Type`)
-    pub fn parse_and_register_go_module(&mut self, module_id: &str, source: &str) {
+    /// Register a Go module (stdlib or third-party). Unlike regular modules,
+    /// Go modules export everything as public and do not put their own module
+    /// in scope (no self-references like `MyModule.Type`).
+    pub fn parse_and_register_go_module(
+        &mut self,
+        module_id: &str,
+        source: &str,
+        go_resolver: &GoDepResolver,
+    ) {
         if self.store.is_visited(module_id) {
             return;
         }
@@ -179,8 +184,8 @@ impl Checker<'_, '_> {
         for import in &imports {
             if let Some(go_pkg) = import.name.strip_prefix("go:") {
                 let import_module_id = format!("go:{}", go_pkg);
-                if let Some(import_source) = get_go_stdlib_typedef(go_pkg) {
-                    self.parse_and_register_go_module(&import_module_id, import_source);
+                if let deps::GoTypedefResult::Found { source, .. } = go_resolver.resolve(go_pkg) {
+                    self.parse_and_register_go_module(&import_module_id, &source, go_resolver);
                 }
             }
         }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -2,13 +2,13 @@ pub mod kahn;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use deps::{GoDepResolver, GoTypedefResult};
 use syntax::ast::Span;
 use syntax::program::File;
 
 use crate::loader::Loader;
 use crate::store::Store;
 use diagnostics::DiagnosticSink;
-use stdlib::get_go_stdlib_typedef;
 
 pub type ModuleId = String;
 
@@ -28,6 +28,7 @@ pub fn build_module_graph(
     entry_module: &str,
     sink: &DiagnosticSink,
     standalone_mode: bool,
+    go_resolver: &GoDepResolver,
 ) -> ModuleGraphResult {
     let mut edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut to_visit = vec![entry_module.to_string()];
@@ -41,8 +42,14 @@ pub fn build_module_graph(
         }
         visited.insert(module_id.clone());
 
-        let (imports_with_spans, module_files) =
-            collect_imports(&module_id, store, loader, sink, standalone_mode);
+        let (imports_with_spans, module_files) = collect_imports(
+            &module_id,
+            store,
+            loader,
+            sink,
+            standalone_mode,
+            go_resolver,
+        );
 
         let module_exists = !module_files.is_empty()
             || store.has(&module_id)
@@ -51,7 +58,7 @@ pub fn build_module_graph(
 
         if !module_exists {
             if let Some(span) = import_spans.get(&module_id) {
-                let is_go_stdlib = get_go_stdlib_typedef(&module_id).is_some();
+                let is_go_stdlib = stdlib::get_go_stdlib_typedef(&module_id).is_some();
 
                 let src_prefix_hint = module_id
                     .strip_prefix("src/")
@@ -133,6 +140,7 @@ fn collect_imports(
     loader: Option<&dyn Loader>,
     sink: &DiagnosticSink,
     standalone_mode: bool,
+    go_resolver: &GoDepResolver,
 ) -> (HashMap<ModuleId, Span>, Vec<File>) {
     let mut imports = HashMap::default();
 
@@ -159,20 +167,51 @@ fn collect_imports(
         }
 
         if let Some(go_pkg) = file_import.name.strip_prefix("go:") {
-            if get_go_stdlib_typedef(go_pkg).is_some() {
-                imports.insert(file_import.name.to_string(), file_import.name_span);
-                continue;
+            match go_resolver.resolve(go_pkg) {
+                GoTypedefResult::Found { .. } => {
+                    imports.insert(file_import.name.to_string(), file_import.name_span);
+                }
+                GoTypedefResult::UnknownStdlib => {
+                    sink.push(diagnostics::module_graph::module_not_found(
+                        &file_import.name,
+                        file_import.name_span,
+                        false,
+                        standalone_mode,
+                        None,
+                    ));
+                }
+                GoTypedefResult::UndeclaredImport => {
+                    if standalone_mode {
+                        sink.push(diagnostics::module_graph::module_not_found(
+                            &file_import.name,
+                            file_import.name_span,
+                            false,
+                            true,
+                            None,
+                        ));
+                    } else {
+                        sink.push(diagnostics::module_graph::undeclared_go_import(
+                            go_pkg,
+                            file_import.name_span,
+                        ));
+                    }
+                }
+                GoTypedefResult::MissingTypedef { module, version } => {
+                    sink.push(diagnostics::module_graph::missing_go_typedef(
+                        go_pkg,
+                        &module,
+                        &version,
+                        file_import.name_span,
+                    ));
+                }
+                GoTypedefResult::UnreadableTypedef { path, error } => {
+                    sink.push(diagnostics::module_graph::unreadable_go_typedef(
+                        &path,
+                        &error,
+                        file_import.name_span,
+                    ));
+                }
             }
-
-            // @TODO: Check cache at ~/.lisette (and other spots)
-
-            sink.push(diagnostics::module_graph::module_not_found(
-                &file_import.name,
-                file_import.name_span,
-                false,
-                standalone_mode,
-                None,
-            ));
             continue;
         }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -153,11 +153,31 @@ impl Store {
     }
 
     pub fn get_definition(&self, qualified_name: &str) -> Option<&Definition> {
-        let (module_name, _) = qualified_name.split_once('.')?;
+        let module_name = self.module_for_qualified_name(qualified_name)?;
 
         self.get_module(module_name)?
             .definitions
             .get(qualified_name)
+    }
+
+    pub fn module_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
+        if !qualified_name.starts_with("go:") || !qualified_name.contains('/') {
+            let (module_name, _) = qualified_name.split_once('.')?;
+            return Some(module_name);
+        }
+
+        let mut best: Option<&str> = None;
+        for module_id in self.modules.keys() {
+            if qualified_name.starts_with(module_id.as_str())
+                && qualified_name.as_bytes().get(module_id.len()) == Some(&b'.')
+                && best
+                    .as_ref()
+                    .is_none_or(|prev| module_id.len() > prev.len())
+            {
+                best = Some(module_id.as_str());
+            }
+        }
+        best
     }
 
     pub fn get_enum_variants(&self, qualified_name: &str) -> Option<&[EnumVariant]> {

--- a/playground/wasm/Cargo.toml
+++ b/playground/wasm/Cargo.toml
@@ -21,6 +21,7 @@ lisette-syntax      = { git = "https://github.com/ivov/lisette", package = "lise
 lisette-semantics   = { git = "https://github.com/ivov/lisette", package = "lisette-semantics" }
 lisette-emit        = { git = "https://github.com/ivov/lisette", package = "lisette-emit" }
 lisette-diagnostics = { git = "https://github.com/ivov/lisette", package = "lisette-diagnostics" }
+lisette-deps        = { git = "https://github.com/ivov/lisette", package = "lisette-deps" }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -217,6 +217,7 @@ fn run_analysis(code: &str) -> AnalysisResult {
         filename: PLAYGROUND_FILE.to_string(),
         ast: ast_result.ast,
         project_root: None,
+        go_resolver: lisette_deps::GoDepResolver::default(),
         compile_phase: CompilePhase::Check,
     };
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,6 +17,7 @@ changelog_include = [
   "lisette-emit",
   "lisette-format",
   "lisette-stdlib",
+  "lisette-deps",
   "lisette-lsp",
 ]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,6 +12,7 @@ diagnostics = { package = "lisette-diagnostics", path = "../crates/diagnostics" 
 format = { package = "lisette-format", path = "../crates/format" }
 emit = { package = "lisette-emit", path = "../crates/emit" }
 stdlib = { package = "lisette-stdlib", path = "../crates/stdlib" }
+deps = { package = "lisette-deps", path = "../crates/deps" }
 lsp = { package = "lisette-lsp", path = "../crates/lsp" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -31,6 +31,7 @@ pub fn compile_check(fs: MockFileSystem) -> SemanticResult {
         filename: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
+        go_resolver: deps::GoDepResolver::default(),
         compile_phase: semantics::analyze::CompilePhase::Check,
     })
     .0
@@ -59,6 +60,7 @@ pub fn compile_check_standalone(fs: MockFileSystem) -> SemanticResult {
         filename: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
+        go_resolver: deps::GoDepResolver::default(),
         compile_phase: semantics::analyze::CompilePhase::Check,
     })
     .0
@@ -89,6 +91,7 @@ pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {
         filename: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
+        go_resolver: deps::GoDepResolver::default(),
         compile_phase: semantics::analyze::CompilePhase::Emit,
     });
 

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -33,7 +33,15 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
 
     let sink = DiagnosticSink::new();
 
-    let mut graph_result = build_module_graph(&mut store, Some(&fs), module_name, &sink, false);
+    let go_resolver = deps::GoDepResolver::default();
+    let mut graph_result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        module_name,
+        &sink,
+        false,
+        &go_resolver,
+    );
 
     if sink.has_errors() {
         return InferResult {
@@ -56,7 +64,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         for module_id in order {
             if let Some(go_pkg) = module_id.strip_prefix("go:") {
                 if let Some(typedef) = get_go_stdlib_typedef(go_pkg) {
-                    checker.parse_and_register_go_module(&module_id, typedef);
+                    checker.parse_and_register_go_module(&module_id, typedef, &go_resolver);
                 }
                 continue;
             }

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -89,6 +89,7 @@ impl CompiledTest {
             register_test_builtins(&mut checker);
             checker.put_prelude_in_scope();
 
+            let go_resolver = deps::GoDepResolver::default();
             let imports: Vec<FileImport> = self
                 .ast
                 .iter()
@@ -103,7 +104,7 @@ impl CompiledTest {
                         if let Some(go_pkg) = name.strip_prefix("go:")
                             && let Some(typedef) = get_go_stdlib_typedef(go_pkg)
                         {
-                            checker.parse_and_register_go_module(name, typedef);
+                            checker.parse_and_register_go_module(name, typedef, &go_resolver);
                         }
                         Some(FileImport {
                             name: name.clone(),

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -9826,3 +9826,82 @@ async fn goto_definition_type_alias_in_struct_call() {
 
     client.shutdown().await;
 }
+
+#[tokio::test]
+async fn diagnostics_invalid_manifest_surfaces_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Write an invalid lisette.toml (missing required [project] section)
+    std::fs::write(root.join("lisette.toml"), "[invalid]\nfoo = 1\n").unwrap();
+
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+
+    let content = "fn main() { 1 }";
+    std::fs::write(src.join("main.lis"), content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let main_uri = Url::from_file_path(src.join("main.lis"))
+        .unwrap()
+        .to_string();
+    client.open(&main_uri, content).await;
+
+    let diagnostics = client.await_diagnostics().await;
+
+    let has_manifest_error = diagnostics.iter().any(|d| {
+        d.severity == Some(DiagnosticSeverity::ERROR)
+            && d.code.as_ref().is_some_and(
+                |c| matches!(c, NumberOrString::String(s) if s == "resolve.manifest_error"),
+            )
+    });
+
+    assert!(
+        has_manifest_error,
+        "invalid lisette.toml should produce a manifest_error diagnostic, got: {diagnostics:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn diagnostics_toolchain_mismatch_surfaces_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Pin a lis version that does not match the running binary
+    std::fs::write(
+        root.join("lisette.toml"),
+        "[project]\nname = \"test\"\nversion = \"0.1.0\"\n\n[toolchain]\nlis = \"99.99.99\"\n",
+    )
+    .unwrap();
+
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+
+    let content = "fn main() { 1 }";
+    std::fs::write(src.join("main.lis"), content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let main_uri = Url::from_file_path(src.join("main.lis"))
+        .unwrap()
+        .to_string();
+    client.open(&main_uri, content).await;
+
+    let diagnostics = client.await_diagnostics().await;
+
+    let has_toolchain_error = diagnostics.iter().any(|d| {
+        d.severity == Some(DiagnosticSeverity::ERROR) && d.message.contains("Toolchain mismatch")
+    });
+
+    assert!(
+        has_toolchain_error,
+        "toolchain version mismatch should produce a diagnostic, got: {diagnostics:?}"
+    );
+
+    client.shutdown().await;
+}

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -7,6 +7,14 @@ use semantics::store::Store;
 
 use crate::_harness::filesystem::MockFileSystem;
 
+fn default_resolver() -> deps::GoDepResolver {
+    deps::GoDepResolver::default()
+}
+
+fn has_diagnostic_code(sink: &DiagnosticSink, code: &str) -> bool {
+    sink.take().iter().any(|d| d.code_str() == Some(code))
+}
+
 #[test]
 fn kahn_simple_dependency_chain() {
     let mut edges = HashMap::default();
@@ -84,7 +92,14 @@ fn graph_simple_dependency() {
     store.module_ids.push("lib".to_string());
 
     let sink = DiagnosticSink::new();
-    let result = build_module_graph(&mut store, Some(&fs), "main", &sink, false);
+    let result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        false,
+        &default_resolver(),
+    );
 
     assert!(result.cycles.is_empty());
     assert!(!sink.has_errors());
@@ -106,7 +121,14 @@ fn graph_missing_module() {
     store.module_ids.push("main".to_string());
 
     let sink = DiagnosticSink::new();
-    let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false);
+    let _result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        false,
+        &default_resolver(),
+    );
 
     assert!(sink.has_errors());
 }
@@ -124,7 +146,128 @@ fn graph_cycle_detection() {
     store.module_ids.push("c".to_string());
 
     let sink = DiagnosticSink::new();
-    let result = build_module_graph(&mut store, Some(&fs), "a", &sink, false);
+    let result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "a",
+        &sink,
+        false,
+        &default_resolver(),
+    );
 
     assert!(!result.cycles.is_empty());
+}
+
+#[test]
+fn graph_standalone_third_party_go_import_uses_module_not_found() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
+
+    let mut store = Store::new();
+    store.module_ids.push("main".to_string());
+
+    let sink = DiagnosticSink::new();
+    let _result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        true, // standalone mode
+        &default_resolver(),
+    );
+
+    assert!(sink.has_errors());
+    assert!(has_diagnostic_code(&sink, "resolve.module_not_found"));
+}
+
+#[test]
+fn graph_project_third_party_go_import_undeclared() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
+
+    let mut store = Store::new();
+    store.module_ids.push("main".to_string());
+
+    let sink = DiagnosticSink::new();
+    let _result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        false, // project mode
+        &default_resolver(),
+    );
+
+    assert!(sink.has_errors());
+    assert!(has_diagnostic_code(&sink, "resolve.undeclared_go_import"));
+}
+
+#[test]
+fn graph_declared_dep_missing_typedef() {
+    use std::collections::BTreeMap;
+
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
+
+    let mut store = Store::new();
+    store.module_ids.push("main".to_string());
+
+    // Declare the dep in the resolver but do not place any .d.lis file on disk
+    let mut go_deps = BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::GoDepResolver::new(go_deps, None, None);
+
+    let sink = DiagnosticSink::new();
+    let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver);
+
+    assert!(sink.has_errors());
+    assert!(has_diagnostic_code(&sink, "resolve.missing_go_typedef"));
+}
+
+#[test]
+fn resolver_project_override_takes_precedence_over_cache() {
+    use std::collections::BTreeMap;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path();
+
+    // Set up override and cache with different content
+    let override_dir = project_root.join(".lisette/deps/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&override_dir).unwrap();
+    std::fs::write(override_dir.join("mux.d.lis"), "// override version\n").unwrap();
+
+    let cache_dir = tmp
+        .path()
+        .join("fake_home/.lisette/cache/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join("mux.d.lis"), "// cache version\n").unwrap();
+
+    let mut go_deps = BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+
+    let resolver = deps::GoDepResolver::new(
+        go_deps,
+        Some(project_root.to_path_buf()),
+        Some(tmp.path().join("fake_home").to_string_lossy().to_string()),
+    );
+
+    match resolver.resolve("github.com/gorilla/mux") {
+        deps::GoTypedefResult::Found { source, origin } => {
+            assert_eq!(origin, deps::TypedefOrigin::ProjectOverride);
+            assert!(source.contains("override version"));
+        }
+        other => panic!("Expected Found with ProjectOverride, got {:?}", other),
+    }
 }

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -271,3 +271,389 @@ fn resolver_project_override_takes_precedence_over_cache() {
         other => panic!("Expected Found with ProjectOverride, got {:?}", other),
     }
 }
+
+#[test]
+fn store_get_definition_domain_style_go_module() {
+    let mut store = Store::new();
+    store.add_module("go:github.com/gorilla/mux");
+
+    let module = store.get_module_mut("go:github.com/gorilla/mux").unwrap();
+    module.definitions.insert(
+        "go:github.com/gorilla/mux.Router".into(),
+        syntax::program::Definition::Struct {
+            visibility: syntax::program::Visibility::Public,
+            ty: syntax::types::Type::Constructor {
+                id: "go:github.com/gorilla/mux.Router".into(),
+                params: vec![],
+                underlying_ty: None,
+            },
+            name: "Router".into(),
+            name_span: syntax::ast::Span::dummy(),
+            generics: vec![],
+            fields: vec![],
+            kind: syntax::ast::StructKind::Record,
+            methods: Default::default(),
+            constructor: None,
+            doc: None,
+        },
+    );
+
+    // Must find the definition despite dots in the module path
+    let def = store.get_definition("go:github.com/gorilla/mux.Router");
+    assert!(
+        def.is_some(),
+        "get_definition must resolve domain-style Go module qualified names"
+    );
+}
+
+#[test]
+fn store_module_for_qualified_name_domain_style() {
+    let mut store = Store::new();
+    store.add_module("go:github.com/gorilla/mux");
+    store.add_module("go:net/http");
+    store.add_module("mymod");
+
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/gorilla/mux.Router"),
+        Some("go:github.com/gorilla/mux"),
+    );
+    assert_eq!(
+        store.module_for_qualified_name("go:net/http.Request"),
+        Some("go:net/http"),
+    );
+    assert_eq!(
+        store.module_for_qualified_name("mymod.MyType"),
+        Some("mymod"),
+    );
+    // Value enum variant: three dot-separated segments
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/gorilla/mux.Method.Get"),
+        Some("go:github.com/gorilla/mux"),
+    );
+}
+
+#[test]
+fn stdlib_cache_excludes_third_party_modules() {
+    // The stdlib cache save filters modules by id.starts_with("go:") and
+    // !id.contains('/') after stripping "go:". Third-party modules like
+    // "go:github.com/gorilla/mux" contain '/' and must be excluded.
+    let third_party = "go:github.com/gorilla/mux";
+    let stdlib = "go:net/http";
+
+    // The canonical check: deps::has_domain returns true for third-party
+    // paths (dot in first segment), false for stdlib paths.
+    let is_stdlib_go = |id: &str| id.strip_prefix("go:").is_some_and(|p| !deps::has_domain(p));
+
+    assert!(!is_stdlib_go(third_party));
+    assert!(is_stdlib_go(stdlib));
+    assert!(is_stdlib_go("go:fmt"));
+    assert!(is_stdlib_go("go:crypto/tls"));
+}
+
+#[test]
+fn store_module_for_qualified_name_major_version_suffix() {
+    let mut store = Store::new();
+    store.add_module("go:github.com/jackc/pgx/v5");
+
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/jackc/pgx/v5.Conn"),
+        Some("go:github.com/jackc/pgx/v5"),
+    );
+    // Must not match a shorter prefix that is not registered
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/jackc/pgx.Row"),
+        None,
+    );
+}
+
+#[test]
+fn store_module_for_qualified_name_nested_subpackage() {
+    let mut store = Store::new();
+    store.add_module("go:github.com/gorilla/mux");
+
+    // Subpackage types are qualified under the same module
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/gorilla/mux.Router"),
+        Some("go:github.com/gorilla/mux"),
+    );
+    // Method on a type: three segments after module prefix
+    assert_eq!(
+        store.module_for_qualified_name("go:github.com/gorilla/mux.Router.ServeHTTP"),
+        Some("go:github.com/gorilla/mux"),
+    );
+}
+
+#[test]
+fn resolver_root_vs_subpackage_typedef_lookup() {
+    use std::collections::BTreeMap;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Set up cache with root package and subpackage
+    let root_dir = tmp
+        .path()
+        .join("home/.lisette/cache/go/github.com/gorilla/mux@v1.8.0");
+    let sub_dir = root_dir.join("middleware");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    std::fs::write(root_dir.join("mux.d.lis"), "// root\n").unwrap();
+    std::fs::write(sub_dir.join("middleware.d.lis"), "// sub\n").unwrap();
+
+    let mut go_deps = BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::GoDepResolver::new(
+        go_deps,
+        None,
+        Some(tmp.path().join("home").to_string_lossy().to_string()),
+    );
+
+    // Root package resolves to root .d.lis
+    match resolver.resolve("github.com/gorilla/mux") {
+        deps::GoTypedefResult::Found { source, .. } => {
+            assert!(source.contains("root"));
+        }
+        other => panic!("Root package: expected Found, got {:?}", other),
+    }
+
+    // Subpackage resolves to subpackage .d.lis
+    match resolver.resolve("github.com/gorilla/mux/middleware") {
+        deps::GoTypedefResult::Found { source, .. } => {
+            assert!(source.contains("sub"));
+        }
+        other => panic!("Subpackage: expected Found, got {:?}", other),
+    }
+}
+
+#[test]
+fn resolver_override_vs_cache_precedence() {
+    use std::collections::BTreeMap;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+
+    // Override (higher priority)
+    let override_dir = project_root.join(".lisette/deps/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&override_dir).unwrap();
+    std::fs::write(override_dir.join("mux.d.lis"), "// override\n").unwrap();
+
+    // Cache (lower priority)
+    let cache_dir = tmp
+        .path()
+        .join("home/.lisette/cache/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join("mux.d.lis"), "// cache\n").unwrap();
+
+    let mut go_deps = BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::GoDepResolver::new(
+        go_deps,
+        Some(project_root),
+        Some(tmp.path().join("home").to_string_lossy().to_string()),
+    );
+
+    // Override must win over cache
+    match resolver.resolve("github.com/gorilla/mux") {
+        deps::GoTypedefResult::Found { source, origin } => {
+            assert_eq!(origin, deps::TypedefOrigin::ProjectOverride);
+            assert!(source.contains("override"));
+        }
+        other => panic!("Expected ProjectOverride, got {:?}", other),
+    }
+}
+
+/// Impl block on a third-party Go struct must not be rejected as foreign.
+/// Regression: methods.rs used `find('.')` to extract the module from a
+/// qualified name, which broke on `go:github.com/gorilla/mux.Router`.
+#[test]
+fn third_party_go_struct_impl_methods_registered() {
+    use semantics::analyze::{AnalyzeInput, CompilePhase, SemanticConfig, analyze};
+    use semantics::loader::Loader;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = tmp
+        .path()
+        .join("home/.lisette/cache/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(
+        cache_dir.join("mux.d.lis"),
+        "pub struct Router {}\nimpl Router {\n    fn route(self, path: string) -> string\n}\npub fn new_router() -> Router\n",
+    )
+    .unwrap();
+
+    let mut go_deps = std::collections::BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::GoDepResolver::new(
+        go_deps,
+        None,
+        Some(tmp.path().join("home").to_string_lossy().to_string()),
+    );
+
+    let source = r#"
+import "go:github.com/gorilla/mux"
+
+fn main() {
+    let r = mux.new_router()
+    r.route("/api")
+}
+"#;
+
+    struct NoLoader;
+    impl Loader for NoLoader {
+        fn scan_folder(&self, _: &str) -> rustc_hash::FxHashMap<String, String> {
+            rustc_hash::FxHashMap::default()
+        }
+    }
+
+    let build_result = syntax::build_ast(source, 0);
+    let (result, _) = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: false,
+            standalone_mode: false,
+            load_siblings: false,
+        },
+        loader: &NoLoader,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        ast: build_result.ast,
+        project_root: None,
+        compile_phase: CompilePhase::Check,
+        go_resolver: resolver,
+    });
+
+    let impl_errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| {
+            e.code_str()
+                .is_some_and(|c| c == "infer.impl_on_foreign_type")
+        })
+        .collect();
+
+    assert!(
+        impl_errors.is_empty(),
+        "impl block on third-party Go struct must not be rejected as foreign: {:?}",
+        impl_errors,
+    );
+
+    let method_errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.code_str().is_some_and(|c| c == "infer.member_not_found"))
+        .collect();
+
+    assert!(
+        method_errors.is_empty(),
+        "method call on third-party Go struct must resolve: {:?}",
+        method_errors,
+    );
+}
+
+/// Third-party Go modules must not be saved into the stdlib definition
+/// cache. Regression: analyze.rs filtered by `starts_with("go:")` which
+/// included third-party modules, causing stale cache entries to bypass
+/// the resolver on subsequent runs.
+#[test]
+fn stdlib_cache_save_load_excludes_third_party() {
+    use semantics::analyze::{AnalyzeInput, CompilePhase, SemanticConfig, analyze};
+    use semantics::loader::Loader;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = tmp
+        .path()
+        .join("home/.lisette/cache/go/github.com/gorilla/mux@v1.8.0");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join("mux.d.lis"), "pub const VERSION: string\n").unwrap();
+
+    let mut go_deps = std::collections::BTreeMap::new();
+    go_deps.insert(
+        "github.com/gorilla/mux".to_string(),
+        deps::GoDependency {
+            version: "v1.8.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::GoDepResolver::new(
+        go_deps,
+        None,
+        Some(tmp.path().join("home").to_string_lossy().to_string()),
+    );
+
+    let source = r#"
+import "go:github.com/gorilla/mux"
+
+fn main() {
+    mux.VERSION
+}
+"#;
+
+    struct NoLoader;
+    impl Loader for NoLoader {
+        fn scan_folder(&self, _: &str) -> rustc_hash::FxHashMap<String, String> {
+            rustc_hash::FxHashMap::default()
+        }
+    }
+
+    let build_result = syntax::build_ast(source, 0);
+
+    // First run — registers third-party module
+    let (result1, _) = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: false,
+            standalone_mode: false,
+            load_siblings: false,
+        },
+        loader: &NoLoader,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        ast: build_result.ast.clone(),
+        project_root: None,
+        compile_phase: CompilePhase::Check,
+        go_resolver: resolver.clone(),
+    });
+
+    assert!(
+        result1.errors.is_empty(),
+        "first run should succeed: {:?}",
+        result1.errors,
+    );
+
+    // Second run — must still succeed (not load stale cache for third-party)
+    let (result2, _) = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: false,
+            standalone_mode: false,
+            load_siblings: false,
+        },
+        loader: &NoLoader,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        ast: build_result.ast,
+        project_root: None,
+        compile_phase: CompilePhase::Check,
+        go_resolver: resolver,
+    });
+
+    assert!(
+        result2.errors.is_empty(),
+        "second run must not fail from stale stdlib cache: {:?}",
+        result2.errors,
+    );
+}


### PR DESCRIPTION
> This is the first step in supporting third-party Go dependencies.

The compiler can now parse, resolve, typecheck, and emit code for third-party Go imports, given that the `.d.lis` typedef exists on disk and the manifest entry is in `lisette.toml`.

A new `crates/deps/` crate handles:

- manifest parsing, i.e. `[dependencies.go]` with string and `{version, via}` table forms, 
- optional `[toolchain]` version pinning), and 
- typedef resolution across project overrides (`.lisette/deps/go/`) and the global cache (`~/.lisette/cache/go/`). 

Go typedef resolution, previously hardcoded to stdlib, now handles both stdlib and third-party deps through a single path. `lis build` emits `require` entries in `target/go.mod` for all manifest deps.