### PR TITLE
fix: reset emit scope between impl methods to prevent name leak

### DIFF
--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -48,6 +48,9 @@ impl Emitter<'_> {
         if self.ctx.unused.is_unused_definition(name_span) {
             return None;
         }
+
+        self.scope.reset_for_top_level();
+
         let function = method.to_function_definition();
         let is_public = matches!(visibility, Visibility::Public);
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -116,6 +116,15 @@ struct ScopeState {
     assign_targets: HashSet<String>,
 }
 
+impl ScopeState {
+    fn reset_for_top_level(&mut self) {
+        self.next_var = 0;
+        self.bindings.reset();
+        self.declared.clear();
+        self.declared.push(HashSet::default());
+    }
+}
+
 pub struct Emitter<'a> {
     ctx: EmitContext<'a>,
     module: ModuleData,
@@ -527,9 +536,7 @@ impl<'a> Emitter<'a> {
             self.pending_adapter_types.clear();
 
             for expression in &file.items {
-                self.scope.next_var = 0;
-                self.scope.bindings.reset();
-                self.scope.declared = vec![HashSet::default()];
+                self.scope.reset_for_top_level();
                 let code = self.emit_top_item(expression);
                 if !code.is_empty() {
                     source.collect_with_blank(code);

--- a/tests/spec/emit/snapshots/impl_methods_share_local_variable_name.snap
+++ b/tests/spec/emit/snapshots/impl_methods_share_local_variable_name.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \npub struct Calc {}\nimpl Calc {\n  pub fn wider(self) -> uint64 {\n    let mut total: uint64 = 0\n    total += 1\n    total\n  }\n\n  pub fn narrower(self) -> uint32 {\n    let mut total: uint32 = 0\n    total += 1\n    total\n  }\n}\n"
+---
+package main
+
+type Calc struct{}
+
+func (c Calc) String() string {
+	return "Calc"
+}
+
+func (c Calc) Wider() uint64 {
+	var total uint64 = 0
+	total++
+	return total
+}
+
+func (c Calc) Narrower() uint32 {
+	var total uint32 = 0
+	total++
+	return total
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2629,3 +2629,24 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn impl_methods_share_local_variable_name() {
+    let input = r#"
+pub struct Calc {}
+impl Calc {
+  pub fn wider(self) -> uint64 {
+    let mut total: uint64 = 0
+    total += 1
+    total
+  }
+
+  pub fn narrower(self) -> uint32 {
+    let mut total: uint32 = 0
+    total += 1
+    total
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}


### PR DESCRIPTION
Fix #150