### PR TITLE
fix: emit value equality for Go sentinel patterns like Err(io.EOF)

### DIFF
--- a/crates/emit/src/go/patterns/decision_tree.rs
+++ b/crates/emit/src/go/patterns/decision_tree.rs
@@ -712,6 +712,14 @@ fn collect_enum_variant_checks(
         return;
     }
 
+    if emitter.as_enum(ty).is_none() && identifier.contains('.') {
+        collector.checks.push(Check::Literal {
+            path: path.clone(),
+            go_literal: identifier.to_string(),
+        });
+        return;
+    }
+
     collect_tagged_enum_checks(emitter, path, &variant_data, collector);
 }
 

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1033,3 +1033,26 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn interop_err_sentinel_pattern() {
+    let input = r#"
+import "go:bufio"
+import "go:fmt"
+import "go:io"
+import "go:os"
+
+fn main() {
+  let reader = bufio.NewReader(os.Stdin)
+  while true {
+    let r = match reader.ReadRune() {
+      Ok((r, _)) => r,
+      Err(io.EOF) => break,
+      Err(_) => panic("error"),
+    }
+    fmt.Printf("%c", r)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
+++ b/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:bufio\"\nimport \"go:fmt\"\nimport \"go:io\"\nimport \"go:os\"\n\nfn main() {\n  let reader = bufio.NewReader(os.Stdin)\n  while true {\n    let r = match reader.ReadRune() {\n      Ok((r, _)) => r,\n      Err(io.EOF) => break,\n      Err(_) => panic(\"error\"),\n    }\n    fmt.Printf(\"%c\", r)\n  }\n}\n"
+---
+package main
+
+import (
+	"bufio"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+loop_1:
+	for {
+		var r_2 int32
+		ret_4, ret_5, ret_6 := reader.ReadRune()
+		tup_7 := lisette.MakeTuple2(ret_4, ret_5)
+		var subject_3 lisette.Result[lisette.Tuple2[int32, int], error]
+		if ret_6 != nil {
+			subject_3 = lisette.MakeResultErr[lisette.Tuple2[int32, int], error](ret_6)
+		} else {
+			subject_3 = lisette.MakeResultOk[lisette.Tuple2[int32, int], error](tup_7)
+		}
+		if subject_3.Tag == lisette.ResultOk {
+			r_2 = subject_3.OkVal.First
+		} else {
+			if subject_3.ErrVal == io.EOF {
+				break loop_1
+			}
+			panic("error")
+		}
+		fmt.Printf("%c", r_2)
+	}
+}


### PR DESCRIPTION
Fix #95