### PR TITLE
fix: prune stale .go files from target on rebuild

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -1,6 +1,8 @@
 use std::{
-    collections::HashMap,
-    fs::{read_dir, read_to_string},
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    fs::{read_dir, read_to_string, remove_file},
+    io,
     path::{Path, PathBuf},
 };
 
@@ -52,6 +54,44 @@ fn to_fs_path(folder_name: &str) -> &str {
     } else {
         folder_name
     }
+}
+
+pub fn prune_orphan_go_files(target_dir: &Path, produced: &[&str]) -> io::Result<()> {
+    let mut produced_by_dir: HashMap<&Path, HashSet<&OsStr>> = HashMap::new();
+    for rel in produced {
+        let rel = Path::new(rel);
+        let Some(name) = rel.file_name() else {
+            continue;
+        };
+        let parent = rel.parent().unwrap_or(Path::new(""));
+        produced_by_dir.entry(parent).or_default().insert(name);
+    }
+
+    for (rel_parent, names) in &produced_by_dir {
+        let dir = target_dir.join(rel_parent);
+        let entries = match read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = entry.file_name();
+            if Path::new(&name).extension().is_some_and(|ext| ext == "go")
+                && !names.contains(name.as_os_str())
+            {
+                remove_file(entry.path())?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn collect_lis_filepaths_recursive(dir: &Path) -> Vec<PathBuf> {

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use crate::cli_error;
 use crate::go_cli;
 use diagnostics::render::{self, Filter};
-use lisette::fs::LocalFileSystem;
+use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 
 pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
@@ -155,6 +155,20 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
             );
             return 1;
         }
+    }
+
+    let produced: Vec<&str> = result
+        .output
+        .iter()
+        .map(|file| file.name.as_str())
+        .collect();
+    if let Err(e) = prune_orphan_go_files(&target_dir, &produced) {
+        cli_error!(
+            "Failed to compile Lisette project to Go",
+            format!("Failed to prune stale Go files: {}", e),
+            "Check file permissions"
+        );
+        return 1;
     }
 
     if let Err(e) = go_cli::go_fmt(&target_dir) {


### PR DESCRIPTION
Deleting a `.lis` file and running `lis build` was leaving behind its emitted `.go` counterpart. Now we're pruning any `.go` orphan files under a `target` dir this build emitted into that wasn't produced this run.

This was more than a papercut and had insidious implications:

- Duplicate declaration errors when a `.lis` file is renamed and both the old and new `.go` outputs coexist.
- Stale-reference compile errors when an orphan `.go` references a symbol that was removed or renamed in a sibling file.
- Silent inclusionof `init()` side effects and package-level variable initializers from dead files.
- Confusing "error in a file the user has no source for" diagnostics during refactors.

I intentionally descoped deleting an entire module folder. That module is neither re-emitted nor cached, so its `target/` subdir is never visited by the prune pass and its files remain.

Fixes #77