### PR TITLE
fix: allow type alias to fn as type conversion

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1168,6 +1168,23 @@ pub fn not_callable(ty: &Type, span: Span) -> LisetteDiagnostic {
         .with_help(help)
 }
 
+pub fn type_conversion_arity(
+    type_name: &str,
+    actual_count: usize,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Wrong argument count")
+        .with_infer_code("type_conversion_arity")
+        .with_span_label(
+            &span,
+            format!("expected 1 argument, found {}", actual_count),
+        )
+        .with_help(format!(
+            "Type conversion `{}(value)` takes exactly one argument — the value to convert",
+            type_name
+        ))
+}
+
 #[derive(Debug, Clone)]
 pub struct InterfaceViolation {
     pub interface_name: String,

--- a/crates/emit/src/go/definitions/toplevel.rs
+++ b/crates/emit/src/go/definitions/toplevel.rs
@@ -556,19 +556,32 @@ impl Emitter<'_> {
         generics: &[Generic],
         ty: &Type,
     ) -> String {
+        let is_fn_alias;
         let underlying = match ty {
             Type::Forall { body, .. } => match body.as_ref() {
                 Type::Constructor {
                     underlying_ty: Some(inner),
                     ..
-                } if matches!(inner.as_ref(), Type::Function { .. }) => inner.as_ref(),
-                other => other,
+                } if matches!(inner.as_ref(), Type::Function { .. }) => {
+                    is_fn_alias = true;
+                    inner.as_ref()
+                }
+                other => {
+                    is_fn_alias = false;
+                    other
+                }
             },
             Type::Constructor {
                 underlying_ty: Some(inner),
                 ..
-            } if matches!(inner.as_ref(), Type::Function { .. }) => inner.as_ref(),
-            _ => ty,
+            } if matches!(inner.as_ref(), Type::Function { .. }) => {
+                is_fn_alias = true;
+                inner.as_ref()
+            }
+            _ => {
+                is_fn_alias = false;
+                ty
+            }
         };
         let ty_string = self.go_type_as_string(underlying);
 
@@ -586,10 +599,12 @@ impl Emitter<'_> {
             Self::collect_map_key_generics(std::iter::once(underlying), &generic_names);
         let generics_string = self.generics_to_string_with_map_keys(generics, &map_key_generics);
 
+        let separator = if is_fn_alias { " " } else { " = " };
         format!(
-            "type {}{} = {}",
+            "type {}{}{}{}",
             go_name::escape_keyword(name),
             generics_string,
+            separator,
             ty_string
         )
     }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::BindingKind;
 use syntax::ast::{Annotation, Binding, Expression, Pattern, Span, StructKind};
 use syntax::program::{CallKind, Definition, NativeTypeKind};
-use syntax::types::{Bound, SubstitutionMap, Type, substitute};
+use syntax::types::{Bound, SubstitutionMap, Type, substitute, unqualified_name};
 
 use super::super::Checker;
 use super::super::checks::check_binding_pattern;
@@ -221,6 +221,19 @@ impl Checker<'_, '_> {
         let forall_ty = self.resolve_callee_forall_type(&callee_expression, &type_args);
         let (callee_ty, new_type_args) =
             self.instantiate_callee_type(&forall_ty, &type_args, &callee_expression, &span);
+
+        if let Some(underlying_fn) = self.try_as_type_conversion(&callee_expression, &callee_ty) {
+            return self.infer_type_conversion_call(
+                callee_expression,
+                callee_ty,
+                underlying_fn,
+                args,
+                new_type_args,
+                span,
+                expected_ty,
+            );
+        }
+
         let (param_types, param_mutability, return_ty, bounds) =
             self.extract_call_signature(callee_ty, args.len(), &callee_expression);
 
@@ -577,6 +590,96 @@ impl Checker<'_, '_> {
         }
 
         None
+    }
+
+    fn try_as_type_conversion(&self, callee: &Expression, callee_ty: &Type) -> Option<Type> {
+        let Type::Constructor {
+            id,
+            underlying_ty: Some(underlying),
+            ..
+        } = callee_ty
+        else {
+            return None;
+        };
+
+        if !matches!(underlying.as_ref(), Type::Function { .. }) {
+            return None;
+        }
+
+        if !matches!(
+            self.store.get_definition(id),
+            Some(Definition::TypeAlias { .. })
+        ) {
+            return None;
+        }
+
+        let is_bare_type_name = match callee.unwrap_parens() {
+            Expression::Identifier { binding_id, .. } => binding_id.is_none(),
+            Expression::DotAccess {
+                expression: base, ..
+            } => matches!(
+                base.get_type().resolve(),
+                Type::Constructor { id, .. } if id.starts_with("@import/")
+            ),
+            _ => false,
+        };
+
+        if !is_bare_type_name {
+            return None;
+        }
+
+        Some(underlying.as_ref().clone())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn infer_type_conversion_call(
+        &mut self,
+        callee_expression: Expression,
+        named_ty: Type,
+        underlying_fn: Type,
+        args: Vec<Expression>,
+        type_args: Vec<Annotation>,
+        span: Span,
+        expected_ty: &Type,
+    ) -> Expression {
+        if args.len() != 1 {
+            let Type::Constructor { id, .. } = &named_ty else {
+                unreachable!("type_conversion_underlying only fires for Constructor callees")
+            };
+            self.sink.push(diagnostics::infer::type_conversion_arity(
+                unqualified_name(id),
+                args.len(),
+                span,
+            ));
+            let new_args: Vec<Expression> = args
+                .into_iter()
+                .map(|arg| self.with_value_context(|s| s.infer_expression(arg, &Type::Error)))
+                .collect();
+            self.unify(expected_ty, &Type::Error, &span);
+            self.resolutions.mark_call(span, CallKind::Regular);
+            return Expression::Call {
+                expression: callee_expression.into(),
+                args: new_args,
+                type_args,
+                ty: Type::Error,
+                span,
+            };
+        }
+
+        let arg = args.into_iter().next().unwrap();
+        let new_arg = self.with_value_context(|s| s.infer_expression(arg, &underlying_fn));
+        self.check_not_temp_producing(&new_arg);
+
+        self.unify(expected_ty, &named_ty, &span);
+        self.resolutions.mark_call(span, CallKind::Regular);
+
+        Expression::Call {
+            expression: callee_expression.into(),
+            args: vec![new_arg],
+            type_args,
+            ty: named_ty,
+            span,
+        }
     }
 
     fn infer_call_arguments(

--- a/tests/e2e/src/main.lis
+++ b/tests/e2e/src/main.lis
@@ -1,6 +1,7 @@
 import "go:bytes"
 import "go:fmt"
 import httpx "go:net/http"
+import "go:net/http/httptest"
 import "go:math"
 import "go:path"
 import "go:strconv"
@@ -3514,6 +3515,20 @@ fn test_go_import_not_shadowed_by_transitive() -> int {
   if c.is_none() { 100 } else { 0 }
 }
 
+fn serve(h: httpx.Handler) -> int {
+  let rec = httptest.NewRecorder()
+  let req = httptest.NewRequest("GET", "/", bytes.NewBufferString(""))
+  h.ServeHTTP(rec, req)
+  rec.Code
+}
+
+fn test_handlerfunc_conversion() -> int {
+  let h = httpx.HandlerFunc(|w: httpx.ResponseWriter, _r: Ref<httpx.Request>| {
+    w.WriteHeader(httpx.StatusNoContent)
+  })
+  if serve(h) == httpx.StatusNoContent { 100 } else { 0 }
+}
+
 // Pointer receiver on struct literal (value type) — needs `mut`
 fn test_pointer_receiver_struct_literal() -> int {
   let mut wg = sync.WaitGroup {}
@@ -4113,6 +4128,9 @@ fn main() {
     test_go_import_not_shadowed_by_transitive(),
     100,
   )
+
+  section("go fn-alias type conversion")
+  report("handlerfunc_conversion", test_handlerfunc_conversion(), 100)
 
   section("go pointer receiver")
   report(

--- a/tests/spec/emit/snapshots/call_through_deref_ref_fn.snap
+++ b/tests/spec/emit/snapshots/call_through_deref_ref_fn.snap
@@ -4,7 +4,7 @@ description: "input: \ntype IntFn = fn(int) -> int\n\nfn apply(f: Ref<IntFn>, x:
 ---
 package main
 
-type IntFn = func(int) int
+type IntFn func(int) int
 
 func apply(f *IntFn, x int) int {
 	return (*f)(x)

--- a/tests/spec/emit/snapshots/cast_fn_to_type_alias.snap
+++ b/tests/spec/emit/snapshots/cast_fn_to_type_alias.snap
@@ -4,7 +4,7 @@ description: "input: \ntype Handler = fn(int) -> string\n\nfn my_handler(x: int)
 ---
 package main
 
-type Handler = func(int) string
+type Handler func(int) string
 
 func my_handler(_ int) string {
 	return "ok"

--- a/tests/spec/emit/snapshots/cast_type_alias_to_fn.snap
+++ b/tests/spec/emit/snapshots/cast_type_alias_to_fn.snap
@@ -4,7 +4,7 @@ description: "input: \ntype Handler = fn(int) -> string\n\nfn my_handler(x: int)
 ---
 package main
 
-type Handler = func(int) string
+type Handler func(int) string
 
 func my_handler(_ int) string {
 	return "ok"

--- a/tests/spec/emit/snapshots/e2e.snap
+++ b/tests/spec/emit/snapshots/e2e.snap
@@ -589,6 +589,10 @@ string_range_slicing: PASS
 
 go_import_not_shadowed_by_transitive: PASS
 
+// go fn-alias type conversion
+
+handlerfunc_conversion: PASS
+
 // go pointer receiver
 
 pointer_receiver_struct_literal: PASS

--- a/tests/spec/emit/snapshots/function_type_alias.snap
+++ b/tests/spec/emit/snapshots/function_type_alias.snap
@@ -4,7 +4,7 @@ description: "input: \ntype IntPredicate = fn(int) -> bool\n\nfn apply(f: IntPre
 ---
 package main
 
-type IntPredicate = func(int) bool
+type IntPredicate func(int) bool
 
 func apply(f IntPredicate, x int) bool {
 	return f(x)

--- a/tests/spec/emit/snapshots/function_type_alias_callable.snap
+++ b/tests/spec/emit/snapshots/function_type_alias_callable.snap
@@ -4,7 +4,7 @@ description: "input: \ntype Transformer = fn(int) -> int\n\nfn apply(t: Transfor
 ---
 package main
 
-type Transformer = func(int) int
+type Transformer func(int) int
 
 func apply(t Transformer, val int) int {
 	return t(val)

--- a/tests/spec/emit/snapshots/generic_function_type_alias.snap
+++ b/tests/spec/emit/snapshots/generic_function_type_alias.snap
@@ -4,7 +4,7 @@ description: "input: \ntype Transform<T> = fn(T) -> T\n\nfn apply_transform<T>(v
 ---
 package main
 
-type Transform[T any] = func(T) T
+type Transform[T any] func(T) T
 
 func apply_transform[T any](val T, f Transform[T]) T {
 	return f(val)

--- a/tests/spec/emit/snapshots/interop_result_expression_position_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_expression_position_assignment.snap
@@ -9,7 +9,7 @@ import (
 	"strconv"
 )
 
-type F = func(string) lisette.Result[int, error]
+type F func(string) lisette.Result[int, error]
 
 func main() {
 	f := func(_ string) lisette.Result[int, error] {

--- a/tests/spec/emit/snapshots/interop_result_slice_append.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_append.snap
@@ -9,7 +9,7 @@ import (
 	"strconv"
 )
 
-type F = func(string) lisette.Result[int, error]
+type F func(string) lisette.Result[int, error]
 
 func main() {
 	xs := []F{}

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-type F = func(string) lisette.Result[int, error]
+type F func(string) lisette.Result[int, error]
 
 type Pair struct {
 	F0 F

--- a/tests/spec/infer/basics.rs
+++ b/tests/spec/infer/basics.rs
@@ -747,6 +747,24 @@ fn simple_type_alias() {
 }
 
 #[test]
+fn fn_type_alias_conversion_call() {
+    infer(
+        r#"
+    type Transformer = fn(int) -> int
+
+    fn apply(t: Transformer, x: int) -> int {
+      t(x)
+    }
+
+    fn test() -> int {
+      apply(Transformer(|x| x * 2), 21)
+    }
+        "#,
+    )
+    .assert_last_function_type(vec![], int_type());
+}
+
+#[test]
 fn type_alias_in_function_param() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1002,6 +1002,19 @@ fn test() {
 }
 
 #[test]
+fn infer_type_conversion_arity() {
+    let input = r#"
+type Transformer = fn(int) -> int
+
+fn test() {
+  let f = |x: int| x * 2
+  let _ = Transformer(f, f)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_struct_member_not_found_with_suggestion() {
     let input = r#"
 struct Point { x: int, y: int }

--- a/tests/ui/errors/snapshots/infer_type_conversion_arity.snap
+++ b/tests/ui/errors/snapshots/infer_type_conversion_arity.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Wrong argument count
+   ╭─[test.lis:6:11]
+ 5 │   let f = |x: int| x * 2
+ 6 │   let _ = Transformer(f, f)
+   ·           ────────┬────────
+   ·                   ╰── expected 1 argument, found 2
+ 7 │ }
+   ╰────
+  help: Type conversion `Transformer(value)` takes exactly one argument — the value to convert · code: [infer.type_conversion_arity]


### PR DESCRIPTION
In Go, `http.HandlerFunc(f)` wraps a plain function so that it satisfies the `http.Handler` interface. This is the standard idiom for adapting a function into an HTTP handler. Lisette was rejecting this with a confusing cascade of type errors.

Lisette now recognizes `T(value)` as a type conversion when `T` is a type alias over a function, matching Go's semantics. The wrapped value carries the alias's methods and therefore satisfies any interface they implement.

Fixes #63