### PR TITLE
fix: don't flag wildcard as redundant in interface match

### DIFF
--- a/crates/semantics/src/pattern_analysis/mod.rs
+++ b/crates/semantics/src/pattern_analysis/mod.rs
@@ -24,6 +24,7 @@ use diagnostics::{DiagnosticSink, IssueKind, PatternIssue};
 use syntax::ast::{
     Expression, Literal, MatchOrigin, Pattern, SelectArmPattern, Span, TypedPattern,
 };
+use syntax::types::Type;
 
 use maranget::is_useful;
 use normalize::normalize_arm;
@@ -49,6 +50,15 @@ impl<'a> PatternAnalysisContext<'a> {
         NormalizationContext {
             store: self.store,
             cache: &self.cache,
+            scrutinee_type: None,
+        }
+    }
+
+    fn normalize_context_for_match(&self, scrutinee_type: Type) -> NormalizationContext<'_> {
+        NormalizationContext {
+            store: self.store,
+            cache: &self.cache,
+            scrutinee_type: Some(scrutinee_type),
         }
     }
 
@@ -161,7 +171,7 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Diagn
             }
 
             let mut unions = HashMap::default();
-            let norm_ctx = ctx.normalize_context();
+            let norm_ctx = ctx.normalize_context_for_match(subject.get_type());
 
             let unguarded_rows: Vec<Row> = arms
                 .iter()
@@ -522,6 +532,7 @@ pub fn is_pattern_irrefutable(typed_pattern: &TypedPattern, store: &Store) -> bo
     let norm_ctx = NormalizationContext {
         store,
         cache: &cache,
+        scrutinee_type: None,
     };
 
     let mut unions = HashMap::default();

--- a/crates/semantics/src/pattern_analysis/normalize.rs
+++ b/crates/semantics/src/pattern_analysis/normalize.rs
@@ -24,6 +24,7 @@ fn make_type_key(name: &str, type_args: &[Type]) -> String {
 pub struct NormalizationContext<'a> {
     pub store: &'a Store,
     pub cache: &'a InhabitanceCache,
+    pub scrutinee_type: Option<Type>,
 }
 
 pub fn normalize_arm(
@@ -197,6 +198,59 @@ pub fn normalize_typed_pattern(
                         .unwrap_or(Wildcard)
                 })
                 .collect();
+
+            // Interfaces are open: unknown structs can implement them at any time,
+            // so a wildcard after a struct arm is always reachable.
+            if let Some(scrutinee_ty) = &ctx.scrutinee_type {
+                let resolved = scrutinee_ty.resolve();
+                if let Type::Constructor {
+                    id: interface_id,
+                    params: interface_params,
+                    ..
+                } = &resolved
+                    && ctx.store.get_interface(interface_id).is_some()
+                {
+                    let interface_type_name = make_type_key(interface_id, interface_params);
+                    let struct_ctor = Constructor {
+                        tag_id: struct_name.to_string(),
+                        arity: struct_fields.len(),
+                    };
+
+                    if let Some(union) = unions.get_mut(&interface_type_name) {
+                        let mut found = false;
+                        let mut unknown_pos = union.len();
+                        for (i, c) in union.iter().enumerate() {
+                            if c.tag_id == struct_name.as_str() {
+                                found = true;
+                                break;
+                            }
+                            if c.tag_id == INTERFACE_UNKNOWN_TAG {
+                                unknown_pos = i;
+                            }
+                        }
+                        if !found {
+                            union.insert(unknown_pos, struct_ctor);
+                        }
+                    } else {
+                        unions.insert(
+                            interface_type_name.clone(),
+                            vec![
+                                struct_ctor,
+                                Constructor {
+                                    tag_id: INTERFACE_UNKNOWN_TAG.to_string(),
+                                    arity: 0,
+                                },
+                            ],
+                        );
+                    }
+
+                    return NormalizedPattern::Constructor {
+                        type_name: interface_type_name,
+                        tag: struct_name.to_string(),
+                        args: patterns,
+                    };
+                }
+            }
 
             let type_name = make_type_key(struct_name, type_args);
 

--- a/crates/semantics/src/pattern_analysis/types.rs
+++ b/crates/semantics/src/pattern_analysis/types.rs
@@ -27,3 +27,5 @@ pub enum NormalizedPattern {
 }
 
 pub type UnionTable = HashMap<TypeName, Union>;
+
+pub const INTERFACE_UNKNOWN_TAG: &str = "__interface_unknown__";

--- a/crates/semantics/src/pattern_analysis/witness.rs
+++ b/crates/semantics/src/pattern_analysis/witness.rs
@@ -1,4 +1,5 @@
 use super::NormalizedPattern;
+use super::types::INTERFACE_UNKNOWN_TAG;
 use syntax::ast::Literal;
 
 pub fn format_witness(pattern: &NormalizedPattern) -> String {
@@ -29,7 +30,7 @@ pub fn format_witness(pattern: &NormalizedPattern) -> String {
 
             let display_tag = strip_module_prefix(tag);
 
-            if display_tag == "__value_enum_unknown__" {
+            if display_tag == "__value_enum_unknown__" || display_tag == INTERFACE_UNKNOWN_TAG {
                 return "_".to_string();
             }
 
@@ -77,7 +78,7 @@ pub fn format_pattern(pattern: &NormalizedPattern) -> String {
 
             let display_tag = strip_module_prefix(tag);
 
-            if display_tag == "__value_enum_unknown__" {
+            if display_tag == "__value_enum_unknown__" || display_tag == INTERFACE_UNKNOWN_TAG {
                 return "_".to_string();
             }
 

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -1613,3 +1613,52 @@ fn test(p: Partial<int, string>) -> int {
 "#;
     infer(input).assert_no_errors();
 }
+
+#[test]
+fn test_struct_arm_against_interface_wildcard_not_redundant() {
+    let input = r#"
+interface Event {}
+struct ClickEvent { x: int, y: int }
+
+fn handle(event: Event) -> int {
+  match event {
+    ClickEvent { x, .. } => x,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_multiple_struct_arms_against_interface_wildcard_not_redundant() {
+    let input = r#"
+interface Event {}
+struct ClickEvent { x: int, y: int }
+struct KeyEvent { key: string }
+
+fn handle(event: Event) -> int {
+  match event {
+    ClickEvent { x, .. } => x,
+    KeyEvent { .. } => 1,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_struct_arm_against_interface_without_wildcard_is_non_exhaustive() {
+    let input = r#"
+interface Event {}
+struct ClickEvent { x: int, y: int }
+
+fn handle(event: Event) -> int {
+  match event {
+    ClickEvent { x, .. } => x,
+  }
+}
+"#;
+    infer(input).assert_exhaustiveness_error();
+}


### PR DESCRIPTION
Fix #112