### PR TITLE
fix: reject bare record struct names used as values

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2095,6 +2095,15 @@ pub fn native_constructor_value(name: &str, span: Span) -> LisetteDiagnostic {
         .with_help(format!("Use a closure instead: `|args| {name}(args)`"))
 }
 
+pub fn record_struct_value(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot use struct type as a value")
+        .with_infer_code("record_struct_value")
+        .with_span_label(&span, "struct types cannot be used as expressions")
+        .with_help(format!(
+            "Use a struct literal instead: `{name} {{ field: value, ... }}`"
+        ))
+}
+
 pub fn private_method_expression(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot use private method as a value")
         .with_infer_code("private_method_expression")

--- a/crates/semantics/src/checker/infer/checks.rs
+++ b/crates/semantics/src/checker/infer/checks.rs
@@ -470,6 +470,23 @@ impl Checker<'_, '_> {
         }
     }
 
+    fn resolves_to_struct_kind(&self, qualified: &str, kind: StructKind) -> bool {
+        match self.store.get_definition(qualified) {
+            Some(Definition::Struct { kind: k, .. }) => *k == kind,
+            Some(Definition::TypeAlias { ty: alias_ty, .. }) => {
+                if let Type::Constructor { id, .. } = alias_ty.unwrap_forall() {
+                    matches!(
+                        self.store.get_definition(id),
+                        Some(Definition::Struct { kind: k, .. }) if *k == kind
+                    )
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
     /// Check if an identifier used as a value (not in call position) refers to a
     /// native method, native constructor, or private method expression.
     pub(crate) fn check_native_value_usage(&mut self, value: &str, ty: &Type, span: Span) {
@@ -491,29 +508,16 @@ impl Checker<'_, '_> {
             } else {
                 format!("{}.{}", self.cursor.module_id, value)
             };
-            let is_tuple_struct = match self.store.get_definition(&qualified) {
-                Some(Definition::Struct {
-                    kind: StructKind::Tuple,
-                    ..
-                }) => true,
-                Some(Definition::TypeAlias { ty: alias_ty, .. }) => {
-                    if let Type::Constructor { id, .. } = alias_ty.unwrap_forall() {
-                        matches!(
-                            self.store.get_definition(id),
-                            Some(Definition::Struct {
-                                kind: StructKind::Tuple,
-                                ..
-                            })
-                        )
-                    } else {
-                        false
-                    }
-                }
-                _ => false,
-            };
-            if is_tuple_struct {
+            if self.resolves_to_struct_kind(&qualified, StructKind::Tuple) {
                 self.sink
                     .push(diagnostics::infer::native_constructor_value(value, span));
+                return;
+            }
+            if !self.inference.dot_access_base
+                && self.resolves_to_struct_kind(&qualified, StructKind::Record)
+            {
+                self.sink
+                    .push(diagnostics::infer::record_struct_value(value, span));
                 return;
             }
         }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -158,7 +158,10 @@ impl Checker<'_, '_> {
         expected_ty: &Type,
     ) -> Expression {
         let expression_ty = self.new_type_var();
+        let prior_dot_access_base = self.inference.dot_access_base;
+        self.inference.dot_access_base = true;
         let new_expression = self.infer_expression(*expression, &expression_ty);
+        self.inference.dot_access_base = prior_dot_access_base;
         let resolved_expression_ty = expression_ty.resolve();
 
         if resolved_expression_ty.is_error() {
@@ -482,6 +485,23 @@ impl Checker<'_, '_> {
             {
                 let display_name = format!("{}.{}", type_name, args.member_name);
                 self.sink.push(diagnostics::infer::native_constructor_value(
+                    &display_name,
+                    *args.span,
+                ));
+            }
+
+            if !self.scopes.is_callee_context()
+                && !self.inference.dot_access_base
+                && matches!(
+                    self.store.get_definition(&qualified_name),
+                    Some(Definition::Struct {
+                        kind: StructKind::Record,
+                        ..
+                    })
+                )
+            {
+                let display_name = format!("{}.{}", type_name, args.member_name);
+                self.sink.push(diagnostics::infer::record_struct_value(
                     &display_name,
                     *args.span,
                 ));

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -111,6 +111,9 @@ pub(crate) struct InferenceState {
     /// etc.).  Used to reject `Err(x)?`/`None?` in value positions where they
     /// can never produce a value.
     pub in_subexpression: bool,
+    /// Suppresses record-struct-as-value errors when the struct name is a type
+    /// qualifier in a method chain (e.g. `lib.Point` in `lib.Point.sum`).
+    pub dot_access_base: bool,
 }
 
 impl InferenceState {
@@ -124,6 +127,7 @@ impl InferenceState {
             in_match_arm: false,
             loop_needs_label_stack: Vec::new(),
             in_subexpression: false,
+            dot_access_base: false,
         }
     }
 }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5723,6 +5723,59 @@ fn main() {
 }
 
 #[test]
+fn infer_record_struct_as_value() {
+    let input = r#"
+struct Coord { x: int, y: int }
+
+fn main() {
+  let c = Coord
+  let _ = c
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_alias_record_struct_as_value() {
+    let input = r#"
+struct Coord { x: int, y: int }
+type C = Coord
+
+fn main() {
+  let c = C
+  let _ = c
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_cross_module_record_struct_as_value() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "lib.lis",
+        r#"
+pub struct Point { x: int, y: int }
+"#,
+    );
+
+    let source = r#"
+import "util"
+
+fn main() {
+  let p = util.Point
+  let _ = p
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
 fn infer_type_alias_as_qualifier_parameterized() {
     let input = r#"
 type O<T> = Option<T>

--- a/tests/ui/errors/snapshots/infer_cross_module_record_struct_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_cross_module_record_struct_as_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use struct type as a value
+   ╭─[main.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let p = util.Point
+   ·           ─────┬────
+   ·                ╰── struct types cannot be used as expressions
+ 6 │   let _ = p
+   ╰────
+  help: Use a struct literal instead: `util.Point { field: value, ... }` · code: [infer.record_struct_value]

--- a/tests/ui/errors/snapshots/infer_record_struct_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_record_struct_as_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use struct type as a value
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let c = Coord
+   ·           ──┬──
+   ·             ╰── struct types cannot be used as expressions
+ 6 │   let _ = c
+   ╰────
+  help: Use a struct literal instead: `Coord { field: value, ... }` · code: [infer.record_struct_value]

--- a/tests/ui/errors/snapshots/infer_type_alias_record_struct_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_record_struct_as_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use struct type as a value
+   ╭─[test.lis:6:11]
+ 5 │ fn main() {
+ 6 │   let c = C
+   ·           ┬
+   ·           ╰── struct types cannot be used as expressions
+ 7 │   let _ = c
+   ╰────
+  help: Use a struct literal instead: `C { field: value, ... }` · code: [infer.record_struct_value]


### PR DESCRIPTION
Fix #146