### PR TITLE
fix: synthesize Go interface adapters for Lisette impls

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -329,6 +329,7 @@
       "non_nilable_return": {
         "container/list": ["List.PushBack", "List.PushFront"],
         "container/ring": ["Ring.Next", "Ring.Prev"],
+        "context": ["AfterFunc"],
         "crypto/ecdh": ["PrivateKey.PublicKey"],
         "crypto/elliptic": ["Curve.Params", "CurveParams.Params"],
         "go/doc/comment": ["Parser.Parse"],
@@ -348,6 +349,7 @@
         "hash/crc32": ["IEEETable"],
         "net/http/httptest": ["ResponseRecorder.Result", "Server.Client"],
         "os/exec": ["CommandContext"],
+        "sync": ["OnceFunc", "OnceValue", "OnceValues"],
         "time": ["AfterFunc", "FixedZone", "Time.Location"]
       },
       "non_nilable_var": {

--- a/bindgen/internal/convert/returns.go
+++ b/bindgen/internal/convert/returns.go
@@ -14,6 +14,18 @@ func ReturnsToLisette(signature *types.Signature, conv *Converter, qualifiedName
 	return returnsToLisetteRecursive(signature, make(map[types.Type]bool), conv, qualifiedName)
 }
 
+// Wrap a function-typed Lisette return in Option unless the symbol is
+// annotated as non-nilable. Every Go function value is nilable.
+func maybeWrapNilableFunction(t types.Type, lisetteType string, conv *Converter, qualifiedName string) string {
+	if !isNilableGoFunctionType(t) {
+		return lisetteType
+	}
+	if conv != nil && conv.cfg != nil && conv.cfg.IsNonNilableReturn(conv.currentPkgPath, qualifiedName) {
+		return lisetteType
+	}
+	return fmt.Sprintf("Option<%s>", lisetteType)
+}
+
 func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]bool, conv *Converter, qualifiedName string) TypeResult {
 	results := signature.Results()
 
@@ -38,13 +50,17 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 		if isPointerToErrorImpl(results.At(0).Type()) {
 			return TypeResult{LisetteType: "error", IsDirectError: true}
 		}
-		return toLisetteRecursive(results.At(0).Type(), seen, conv)
+		elem := toLisetteRecursive(results.At(0).Type(), seen, conv)
+		if elem.SkipReason == nil {
+			elem.LisetteType = maybeWrapNilableFunction(results.At(0).Type(), elem.LisetteType, conv, qualifiedName)
+		}
+		return elem
 	}
 
 	last := results.At(results.Len() - 1)
 
 	if isErrorType(last.Type()) {
-		inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv)
+		inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName)
 		innerType := inner.LisetteType
 		if inner.SkipReason != nil {
 			innerType = "Unknown"
@@ -66,7 +82,7 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 	if isBoolType(last.Type()) {
 		if shouldConvertToOption(last.Name(), conv, qualifiedName) {
 			nilable := results.Len() == 2 && isNilableGoType(results.At(0).Type())
-			inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv)
+			inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName)
 			innerType := inner.LisetteType
 			if inner.SkipReason != nil {
 				innerType = "Unknown"
@@ -79,7 +95,7 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 		}
 	}
 
-	return collectReturnTypes(results, 0, results.Len(), seen, conv)
+	return collectReturnTypes(results, 0, results.Len(), seen, conv, qualifiedName)
 }
 
 // shouldConvertToOption determines if a (T, bool) return should become Option<T>.
@@ -105,7 +121,7 @@ func shouldConvertToOption(boolName string, conv *Converter, qualifiedName strin
 // crates/syntax/src/parse/mod.rs.
 const maxReturnTupleArity = 5
 
-func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Type]bool, conv *Converter) TypeResult {
+func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Type]bool, conv *Converter, qualifiedName string) TypeResult {
 	count := end - start
 
 	if count == 0 {
@@ -113,7 +129,11 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 	}
 
 	if count == 1 {
-		return toLisetteRecursive(results.At(start).Type(), seen, conv)
+		elem := toLisetteRecursive(results.At(start).Type(), seen, conv)
+		if elem.SkipReason == nil {
+			elem.LisetteType = maybeWrapNilableFunction(results.At(start).Type(), elem.LisetteType, conv, qualifiedName)
+		}
+		return elem
 	}
 
 	if count > maxReturnTupleArity {
@@ -129,7 +149,7 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 		if elem.SkipReason != nil {
 			return elem
 		}
-		elems = append(elems, elem.LisetteType)
+		elems = append(elems, maybeWrapNilableFunction(results.At(i).Type(), elem.LisetteType, conv, qualifiedName))
 	}
 
 	return TypeResult{LisetteType: fmt.Sprintf("(%s)", strings.Join(elems, ", "))}

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -48,6 +48,20 @@ func isNilableGoType(t types.Type) bool {
 	return false
 }
 
+// isNilableGoFunctionType returns true if the Go type is a function
+// type (bare signature or a named alias of a signature). Function
+// values are always nilable in Go.
+func isNilableGoFunctionType(t types.Type) bool {
+	switch t := t.(type) {
+	case *types.Signature:
+		return true
+	case *types.Named:
+		_, ok := t.Underlying().(*types.Signature)
+		return ok
+	}
+	return false
+}
+
 func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter) TypeResult {
 	if seen[t] {
 		return TypeResult{LisetteType: "Unknown"}

--- a/bindgen/tests/testdata/snapshots/skipped.d.lis
+++ b/bindgen/tests/testdata/snapshots/skipped.d.lis
@@ -14,7 +14,7 @@ pub fn BadResultReturn() -> Result<Unknown, error>
 
 pub fn BadUnsafeFunc(p: Unknown)
 
-pub fn MakeOpaqueFunc() -> OpaqueFunc
+pub fn MakeOpaqueFunc() -> Option<OpaqueFunc>
 
 // SKIPPED: SkippedMin - constraint:comparable
 // type constraint T cannot be represented

--- a/bindgen/tests/testdata/snapshots/structs.d.lis
+++ b/bindgen/tests/testdata/snapshots/structs.d.lis
@@ -6,7 +6,7 @@
 import "go:io"
 
 /// Function that returns a function
-pub fn MakeAdder(x: int) -> fn(int) -> int
+pub fn MakeAdder(x: int) -> Option<fn(int) -> int>
 
 pub fn ReturnsAnon() -> Unknown
 

--- a/crates/emit/src/go/calls/dispatch.rs
+++ b/crates/emit/src/go/calls/dispatch.rs
@@ -333,7 +333,9 @@ impl Emitter<'_> {
             && let Type::Constructor { id, params, .. } = call_result_ty.resolve()
             && (id == "prelude.Option" || id == "prelude.Result")
             && !params.is_empty()
-            && params.iter().any(|p| self.as_interface(p).is_some())
+            && params
+                .iter()
+                .any(|p| self.as_interface(p).is_some() || self.is_go_function_alias(p))
         {
             type_args_string = self.format_type_args(&params);
         }
@@ -403,7 +405,11 @@ impl Emitter<'_> {
             return format!("&{}", temp);
         }
 
-        self.emit_composite_value(output, arg)
+        let value = self.emit_composite_value(output, arg);
+        match effective_param_ty {
+            Some(target) => self.maybe_wrap_as_go_interface(value, &arg.get_type(), target),
+            None => value,
+        }
     }
 
     fn effective_param_type<'a>(

--- a/crates/emit/src/go/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/go/calls/go_interop/wrappers.rs
@@ -441,6 +441,132 @@ impl Emitter<'_> {
         )
     }
 
+    pub(crate) fn emit_return_adapter(
+        &mut self,
+        inner_call: &str,
+        lisette_return_type: &Type,
+    ) -> Option<(String, String)> {
+        let return_type = lisette_return_type.resolve();
+        self.flags.needs_stdlib = true;
+
+        if return_type.is_result() {
+            let ok_ty = return_type.ok_type();
+            let err_ty = return_type.err_type();
+            let err_ty_str = self.go_type_as_string(&err_ty);
+            let res = self.fresh_var(Some("res"));
+            self.declare(&res);
+
+            let mut b = format!("{res} := {inner_call}\n");
+            if ok_ty.is_unit() {
+                // Result<(), error> → error
+                let ok_tag = RESULT_OK_TAG;
+                write_line!(
+                    b,
+                    "if {res}.Tag == {ok_tag} {{\nreturn nil\n}}\nreturn {res}.ErrVal"
+                );
+                return Some((err_ty_str, b));
+            }
+            // Result<T, error> → (T, error)
+            let ok_ty_str = self.go_type_as_string(&ok_ty);
+            let ok_tag = RESULT_OK_TAG;
+            write_line!(
+                b,
+                "if {res}.Tag == {ok_tag} {{\nreturn {res}.OkVal, nil\n}}\n\
+                 return *new({ok_ty_str}), {res}.ErrVal"
+            );
+            return Some((format!("({ok_ty_str}, {err_ty_str})"), b));
+        }
+
+        if return_type.is_partial() {
+            // Partial<T, error> → (T, error)
+            let ok_ty = return_type.ok_type();
+            let err_ty = return_type.err_type();
+            let ok_ty_str = self.go_type_as_string(&ok_ty);
+            let err_ty_str = self.go_type_as_string(&err_ty);
+            let res = self.fresh_var(Some("res"));
+            self.declare(&res);
+
+            let b = format!(
+                "{res} := {inner_call}\n\
+                 if {res}.Tag == {PARTIAL_OK_TAG} {{\nreturn {res}.OkVal, nil\n}}\n\
+                 if {res}.Tag == {PARTIAL_ERR_TAG} {{\nreturn *new({ok_ty_str}), {res}.ErrVal\n}}\n\
+                 return {res}.OkVal, {res}.ErrVal\n"
+            );
+            return Some((format!("({ok_ty_str}, {err_ty_str})"), b));
+        }
+
+        if return_type.is_option() {
+            let inner = return_type.ok_type();
+            let is_nilable = self.resolve_to_function_type(&inner).is_some()
+                || self.is_nullable_option(&return_type);
+            if is_nilable {
+                // Option<fn>, Option<Ref<T>>, Option<Interface> → bare nilable Go type
+                let go_ret = self.go_type_as_string(&inner);
+                let opt = self.fresh_var(Some("opt"));
+                self.declare(&opt);
+                let some_tag = OPTION_SOME_TAG;
+                let b = format!(
+                    "{opt} := {inner_call}\n\
+                     if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal\n}}\n\
+                     return nil\n"
+                );
+                return Some((go_ret, b));
+            }
+
+            let inner_ty_str = self.go_type_as_string(&inner);
+            let opt = self.fresh_var(Some("opt"));
+            self.declare(&opt);
+
+            let some_tag = OPTION_SOME_TAG;
+            let b = format!(
+                "{opt} := {inner_call}\n\
+                 if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal, true\n}}\n\
+                 return *new({inner_ty_str}), false\n"
+            );
+            return Some((format!("({inner_ty_str}, bool)"), b));
+        }
+
+        if let Some(arity) = return_type.tuple_arity()
+            && arity >= 2
+        {
+            let tuple_params: Vec<Type> = match &return_type {
+                Type::Tuple(elements) => elements.clone(),
+                Type::Constructor { params, .. } => params.clone(),
+                _ => return None,
+            };
+            let tup = self.fresh_var(Some("tup"));
+            self.declare(&tup);
+
+            let mut body = format!("{tup} := {inner_call}\n");
+            let mut ret_types: Vec<String> = Vec::with_capacity(arity);
+            let mut field_exprs: Vec<String> = Vec::with_capacity(arity);
+
+            for (i, slot_ty) in tuple_params.iter().enumerate() {
+                let raw_field = format!("{tup}.{}", TUPLE_FIELDS[i]);
+                match self.emit_return_adapter(&raw_field, slot_ty) {
+                    Some((inner_ret, inner_body)) => {
+                        let sub = self.fresh_var(Some("sub"));
+                        self.declare(&sub);
+                        body.push_str(&format!(
+                            "{sub} := func() {inner_ret} {{\n{inner_body}}}()\n"
+                        ));
+                        field_exprs.push(sub);
+                        ret_types.push(inner_ret);
+                    }
+                    None => {
+                        ret_types.push(self.go_type_as_string(slot_ty));
+                        field_exprs.push(raw_field);
+                    }
+                }
+            }
+
+            body.push_str(&format!("return {}\n", field_exprs.join(", ")));
+            return Some((format!("({})", ret_types.join(", ")), body));
+        }
+
+        None
+    }
+
     pub(crate) fn emit_lisette_callback_wrapper(
         &mut self,
         output: &mut String,
@@ -467,84 +593,17 @@ impl Emitter<'_> {
 
         let call_str = format!("{}({})", cb_var, arg_names.join(", "));
 
-        self.flags.needs_stdlib = true;
-
-        let (go_ret, body) = if return_type.is_result() {
-            let ok_ty = return_type.ok_type();
-            let err_ty = return_type.err_type();
-            let err_ty_str = self.go_type_as_string(&err_ty);
-            let res = self.fresh_var(Some("res"));
-            self.declare(&res);
-
-            let mut b = format!("{res} := {call_str}\n");
-            if ok_ty.is_unit() {
-                // Result<(), error> → func(...) error
-                let ok_tag = RESULT_OK_TAG;
-                write_line!(
-                    b,
-                    "if {res}.Tag == {ok_tag} {{\nreturn nil\n}}\nreturn {res}.ErrVal"
-                );
-                (err_ty_str, b)
-            } else {
-                // Result<T, error> → func(...) (T, error)
-                let ok_ty_str = self.go_type_as_string(&ok_ty);
-                let ok_tag = RESULT_OK_TAG;
-                write_line!(
-                    b,
-                    "if {res}.Tag == {ok_tag} {{\nreturn {res}.OkVal, nil\n}}\n\
-                     return *new({ok_ty_str}), {res}.ErrVal"
-                );
-                (format!("({ok_ty_str}, {err_ty_str})"), b)
-            }
-        } else if return_type.is_partial() {
-            // Partial<T, error> → func(...) (T, error)
-            let ok_ty = return_type.ok_type();
-            let err_ty = return_type.err_type();
-            let ok_ty_str = self.go_type_as_string(&ok_ty);
-            let err_ty_str = self.go_type_as_string(&err_ty);
-            let res = self.fresh_var(Some("res"));
-            self.declare(&res);
-
-            let b = format!(
-                "{res} := {call_str}\n\
-                 if {res}.Tag == {PARTIAL_OK_TAG} {{\nreturn {res}.OkVal, nil\n}}\n\
-                 if {res}.Tag == {PARTIAL_ERR_TAG} {{\nreturn *new({ok_ty_str}), {res}.ErrVal\n}}\n\
-                 return {res}.OkVal, {res}.ErrVal\n"
-            );
-            (format!("({ok_ty_str}, {err_ty_str})"), b)
-        } else if return_type.is_option() {
-            // Option<T> → func(...) (T, bool)
-            let inner_ty_str = self.go_type_as_string(&return_type.ok_type());
-            let opt = self.fresh_var(Some("opt"));
-            self.declare(&opt);
-
-            let some_tag = OPTION_SOME_TAG;
-            let b = format!(
-                "{opt} := {call_str}\n\
-                 if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal, true\n}}\n\
-                 return *new({inner_ty_str}), false\n"
-            );
-            (format!("({inner_ty_str}, bool)"), b)
-        } else if let Some(arity) = return_type.tuple_arity()
-            && arity >= 2
+        // Option<fn> adaptation only fires in interface-method shims. Here
+        // a closure-valued Option means the caller owns the nil check.
+        if let Type::Constructor { id, params: ps, .. } = &return_type
+            && id == "Option"
+            && let Some(inner) = ps.first()
+            && matches!(inner.resolve(), Type::Function { .. })
         {
-            // Tuple<T1, T2, ...> → func(...) (T1, T2, ...)
-            let tuple_params = match &return_type {
-                Type::Constructor { params, .. } => params,
-                _ => return fn_value.to_string(),
-            };
-            let ret_types: Vec<String> = tuple_params
-                .iter()
-                .map(|t| self.go_type_as_string(t))
-                .collect();
-            let tup = self.fresh_var(Some("tup"));
-            self.declare(&tup);
-            let fields: Vec<String> = (0..arity)
-                .map(|i| format!("{tup}.{}", TUPLE_FIELDS[i]))
-                .collect();
-            let b = format!("{tup} := {call_str}\nreturn {}\n", fields.join(", "));
-            (format!("({})", ret_types.join(", ")), b)
-        } else {
+            return fn_value.to_string();
+        }
+
+        let Some((go_ret, body)) = self.emit_return_adapter(&call_str, &return_type) else {
             return fn_value.to_string();
         };
 

--- a/crates/emit/src/go/control_flow/branching.rs
+++ b/crates/emit/src/go/control_flow/branching.rs
@@ -285,6 +285,7 @@ impl Emitter<'_> {
                 }
                 _ => {
                     let expression_string = self.emit_value(output, last);
+                    let expression_string = self.adapt_to_assign_target(last, expression_string);
                     write_line!(output, "{} = {}", var, expression_string);
                 }
             }
@@ -391,9 +392,21 @@ impl Emitter<'_> {
             }
             _ => {
                 let expression_string = self.emit_value(output, last);
+                let expression_string = self.adapt_return_to_context(last, expression_string);
                 write_line!(output, "{}return {}", directive, expression_string);
             }
         }
+    }
+
+    pub(crate) fn adapt_to_assign_target(
+        &mut self,
+        expression: &Expression,
+        emitted: String,
+    ) -> String {
+        let Some(target) = self.assign_target_ty.clone() else {
+            return emitted;
+        };
+        self.maybe_wrap_as_go_interface(emitted, &expression.get_type(), &target)
     }
 
     pub(crate) fn emit_in_position(&mut self, output: &mut String, expression: &Expression) {

--- a/crates/emit/src/go/control_flow/propagation.rs
+++ b/crates/emit/src/go/control_flow/propagation.rs
@@ -190,8 +190,20 @@ impl Emitter<'_> {
             output.push_str("return\n");
         } else if !self.emit_wrapped_return(output, expression) {
             let expression_string = self.emit_value(output, expression);
+            let expression_string = self.adapt_return_to_context(expression, expression_string);
             write_line!(output, "return {}", expression_string);
         }
+    }
+
+    pub(crate) fn adapt_return_to_context(
+        &mut self,
+        expression: &Expression,
+        emitted: String,
+    ) -> String {
+        let Some(return_ty) = self.current_return_context.clone() else {
+            return emitted;
+        };
+        self.maybe_wrap_as_go_interface(emitted, &expression.get_type(), &return_ty)
     }
 
     /// Emit a return statement with Result/Option wrapping if applicable.

--- a/crates/emit/src/go/definitions/functions.rs
+++ b/crates/emit/src/go/definitions/functions.rs
@@ -65,6 +65,7 @@ impl Emitter<'_> {
         self.with_position(Position::Tail, |this| {
             if !requires_temp_var(last) {
                 let expression = this.emit_value(output, last);
+                let expression = this.adapt_return_to_context(last, expression);
                 output.push_str(&this.wrap_value(&expression));
             } else {
                 match last {

--- a/crates/emit/src/go/definitions/interface_adapter.rs
+++ b/crates/emit/src/go/definitions/interface_adapter.rs
@@ -1,0 +1,310 @@
+use crate::Emitter;
+use crate::go::names::go_name::GO_IMPORT_PREFIX;
+use crate::go::write_line;
+use ecow::EcoString;
+use syntax::program::{Definition, Interface};
+use syntax::types::Type;
+pub(crate) struct AdapterPlan {
+    pub(crate) concrete_id: EcoString,
+    pub(crate) interface_id: EcoString,
+    pub(crate) concrete_ty: Type,
+    pub(crate) methods: Vec<AdapterMethod>,
+}
+
+pub(crate) struct AdapterMethod {
+    pub(crate) name: EcoString,
+    pub(crate) param_types: Vec<Type>,
+    pub(crate) return_type: Type,
+}
+
+impl Emitter<'_> {
+    pub(crate) fn maybe_wrap_as_go_interface(
+        &mut self,
+        emitted: String,
+        source_ty: &Type,
+        target_ty: &Type,
+    ) -> String {
+        let Some(plan) = self.needs_adapter(source_ty, target_ty) else {
+            return emitted;
+        };
+        let adapter_name = self.ensure_adapter_type(plan);
+        format!("{}{{inner: {}}}", adapter_name, emitted)
+    }
+
+    pub(crate) fn lookup_struct_field_ty(
+        &self,
+        struct_ty: &Type,
+        field_name: &str,
+    ) -> Option<Type> {
+        let resolved = struct_ty.resolve();
+        let Type::Constructor { id, .. } = resolved.strip_refs() else {
+            return None;
+        };
+        let Some(Definition::Struct { fields, .. }) = self.ctx.definitions.get(id.as_str()) else {
+            return None;
+        };
+        fields
+            .iter()
+            .find(|f| f.name == field_name)
+            .map(|f| f.ty.clone())
+    }
+
+    pub(crate) fn is_go_function_alias(&self, ty: &Type) -> bool {
+        let resolved = ty.resolve();
+        let Type::Constructor { id, .. } = &resolved else {
+            return false;
+        };
+        if !id.starts_with(GO_IMPORT_PREFIX) {
+            return false;
+        }
+        self.resolve_to_function_type(&resolved).is_some()
+    }
+
+    pub(crate) fn resolve_to_function_type(&self, ty: &Type) -> Option<Type> {
+        let resolved = ty.resolve();
+        if matches!(resolved, Type::Function { .. }) {
+            return Some(resolved);
+        }
+        if let Some(underlying) = resolved.get_underlying() {
+            let under = underlying.resolve();
+            if matches!(under, Type::Function { .. }) {
+                return Some(under);
+            }
+        }
+        let Type::Constructor { id, .. } = &resolved else {
+            return None;
+        };
+        match self.ctx.definitions.get(id.as_str()) {
+            Some(Definition::TypeAlias { ty: alias_ty, .. }) => {
+                let aliased = alias_ty.resolve();
+                if matches!(aliased, Type::Function { .. }) {
+                    Some(aliased)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn collect_all_interface_methods(&self, iface: &Interface) -> Vec<(EcoString, Type)> {
+        let mut result: Vec<(EcoString, Type)> = Vec::new();
+        let mut seen: std::collections::HashSet<EcoString> = std::collections::HashSet::new();
+        let mut queue: Vec<&Interface> = vec![iface];
+        while let Some(current) = queue.pop() {
+            for (name, ty) in &current.methods {
+                if seen.insert(name.clone()) {
+                    result.push((name.clone(), ty.clone()));
+                }
+            }
+            for parent_ty in &current.parents {
+                let parent = parent_ty.resolve();
+                let Type::Constructor { id, .. } = &parent else {
+                    continue;
+                };
+                if let Some(Definition::Interface {
+                    definition: parent_def,
+                    ..
+                }) = self.ctx.definitions.get(id.as_str())
+                {
+                    queue.push(parent_def);
+                }
+            }
+        }
+        result
+    }
+
+    fn needs_adapter(&self, source_ty: &Type, target_ty: &Type) -> Option<AdapterPlan> {
+        let target = target_ty.resolve();
+        let Type::Constructor { id: target_id, .. } = &target else {
+            return None;
+        };
+        if !target_id.starts_with(GO_IMPORT_PREFIX) {
+            return None;
+        }
+        let Some(Definition::Interface { definition, .. }) =
+            self.ctx.definitions.get(target_id.as_str())
+        else {
+            return None;
+        };
+
+        let source_stripped = source_ty.strip_refs();
+        let source = source_stripped.resolve();
+        let Type::Constructor { id: source_id, .. } = &source else {
+            return None;
+        };
+        if source_id.starts_with(GO_IMPORT_PREFIX) {
+            return None;
+        }
+        let Some(Definition::Struct {
+            methods: struct_methods,
+            ..
+        }) = self.ctx.definitions.get(source_id.as_str())
+        else {
+            return None;
+        };
+
+        let all_iface_methods = self.collect_all_interface_methods(definition);
+        let mut methods = Vec::with_capacity(all_iface_methods.len());
+        let mut any_adapted = false;
+
+        for (method_name, _iface_method_ty) in &all_iface_methods {
+            let impl_ty = struct_methods.get(method_name)?;
+            let Type::Function {
+                params,
+                return_type,
+                ..
+            } = impl_ty.resolve()
+            else {
+                return None;
+            };
+            let method_params: Vec<Type> = if params.is_empty() {
+                Vec::new()
+            } else {
+                params[1..].to_vec()
+            };
+            let return_ty = return_type.resolve();
+            if return_ty.is_result()
+                || return_ty.is_partial()
+                || return_ty.is_option()
+                || return_ty.tuple_arity().is_some_and(|n| n >= 2)
+            {
+                any_adapted = true;
+            }
+            methods.push(AdapterMethod {
+                name: method_name.clone(),
+                param_types: method_params,
+                return_type: return_ty,
+            });
+        }
+
+        if !any_adapted {
+            return None;
+        }
+
+        Some(AdapterPlan {
+            concrete_id: source_id.clone(),
+            interface_id: target_id.clone(),
+            concrete_ty: source_ty.clone(),
+            methods,
+        })
+    }
+
+    fn concrete_dedup_key(concrete_ty: &Type, concrete_id: &EcoString) -> EcoString {
+        let mut depth = 0usize;
+        let mut t = concrete_ty.clone();
+        while t.is_ref() {
+            depth += 1;
+            t = t.inner().expect("Ref<T> must have inner").clone();
+        }
+        if depth == 0 {
+            concrete_id.clone()
+        } else {
+            EcoString::from("*".repeat(depth) + concrete_id.as_str())
+        }
+    }
+
+    fn ensure_adapter_type(&mut self, plan: AdapterPlan) -> String {
+        let key = (
+            Self::concrete_dedup_key(&plan.concrete_ty, &plan.concrete_id),
+            plan.interface_id.clone(),
+        );
+        if let Some(name) = self.synthesized_adapter_types.get(&key) {
+            return name.clone();
+        }
+
+        let index = self.synthesized_adapter_types.len();
+        let adapter_name = Self::adapter_type_name(&plan, index);
+        self.synthesized_adapter_types
+            .insert(key, adapter_name.clone());
+
+        let concrete_go_ty = self.go_type_as_string(&plan.concrete_ty);
+
+        let mut decl = String::new();
+        write_line!(decl, "type {} struct {{", adapter_name);
+        write_line!(decl, "inner {}", concrete_go_ty);
+        write_line!(decl, "}}");
+        decl.push('\n');
+
+        for method in &plan.methods {
+            self.emit_adapter_method(&mut decl, &adapter_name, method);
+            decl.push('\n');
+        }
+
+        self.pending_adapter_types.push(decl);
+        adapter_name
+    }
+
+    fn emit_adapter_method(
+        &mut self,
+        decl: &mut String,
+        adapter_name: &str,
+        method: &AdapterMethod,
+    ) {
+        self.enter_scope();
+
+        let param_names: Vec<String> = (0..method.param_types.len())
+            .map(|i| format!("arg{}", i))
+            .collect();
+        for name in &param_names {
+            self.declare(name);
+        }
+
+        let param_type_strs: Vec<String> = method
+            .param_types
+            .iter()
+            .map(|t| self.go_type_as_string(t))
+            .collect();
+        let params_decl: Vec<String> = param_names
+            .iter()
+            .zip(param_type_strs.iter())
+            .map(|(n, t)| format!("{} {}", n, t))
+            .collect();
+
+        let inner_call = format!("a.inner.{}({})", method.name, param_names.join(", "));
+
+        let (go_ret, body) = match self.emit_return_adapter(&inner_call, &method.return_type) {
+            Some((ret, body)) => (ret, body),
+            None => {
+                if method.return_type.is_unit() {
+                    (String::new(), format!("{}\n", inner_call))
+                } else {
+                    let ret = self.go_type_as_string(&method.return_type);
+                    (ret, format!("return {}\n", inner_call))
+                }
+            }
+        };
+
+        let ret_suffix = if go_ret.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", go_ret)
+        };
+        write_line!(
+            decl,
+            "func (a {}) {}({}){} {{",
+            adapter_name,
+            method.name,
+            params_decl.join(", "),
+            ret_suffix
+        );
+        decl.push_str(&body);
+        write_line!(decl, "}}");
+
+        self.exit_scope();
+    }
+
+    fn adapter_type_name(plan: &AdapterPlan, index: usize) -> String {
+        let concrete_name = plan
+            .concrete_id
+            .rsplit('.')
+            .next()
+            .unwrap_or(plan.concrete_id.as_str());
+        let go_path = plan
+            .interface_id
+            .strip_prefix(GO_IMPORT_PREFIX)
+            .unwrap_or(plan.interface_id.as_str());
+        let iface_name = go_path.rsplit('.').next().unwrap_or(go_path);
+        format!("_lisAdapter_{}_{}_{}", concrete_name, iface_name, index)
+    }
+}

--- a/crates/emit/src/go/definitions/mod.rs
+++ b/crates/emit/src/go/definitions/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod enum_layout;
 mod functions;
+mod interface_adapter;
 mod tags;
 mod toplevel;

--- a/crates/emit/src/go/expressions/access.rs
+++ b/crates/emit/src/go/expressions/access.rs
@@ -524,6 +524,11 @@ impl Emitter<'_> {
             } else {
                 value
             };
+            let value = if let Some(field_ty) = self.lookup_struct_field_ty(ty, &f.name) {
+                self.maybe_wrap_as_go_interface(value, &f.value.get_type(), &field_ty)
+            } else {
+                value
+            };
             field_names.push(field_name);
             field_values.push(value);
         }

--- a/crates/emit/src/go/expressions/values.rs
+++ b/crates/emit/src/go/expressions/values.rs
@@ -240,17 +240,52 @@ impl Emitter<'_> {
             Expression::RecoverBlock { items, ty, .. } => {
                 self.emit_recover_block(output, items, ty)
             }
-            Expression::Tuple { elements, .. } => {
+            Expression::Tuple { elements, ty, .. } => {
                 let stages: Vec<Staged> =
                     elements.iter().map(|e| self.stage_composite(e)).collect();
                 let elem_expressions = self.sequence(output, stages, "_v");
 
+                let slot_types: Vec<Type> = match ty.resolve() {
+                    Type::Tuple(slots) => slots,
+                    _ => Vec::new(),
+                };
+
+                let elem_expressions: Vec<String> = elements
+                    .iter()
+                    .zip(elem_expressions)
+                    .enumerate()
+                    .map(|(i, (expr, emitted))| match slot_types.get(i) {
+                        Some(slot) => {
+                            self.maybe_wrap_as_go_interface(emitted, &expr.get_type(), slot)
+                        }
+                        None => emitted,
+                    })
+                    .collect();
+
                 self.flags.needs_stdlib = true;
-                format!(
-                    "lisette.MakeTuple{}({})",
-                    elem_expressions.len(),
-                    elem_expressions.join(", ")
-                )
+                let arity = elem_expressions.len();
+
+                let needs_explicit_type_args = !slot_types.is_empty()
+                    && slot_types.iter().any(|t| self.as_interface(t).is_some());
+
+                if needs_explicit_type_args {
+                    let slot_ty_strs: Vec<String> = slot_types
+                        .iter()
+                        .map(|t| self.go_type_as_string(t))
+                        .collect();
+                    format!(
+                        "lisette.MakeTuple{}[{}]({})",
+                        arity,
+                        slot_ty_strs.join(", "),
+                        elem_expressions.join(", ")
+                    )
+                } else {
+                    format!(
+                        "lisette.MakeTuple{}({})",
+                        arity,
+                        elem_expressions.join(", ")
+                    )
+                }
             }
             Expression::If { ty, .. }
             | Expression::Match { ty, .. }
@@ -324,7 +359,8 @@ impl Emitter<'_> {
                 Some(Definition::Interface { .. })
             )
         {
-            return inner;
+            let source_ty = expression.get_type();
+            return self.maybe_wrap_as_go_interface(inner, &source_ty, ty);
         }
 
         let go_type = self.annotation_to_go_type(target_type);
@@ -486,12 +522,22 @@ impl Emitter<'_> {
                 let stages: Vec<Staged> = elems.iter().map(|e| self.stage_composite(e)).collect();
                 let elements = self.sequence(output, stages, "_v");
 
-                let elem_ty = self.go_type_as_string(
-                    ty.get_type_params()
-                        .expect("Slice type must have type args")
-                        .first()
-                        .expect("Slice type must have element type"),
-                );
+                let elem_lisette_ty = ty
+                    .get_type_params()
+                    .expect("Slice type must have type args")
+                    .first()
+                    .expect("Slice type must have element type")
+                    .clone();
+                let elem_ty = self.go_type_as_string(&elem_lisette_ty);
+
+                let elements: Vec<String> = elems
+                    .iter()
+                    .zip(elements)
+                    .map(|(expr, emitted)| {
+                        self.maybe_wrap_as_go_interface(emitted, &expr.get_type(), &elem_lisette_ty)
+                    })
+                    .collect();
+
                 if elements.len() > 1 && elements.iter().any(|e| e.len() > 30) {
                     let indented = elements
                         .iter()

--- a/crates/emit/src/go/statements/assignments.rs
+++ b/crates/emit/src/go/statements/assignments.rs
@@ -98,7 +98,12 @@ impl Emitter<'_> {
                     );
                     write_line!(output, "{} = {}", target_str, unwrapped);
                 } else {
-                    write_line!(output, "{} = {}", target_str, rhs_staged.value);
+                    let adapted = self.maybe_wrap_as_go_interface(
+                        rhs_staged.value,
+                        &value.get_type(),
+                        &target.get_type(),
+                    );
+                    write_line!(output, "{} = {}", target_str, adapted);
                 }
             }
             Expression::Break { value, .. } => {

--- a/crates/emit/src/go/statements/let_bindings.rs
+++ b/crates/emit/src/go/statements/let_bindings.rs
@@ -186,6 +186,12 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         } else {
             let value_expression = self.emitter.emit_value(output, self.value);
 
+            let value_expression = self.emitter.maybe_wrap_as_go_interface(
+                value_expression,
+                &self.value.get_type(),
+                &self.binding.ty,
+            );
+
             let value_expression = if self.is_mutable_subslice_binding() {
                 self.emitter.flags.needs_slices = true;
                 format!("slices.Clone({})", value_expression)

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -107,6 +107,9 @@ pub struct Emitter<'a> {
 
     current_module: ModuleId,
 
+    synthesized_adapter_types: HashMap<(EcoString, EcoString), String>,
+    pending_adapter_types: Vec<String>,
+
     // Per-file accumulated state (reset between files)
     flags: EmitFlags,
     ensure_imported: HashSet<ModuleId>,
@@ -243,6 +246,8 @@ impl<'a> Emitter<'a> {
                 assign_targets: HashSet::default(),
             },
             current_module: current_module.to_string(),
+            synthesized_adapter_types: HashMap::default(),
+            pending_adapter_types: Vec::new(),
             flags: EmitFlags::default(),
             ensure_imported: HashSet::default(),
             position: Position::Expression,
@@ -478,6 +483,8 @@ impl<'a> Emitter<'a> {
                 }
             }
 
+            self.pending_adapter_types.clear();
+
             for expression in &file.items {
                 self.scope.next_var = 0;
                 self.scope.bindings.reset();
@@ -486,6 +493,10 @@ impl<'a> Emitter<'a> {
                 if !code.is_empty() {
                     source.collect_with_blank(code);
                 }
+            }
+
+            for adapter_decl in std::mem::take(&mut self.pending_adapter_types) {
+                source.collect_with_blank(adapter_decl);
             }
 
             let unused_imports =

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -252,12 +252,16 @@ impl Checker<'_, '_> {
         // Speculatively unify the expected type with the return type before
         // checking arguments, so e.g. `Some(Text{})` with expected `Option<Printable>`
         // constrains T = Printable and the argument coerces via interface satisfaction.
-        // Guarded to interface type params only to avoid affecting numeric literal inference.
+        // Also fires for Go-imported named types so that `Some(tea.Quit)` in
+        // context `Option<tea.Cmd>` constrains T = tea.Cmd instead of
+        // collapsing to the Cmd alias's underlying function shape. Guarded
+        // to named types to avoid affecting numeric literal inference.
         if self.is_generic_callee(&callee_expression)
             && !expected_ty.resolve().is_variable()
             && !expected_ty.is_ignored()
             && self.is_enum_type(&return_ty.resolve())
-            && self.has_interface_type_param(expected_ty)
+            && (self.has_interface_type_param(expected_ty)
+                || self.has_go_named_type_param(expected_ty))
         {
             let _ = self.speculatively(|this| this.try_unify(expected_ty, &return_ty, &span));
         }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -377,8 +377,8 @@ impl Checker<'_, '_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
-        let expected_elements: Vec<Type> = match expected_ty {
-            Type::Tuple(elems) if elems.len() == elements.len() => elems.clone(),
+        let expected_elements: Vec<Type> = match expected_ty.resolve() {
+            Type::Tuple(elems) if elems.len() == elements.len() => elems,
             _ => elements.iter().map(|_| self.new_type_var()).collect(),
         };
 

--- a/crates/semantics/src/checker/registration/builtins.rs
+++ b/crates/semantics/src/checker/registration/builtins.rs
@@ -156,8 +156,12 @@ impl Checker<'_, '_> {
         }
     }
 
-    /// Checks if a type is a generic container (Option, Result) with interface type parameters.
-    /// Used to determine when to use the expected type for codegen instead of the inferred type.
+    /// Checks if a type is a generic container (Option, Result) whose
+    /// type parameter needs the expected type to flow through for
+    /// codegen: Go interfaces (for method-set satisfaction) or
+    /// Go-imported named types (for Go generic instantiation preserving
+    /// alias names like `tea.Cmd` instead of collapsing to the
+    /// underlying `func() Msg`).
     pub fn is_generic_container_with_interface(&self, ty: &Type) -> bool {
         let Type::Constructor { id, params, .. } = ty.resolve() else {
             return false;
@@ -169,7 +173,7 @@ impl Checker<'_, '_> {
 
         params.iter().any(|p| {
             if let Type::Constructor { id, .. } = p.resolve() {
-                self.store.get_interface(&id).is_some()
+                self.store.get_interface(&id).is_some() || id.starts_with("go:")
             } else {
                 false
             }
@@ -184,6 +188,20 @@ impl Checker<'_, '_> {
         params.iter().any(|p| {
             if let Type::Constructor { id, .. } = p.resolve() {
                 self.store.get_interface(&id).is_some()
+            } else {
+                false
+            }
+        })
+    }
+
+    pub fn has_go_named_type_param(&self, ty: &Type) -> bool {
+        let Type::Constructor { params, .. } = ty.resolve() else {
+            return false;
+        };
+
+        params.iter().any(|p| {
+            if let Type::Constructor { id, .. } = p.resolve() {
+                id.starts_with("go:")
             } else {
                 false
             }

--- a/crates/stdlib/typedefs/bytes.d.lis
+++ b/crates/stdlib/typedefs/bytes.d.lis
@@ -90,13 +90,13 @@ pub fn FieldsFunc(s: Slice<uint8>, f: fn(int32) -> bool) -> Slice<Slice<uint8>>
 /// Unicode code points satisfying f(c).
 /// The iterator yields the same subslices that would be returned by [FieldsFunc](s),
 /// but without constructing a new slice containing the subslices.
-pub fn FieldsFuncSeq(s: Slice<uint8>, f: fn(int32) -> bool) -> iter.Seq<Slice<uint8>>
+pub fn FieldsFuncSeq(s: Slice<uint8>, f: fn(int32) -> bool) -> Option<iter.Seq<Slice<uint8>>>
 
 /// FieldsSeq returns an iterator over subslices of s split around runs of
 /// whitespace characters, as defined by [unicode.IsSpace].
 /// The iterator yields the same subslices that would be returned by [Fields](s),
 /// but without constructing a new slice containing the subslices.
-pub fn FieldsSeq(s: Slice<uint8>) -> iter.Seq<Slice<uint8>>
+pub fn FieldsSeq(s: Slice<uint8>) -> Option<iter.Seq<Slice<uint8>>>
 
 /// HasPrefix reports whether the byte slice s begins with prefix.
 pub fn HasPrefix(s: Slice<uint8>, prefix: Slice<uint8>) -> bool
@@ -154,7 +154,7 @@ pub fn LastIndexFunc(s: Slice<uint8>, f: fn(int32) -> bool) -> int
 /// If s is empty, the iterator yields no lines at all.
 /// If s does not end in a newline, the final yielded line will not end in a newline.
 /// It returns a single-use iterator.
-pub fn Lines(s: Slice<uint8>) -> iter.Seq<Slice<uint8>>
+pub fn Lines(s: Slice<uint8>) -> Option<iter.Seq<Slice<uint8>>>
 
 /// Map returns a copy of the byte slice s with all its characters modified
 /// according to the mapping function. If mapping returns a negative value, the character is
@@ -220,7 +220,7 @@ pub fn SplitAfterN(s: Slice<uint8>, sep: Slice<uint8>, n: int) -> Slice<Slice<ui
 /// The iterator yields the same subslices that would be returned by [SplitAfter](s, sep),
 /// but without constructing a new slice containing the subslices.
 /// It returns a single-use iterator.
-pub fn SplitAfterSeq(s: Slice<uint8>, sep: Slice<uint8>) -> iter.Seq<Slice<uint8>>
+pub fn SplitAfterSeq(s: Slice<uint8>, sep: Slice<uint8>) -> Option<iter.Seq<Slice<uint8>>>
 
 /// SplitN slices s into subslices separated by sep and returns a slice of
 /// the subslices between those separators.
@@ -237,7 +237,7 @@ pub fn SplitN(s: Slice<uint8>, sep: Slice<uint8>, n: int) -> Slice<Slice<uint8>>
 /// The iterator yields the same subslices that would be returned by [Split](s, sep),
 /// but without constructing a new slice containing the subslices.
 /// It returns a single-use iterator.
-pub fn SplitSeq(s: Slice<uint8>, sep: Slice<uint8>) -> iter.Seq<Slice<uint8>>
+pub fn SplitSeq(s: Slice<uint8>, sep: Slice<uint8>) -> Option<iter.Seq<Slice<uint8>>>
 
 /// Title treats s as UTF-8-encoded bytes and returns a copy with all Unicode letters that begin
 /// words mapped to their title case.

--- a/crates/stdlib/typedefs/context.d.lis
+++ b/crates/stdlib/typedefs/context.d.lis
@@ -43,7 +43,7 @@ pub fn TODO() -> Context
 /// 
 /// Canceling this context releases resources associated with it, so code should
 /// call cancel as soon as the operations running in this [Context] complete.
-pub fn WithCancel(parent: Context) -> (Context, CancelFunc)
+pub fn WithCancel(parent: Context) -> (Context, Option<CancelFunc>)
 
 /// WithCancelCause behaves like [WithCancel] but returns a [CancelCauseFunc] instead of a [CancelFunc].
 /// Calling cancel with a non-nil error (the "cause") records that error in ctx;
@@ -56,7 +56,7 @@ pub fn WithCancel(parent: Context) -> (Context, CancelFunc)
 /// 	cancel(myError)
 /// 	ctx.Err() // returns context.Canceled
 /// 	context.Cause(ctx) // returns myError
-pub fn WithCancelCause(parent: Context) -> (Context, CancelCauseFunc)
+pub fn WithCancelCause(parent: Context) -> (Context, Option<CancelCauseFunc>)
 
 /// WithDeadline returns a derived context that points to the parent context
 /// but has the deadline adjusted to be no later than d. If the parent's
@@ -67,12 +67,12 @@ pub fn WithCancelCause(parent: Context) -> (Context, CancelCauseFunc)
 /// 
 /// Canceling this context releases resources associated with it, so code should
 /// call cancel as soon as the operations running in this [Context] complete.
-pub fn WithDeadline(parent: Context, d: time.Time) -> (Context, CancelFunc)
+pub fn WithDeadline(parent: Context, d: time.Time) -> (Context, Option<CancelFunc>)
 
 /// WithDeadlineCause behaves like [WithDeadline] but also sets the cause of the
 /// returned Context when the deadline is exceeded. The returned [CancelFunc] does
 /// not set the cause.
-pub fn WithDeadlineCause(parent: Context, d: time.Time, cause: error) -> (Context, CancelFunc)
+pub fn WithDeadlineCause(parent: Context, d: time.Time, cause: error) -> (Context, Option<CancelFunc>)
 
 /// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
 /// 
@@ -84,12 +84,12 @@ pub fn WithDeadlineCause(parent: Context, d: time.Time, cause: error) -> (Contex
 /// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
 /// 		return slowOperation(ctx)
 /// 	}
-pub fn WithTimeout(parent: Context, timeout: time.Duration) -> (Context, CancelFunc)
+pub fn WithTimeout(parent: Context, timeout: time.Duration) -> (Context, Option<CancelFunc>)
 
 /// WithTimeoutCause behaves like [WithTimeout] but also sets the cause of the
 /// returned Context when the timeout expires. The returned [CancelFunc] does
 /// not set the cause.
-pub fn WithTimeoutCause(parent: Context, timeout: time.Duration, cause: error) -> (Context, CancelFunc)
+pub fn WithTimeoutCause(parent: Context, timeout: time.Duration, cause: error) -> (Context, Option<CancelFunc>)
 
 pub fn WithValue(parent: Context, key: Unknown, val: Unknown) -> Context
 

--- a/crates/stdlib/typedefs/go/ast.d.lis
+++ b/crates/stdlib/typedefs/go/ast.d.lis
@@ -159,7 +159,7 @@ pub fn PackageExports(pkg: Ref<Package>) -> bool
 /// 
 /// For greater control over the traversal of each subtree, use
 /// [Inspect] or [PreorderStack].
-pub fn Preorder(root: Node) -> iter.Seq<Node>
+pub fn Preorder(root: Node) -> Option<iter.Seq<Node>>
 
 /// PreorderStack traverses the tree rooted at root,
 /// calling f before visiting each node.

--- a/crates/stdlib/typedefs/go/types.d.lis
+++ b/crates/stdlib/typedefs/go/types.d.lis
@@ -353,7 +353,7 @@ pub fn NewVar(pos: token.Pos, pkg: Ref<Package>, name: string, typ: Type) -> Ref
 /// package-level objects, and may be nil.
 pub fn ObjectString(obj: Object, qf: Qualifier) -> string
 
-pub fn RelativeTo(pkg: Ref<Package>) -> Qualifier
+pub fn RelativeTo(pkg: Ref<Package>) -> Option<Qualifier>
 
 /// Satisfies reports whether type V satisfies the constraint T.
 /// 
@@ -1118,7 +1118,7 @@ impl Interface {
   /// EmbeddedTypes returns a go1.23 iterator over the types embedded within an interface.
   /// 
   /// Example: for e := range t.EmbeddedTypes() { ... }
-  fn EmbeddedTypes(self: Ref<Interface>) -> iter.Seq<Type>
+  fn EmbeddedTypes(self: Ref<Interface>) -> Option<iter.Seq<Type>>
 
   /// Empty reports whether t is the empty interface.
   fn Empty(self: Ref<Interface>) -> bool
@@ -1131,7 +1131,7 @@ impl Interface {
   /// an interface, ordered by Id.
   /// 
   /// Example: for m := range t.ExplicitMethods() { ... }
-  fn ExplicitMethods(self: Ref<Interface>) -> iter.Seq<Ref<Func>>
+  fn ExplicitMethods(self: Ref<Interface>) -> Option<iter.Seq<Ref<Func>>>
 
   /// IsComparable reports whether each type in interface t's type set is comparable.
   fn IsComparable(self: Ref<Interface>) -> bool
@@ -1157,7 +1157,7 @@ impl Interface {
   /// interface, ordered by Id.
   /// 
   /// Example: for m := range t.Methods() { ... }
-  fn Methods(self: Ref<Interface>) -> iter.Seq<Ref<Func>>
+  fn Methods(self: Ref<Interface>) -> Option<iter.Seq<Ref<Func>>>
 
   /// NumEmbeddeds returns the number of embedded types in interface t.
   fn NumEmbeddeds(self: Ref<Interface>) -> int
@@ -1227,7 +1227,7 @@ impl MethodSet {
   /// Methods returns a go1.23 iterator over the methods of a method set.
   /// 
   /// Example: for method := range s.Methods() { ... }
-  fn Methods(self: Ref<MethodSet>) -> iter.Seq<Ref<Selection>>
+  fn Methods(self: Ref<MethodSet>) -> Option<iter.Seq<Ref<Selection>>>
 
   fn String(self: Ref<MethodSet>) -> string
 }
@@ -1254,7 +1254,7 @@ impl Named {
   /// Methods returns a go1.23 iterator over the declared methods of a named type.
   /// 
   /// Example: for m := range t.Methods() { ... }
-  fn Methods(self: Ref<Named>) -> iter.Seq<Ref<Func>>
+  fn Methods(self: Ref<Named>) -> Option<iter.Seq<Ref<Func>>>
 
   /// NumMethods returns the number of explicit methods defined for t.
   fn NumMethods(self: Ref<Named>) -> int
@@ -1417,7 +1417,7 @@ impl Scope {
   /// Children returns a go1.23 iterator over the child scopes nested within scope s.
   /// 
   /// Example: for child := range scope.Children() { ... }
-  fn Children(self: Ref<Scope>) -> iter.Seq<Ref<Scope>>
+  fn Children(self: Ref<Scope>) -> Option<iter.Seq<Ref<Scope>>>
 
   /// Contains reports whether pos is within the scope's extent.
   /// The result is guaranteed to be valid only if the type-checked
@@ -1579,7 +1579,7 @@ impl Struct {
   /// Fields returns a go1.23 iterator over the fields of a struct type.
   /// 
   /// Example: for field := range s.Fields() { ... }
-  fn Fields(self: Ref<Struct>) -> iter.Seq<Ref<Var>>
+  fn Fields(self: Ref<Struct>) -> Option<iter.Seq<Ref<Var>>>
 
   /// NumFields returns the number of fields in the struct (including blank and embedded fields).
   fn NumFields(self: Ref<Struct>) -> int
@@ -1614,7 +1614,7 @@ impl Tuple {
   /// Variables returns a go1.23 iterator over the variables of a tuple type.
   /// 
   /// Example: for v := range tuple.Variables() { ... }
-  fn Variables(self: Ref<Tuple>) -> iter.Seq<Ref<Var>>
+  fn Variables(self: Ref<Tuple>) -> Option<iter.Seq<Ref<Var>>>
 }
 
 impl TypeAndValue {
@@ -1662,7 +1662,7 @@ impl TypeList {
   /// Types returns a go1.23 iterator over the elements of a list of types.
   /// 
   /// Example: for t := range l.Types() { ... }
-  fn Types(self: Ref<TypeList>) -> iter.Seq<Type>
+  fn Types(self: Ref<TypeList>) -> Option<iter.Seq<Type>>
 }
 
 impl TypeName {
@@ -1736,7 +1736,7 @@ impl TypeParamList {
   /// TypeParams returns a go1.23 iterator over a list of type parameters.
   /// 
   /// Example: for tparam := range l.TypeParams() { ... }
-  fn TypeParams(self: Ref<TypeParamList>) -> iter.Seq<Ref<TypeParam>>
+  fn TypeParams(self: Ref<TypeParamList>) -> Option<iter.Seq<Ref<TypeParam>>>
 }
 
 impl Union {
@@ -1749,7 +1749,7 @@ impl Union {
   /// Terms returns a go1.23 iterator over the terms of a union.
   /// 
   /// Example: for term := range union.Terms() { ... }
-  fn Terms(self: Ref<Union>) -> iter.Seq<Ref<Term>>
+  fn Terms(self: Ref<Union>) -> Option<iter.Seq<Ref<Term>>>
 
   fn Underlying(self: Ref<Union>) -> Type
 }

--- a/crates/stdlib/typedefs/iter.d.lis
+++ b/crates/stdlib/typedefs/iter.d.lis
@@ -25,7 +25,7 @@
 /// 
 /// If the iterator panics during a call to next (or stop),
 /// then next (or stop) itself panics with the same value.
-pub fn Pull<V>(seq: Seq<V>) -> (fn() -> Option<V>, fn() -> ())
+pub fn Pull<V>(seq: Seq<V>) -> (Option<fn() -> Option<V>>, Option<fn() -> ()>)
 
 /// Pull2 converts the “push-style” iterator sequence seq
 /// into a “pull-style” iterator accessed by the two functions
@@ -49,7 +49,7 @@ pub fn Pull<V>(seq: Seq<V>) -> (fn() -> Option<V>, fn() -> ())
 /// 
 /// If the iterator panics during a call to next (or stop),
 /// then next (or stop) itself panics with the same value.
-pub fn Pull2<K, V>(seq: Seq2<K, V>) -> (fn() -> Option<(K, V)>, fn() -> ())
+pub fn Pull2<K, V>(seq: Seq2<K, V>) -> (Option<fn() -> Option<(K, V)>>, Option<fn() -> ()>)
 
 /// Seq is an iterator over sequences of individual values.
 /// When called as seq(yield), seq calls yield(v) for each value v in the sequence,

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -263,7 +263,7 @@ pub fn ProxyFromEnvironment(req: Ref<Request>) -> Result<Ref<url.URL>, error>
 
 /// ProxyURL returns a proxy function (for use in a [Transport])
 /// that always returns the same URL.
-pub fn ProxyURL(fixedURL: Ref<url.URL>) -> fn(Ref<Request>) -> Result<Ref<url.URL>, error>
+pub fn ProxyURL(fixedURL: Ref<url.URL>) -> Option<fn(Ref<Request>) -> Result<Ref<url.URL>, error>>
 
 /// ReadRequest reads and parses an incoming request from b.
 /// 

--- a/crates/stdlib/typedefs/os/signal.d.lis
+++ b/crates/stdlib/typedefs/os/signal.d.lis
@@ -48,7 +48,7 @@ pub fn Notify(c: Sender<os.Signal>, sig: VarArgs<os.Signal>)
 /// The stop function releases resources associated with it, so code should
 /// call stop as soon as the operations running in this Context complete and
 /// signals no longer need to be diverted to the context.
-pub fn NotifyContext(parent: context.Context, signals: VarArgs<os.Signal>) -> (context.Context, context.CancelFunc)
+pub fn NotifyContext(parent: context.Context, signals: VarArgs<os.Signal>) -> (context.Context, Option<context.CancelFunc>)
 
 /// Reset undoes the effect of any prior calls to [Notify] for the provided
 /// signals.

--- a/crates/stdlib/typedefs/reflect.d.lis
+++ b/crates/stdlib/typedefs/reflect.d.lis
@@ -208,7 +208,7 @@ pub fn StructOf(fields: Slice<StructField>) -> Type
 /// slice.
 /// 
 /// Swapper panics if the provided interface is not a slice.
-pub fn Swapper(slice: Unknown) -> fn(int, int) -> ()
+pub fn Swapper(slice: Unknown) -> Option<fn(int, int) -> ()>
 
 /// TypeAssert is semantically equivalent to:
 /// 
@@ -783,14 +783,14 @@ impl Value {
   /// Otherwise v's kind must be Int, Int8, Int16, Int32, Int64,
   /// Uint, Uint8, Uint16, Uint32, Uint64, Uintptr,
   /// Array, Chan, Map, Slice, or String.
-  fn Seq(self) -> iter.Seq<Value>
+  fn Seq(self) -> Option<iter.Seq<Value>>
 
   /// Seq2 returns an iter.Seq2[Value, Value] that loops over the elements of v.
   /// If v's kind is Func, it must be a function that has no results and
   /// that takes a single argument of type func(K, V) bool for some type K, V.
   /// If v's kind is Pointer, the pointer element type must have kind Array.
   /// Otherwise v's kind must be Array, Map, Slice, or String.
-  fn Seq2(self) -> iter.Seq2<Value, Value>
+  fn Seq2(self) -> Option<iter.Seq2<Value, Value>>
 
   /// Set assigns x to the value v.
   /// It panics if [Value.CanSet] returns false.

--- a/crates/stdlib/typedefs/strings.d.lis
+++ b/crates/stdlib/typedefs/strings.d.lis
@@ -87,13 +87,13 @@ pub fn FieldsFunc(s: string, f: fn(int32) -> bool) -> Slice<string>
 /// Unicode code points satisfying f(c).
 /// The iterator yields the same strings that would be returned by [FieldsFunc](s),
 /// but without constructing the slice.
-pub fn FieldsFuncSeq(s: string, f: fn(int32) -> bool) -> iter.Seq<string>
+pub fn FieldsFuncSeq(s: string, f: fn(int32) -> bool) -> Option<iter.Seq<string>>
 
 /// FieldsSeq returns an iterator over substrings of s split around runs of
 /// whitespace characters, as defined by [unicode.IsSpace].
 /// The iterator yields the same strings that would be returned by [Fields](s),
 /// but without constructing the slice.
-pub fn FieldsSeq(s: string) -> iter.Seq<string>
+pub fn FieldsSeq(s: string) -> Option<iter.Seq<string>>
 
 /// HasPrefix reports whether the string s begins with prefix.
 pub fn HasPrefix(s: string, prefix: string) -> bool
@@ -145,7 +145,7 @@ pub fn LastIndexFunc(s: string, f: fn(int32) -> bool) -> int
 /// If s is empty, the iterator yields no lines at all.
 /// If s does not end in a newline, the final yielded line will not end in a newline.
 /// It returns a single-use iterator.
-pub fn Lines(s: string) -> iter.Seq<string>
+pub fn Lines(s: string) -> Option<iter.Seq<string>>
 
 /// Map returns a copy of the string s with all its characters modified
 /// according to the mapping function. If mapping returns a negative value, the character is
@@ -219,7 +219,7 @@ pub fn SplitAfterN(s: string, sep: string, n: int) -> Slice<string>
 /// The iterator yields the same strings that would be returned by [SplitAfter](s, sep),
 /// but without constructing the slice.
 /// It returns a single-use iterator.
-pub fn SplitAfterSeq(s: string, sep: string) -> iter.Seq<string>
+pub fn SplitAfterSeq(s: string, sep: string) -> Option<iter.Seq<string>>
 
 /// SplitN slices s into substrings separated by sep and returns a slice of
 /// the substrings between those separators.
@@ -239,7 +239,7 @@ pub fn SplitN(s: string, sep: string, n: int) -> Slice<string>
 /// The iterator yields the same strings that would be returned by [Split](s, sep),
 /// but without constructing the slice.
 /// It returns a single-use iterator.
-pub fn SplitSeq(s: string, sep: string) -> iter.Seq<string>
+pub fn SplitSeq(s: string, sep: string) -> Option<iter.Seq<string>>
 
 /// Title returns a copy of the string s with all Unicode letters that begin words
 /// mapped to their Unicode title case.

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -1,0 +1,491 @@
+use crate::assert_emit_snapshot_with_go_typedefs;
+
+// Issue #90: a Lisette concrete whose `Read` returns `Partial<int, error>`
+// must be wrappable as `io.Reader`. The adapter unpacks Partial into
+// Go's native `(int, error)`.
+#[test]
+fn partial_return_is_wrapped_when_used_as_go_interface() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn consume(r: io.Reader) {
+  let _ = r
+}
+
+fn main() {
+  let d = Doubler {}
+  consume(d as io.Reader)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// A Lisette struct satisfying a Go interface whose methods use bare Go
+// shapes (no Result/Partial/Option/tuple) must NOT trigger the adapter
+// pass. Regression guard for the pass-through path.
+#[test]
+fn pure_signature_interface_skips_adapter() {
+    let input = r#"
+import "go:example.com/simple"
+
+struct Greeter {}
+
+impl Greeter {
+  fn Greet(self, name: string) -> string {
+    name
+  }
+}
+
+fn call(g: simple.Greeter) -> string {
+  g.Greet("world")
+}
+
+fn main() {
+  let g = Greeter {}
+  let _ = call(g as simple.Greeter)
+}
+"#;
+    let typedef = r#"
+pub interface Greeter {
+  fn Greet(name: string) -> string
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/simple", typedef)]);
+}
+
+// Mixed adaptation: one method's return is adapted, another is bare.
+// The adapter forwards both; only the adapted method runs the shim.
+#[test]
+fn mixed_adapted_and_bare_methods() {
+    let input = r#"
+import "go:example.com/mixed"
+
+struct Svc {}
+
+impl Svc {
+  fn Load(self, key: string) -> Result<int, error> {
+    Ok(1)
+  }
+  fn Name(self) -> string {
+    "svc"
+  }
+}
+
+fn run(s: mixed.Service) -> string {
+  s.Name()
+}
+
+fn main() {
+  let s = Svc {}
+  let _ = run(s as mixed.Service)
+}
+"#;
+    let typedef = r#"
+pub interface Service {
+  fn Load(key: string) -> Result<int, error>
+  fn Name() -> string
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/mixed", typedef)]);
+}
+
+// Two cast sites that refer to the same (concrete, interface) pair
+// share a single synthesized adapter type declaration.
+#[test]
+fn adapter_type_is_deduplicated_across_cast_sites() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn consume_a(r: io.Reader) {
+  let _ = r
+}
+
+fn consume_b(r: io.Reader) {
+  let _ = r
+}
+
+fn main() {
+  let d = Doubler {}
+  consume_a(d as io.Reader)
+  consume_b(d as io.Reader)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 3: function argument. The concrete flows
+// through a call arg position without an explicit `as` cast.
+#[test]
+fn implicit_coercion_in_function_argument() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn consume(r: io.Reader) {
+  let _ = r
+}
+
+fn main() {
+  let d = Doubler {}
+  consume(d)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 4: return value. The function returns a
+// concrete in a slot typed as the Go interface.
+#[test]
+fn coercion_in_tail_return_position() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn make() -> io.Reader {
+  let d = Doubler {}
+  d
+}
+
+fn main() {
+  let _ = make()
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 2: typed let binding. A concrete is assigned
+// to a local declared as the Go interface type.
+#[test]
+fn coercion_in_typed_let_binding() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn main() {
+  let d = Doubler {}
+  let r: io.Reader = d
+  let _ = r
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 6: struct literal field.
+#[test]
+fn coercion_in_struct_literal_field() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+struct Wrapper {
+  reader: io.Reader,
+}
+
+fn main() {
+  let d = Doubler {}
+  let w = Wrapper { reader: d }
+  let _ = w
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 8: map value. Lisette has no map literal; maps are
+// built via `Map.new()` + indexed assignment, which routes through the
+// assignment hook already covered by `assignments.rs`.
+#[test]
+fn coercion_in_map_value_via_indexed_assignment() {
+    let input = r#"
+import "go:io"
+
+struct Doubler {}
+
+impl Doubler {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn main() {
+  let mut m = Map.new<string, io.Reader>()
+  let d = Doubler {}
+  m["src"] = d
+  let _ = m
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 9, Position::Assign variant: match is stored in
+// a typed let binding. Arm values must be wrapped as the match flows
+// through `emit_block_to_var_with_braces`.
+#[test]
+fn coercion_in_match_arm_via_typed_let() {
+    let input = r#"
+import "go:io"
+
+struct A {}
+struct B {}
+
+impl A {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+impl B {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn main() {
+  let flag = true
+  let r: io.Reader = match flag {
+    true => A {},
+    false => B {},
+  }
+  let _ = r
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Coverage for scenario 9: match arm value. Each arm produces a
+// concrete and the match's result type is a Go interface.
+#[test]
+fn coercion_in_match_arm_value() {
+    let input = r#"
+import "go:io"
+
+struct A {}
+struct B {}
+
+impl A {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+impl B {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn pick(flag: bool) -> io.Reader {
+  match flag {
+    true => A {},
+    false => B {},
+  }
+}
+
+fn main() {
+  let _ = pick(true)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+// Regression: an interface that embeds another interface must expose
+// its inherited methods in the synthesized adapter. A Lisette struct
+// satisfying `ReadWriteCloser` (which embeds `Reader` and `Writer`)
+// must have the adapter emit `Read` and `Write` even though
+// `ReadWriteCloser.methods` is empty — inherited methods live under
+// `parents`.
+#[test]
+fn adapter_includes_methods_inherited_from_parent_interfaces() {
+    let input = r#"
+import "go:example.com/rw"
+
+struct Dev {}
+
+impl Dev {
+  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+  fn Write(self, p: Slice<uint8>) -> Partial<int, error> {
+    Partial.Ok(0)
+  }
+}
+
+fn use_rw(rw: rw.ReadWriter) {
+  let _ = rw
+}
+
+fn main() {
+  let d = Dev {}
+  use_rw(d as rw.ReadWriter)
+}
+"#;
+    let typedef = r#"
+pub interface Reader {
+  fn Read(mut p: Slice<uint8>) -> Partial<int, error>
+}
+
+pub interface Writer {
+  fn Write(p: Slice<uint8>) -> Partial<int, error>
+}
+
+pub interface ReadWriter {
+  impl Reader
+  impl Writer
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/rw", typedef)]);
+}
+
+// Regression: Option<Ref<T>> and Option<Interface> are nullable Go
+// shapes. A Lisette impl of a Go interface method returning such an
+// Option must emit the adapter's Go method with the bare nilable
+// pointer/interface and unwrap `Some(v) -> v, None -> nil`. The old
+// behavior emitted `(T, bool)` which does not satisfy the Go
+// interface.
+#[test]
+fn option_ref_in_interface_method_adapts_to_bare_nilable_pointer() {
+    let input = r#"
+import "go:example.com/store"
+
+struct Store {}
+
+impl Store {
+  fn Find(self, key: string) -> Option<Ref<store.Entry>> {
+    None
+  }
+}
+
+fn use_store(s: store.Storage) {
+  let _ = s
+}
+
+fn main() {
+  let s = Store {}
+  use_store(s as store.Storage)
+}
+"#;
+    let typedef = r#"
+pub struct Entry { pub Name: string }
+
+pub interface Storage {
+  fn Find(key: string) -> Option<Ref<Entry>>
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/store", typedef)]);
+}
+
+// Regression for tea.Cmd alias collapse. A Go function-type alias
+// (`type Cmd func() Msg`) used inside an `Option<Cmd>` in return
+// position must preserve the Cmd name end-to-end — otherwise Go's
+// strict generic inference instantiates `Option[func() Msg]` and
+// rejects it where `Option[Cmd]` is expected. The fix required:
+// (1) `infer_tuple` resolving expected_ty through type variables,
+// (2) `is_generic_container_with_interface` firing for go:-prefixed
+// params, and (3) `resolve_call_type_args` emitting explicit type
+// args for Go function aliases on Some/Ok/Err.
+#[test]
+fn go_named_function_alias_preserved_through_option_tuple_return() {
+    let input = r#"
+import "go:example.com/tea"
+
+struct Model {}
+
+impl Model {
+  fn Init(self) -> Option<tea.Cmd> {
+    None
+  }
+  fn Update(self, msg: tea.Msg) -> (tea.Model, Option<tea.Cmd>) {
+    (self as tea.Model, Some(tea.Quit))
+  }
+  fn View(self) -> string {
+    ""
+  }
+}
+
+fn main() {
+  let _ = tea.NewProgram(Model {} as tea.Model)
+}
+"#;
+    let typedef = r#"// Package: tea
+
+pub interface Msg {}
+
+pub type Cmd = fn() -> Msg
+
+pub interface Model {
+  fn Init() -> Option<Cmd>
+  fn Update(arg0: Msg) -> (Model, Option<Cmd>)
+  fn View() -> string
+}
+
+pub type Program
+
+pub fn NewProgram(model: Model) -> Ref<Program>
+
+pub fn Quit() -> Msg
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/tea", typedef)]);
+}
+
+// Coverage for scenario 11: interface-to-interface. A Go interface value
+// assigned to another Go interface uses Go's structural conversion; no
+// adapter is synthesized (the `needs_adapter` source-side guard early-
+// returns when source is already Go-imported).
+#[test]
+fn interface_to_interface_does_not_synthesize_adapter() {
+    let input = r#"
+import "go:io"
+
+fn narrow(rwc: io.ReadWriteCloser) -> io.Reader {
+  rwc
+}
+
+fn main() {
+  let _ = narrow
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}

--- a/tests/spec/emit/mod.rs
+++ b/tests/spec/emit/mod.rs
@@ -2,6 +2,7 @@ mod concurrency;
 mod control_flow;
 mod expressions;
 mod functions;
+mod go_interface_adapter;
 mod imports;
 mod interop_matrix;
 mod line_directives;

--- a/tests/spec/emit/snapshots/adapter_includes_methods_inherited_from_parent_interfaces.snap
+++ b/tests/spec/emit/snapshots/adapter_includes_methods_inherited_from_parent_interfaces.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/rw\"\n\nstruct Dev {}\n\nimpl Dev {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n  fn Write(self, p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn use_rw(rw: rw.ReadWriter) {\n  let _ = rw\n}\n\nfn main() {\n  let d = Dev {}\n  use_rw(d as rw.ReadWriter)\n}\n"
+---
+package main
+
+import (
+	"example.com/rw"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Dev struct{}
+
+func (d Dev) String() string {
+	return "Dev"
+}
+
+func (d Dev) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func (d Dev) Write(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func use_rw(rw rw.ReadWriter) {
+	_ = rw
+}
+
+func main() {
+	d := Dev{}
+	use_rw(_lisAdapter_Dev_ReadWriter_0{inner: d})
+}
+
+type _lisAdapter_Dev_ReadWriter_0 struct {
+	inner Dev
+}
+
+func (a _lisAdapter_Dev_ReadWriter_0) Write(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Write(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}
+
+func (a _lisAdapter_Dev_ReadWriter_0) Read(arg0 []uint8) (int, error) {
+	res_2 := a.inner.Read(arg0)
+	if res_2.Tag == lisette.PartialOk {
+		return res_2.OkVal, nil
+	}
+	if res_2.Tag == lisette.PartialErr {
+		return *new(int), res_2.ErrVal
+	}
+	return res_2.OkVal, res_2.ErrVal
+}

--- a/tests/spec/emit/snapshots/adapter_type_is_deduplicated_across_cast_sites.snap
+++ b/tests/spec/emit/snapshots/adapter_type_is_deduplicated_across_cast_sites.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn consume_a(r: io.Reader) {\n  let _ = r\n}\n\nfn consume_b(r: io.Reader) {\n  let _ = r\n}\n\nfn main() {\n  let d = Doubler {}\n  consume_a(d as io.Reader)\n  consume_b(d as io.Reader)\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func consume_a(r io.Reader) {
+	_ = r
+}
+
+func consume_b(r io.Reader) {
+	_ = r
+}
+
+func main() {
+	d := Doubler{}
+	consume_a(_lisAdapter_Doubler_Reader_0{inner: d})
+	consume_b(_lisAdapter_Doubler_Reader_0{inner: d})
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_map_value_via_indexed_assignment.snap
+++ b/tests/spec/emit/snapshots/coercion_in_map_value_via_indexed_assignment.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn main() {\n  let mut m = Map.new<string, io.Reader>()\n  let d = Doubler {}\n  m[\"src\"] = d\n  let _ = m\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func main() {
+	m := make(map[string]io.Reader)
+	d := Doubler{}
+	m["src"] = _lisAdapter_Doubler_Reader_0{inner: d}
+	_ = m
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_match_arm_value.snap
+++ b/tests/spec/emit/snapshots/coercion_in_match_arm_value.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct A {}\nstruct B {}\n\nimpl A {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nimpl B {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn pick(flag: bool) -> io.Reader {\n  match flag {\n    true => A {},\n    false => B {},\n  }\n}\n\nfn main() {\n  let _ = pick(true)\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type A struct{}
+
+func (a A) String() string {
+	return "A"
+}
+
+type B struct{}
+
+func (b B) String() string {
+	return "B"
+}
+
+func (a A) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func (b B) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func pick(flag bool) io.Reader {
+	if flag {
+		return _lisAdapter_A_Reader_0{inner: A{}}
+	}
+	return _lisAdapter_B_Reader_1{inner: B{}}
+}
+
+func main() {
+	_ = pick(true)
+}
+
+type _lisAdapter_A_Reader_0 struct {
+	inner A
+}
+
+func (a _lisAdapter_A_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}
+
+type _lisAdapter_B_Reader_1 struct {
+	inner B
+}
+
+func (a _lisAdapter_B_Reader_1) Read(arg0 []uint8) (int, error) {
+	res_2 := a.inner.Read(arg0)
+	if res_2.Tag == lisette.PartialOk {
+		return res_2.OkVal, nil
+	}
+	if res_2.Tag == lisette.PartialErr {
+		return *new(int), res_2.ErrVal
+	}
+	return res_2.OkVal, res_2.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_match_arm_via_typed_let.snap
+++ b/tests/spec/emit/snapshots/coercion_in_match_arm_via_typed_let.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct A {}\nstruct B {}\n\nimpl A {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nimpl B {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn main() {\n  let flag = true\n  let r: io.Reader = match flag {\n    true => A {},\n    false => B {},\n  }\n  let _ = r\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type A struct{}
+
+func (a A) String() string {
+	return "A"
+}
+
+type B struct{}
+
+func (b B) String() string {
+	return "B"
+}
+
+func (a A) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func (b B) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func main() {
+	flag := true
+	var r io.Reader
+	if flag {
+		r = _lisAdapter_A_Reader_0{inner: A{}}
+	} else {
+		r = _lisAdapter_B_Reader_1{inner: B{}}
+	}
+	_ = r
+}
+
+type _lisAdapter_A_Reader_0 struct {
+	inner A
+}
+
+func (a _lisAdapter_A_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}
+
+type _lisAdapter_B_Reader_1 struct {
+	inner B
+}
+
+func (a _lisAdapter_B_Reader_1) Read(arg0 []uint8) (int, error) {
+	res_2 := a.inner.Read(arg0)
+	if res_2.Tag == lisette.PartialOk {
+		return res_2.OkVal, nil
+	}
+	if res_2.Tag == lisette.PartialErr {
+		return *new(int), res_2.ErrVal
+	}
+	return res_2.OkVal, res_2.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_struct_literal_field.snap
+++ b/tests/spec/emit/snapshots/coercion_in_struct_literal_field.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nstruct Wrapper {\n  reader: io.Reader,\n}\n\nfn main() {\n  let d = Doubler {}\n  let w = Wrapper { reader: d }\n  let _ = w\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+type Wrapper struct {
+	reader io.Reader
+}
+
+func (w Wrapper) String() string {
+	return fmt.Sprintf("Wrapper { reader: %v }", w.reader)
+}
+
+func main() {
+	d := Doubler{}
+	_ = Wrapper{reader: _lisAdapter_Doubler_Reader_0{inner: d}}
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_tail_return_position.snap
+++ b/tests/spec/emit/snapshots/coercion_in_tail_return_position.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn make() -> io.Reader {\n  let d = Doubler {}\n  d\n}\n\nfn main() {\n  let _ = make()\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func make_() io.Reader {
+	d := Doubler{}
+	return _lisAdapter_Doubler_Reader_0{inner: d}
+}
+
+func main() {
+	_ = make_()
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/coercion_in_typed_let_binding.snap
+++ b/tests/spec/emit/snapshots/coercion_in_typed_let_binding.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn main() {\n  let d = Doubler {}\n  let r: io.Reader = d\n  let _ = r\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func main() {
+	d := Doubler{}
+	var r io.Reader = _lisAdapter_Doubler_Reader_0{inner: d}
+	_ = r
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/go_named_function_alias_preserved_through_option_tuple_return.snap
+++ b/tests/spec/emit/snapshots/go_named_function_alias_preserved_through_option_tuple_return.snap
@@ -1,0 +1,60 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/tea\"\n\nstruct Model {}\n\nimpl Model {\n  fn Init(self) -> Option<tea.Cmd> {\n    None\n  }\n  fn Update(self, msg: tea.Msg) -> (tea.Model, Option<tea.Cmd>) {\n    (self as tea.Model, Some(tea.Quit))\n  }\n  fn View(self) -> string {\n    \"\"\n  }\n}\n\nfn main() {\n  let _ = tea.NewProgram(Model {} as tea.Model)\n}\n"
+---
+package main
+
+import (
+	"example.com/tea"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Model struct{}
+
+func (m Model) String() string {
+	return "Model"
+}
+
+func (m Model) Init() lisette.Option[tea.Cmd] {
+	return lisette.MakeOptionNone[tea.Cmd]()
+}
+
+func (m Model) Update(_ tea.Msg) lisette.Tuple2[tea.Model, lisette.Option[tea.Cmd]] {
+	return lisette.MakeTuple2[tea.Model, lisette.Option[tea.Cmd]](_lisAdapter_Model_Model_0{inner: m}, lisette.MakeOptionSome[tea.Cmd](tea.Quit))
+}
+
+func (m Model) View() string {
+	return ""
+}
+
+func main() {
+	_ = tea.NewProgram(_lisAdapter_Model_Model_0{inner: Model{}})
+}
+
+type _lisAdapter_Model_Model_0 struct {
+	inner Model
+}
+
+func (a _lisAdapter_Model_Model_0) View() string {
+	return a.inner.View()
+}
+
+func (a _lisAdapter_Model_Model_0) Init() tea.Cmd {
+	opt_1 := a.inner.Init()
+	if opt_1.Tag == lisette.OptionSome {
+		return opt_1.SomeVal
+	}
+	return nil
+}
+
+func (a _lisAdapter_Model_Model_0) Update(arg0 tea.Msg) (tea.Model, tea.Cmd) {
+	tup_2 := a.inner.Update(arg0)
+	sub_4 := func() tea.Cmd {
+		opt_3 := tup_2.Second
+		if opt_3.Tag == lisette.OptionSome {
+			return opt_3.SomeVal
+		}
+		return nil
+	}()
+	return tup_2.First, sub_4
+}

--- a/tests/spec/emit/snapshots/implicit_coercion_in_function_argument.snap
+++ b/tests/spec/emit/snapshots/implicit_coercion_in_function_argument.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn consume(r: io.Reader) {\n  let _ = r\n}\n\nfn main() {\n  let d = Doubler {}\n  consume(d)\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func consume(r io.Reader) {
+	_ = r
+}
+
+func main() {
+	d := Doubler{}
+	consume(_lisAdapter_Doubler_Reader_0{inner: d})
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/interface_to_interface_does_not_synthesize_adapter.snap
+++ b/tests/spec/emit/snapshots/interface_to_interface_does_not_synthesize_adapter.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nfn narrow(rwc: io.ReadWriteCloser) -> io.Reader {\n  rwc\n}\n\nfn main() {\n  let _ = narrow\n}\n"
+---
+package main
+
+import "io"
+
+func narrow(rwc io.ReadWriteCloser) io.Reader {
+	return rwc
+}
+
+func main() {
+	_ = narrow
+}

--- a/tests/spec/emit/snapshots/mixed_adapted_and_bare_methods.snap
+++ b/tests/spec/emit/snapshots/mixed_adapted_and_bare_methods.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/mixed\"\n\nstruct Svc {}\n\nimpl Svc {\n  fn Load(self, key: string) -> Result<int, error> {\n    Ok(1)\n  }\n  fn Name(self) -> string {\n    \"svc\"\n  }\n}\n\nfn run(s: mixed.Service) -> string {\n  s.Name()\n}\n\nfn main() {\n  let s = Svc {}\n  let _ = run(s as mixed.Service)\n}\n"
+---
+package main
+
+import (
+	"example.com/mixed"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Svc struct{}
+
+func (s Svc) String() string {
+	return "Svc"
+}
+
+func (s Svc) Load(_ string) lisette.Result[int, error] {
+	return lisette.MakeResultOk[int, error](1)
+}
+
+func (s Svc) Name() string {
+	return "svc"
+}
+
+func run(s mixed.Service) string {
+	return s.Name()
+}
+
+func main() {
+	s := Svc{}
+	_ = run(_lisAdapter_Svc_Service_0{inner: s})
+}
+
+type _lisAdapter_Svc_Service_0 struct {
+	inner Svc
+}
+
+func (a _lisAdapter_Svc_Service_0) Load(arg0 string) (int, error) {
+	res_1 := a.inner.Load(arg0)
+	if res_1.Tag == lisette.ResultOk {
+		return res_1.OkVal, nil
+	}
+	return *new(int), res_1.ErrVal
+}
+
+func (a _lisAdapter_Svc_Service_0) Name() string {
+	return a.inner.Name()
+}

--- a/tests/spec/emit/snapshots/option_ref_in_interface_method_adapts_to_bare_nilable_pointer.snap
+++ b/tests/spec/emit/snapshots/option_ref_in_interface_method_adapts_to_bare_nilable_pointer.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/store\"\n\nstruct Store {}\n\nimpl Store {\n  fn Find(self, key: string) -> Option<Ref<store.Entry>> {\n    None\n  }\n}\n\nfn use_store(s: store.Storage) {\n  let _ = s\n}\n\nfn main() {\n  let s = Store {}\n  use_store(s as store.Storage)\n}\n"
+---
+package main
+
+import (
+	"example.com/store"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Store struct{}
+
+func (s Store) String() string {
+	return "Store"
+}
+
+func (s Store) Find(_ string) lisette.Option[*store.Entry] {
+	return lisette.MakeOptionNone[*store.Entry]()
+}
+
+func use_store(s store.Storage) {
+	_ = s
+}
+
+func main() {
+	s := Store{}
+	use_store(_lisAdapter_Store_Storage_0{inner: s})
+}
+
+type _lisAdapter_Store_Storage_0 struct {
+	inner Store
+}
+
+func (a _lisAdapter_Store_Storage_0) Find(arg0 string) *store.Entry {
+	opt_1 := a.inner.Find(arg0)
+	if opt_1.Tag == lisette.OptionSome {
+		return opt_1.SomeVal
+	}
+	return nil
+}

--- a/tests/spec/emit/snapshots/partial_return_is_wrapped_when_used_as_go_interface.snap
+++ b/tests/spec/emit/snapshots/partial_return_is_wrapped_when_used_as_go_interface.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n  fn Read(self, mut p: Slice<uint8>) -> Partial<int, error> {\n    Partial.Ok(0)\n  }\n}\n\nfn consume(r: io.Reader) {\n  let _ = r\n}\n\nfn main() {\n  let d = Doubler {}\n  consume(d as io.Reader)\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+type Doubler struct{}
+
+func (d Doubler) String() string {
+	return "Doubler"
+}
+
+func (d Doubler) Read(_ []uint8) lisette.Partial[int, error] {
+	return lisette.MakePartialOk[int, error](0)
+}
+
+func consume(r io.Reader) {
+	_ = r
+}
+
+func main() {
+	d := Doubler{}
+	consume(_lisAdapter_Doubler_Reader_0{inner: d})
+}
+
+type _lisAdapter_Doubler_Reader_0 struct {
+	inner Doubler
+}
+
+func (a _lisAdapter_Doubler_Reader_0) Read(arg0 []uint8) (int, error) {
+	res_1 := a.inner.Read(arg0)
+	if res_1.Tag == lisette.PartialOk {
+		return res_1.OkVal, nil
+	}
+	if res_1.Tag == lisette.PartialErr {
+		return *new(int), res_1.ErrVal
+	}
+	return res_1.OkVal, res_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/pure_signature_interface_skips_adapter.snap
+++ b/tests/spec/emit/snapshots/pure_signature_interface_skips_adapter.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/simple\"\n\nstruct Greeter {}\n\nimpl Greeter {\n  fn Greet(self, name: string) -> string {\n    name\n  }\n}\n\nfn call(g: simple.Greeter) -> string {\n  g.Greet(\"world\")\n}\n\nfn main() {\n  let g = Greeter {}\n  let _ = call(g as simple.Greeter)\n}\n"
+---
+package main
+
+import "example.com/simple"
+
+type Greeter struct{}
+
+func (g Greeter) String() string {
+	return "Greeter"
+}
+
+func (g Greeter) Greet(name string) string {
+	return name
+}
+
+func call(g simple.Greeter) string {
+	return g.Greet("world")
+}
+
+func main() {
+	g := Greeter{}
+	_ = call(g)
+}


### PR DESCRIPTION
This PR adds Go interface adapter emission, so Lisette structs can satisfy Go interfaces when their methods use Lisette-native adapted return shapes.

The core change is a cast-site wrapper generator in the Go emitter. When a Lisette concrete value flows into a Go-interface-typed position, the emitter now synthesizes a small adapter type that forwards methods to the original struct and unwraps Lisette returns into bare Go shapes.

Fix #90