### PR TITLE
fix: align const semantics with Go

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -182,6 +182,32 @@ pub fn circular_type_alias(type_name: &str, span: Span) -> LisetteDiagnostic {
         .with_help("Type aliases cannot be recursive")
 }
 
+pub fn const_disallows_composite(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Composite value in `const`")
+        .with_infer_code("const_disallows_composite")
+        .with_span_label(&span, "not allowed")
+        .with_help("`const` only accepts primitive values: `bool`, `int`, `float`, and `string`")
+}
+
+pub fn const_cycle(cycle: &[String], span: Span) -> LisetteDiagnostic {
+    let mut diagnostic = LisetteDiagnostic::error("`const` init cycle")
+        .with_infer_code("const_cycle")
+        .with_help(
+            "`const` initializers cannot refer to themselves, either directly or transitively",
+        );
+    diagnostic = if cycle.len() == 1 {
+        diagnostic.with_span_label(&span, "self-reference")
+    } else {
+        let chain = cycle
+            .iter()
+            .map(|name| format!("`{}`", name))
+            .collect::<Vec<_>>()
+            .join(" → ");
+        diagnostic.with_span_label(&span, format!("cycle: {} → `{}`", chain, cycle[0]))
+    };
+    diagnostic
+}
+
 pub fn name_not_found(
     variable_name: &str,
     span: Span,
@@ -286,6 +312,7 @@ pub fn disallowed_mutation(
     span: Span,
     self_type_name: Option<&str>,
     is_match_arm_binding: bool,
+    is_const_binding: bool,
 ) -> LisetteDiagnostic {
     if variable_name == "self" {
         if let Some(type_name) = self_type_name {
@@ -301,6 +328,13 @@ pub fn disallowed_mutation(
                 .with_span_label(&span, "receiver is immutable")
                 .with_help("Use `self: Ref<Self>` to make the receiver mutable")
         }
+    } else if is_const_binding {
+        LisetteDiagnostic::error("Cannot mutate `const`")
+            .with_infer_code("immutable")
+            .with_span_label(&span, "cannot mutate a `const`")
+            .with_help(format!(
+                "`const` bindings are immutable. Rebind with `let mut {variable_name} = {variable_name}` to mutate a local copy"
+            ))
     } else if is_match_arm_binding {
         LisetteDiagnostic::error("Immutable variable")
             .with_infer_code("immutable")
@@ -1565,6 +1599,15 @@ pub fn non_addressable_expression(expression_kind: &str, span: Span) -> LisetteD
         .with_infer_code("non_addressable_expression")
         .with_span_label(&span, format!("cannot take address of {}", expression_kind))
         .with_help("Assign the value to a variable first, then take its address")
+}
+
+pub fn non_addressable_const(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot take address of `const`")
+        .with_infer_code("non_addressable_const")
+        .with_span_label(&span, "not addressable")
+        .with_help(
+            "`const` bindings are not addressable. Copy the value into a local `let` first if you need a reference",
+        )
 }
 
 pub fn non_addressable_assignment(expression_kind: &str, span: Span) -> LisetteDiagnostic {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -1,6 +1,6 @@
 use crate::Emitter;
 use crate::names::go_name;
-use syntax::ast::{Expression, Generic, UnaryOperator};
+use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
 use syntax::types::Type;
 
 impl Emitter<'_> {
@@ -79,7 +79,8 @@ impl Emitter<'_> {
         } else {
             &expression_string
         };
-        let keyword = if Self::is_go_const_eligible(expression) {
+        let keyword = if self.is_go_const_eligible(expression) {
+            self.scope.go_const_bindings.insert(go_identifier.clone());
             "const"
         } else {
             "var"
@@ -87,17 +88,28 @@ impl Emitter<'_> {
         format!("{} {} {} = {}", keyword, go_identifier, ty_str, value)
     }
 
-    fn is_go_const_eligible(expression: &Expression) -> bool {
+    fn is_go_const_eligible(&self, expression: &Expression) -> bool {
         match expression.unwrap_parens() {
-            Expression::Literal { .. } => true,
+            Expression::Literal { literal, .. } => matches!(
+                literal,
+                Literal::Integer { .. }
+                    | Literal::Float { .. }
+                    | Literal::Imaginary(_)
+                    | Literal::Boolean(_)
+                    | Literal::String(_)
+                    | Literal::Char(_)
+            ),
+            Expression::Identifier { value, .. } => {
+                self.scope.go_const_bindings.contains(value.as_str())
+            }
             Expression::Binary { left, right, .. } => {
-                Self::is_go_const_eligible(left) && Self::is_go_const_eligible(right)
+                self.is_go_const_eligible(left) && self.is_go_const_eligible(right)
             }
             Expression::Unary {
                 operator: UnaryOperator::Negative | UnaryOperator::Not,
                 expression,
                 ..
-            } => Self::is_go_const_eligible(expression),
+            } => self.is_go_const_eligible(expression),
             _ => false,
         }
     }

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -114,6 +114,8 @@ struct ScopeState {
     loop_stack: Vec<LoopContext>,
     /// Go variable names currently used as block-to-var assign targets.
     assign_targets: HashSet<String>,
+    /// Go identifiers emitted as `const` (not `var`).
+    go_const_bindings: HashSet<String>,
 }
 
 impl ScopeState {
@@ -272,6 +274,7 @@ impl<'a> Emitter<'a> {
                 scope_depth: 0,
                 loop_stack: Vec::new(),
                 assign_targets: HashSet::default(),
+                go_const_bindings: HashSet::default(),
             },
             current_module: current_module.to_string(),
             synthesized_adapter_types: HashMap::default(),

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -1,22 +1,31 @@
 use crate::checker::EnvResolve;
 use ecow::EcoString;
 use syntax::ast::BindingKind;
-use syntax::ast::{Annotation, Binding, Expression, Span, Visibility};
+use syntax::ast::{Annotation, Binding, Expression, Literal, Span, Visibility};
 use syntax::types::Type;
 
 use super::super::Checker;
 
-fn is_const_eligible(expression: &Expression) -> bool {
+enum ConstInitReject {
+    NotSimple,
+    Composite,
+}
+
+fn classify_const_init(expression: &Expression) -> Option<ConstInitReject> {
     match expression.unwrap_parens() {
-        Expression::Literal { .. } => true,
-        Expression::Identifier { .. } => true,
+        Expression::Literal { literal, .. } => match literal {
+            Literal::Slice(_) => Some(ConstInitReject::Composite),
+            Literal::FormatString(_) => Some(ConstInitReject::NotSimple),
+            _ => None,
+        },
+        Expression::Identifier { .. } => None,
         Expression::Binary { left, right, .. } => {
-            is_const_eligible(left) && is_const_eligible(right)
+            classify_const_init(left).or_else(|| classify_const_init(right))
         }
-        Expression::Unary { expression, .. } => is_const_eligible(expression),
-        Expression::StructCall { .. } => true,
-        Expression::Tuple { elements, .. } => elements.iter().all(is_const_eligible),
-        _ => false,
+        Expression::Unary { expression, .. } => classify_const_init(expression),
+        Expression::StructCall { .. } => Some(ConstInitReject::Composite),
+        Expression::Tuple { .. } => Some(ConstInitReject::Composite),
+        _ => Some(ConstInitReject::NotSimple),
     }
 }
 
@@ -43,11 +52,20 @@ impl Checker<'_, '_> {
 
         let new_expression = self.infer_expression(*expression, &ty);
 
-        if !is_const_eligible(&new_expression) {
-            self.sink
-                .push(diagnostics::infer::const_requires_simple_expression(
-                    new_expression.get_span(),
-                ));
+        match classify_const_init(&new_expression) {
+            None => {}
+            Some(ConstInitReject::NotSimple) => {
+                self.sink
+                    .push(diagnostics::infer::const_requires_simple_expression(
+                        new_expression.get_span(),
+                    ));
+            }
+            Some(ConstInitReject::Composite) => {
+                self.sink
+                    .push(diagnostics::infer::const_disallows_composite(
+                        new_expression.get_span(),
+                    ));
+            }
         }
 
         Expression::Const {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -761,11 +761,13 @@ impl Checker<'_, '_> {
                 .lookup_binding_id(&var_name)
                 .and_then(|id| self.facts.bindings.get(&id))
                 .is_some_and(|b| b.kind.is_match_arm());
+            let is_const = self.is_const_var(&var_name);
             self.sink.push(diagnostics::infer::disallowed_mutation(
                 &var_name,
                 *span,
                 self_type_name.as_deref(),
                 is_match_arm,
+                is_const,
             ));
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1230,11 +1230,13 @@ impl Checker<'_, '_> {
                 .lookup_binding_id(&var_name)
                 .and_then(|id| self.facts.bindings.get(&id))
                 .is_some_and(|b| b.kind.is_match_arm());
+            let is_const = self.is_const_var(&var_name);
             self.sink.push(diagnostics::infer::disallowed_mutation(
                 &var_name,
                 *span,
                 None,
                 is_match_arm,
+                is_const,
             ));
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -195,6 +195,14 @@ impl Checker<'_, '_> {
             if let Some(kind) = check_is_non_addressable(&new_expression, &self.env) {
                 self.sink
                     .push(diagnostics::infer::non_addressable_expression(kind, span));
+            } else if let Expression::Identifier {
+                qualified: Some(qname),
+                ..
+            } = &new_expression
+                && self.is_const_name(qname.as_str())
+            {
+                self.sink
+                    .push(diagnostics::infer::non_addressable_const(span));
             }
 
             if let Some(var_name) = new_expression.get_var_name()
@@ -338,11 +346,13 @@ impl Checker<'_, '_> {
                     .lookup_binding_id(&var_name)
                     .and_then(|id| self.facts.bindings.get(&id))
                     .is_some_and(|b| b.kind.is_match_arm());
+                let is_const = self.is_const_var(&var_name);
                 self.sink.push(diagnostics::infer::disallowed_mutation(
                     &var_name,
                     span,
                     self_type_name.as_deref(),
                     is_match_arm,
+                    is_const,
                 ));
             }
 

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -23,6 +23,9 @@ impl Checker<'_, '_> {
             std::mem::take(&mut module.files).into_values().collect()
         };
 
+        let items_per_file: Vec<&[Expression]> = files.iter().map(|f| f.items.as_slice()).collect();
+        self.check_const_cycles(&items_per_file);
+
         for file in files {
             let imports = file.imports();
 

--- a/crates/semantics/src/checker/infer/validation/const_cycles.rs
+++ b/crates/semantics/src/checker/infer/validation/const_cycles.rs
@@ -1,0 +1,144 @@
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use ecow::EcoString;
+use syntax::ast::{Expression, Span};
+
+use crate::checker::Checker;
+
+struct ConstEntry<'a> {
+    name: &'a EcoString,
+    name_span: Span,
+    body: &'a Expression,
+}
+
+impl Checker<'_, '_> {
+    pub fn check_const_cycles(&mut self, items_per_file: &[&[Expression]]) {
+        let module_const_names_empty = self
+            .store
+            .get_module(&self.cursor.module_id)
+            .is_some_and(|m| m.const_names.is_empty());
+        if module_const_names_empty {
+            return;
+        }
+
+        let mut consts: Vec<ConstEntry<'_>> = Vec::new();
+        for items in items_per_file {
+            for item in *items {
+                if let Expression::Const {
+                    identifier,
+                    identifier_span,
+                    expression,
+                    ..
+                } = item
+                {
+                    consts.push(ConstEntry {
+                        name: identifier,
+                        name_span: *identifier_span,
+                        body: expression,
+                    });
+                }
+            }
+        }
+
+        if consts.is_empty() {
+            return;
+        }
+
+        let const_names: HashSet<&EcoString> = consts.iter().map(|c| c.name).collect();
+
+        let mut deps: HashMap<&EcoString, Vec<&EcoString>> = HashMap::default();
+        let mut spans: HashMap<&EcoString, Span> = HashMap::default();
+        for entry in &consts {
+            let mut refs: Vec<&EcoString> = Vec::new();
+            collect_const_refs(entry.body, &const_names, &mut refs);
+            refs.sort();
+            refs.dedup();
+            deps.insert(entry.name, refs);
+            spans.insert(entry.name, entry.name_span);
+        }
+
+        let mut color: HashMap<&EcoString, Color> = HashMap::default();
+        for entry in &consts {
+            color.insert(entry.name, Color::White);
+        }
+
+        let mut reported: HashSet<&EcoString> = HashSet::default();
+        for entry in &consts {
+            if color[&entry.name] == Color::White {
+                let mut path: Vec<&EcoString> = Vec::new();
+                dfs(
+                    entry.name,
+                    &deps,
+                    &spans,
+                    &mut color,
+                    &mut path,
+                    &mut reported,
+                    self.sink,
+                );
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum Color {
+    White,
+    Gray,
+    Black,
+}
+
+fn dfs<'a>(
+    node: &'a EcoString,
+    deps: &HashMap<&'a EcoString, Vec<&'a EcoString>>,
+    spans: &HashMap<&'a EcoString, Span>,
+    color: &mut HashMap<&'a EcoString, Color>,
+    path: &mut Vec<&'a EcoString>,
+    reported: &mut HashSet<&'a EcoString>,
+    sink: &diagnostics::DiagnosticSink,
+) {
+    color.insert(node, Color::Gray);
+    path.push(node);
+
+    if let Some(neighbors) = deps.get(node) {
+        for next in neighbors {
+            match color.get(next).copied().unwrap_or(Color::White) {
+                Color::White => dfs(next, deps, spans, color, path, reported, sink),
+                Color::Gray => {
+                    let start = path.iter().position(|n| *n == *next).unwrap_or(0);
+                    let cycle: Vec<String> = path[start..].iter().map(|n| n.to_string()).collect();
+                    let representative = path[start];
+                    if reported.insert(representative)
+                        && let Some(span) = spans.get(representative)
+                    {
+                        sink.push(diagnostics::infer::const_cycle(&cycle, *span));
+                    }
+                }
+                Color::Black => {}
+            }
+        }
+    }
+
+    path.pop();
+    color.insert(node, Color::Black);
+}
+
+fn collect_const_refs<'a>(
+    expression: &'a Expression,
+    const_names: &HashSet<&'a EcoString>,
+    out: &mut Vec<&'a EcoString>,
+) {
+    if let Expression::Identifier {
+        value, qualified, ..
+    } = expression
+    {
+        if qualified.is_none()
+            && let Some(&name) = const_names.get(value)
+        {
+            out.push(name);
+        }
+        return;
+    }
+    for child in expression.children() {
+        collect_const_refs(child, const_names, out);
+    }
+}

--- a/crates/semantics/src/checker/infer/validation/mod.rs
+++ b/crates/semantics/src/checker/infer/validation/mod.rs
@@ -1,4 +1,5 @@
 mod casts;
+mod const_cycles;
 mod control_flow;
 mod numeric;
 mod references;

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -289,6 +289,23 @@ impl<'r, 's> Checker<'r, 's> {
         self.store.get_definition(qualified_name)?.name_span()
     }
 
+    pub(crate) fn is_const_name(&self, qualified_name: &str) -> bool {
+        if qualified_name.starts_with("go:") {
+            return false;
+        }
+        self.store
+            .module_for_qualified_name(qualified_name)
+            .and_then(|module_id| self.store.get_module(module_id))
+            .is_some_and(|module| module.const_names.contains(qualified_name))
+    }
+
+    pub(crate) fn is_const_var(&self, var_name: &str) -> bool {
+        self.scopes.lookup_binding_id(var_name).is_none()
+            && self
+                .lookup_qualified_name(var_name)
+                .is_some_and(|qname| self.is_const_name(&qname))
+    }
+
     /// Track that `name` (at the start of `span`) refers to the definition at `qualified_name`.
     pub(crate) fn track_name_usage(&mut self, qualified_name: &str, span: &Span, name_len: u32) {
         if let Some(definition_span) = self.get_definition_name_span(qualified_name) {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -622,6 +622,7 @@ impl Checker<'_, '_> {
             .store
             .get_module_mut(&self.cursor.module_id)
             .expect("current module must exist in store");
+        module.const_names.insert(qualified_name.clone());
         module.definitions.insert(
             qualified_name,
             Definition::Value {

--- a/crates/syntax/src/program/module.rs
+++ b/crates/syntax/src/program/module.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::definition::{Definition, Visibility};
 use super::file::{File, FileImport};
@@ -15,6 +15,8 @@ pub struct Module {
     pub typedefs: HashMap<u32, File>,
     /// qualified name -> definition
     pub definitions: HashMap<Symbol, Definition>,
+    /// Qualified names of module-level `const` bindings.
+    pub const_names: HashSet<Symbol>,
 }
 
 impl Module {
@@ -24,6 +26,7 @@ impl Module {
             files: Default::default(),
             typedefs: Default::default(),
             definitions: Default::default(),
+            const_names: Default::default(),
         }
     }
 

--- a/docs/reference/02-types.md
+++ b/docs/reference/02-types.md
@@ -257,10 +257,20 @@ let mut count = 0
 count += 1
 ```
 
-`const` defines a constant. Constants must be compile-time evaluable.
+`const` defines a compile-time constant. As in Go, only primitive values are allowed: `bool`, `int`, `float`, `string`. The initializer must be a literal or an expression built from literals. `const` bindings are immutable and unaddressable.
 
 ```rust
 const MAX_SIZE = 1024
+const GREETING = "hello"
+const DOUBLED = MAX_SIZE * 2
+```
+
+Composite values (tuples, structs, lists) cannot be `const`. Use a function that returns the value instead:
+
+```rust
+fn origin() -> Point {
+  Point { x: 0, y: 0 }
+}
 ```
 
 Add a type annotation with `:` after the binding name. Annotations are optional on bindings; the type typically can inferred from the value. Function parameters require annotations.

--- a/docs/reference/07-pointers.md
+++ b/docs/reference/07-pointers.md
@@ -33,6 +33,15 @@ Some expressions cannot be referenced:
   help: Assign the value to a variable first, then take its address
 ```
 
+`const` bindings are also not addressable. Copy the value into a local `let` first if you need a reference:
+
+```rust
+const N = 42
+
+let x = N
+let r = &x          // ok
+```
+
 ## Dereferencing
 
 Use `.*` to access the referenced value:
@@ -57,7 +66,7 @@ increment(&x)
 // x is now 2
 ```
 
-Mutation through a `Ref<T>` does not require `mut` on either the reference binding or the original binding. `Ref<T>` is a Go pointer, so it can always write to its target.
+Mutation through a `Ref<T>` does not require `mut` on either the reference binding or the original binding. `Ref<T>` is a Go pointer, so it can always write to its target. This escape hatch does not apply to `const` bindings, since `&CONST` is rejected at compile time.
 
 ## Nil safety
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -145,6 +145,7 @@ impl CompiledTest {
             checker.put_imported_modules_in_scope(&imports);
 
             checker.register_types_and_values(&self.ast, &Visibility::Local);
+            checker.check_const_cycles(&[self.ast.as_slice()]);
 
             // Store AST in module so compute_module_ufcs can scan impl blocks (condition 3)
             let test_file_id = checker.store.new_file_id();

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -359,6 +359,21 @@ fn main() {
 }
 
 #[test]
+fn const_reference_to_const_stays_const() {
+    let input = r#"
+import "go:fmt"
+
+const X = 10
+const Y = X + 5
+
+fn main() {
+  fmt.Println(Y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn format_string_simple() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/const_reference_to_const_stays_const.snap
+++ b/tests/spec/emit/snapshots/const_reference_to_const_stays_const.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nconst X = 10\nconst Y = X + 5\n\nfn main() {\n  fmt.Println(Y)\n}\n"
+---
+package main
+
+import "fmt"
+
+const X int = 10
+
+const Y int = X + 5
+
+func main() {
+	fmt.Println(Y)
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5179,6 +5179,77 @@ const VALUE = {
 }
 
 #[test]
+fn infer_const_self_reference_cycle() {
+    let input = r#"
+const SELF = SELF
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_const_mutual_cycle() {
+    let input = r#"
+const A = B
+const B = A
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_reference_to_scalar_const() {
+    let input = r#"
+const N = 42
+
+fn bump(r: Ref<int>) {
+  r.* = r.* + 1
+}
+
+fn main() {
+  bump(&N)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mutate_const_shows_const_hint() {
+    let input = r#"
+const N = 5
+
+fn main() {
+  N = 10
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_const_disallows_list_literal() {
+    let input = r#"
+const ITEMS = ["a", "b"]
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_const_disallows_tuple_literal() {
+    let input = r#"
+const PAIR = (1, 2)
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_const_disallows_struct_literal() {
+    let input = r#"
+struct Point { x: int, y: int }
+
+const ORIGIN = Point { x: 0, y: 0 }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_complex_sub_expression() {
     let input = r#"
 fn side_effect() -> int { 1 }

--- a/tests/ui/errors/snapshots/infer_const_disallows_list_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_list_literal.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Composite value in `const`
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ const ITEMS = ["a", "b"]
+   ·               ─────┬────
+   ·                    ╰── not allowed
+   ╰────
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_const_disallows_struct_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_struct_literal.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Composite value in `const`
+   ╭─[test.lis:4:16]
+ 3 │ 
+ 4 │ const ORIGIN = Point { x: 0, y: 0 }
+   ·                ──────────┬─────────
+   ·                          ╰── not allowed
+   ╰────
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_const_disallows_tuple_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_tuple_literal.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Composite value in `const`
+   ╭─[test.lis:2:14]
+ 1 │ 
+ 2 │ const PAIR = (1, 2)
+   ·              ───┬──
+   ·                 ╰── not allowed
+   ╰────
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_const_mutual_cycle.snap
+++ b/tests/ui/errors/snapshots/infer_const_mutual_cycle.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `const` init cycle
+   ╭─[test.lis:2:7]
+ 1 │ 
+ 2 │ const A = B
+   ·       ┬
+   ·       ╰── cycle: `A` → `B` → `A`
+ 3 │ const B = A
+   ╰────
+  help: `const` initializers cannot refer to themselves, either directly or transitively · code: [infer.const_cycle]

--- a/tests/ui/errors/snapshots/infer_const_self_reference_cycle.snap
+++ b/tests/ui/errors/snapshots/infer_const_self_reference_cycle.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `const` init cycle
+   ╭─[test.lis:2:7]
+ 1 │ 
+ 2 │ const SELF = SELF
+   ·       ──┬─
+   ·         ╰── self-reference
+   ╰────
+  help: `const` initializers cannot refer to themselves, either directly or transitively · code: [infer.const_cycle]

--- a/tests/ui/errors/snapshots/infer_mutate_const_shows_const_hint.snap
+++ b/tests/ui/errors/snapshots/infer_mutate_const_shows_const_hint.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot mutate `const`
+   ╭─[test.lis:5:3]
+ 4 │ fn main() {
+ 5 │   N = 10
+   ·   ───┬──
+   ·      ╰── cannot mutate a `const`
+ 6 │ }
+   ╰────
+  help: `const` bindings are immutable. Rebind with `let mut N = N` to mutate a local copy · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_reference_to_scalar_const.snap
+++ b/tests/ui/errors/snapshots/infer_reference_to_scalar_const.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot take address of `const`
+    ╭─[test.lis:9:8]
+  8 │ fn main() {
+  9 │   bump(&N)
+    ·        ─┬
+    ·         ╰── not addressable
+ 10 │ }
+    ╰────
+  help: `const` bindings are not addressable. Copy the value into a local `let` first if you need a reference · code: [infer.non_addressable_const]


### PR DESCRIPTION
Fix #159