### PR TITLE
fix: formatter moves comments into impl, try, and recover blocks

### DIFF
--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -227,11 +227,12 @@ impl<'a> Formatter<'a> {
                 annotation,
                 generics,
                 methods,
+                span,
                 ..
             } => (
                 Document::Sequence(vec![]),
                 Visibility::Private,
-                self.impl_block(annotation, generics, methods),
+                self.impl_block(annotation, generics, methods, span.end()),
             ),
 
             Expression::Const {
@@ -1534,6 +1535,7 @@ impl<'a> Formatter<'a> {
         annotation: &'a Annotation,
         generics: &'a [Generic],
         methods: &'a [Expression],
+        impl_end: u32,
     ) -> Document<'a> {
         let generics_doc = Self::generics(generics);
         let header = Document::str("impl")
@@ -1545,11 +1547,31 @@ impl<'a> Formatter<'a> {
             return header.append(" {}");
         }
 
-        let methods_docs: Vec<_> = methods.iter().map(|m| self.definition(m)).collect();
-        Self::braced_body(
-            header,
-            join(methods_docs, concat([Document::Newline, Document::Newline])),
-        )
+        let mut docs = Vec::with_capacity(methods.len() * 5);
+
+        for (i, m) in methods.iter().enumerate() {
+            let start = m.get_span().byte_offset;
+
+            if i > 0 {
+                docs.push(Document::Newline);
+                docs.push(Document::Newline);
+            }
+
+            if let Some(comment_doc) = self.comments.take_comments_before(start) {
+                docs.push(comment_doc.force_break());
+                docs.push(Document::Newline);
+            }
+
+            docs.push(self.definition(m));
+        }
+
+        if let Some(trailing) = self.comments.take_comments_before(impl_end) {
+            docs.push(Document::Newline);
+            docs.push(Document::Newline);
+            docs.push(trailing.force_break());
+        }
+
+        Self::braced_body(header, concat(docs))
     }
 
     fn const_definition(

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -489,6 +489,10 @@ impl Span {
     pub fn is_dummy(&self) -> bool {
         self.byte_length == 0
     }
+
+    pub fn end(&self) -> u32 {
+        self.byte_offset + self.byte_length
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -534,18 +534,14 @@ impl<'source> Parser<'source> {
             }
         }
 
-        if self.is(RightCurlyBrace) {
-            self.next();
-        } else {
-            self.error_unclosed_block(&start);
-        }
+        let span = self.close_brace_span(start, start);
 
         self.leave_recursion();
 
         Expression::Block {
             ty: Type::uninferred(),
             items,
-            span: self.span_from_tokens(start),
+            span,
         }
     }
 
@@ -1139,11 +1135,7 @@ impl<'source> Parser<'source> {
             }
         }
 
-        if self.is(RightCurlyBrace) {
-            self.next();
-        } else {
-            self.error_unclosed_block(&brace_token);
-        }
+        let span = self.close_brace_span(start, brace_token);
 
         self.leave_recursion();
 
@@ -1151,7 +1143,7 @@ impl<'source> Parser<'source> {
             items,
             ty: Type::uninferred(),
             try_keyword_span,
-            span: self.span_from_tokens(start),
+            span,
         }
     }
 
@@ -1215,11 +1207,7 @@ impl<'source> Parser<'source> {
             }
         }
 
-        if self.is(RightCurlyBrace) {
-            self.next();
-        } else {
-            self.error_unclosed_block(&brace_token);
-        }
+        let span = self.close_brace_span(start, brace_token);
 
         self.leave_recursion();
 
@@ -1227,7 +1215,7 @@ impl<'source> Parser<'source> {
             items,
             ty: Type::uninferred(),
             recover_keyword_span,
-            span: self.span_from_tokens(start),
+            span,
         }
     }
 

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -594,6 +594,22 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
+    fn close_brace_span(&mut self, start: Token<'source>, error_anchor: Token<'source>) -> Span {
+        if self.is(RightCurlyBrace) {
+            let close = self.current_token();
+            self.next();
+            let end = close.byte_offset + close.byte_length;
+            Span::new(
+                self.file_id,
+                start.byte_offset,
+                end.saturating_sub(start.byte_offset),
+            )
+        } else {
+            self.error_unclosed_block(&error_anchor);
+            self.span_from_tokens(start)
+        }
+    }
+
     fn error_unclosed_block(&mut self, open_brace: &Token) {
         let span = ast::Span::new(self.file_id, open_brace.byte_offset, open_brace.byte_length);
         let error = ParseError::new("Unclosed block", span, "opening brace here")

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -433,6 +433,26 @@ fn impl_empty() {
 }
 
 #[test]
+fn impl_comment_before_method() {
+    assert_format_snapshot!("struct Foo {}\n\nimpl Foo {\n  // test\n  fn foo() {}\n}");
+}
+
+#[test]
+fn impl_comment_after_method() {
+    assert_format_snapshot!("struct Foo {}\n\nimpl Foo {\n  fn foo() {}\n  // test\n}");
+}
+
+#[test]
+fn try_block_comment_after() {
+    assert_format_snapshot!("fn foo() {\n  try {}\n  // comment\n}");
+}
+
+#[test]
+fn recover_block_comment_after() {
+    assert_format_snapshot!("fn foo() {\n  recover {}\n  // comment\n}");
+}
+
+#[test]
 fn import_single() {
     assert_format_snapshot!("import \"go:fmt\"");
 }

--- a/tests/spec/format/snapshots/impl_comment_after_method.snap
+++ b/tests/spec/format/snapshots/impl_comment_after_method.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Foo {}\n\nimpl Foo {\n  fn foo() {}\n  // test\n}"
+---
+struct Foo {}
+
+impl Foo {
+  fn foo() {}
+
+  // test
+}

--- a/tests/spec/format/snapshots/impl_comment_before_method.snap
+++ b/tests/spec/format/snapshots/impl_comment_before_method.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Foo {}\n\nimpl Foo {\n  // test\n  fn foo() {}\n}"
+---
+struct Foo {}
+
+impl Foo {
+  // test
+  fn foo() {}
+}

--- a/tests/spec/format/snapshots/recover_block_comment_after.snap
+++ b/tests/spec/format/snapshots/recover_block_comment_after.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn foo() {\n  recover {}\n  // comment\n}"
+---
+fn foo() {
+  recover {} // comment
+}

--- a/tests/spec/format/snapshots/try_block_comment_after.snap
+++ b/tests/spec/format/snapshots/try_block_comment_after.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn foo() {\n  try {}\n  // comment\n}"
+---
+fn foo() {
+  try {} // comment
+}


### PR DESCRIPTION
Fix #111