### PR TITLE
fix: harden lis add command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +494,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 name = "lisette"
 version = "0.1.8"
 dependencies = [
+ "fs2",
  "lisette-deps",
  "lisette-diagnostics",
  "lisette-emit",
@@ -1291,6 +1302,28 @@ checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,7 @@ deps = { package = "lisette-deps", version = "0.1.8", path = "../deps" }
 lsp = { package = "lisette-lsp", version = "0.1.8", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
+fs2 = "0.4"
 owo-colors.workspace = true
 rustc-hash.workspace = true
 serde_json.workspace = true

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -60,6 +60,7 @@ pub enum ParseError {
     UnknownFlag(String),
     UnexpectedArgument {
         message: String,
+        reason: String,
         hint: String,
     },
 }
@@ -179,7 +180,16 @@ impl Command {
             "version" => Ok(Command::Version),
 
             "add" => match arguments.next() {
-                Some(dependency) => Ok(Command::Add { dependency }),
+                Some(dependency) => {
+                    if let Some(extra) = arguments.next() {
+                        return Err(ParseError::UnexpectedArgument {
+                            message: format!("unexpected argument `{}`", extra),
+                            reason: "`lis add` accepts a single dependency".to_string(),
+                            hint: "Run `lis add` once per dep".to_string(),
+                        });
+                    }
+                    Ok(Command::Add { dependency })
+                }
                 None => Err(ParseError::MissingArgument {
                     command: "add",
                     argument: "dependency",
@@ -223,6 +233,7 @@ impl Command {
                     if let (Some(q), Some(item)) = (&query, &extra) {
                         return Err(ParseError::UnexpectedArgument {
                             message: format!("unexpected argument `{}`", item),
+                            reason: "The `doc` command takes a single query argument".to_string(),
                             hint: format!("Did you mean `lis doc {}.{}`?", q, item),
                         });
                     }

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -7,6 +7,17 @@ include!(concat!(env!("OUT_DIR"), "/go_version.rs"));
 use deps::TypedefLocator;
 use emit::PRELUDE_IMPORT_PATH;
 
+pub fn go_command() -> Command {
+    let mut c = Command::new("go");
+    // Isolate from any user-side env that would change Go's mode against
+    // lisette's `target/`: a stray `go.work` (workspace mode) or a stray
+    // `GOFLAGS=-mod=vendor` (vendor mode) both turn into multi-line errors
+    // for unrelated `lis add` invocations otherwise.
+    c.env("GOWORK", "off");
+    c.env("GOFLAGS", "");
+    c
+}
+
 pub fn require_go() -> Result<(), i32> {
     match go_status() {
         GoStatus::Ready => Ok(()),
@@ -155,7 +166,7 @@ pub fn ensure_go_sum(dir: &Path) -> Result<(), String> {
 
 pub fn prewarm_module_cache() {
     let prelude_version = env!("CARGO_PKG_VERSION");
-    let _ = Command::new("go")
+    let _ = go_command()
         .args([
             "mod",
             "download",
@@ -167,7 +178,7 @@ pub fn prewarm_module_cache() {
 }
 
 fn go_mod_tidy(path: &Path) -> Result<(), String> {
-    let output = Command::new("go")
+    let output = go_command()
         .args(["mod", "tidy"])
         .current_dir(path)
         .output()

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
 
 use crate::go_cli;
 use crate::output::{print_add_success, print_preview_notice, print_progress};
@@ -18,6 +21,7 @@ struct ProjectContext {
     manifest: deps::Manifest,
     typedef_cache_dir: PathBuf,
     resolved_version: String,
+    _lock: File,
 }
 
 struct GraphResult {
@@ -43,6 +47,9 @@ impl GraphResult {
                 }
             }
         }
+        for parents in transitives.values_mut() {
+            parents.sort();
+        }
         transitives
     }
 }
@@ -64,8 +71,6 @@ pub fn add(dep_string: &str) -> i32 {
         }
     };
 
-    print_preview_notice();
-
     let project_ctx = match setup_project(&dep) {
         Ok(v) => v,
         Err(code) => return code,
@@ -78,11 +83,11 @@ pub fn add(dep_string: &str) -> i32 {
         Err(code) => return code,
     };
 
-    if let Err(code) =
-        apply_graph_to_manifest(&dep.module_path, &project_ctx, &workspace, &module_graph)
-    {
-        return code;
-    }
+    let upgraded =
+        match apply_graph_to_manifest(&dep.module_path, &project_ctx, &workspace, &module_graph) {
+            Ok(u) => u,
+            Err(code) => return code,
+        };
 
     let dep_version = module_graph
         .versions
@@ -90,34 +95,146 @@ pub fn add(dep_string: &str) -> i32 {
         .cloned()
         .unwrap_or(project_ctx.resolved_version);
 
+    let upgraded_tuples: Vec<(&str, &str, &str)> = upgraded
+        .iter()
+        .map(|u| {
+            (
+                u.path.as_str(),
+                u.old_version.as_str(),
+                u.new_version.as_str(),
+            )
+        })
+        .collect();
+
     print_add_success(
         &dep.module_path,
         &dep_version,
         &module_graph.edges,
         &module_graph.versions,
+        &upgraded_tuples,
     );
 
     0
 }
 
+const PRELUDE_MODULE: &str = "github.com/ivov/lisette/prelude";
+
 fn parse_dep_string(input: &str) -> Result<ParsedDependency, String> {
-    let (path, version) = match input.rsplit_once('@') {
+    let input = input.trim();
+    if input.starts_with('-') {
+        return Err(format!(
+            "`{}` looks like a flag, but `lis add` does not accept flags",
+            input
+        ));
+    }
+
+    if let Some(hint) = detect_non_module_shape(input) {
+        return Err(format!("`{}` {}", input, hint));
+    }
+
+    if input.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err("dependency string contains whitespace or control characters".to_string());
+    }
+
+    let (raw_path, version) = match input.rsplit_once('@') {
         Some((p, v)) if !p.is_empty() && !v.is_empty() => (p, v.to_string()),
         None if !input.is_empty() => (input, "latest".to_string()),
         _ => return Err(format!("Cannot parse `{}`", input)),
     };
 
-    let module_path = if !deps::is_third_party(path) {
+    if raw_path.contains('@') {
+        return Err(format!(
+            "`{}` contains more than one `@` but expected `<module>@<version>`",
+            input
+        ));
+    }
+
+    let path = raw_path.trim_end_matches('/');
+    if path.is_empty() {
+        return Err(format!("Cannot parse `{}`", input));
+    }
+
+    if path.starts_with("./") || path.split('/').any(|s| s == "..") {
+        return Err(format!(
+            "`{}` is a relative path; `lis add` accepts only absolute Go module paths",
+            path
+        ));
+    }
+    if path.split('/').any(|s| s.is_empty()) {
+        return Err(format!(
+            "`{}` contains an empty segment (consecutive `/`); fix the path and retry",
+            path
+        ));
+    }
+    if !path.contains('/') && path.contains('.') {
+        return Err(format!(
+            "`{}` looks like a host without an owner/repo; module paths must include all path segments (e.g. `{}/owner/repo`)",
+            path, path
+        ));
+    }
+
+    if path.contains('%') {
+        return Err(format!(
+            "`{}` looks URL-encoded; use literal `/` instead of `%2F` in module paths",
+            path
+        ));
+    }
+    if let Some((module, sep, version)) = wrong_version_separator(path) {
+        return Err(format!(
+            "`{}{}{}` uses `{}` as a version separator; `lis add` uses `@`, like Go modules (try `{}@{}`)",
+            module, sep, version, sep, module, version
+        ));
+    }
+    if let Some(corrected) = miscased_known_host(path) {
+        return Err(format!(
+            "`{}` — Go module paths are case-sensitive (try `{}` instead)",
+            path, corrected
+        ));
+    }
+    if let Some(bad) = path
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '~' | '/')))
+    {
+        return Err(format!(
+            "`{}` contains `{}`, which is not allowed in a Go module path (only ASCII letters, digits, and `.-_~/`)",
+            path, bad
+        ));
+    }
+
+    if stdlib::get_go_stdlib_typedef(path).is_some() {
+        return Err(format!(
+            "`{}` is a Go standard library package; stdlib packages do not need `lis add` (just `import \"go:{}\"`)",
+            path, path
+        ));
+    }
+
+    let module_path = if deps::is_third_party(path) {
+        path.to_string()
+    } else if path.contains('/') {
         format!("github.com/{}", path)
     } else {
-        path.to_string()
+        return Err(format!(
+            "`{}` is not a valid module path; expected something like `github.com/owner/repo`",
+            path
+        ));
     };
+
+    if module_path == PRELUDE_MODULE {
+        return Err(
+            "the Lisette prelude is built into every project and cannot be added as a dependency"
+                .to_string(),
+        );
+    }
 
     let version = if version == "latest" {
         version
-    } else if !version.starts_with('v') {
+    } else if version.starts_with('v') || version.starts_with('V') {
+        format!("v{}", &version[1..])
+    } else if version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
         format!("v{}", version)
     } else {
+        // Pass through branch names, commit hashes, HEAD, etc. unchanged so
+        // `go get` can resolve them to pseudo-versions.
         version
     };
 
@@ -127,18 +244,96 @@ fn parse_dep_string(input: &str) -> Result<ParsedDependency, String> {
     })
 }
 
-fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
-    let project_root = Path::new(".");
-    if !project_root.join("lisette.toml").exists() {
-        cli_error!(
-            "No project found",
-            "No `lisette.toml` in current directory",
-            "Run `lis new <name>` to create a project"
-        );
-        return Err(1);
+/// Detect the common typo where the user uses a non-`@` version separator
+/// (Cargo's `^`, npm's `:`, a URL fragment `#`, or a `key=value` style `=`).
+/// Returns `(module, sep, version)` when the suffix after the separator looks
+/// version-shaped (`v1.2.3`, `1.2.3`, `v1`, etc.) so the caller can suggest
+/// the right form.
+fn wrong_version_separator(path: &str) -> Option<(&str, char, &str)> {
+    for sep in ['#', '^', ':', '='] {
+        if let Some((module, version)) = path.rsplit_once(sep)
+            && !module.is_empty()
+            && looks_like_version(version)
+        {
+            return Some((module, sep, version));
+        }
     }
+    None
+}
 
-    let manifest = match deps::parse_manifest(project_root) {
+fn looks_like_version(s: &str) -> bool {
+    if s.contains('/') {
+        return false;
+    }
+    let stripped = s.strip_prefix('v').unwrap_or(s);
+    !stripped.is_empty() && stripped.chars().next().is_some_and(|c| c.is_ascii_digit())
+}
+
+/// Detect common shapes that look like a published module path but are not:
+/// browser URLs, SSH clone strings, absolute or home-directory filesystem
+/// paths, dot-only paths. Returns a hint suffix the caller can append to the
+/// rejected input.
+fn detect_non_module_shape(s: &str) -> Option<&'static str> {
+    if s.starts_with("https://") || s.starts_with("http://") {
+        return Some("looks like a URL; strip the `https://` prefix and use the bare module path");
+    }
+    if s.starts_with("git@") && s.contains(':') {
+        return Some(
+            "looks like an SSH clone URL; use the module path form (e.g. `github.com/owner/repo`) instead",
+        );
+    }
+    if s.starts_with('/') {
+        return Some(
+            "is an absolute filesystem path; `lis add` accepts only published Go module paths",
+        );
+    }
+    if s.starts_with("~/") {
+        return Some("is a home-directory path; `lis add` accepts only published Go module paths");
+    }
+    if s != ".." && !s.is_empty() && s.chars().all(|c| c == '.') {
+        return Some("is not a valid Go module path");
+    }
+    None
+}
+
+/// Detect a case-only typo of a popular Go-module host. Returns the path with
+/// the host segment lowercased so the caller can suggest it.
+fn miscased_known_host(path: &str) -> Option<String> {
+    const KNOWN_HOSTS: &[&str] = &["github.com", "gitlab.com", "bitbucket.org", "codeberg.org"];
+    let (first, rest) = path.split_once('/')?;
+    for host in KNOWN_HOSTS {
+        if first != *host && first.eq_ignore_ascii_case(host) {
+            return Some(format!("{}/{}", host, rest));
+        }
+    }
+    None
+}
+
+fn find_project_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let mut current: &Path = &cwd;
+    loop {
+        if current.join("lisette.toml").is_file() {
+            return Some(current.to_path_buf());
+        }
+        current = current.parent()?;
+    }
+}
+
+fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
+    let project_root = match find_project_root() {
+        Some(root) => root,
+        None => {
+            cli_error!(
+                "No project found",
+                "No `lisette.toml` in current directory or in any parent",
+                "Run `lis new <name>` to create a project"
+            );
+            return Err(1);
+        }
+    };
+
+    let manifest = match deps::parse_manifest(&project_root) {
         Ok(m) => m,
         Err(msg) => {
             cli_error!("Failed to read manifest", msg, "Fix `lisette.toml`");
@@ -147,11 +342,34 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
     };
 
     if let Err(msg) = deps::check_toolchain_version(&manifest) {
-        error!("toolchain mismatch", msg);
+        let trimmed = msg
+            .strip_prefix("Toolchain mismatch: ")
+            .unwrap_or(&msg)
+            .to_string();
+        error!("toolchain mismatch", trimmed);
         return Err(1);
     }
 
+    if let Err(msg) = deps::validate_project_name(&manifest.project.name) {
+        cli_error!(
+            "Invalid project name",
+            msg,
+            "Rename `project.name` in `lisette.toml`"
+        );
+        return Err(1);
+    }
+
+    print_preview_notice();
+
     let project_target_dir = project_root.join("target");
+    if project_target_dir.is_file() {
+        cli_error!(
+            "Failed to set up target directory",
+            "`target/` exists but is a file, not a directory",
+            "Remove or move `target/` and retry"
+        );
+        return Err(1);
+    }
     if let Err(e) = std::fs::create_dir_all(&project_target_dir) {
         error!(
             "failed to set up target directory",
@@ -160,9 +378,11 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         return Err(1);
     }
 
+    let lock = acquire_add_lock(&project_target_dir)?;
+
     let locator = deps::TypedefLocator::new(
         manifest.go_deps(),
-        Some(project_root.to_path_buf()),
+        Some(project_root.clone()),
         std::env::var("HOME").ok(),
     );
 
@@ -186,9 +406,8 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
 
     let dep_version = if dep.version == "latest" {
         print_progress(&format!("Resolving {}@latest", dep.module_path));
-        let query = format!("{}@latest", dep.module_path);
-        match workspace.query_module(&query) {
-            Ok(info) => info.version,
+        match workspace.query_latest_version(&dep.module_path) {
+            Ok(v) => v,
             Err(msg) => {
                 error!("failed to resolve latest version", msg);
                 return Err(1);
@@ -209,12 +428,42 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
     }
 
     Ok(ProjectContext {
-        project_root: project_root.to_path_buf(),
+        project_root,
         target_dir: project_target_dir,
         manifest,
         typedef_cache_dir,
         resolved_version: dep_version,
+        _lock: lock,
     })
+}
+
+fn acquire_add_lock(target_dir: &Path) -> Result<File, i32> {
+    let lock_path = target_dir.join(".lis-add.lock");
+    let file = match File::create(&lock_path) {
+        Ok(f) => f,
+        Err(e) => {
+            error!(
+                "failed to create lock file",
+                format!("Failed to create `{}`: {}", lock_path.display(), e)
+            );
+            return Err(1);
+        }
+    };
+
+    if let Err(e) = file.try_lock_exclusive() {
+        if e.kind() == std::io::ErrorKind::WouldBlock {
+            cli_error!(
+                "Another `lis add` is in progress",
+                "A concurrent `lis add` holds the project lock",
+                "Wait for the other invocation to finish, then retry"
+            );
+        } else {
+            error!("failed to acquire lock", format!("{}", e));
+        }
+        return Err(1);
+    }
+
+    Ok(file)
 }
 
 /// Walk the dependency tree reachable from `dep` and cache typedefs for every
@@ -316,16 +565,24 @@ fn reconcile_module_graph(
     })
 }
 
+struct DirectUpgrade {
+    path: String,
+    old_version: String,
+    new_version: String,
+}
+
 /// Update `lisette.toml` to reflect the newly reconciled `added_dep` subgraph,
 /// leaving every other direct dep and its transitives untouched.
 ///
-/// Three kinds of writes:
+/// Four kinds of writes:
 /// 1. `added_dep` itself - upsert with its final version
 /// 2. Transitives reachable from `added_dep` - upsert with `via` entries
 ///    pointing back to their parents in the new graph
 /// 3. Cleanup: for transitives in the old manifest that listed `added_dep` as a
 ///    parent but no longer appear in the new graph, strip `added_dep` from
 ///    their `via`; remove the entry entirely if nothing is left
+/// 4. Hygiene: prune `via` entries that point to modules no longer present in
+///    the manifest, and drop transitives left without any parent
 ///
 /// Example of (3): before `lis add mux@newer`, the manifest has
 /// `gorilla/context = { via = ["mux"] }`. The new mux version no longer imports
@@ -336,7 +593,7 @@ fn apply_graph_to_manifest(
     ctx: &ProjectContext,
     workspace: &GoWorkspace,
     graph: &GraphResult,
-) -> Result<(), i32> {
+) -> Result<Vec<DirectUpgrade>, i32> {
     let project_root = &ctx.project_root;
     let existing_deps = ctx.manifest.go_deps();
     let transitives = graph.transitive_map(added_dep);
@@ -345,13 +602,17 @@ fn apply_graph_to_manifest(
         .get(added_dep)
         .map(|v| v.as_str())
         .unwrap_or("");
+    let mut upgraded: Vec<DirectUpgrade> = Vec::new();
 
     if let Err(msg) = upsert_go_dep(project_root, added_dep, added_dep_version, None) {
         error!("failed to update manifest", msg);
         return Err(1);
     }
 
-    for (module_path, parents) in &transitives {
+    let mut sorted_transitives: Vec<(&String, &Vec<String>)> = transitives.iter().collect();
+    sorted_transitives.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (module_path, parents) in &sorted_transitives {
         let version = match graph.versions.get(module_path.as_str()) {
             Some(v) => v.as_str(),
             None => continue,
@@ -366,6 +627,11 @@ fn apply_graph_to_manifest(
                     error!("failed to update manifest", msg);
                     1
                 })?;
+                upgraded.push(DirectUpgrade {
+                    path: (*module_path).clone(),
+                    old_version: existing.version.clone(),
+                    new_version: version.to_string(),
+                });
             }
             continue;
         }
@@ -378,11 +644,12 @@ fn apply_graph_to_manifest(
             .filter(|p| p != added_dep)
             .collect();
 
-        for parent in parents {
+        for parent in parents.iter() {
             if !via.contains(parent) {
                 via.push(parent.clone());
             }
         }
+        via.sort();
 
         if let Err(msg) = upsert_go_dep(project_root, module_path, version, Some(via)) {
             error!("failed to update manifest", msg);
@@ -390,7 +657,10 @@ fn apply_graph_to_manifest(
         }
     }
 
-    for (dep_path, dep) in &existing_deps {
+    let mut sorted_existing: Vec<(&String, &deps::GoDependency)> = existing_deps.iter().collect();
+    sorted_existing.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (dep_path, dep) in &sorted_existing {
         if transitives.contains_key(dep_path.as_str()) {
             continue;
         }
@@ -401,11 +671,12 @@ fn apply_graph_to_manifest(
             continue;
         }
 
-        let filtered: Vec<String> = old_via
+        let mut filtered: Vec<String> = old_via
             .iter()
             .filter(|p| *p != added_dep)
             .cloned()
             .collect();
+        filtered.sort();
 
         if filtered.is_empty() {
             remove_go_dep(project_root, dep_path).map_err(|msg| {
@@ -421,6 +692,57 @@ fn apply_graph_to_manifest(
         })?;
 
         upsert_go_dep(project_root, dep_path, &dep_version, Some(filtered)).map_err(|msg| {
+            error!("failed to update manifest", msg);
+            1
+        })?;
+    }
+
+    prune_stale_via(project_root)?;
+
+    Ok(upgraded)
+}
+
+/// Drop `via` entries that point to parents no longer present in the manifest,
+/// and remove transitives left with an empty `via` list.
+fn prune_stale_via(project_root: &Path) -> Result<(), i32> {
+    let manifest = match deps::parse_manifest(project_root) {
+        Ok(m) => m,
+        Err(msg) => {
+            error!("failed to re-read manifest for hygiene pass", msg);
+            return Err(1);
+        }
+    };
+    let live_deps = manifest.go_deps();
+    let live_paths: std::collections::HashSet<&str> =
+        live_deps.keys().map(|s| s.as_str()).collect();
+
+    let mut sorted: Vec<(&String, &deps::GoDependency)> = live_deps.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (dep_path, dep) in &sorted {
+        let Some(ref via) = dep.via else { continue };
+
+        let mut canonical: Vec<String> = via
+            .iter()
+            .filter(|parent| live_paths.contains(parent.as_str()))
+            .cloned()
+            .collect();
+        canonical.sort();
+        canonical.dedup();
+
+        if canonical.iter().eq(via.iter()) {
+            continue;
+        }
+
+        if canonical.is_empty() {
+            remove_go_dep(project_root, dep_path).map_err(|msg| {
+                error!("failed to update manifest", msg);
+                1
+            })?;
+            continue;
+        }
+
+        upsert_go_dep(project_root, dep_path, &dep.version, Some(canonical)).map_err(|msg| {
             error!("failed to update manifest", msg);
             1
         })?;

--- a/crates/cli/src/handlers/new.rs
+++ b/crates/cli/src/handlers/new.rs
@@ -11,6 +11,15 @@ pub fn new_project(name: &str) -> i32 {
         .and_then(|n| n.to_str())
         .unwrap_or(name);
 
+    if let Err(msg) = deps::validate_project_name(project_name) {
+        cli_error!(
+            "Invalid project name",
+            msg,
+            "Choose a different project name"
+        );
+        return 1;
+    }
+
     if is_go_stdlib_package(project_name) {
         cli_error!(
             "Invalid project name",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -43,12 +43,12 @@ fn main() {
             );
             std::process::exit(1);
         }
-        Err(command::ParseError::UnexpectedArgument { message, hint }) => {
-            cli_error!(
-                message,
-                "The `doc` command takes a single query argument",
-                hint
-            );
+        Err(command::ParseError::UnexpectedArgument {
+            message,
+            reason,
+            hint,
+        }) => {
+            cli_error!(message, reason, hint);
             std::process::exit(1);
         }
     };

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -1,7 +1,13 @@
+use std::io::IsTerminal;
+use std::sync::LazyLock;
+
 use owo_colors::OwoColorize;
 
+static USE_COLOR: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("NO_COLOR").is_err() && std::io::stderr().is_terminal());
+
 pub fn use_color() -> bool {
-    std::env::var("NO_COLOR").is_err()
+    *USE_COLOR
 }
 
 pub fn format_elapsed(elapsed: std::time::Duration) -> String {
@@ -189,15 +195,35 @@ pub fn print_add_success(
     version: &str,
     edges: &std::collections::HashMap<String, Vec<String>>,
     versions: &std::collections::HashMap<String, String>,
+    upgraded_directs: &[(&str, &str, &str)],
 ) {
     eprintln!();
 
     let colored = use_color();
+    for (path, old, new) in upgraded_directs {
+        if colored {
+            eprintln!(
+                "  ↑ Upgraded {} {} → {}",
+                path.green(),
+                old.blue(),
+                new.blue()
+            );
+        } else {
+            eprintln!("  ↑ Upgraded {} {} → {}", path, old, new);
+        }
+    }
+    if !upgraded_directs.is_empty() {
+        eprintln!();
+    }
+
     if colored {
         eprintln!("  ✓ Added {} {}", module_path.green(), version.blue());
     } else {
         eprintln!("  ✓ Added {} {}", module_path, version);
     }
+
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+    visited.insert(module_path.to_string());
 
     let empty: Vec<String> = Vec::new();
     let children = edges.get(module_path).unwrap_or(&empty);
@@ -205,7 +231,15 @@ pub fn print_add_success(
     sorted.sort();
     for (i, child) in sorted.iter().enumerate() {
         let is_last = i == sorted.len() - 1;
-        print_tree_node(child, "    ", is_last, edges, versions, colored);
+        print_tree_node(
+            child,
+            "    ",
+            is_last,
+            edges,
+            versions,
+            colored,
+            &mut visited,
+        );
     }
 }
 
@@ -216,14 +250,33 @@ fn print_tree_node(
     edges: &std::collections::HashMap<String, Vec<String>>,
     versions: &std::collections::HashMap<String, String>,
     colored: bool,
+    visited: &mut std::collections::HashSet<String>,
 ) {
     let branch = if is_last { "└─ " } else { "├─ " };
     let version = versions.get(node).map(String::as_str).unwrap_or("");
+    let already_seen = !visited.insert(node.to_string());
 
     if colored {
-        eprintln!("{}{}{} {}", prefix, branch, node.green(), version.blue());
+        if already_seen {
+            eprintln!(
+                "{}{}{} {} {}",
+                prefix,
+                branch,
+                node.green(),
+                version.blue(),
+                "(*)".dimmed()
+            );
+        } else {
+            eprintln!("{}{}{} {}", prefix, branch, node.green(), version.blue());
+        }
+    } else if already_seen {
+        eprintln!("{}{}{} {} (*)", prefix, branch, node, version);
     } else {
         eprintln!("{}{}{} {}", prefix, branch, node, version);
+    }
+
+    if already_seen {
+        return;
     }
 
     let empty: Vec<String> = Vec::new();
@@ -240,6 +293,7 @@ fn print_tree_node(
             edges,
             versions,
             colored,
+            visited,
         );
     }
 }

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -14,7 +14,6 @@ const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct GoModuleInfo {
     pub path: String,
     pub version: String,
-    pub dir: String,
 }
 
 /// A directory with a `go.mod` that `go` commands run against.
@@ -36,7 +35,7 @@ impl<'a> GoWorkspace<'a> {
     /// Run a `go` subcommand and return its stdout on success.
     fn run_go(&self, args: &[&str]) -> Result<String, String> {
         let cmd_display = format!("go {}", args.join(" "));
-        let output = Command::new("go")
+        let output = crate::go_cli::go_command()
             .args(args)
             .current_dir(self.root)
             .output()
@@ -44,7 +43,7 @@ impl<'a> GoWorkspace<'a> {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("`{}` failed: {}", cmd_display, stderr.trim()));
+            return Err(translate_go_error(args, stderr.trim()));
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
@@ -80,14 +79,36 @@ impl<'a> GoWorkspace<'a> {
         Ok(GoModuleInfo {
             path: value["Path"].as_str().unwrap_or("").to_string(),
             version: value["Version"].as_str().unwrap_or("").to_string(),
-            dir: value["Dir"].as_str().unwrap_or("").to_string(),
         })
     }
 
+    /// Resolve a module's `@latest` alias to a concrete version.
+    ///
+    /// Uses `-mod=mod` so Go is allowed to refresh `go.sum` if the proxy
+    /// returns a version that matches the existing pin (a plain readonly
+    /// `go list -m -json X@latest` errors with `updates to go.sum needed`
+    /// in that case).
+    pub fn query_latest_version(&self, module_path: &str) -> Result<String, String> {
+        let target = format!("{}@latest", module_path);
+        let stdout = self.run_go(&["list", "-mod=mod", "-m", "-json", &target])?;
+        let value: serde_json::Value = serde_json::from_str(&stdout)
+            .map_err(|e| format!("Failed to parse Go module JSON: {}", e))?;
+        let version = value["Version"].as_str().unwrap_or("").to_string();
+        if version.is_empty() {
+            return Err(format!("`go list -m -json {}` returned no version", target));
+        }
+        Ok(version)
+    }
+
     /// List all public packages in a Go module.
+    ///
+    /// Uses `-mod=mod` so the BFS reconcile can add newly-discovered transitives
+    /// to `target/go.mod` while resolving the package list. Without it, deep
+    /// graphs (otel, gRPC) hit `updates to go.mod needed; to update it: go mod
+    /// tidy` mid-walk and abort the whole add.
     pub fn list_packages(&self, module_path: &str) -> Result<Vec<String>, String> {
         let pattern = format!("{}/...", module_path);
-        let stdout = self.run_go(&["list", "-e", &pattern])?;
+        let stdout = self.run_go(&["list", "-mod=mod", "-e", &pattern])?;
         let packages: Vec<String> = stdout
             .lines()
             .filter(|l| !l.is_empty())
@@ -111,10 +132,10 @@ impl<'a> GoWorkspace<'a> {
     /// github.com/gorilla/mux            → github.com/gorilla/mux
     /// ```
     ///
-    /// Requires a prior `go get` so the module is in `target/go.mod`.
+    /// Requires the module to be in the build graph (direct or indirect).
     pub fn find_containing_module(&self, pkg_path: &str) -> Result<GoModuleInfo, String> {
         if let Ok(info) = self.query_module(pkg_path)
-            && !info.dir.is_empty()
+            && !info.path.is_empty()
         {
             return Ok(info);
         }
@@ -123,7 +144,7 @@ impl<'a> GoWorkspace<'a> {
         while let Some(pos) = path.rfind('/') {
             path = &path[..pos];
             if let Ok(info) = self.query_module(path)
-                && !info.dir.is_empty()
+                && !info.path.is_empty()
             {
                 return Ok(info);
             }
@@ -146,7 +167,7 @@ impl<'a> GoWorkspace<'a> {
             c
         } else {
             let bindgen_at_version = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
-            let mut c = Command::new("go");
+            let mut c = crate::go_cli::go_command();
             c.args(["run", &bindgen_at_version, "pkg", package]);
             c
         };
@@ -240,6 +261,207 @@ impl<'a> GoWorkspace<'a> {
 
         Ok(third_party_deps)
     }
+}
+
+/// Translate raw `go` stderr into a one-line message for the common failure modes.
+///
+/// Falls back to the trimmed stderr verbatim if no pattern matches, so callers
+/// never lose information.
+fn translate_go_error(args: &[&str], stderr: &str) -> String {
+    let target = args
+        .iter()
+        .find(|a| {
+            !a.starts_with('-')
+                && **a != "get"
+                && **a != "list"
+                && **a != "-m"
+                && **a != "-json"
+                && **a != "-e"
+        })
+        .copied()
+        .unwrap_or("");
+    let module = target.rsplit_once('@').map(|(m, _)| m).unwrap_or(target);
+
+    if stderr.contains("unknown revision") {
+        return format!("Version not found for `{}`", target);
+    }
+    if stderr.contains("Repository not found") || stderr.contains("repository not found") {
+        return format!("Module `{}` not found", module);
+    }
+    if stderr.contains("no matching versions for query") {
+        return format!("No matching versions found for `{}`", target);
+    }
+    if let Some(corrected) = extract_post_v_path(stderr) {
+        return format!(
+            "`{}` is a v2+ Go module and requires the major-version suffix `{}` (try `{}@<version>`)",
+            module, corrected, corrected
+        );
+    }
+    if stderr.contains("module declares its path as") {
+        if let Some((declared, required)) = extract_path_mismatch(stderr) {
+            return format!(
+                "Module path mismatch: `{}` was required, but the upstream module declares its path as `{}` (try `{}` instead). If `{}` is in your `lisette.toml`, fix it there.",
+                required, declared, declared, required
+            );
+        }
+        return format!(
+            "Module path mismatch: `{}` does not match the module's declared path",
+            module
+        );
+    }
+    if stderr.contains("malformed module path") {
+        return format!(
+            "`{}` is not a valid module path. If this is a Go package import path, use the module root instead (e.g. `k8s.io/api`, not `k8s.io/api/core/v1`)",
+            module
+        );
+    }
+    if stderr.contains("errors parsing go.mod") {
+        if let Some(culprit) = extract_invalid_pin(stderr) {
+            return format!(
+                "`lisette.toml` has an invalid Go version for `{}` (`{}`); fix the pin and retry",
+                culprit.0, culprit.1
+            );
+        }
+        return "`lisette.toml` contains an invalid Go version; fix the offending pin and retry"
+            .to_string();
+    }
+    // Must precede the generic `invalid version` branch below; Go's
+    // `invalid version control suffix` error string contains `invalid version`
+    // as a substring and would otherwise hit the wrong branch.
+    if stderr.contains("invalid version control suffix") {
+        return format!(
+            "`{}` is not a valid Go module path (do not include `.git` or other VCS suffixes)",
+            module
+        );
+    }
+    if stderr.contains("invalid version") || stderr.contains("should be v0 or v1") {
+        return format!(
+            "Invalid Go module version in `{}` (must look like `v1.2.3`)",
+            target
+        );
+    }
+    if stderr.contains("invalid github.com import path") {
+        return format!(
+            "`{}` is not a valid github.com import path (github only allows letters, digits, and `.-_`)",
+            module
+        );
+    }
+    if let Some((found, missing)) = extract_missing_subpackage(stderr) {
+        return format!(
+            "Module `{}` exists but does not contain package `{}`; v1 Go modules do not use a `/v1` suffix (only v2+ require the major-version suffix)",
+            found, missing
+        );
+    }
+    if stderr.contains("no required module provides package")
+        || stderr.contains("cannot find module providing package")
+    {
+        return format!("No module provides package `{}`", module);
+    }
+    if stderr.contains("existing contents have changed since last read") {
+        return "Another `lis add` is in progress against this project; wait for it to finish and retry".to_string();
+    }
+    if stderr.contains("unable to access") || stderr.contains("requested URL returned error: 4") {
+        return format!(
+            "Module `{}` is unreachable (the host returned an error)",
+            module
+        );
+    }
+    if stderr.contains("module lookup disabled by GOPROXY") {
+        return format!(
+            "Module `{}` is not in the local cache and `GOPROXY=off` disables remote lookups; unset `GOPROXY` or set it to a working proxy",
+            module
+        );
+    }
+    if stderr.contains("modules disabled by GO111MODULE") {
+        return "`GO111MODULE=off` disables Go modules entirely; unset `GO111MODULE` (Go modules are required by lisette)".to_string();
+    }
+    if stderr.contains("-insecure flag is no longer supported") {
+        return "`-insecure` is no longer a valid Go flag; remove it from `GOFLAGS` or set `GOINSECURE` instead".to_string();
+    }
+    if stderr.contains("unrecognized import path") {
+        return format!(
+            "`{}` is not a recognized Go module path; the host does not serve `go-import` metadata",
+            module
+        );
+    }
+    if stderr.contains("updates to go.mod needed") {
+        return format!(
+            "Resolving `{}` requires updates to `target/go.mod` that lisette could not perform; please file an issue",
+            target
+        );
+    }
+
+    let cmd_display = format!("go {}", args.join(" "));
+    format!("`{}` failed: {}", cmd_display, stderr)
+}
+
+/// Pull `(module_path, version)` out of a `go.mod` parse error like
+/// `require github.com/gorilla/mux: version "v999.999.999" invalid: ...`.
+fn extract_invalid_pin(stderr: &str) -> Option<(String, String)> {
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("require ") && l.contains("version "))?;
+    let after_require = line.split("require ").nth(1)?;
+    let module = after_require.split(':').next()?.trim().to_string();
+    let after_version = line.split("version \"").nth(1)?;
+    let version = after_version.split('"').next()?.to_string();
+    Some((module, version))
+}
+
+/// Pull the corrected module path out of a `go.mod has post-vN module path
+/// "github.com/foo/bar/vN" at revision vN.x.y` error.
+fn extract_post_v_path(stderr: &str) -> Option<String> {
+    let after = stderr.split("post-v").nth(1)?;
+    let after_quote = after.split("module path \"").nth(1)?;
+    let path = after_quote.split('"').next()?;
+    Some(path.to_string())
+}
+
+/// Pull `(declared, required)` out of a Go path-mismatch error:
+///
+/// ```text
+/// module declares its path as: golang.org/x/example
+///         but was required as: github.com/golang/example
+/// ```
+fn extract_path_mismatch(stderr: &str) -> Option<(String, String)> {
+    let declared = stderr
+        .lines()
+        .find_map(|l| l.split("module declares its path as:").nth(1))?
+        .trim()
+        .to_string();
+    let required = stderr
+        .lines()
+        .find_map(|l| l.split("but was required as:").nth(1))?
+        .trim()
+        .to_string();
+    if declared.is_empty() || required.is_empty() {
+        return None;
+    }
+    Some((declared, required))
+}
+
+/// Pull `(found_module, missing_package)` out of a Go missing-subpackage error:
+///
+/// ```text
+/// module github.com/gorilla/mux@v1.8.0 found, but does not contain package github.com/gorilla/mux/v1
+/// ```
+fn extract_missing_subpackage(stderr: &str) -> Option<(String, String)> {
+    let after_module = stderr.split("module ").nth(1)?;
+    let found = after_module
+        .split('@')
+        .next()
+        .or_else(|| after_module.split(' ').next())?
+        .trim()
+        .to_string();
+    let after_pkg = stderr.split("does not contain package ").nth(1)?;
+    let missing = after_pkg
+        .split(|c: char| c.is_whitespace())
+        .next()?
+        .to_string();
+    if found.is_empty() || missing.is_empty() {
+        return None;
+    }
+    Some((found, missing))
 }
 
 fn extract_third_party_imports(typedef: &str) -> Vec<String> {

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 pub use project_manifest::{
     GoDependency, Manifest, check_toolchain_version, parse_manifest, remove_go_dep, upsert_go_dep,
+    validate_project_name,
 };
 pub use typedef_locator::{TypedefLocator, TypedefLocatorResult, TypedefOrigin};
 

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -92,10 +92,28 @@ impl Manifest {
 pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
     let project_toml_path = project_root.join("lisette.toml");
 
-    let content = fs::read_to_string(&project_toml_path)
+    let bytes = fs::read(&project_toml_path)
         .map_err(|_| format!("No `lisette.toml` manifest in `{}`", project_root.display()))?;
+    let content =
+        strip_bom_to_str(&bytes).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))?;
 
-    toml::from_str(&content).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))
+    toml::from_str(content).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))
+}
+
+pub fn validate_project_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("project name is empty".to_string());
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '~')))
+    {
+        return Err(format!(
+            "`{}` contains `{}`, which is not allowed in a project name (only ASCII letters, digits, and `.-_~`)",
+            name, bad
+        ));
+    }
+    Ok(())
 }
 
 pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
@@ -114,6 +132,50 @@ pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
     Ok(())
 }
 
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
+fn strip_bom_to_str(bytes: &[u8]) -> Result<&str, std::str::Utf8Error> {
+    let body = bytes.strip_prefix(UTF8_BOM).unwrap_or(bytes);
+    std::str::from_utf8(body)
+}
+
+struct ManifestEncoding {
+    had_bom: bool,
+    had_crlf: bool,
+}
+
+fn open_manifest(path: &Path) -> Result<(ManifestEncoding, toml_edit::DocumentMut), String> {
+    let bytes = fs::read(path).map_err(|e| format!("Failed to read `lisette.toml`: {}", e))?;
+    let had_bom = bytes.starts_with(UTF8_BOM);
+    let content =
+        strip_bom_to_str(&bytes).map_err(|e| format!("Failed to read `lisette.toml`: {}", e))?;
+    let had_crlf = content.contains("\r\n");
+    let manifest: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|e| format!("Failed to parse `lisette.toml`: {}", e))?;
+    Ok((ManifestEncoding { had_bom, had_crlf }, manifest))
+}
+
+fn save_manifest(
+    path: &Path,
+    encoding: &ManifestEncoding,
+    manifest: &toml_edit::DocumentMut,
+) -> Result<(), String> {
+    let mut serialized = manifest.to_string();
+    if encoding.had_crlf {
+        serialized = serialized.replace('\n', "\r\n");
+    }
+    if encoding.had_bom {
+        let mut out = Vec::with_capacity(UTF8_BOM.len() + serialized.len());
+        out.extend_from_slice(UTF8_BOM);
+        out.extend_from_slice(serialized.as_bytes());
+        fs::write(path, out)
+    } else {
+        fs::write(path, serialized)
+    }
+    .map_err(|e| format!("Failed to write `lisette.toml`: {}", e))
+}
+
 /// Add or update a Go dependency in `lisette.toml`.
 ///
 /// ```text
@@ -126,31 +188,9 @@ pub fn upsert_go_dep(
     version: &str,
     via: Option<Vec<String>>,
 ) -> Result<(), String> {
-    let manifest_toml_path = project_root.join("lisette.toml");
-    let manifest_content = fs::read_to_string(&manifest_toml_path)
-        .map_err(|e| format!("Failed to read `lisette.toml`: {}", e))?;
-
-    let mut manifest: toml_edit::DocumentMut = manifest_content
-        .parse()
-        .map_err(|e| format!("Failed to parse `lisette.toml`: {}", e))?;
-
-    if manifest.get("dependencies").is_none() {
-        let mut table = toml_edit::Table::new();
-        table.set_implicit(true);
-        manifest.insert("dependencies", toml_edit::Item::Table(table));
-    }
-
-    let deps = manifest["dependencies"]
-        .as_table_mut()
-        .ok_or("Invalid `lisette.toml`: `dependencies` is not a table")?;
-
-    if deps.get("go").is_none() {
-        deps.insert("go", toml_edit::Item::Table(toml_edit::Table::new()));
-    }
-
-    let go = deps["go"]
-        .as_table_mut()
-        .ok_or("Invalid `lisette.toml`: `dependencies.go` is not a table")?;
+    let path = project_root.join("lisette.toml");
+    let (encoding, mut manifest) = open_manifest(&path)?;
+    let go = ensure_go_deps_table(&mut manifest)?;
 
     match via {
         Some(mut via_list) => {
@@ -173,20 +213,12 @@ pub fn upsert_go_dep(
         }
     }
 
-    fs::write(&manifest_toml_path, manifest.to_string())
-        .map_err(|e| format!("Failed to write `lisette.toml`: {}", e))?;
-
-    Ok(())
+    save_manifest(&path, &encoding, &manifest)
 }
 
 pub fn remove_go_dep(project_root: &Path, go_dep_path: &str) -> Result<(), String> {
-    let manifest_toml_path = project_root.join("lisette.toml");
-    let manifest_content = fs::read_to_string(&manifest_toml_path)
-        .map_err(|e| format!("Failed to read `lisette.toml`: {}", e))?;
-
-    let mut manifest: toml_edit::DocumentMut = manifest_content
-        .parse()
-        .map_err(|e| format!("Failed to parse `lisette.toml`: {}", e))?;
+    let path = project_root.join("lisette.toml");
+    let (encoding, mut manifest) = open_manifest(&path)?;
 
     if let Some(deps) = manifest
         .get_mut("dependencies")
@@ -196,8 +228,24 @@ pub fn remove_go_dep(project_root: &Path, go_dep_path: &str) -> Result<(), Strin
         go.remove(go_dep_path);
     }
 
-    fs::write(&manifest_toml_path, manifest.to_string())
-        .map_err(|e| format!("Failed to write `lisette.toml`: {}", e))?;
+    save_manifest(&path, &encoding, &manifest)
+}
 
-    Ok(())
+fn ensure_go_deps_table(
+    manifest: &mut toml_edit::DocumentMut,
+) -> Result<&mut toml_edit::Table, String> {
+    if manifest.get("dependencies").is_none() {
+        let mut table = toml_edit::Table::new();
+        table.set_implicit(true);
+        manifest.insert("dependencies", toml_edit::Item::Table(table));
+    }
+    let deps = manifest["dependencies"]
+        .as_table_mut()
+        .ok_or("Invalid `lisette.toml`: `dependencies` is not a table")?;
+    if deps.get("go").is_none() {
+        deps.insert("go", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    deps["go"]
+        .as_table_mut()
+        .ok_or_else(|| "Invalid `lisette.toml`: `dependencies.go` is not a table".to_string())
 }

--- a/crates/emit/src/go/types/go_type.rs
+++ b/crates/emit/src/go/types/go_type.rs
@@ -152,8 +152,8 @@ impl Emitter<'_> {
             return result;
         }
 
-        if let Some((module, _)) = qualified_name.split_once('.')
-            && let Some(go_path) = module.strip_prefix(go_name::GO_IMPORT_PREFIX)
+        if let Some(rest) = qualified_name.strip_prefix(go_name::GO_IMPORT_PREFIX)
+            && let Some((go_path, _)) = rest.rsplit_once('.')
         {
             let mut result = if params.is_empty() {
                 GoType::with_go_import(name, go_path.to_string())
@@ -243,8 +243,16 @@ impl Emitter<'_> {
     }
 
     fn unqualify_name(&self, id: &str) -> String {
-        let Some((module, unqualified)) = id.split_once('.') else {
-            return go_name::escape_keyword(id).into_owned();
+        let (module, unqualified) = if let Some(rest) = id.strip_prefix(go_name::GO_IMPORT_PREFIX) {
+            let Some((path, ty)) = rest.rsplit_once('.') else {
+                return go_name::escape_keyword(id).into_owned();
+            };
+            (&id[..go_name::GO_IMPORT_PREFIX.len() + path.len()], ty)
+        } else {
+            let Some(split) = id.split_once('.') else {
+                return go_name::escape_keyword(id).into_owned();
+            };
+            split
         };
 
         if unqualified == "Unknown" {

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -4,15 +4,27 @@ use syntax::program::File;
 use super::pipeline::TestPipeline;
 
 pub fn emit_with_debug_info(raw_source: &str) -> EmitResult {
-    emit_inner(raw_source, Some(raw_source))
+    emit_inner(raw_source, Some(raw_source), &[])
 }
 
 pub fn emit(raw_source: &str) -> EmitResult {
-    emit_inner(raw_source, None)
+    emit_inner(raw_source, None, &[])
 }
 
-fn emit_inner(raw_source: &str, source_for_debug: Option<&str>) -> EmitResult {
-    let compiled = TestPipeline::new(raw_source).wrapped().compile();
+pub fn emit_with_go_typedefs(raw_source: &str, typedefs: &[(&str, &str)]) -> EmitResult {
+    emit_inner(raw_source, None, typedefs)
+}
+
+fn emit_inner(
+    raw_source: &str,
+    source_for_debug: Option<&str>,
+    extra_go_typedefs: &[(&str, &str)],
+) -> EmitResult {
+    let mut pipeline = TestPipeline::new(raw_source).wrapped();
+    for (name, source) in extra_go_typedefs {
+        pipeline = pipeline.with_go_typedef(name, source);
+    }
+    let compiled = pipeline.compile();
 
     let result = compiled.run_inference();
 

--- a/tests/_harness/macros.rs
+++ b/tests/_harness/macros.rs
@@ -215,6 +215,22 @@ macro_rules! assert_emit_snapshot {
 }
 
 #[macro_export]
+macro_rules! assert_emit_snapshot_with_go_typedefs {
+    ($input:expr, $typedefs:expr) => {
+        let emit_result = $crate::_harness::emit::emit_with_go_typedefs($input, $typedefs);
+        let go_code = emit_result.go_code();
+
+        insta::with_settings!({
+            description => format!("input: {}", $input),
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+        }, {
+            insta::assert_snapshot!(go_code);
+        });
+    };
+}
+
+#[macro_export]
 macro_rules! assert_lint_snapshot {
     ($source:expr) => {
         let warnings = $crate::_harness::lint::lint($source);

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -26,6 +26,7 @@ pub struct TestPipeline {
     source: String,
     raw_source: String,
     wrapped: bool,
+    extra_go_typedefs: Vec<(String, String)>,
 }
 
 impl TestPipeline {
@@ -34,12 +35,19 @@ impl TestPipeline {
             source: source.to_string(),
             raw_source: source.to_string(),
             wrapped: false,
+            extra_go_typedefs: Vec::new(),
         }
     }
 
     pub fn wrapped(mut self) -> Self {
         self.wrapped = true;
         self.source = wrap(&self.raw_source);
+        self
+    }
+
+    pub fn with_go_typedef(mut self, module_name: &str, typedef_source: &str) -> Self {
+        self.extra_go_typedefs
+            .push((module_name.to_string(), typedef_source.to_string()));
         self
     }
 
@@ -62,6 +70,7 @@ impl TestPipeline {
         CompiledTest {
             ast: desugar_result.ast,
             wrapped: self.wrapped,
+            extra_go_typedefs: self.extra_go_typedefs,
         }
     }
 }
@@ -69,6 +78,7 @@ impl TestPipeline {
 pub struct CompiledTest {
     ast: Vec<Expression>,
     wrapped: bool,
+    extra_go_typedefs: Vec<(String, String)>,
 }
 
 impl CompiledTest {
@@ -101,10 +111,16 @@ impl CompiledTest {
                         span,
                     } = item
                     {
-                        if let Some(go_pkg) = name.strip_prefix("go:")
-                            && let Some(typedef) = get_go_stdlib_typedef(go_pkg)
-                        {
-                            checker.parse_and_register_go_module(name, typedef, &locator);
+                        if let Some(go_pkg) = name.strip_prefix("go:") {
+                            if let Some(typedef) = get_go_stdlib_typedef(go_pkg) {
+                                checker.parse_and_register_go_module(name, typedef, &locator);
+                            } else if let Some((_, typedef)) = self
+                                .extra_go_typedefs
+                                .iter()
+                                .find(|(n, _)| n.as_str() == name.as_str())
+                            {
+                                checker.parse_and_register_go_module(name, typedef, &locator);
+                            }
                         }
                         Some(FileImport {
                             name: name.clone(),

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -1,4 +1,4 @@
-use crate::assert_emit_snapshot;
+use crate::{assert_emit_snapshot, assert_emit_snapshot_with_go_typedefs};
 
 #[test]
 fn import_single() {
@@ -163,4 +163,35 @@ fn test() {
 }
 "#;
     assert_emit_snapshot!(input);
+}
+
+#[test]
+fn third_party_go_import_path_emitted_in_full() {
+    let input = r#"
+import "go:github.com/bwmarrin/discordgo"
+
+fn test() {
+  let s = discordgo.Session{}
+  let _ = s
+}
+"#;
+    let typedef = r#"
+pub struct Session {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:github.com/bwmarrin/discordgo", typedef)]);
+}
+
+#[test]
+fn third_party_go_type_uses_short_package_qualifier() {
+    let input = r#"
+import "go:github.com/bwmarrin/discordgo"
+
+fn make() -> Ref<discordgo.Session> {
+  &discordgo.Session{}
+}
+"#;
+    let typedef = r#"
+pub struct Session {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:github.com/bwmarrin/discordgo", typedef)]);
 }

--- a/tests/spec/emit/snapshots/third_party_go_import_path_emitted_in_full.snap
+++ b/tests/spec/emit/snapshots/third_party_go_import_path_emitted_in_full.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:github.com/bwmarrin/discordgo\"\n\nfn test() {\n  let s = discordgo.Session{}\n  let _ = s\n}\n"
+---
+package main
+
+import "github.com/bwmarrin/discordgo"
+
+func test() {
+	_ = discordgo.Session{}
+}

--- a/tests/spec/emit/snapshots/third_party_go_type_uses_short_package_qualifier.snap
+++ b/tests/spec/emit/snapshots/third_party_go_type_uses_short_package_qualifier.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:github.com/bwmarrin/discordgo\"\n\nfn make() -> Ref<discordgo.Session> {\n  &discordgo.Session{}\n}\n"
+---
+package main
+
+import "github.com/bwmarrin/discordgo"
+
+func make_() *discordgo.Session {
+	return &discordgo.Session{}
+}


### PR DESCRIPTION

Harden `lis add` based on my own testing and user feedback. 

- Reject malformed inputs (flags, whitespace, double `@`, URL-encoded paths, SSH/URL/absolute shapes, stdlib, prelude, etc.) with explanatory errors.
- Detect common typos and suggest fixes: wrong version separators, miscased hosts, missing `v` prefix.
- Translate ~20 raw `go` stderr patterns into clear one-line messages, falling back to raw stderr otherwise.
- Isolate `go` invocations from user env (`GOWORK=off`, empty `GOFLAGS`) so stray workspace files or vendor mode cannot scramble `lis add`.
- Lock `target/.lis-add.lock` via `fs2` so concurrent runs cannot corrupt `go.mod`/`lisette.toml`.
- Pass `-mod=mod` to `go list` so `@latest` resolution and deep transitive walks can extend `target/go.mod` instead of aborting.
- Prune stale `via` entries and drop transitives left without a parent.
- Sort all manifest iteration for deterministic diffs.
- Preserve UTF-8 BOM and CRLF line endings on manifest save.
- Find the project root by walking upward from cwd.
- Treat `target/` being a file as a clean error.
- Report direct-dep upgrades in the success output.
- Detect cycles in the dependency tree printer and mark repeats with `(*)`.
- Cache `use_color()` and honor non-TTY stderr.
- Share `validate_project_name` between `lis new` and `lis add`.
- Reject extra positional args to `lis add`.
- Strip `go:` prefix before splitting qualified ids on `.`, so third-party Go module paths no longer produce stray `"github"` imports or malformed `*github.com/bwmarrin/discordgo.Session` type refs.

Close #62