### PR TITLE
fix: always break multi-step pipelines

### DIFF
--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -875,9 +875,7 @@ impl<'a> Formatter<'a> {
                 if i == 0 {
                     self.expression(seg)
                 } else {
-                    Document::Newline
-                        .append("|> ")
-                        .append(self.expression(seg))
+                    Document::Newline.append("|> ").append(self.expression(seg))
                 }
             })
             .collect();

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -858,6 +858,16 @@ impl<'a> Formatter<'a> {
         segments.push(current);
         segments.reverse();
 
+        if segments.len() == 2 {
+            return self
+                .expression(segments[0])
+                .append(flex_break("", " "))
+                .append("|> ")
+                .append(self.expression(segments[1]))
+                .nest_if_broken(INDENT_WIDTH)
+                .group();
+        }
+
         let docs: Vec<_> = segments
             .iter()
             .enumerate()
@@ -865,14 +875,14 @@ impl<'a> Formatter<'a> {
                 if i == 0 {
                     self.expression(seg)
                 } else {
-                    flex_break("", " ")
+                    Document::Newline
                         .append("|> ")
                         .append(self.expression(seg))
                 }
             })
             .collect();
 
-        concat(docs).nest_if_broken(INDENT_WIDTH).group()
+        concat(docs).nest(INDENT_WIDTH)
     }
 
     fn unary_operator(

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -71,6 +71,11 @@ fn binary_no_spaces() {
 }
 
 #[test]
+fn binary_pipeline_single() {
+    assert_format_snapshot!("fn test() { x |> foo() }");
+}
+
+#[test]
 fn binary_pipeline() {
     assert_format_snapshot!("fn test() { x |> foo() |> bar() }");
 }

--- a/tests/spec/format/snapshots/binary_pipeline.snap
+++ b/tests/spec/format/snapshots/binary_pipeline.snap
@@ -3,5 +3,7 @@ source: tests/spec/format/mod.rs
 description: "input: fn test() { x |> foo() |> bar() }"
 ---
 fn test() {
-  x |> foo() |> bar()
+  x
+    |> foo()
+    |> bar()
 }

--- a/tests/spec/format/snapshots/binary_pipeline_single.snap
+++ b/tests/spec/format/snapshots/binary_pipeline_single.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { x |> foo() }"
+---
+fn test() {
+  x |> foo()
+}

--- a/tests/spec/format/snapshots/binary_pipeline_with_comment.snap
+++ b/tests/spec/format/snapshots/binary_pipeline_with_comment.snap
@@ -3,7 +3,8 @@ source: tests/spec/format/mod.rs
 description: "input: fn test() {\n  x\n  |> foo()\n  // comment before bar\n  |> bar()\n}"
 ---
 fn test() {
-  x |> foo()
+  x
+    |> foo()
     |> // comment before bar
     bar()
 }


### PR DESCRIPTION
This change formats the pipeline flow either on one line (if only one pipe) or multiple, in case of N+1 pipes. This is similar to how other formatters handle pipelines in eg. OCaml or Elm.

Taking the example from the lisette website:

```
fn slugify(input: string) -> string {
  input
    |> strings.TrimSpace
    |> strings.ToLower
    |> strings.ReplaceAll(" ", "-")
}
```

It is currently being formatted as:

```
fn slugify(input: string) -> string {
  input |> strings.TrimSpace |> strings.ToLower |> strings.ReplaceAll(" ", "-")
}
```
And after this change:

```
fn slugify(input: string) -> string {
  input
    |> strings.TrimSpace
    |> strings.ToLower
    |> strings.ReplaceAll(" ", "-")
}
```
Single pipes are still a one-liner

```
fn positive(n: float64) -> float64 {
  n |> math.Abs
}
```