### PR TITLE
fix: erase self-referential bounds on interface type parameters

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -232,6 +232,16 @@ pub fn unused_type_parameter(span: &Span) -> LisetteDiagnostic {
         .with_help("Remove the unused type parameter or use it in the signature")
 }
 
+pub fn type_param_only_in_bound(span: &Span, name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Type parameter only used in bound")
+        .with_lint_code("type_param_only_in_bound")
+        .with_span_label(
+            span,
+            format!("`{}` is only used inside another parameter's bound", name),
+        )
+        .with_help("Remove it, or use it in a parameter type, return type, or bound left-hand side")
+}
+
 pub fn ineffective_try_block(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Ineffective `try` block")
         .with_lint_code("try_block_no_success_path")

--- a/crates/emit/src/go/definitions/toplevel.rs
+++ b/crates/emit/src/go/definitions/toplevel.rs
@@ -11,7 +11,7 @@ use syntax::ast::{
     Visibility,
 };
 use syntax::program::Definition;
-use syntax::types::Type;
+use syntax::types::{Type, unqualified_name};
 
 impl Emitter<'_> {
     /// Returns the name for the auto-generated stringer method, or `None` if no
@@ -639,7 +639,8 @@ impl Emitter<'_> {
             }
         }
 
-        let generics_str = self.generics_to_string_with_map_keys(generics, &map_key_generics);
+        let filtered = strip_self_referential_bounds(generics, name);
+        let generics_str = self.generics_to_string_with_map_keys(&filtered, &map_key_generics);
 
         let mut output = Vec::new();
         output.push(format!(
@@ -954,4 +955,27 @@ fn is_option_type(ty: &Type) -> bool {
         Type::Constructor { id, .. } => id == "Option" || id.ends_with(".Option"),
         _ => false,
     }
+}
+
+fn bound_references_interface(annotation: &Annotation, interface_name: &str) -> bool {
+    let Annotation::Constructor { name, .. } = annotation else {
+        return false;
+    };
+    unqualified_name(name) == interface_name
+}
+
+fn strip_self_referential_bounds(generics: &[Generic], interface_name: &str) -> Vec<Generic> {
+    generics
+        .iter()
+        .map(|g| Generic {
+            name: g.name.clone(),
+            bounds: g
+                .bounds
+                .iter()
+                .filter(|ann| !bound_references_interface(ann, interface_name))
+                .cloned()
+                .collect(),
+            span: g.span,
+        })
+        .collect()
 }

--- a/crates/semantics/src/checker/infer/checks.rs
+++ b/crates/semantics/src/checker/infer/checks.rs
@@ -1,3 +1,4 @@
+use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::UnusedExpressionKind;
@@ -121,6 +122,39 @@ impl Checker<'_, '_> {
                     is_typedef,
                 );
             }
+        }
+    }
+
+    pub(crate) fn check_type_params_only_in_bound(&mut self, generics: &[Generic], fn_ty: &Type) {
+        if generics.is_empty() {
+            return;
+        }
+        let bounds = fn_ty.get_bounds();
+        if bounds.is_empty() {
+            return;
+        }
+        let (Some(params), Some(return_type)) =
+            (fn_ty.get_function_params(), fn_ty.get_function_ret())
+        else {
+            return;
+        };
+
+        let only_in_bound =
+            collect_type_params_only_in_bound(generics, params, return_type, bounds);
+        if only_in_bound.is_empty() {
+            return;
+        }
+
+        let is_typedef = self.is_d_lis();
+        for generic in generics {
+            if generic.name.starts_with('_') || !only_in_bound.contains(&generic.name) {
+                continue;
+            }
+            self.facts.add_type_param_only_in_bound(
+                generic.name.to_string(),
+                generic.span,
+                is_typedef,
+            );
         }
     }
 
@@ -879,4 +913,36 @@ pub fn check_interface_visibility(
             }
         }
     }
+}
+
+/// Returns generic names that appear inside some `bound.ty` and nowhere else
+/// in the signature — not in a parameter, the return type, or as a bound's
+/// subject.
+fn collect_type_params_only_in_bound(
+    generics: &[Generic],
+    params: &[Type],
+    return_type: &Type,
+    bounds: &[Bound],
+) -> HashSet<EcoString> {
+    let mut unseen_outside_constraint: HashSet<EcoString> =
+        generics.iter().map(|g| g.name.clone()).collect();
+    for param in params {
+        param.remove_found_type_names(&mut unseen_outside_constraint);
+    }
+    return_type.remove_found_type_names(&mut unseen_outside_constraint);
+    for bound in bounds {
+        bound
+            .generic
+            .remove_found_type_names(&mut unseen_outside_constraint);
+    }
+
+    let mut unseen_anywhere = unseen_outside_constraint.clone();
+    for bound in bounds {
+        bound.ty.remove_found_type_names(&mut unseen_anywhere);
+    }
+
+    unseen_outside_constraint
+        .into_iter()
+        .filter(|name| !unseen_anywhere.contains(name))
+        .collect()
 }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -126,6 +126,7 @@ impl Checker<'_, '_> {
         );
 
         self.check_unused_type_parameters(&generics, &base_fn_ty);
+        self.check_type_params_only_in_bound(&generics, &base_fn_ty);
 
         let fn_forall_ty = if generics.is_empty() {
             base_fn_ty.clone()

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -13,6 +13,7 @@ pub struct Facts {
     pub discarded_tail_expressions: Vec<DiscardedTailFact>,
     pub overused_references: Vec<OverusedReferenceFact>,
     pub unused_type_params: Vec<UnusedTypeParamFact>,
+    pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<Span>,
     /// Spans of or-patterns with binding errors, used to suppress contradictory lints.
@@ -111,6 +112,15 @@ impl Facts {
         });
     }
 
+    pub fn add_type_param_only_in_bound(&mut self, name: String, span: Span, is_typedef: bool) {
+        self.type_params_only_in_bound
+            .push(TypeParamOnlyInBoundFact {
+                name,
+                span,
+                is_typedef,
+            });
+    }
+
     pub fn add_always_failing_try_block(&mut self, span: Span) {
         self.always_failing_try_blocks.push(span);
     }
@@ -187,6 +197,13 @@ pub struct OverusedReferenceFact {
 
 #[derive(Debug, Clone)]
 pub struct UnusedTypeParamFact {
+    pub name: String,
+    pub span: Span,
+    pub is_typedef: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeParamOnlyInBoundFact {
     pub name: String,
     pub span: Span,
     pub is_typedef: bool,

--- a/crates/semantics/src/lint/fact_lints.rs
+++ b/crates/semantics/src/lint/fact_lints.rs
@@ -18,6 +18,7 @@ impl LintRule for FactLintGroup {
         check_discarded_tail_expressions(ctx, &mut diagnostics);
         check_overused_references(ctx, &mut diagnostics);
         check_unused_type_params(ctx, &mut diagnostics);
+        check_type_params_only_in_bound(ctx, &mut diagnostics);
         check_always_failing_try_blocks(ctx, &mut diagnostics);
         check_expression_only_fstrings(ctx, &mut diagnostics);
 
@@ -116,6 +117,17 @@ fn check_unused_type_params(ctx: &LintContext, diagnostics: &mut Vec<LisetteDiag
             continue;
         }
         diagnostics.push(diagnostics::lint::unused_type_parameter(&fact.span));
+    }
+}
+
+fn check_type_params_only_in_bound(ctx: &LintContext, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    for fact in &ctx.facts.type_params_only_in_bound {
+        if fact.is_typedef {
+            continue;
+        }
+        diagnostics.push(diagnostics::lint::type_param_only_in_bound(
+            &fact.span, &fact.name,
+        ));
     }
 }
 

--- a/crates/semantics/src/lint/mod.rs
+++ b/crates/semantics/src/lint/mod.rs
@@ -48,6 +48,7 @@ pub enum Lint {
     InternalTypeLeak,
     UnnecessaryReference,
     UnusedTypeParameter,
+    TypeParamOnlyInBound,
     RestOnlySlicePattern,
     NonPascalCaseType,
     NonPascalCaseTypeParameter,

--- a/tests/spec/emit/snapshots/interface_self_referential_fbound_erased.snap
+++ b/tests/spec/emit/snapshots/interface_self_referential_fbound_erased.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \npub interface Cloner<T: Cloner<T>> {\n  fn clone(self) -> T\n}\n\nstruct Foo{}\n\nimpl Foo {\n  fn clone(self) -> Foo { Foo{} }\n}\n\nfn squiggle<A: Cloner<B>, B>(_: A, _: B) {}\n\nfn main() {\n  squiggle(Foo{}, Foo{})\n}\n"
+---
+package main
+
+type Cloner[T any] interface {
+	Clone() T
+}
+
+type Foo struct{}
+
+func (f Foo) String() string {
+	return "Foo"
+}
+
+func (f Foo) Clone() Foo {
+	return Foo{}
+}
+
+func squiggle[A Cloner[B], B any](_ A, _ B) {}
+
+func main() {
+	squiggle(Foo{}, Foo{})
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -370,6 +370,28 @@ fn test() {
 }
 
 #[test]
+fn interface_self_referential_fbound_erased() {
+    let input = r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+struct Foo{}
+
+impl Foo {
+  fn clone(self) -> Foo { Foo{} }
+}
+
+fn squiggle<A: Cloner<B>, B>(_: A, _: B) {}
+
+fn main() {
+  squiggle(Foo{}, Foo{})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interface_self_param_stripped() {
     let input = r#"
 interface Greetable {

--- a/tests/spec/infer/equality.rs
+++ b/tests/spec/infer/equality.rs
@@ -2508,3 +2508,51 @@ fn match_branches_incompatible_interfaces_rejected() {
     )
     .assert_infer_code("interface_not_implemented");
 }
+
+#[test]
+fn self_referential_fbound_accepts_matching_type() {
+    infer(
+        r#"
+        pub interface Cloner<T: Cloner<T>> {
+          fn clone(self) -> T
+        }
+
+        struct Foo{}
+
+        impl Foo {
+          fn clone(self) -> Foo { Foo{} }
+        }
+
+        fn squiggle<A: Cloner<B>, B>(_: A, _: B) {}
+
+        fn main() {
+          squiggle(Foo{}, Foo{})
+        }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn self_referential_fbound_rejects_mismatched_type() {
+    infer(
+        r#"
+        pub interface Cloner<T: Cloner<T>> {
+          fn clone(self) -> T
+        }
+
+        struct Foo{}
+
+        impl Foo {
+          fn clone(self) -> Foo { Foo{} }
+        }
+
+        fn squiggle<A: Cloner<B>, B>(_: A, _: B) {}
+
+        fn main() {
+          squiggle(Foo{}, "hello")
+        }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2041,6 +2041,76 @@ fn main() {
 }
 
 #[test]
+fn type_param_only_in_bound_warns() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+pub fn squiggle<A: Cloner<B>, B>(_: A) {}
+"#
+    );
+}
+
+#[test]
+fn type_param_in_bound_and_used_as_parameter_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+struct Foo{}
+
+impl Foo {
+  fn clone(self) -> Foo { Foo{} }
+}
+
+pub fn squiggle<A: Cloner<B>, B>(_: A, _: B) {}
+
+fn main() {
+  squiggle(Foo{}, Foo{})
+}
+"#
+    );
+}
+
+#[test]
+fn type_param_in_bound_and_used_as_return_type_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+struct Foo{}
+
+impl Foo {
+  fn clone(self) -> Foo { Foo{} }
+}
+
+pub fn squiggle<A: Cloner<B>, B>(a: A) -> B {
+  a.clone()
+}
+"#
+    );
+}
+
+#[test]
+fn type_param_only_in_bound_underscore_prefix_suppressed() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+pub fn squiggle<A: Cloner<_B>, _B>(_: A) {}
+"#
+    );
+}
+
+#[test]
 fn interface_used_as_struct_type_parameter_constraint_no_warning() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/type_param_only_in_bound_warns.snap
+++ b/tests/ui/lint/snapshots/type_param_only_in_bound_warns.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Type parameter only used in bound
+   ╭─[test.lis:6:31]
+ 5 │ 
+ 6 │ pub fn squiggle<A: Cloner<B>, B>(_: A) {}
+   ·                               ┬
+   ·                               ╰── `B` is only used inside another parameter's bound
+   ╰────
+  help: Remove it, or use it in a parameter type, return type, or bound left-hand side · code: [lint.type_param_only_in_bound]


### PR DESCRIPTION
Go rejects `type Cloner[T Cloner[T]] interface { ... }` as an invalid recursive type, so `lis run` was failing on any interface whose own type param was bounded by the interface itself, even when `lis build` succeeded. The checker already enforces these bounds semantically, so the emitter now drops them from the interface declaration and lets the Go type parameter fall back to `any`.

This PR also adds a `type_param_only_in_bound` lint that warns when a function type param is used only insde another param's bound and nowhere else. This catches the case where `B` in `<A: Cloner<B>, B>` is never used outside A's bound (usually a typo for `A: Cloner<A>` or leftover after a refactor), but we stay quiet on signatures that actually use `B` as a parameter or return type.

Closes #66