### PR TITLE
fix: keep transitive go imports whose package name differs from path

### DIFF
--- a/crates/emit/src/imports.rs
+++ b/crates/emit/src/imports.rs
@@ -51,13 +51,16 @@ impl<'a> ImportBuilder<'a> {
 
     pub fn extend_with_modules(&mut self, module_ids: &HashSet<ModuleId>) {
         for module_id in module_ids {
-            if let Some(alias) = self.dropped_aliases.get(module_id) {
-                self.imports
-                    .entry(module_id.clone())
-                    .or_insert_with(|| alias.clone());
-            } else {
-                self.imports.entry(module_id.clone()).or_default();
-            }
+            let alias = self
+                .dropped_aliases
+                .get(module_id)
+                .or_else(|| {
+                    self.go_package_names
+                        .get(&format!("{}{module_id}", go_name::GO_IMPORT_PREFIX))
+                })
+                .cloned()
+                .unwrap_or_default();
+            self.imports.entry(module_id.clone()).or_insert(alias);
         }
     }
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -109,6 +109,11 @@ impl CompiledTest {
             checker.put_prelude_in_scope();
 
             let locator = deps::TypedefLocator::default();
+
+            for (name, typedef) in &self.extra_go_typedefs {
+                checker.parse_and_register_go_module(name, typedef, &locator);
+            }
+
             let imports: Vec<FileImport> = self
                 .ast
                 .iter()
@@ -120,16 +125,10 @@ impl CompiledTest {
                         span,
                     } = item
                     {
-                        if let Some(go_pkg) = name.strip_prefix("go:") {
-                            if let Some(typedef) = get_go_stdlib_typedef(go_pkg) {
-                                checker.parse_and_register_go_module(name, typedef, &locator);
-                            } else if let Some((_, typedef)) = self
-                                .extra_go_typedefs
-                                .iter()
-                                .find(|(n, _)| n.as_str() == name.as_str())
-                            {
-                                checker.parse_and_register_go_module(name, typedef, &locator);
-                            }
+                        if let Some(go_pkg) = name.strip_prefix("go:")
+                            && let Some(typedef) = get_go_stdlib_typedef(go_pkg)
+                        {
+                            checker.parse_and_register_go_module(name, typedef, &locator);
                         }
                         Some(FileImport {
                             name: name.clone(),

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -256,6 +256,38 @@ pub struct Event {}
 }
 
 #[test]
+fn transitive_go_import_uses_declared_package_name() {
+    let input = r#"
+import "go:example.com/bubbletea"
+
+struct Model {}
+
+impl Model {
+  fn Init(self: Model) -> tea.Cmd {
+    || ()
+  }
+}
+"#;
+    let tea_typedef = r#"// Package: tea
+
+import "go:example.com/ultraviolet"
+
+pub type Cmd = fn() -> uv.Event
+"#;
+    let uv_typedef = r#"// Package: uv
+
+pub interface Event {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(
+        input,
+        &[
+            ("go:example.com/ultraviolet", uv_typedef),
+            ("go:example.com/bubbletea", tea_typedef),
+        ]
+    );
+}
+
+#[test]
 fn package_local_option_alias_does_not_collide_with_prelude_option() {
     // Regression: a Go module that declares its own `type Option = ...`
     // (e.g. the functional-options pattern) would trip `Type::is_option`

--- a/tests/spec/emit/snapshots/transitive_go_import_uses_declared_package_name.snap
+++ b/tests/spec/emit/snapshots/transitive_go_import_uses_declared_package_name.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:example.com/bubbletea\"\n\nstruct Model {}\n\nimpl Model {\n  fn Init(self: Model) -> tea.Cmd {\n    || ()\n  }\n}\n"
+---
+package main
+
+import (
+	tea "example.com/bubbletea"
+	uv "example.com/ultraviolet"
+)
+
+type Model struct{}
+
+func (m Model) String() string {
+	return "Model"
+}
+
+func (m Model) Init() tea.Cmd {
+	return func() uv.Event {
+	}
+}


### PR DESCRIPTION
Fix #127