### PR TITLE
fix: accept \a \b \f \v escape sequences in string and rune literals

### DIFF
--- a/crates/syntax/src/lex/errors.rs
+++ b/crates/syntax/src/lex/errors.rs
@@ -195,7 +195,7 @@ impl<'source> Lexer<'source> {
         )
         .with_lex_code("invalid_escape_sequence")
         .with_help(
-            "Valid escapes are `\\n`, `\\t`, `\\r`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
+            "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
         );
         self.errors.push(error);
     }

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -843,7 +843,8 @@ impl<'source> Lexer<'source> {
                         escaped = false;
                         continue;
                     }
-                    b'n' | b't' | b'r' | b'\\' | b'"' | b'x' | b'U' => {}
+                    b'a' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' | b'\\' | b'"' | b'x' | b'U' => {
+                    }
                     b'\'' => {}
                     _ => {
                         self.error_invalid_escape(self.current_char());
@@ -1167,7 +1168,7 @@ impl<'source> Lexer<'source> {
                         self.error_octal_escape_out_of_range(escape_start, escape_len);
                     }
                 }
-                b'n' | b't' | b'r' | b'\\' | b'\'' | b'x' => {
+                b'a' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' | b'\\' | b'\'' | b'x' => {
                     self.next();
                 }
                 _ => {

--- a/tests/spec/lex/mod.rs
+++ b/tests/spec/lex/mod.rs
@@ -83,6 +83,12 @@ fn char_escaped_tab() {
 }
 
 #[test]
+fn char_escaped_bell() {
+    let input = "'\\a'";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
 fn char_escaped_backslash() {
     let input = "'\\\\'";
     assert_lex_snapshot!(input);
@@ -397,6 +403,18 @@ fn string_literal_empty() {
 #[test]
 fn string_literal_with_escaped_char() {
     let input = "\"hello\\nworld\\t\"";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn string_literal_with_bell_escape() {
+    let input = "\"\\x1b]11;?\\a\"";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn string_literal_with_c_style_escapes() {
+    let input = "\"\\a\\b\\f\\v\"";
     assert_lex_snapshot!(input);
 }
 

--- a/tests/spec/lex/snapshots/char_escaped_bell.snap
+++ b/tests/spec/lex/snapshots/char_escaped_bell.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: '\\a'"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Char,
+            text: "'\\a'",
+            byte_offset: 0,
+            byte_length: 4,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 4,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/string_literal_with_bell_escape.snap
+++ b/tests/spec/lex/snapshots/string_literal_with_bell_escape.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: \"\\x1b]11;?\\a\""
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: String,
+            text: "\"\\x1b]11;?\\a\"",
+            byte_offset: 0,
+            byte_length: 13,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 13,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/string_literal_with_c_style_escapes.snap
+++ b/tests/spec/lex/snapshots/string_literal_with_c_style_escapes.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: \"\\a\\b\\f\\v\""
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: String,
+            text: "\"\\a\\b\\f\\v\"",
+            byte_offset: 0,
+            byte_length: 10,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 10,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
+++ b/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
@@ -31,7 +31,7 @@ LexResult {
                 ),
             ],
             help: Some(
-                "Valid escapes are `\\n`, `\\t`, `\\r`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
+                "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
             ),
             note: None,
             code: "lex.invalid_escape_sequence",

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -157,7 +157,7 @@ fn lex_empty_char() {
 
 #[test]
 fn lex_invalid_escape() {
-    let input = r#"let x = '\v'"#;
+    let input = r#"let x = '\q'"#;
     assert_lex_error_snapshot!(input);
 }
 

--- a/tests/ui/errors/snapshots/lex_invalid_escape.snap
+++ b/tests/ui/errors/snapshots/lex_invalid_escape.snap
@@ -3,8 +3,8 @@ source: tests/ui/errors/mod.rs
 ---
   [error] Invalid escape sequence
    ╭─[test.lis:1:10]
- 1 │ let x = '\v'
+ 1 │ let x = '\q'
    ·          ─┬
-   ·           ╰── `\v` is not a valid escape
+   ·           ╰── `\q` is not a valid escape
    ╰────
-  help: Valid escapes are `\n`, `\t`, `\r`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]
+  help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_invalid_escape_sequence_in_string.snap
+++ b/tests/ui/errors/snapshots/lex_invalid_escape_sequence_in_string.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                  ╰── `\!` is not a valid escape
  4 │ }
    ╰────
-  help: Valid escapes are `\n`, `\t`, `\r`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]
+  help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_invalid_escape_sequence_question_mark.snap
+++ b/tests/ui/errors/snapshots/lex_invalid_escape_sequence_question_mark.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                 ╰── `\?` is not a valid escape
  4 │ }
    ╰────
-  help: Valid escapes are `\n`, `\t`, `\r`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]
+  help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]


### PR DESCRIPTION
Fix #70