### PR TITLE
fix: preserve snake_case field name on ref receiver access

### DIFF
--- a/crates/emit/src/go/expressions/access.rs
+++ b/crates/emit/src/go/expressions/access.rs
@@ -154,6 +154,7 @@ impl Emitter<'_> {
 
         let is_prelude_type = expression_ty
             .resolve()
+            .strip_refs()
             .get_qualified_id()
             .is_some_and(|id| id.starts_with(go_name::PRELUDE_PREFIX));
 

--- a/tests/spec/emit/snapshots/ref_receiver_preserves_snake_case_in_public_field.snap
+++ b/tests/spec/emit/snapshots/ref_receiver_preserves_snake_case_in_public_field.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+assertion_line: 1538
+description: "input: \nstruct Foo {\n  pub bar_baz: string,\n}\n\nimpl Foo {\n  fn show(self: Ref<Foo>) -> string {\n    self.bar_baz\n  }\n}\n\nfn test() {\n  let mut foo = Foo { bar_baz: \"quux\" }\n  let _ = foo.show()\n}\n"
+---
+package main
+
+import "fmt"
+
+type Foo struct {
+	Bar_baz string
+}
+
+func (f Foo) String() string {
+	return fmt.Sprintf("Foo { bar_baz: %v }", f.Bar_baz)
+}
+
+func (f *Foo) show() string {
+	return f.Bar_baz
+}
+
+func test() {
+	foo := Foo{Bar_baz: "quux"}
+	_ = foo.show()
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1518,6 +1518,27 @@ fn test() {
 }
 
 #[test]
+fn ref_receiver_preserves_snake_case_in_public_field() {
+    let input = r#"
+struct Foo {
+  pub bar_baz: string,
+}
+
+impl Foo {
+  fn show(self: Ref<Foo>) -> string {
+    self.bar_baz
+  }
+}
+
+fn test() {
+  let mut foo = Foo { bar_baz: "quux" }
+  let _ = foo.show()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn ref_map() {
     let input = r#"
 fn test(m: Ref<Map<string, int>>) {


### PR DESCRIPTION
Accessing a public snake_case field through a `Ref<T>` receiver emitted the Go name in PascalCase, so the generated code did not compile. The fix keeps the original snake_case casing in this path.

Fixes #78