### PR TITLE
fix: peel type aliases in interface and field checks

### DIFF
--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -16,12 +16,16 @@ use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
 use crate::state::{CachedSnapshot, SharedState};
 
-/// Extract the constructor type name, unwrapping Ref<T> if present.
+/// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
 pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<&str> {
     match ty {
         syntax::types::Type::Constructor { id, params, .. } if id == "prelude.Ref" => {
             params.first().and_then(type_name)
         }
+        syntax::types::Type::Constructor {
+            underlying_ty: Some(u),
+            ..
+        } => type_name(u),
         syntax::types::Type::Constructor { id, .. } => Some(id.as_str()),
         _ => None,
     }

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -442,7 +442,7 @@ impl Checker<'_, '_> {
         let iterable_ty = self.new_type_var();
         let new_iterable = self.infer_expression(*iterable, &iterable_ty);
 
-        let resolved_iterable_ty = self.peel_alias(&iterable_ty.resolve());
+        let resolved_iterable_ty = self.store.peel_alias(&iterable_ty.resolve());
 
         let iterable_ty_name = match resolved_iterable_ty.get_name() {
             Some(name) => name,

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -27,7 +27,7 @@ impl Checker<'_, '_> {
         self.check_not_temp_producing(&index_expression);
 
         let resolved_index_ty = index_ty_var.resolve();
-        let resolved_collection_ty = self.peel_alias(&collection_ty_var.resolve());
+        let resolved_collection_ty = self.store.peel_alias(&collection_ty_var.resolve());
 
         if resolved_collection_ty.is_error() {
             self.unify(expected_ty, &Type::Error, &span);
@@ -168,7 +168,7 @@ impl Checker<'_, '_> {
         let collection_ty_var = self.new_type_var();
         let collection_expression =
             self.with_value_context(|s| s.infer_expression(*expression, &collection_ty_var));
-        let resolved_collection_ty = self.peel_alias(&collection_ty_var.resolve());
+        let resolved_collection_ty = self.store.peel_alias(&collection_ty_var.resolve());
 
         if resolved_collection_ty.is_error() {
             self.unify(expected_ty, &Type::Error, &span);

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -50,7 +50,8 @@ impl Checker<'_, '_> {
         // Concrete type -> interface: allowed if source satisfies the interface.
         // Used for explicit coercion before wrapping in generic containers,
         // e.g. `Some(my_dog as Animal)` to get `Option<Animal>`.
-        if let Type::Constructor { id, params, .. } = &target_ty
+        let peeled_target = self.store.peel_alias(&target_ty);
+        if let Type::Constructor { id, params, .. } = &peeled_target
             && let Some(interface) = self.store.get_interface(id).cloned()
             && self
                 .satisfies_interface(&source_ty, &interface, params, &span)

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -460,26 +460,6 @@ impl<'r, 's> Checker<'r, 's> {
         Some((qualified_name, ty))
     }
 
-    pub(crate) fn peel_alias(&self, ty: &Type) -> Type {
-        let mut current = ty.clone();
-        while let Type::Constructor {
-            id,
-            underlying_ty: Some(u),
-            ..
-        } = &current
-        {
-            if !self
-                .store
-                .get_definition(id)
-                .is_some_and(|d| matches!(d, Definition::TypeAlias { .. }))
-            {
-                break;
-            }
-            current = *u.clone();
-        }
-        current
-    }
-
     pub(crate) fn get_all_methods(&self, ty: &Type) -> MethodSignatures {
         if let Type::Parameter(name) = ty {
             let trait_bounds = self.scopes.collect_all_trait_bounds();
@@ -489,23 +469,29 @@ impl<'r, 's> Checker<'r, 's> {
                 .get_methods_from_bounds(&qualified_name, &trait_bounds);
         }
 
-        let Type::Constructor { id, .. } = ty.strip_refs().resolve() else {
+        let resolved = ty.strip_refs().resolve();
+        let Type::Constructor { id, .. } = &resolved else {
             return MethodSignatures::default();
         };
 
         // Interfaces need type-arg-dependent generic substitution, skip cache.
-        if self.store.get_interface(&id).is_some() {
+        let peeled = self.store.peel_alias(&resolved);
+        if let Type::Constructor { id: peeled_id, .. } = &peeled
+            && self.store.get_interface(peeled_id).is_some()
+        {
             let empty = HashMap::default();
-            return self.store.get_all_methods(ty, &empty);
+            return self.store.get_all_methods(&peeled, &empty);
         }
 
-        if let Some(cached) = self.method_cache.borrow().get(&id) {
+        if let Some(cached) = self.method_cache.borrow().get(id.as_str()) {
             return cached.clone();
         }
 
         let empty = HashMap::default();
         let methods = self.store.get_all_methods(ty, &empty);
-        self.method_cache.borrow_mut().insert(id, methods.clone());
+        self.method_cache
+            .borrow_mut()
+            .insert(id.clone(), methods.clone());
         methods
     }
 

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -122,13 +122,16 @@ impl Checker<'_, '_> {
                     && qualified_name == "prelude.Ref"
                     && params.len() == 1
                     && let Some(inner) = resolved_ty.inner()
-                    && let Some(inner_id) = inner.resolve().get_qualified_id()
-                    && self.store.get_interface(inner_id).is_some()
                 {
-                    self.sink.push(diagnostics::infer::ref_of_interface_type(
-                        &inner,
-                        *annotation_span,
-                    ));
+                    let peeled_inner = self.store.peel_alias(&inner.resolve());
+                    if let Some(inner_id) = peeled_inner.get_qualified_id()
+                        && self.store.get_interface(inner_id).is_some()
+                    {
+                        self.sink.push(diagnostics::infer::ref_of_interface_type(
+                            &inner,
+                            *annotation_span,
+                        ));
+                    }
                 }
 
                 if qualified_name == "prelude.Map"

--- a/crates/semantics/src/lint/ref_lints/extract.rs
+++ b/crates/semantics/src/lint/ref_lints/extract.rs
@@ -659,8 +659,11 @@ fn add_ref(
 }
 
 fn type_name(ty: &Type) -> Option<String> {
-    let ty = ty.resolve().strip_refs();
-    match ty {
+    let mut current = ty.resolve().strip_refs();
+    while let Some(next) = current.get_underlying().cloned() {
+        current = next;
+    }
+    match current {
         Type::Constructor { id, .. } => id.split('.').next_back().map(String::from),
         _ => None,
     }

--- a/crates/semantics/src/pattern_analysis/normalize.rs
+++ b/crates/semantics/src/pattern_analysis/normalize.rs
@@ -202,12 +202,12 @@ pub fn normalize_typed_pattern(
             // Interfaces are open: unknown structs can implement them at any time,
             // so a wildcard after a struct arm is always reachable.
             if let Some(scrutinee_ty) = &ctx.scrutinee_type {
-                let resolved = scrutinee_ty.resolve();
+                let peeled = ctx.store.peel_alias(&scrutinee_ty.resolve());
                 if let Type::Constructor {
                     id: interface_id,
                     params: interface_params,
                     ..
-                } = &resolved
+                } = &peeled
                     && ctx.store.get_interface(interface_id).is_some()
                 {
                     let interface_type_name = make_type_key(interface_id, interface_params);

--- a/crates/semantics/src/pattern_analysis/normalize.rs
+++ b/crates/semantics/src/pattern_analysis/normalize.rs
@@ -27,6 +27,66 @@ pub struct NormalizationContext<'a> {
     pub scrutinee_type: Option<Type>,
 }
 
+fn try_normalize_interface_implementer(
+    ctx: &NormalizationContext,
+    struct_name: &str,
+    arity: usize,
+    args: Vec<NormalizedPattern>,
+    unions: &mut UnionTable,
+) -> Option<NormalizedPattern> {
+    let scrutinee_ty = ctx.scrutinee_type.as_ref()?;
+    let peeled = ctx.store.peel_alias(&scrutinee_ty.resolve());
+    let Type::Constructor {
+        id: interface_id,
+        params: interface_params,
+        ..
+    } = &peeled
+    else {
+        return None;
+    };
+    ctx.store.get_interface(interface_id)?;
+
+    let interface_type_name = make_type_key(interface_id, interface_params);
+    let struct_ctor = Constructor {
+        tag_id: struct_name.to_string(),
+        arity,
+    };
+
+    if let Some(union) = unions.get_mut(&interface_type_name) {
+        let mut found = false;
+        let mut unknown_pos = union.len();
+        for (i, c) in union.iter().enumerate() {
+            if c.tag_id == struct_name {
+                found = true;
+                break;
+            }
+            if c.tag_id == INTERFACE_UNKNOWN_TAG {
+                unknown_pos = i;
+            }
+        }
+        if !found {
+            union.insert(unknown_pos, struct_ctor);
+        }
+    } else {
+        unions.insert(
+            interface_type_name.clone(),
+            vec![
+                struct_ctor,
+                Constructor {
+                    tag_id: INTERFACE_UNKNOWN_TAG.to_string(),
+                    arity: 0,
+                },
+            ],
+        );
+    }
+
+    Some(NormalizedPattern::Constructor {
+        type_name: interface_type_name,
+        tag: struct_name.to_string(),
+        args,
+    })
+}
+
 pub fn normalize_arm(
     arm: &MatchArm,
     unions: &mut UnionTable,
@@ -71,15 +131,34 @@ pub fn normalize_typed_pattern(
             type_args,
             ..
         } => {
-            let patterns = fields
+            let patterns: Vec<NormalizedPattern> = fields
                 .iter()
                 .map(|f| normalize_typed_pattern(f, unions, ctx))
                 .collect();
 
+            let enum_def = ctx.store.get_definition(enum_name);
+
+            if let Some(Definition::Struct {
+                fields: struct_fields,
+                ..
+            }) = enum_def
+            {
+                let arity = struct_fields.len();
+                let mut args = patterns.clone();
+                while args.len() < arity {
+                    args.push(Wildcard);
+                }
+                if let Some(normalized) =
+                    try_normalize_interface_implementer(ctx, enum_name, arity, args, unions)
+                {
+                    return normalized;
+                }
+            }
+
             let type_name = make_type_key(enum_name, type_args);
 
             if unions.get(&type_name).is_none() {
-                let alternatives = match ctx.store.get_definition(enum_name) {
+                let alternatives = match enum_def {
                     Some(Definition::Enum {
                         variants, generics, ..
                     }) => variants
@@ -183,7 +262,7 @@ pub fn normalize_typed_pattern(
             pattern_fields,
             type_args,
         } => {
-            let patterns = struct_fields
+            let patterns: Vec<NormalizedPattern> = struct_fields
                 .iter()
                 .map(|f| {
                     pattern_fields
@@ -199,57 +278,14 @@ pub fn normalize_typed_pattern(
                 })
                 .collect();
 
-            // Interfaces are open: unknown structs can implement them at any time,
-            // so a wildcard after a struct arm is always reachable.
-            if let Some(scrutinee_ty) = &ctx.scrutinee_type {
-                let peeled = ctx.store.peel_alias(&scrutinee_ty.resolve());
-                if let Type::Constructor {
-                    id: interface_id,
-                    params: interface_params,
-                    ..
-                } = &peeled
-                    && ctx.store.get_interface(interface_id).is_some()
-                {
-                    let interface_type_name = make_type_key(interface_id, interface_params);
-                    let struct_ctor = Constructor {
-                        tag_id: struct_name.to_string(),
-                        arity: struct_fields.len(),
-                    };
-
-                    if let Some(union) = unions.get_mut(&interface_type_name) {
-                        let mut found = false;
-                        let mut unknown_pos = union.len();
-                        for (i, c) in union.iter().enumerate() {
-                            if c.tag_id == struct_name.as_str() {
-                                found = true;
-                                break;
-                            }
-                            if c.tag_id == INTERFACE_UNKNOWN_TAG {
-                                unknown_pos = i;
-                            }
-                        }
-                        if !found {
-                            union.insert(unknown_pos, struct_ctor);
-                        }
-                    } else {
-                        unions.insert(
-                            interface_type_name.clone(),
-                            vec![
-                                struct_ctor,
-                                Constructor {
-                                    tag_id: INTERFACE_UNKNOWN_TAG.to_string(),
-                                    arity: 0,
-                                },
-                            ],
-                        );
-                    }
-
-                    return NormalizedPattern::Constructor {
-                        type_name: interface_type_name,
-                        tag: struct_name.to_string(),
-                        args: patterns,
-                    };
-                }
+            if let Some(normalized) = try_normalize_interface_implementer(
+                ctx,
+                struct_name,
+                struct_fields.len(),
+                patterns.clone(),
+                unions,
+            ) {
+                return normalized;
             }
 
             let type_name = make_type_key(struct_name, type_args);

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -210,6 +210,25 @@ impl Store {
         }
     }
 
+    pub fn peel_alias(&self, ty: &Type) -> Type {
+        let mut current = ty.clone();
+        while let Type::Constructor {
+            id,
+            underlying_ty: Some(u),
+            ..
+        } = &current
+        {
+            if !self
+                .get_definition(id)
+                .is_some_and(|d| matches!(d, Definition::TypeAlias { .. }))
+            {
+                break;
+            }
+            current = *u.clone();
+        }
+        current
+    }
+
     pub fn get_own_methods(&self, qualified_name: &str) -> Option<&MethodSignatures> {
         match self.get_definition(qualified_name)? {
             Definition::Struct { methods, .. } => Some(methods),

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -9828,6 +9828,31 @@ async fn goto_definition_type_alias_in_struct_call() {
 }
 
 #[tokio::test]
+async fn goto_definition_field_in_aliased_struct_call() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "struct Point {\n  pub x: int,\n  pub y: int,\n}\n\ntype Alias = Point\n\nfn main() {\n  let p = Alias { x: 1, y: 2 }\n}",
+        )
+        .await;
+
+    let response = client.goto_definition(TEST_URI, 8, 18).await;
+    assert!(
+        response.is_some(),
+        "goto-def on field `x` in aliased struct call should find the underlying struct field"
+    );
+    let loc = definition_location(&response.unwrap()).unwrap();
+    assert_eq!(
+        loc.range.start.line, 1,
+        "goto-def should land on `pub x: int` in the struct definition"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn diagnostics_invalid_manifest_surfaces_error() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4025,3 +4025,57 @@ fn test() { let _w: Worker = MyWorker { label: "t", count: 0 } }
     )
     .assert_infer_code("interface_not_implemented");
 }
+
+#[test]
+fn cast_to_type_alias_to_interface() {
+    infer(
+        r#"
+interface Named {
+  fn Name() -> string
+}
+type MyNamed = Named
+struct Dog { name: string }
+impl Dog {
+  fn Name(self: Dog) -> string { self.name }
+}
+fn test() -> MyNamed {
+  Dog { name: "Rex" } as MyNamed
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn ref_of_type_alias_to_interface_is_rejected() {
+    infer(
+        r#"
+interface Named {
+  fn Name() -> string
+}
+type MyNamed = Named
+fn takes_ref(_r: Ref<MyNamed>) {}
+"#,
+    )
+    .assert_infer_code("ref_of_interface");
+}
+
+#[test]
+fn generic_type_alias_to_generic_interface_substitutes_methods() {
+    infer(
+        r#"
+interface Container<T> {
+  fn Get() -> T
+}
+type MyContainer<T> = Container<T>
+struct IntBox { n: int }
+impl IntBox {
+  fn Get(self: IntBox) -> int { self.n }
+}
+fn take_int(c: MyContainer<int>) -> int {
+  c.Get()
+}
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -1699,6 +1699,24 @@ fn handle(msg: OuterMsg) -> int {
 }
 
 #[test]
+fn test_bare_struct_name_arm_against_interface_wildcard_not_redundant() {
+    let input = r#"
+interface Event {}
+struct ClickEvent { x: int, y: int }
+struct KeyEvent { key: string }
+
+fn handle(e: Event) -> int {
+  match e {
+    ClickEvent { x, .. } => x,
+    KeyEvent => 0,
+    _ => -1,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
 fn test_struct_arm_against_type_alias_to_interface_without_wildcard_is_non_exhaustive() {
     let input = r#"
 interface Event {}

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -1662,3 +1662,54 @@ fn handle(event: Event) -> int {
 "#;
     infer(input).assert_exhaustiveness_error();
 }
+
+#[test]
+fn test_struct_arm_against_type_alias_to_interface_wildcard_not_redundant() {
+    let input = r#"
+interface Event {}
+type Msg = Event
+struct ClickEvent { x: int, y: int }
+
+fn handle(msg: Msg) -> int {
+  match msg {
+    ClickEvent { x, .. } => x,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_struct_arm_against_chained_type_alias_to_interface_wildcard_not_redundant() {
+    let input = r#"
+interface Event {}
+type Msg = Event
+type OuterMsg = Msg
+struct ClickEvent { x: int, y: int }
+
+fn handle(msg: OuterMsg) -> int {
+  match msg {
+    ClickEvent { x, .. } => x,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_struct_arm_against_type_alias_to_interface_without_wildcard_is_non_exhaustive() {
+    let input = r#"
+interface Event {}
+type Msg = Event
+struct ClickEvent { x: int, y: int }
+
+fn handle(msg: Msg) -> int {
+  match msg {
+    ClickEvent { x, .. } => x,
+  }
+}
+"#;
+    infer(input).assert_exhaustiveness_error();
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1068,6 +1068,28 @@ fn main() {
 }
 
 #[test]
+fn struct_field_used_via_type_alias_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct Point {
+  x: int,
+  y: int,
+}
+
+type MyPoint = Point
+
+fn read(p: MyPoint) -> int {
+  p.x + p.y
+}
+
+fn main() {
+  read(Point { x: 1, y: 2 })
+}
+"#
+    );
+}
+
+#[test]
 fn unused_enum_variant() {
     assert_lint_snapshot!(
         r#"


### PR DESCRIPTION
For `match msg { tea.WindowSizeMsg { .. } => ..., _ => ... }` the compiler was reporting the `_` branch as unreachable, which is incorrect since any other type can implement `tea.Msg`. The root issue was that the special handling for matches on interfaces from #121 didn't see through type aliases as reworked in #122. `tea.Msg` is an alias for the `uv.Event` interface, so the check missed.

Fixes #125