### PR TITLE
fix: auto-address struct literal receivers for ref methods

### DIFF
--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -264,16 +264,16 @@ impl Emitter<'_> {
         match (coercion, had_explicit_deref) {
             _ if is_absorbed_ref => expression_string,
             (Some(ReceiverCoercion::AutoAddress), true) => expression_string,
-            (Some(ReceiverCoercion::AutoAddress), false) => {
-                if matches!(expression.unwrap_parens(), Expression::Call { .. }) {
+            (Some(ReceiverCoercion::AutoAddress), false) => match expression.unwrap_parens() {
+                Expression::Call { .. } => {
                     let tmp = self.fresh_var(Some("ref"));
                     self.declare(&tmp);
                     write_line!(output, "{} := {}", tmp, expression_string);
                     tmp
-                } else {
-                    expression_string
                 }
-            }
+                Expression::StructCall { .. } => format!("(&{})", expression_string),
+                _ => expression_string,
+            },
             (Some(ReceiverCoercion::AutoDeref), _) => expression_string,
             (None, true) => expression_string,
             (None, false) => expression_string,

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1308,6 +1308,58 @@ fn test() {
 }
 
 #[test]
+fn auto_address_struct_literal_receiver() {
+    let input = r#"
+struct Foo { value: int }
+
+impl Foo {
+  fn increment(self: Ref<Foo>) {
+    self.value = self.value + 1
+  }
+}
+
+fn test() {
+  Foo { value: 42 }.increment()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn auto_address_parenthesized_struct_literal_receiver() {
+    let input = r#"
+struct Foo { value: int }
+
+impl Foo {
+  fn increment(self: Ref<Foo>) {
+    self.value = self.value + 1
+  }
+}
+
+fn test() {
+  (Foo { value: 42 }).increment()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn auto_address_empty_struct_literal_receiver() {
+    let input = r#"
+struct Foo {}
+
+impl Foo {
+  fn need_ref(self: Ref<Foo>) {}
+}
+
+fn test() {
+  Foo {}.need_ref()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn deref_map_index_assignment() {
     let input = r#"
 fn update(m: Ref<Map<string, int>>, key: string, val: int) {

--- a/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Foo {}\n\nimpl Foo {\n  fn need_ref(self: Ref<Foo>) {}\n}\n\nfn test() {\n  Foo {}.need_ref()\n}\n"
+---
+package main
+
+type Foo struct{}
+
+func (f Foo) String() string {
+	return "Foo"
+}
+
+func (f *Foo) need_ref() {}
+
+func test() {
+	(&Foo{}).need_ref()
+}

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(self: Ref<Foo>) {\n    self.value = self.value + 1\n  }\n}\n\nfn test() {\n  (Foo { value: 42 }).increment()\n}\n"
+---
+package main
+
+import "fmt"
+
+type Foo struct {
+	value int
+}
+
+func (f Foo) String() string {
+	return fmt.Sprintf("Foo { value: %v }", f.value)
+}
+
+func (f *Foo) increment() {
+	f.value++
+}
+
+func test() {
+	(&(Foo{value: 42})).increment()
+}

--- a/tests/spec/emit/snapshots/auto_address_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_struct_literal_receiver.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(self: Ref<Foo>) {\n    self.value = self.value + 1\n  }\n}\n\nfn test() {\n  Foo { value: 42 }.increment()\n}\n"
+---
+package main
+
+import "fmt"
+
+type Foo struct {
+	value int
+}
+
+func (f Foo) String() string {
+	return fmt.Sprintf("Foo { value: %v }", f.value)
+}
+
+func (f *Foo) increment() {
+	f.value++
+}
+
+func test() {
+	(&Foo{value: 42}).increment()
+}


### PR DESCRIPTION
Fix #149