### PR TITLE
feat: groundwork for lis add command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "lisette-syntax",
  "owo-colors",
  "rustc-hash",
+ "serde_json",
  "tokio",
  "tower-lsp",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,3 +30,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 owo-colors.workspace = true
 rustc-hash.workspace = true
+serde_json.workspace = true

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -180,24 +180,3 @@ fn go_mod_tidy(path: &Path) -> Result<(), String> {
 
     Ok(())
 }
-
-const BINDGEN_GO_MODULE: &str = "github.com/ivov/lisette/bindgen";
-const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Return a `Command` to run bindgen on a target package.
-///
-/// - For local dev, runs: `bindgen/bin/bindgen pkg {target_pkg}`
-/// - For end users, runs: `go run github.com/ivov/lisette/bindgen@v{version} pkg {target_pkg}`
-pub fn build_bindgen_command(target_pkg: &str) -> Command {
-    let bindgen_dev_path = Path::new("bindgen/bin/bindgen");
-    if let Ok(bin) = bindgen_dev_path.canonicalize() {
-        let mut cmd = Command::new(bin);
-        cmd.args(["pkg", target_pkg]);
-        return cmd;
-    }
-
-    let bindgen_published_path = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
-    let mut cmd = Command::new("go");
-    cmd.args(["run", &bindgen_published_path, "pkg", target_pkg]);
-    cmd
-}

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -1,5 +1,430 @@
-pub fn add(dependency: &str) -> i32 {
-    eprintln!("lis add: not yet implemented");
-    let _ = dependency;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::go_cli;
+use crate::output::{print_add_success, print_preview_notice, print_progress};
+use crate::workspace::GoWorkspace;
+use crate::{cli_error, error};
+use deps::{GoModule, remove_go_dep, upsert_go_dep};
+
+struct ParsedDependency {
+    module_path: String,
+    version: String,
+}
+
+struct ProjectContext {
+    project_root: PathBuf,
+    target_dir: PathBuf,
+    manifest: deps::Manifest,
+    typedef_cache_dir: PathBuf,
+    resolved_version: String,
+}
+
+struct GraphResult {
+    /// Final MVS-selected version for each reconciled module, e.g.
+    /// `{ "github.com/gorilla/mux" → "v1.8.1" }`.
+    versions: HashMap<String, String>,
+    /// For each reconciled module, the third-party modules it imports
+    /// via its typedefs, e.g. `{ "mux" → ["context"] }`.
+    edges: HashMap<String, Vec<String>>,
+}
+
+impl GraphResult {
+    /// Invert `edges` into a `module → parents` map, excluding the added root.
+    fn transitive_map(&self, added_module: &str) -> HashMap<String, Vec<String>> {
+        let mut transitives: HashMap<String, Vec<String>> = HashMap::new();
+        for (parent, children) in &self.edges {
+            for child in children {
+                if child != added_module {
+                    let parents = transitives.entry(child.clone()).or_default();
+                    if !parents.contains(parent) {
+                        parents.push(parent.clone());
+                    }
+                }
+            }
+        }
+        transitives
+    }
+}
+
+pub fn add(dep_string: &str) -> i32 {
+    if let Err(code) = go_cli::require_go() {
+        return code;
+    }
+
+    let dep = match parse_dep_string(dep_string) {
+        Ok(dep) => dep,
+        Err(msg) => {
+            cli_error!(
+                "Invalid dependency",
+                msg,
+                "Example: `lis add github.com/gorilla/mux@v1.8.0`"
+            );
+            return 1;
+        }
+    };
+
+    print_preview_notice();
+
+    let project_ctx = match setup_project(&dep) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+
+    let workspace = GoWorkspace::new(&project_ctx.target_dir, &project_ctx.typedef_cache_dir);
+
+    let module_graph = match reconcile_module_graph(&dep, &workspace) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+
+    if let Err(code) =
+        apply_graph_to_manifest(&dep.module_path, &project_ctx, &workspace, &module_graph)
+    {
+        return code;
+    }
+
+    let dep_version = module_graph
+        .versions
+        .get(&dep.module_path)
+        .cloned()
+        .unwrap_or(project_ctx.resolved_version);
+
+    print_add_success(
+        &dep.module_path,
+        &dep_version,
+        &module_graph.edges,
+        &module_graph.versions,
+    );
+
     0
+}
+
+fn parse_dep_string(input: &str) -> Result<ParsedDependency, String> {
+    let (path, version) = match input.rsplit_once('@') {
+        Some((p, v)) if !p.is_empty() && !v.is_empty() => (p, v.to_string()),
+        None if !input.is_empty() => (input, "latest".to_string()),
+        _ => return Err(format!("Cannot parse `{}`", input)),
+    };
+
+    let module_path = if !deps::is_third_party(path) {
+        format!("github.com/{}", path)
+    } else {
+        path.to_string()
+    };
+
+    let version = if version == "latest" {
+        version
+    } else if !version.starts_with('v') {
+        format!("v{}", version)
+    } else {
+        version
+    };
+
+    Ok(ParsedDependency {
+        module_path,
+        version,
+    })
+}
+
+fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
+    let project_root = Path::new(".");
+    if !project_root.join("lisette.toml").exists() {
+        cli_error!(
+            "No project found",
+            "No `lisette.toml` in current directory",
+            "Run `lis new <name>` to create a project"
+        );
+        return Err(1);
+    }
+
+    let manifest = match deps::parse_manifest(project_root) {
+        Ok(m) => m,
+        Err(msg) => {
+            cli_error!("Failed to read manifest", msg, "Fix `lisette.toml`");
+            return Err(1);
+        }
+    };
+
+    if let Err(msg) = deps::check_toolchain_version(&manifest) {
+        error!("toolchain mismatch", msg);
+        return Err(1);
+    }
+
+    let project_target_dir = project_root.join("target");
+    if let Err(e) = std::fs::create_dir_all(&project_target_dir) {
+        error!(
+            "failed to set up target directory",
+            format!("Failed to create target directory: {}", e)
+        );
+        return Err(1);
+    }
+
+    let locator = deps::TypedefLocator::new(
+        manifest.go_deps(),
+        Some(project_root.to_path_buf()),
+        std::env::var("HOME").ok(),
+    );
+
+    if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
+        error!("failed to write target/go.mod", msg);
+        return Err(1);
+    }
+
+    let typedef_cache_dir = match std::env::var("HOME") {
+        Ok(h) => deps::typedef_cache_dir(&h),
+        Err(_) => {
+            error!(
+                "failed to add dependency",
+                "HOME environment variable not set".to_string()
+            );
+            return Err(1);
+        }
+    };
+
+    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir);
+
+    let dep_version = if dep.version == "latest" {
+        print_progress(&format!("Resolving {}@latest", dep.module_path));
+        let query = format!("{}@latest", dep.module_path);
+        match workspace.query_module(&query) {
+            Ok(info) => info.version,
+            Err(msg) => {
+                error!("failed to resolve latest version", msg);
+                return Err(1);
+            }
+        }
+    } else {
+        dep.version.clone()
+    };
+
+    print_progress(&format!("Fetching {}@{}", dep.module_path, dep_version));
+
+    if let Err(msg) = workspace.go_get(GoModule {
+        path: &dep.module_path,
+        version: &dep_version,
+    }) {
+        error!("failed to download dependency", msg);
+        return Err(1);
+    }
+
+    Ok(ProjectContext {
+        project_root: project_root.to_path_buf(),
+        target_dir: project_target_dir,
+        manifest,
+        typedef_cache_dir,
+        resolved_version: dep_version,
+    })
+}
+
+/// Walk the dependency tree reachable from `dep` and cache typedefs for every
+/// module at its final MVS-selected version.
+///
+/// BFS-discovers modules by scanning each reconciled module's typedefs for
+/// `import "go:..."` references. Because Go's MVS can upgrade an
+/// already-reconciled module when a later `go get` raises its version, a drift
+/// fixup pass re-queries every reconciled module after the BFS drains and
+/// re-enqueues any that shifted. MVS only moves upward, so this converges.
+///
+/// Example: `lis add gorilla/mux` reconciles `mux`, finds it imports
+/// `gorilla/context`, reconciles `context`. Returns:
+///
+/// ```text
+/// module_versions: { mux → v1.8.1, context → v1.1.1 }
+/// edges:           { mux → [context], context → [] }
+/// ```
+fn reconcile_module_graph(
+    dep: &ParsedDependency,
+    workspace: &GoWorkspace,
+) -> Result<GraphResult, i32> {
+    let mut module_versions: HashMap<String, String> = HashMap::new();
+    let mut edges: HashMap<String, Vec<String>> = HashMap::new();
+    let mut queue: Vec<String> = vec![dep.module_path.clone()];
+
+    loop {
+        while let Some(module_path) = queue.pop() {
+            let module_version = workspace.query_version(&module_path).map_err(|msg| {
+                error!("failed to resolve module version", msg);
+                1
+            })?;
+
+            if module_versions
+                .get(&module_path)
+                .is_some_and(|v| *v == module_version)
+            {
+                continue;
+            }
+
+            if module_path != dep.module_path && !module_versions.contains_key(&module_path) {
+                print_progress(&format!("Resolving transitive dep {}", module_path));
+            }
+
+            let module = GoModule {
+                path: &module_path,
+                version: &module_version,
+            };
+
+            let packages = match workspace.reconcile(module) {
+                Ok(p) => p,
+                Err(msg) => {
+                    error!("failed to reconcile dependency", msg);
+                    return Err(1);
+                }
+            };
+
+            let dep_modules = match workspace.find_third_party_deps(module, &packages) {
+                Ok(t) => t,
+                Err(msg) => {
+                    error!("failed to scan transitive imports", msg);
+                    return Err(1);
+                }
+            };
+
+            module_versions.insert(module_path.clone(), module_version);
+            edges.insert(module_path, dep_modules.clone());
+
+            for dep_module in dep_modules {
+                queue.push(dep_module);
+            }
+        }
+
+        // Check if MVS upgraded any module since it was reconciled
+        let mut more_work = false;
+        let snapshot: Vec<_> = module_versions
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        for (module, reconciled_version) in snapshot {
+            let current_version = workspace.query_version(&module).map_err(|msg| {
+                error!("failed to resolve module version", msg);
+                1
+            })?;
+            if current_version != reconciled_version {
+                queue.push(module);
+                more_work = true;
+            }
+        }
+
+        if !more_work {
+            break;
+        }
+    }
+
+    Ok(GraphResult {
+        versions: module_versions,
+        edges,
+    })
+}
+
+/// Update `lisette.toml` to reflect the newly reconciled `added_dep` subgraph,
+/// leaving every other direct dep and its transitives untouched.
+///
+/// Three kinds of writes:
+/// 1. `added_dep` itself - upsert with its final version
+/// 2. Transitives reachable from `added_dep` - upsert with `via` entries
+///    pointing back to their parents in the new graph
+/// 3. Cleanup: for transitives in the old manifest that listed `added_dep` as a
+///    parent but no longer appear in the new graph, strip `added_dep` from
+///    their `via`; remove the entry entirely if nothing is left
+///
+/// Example of (3): before `lis add mux@newer`, the manifest has
+/// `gorilla/context = { via = ["mux"] }`. The new mux version no longer imports
+/// context, so context is no longer reachable from the added subgraph. `via`
+/// becomes `[]`, and the entry is removed.
+fn apply_graph_to_manifest(
+    added_dep: &str,
+    ctx: &ProjectContext,
+    workspace: &GoWorkspace,
+    graph: &GraphResult,
+) -> Result<(), i32> {
+    let project_root = &ctx.project_root;
+    let existing_deps = ctx.manifest.go_deps();
+    let transitives = graph.transitive_map(added_dep);
+    let added_dep_version = graph
+        .versions
+        .get(added_dep)
+        .map(|v| v.as_str())
+        .unwrap_or("");
+
+    if let Err(msg) = upsert_go_dep(project_root, added_dep, added_dep_version, None) {
+        error!("failed to update manifest", msg);
+        return Err(1);
+    }
+
+    for (module_path, parents) in &transitives {
+        let version = match graph.versions.get(module_path.as_str()) {
+            Some(v) => v.as_str(),
+            None => continue,
+        };
+
+        // If already a direct dep, refresh the version but keep it direct
+        if let Some(existing) = existing_deps.get(module_path.as_str())
+            && existing.via.is_none()
+        {
+            if existing.version != version {
+                upsert_go_dep(project_root, module_path, version, None).map_err(|msg| {
+                    error!("failed to update manifest", msg);
+                    1
+                })?;
+            }
+            continue;
+        }
+
+        let mut via: Vec<String> = existing_deps
+            .get(module_path.as_str())
+            .and_then(|d| d.via.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|p| p != added_dep)
+            .collect();
+
+        for parent in parents {
+            if !via.contains(parent) {
+                via.push(parent.clone());
+            }
+        }
+
+        if let Err(msg) = upsert_go_dep(project_root, module_path, version, Some(via)) {
+            error!("failed to update manifest", msg);
+            return Err(1);
+        }
+    }
+
+    for (dep_path, dep) in &existing_deps {
+        if transitives.contains_key(dep_path.as_str()) {
+            continue;
+        }
+
+        let Some(ref old_via) = dep.via else { continue };
+
+        if !old_via.iter().any(|p| p == added_dep) {
+            continue;
+        }
+
+        let filtered: Vec<String> = old_via
+            .iter()
+            .filter(|p| *p != added_dep)
+            .cloned()
+            .collect();
+
+        if filtered.is_empty() {
+            remove_go_dep(project_root, dep_path).map_err(|msg| {
+                error!("failed to update manifest", msg);
+                1
+            })?;
+            continue;
+        }
+
+        let dep_version = workspace.query_version(dep_path).map_err(|msg| {
+            error!("failed to resolve module version", msg);
+            1
+        })?;
+
+        upsert_go_dep(project_root, dep_path, &dep_version, Some(filtered)).map_err(|msg| {
+            error!("failed to update manifest", msg);
+            1
+        })?;
+    }
+
+    Ok(())
 }

--- a/crates/cli/src/handlers/bindgen.rs
+++ b/crates/cli/src/handlers/bindgen.rs
@@ -42,11 +42,12 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
         eprintln!("Generating bindings for {} -> {}", target_pkg, output_path);
     }
 
-    let result = crate::go_cli::build_bindgen_command(target_pkg).output();
+    // lis bindgen writes to a user-specified path, not the typedef cache
+    let workspace = crate::workspace::GoWorkspace::new(Path::new("."), Path::new(""));
 
-    match result {
-        Ok(output) if output.status.success() => {
-            if let Err(e) = std::fs::write(&output_path, &output.stdout) {
+    match workspace.run_bindgen(target_pkg) {
+        Ok(content) => {
+            if let Err(e) = std::fs::write(&output_path, &content) {
                 cli_error!(
                     "Failed to write bindings",
                     format!("Could not write to {}: {}", output_path, e),
@@ -58,19 +59,10 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
             eprintln!("  ✓ Generated bindings: {}", output_path);
             0
         }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(msg) => {
             cli_error!(
                 "Failed to generate bindings",
-                format!("Bindgen exited with code {:?}", output.status.code()),
-                stderr.trim().to_string()
-            );
-            1
-        }
-        Err(e) => {
-            cli_error!(
-                "Failed to run bindgen",
-                e.to_string(),
+                msg,
                 "Check Go installation with `go version`"
             );
             1

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -127,15 +127,6 @@ Arguments:
 Abbreviation: `x`",
         ),
 
-        "add" => print_help(
-            "`lis add` <dependency>
-
-Add a dependency to the project.
-
-Arguments:
-    <dependency>    Dependency to add (e.g., `github.com/user/repo`)",
-        ),
-
         "lsp" => print_help(
             "`lis lsp`
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@ mod go_cli;
 mod handlers;
 mod output;
 mod panic;
+mod workspace;
 
 use command::Command;
 

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -1,3 +1,5 @@
+use owo_colors::OwoColorize;
+
 pub fn use_color() -> bool {
     std::env::var("NO_COLOR").is_err()
 }
@@ -12,7 +14,6 @@ pub fn format_elapsed(elapsed: std::time::Duration) -> String {
     };
 
     if use_color() {
-        use owo_colors::OwoColorize;
         format!("{}", format!("({})", time_str).dimmed())
     } else {
         format!("({})", time_str)
@@ -23,8 +24,6 @@ pub fn format_backticks(text: &str, use_color: bool) -> String {
     if !use_color {
         return text.to_string();
     }
-
-    use owo_colors::OwoColorize;
 
     let mut result = String::new();
     let mut chars = text.char_indices().peekable();
@@ -95,8 +94,6 @@ fn format_help_text(text: &str, use_color: bool) -> String {
         }
         return out;
     }
-
-    use owo_colors::OwoColorize;
 
     let mut result = String::new();
     let mut chars = text.char_indices().peekable();
@@ -170,6 +167,88 @@ pub fn capitalize_first(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+pub fn print_preview_notice() {
+    eprintln!();
+    if use_color() {
+        eprintln!(
+            "  ! Support for third-party Go dependencies is in {}",
+            "early preview".yellow().underline()
+        );
+    } else {
+        eprintln!("  ! Support for third-party Go dependencies is in early preview");
+    }
+    eprintln!("  ! Please report issues at: https://github.com/ivov/lisette/issues");
+    eprintln!();
+}
+
+pub fn print_add_success(
+    module_path: &str,
+    version: &str,
+    edges: &std::collections::HashMap<String, Vec<String>>,
+    versions: &std::collections::HashMap<String, String>,
+) {
+    eprintln!();
+
+    let colored = use_color();
+    if colored {
+        eprintln!("  ✓ Added {} {}", module_path.green(), version.blue());
+    } else {
+        eprintln!("  ✓ Added {} {}", module_path, version);
+    }
+
+    let empty: Vec<String> = Vec::new();
+    let children = edges.get(module_path).unwrap_or(&empty);
+    let mut sorted: Vec<&String> = children.iter().collect();
+    sorted.sort();
+    for (i, child) in sorted.iter().enumerate() {
+        let is_last = i == sorted.len() - 1;
+        print_tree_node(child, "    ", is_last, edges, versions, colored);
+    }
+}
+
+fn print_tree_node(
+    node: &str,
+    prefix: &str,
+    is_last: bool,
+    edges: &std::collections::HashMap<String, Vec<String>>,
+    versions: &std::collections::HashMap<String, String>,
+    colored: bool,
+) {
+    let branch = if is_last { "└─ " } else { "├─ " };
+    let version = versions.get(node).map(String::as_str).unwrap_or("");
+
+    if colored {
+        eprintln!("{}{}{} {}", prefix, branch, node.green(), version.blue());
+    } else {
+        eprintln!("{}{}{} {}", prefix, branch, node, version);
+    }
+
+    let empty: Vec<String> = Vec::new();
+    let children = edges.get(node).unwrap_or(&empty);
+    let mut sorted: Vec<&String> = children.iter().collect();
+    sorted.sort();
+    let child_prefix = format!("{}{}", prefix, if is_last { "   " } else { "│  " });
+    for (i, child) in sorted.iter().enumerate() {
+        let child_is_last = i == sorted.len() - 1;
+        print_tree_node(
+            child,
+            &child_prefix,
+            child_is_last,
+            edges,
+            versions,
+            colored,
+        );
+    }
+}
+
+pub fn print_progress(msg: &str) {
+    if use_color() {
+        eprintln!("  · {}", msg.dimmed());
+    } else {
+        eprintln!("  · {}", msg);
     }
 }
 

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1,0 +1,277 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use deps::{GoModule, GoPackage};
+use syntax::ast::Expression;
+use syntax::parse::Parser;
+
+const BINDGEN_GO_MODULE: &str = "github.com/ivov/lisette/bindgen";
+const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Information about a Go module from `go list -m -json`.
+pub struct GoModuleInfo {
+    pub path: String,
+    pub version: String,
+    pub dir: String,
+}
+
+/// A directory with a `go.mod` that `go` commands run against.
+pub struct GoWorkspace<'a> {
+    /// The dir with the `go.mod` that `go` commands run against.
+    root: &'a Path,
+    /// The typedef cache root, e.g. `~/.lisette/cache/typedefs/lis@v0.1.7`.
+    pub typedef_cache_dir: &'a Path,
+}
+
+impl<'a> GoWorkspace<'a> {
+    pub fn new(root: &'a Path, typedef_cache_dir: &'a Path) -> Self {
+        Self {
+            root,
+            typedef_cache_dir,
+        }
+    }
+
+    /// Run a `go` subcommand and return its stdout on success.
+    fn run_go(&self, args: &[&str]) -> Result<String, String> {
+        let cmd_display = format!("go {}", args.join(" "));
+        let output = Command::new("go")
+            .args(args)
+            .current_dir(self.root)
+            .output()
+            .map_err(|e| format!("Failed to run `{}`: {}", cmd_display, e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("`{}` failed: {}", cmd_display, stderr.trim()));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    /// Download a Go module. Runs `go get {module}@{version}`.
+    pub fn go_get(&self, module: GoModule) -> Result<(), String> {
+        let target = format!("{}@{}", module.path, module.version);
+        self.run_go(&["get", &target])?;
+        Ok(())
+    }
+
+    /// Query a Go module's current graph version.
+    pub fn query_version(&self, module: &str) -> Result<String, String> {
+        let info = self.query_module(module)?;
+        if info.version.is_empty() {
+            return Err(format!("`go list -m -json {}` returned no version", module));
+        }
+        Ok(info.version)
+    }
+
+    /// Query a Go module's path, version, and local directory.
+    ///
+    /// ```text
+    /// query_module("github.com/gorilla/mux")          // version from go.mod
+    /// query_module("github.com/gorilla/mux@v1.8.0")   // specific version
+    /// ```
+    pub fn query_module(&self, query: &str) -> Result<GoModuleInfo, String> {
+        let stdout = self.run_go(&["list", "-m", "-json", query])?;
+        let value: serde_json::Value = serde_json::from_str(&stdout)
+            .map_err(|e| format!("Failed to parse Go module JSON: {}", e))?;
+
+        Ok(GoModuleInfo {
+            path: value["Path"].as_str().unwrap_or("").to_string(),
+            version: value["Version"].as_str().unwrap_or("").to_string(),
+            dir: value["Dir"].as_str().unwrap_or("").to_string(),
+        })
+    }
+
+    /// List all public packages in a Go module.
+    pub fn list_packages(&self, module_path: &str) -> Result<Vec<String>, String> {
+        let pattern = format!("{}/...", module_path);
+        let stdout = self.run_go(&["list", "-e", &pattern])?;
+        let packages: Vec<String> = stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .filter(|l| {
+                let relative = l.strip_prefix(module_path).unwrap_or(l);
+                !relative.split('/').any(|segment| segment == "internal")
+            })
+            .map(|l| l.to_string())
+            .collect();
+
+        Ok(packages)
+    }
+
+    /// Find the Go module that contains a package path.
+    ///
+    /// Queries `go list -m -json` with progressively shorter path prefixes
+    /// until a module is found:
+    ///
+    /// ```text
+    /// github.com/gorilla/mux/middleware → github.com/gorilla/mux
+    /// github.com/gorilla/mux            → github.com/gorilla/mux
+    /// ```
+    ///
+    /// Requires a prior `go get` so the module is in `target/go.mod`.
+    pub fn find_containing_module(&self, pkg_path: &str) -> Result<GoModuleInfo, String> {
+        if let Ok(info) = self.query_module(pkg_path)
+            && !info.dir.is_empty()
+        {
+            return Ok(info);
+        }
+
+        let mut path = pkg_path;
+        while let Some(pos) = path.rfind('/') {
+            path = &path[..pos];
+            if let Ok(info) = self.query_module(path)
+                && !info.dir.is_empty()
+            {
+                return Ok(info);
+            }
+        }
+
+        Err(format!(
+            "Could not find containing module for package `{}`",
+            pkg_path
+        ))
+    }
+
+    /// Run bindgen on a Go package and return the generated typedef content.
+    ///
+    /// - For local dev, runs: `bindgen/bin/bindgen pkg {package}`
+    /// - For end users, runs: `go run github.com/ivov/lisette/bindgen@v{version} pkg {package}`
+    pub fn run_bindgen(&self, package: &str) -> Result<String, String> {
+        let mut cmd = if let Some(bin) = dev_bindgen_path() {
+            let mut c = Command::new(bin);
+            c.args(["pkg", package]);
+            c
+        } else {
+            let bindgen_at_version = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
+            let mut c = Command::new("go");
+            c.args(["run", &bindgen_at_version, "pkg", package]);
+            c
+        };
+
+        let result = cmd
+            .current_dir(self.root)
+            .output()
+            .map_err(|e| format!("Failed to run bindgen for `{}`: {}", package, e))?;
+
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            return Err(format!(
+                "Bindgen failed for `{}`: {}",
+                package,
+                stderr.trim()
+            ));
+        }
+
+        String::from_utf8(result.stdout)
+            .map_err(|e| format!("Bindgen produced invalid UTF-8 for `{}`: {}", package, e))
+    }
+
+    /// Ensure typedefs exist in cache for every public package in a Go module.
+    ///
+    /// Returns the list of packages in the module.
+    pub fn reconcile(&self, module: GoModule) -> Result<Vec<String>, String> {
+        self.go_get(module)?;
+
+        let packages = self.list_packages(module.path)?;
+
+        for pkg_path in &packages {
+            let pkg = GoPackage {
+                module,
+                package: pkg_path,
+            };
+            let pkg_typedef_path = pkg.typedef_path(self.typedef_cache_dir);
+
+            if pkg_typedef_path.exists() {
+                continue;
+            }
+
+            let typedef = self.run_bindgen(pkg_path)?;
+
+            if let Some(parent_dir) = pkg_typedef_path.parent() {
+                fs::create_dir_all(parent_dir)
+                    .map_err(|e| format!("Failed to create cache directory: {}", e))?;
+            }
+
+            fs::write(&pkg_typedef_path, &typedef)
+                .map_err(|e| format!("Failed to cache typedef for `{}`: {}", pkg_path, e))?;
+        }
+
+        Ok(packages)
+    }
+
+    /// Find the third-party Go modules this module's typedefs depend on.
+    pub fn find_third_party_deps(
+        &self,
+        module: GoModule,
+        module_packages: &[String],
+    ) -> Result<Vec<String>, String> {
+        let mut third_party_deps = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+
+        for pkg_path in module_packages {
+            let pkg = GoPackage {
+                module,
+                package: pkg_path,
+            };
+            let pkg_typedef_path = pkg.typedef_path(self.typedef_cache_dir);
+
+            let typedef = fs::read_to_string(&pkg_typedef_path)
+                .map_err(|e| format!("Failed to read cached typedef for `{}`: {}", pkg_path, e))?;
+
+            for import_path in extract_third_party_imports(&typedef) {
+                let containing = self.find_containing_module(&import_path).map_err(|e| {
+                    format!(
+                        "Failed to resolve transitive import `{}` from `{}`: {}",
+                        import_path, pkg_path, e
+                    )
+                })?;
+
+                if containing.path == module.path || seen.contains(&containing.path) {
+                    continue;
+                }
+
+                seen.insert(containing.path.clone());
+                third_party_deps.push(containing.path);
+            }
+        }
+
+        Ok(third_party_deps)
+    }
+}
+
+fn extract_third_party_imports(typedef: &str) -> Vec<String> {
+    let parse_result = Parser::lex_and_parse_file(typedef, 0);
+
+    parse_result
+        .ast
+        .iter()
+        .filter_map(|expr| match expr {
+            Expression::ModuleImport { name, .. } => {
+                let pkg = name.strip_prefix("go:")?;
+                if deps::is_third_party(pkg) {
+                    Some(pkg.to_string())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+#[cfg(debug_assertions)]
+fn dev_bindgen_path() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../bindgen/bin/bindgen"
+    ));
+    path.canonicalize().ok()
+}
+
+#[cfg(not(debug_assertions))]
+fn dev_bindgen_path() -> Option<std::path::PathBuf> {
+    None
+}

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -4,8 +4,7 @@ mod typedef_locator;
 use std::path::{Path, PathBuf};
 
 pub use project_manifest::{
-    GoDependency, Manifest, check_toolchain_version, parse_manifest, remove_go_dep_from_manifest,
-    write_go_dep_to_manifest,
+    GoDependency, Manifest, check_toolchain_version, parse_manifest, remove_go_dep, upsert_go_dep,
 };
 pub use typedef_locator::{TypedefLocator, TypedefLocatorResult, TypedefOrigin};
 
@@ -24,41 +23,43 @@ pub fn typedef_cache_dir(home: &str) -> PathBuf {
     PathBuf::from(home).join(format!(".lisette/cache/typedefs/lis@v{}", lis_version))
 }
 
-/// A Go package within a versioned module.
-pub struct GoPackageRef<'a> {
+#[derive(Clone, Copy)]
+pub struct GoModule<'a> {
     /// Module path, e.g. `github.com/gorilla/mux`.
-    pub module_path: &'a str,
+    pub path: &'a str,
     /// Module version, e.g. `v1.8.0`.
     pub version: &'a str,
-    /// Package import path, either identical to `module_path` for the root package,
-    /// or extended for subpackages (e.g. `github.com/gorilla/mux/middleware`).
-    pub package_path: &'a str,
 }
 
-impl GoPackageRef<'_> {
+/// A Go package within a module.
+pub struct GoPackage<'a> {
+    /// The module that contains this package.
+    pub module: GoModule<'a>,
+    /// Package import path, either identical to `module.path` for the root package,
+    /// or extended for subpackages (e.g. `github.com/gorilla/mux/middleware`).
+    pub package: &'a str,
+}
+
+impl GoPackage<'_> {
     /// Build the path to a `.d.lis` file under a base directory.
     ///
     /// ```text
     /// ~/.lisette/cache/typedefs/lis@v0.1.6/github.com/gorilla/mux@v1.8.0/mux.d.lis
     /// ~/.lisette/cache/typedefs/lis@v0.1.6/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
     /// ```
-    pub fn build_typedef_path(&self, base: &Path) -> PathBuf {
-        let module_dir = base.join(format!("{}@{}", self.module_path, self.version));
+    pub fn typedef_path(&self, base_dir: &Path) -> PathBuf {
+        let module_dir = base_dir.join(format!("{}@{}", self.module.path, self.module.version));
 
-        let relative = if self.package_path == self.module_path {
+        let relative = if self.package == self.module.path {
             ""
         } else {
-            self.package_path
-                .strip_prefix(self.module_path)
+            self.package
+                .strip_prefix(self.module.path)
                 .and_then(|s| s.strip_prefix('/'))
                 .unwrap_or("")
         };
 
-        let last_segment = self
-            .package_path
-            .rsplit('/')
-            .next()
-            .unwrap_or(self.package_path);
+        let last_segment = self.package.rsplit('/').next().unwrap_or(self.package);
 
         let filename = format!("{}.d.lis", last_segment);
 

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -120,8 +120,7 @@ pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
 /// "github.com/gorilla/mux" = "v1.8.0"
 /// "github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux"] }
 /// ```
-#[allow(dead_code)]
-pub fn write_go_dep_to_manifest(
+pub fn upsert_go_dep(
     project_root: &Path,
     module_path: &str,
     version: &str,
@@ -180,8 +179,7 @@ pub fn write_go_dep_to_manifest(
     Ok(())
 }
 
-#[allow(dead_code)]
-pub fn remove_go_dep_from_manifest(project_root: &Path, go_dep_path: &str) -> Result<(), String> {
+pub fn remove_go_dep(project_root: &Path, go_dep_path: &str) -> Result<(), String> {
     let manifest_toml_path = project_root.join("lisette.toml");
     let manifest_content = fs::read_to_string(&manifest_toml_path)
         .map_err(|e| format!("Failed to read `lisette.toml`: {}", e))?;

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::project_manifest::{GoDependency, Manifest, check_toolchain_version, parse_manifest};
-use crate::{GoPackageRef, typedef_cache_dir};
+use crate::{GoModule, GoPackage, typedef_cache_dir};
 
 #[derive(Debug)]
 pub enum TypedefLocatorResult {
@@ -76,9 +76,9 @@ impl TypedefLocator {
 
     /// Returns the `.d.lis` content for a Go package (without `go:` prefix).
     /// Checks embedded stdlib typedefs first, then the on-disk cache.
-    pub fn find_typedef_content(&self, go_pkg: &str) -> TypedefLocatorResult {
-        if crate::is_stdlib(go_pkg) {
-            return match stdlib::get_go_stdlib_typedef(go_pkg) {
+    pub fn find_typedef_content(&self, package_path: &str) -> TypedefLocatorResult {
+        if crate::is_stdlib(package_path) {
+            return match stdlib::get_go_stdlib_typedef(package_path) {
                 Some(source) => TypedefLocatorResult::Found {
                     content: Cow::Borrowed(source),
                     origin: TypedefOrigin::Stdlib,
@@ -87,7 +87,7 @@ impl TypedefLocator {
             };
         }
 
-        let Some((module_path, dep)) = self.find_module_for_pkg(go_pkg) else {
+        let Some((module_path, dep)) = self.find_module_for_pkg(package_path) else {
             return TypedefLocatorResult::UndeclaredImport;
         };
 
@@ -100,13 +100,15 @@ impl TypedefLocator {
             };
         };
 
-        let pkg_ref = GoPackageRef {
-            module_path,
-            version,
-            package_path: go_pkg,
+        let pkg = GoPackage {
+            module: GoModule {
+                path: module_path,
+                version,
+            },
+            package: package_path,
         };
         let typedef_cache_dir = typedef_cache_dir(home_path);
-        let typedef_path = pkg_ref.build_typedef_path(&typedef_cache_dir);
+        let typedef_path = pkg.typedef_path(&typedef_cache_dir);
 
         match std::fs::read_to_string(&typedef_path) {
             Ok(source) => TypedefLocatorResult::Found {


### PR DESCRIPTION
> This is the third step in supporting third-party Go dependencies.

This PR adds `lis add`, which pulls a third-party Go module into a Lisette project: 

- resolve version, 
- cache typedefs for every public package, 
- recursively reconcile any third-party modules those typedefs reference, and 
- write the resulting graph into `lisette.toml`.

Reconciliation is a BFS over typedef imports with a drift fixup loop to handle MVS upgrades. The typedef cache is versioned per `lis` release (`~/.lisette/cache/typedefs/lis@v{version}/`). `lis add` is hidden from `lis help` and the CLI output warns the feature as an early preview until stabilized.

Follow-up to #47.