### PR TITLE
fix: emit named empty Go interfaces as Lisette interfaces

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -317,15 +317,13 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 		}
 
 	case *types.Interface:
-		if u.Empty() {
-			result.LisetteType = "Unknown"
-		} else if isErrorInterface(u) {
+		if isErrorInterface(u) {
 			result.LisetteType = "error"
-		} else {
-			methods := c.extractInterfaceMethods(u, result.Name)
-			if methods != nil {
-				result.InterfaceMethods = methods
-			}
+		} else if u.Empty() {
+			result.IsInterface = true
+		} else if methods, ok := c.extractInterfaceMethods(u, result.Name); ok {
+			result.IsInterface = true
+			result.InterfaceMethods = methods
 		}
 
 	case *types.Basic:
@@ -944,11 +942,18 @@ func (c *Converter) analyzeMajorityPointerTypes() {
 	}
 }
 
-func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeName string) []InterfaceMethod {
+// extractInterfaceMethods walks a Go interface's exported methods and converts
+// each to a Lisette InterfaceMethod. The second return value reports whether
+// the interface is representable at all: false when an embedded union or an
+// unrepresentable param/return type is encountered, true otherwise. A true
+// return with an empty slice means the interface has no exported methods
+// (e.g. empty interface or all methods unexported) and should be emitted as
+// `pub interface Name {}`.
+func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeName string) ([]InterfaceMethod, bool) {
 	if _interface.NumEmbeddeds() > 0 {
 		for embedded := range _interface.EmbeddedTypes() {
 			if _, isUnion := embedded.(*types.Union); isUnion {
-				return nil
+				return nil, false
 			}
 		}
 	}
@@ -962,7 +967,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 
 		signature, ok := method.Type().(*types.Signature)
 		if !ok {
-			return nil
+			return nil, false
 		}
 
 		mutParams := c.cfg.MutatingParams(c.currentPkgPath, typeName+"."+method.Name())
@@ -972,7 +977,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 			param := signature.Params().At(j)
 			paramType := ToLisette(param.Type(), c)
 			if paramType.SkipReason != nil {
-				return nil // Cannot represent this interface
+				return nil, false
 			}
 
 			name := param.Name()
@@ -990,7 +995,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 
 		returnType := ReturnsToLisette(signature, c, typeName+"."+method.Name())
 		if returnType.SkipReason != nil {
-			return nil // Cannot represent this interface
+			return nil, false
 		}
 
 		methods = append(methods, InterfaceMethod{
@@ -1002,9 +1007,5 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 		})
 	}
 
-	if len(methods) == 0 {
-		return nil
-	}
-
-	return methods
+	return methods, true
 }

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -23,6 +23,7 @@ type ConvertResult struct {
 	Variants         []EnumVariant     // for enums (via iota)
 	ConstValue       string            // for constants
 	SkipReason       *SkipReason
+	IsInterface      bool // true when this type should be emitted as `pub interface`
 	IsTypeAlias      bool // true for Go type aliases (type X = Y)
 	CommaOk          bool // true when return is from (T, bool) comma-ok with nilable T
 	ArrayReturn      bool // true when Go type is [N]T but Lisette type is Slice<T>

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -325,7 +325,7 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 
 	typeName := result.Name
 
-	if len(result.InterfaceMethods) > 0 {
+	if result.IsInterface {
 		var signature strings.Builder
 		signature.WriteString("pub interface ")
 		signature.WriteString(typeName)
@@ -336,36 +336,40 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 			signature.WriteString(">")
 		}
 
-		signature.WriteString(" {\n")
-		for _, m := range result.InterfaceMethods {
-			if m.CommaOk {
-				signature.WriteString("  #[go(comma_ok)]\n")
-			}
-			if m.ArrayReturn {
-				signature.WriteString("  #[go(array_return)]\n")
-			}
-			signature.WriteString("  fn ")
-			signature.WriteString(m.Name)
-			signature.WriteString("(")
-
-			var params []string
-			for _, p := range m.Params {
-				if p.Mutable {
-					params = append(params, fmt.Sprintf("mut %s: %s", p.Name, p.Type))
-				} else {
-					params = append(params, fmt.Sprintf("%s: %s", p.Name, p.Type))
+		if len(result.InterfaceMethods) == 0 {
+			signature.WriteString(" {}")
+		} else {
+			signature.WriteString(" {\n")
+			for _, m := range result.InterfaceMethods {
+				if m.CommaOk {
+					signature.WriteString("  #[go(comma_ok)]\n")
 				}
-			}
-			signature.WriteString(strings.Join(params, ", "))
-			signature.WriteString(")")
+				if m.ArrayReturn {
+					signature.WriteString("  #[go(array_return)]\n")
+				}
+				signature.WriteString("  fn ")
+				signature.WriteString(m.Name)
+				signature.WriteString("(")
 
-			if m.ReturnType != "" && m.ReturnType != "()" {
-				signature.WriteString(" -> ")
-				signature.WriteString(m.ReturnType)
+				var params []string
+				for _, p := range m.Params {
+					if p.Mutable {
+						params = append(params, fmt.Sprintf("mut %s: %s", p.Name, p.Type))
+					} else {
+						params = append(params, fmt.Sprintf("%s: %s", p.Name, p.Type))
+					}
+				}
+				signature.WriteString(strings.Join(params, ", "))
+				signature.WriteString(")")
+
+				if m.ReturnType != "" && m.ReturnType != "()" {
+					signature.WriteString(" -> ")
+					signature.WriteString(m.ReturnType)
+				}
+				signature.WriteString("\n")
 			}
-			signature.WriteString("\n")
+			signature.WriteString("}")
 		}
-		signature.WriteString("}")
 
 		e.buf.WriteString(signature.String())
 		e.buf.WriteString("\n\n")

--- a/bindgen/tests/testdata/snapshots/interfaces.d.lis
+++ b/bindgen/tests/testdata/snapshots/interfaces.d.lis
@@ -7,7 +7,7 @@
 pub fn Validate(s: string) -> Result<(), error>
 
 /// Empty interface alias
-pub struct Any(Unknown)
+pub interface Any {}
 
 /// Nilable comma-ok method on interface
 pub interface Cache {
@@ -16,7 +16,7 @@ pub interface Cache {
   fn Set(key: string, value: Ref<Node>)
 }
 
-pub struct Empty(Unknown)
+pub interface Empty {}
 
 /// Error interface - should be detected as error
 pub struct MyError(error)

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -180,13 +180,18 @@ pub fn print_preview_notice() {
     eprintln!();
     if use_color() {
         eprintln!(
-            "  ! Support for third-party Go dependencies is in {}",
-            "early preview".yellow().underline()
+            "  ! You are running an unfinished feature: {}",
+            "lis add".bright_magenta()
+        );
+        eprintln!(
+            "  ! Support for third-party Go dependencies is {}",
+            "not yet stable".yellow().underline()
         );
     } else {
-        eprintln!("  ! Support for third-party Go dependencies is in early preview");
+        eprintln!("  ! You are running an unfinished feature: lis add");
+        eprintln!("  ! Support for third-party Go dependencies is not yet stable");
     }
-    eprintln!("  ! Please report issues at: https://github.com/ivov/lisette/issues");
+    eprintln!("  ! Bug reports are welcome: https://github.com/ivov/lisette/issues");
     eprintln!();
 }
 

--- a/crates/stdlib/typedefs/crypto.d.lis
+++ b/crates/stdlib/typedefs/crypto.d.lis
@@ -89,7 +89,7 @@ pub interface Decrypter {
   fn Public() -> PublicKey
 }
 
-pub struct DecrypterOpts(Unknown)
+pub interface DecrypterOpts {}
 
 /// MessageSigner is an interface for an opaque private key that can be used for
 /// signing operations where the message is not pre-hashed by the caller.
@@ -121,7 +121,7 @@ pub interface MessageSigner {
 /// 
 /// as well as purpose-specific interfaces such as [Signer] and [Decrypter], which
 /// can be used for increased type safety within applications.
-pub struct PrivateKey(Unknown)
+pub interface PrivateKey {}
 
 /// PublicKey represents a public key using an unspecified algorithm.
 /// 
@@ -133,7 +133,7 @@ pub struct PrivateKey(Unknown)
 /// 	}
 /// 
 /// which can be used for increased type safety within applications.
-pub struct PublicKey(Unknown)
+pub interface PublicKey {}
 
 /// Signer is an interface for an opaque private key that can be used for
 /// signing operations. For example, an RSA key kept in a hardware module.

--- a/crates/stdlib/typedefs/database/sql/driver.d.lis
+++ b/crates/stdlib/typedefs/database/sql/driver.d.lis
@@ -344,7 +344,7 @@ pub interface Validator {
 /// in this package. This is used, for example, when a user selects a cursor
 /// such as "select cursor(select * from my_table) from dual". If the [Rows]
 /// from the select is closed, the cursor [Rows] will also be closed.
-pub struct Value(Unknown)
+pub interface Value {}
 
 /// ValueConverter is the interface providing the ConvertValue method.
 /// 

--- a/crates/stdlib/typedefs/encoding/json.d.lis
+++ b/crates/stdlib/typedefs/encoding/json.d.lis
@@ -330,7 +330,7 @@ pub struct SyntaxError {
 ///   - [Number], for JSON numbers
 ///   - string, for JSON string literals
 ///   - nil, for JSON null
-pub struct Token(Unknown)
+pub interface Token {}
 
 /// An UnmarshalFieldError describes a JSON object key that
 /// led to an unexported (and therefore unwritable) struct field.

--- a/crates/stdlib/typedefs/encoding/xml.d.lis
+++ b/crates/stdlib/typedefs/encoding/xml.d.lis
@@ -308,7 +308,7 @@ pub struct TagPathError {
 
 /// A Token is an interface holding one of the token types:
 /// [StartElement], [EndElement], [CharData], [Comment], [ProcInst], or [Directive].
-pub struct Token(Unknown)
+pub interface Token {}
 
 /// A TokenReader is anything that can decode a stream of XML tokens, including a
 /// [Decoder].

--- a/crates/stdlib/typedefs/go/doc/comment.d.lis
+++ b/crates/stdlib/typedefs/go/doc/comment.d.lis
@@ -15,7 +15,7 @@ pub fn DefaultLookupPackage(name: string) -> Option<string>
 
 /// A Block is block-level content in a doc comment,
 /// one of [*Code], [*Heading], [*List], or [*Paragraph].
-pub type Block
+pub interface Block {}
 
 /// A Code is a preformatted code block.
 pub struct Code {
@@ -107,7 +107,7 @@ pub struct Printer {
 
 /// A Text is text-level content in a doc comment,
 /// one of [Plain], [Italic], [*Link], or [*DocLink].
-pub type Text
+pub interface Text {}
 
 impl DocLink {
   /// DefaultURL constructs and returns the documentation URL for l,

--- a/crates/stdlib/typedefs/plugin.d.lis
+++ b/crates/stdlib/typedefs/plugin.d.lis
@@ -37,7 +37,7 @@ pub type Plugin
 /// 	}
 /// 	*v.(*int) = 7
 /// 	f.(func())() // prints "Hello, number 7"
-pub struct Symbol(Unknown)
+pub interface Symbol {}
 
 impl Plugin {
   /// Lookup searches for a symbol named symName in plugin p.

--- a/crates/stdlib/typedefs/syscall.d.lis
+++ b/crates/stdlib/typedefs/syscall.d.lis
@@ -1425,7 +1425,7 @@ pub struct RouteMessage {
 /// RoutingMessage represents a routing message.
 /// 
 /// Deprecated: Use golang.org/x/net/route instead.
-pub type RoutingMessage
+pub interface RoutingMessage {}
 
 pub struct RtMetrics {
   pub Locks: uint32,
@@ -1476,7 +1476,7 @@ pub struct Rusage {
   pub Nivcsw: int64,
 }
 
-pub type Sockaddr
+pub interface Sockaddr {}
 
 pub struct SockaddrDatalink {
   pub Len: uint8,


### PR DESCRIPTION
Named empty Go interfaces like `type Event interface{}` were being imported into Lisette as opaque nominal wrappers, so even though Go lets you pass any value into `Event`, Lisette rejected the assignment as a type mismatch against third-party bindings. They now surface as first-class Lisette interfaces, matching how locally-declared empty interfaces have always behaved.

Fixes #85 