### PR TITLE
fix: regenerate missing Go typedefs before check/build/run

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use crate::cli_error;
 use crate::go_cli;
+use crate::typedef_regen::generate_missing_typedefs;
 use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
@@ -33,6 +34,10 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
             return 1;
         }
     };
+
+    if let Err(code) = generate_missing_typedefs(project_path, &manifest) {
+        return code;
+    }
 
     let main_lis = project_path.join("src/main.lis");
     let go_module_name = &manifest.project.name;
@@ -103,7 +108,7 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
                 .get(&file_id)
                 .map(|info| (info.source.clone(), info.filename.clone()))
         },
-        result.sources.len(),
+        result.user_file_count,
         &filter,
         &main_lis_source,
         &filename,

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -9,6 +9,7 @@ use lisette::fs::LocalFileSystem;
 use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
 use crate::cli_error;
+use crate::typedef_regen::generate_missing_typedefs;
 
 pub fn check(path: Option<String>, errors_only: bool, warnings_only: bool) -> i32 {
     let target = path.unwrap_or_else(|| ".".to_string());
@@ -61,13 +62,17 @@ fn check_project(project_path: &Path, filter: &Filter) -> i32 {
         return 1;
     }
 
-    let locator = match TypedefLocator::from_project(project_path) {
-        Ok(r) => r,
+    let (manifest, locator) = match deps::TypedefLocator::from_project_with_manifest(project_path) {
+        Ok(pair) => pair,
         Err(msg) => {
             cli_error!("Failed to check project", msg, "Fix `lisette.toml`");
             return 1;
         }
     };
+
+    if let Err(code) = generate_missing_typedefs(project_path, &manifest) {
+        return code;
+    }
 
     check_single_file(&src_main, filter, true, locator)
 }
@@ -92,7 +97,7 @@ fn check_single_file(
                 .get(&file_id)
                 .map(|info| (info.source.clone(), info.filename.clone()))
         },
-        result.sources.len(),
+        result.user_file_count,
         filter,
         &source,
         &filename,
@@ -200,14 +205,14 @@ fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
                     .get(&file_id)
                     .map(|info| (info.source.clone(), info.filename.clone()))
             },
-            result.sources.len(),
+            result.user_file_count,
             filter,
             &source,
             &filename,
         );
         total_errors += counts.errors;
         total_warnings += counts.warnings;
-        total_files += result.sources.len();
+        total_files += result.user_file_count;
     }
 
     let elapsed = start.elapsed();

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -130,7 +130,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
                 .get(&file_id)
                 .map(|info| (info.source.clone(), info.filename.clone()))
         },
-        result.sources.len(),
+        result.user_file_count,
         &filter,
         &source,
         file,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@ mod go_cli;
 mod handlers;
 mod output;
 mod panic;
+mod typedef_regen;
 mod workspace;
 
 use command::Command;

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -306,6 +306,14 @@ pub fn print_progress(msg: &str) {
     }
 }
 
+pub fn print_warning(msg: &str) {
+    if use_color() {
+        eprintln!("  {} {}", "!".yellow(), msg);
+    } else {
+        eprintln!("  ! {}", msg);
+    }
+}
+
 pub fn print_help(text: &str) {
     println!();
     println!("{}", format_help_text(text, use_color()));

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -35,6 +35,7 @@ pub struct CompileResult {
     pub errors: Vec<LisetteDiagnostic>,
     pub lints: Vec<LisetteDiagnostic>,
     pub sources: HashMap<u32, SourceInfo>,
+    pub user_file_count: usize,
 }
 
 pub fn compile(
@@ -59,6 +60,7 @@ pub fn compile(
             errors,
             lints: vec![],
             sources,
+            user_file_count: 1,
         };
     }
 
@@ -76,6 +78,8 @@ pub fn compile(
         compile_phase: config.target_phase,
         locator: config.locator.clone(),
     });
+
+    let user_file_count = semantic_result.files.len();
 
     let mut sources: HashMap<u32, SourceInfo> = semantic_result
         .files
@@ -108,6 +112,7 @@ pub fn compile(
             errors,
             lints,
             sources,
+            user_file_count,
         };
     }
 
@@ -124,5 +129,6 @@ pub fn compile(
         errors,
         lints,
         sources,
+        user_file_count,
     }
 }

--- a/crates/cli/src/typedef_regen.rs
+++ b/crates/cli/src/typedef_regen.rs
@@ -1,0 +1,147 @@
+use std::fs;
+use std::fs::File;
+use std::path::Path;
+
+use fs2::FileExt;
+
+use crate::go_cli;
+use crate::output::{print_progress, print_warning};
+use crate::workspace::GoWorkspace;
+use crate::{cli_error, error};
+use deps::{GoModule, Manifest, TypedefLocator};
+
+/// Generate any Go typedefs declared in the manifest but missing from the cache:
+/// `~/.lisette/cache/typedefs/lis@v{version}/{module}@{version}/*.d.lis`
+pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Result<(), i32> {
+    let go_deps = manifest.go_deps();
+    if go_deps.is_empty() {
+        return Ok(());
+    }
+
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => {
+            error!(
+                "failed to regenerate Go typedefs",
+                "HOME environment variable not set".to_string()
+            );
+            return Err(1);
+        }
+    };
+    let typedef_cache_dir = deps::typedef_cache_dir(&home);
+
+    let missing_modules: Vec<(String, String)> = go_deps
+        .iter()
+        .filter(|(module_path, dep)| {
+            !module_dir_populated(&typedef_cache_dir, module_path, &dep.version)
+        })
+        .map(|(module_path, dep)| (module_path.clone(), dep.version.clone()))
+        .collect();
+
+    if missing_modules.is_empty() {
+        return Ok(());
+    }
+
+    go_cli::require_go()?;
+
+    let project_target_dir = project_root.join("target");
+    if project_target_dir.is_file() {
+        cli_error!(
+            "Failed to regenerate Go typedefs",
+            "`target/` exists but is a file, not a directory",
+            "Remove or move `target/` and retry"
+        );
+        return Err(1);
+    }
+    if let Err(e) = fs::create_dir_all(&project_target_dir) {
+        error!(
+            "failed to regenerate Go typedefs",
+            format!("Failed to create target directory: {}", e)
+        );
+        return Err(1);
+    }
+
+    if let Err(e) = fs::create_dir_all(&typedef_cache_dir) {
+        error!(
+            "failed to regenerate Go typedefs",
+            format!("Failed to create typedef cache directory: {}", e)
+        );
+        return Err(1);
+    }
+
+    let _lock = acquire_regen_lock(&typedef_cache_dir)?;
+
+    // Another process may have regenerated everything while we were waiting.
+    let still_missing: Vec<(String, String)> = missing_modules
+        .into_iter()
+        .filter(|(module_path, version)| {
+            !module_dir_populated(&typedef_cache_dir, module_path, version)
+        })
+        .collect();
+
+    if still_missing.is_empty() {
+        return Ok(());
+    }
+
+    let locator = TypedefLocator::new(
+        go_deps.clone(),
+        Some(project_root.to_path_buf()),
+        Some(home),
+    );
+    if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
+        error!("failed to write target/go.mod", msg);
+        return Err(1);
+    }
+
+    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir);
+
+    let lis_version = env!("CARGO_PKG_VERSION");
+    print_progress(&format!(
+        "Regenerating Go typedefs for lis v{}",
+        lis_version
+    ));
+
+    for (module_path, version) in &still_missing {
+        print_progress(&format!("Regenerating {}@{}", module_path, version));
+
+        let module = GoModule {
+            path: module_path,
+            version,
+        };
+        if let Err(msg) = workspace.reconcile(module) {
+            print_warning(&format!("Failed to regenerate {}: {}", module_path, msg));
+        }
+    }
+
+    Ok(())
+}
+
+fn module_dir_populated(cache_dir: &Path, module_path: &str, version: &str) -> bool {
+    let module_dir = cache_dir.join(format!("{}@{}", module_path, version));
+    match fs::read_dir(&module_dir) {
+        Ok(mut entries) => entries.next().is_some(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => false,
+    }
+}
+
+fn acquire_regen_lock(typedef_cache_dir: &Path) -> Result<File, i32> {
+    let lock_path = typedef_cache_dir.join(".lis-regen.lock");
+    let file = match File::create(&lock_path) {
+        Ok(f) => f,
+        Err(e) => {
+            error!(
+                "failed to create regen lock file",
+                format!("Failed to create `{}`: {}", lock_path.display(), e)
+            );
+            return Err(1);
+        }
+    };
+
+    if let Err(e) = file.lock_exclusive() {
+        error!("failed to acquire regen lock", format!("{}", e));
+        return Err(1);
+    }
+
+    Ok(file)
+}

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -73,8 +73,8 @@ pub fn missing_go_typedef(
         .with_resolve_code("missing_go_typedef")
         .with_span_label(&span, "no .d.lis file found")
         .with_help(format!(
-            "Package `{}` is declared via `{}` {} but no typedef was found. Run `lis sync` to generate it.",
-            go_pkg, module, version
+            "Package `{}` is declared via `{}` {} but no typedef was found. Run `lis check` to regenerate all typedefs, or `lis add {}@{}` to regenerate this one.",
+            go_pkg, module, version, module, version
         ))
 }
 

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -550,6 +550,10 @@ impl Checker<'_, '_> {
     }
 
     pub(super) fn error_name_not_found(&mut self, variable_name: &str, span: Span) {
+        if self.imports.failed_imports.contains(variable_name) {
+            return;
+        }
+
         let mut available_names = self.scopes.collect_all_value_names();
 
         let module = self

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -64,6 +64,9 @@ pub struct ImportState {
     pub prefix_to_module: HashMap<String, String>,
     /// Modules whose exports are available without prefix (current module and prelude)
     pub unprefixed_imports: HashSet<String>,
+    /// Effective aliases (e.g. `mux`) of imports whose underlying module
+    /// failed to load (missing typedef, undeclared, module_not_found, etc.).
+    pub failed_imports: HashSet<String>,
 }
 
 impl ImportState {
@@ -84,6 +87,7 @@ impl ImportState {
             self.prefix_to_module.insert("prelude".to_string(), m);
         }
         self.unprefixed_imports.clear();
+        self.failed_imports.clear();
     }
 }
 
@@ -556,7 +560,9 @@ impl<'r, 's> Checker<'r, 's> {
 
             seen_aliases.insert(effective.clone(), import.name.to_string());
 
-            if !self.store.has(&import.name) {
+            let module = self.store.get_module(&import.name);
+            if module.is_none() || module.is_some_and(Module::is_empty_stub) {
+                self.imports.failed_imports.insert(effective);
                 continue;
             }
 

--- a/crates/syntax/src/program/module.rs
+++ b/crates/syntax/src/program/module.rs
@@ -67,6 +67,10 @@ impl Module {
     pub fn is_internal(&self) -> bool {
         self.id == "prelude" || self.id == "**nominal" || self.id.starts_with("go:")
     }
+
+    pub fn is_empty_stub(&self) -> bool {
+        self.files.is_empty() && self.typedefs.is_empty() && self.definitions.is_empty()
+    }
 }
 
 pub struct ModuleInfo {

--- a/plan-issue-84.md
+++ b/plan-issue-84.md
@@ -1,0 +1,122 @@
+# Plan: Auto-regenerate Go typedefs after lis upgrade (issue #84)
+
+## Problem
+
+`~/.lisette/cache/typedefs/` is keyed by lis version (`lis@v{CARGO_PKG_VERSION}`, see `crates/deps/src/lib.rs:22-25`). Upgrading lis points every project at an empty cache dir, so every Go import errors with `missing_go_typedef` even though `lisette.toml` still pins exact versions. The error also recommends `lis sync`, which does not exist.
+
+User expectation (from issue): the next invocation after upgrade should just work.
+
+## Design
+
+Version-keyed cache stays — it is the right design (same lis → same bindgen → deterministic output, per `lisette-specs/lis-imports-go.md`). Fix the two user-visible symptoms:
+
+1. An empty per-version cache when `lisette.toml` has `[dependencies.go]` should trigger a silent, one-shot regeneration on the next command, not an error. All inputs are already pinned; lis has everything it needs.
+2. When an individual regeneration genuinely fails and `missing_go_typedef` does fire, its hint must point at a command that exists.
+
+Typedef resolution itself stays pure local-file lookup. The regeneration hook runs *before* resolution, not from inside it.
+
+## Scope
+
+### 1. Fix the dead-end hint
+
+`crates/diagnostics/src/module_graph.rs:75-78` — replace the `lis sync` suggestion with `lis add <module>@<version>`. `lis add` against an already-pinned version is idempotent and refills the cache (confirmed against current `GoWorkspace::reconcile` behavior). Closes bug #10 in `bugs.md:447`.
+
+New wording (covers CLI and LSP in one line — see note on LSP below):
+
+```
+Package `{go_pkg}` is declared via `{module}` {version} but no typedef
+was found. Run `lis check` to regenerate all typedefs, or
+`lis add {module}@{version}` to regenerate this one.
+```
+
+The `lis check` half is what makes this the LSP fix: when a user opens a file post-upgrade, every broken Go import shows this hint on hover, and one terminal command fixes all N deps at once. The `lis add` half remains the targeted remediation surfaced by the CLI after per-module regen failure.
+
+### 2. New module: `crates/cli/src/go_regen.rs`
+
+Single public entry point:
+
+```rust
+pub fn ensure_typedefs_for_current_version(
+    project_ctx: &ProjectContext,
+) -> Result<(), i32>
+```
+
+Behavior:
+
+1. If `project_ctx.manifest` has no `[dependencies.go]`, return `Ok(())` immediately. No cache-dir stat, no work.
+2. Acquire an exclusive lockfile at `~/.lisette/cache/typedefs/.lis-regen.lock` (use `fs2`, same crate as `add.rs:449-476`). This serializes concurrent `lis check` invocations racing on the same empty cache after upgrade. Release on drop.
+3. Build a `GoWorkspace` pointing at `project_ctx.typedef_cache_dir`.
+4. For each `(module_path, GoDependency)` in `manifest.dependencies.go`:
+   a. Construct a `GoModule { path, version }`.
+   b. Check whether any package for that module already has a typedef file under the current-version cache dir. If yes, skip (reconcile itself is a no-op on fully cached modules, but an early skip avoids calling `go get` and `go list -m` for the common post-upgrade case of "already regenerated in a previous command").
+   c. On first miss across the whole iteration, emit the header: `print_progress("Regenerating Go typedefs for lis v{CARGO_PKG_VERSION}")`. Guarded by a `bool` so it fires at most once.
+   d. Emit per-module line: `print_progress("Regenerating {module}@{version}")`.
+   e. Call `workspace.reconcile(&module)`.
+   f. On error: collect into a `Vec<(String, String)>` of `(module, error_message)`. Do NOT abort the iteration.
+5. After iteration, if the failure vec is non-empty, print each as a warning line (use existing `print_warning` helper if present, otherwise `print_progress` with a `!` marker matching `lis add` conventions). Example:
+   ```
+     ! Failed to regenerate github.com/foo/bar@v1.2.3: <error>
+   ```
+6. Return `Ok(())` regardless of partial failure. Semantic analysis proceeds. For modules that failed, `missing_go_typedef` will fire downstream with the new hint, which the user can act on. For successes, imports resolve normally.
+
+### 3. Call sites
+
+Wire `ensure_typedefs_for_current_version` into three handlers, placed *after* `ProjectContext` is built and *after* `check_toolchain_version` runs (inside `TypedefLocator::from_project[_with_manifest]`), but *before* the typedef locator actually loads files. The cleanest spot is: call it as the first step after the `ProjectContext` is constructed, before any typedef resolution.
+
+Call sites:
+
+- `crates/cli/src/handlers/check.rs` — before `TypedefLocator::from_project()` at line 64.
+- `crates/cli/src/handlers/build.rs` — before `TypedefLocator::from_project_with_manifest()` at line 25.
+- `crates/cli/src/handlers/run.rs` — project-mode branch only. The standalone branch (`run_standalone`, line 53-102) must NOT call it; standalone mode has no manifest and forbids third-party Go imports anyway.
+
+Handlers NOT touched:
+
+- `add` — already reconciles as part of its main flow.
+- `fmt` — does not load typedefs.
+- `doc` — only reads the stdlib index (`crates/cli/src/handlers/doc.rs`).
+- `lsp` — no code change. The widened diagnostic hint (see above) carries `Run \`lis check\`` on every missing Go import, which is what a user hovering red squiggles post-upgrade will see. Follow-up idea: a one-shot `window/showMessage` on LSP init when the current-version cache dir is absent and the manifest has Go deps — non-blocking, no shell-out, ~15 lines. Not in this PR.
+
+### 4. Toolchain pin ordering
+
+`check_toolchain_version` (`crates/deps/src/project_manifest.rs:119-133`) is called from `TypedefLocator::from_project[_with_manifest]` before any typedef I/O. Auto-regen runs *after* the toolchain check passes, so a project pinning `lis = "0.1.9"` on a v0.1.10 machine still gets the loud toolchain error — we never silently regenerate against a mismatched toolchain.
+
+### 5. Standalone mode
+
+Gated implicitly: `run.rs` only calls the helper in the project branch. `check` and `build` are project-only already. No explicit `standalone_mode` check needed in the helper itself.
+
+### 6. Concurrency
+
+File lock at `~/.lisette/cache/typedefs/.lis-regen.lock` (created alongside the cache dir if absent). Lock is process-wide for the duration of the regen loop. If another process already holds it, block until released (use `lock_exclusive`, not `try_lock_exclusive`) — the wait is bounded by the other process finishing its own regen, after which our iteration finds everything cached and exits in one pass of `exists()` checks.
+
+### 7. Tests
+
+Add to `tests/spec/graph/` (mirroring the style of `graph_declared_dep_missing_typedef` at `tests/spec/graph/mod.rs:206-231`):
+
+1. **Post-upgrade regen happy path.** Populate a fake cache under `lis@v{OLD}/` for a declared dep, leave `lis@v{CURRENT}/` empty, set up a mock reconcile that writes the expected typedef to the current-version dir, run `check`, assert no `missing_go_typedef` diagnostic AND assert the current-version dir was written.
+2. **Partial failure.** Two declared deps, reconcile for one succeeds and for the other fails. Assert: success dep has no diagnostic, failure dep gets `missing_go_typedef` with the new `lis add <module>@<version>` hint.
+3. **Idempotency.** Current-version cache already fully populated. Assert: zero reconcile calls, no header line emitted, `check` runs clean.
+4. **Standalone mode.** `lis run foo.lis` with a bare file. Assert: regen helper is not invoked (easiest via not calling from that code path).
+5. **Toolchain mismatch.** Manifest pins an older lis version. Assert: toolchain error fires before regen helper runs.
+6. **Lockfile contention.** Less critical; existing `add.rs` lock tests provide the pattern if we want to reuse infra.
+
+May require a new test helper for "fake typedef cache under a temp home dir" — none exists today (research finding 10). Keep this minimal: a `tempfile::TempDir` plus a small builder that writes `lis@v{X}/{module}@{version}/{pkg}.d.lis` files with given content.
+
+## Implementation order
+
+1. Fix the diagnostic hint (`module_graph.rs`) and update the snapshot in `tests/spec/graph/mod.rs:230` and any related fixtures. This alone is shippable and meaningfully improves the issue for users who hit the error anyway.
+2. Scaffold `crates/cli/src/go_regen.rs` with `ensure_typedefs_for_current_version`, lockfile, skip-if-no-go-deps short-circuit. Unit-test the short-circuit path.
+3. Wire into `check`, `build`, project-mode `run`.
+4. Add the graph tests (happy path, partial failure, idempotency, standalone, toolchain mismatch).
+5. Manual reproduction against the #84 scenario: isolated HOME, `lis add` under v{X}, rename cache dir to simulate upgrade, `lis check` should regenerate silently; flipping the rename to a broken module should surface the warning line and the updated hint.
+
+## File touch list
+
+- `crates/diagnostics/src/module_graph.rs` — hint text.
+- `crates/cli/src/go_regen.rs` — new file.
+- `crates/cli/src/lib.rs` — module declaration.
+- `crates/cli/src/handlers/check.rs` — one call.
+- `crates/cli/src/handlers/build.rs` — one call.
+- `crates/cli/src/handlers/run.rs` — one call in project branch.
+- `tests/spec/graph/mod.rs` — new cases.
+- Possibly new `tests/spec/graph/` helper for fake cache dir setup.
+- `bugs.md` — mark bug #10 as `[FIXED]` once the hint lands.

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -227,7 +227,21 @@ fn graph_declared_dep_missing_typedef() {
     let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver);
 
     assert!(sink.has_errors());
-    assert!(has_diagnostic_code(&sink, "resolve.missing_go_typedef"));
+
+    let diags = sink.take();
+    let missing = diags
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.missing_go_typedef"))
+        .expect("missing_go_typedef diagnostic");
+    let help = missing.plain_help().unwrap_or("");
+    assert!(
+        help.contains("lis check"),
+        "help should suggest `lis check` to regenerate all typedefs, got: {help}",
+    );
+    assert!(
+        help.contains("lis add github.com/gorilla/mux@v1.8.0"),
+        "help should suggest `lis add <module>@<version>` for targeted regen, got: {help}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
This auto-regenerates missing Go typedefs before `check` + `build` + `run` so a lis upgrade (which empties the version-keyed cache) no longer breaks typedef checking.

Plus minor improvements:

- Replace the dead-end `lis sync` hint on `missing_go_typedef` with `lis check` +  `lis add <module>@<version>`
- Suppress cascading `name_not_found` on references to a failed import, so one broken import produces only one diagnostic without noise
- Count only user `.lis` files in the check/build/run summary instead of every loaded Go typedef.

Fixes #84