### PR TITLE
fix: use declared package name over path segment as Go qualifier

### DIFF
--- a/crates/emit/src/go/names/resolution.rs
+++ b/crates/emit/src/go/names/resolution.rs
@@ -98,6 +98,9 @@ impl Emitter<'_> {
         if let Some(alias) = self.module.module_aliases.get(module) {
             return alias.clone();
         }
+        if let Some(pkg_name) = self.ctx.go_package_names.get(module) {
+            return pkg_name.clone();
+        }
         let path = module
             .strip_prefix(go_name::GO_IMPORT_PREFIX)
             .unwrap_or(module);

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -241,6 +241,21 @@ pub struct Style {}
 }
 
 #[test]
+fn go_type_uses_declared_package_name_not_path_segment() {
+    let input = r#"
+import "go:example.com/ultraviolet"
+
+fn handle(_msg: uv.Event) {
+}
+"#;
+    let typedef = r#"// Package: uv
+
+pub struct Event {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ultraviolet", typedef)]);
+}
+
+#[test]
 fn package_local_option_alias_does_not_collide_with_prelude_option() {
     // Regression: a Go module that declares its own `type Option = ...`
     // (e.g. the functional-options pattern) would trip `Type::is_option`

--- a/tests/spec/emit/snapshots/go_type_uses_declared_package_name_not_path_segment.snap
+++ b/tests/spec/emit/snapshots/go_type_uses_declared_package_name_not_path_segment.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:example.com/ultraviolet\"\n\nfn handle(_msg: uv.Event) {\n}\n"
+---
+package main
+
+import uv "example.com/ultraviolet"
+
+func handle(_ uv.Event) {}


### PR DESCRIPTION
Fix #99