### PR TITLE
fix: preserve type alias names in emitter output

### DIFF
--- a/crates/emit/src/go/definitions/toplevel.rs
+++ b/crates/emit/src/go/definitions/toplevel.rs
@@ -967,7 +967,14 @@ impl Emitter<'_> {
 
 fn is_option_type(ty: &Type) -> bool {
     match ty {
-        Type::Constructor { id, .. } => id == "Option" || id.ends_with(".Option"),
+        Type::Constructor {
+            id, underlying_ty, ..
+        } => {
+            if id == "Option" || id.ends_with(".Option") {
+                return true;
+            }
+            underlying_ty.as_deref().is_some_and(is_option_type)
+        }
         _ => false,
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -442,7 +442,7 @@ impl Checker<'_, '_> {
         let iterable_ty = self.new_type_var();
         let new_iterable = self.infer_expression(*iterable, &iterable_ty);
 
-        let resolved_iterable_ty = iterable_ty.resolve();
+        let resolved_iterable_ty = self.peel_alias(&iterable_ty.resolve());
 
         let iterable_ty_name = match resolved_iterable_ty.get_name() {
             Some(name) => name,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -295,13 +295,38 @@ impl Checker<'_, '_> {
 
         let qualified_name = deref_ty.get_qualified_name();
 
+        let struct_name = {
+            let mut name = qualified_name.clone();
+            let mut seen = Vec::new();
+            loop {
+                if seen.contains(&name) {
+                    break;
+                }
+                seen.push(name.clone());
+                let new_name = match self.store.get_definition(&name) {
+                    Some(Definition::TypeAlias { ty, .. }) => {
+                        if let Type::Constructor { id, .. } = ty.unwrap_forall()
+                            && id.as_str() != name.as_str()
+                        {
+                            id.clone()
+                        } else {
+                            break;
+                        }
+                    }
+                    _ => break,
+                };
+                name = new_name;
+            }
+            name
+        };
+
         let Some(Definition::Struct {
             ty: struct_type,
             fields: struct_fields,
             kind: struct_kind,
             generics,
             ..
-        }) = self.store.get_definition(&qualified_name)
+        }) = self.store.get_definition(&struct_name)
         else {
             return None;
         };
@@ -328,7 +353,7 @@ impl Checker<'_, '_> {
 
         self.facts.add_usage(*args.span, field.name_span);
 
-        let struct_module = qualified_name.split('.').next().unwrap_or(&qualified_name);
+        let struct_module = struct_name.split('.').next().unwrap_or(&struct_name);
         let is_cross_module = struct_module != self.cursor.module_id;
 
         if is_cross_module && !field_is_pub {

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -27,7 +27,7 @@ impl Checker<'_, '_> {
         self.check_not_temp_producing(&index_expression);
 
         let resolved_index_ty = index_ty_var.resolve();
-        let resolved_collection_ty = collection_ty_var.resolve();
+        let resolved_collection_ty = self.peel_alias(&collection_ty_var.resolve());
 
         if resolved_collection_ty.is_error() {
             self.unify(expected_ty, &Type::Error, &span);
@@ -150,7 +150,7 @@ impl Checker<'_, '_> {
         let collection_ty_var = self.new_type_var();
         let collection_expression =
             self.with_value_context(|s| s.infer_expression(*expression, &collection_ty_var));
-        let resolved_collection_ty = collection_ty_var.resolve();
+        let resolved_collection_ty = self.peel_alias(&collection_ty_var.resolve());
 
         if resolved_collection_ty.is_error() {
             self.unify(expected_ty, &Type::Error, &span);

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -174,6 +174,22 @@ impl Checker<'_, '_> {
         };
 
         if symbol1 != symbol2 {
+            if let Constructor {
+                underlying_ty: Some(u),
+                ..
+            } = t1
+                && self.try_unify(u, t2, span).is_ok()
+            {
+                return Ok(());
+            }
+            if let Constructor {
+                underlying_ty: Some(u),
+                ..
+            } = t2
+                && self.try_unify(t1, u, span).is_ok()
+            {
+                return Ok(());
+            }
             return self.try_coerce_or_satisfy_interface(t1, t2, span);
         }
 

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -460,6 +460,26 @@ impl<'r, 's> Checker<'r, 's> {
         Some((qualified_name, ty))
     }
 
+    pub(crate) fn peel_alias(&self, ty: &Type) -> Type {
+        let mut current = ty.clone();
+        while let Type::Constructor {
+            id,
+            underlying_ty: Some(u),
+            ..
+        } = &current
+        {
+            if !self
+                .store
+                .get_definition(id)
+                .is_some_and(|d| matches!(d, Definition::TypeAlias { .. }))
+            {
+                break;
+            }
+            current = *u.clone();
+        }
+        current
+    }
+
     pub(crate) fn get_all_methods(&self, ty: &Type) -> MethodSignatures {
         if let Type::Parameter(name) = ty {
             let trait_bounds = self.scopes.collect_all_trait_bounds();

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span};
+use syntax::program::Definition;
 use syntax::types::{SubstitutionMap, Type, substitute};
 
 use crate::checker::Checker;
@@ -105,7 +106,16 @@ impl Checker<'_, '_> {
                     ));
                 }
 
-                let resolved_ty = self.instantiate_from_annotations(&generics, &body, params, span);
+                let concrete_args: Vec<Type> = params
+                    .iter()
+                    .map(|arg| self.convert_to_type(arg, span))
+                    .collect();
+                let map: SubstitutionMap = generics
+                    .iter()
+                    .cloned()
+                    .zip(concrete_args.iter().cloned())
+                    .collect();
+                let resolved_ty = substitute(&body, &map);
 
                 // Reject Ref<InterfaceType> — Go pointer-to-interface is invalid
                 if self.is_lis()
@@ -128,6 +138,22 @@ impl Checker<'_, '_> {
                         .and_then(|p| p.first().cloned())
                 {
                     self.check_map_key_comparable(&key_ty, *annotation_span);
+                }
+
+                // Preserve alias name in emitter output. Guard against re-wrapping bodies whose
+                // id already matches (function aliases are pre-wrapped by populate_type_alias).
+                if let Some(Definition::TypeAlias {
+                    annotation: alias_ann,
+                    ..
+                }) = self.store.get_definition(&qualified_name)
+                    && !alias_ann.is_opaque()
+                    && matches!(&resolved_ty, Type::Constructor { id, .. } if id.as_str() != qualified_name.as_str())
+                {
+                    return Type::Constructor {
+                        id: qualified_name.into(),
+                        params: concrete_args,
+                        underlying_ty: Some(Box::new(resolved_ty)),
+                    };
                 }
 
                 resolved_ty

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -644,9 +644,7 @@ impl Checker<'_, '_> {
 
         let body_ty = self.convert_to_type(annotation, span);
 
-        let is_circular = matches!(&body_ty, Type::Constructor { id, .. } if id == &qualified_name);
-
-        if is_circular {
+        if self.is_alias_body_circular(&body_ty, &qualified_name) {
             self.sink
                 .push(diagnostics::infer::circular_type_alias(name, *span));
         }
@@ -710,5 +708,93 @@ impl Checker<'_, '_> {
                     doc: doc.clone(),
                 },
             );
+    }
+
+    fn is_alias_body_circular(&self, body_ty: &Type, qualified_name: &str) -> bool {
+        if Self::type_contains_name(body_ty, qualified_name) {
+            return true;
+        }
+
+        let mut to_visit: Vec<String> = Vec::new();
+        Self::collect_type_refs(body_ty, &mut to_visit);
+
+        let mut seen: Vec<String> = Vec::new();
+        while let Some(name) = to_visit.pop() {
+            if name == qualified_name {
+                return true;
+            }
+            if seen.contains(&name) {
+                continue;
+            }
+            seen.push(name.clone());
+
+            if let Some(Definition::TypeAlias { ty, .. }) = self.store.get_definition(&name) {
+                let body = ty.unwrap_forall().clone();
+                if Self::type_contains_name(&body, qualified_name) {
+                    return true;
+                }
+                Self::collect_type_refs(&body, &mut to_visit);
+            }
+        }
+
+        false
+    }
+
+    fn type_contains_name(ty: &Type, name: &str) -> bool {
+        match ty {
+            Type::Constructor {
+                id,
+                params,
+                underlying_ty,
+            } => {
+                id.as_str() == name
+                    || params.iter().any(|p| Self::type_contains_name(p, name))
+                    || underlying_ty
+                        .as_deref()
+                        .is_some_and(|u| Self::type_contains_name(u, name))
+            }
+            Type::Tuple(elements) => elements.iter().any(|e| Self::type_contains_name(e, name)),
+            Type::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                params.iter().any(|p| Self::type_contains_name(p, name))
+                    || Self::type_contains_name(return_type, name)
+            }
+            Type::Forall { body, .. } => Self::type_contains_name(body, name),
+            _ => false,
+        }
+    }
+
+    fn collect_type_refs(ty: &Type, refs: &mut Vec<String>) {
+        match ty {
+            Type::Constructor {
+                id,
+                params,
+                underlying_ty,
+            } => {
+                refs.push(id.to_string());
+                params.iter().for_each(|p| Self::collect_type_refs(p, refs));
+                if let Some(u) = underlying_ty {
+                    Self::collect_type_refs(u, refs);
+                }
+            }
+            Type::Tuple(elements) => {
+                elements
+                    .iter()
+                    .for_each(|e| Self::collect_type_refs(e, refs));
+            }
+            Type::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                params.iter().for_each(|p| Self::collect_type_refs(p, refs));
+                Self::collect_type_refs(return_type, refs);
+            }
+            Type::Forall { body, .. } => Self::collect_type_refs(body, refs),
+            _ => {}
+        }
     }
 }

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1019,7 +1019,7 @@ impl Type {
     pub fn is_aliased_numeric_type(&self) -> bool {
         match self {
             Type::Constructor { underlying_ty, .. } => {
-                underlying_ty.is_some() && !self.is_numeric()
+                underlying_ty.is_some() && !self.is_numeric() && self.has_underlying_numeric_type()
             }
             _ => false,
         }

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -351,7 +351,7 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
             Type::Constructor {
                 id: id1,
                 params: args1,
-                ..
+                underlying_ty: u1,
             },
             Type::Constructor {
                 id: id2,
@@ -361,12 +361,21 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
         ) => {
             let name1 = id1.rsplit('.').next().unwrap_or("");
             let name2 = id2.rsplit('.').next().unwrap_or("");
-            name1 == name2
+            if name1 == name2
                 && args1.len() == args2.len()
                 && args1
                     .iter()
                     .zip(args2.iter())
                     .all(|(a1, a2)| types_equal(a1, a2))
+            {
+                return true;
+            }
+            if let Some(u) = u1
+                && types_equal(u, &resolved_t2)
+            {
+                return true;
+            }
+            false
         }
 
         (

--- a/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
@@ -23,7 +23,7 @@ package main
 
 import "github.com/user/myproject/geo"
 
-func get_x(c geo.Point) int {
+func get_x(c geo.Coordinate) int {
 	return c.X
 }
 

--- a/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
@@ -42,7 +42,7 @@ func (e Either[L, R]) String() string {
 	}
 }
 
-func Either_describe(self Either[int, string]) string {
+func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
 		n := self.Left
 		return fmt.Sprintf("int(%d)", n)
@@ -51,7 +51,7 @@ func Either_describe(self Either[int, string]) string {
 	return fmt.Sprintf("str(%s)", s)
 }
 
-func test() string {
-	e := MakeEitherLeft[int, string](42)
+func test() MyString {
+	e := MakeEitherLeft[int, MyString](42)
 	return Either_describe(e)
 }

--- a/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
@@ -42,7 +42,7 @@ func (e Either[L, R]) String() string {
 	}
 }
 
-func Either_describe(self Either[int, string]) string {
+func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
 		n := self.Left
 		return fmt.Sprintf("int(%d)", n)

--- a/tests/spec/emit/snapshots/specialized_impl_uses_ufcs.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_uses_ufcs.snap
@@ -16,6 +16,6 @@ func (b Box[T]) String() string {
 	return fmt.Sprintf("Box { val: %v }", b.val)
 }
 
-func Box_doubled(self Box[int]) int {
+func Box_doubled(self Box[MyInt]) MyInt {
 	return self.val * 2
 }

--- a/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
@@ -12,7 +12,7 @@ import (
 type Maybe[T any] = lisette.Option[T]
 
 type User struct {
-	Name  lisette.Option[string] `json:"name,omitempty,omitzero"`
+	Name  Maybe[string]          `json:"name,omitempty,omitzero"`
 	Email lisette.Option[string] `json:"email,omitempty,omitzero"`
 }
 

--- a/tests/spec/emit/snapshots/type_alias_chained.snap
+++ b/tests/spec/emit/snapshots/type_alias_chained.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location = Point\ntype GeoPoint = Location\n\nfn origin() -> GeoPoint {\n  Point { x: 0, y: 0 }\n}\n"
+---
+package main
+
+import "fmt"
+
+type Point struct {
+	X int
+	Y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
+}
+
+type Location = Point
+
+type GeoPoint = Location
+
+func origin() GeoPoint {
+	return Point{
+		X: 0,
+		Y: 0,
+	}
+}

--- a/tests/spec/emit/snapshots/type_alias_chained_slice_iter_and_index.snap
+++ b/tests/spec/emit/snapshots/type_alias_chained_slice_iter_and_index.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Numbers = Slice<int>\ntype MoreNumbers = Numbers\n\nfn first(nums: MoreNumbers) -> int {\n  nums[0]\n}\n\nfn sum(nums: MoreNumbers) -> int {\n  let mut total = 0\n  for n in nums {\n    total += n\n  }\n  total\n}\n"
+---
+package main
+
+type Numbers = []int
+
+type MoreNumbers = Numbers
+
+func first(nums MoreNumbers) int {
+	return nums[0]
+}
+
+func sum(nums MoreNumbers) int {
+	total := 0
+	for _, n := range nums {
+		total += n
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
+++ b/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
@@ -45,6 +45,6 @@ func (c Color) String() string {
 
 type MyColor = Color
 
-func test() Color {
+func test() MyColor {
 	return MakeColorRed()
 }

--- a/tests/spec/emit/snapshots/type_alias_generic_in_param_and_return.snap
+++ b/tests/spec/emit/snapshots/type_alias_generic_in_param_and_return.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Numbers = Slice<int>\n\nfn sum(nums: Numbers) -> int {\n  let mut total = 0\n  for n in nums {\n    total += n\n  }\n  total\n}\n"
+---
+package main
+
+type Numbers = []int
+
+func sum(nums Numbers) int {
+	total := 0
+	for _, n := range nums {
+		total += n
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/type_alias_generic_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/type_alias_generic_tuple_struct_constructor.snap
@@ -16,6 +16,6 @@ func (w Wrapper[T]) String() string {
 
 type W[T any] = Wrapper[T]
 
-func test() Wrapper[int] {
+func test() W[int] {
 	return Wrapper[int]{F0: 5}
 }

--- a/tests/spec/emit/snapshots/type_alias_in_return_type.snap
+++ b/tests/spec/emit/snapshots/type_alias_in_return_type.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/types.rs
-description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location = Point\n\nfn get_x(loc: Location) -> int {\n  loc.x\n}\n"
+description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location = Point\n\nfn origin() -> Location {\n  Point { x: 0, y: 0 }\n}\n"
 ---
 package main
 
@@ -17,6 +17,9 @@ func (p Point) String() string {
 
 type Location = Point
 
-func get_x(loc Location) int {
-	return loc.X
+func origin() Location {
+	return Point{
+		X: 0,
+		Y: 0,
+	}
 }

--- a/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Inner { pub val: int }\n\ntype Wrapper = Inner\n\nstruct Outer { pub item: Wrapper }\n\nfn get_val(o: Outer) -> int {\n  o.item.val\n}\n"
+---
+package main
+
+import "fmt"
+
+type Inner struct {
+	Val int
+}
+
+func (i Inner) String() string {
+	return fmt.Sprintf("Inner { val: %v }", i.Val)
+}
+
+type Wrapper = Inner
+
+type Outer struct {
+	Item Wrapper
+}
+
+func (o Outer) String() string {
+	return fmt.Sprintf("Outer { item: %v }", o.Item)
+}
+
+func get_val(o Outer) int {
+	return o.Item.Val
+}

--- a/tests/spec/emit/snapshots/type_alias_map_comparable_constraint.snap
+++ b/tests/spec/emit/snapshots/type_alias_map_comparable_constraint.snap
@@ -6,7 +6,7 @@ package main
 
 type KeyVal[K comparable, V any] = map[K]V
 
-func test() map[string]int {
+func test() KeyVal[string, int] {
 	m := make(map[string]int)
 	m["a"] = 1
 	return m

--- a/tests/spec/emit/snapshots/type_alias_multi_field_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/type_alias_multi_field_tuple_struct_constructor.snap
@@ -17,7 +17,7 @@ func (p Point2D) String() string {
 
 type P = Point2D
 
-func test() Point2D {
+func test() P {
 	return Point2D{
 		F0: 1,
 		F1: 2,

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -156,6 +156,88 @@ fn get_x(loc: Location) -> int {
 }
 
 #[test]
+fn type_alias_in_return_type() {
+    let input = r#"
+struct Point { pub x: int, pub y: int }
+
+type Location = Point
+
+fn origin() -> Location {
+  Point { x: 0, y: 0 }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn type_alias_generic_in_param_and_return() {
+    let input = r#"
+type Numbers = Slice<int>
+
+fn sum(nums: Numbers) -> int {
+  let mut total = 0
+  for n in nums {
+    total += n
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn type_alias_in_struct_field() {
+    let input = r#"
+struct Inner { pub val: int }
+
+type Wrapper = Inner
+
+struct Outer { pub item: Wrapper }
+
+fn get_val(o: Outer) -> int {
+  o.item.val
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn type_alias_chained() {
+    let input = r#"
+struct Point { pub x: int, pub y: int }
+
+type Location = Point
+type GeoPoint = Location
+
+fn origin() -> GeoPoint {
+  Point { x: 0, y: 0 }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn type_alias_chained_slice_iter_and_index() {
+    let input = r#"
+type Numbers = Slice<int>
+type MoreNumbers = Numbers
+
+fn first(nums: MoreNumbers) -> int {
+  nums[0]
+}
+
+fn sum(nums: MoreNumbers) -> int {
+  let mut total = 0
+  for n in nums {
+    total += n
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn impl_block_generic() {
     let input = r#"
 struct Box<T> { value: T }

--- a/tests/spec/infer/basics.rs
+++ b/tests/spec/infer/basics.rs
@@ -958,6 +958,78 @@ fn circular_type_alias_mutual() {
 }
 
 #[test]
+fn circular_type_alias_chain() {
+    infer(
+        r#"
+    type A = B
+    type B = C
+    type C = A
+
+    fn test() -> A {
+      return 42;
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
+fn circular_type_alias_slice_param() {
+    infer(
+        r#"
+    type A = Slice<A>
+
+    fn test() -> A {
+      return [];
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
+fn circular_type_alias_tuple_element() {
+    infer(
+        r#"
+    type A = (A, int)
+
+    fn test() -> A {
+      return (42, 1);
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
+fn circular_type_alias_map_value() {
+    infer(
+        r#"
+    type A = Map<int, A>
+
+    fn test() -> A {
+      return {};
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
+fn circular_type_alias_result_param() {
+    infer(
+        r#"
+    type A = Result<int, A>
+
+    fn test() -> A {
+      return Ok(1);
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
 fn reference_to_int() {
     infer(
         r#"


### PR DESCRIPTION
Fix #107