### PR TITLE
feat: support for raw string literals

### DIFF
--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -40,6 +40,9 @@ impl Emitter<'_> {
             Literal::String(s) => {
                 format!("\"{}\"", convert_escape_sequences(s))
             }
+            Literal::RawString(s) => {
+                format!("`{}`", s)
+            }
             Literal::Char(c) => {
                 format!("'{}'", convert_escape_sequences(c))
             }

--- a/crates/emit/src/patterns/bindings.rs
+++ b/crates/emit/src/patterns/bindings.rs
@@ -61,6 +61,9 @@ pub(crate) fn emit_pattern_literal(literal: &Literal) -> String {
         Literal::String(s) => {
             format!("\"{}\"", convert_escape_sequences(s))
         }
+        Literal::RawString(s) => {
+            format!("`{}`", s)
+        }
         Literal::Char(c) => {
             format!("'{}'", convert_escape_sequences(c))
         }

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -535,6 +535,7 @@ impl<'a> Formatter<'a> {
             }
             Literal::Boolean(b) => Document::str(if *b { "true" } else { "false" }),
             Literal::String(s) => Document::string(format!("\"{s}\"")),
+            Literal::RawString(s) => Document::string(format!("`{s}`")),
             Literal::Char(c) => Document::string(format!("'{c}'")),
             Literal::Slice(elements) => self.slice(elements),
             Literal::FormatString(parts) => self.format_string(parts),

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -84,6 +84,7 @@ impl CachedLiteral {
             },
             Literal::Boolean(v) => CachedLiteral::Boolean(*v),
             Literal::String(v) => CachedLiteral::String(v.clone()),
+            Literal::RawString(v) => CachedLiteral::String(v.clone()),
             Literal::Char(v) => CachedLiteral::Char(v.clone()),
             // These shouldn't appear in ValueEnum variants
             Literal::Imaginary(_) | Literal::FormatString(_) | Literal::Slice(_) => {

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -92,6 +92,17 @@ impl Checker<'_, '_> {
                 }
             }
 
+            Literal::RawString(string) => {
+                let string_ty = self.type_string();
+                self.unify(expected_ty, &string_ty, &span);
+
+                Expression::Literal {
+                    literal: Literal::RawString(string),
+                    ty: string_ty,
+                    span,
+                }
+            }
+
             Literal::Char(char) => {
                 let resolved = expected_ty.resolve_in(&self.env);
                 let ty = if resolved.is_numeric() {

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -860,6 +860,7 @@ fn format_literal(lit: &Literal) -> String {
         Literal::Imaginary(v) => format!("{}i", v),
         Literal::Boolean(b) => b.to_string(),
         Literal::String(s) => format!("\"{}\"", s),
+        Literal::RawString(s) => format!("`{}`", s),
         Literal::Char(c) => format!("'{}'", c),
         Literal::FormatString(_) => "f\"...\"".to_string(),
         Literal::Slice(_) => "[...]".to_string(),

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -140,7 +140,7 @@ impl<'r, 's> Checker<'r, 's> {
                 Literal::Integer { .. } => Some(self.type_int()),
                 Literal::Float { .. } => Some(self.type_float()),
                 Literal::Boolean(_) => Some(self.type_bool()),
-                Literal::String(_) => Some(self.type_string()),
+                Literal::String(_) | Literal::RawString(_) => Some(self.type_string()),
                 Literal::Char(_) => Some(self.type_char()),
                 _ => None,
             },

--- a/crates/semantics/src/pattern_analysis/witness.rs
+++ b/crates/semantics/src/pattern_analysis/witness.rs
@@ -103,6 +103,7 @@ fn format_literal(lit: &Literal) -> String {
         Literal::Imaginary(val) => format!("{}i", val),
         Literal::Boolean(b) => b.to_string(),
         Literal::String(s) => format!("\"{}\"", s),
+        Literal::RawString(s) => format!("`{}`", s),
         Literal::Char(c) => format!("'{}'", c),
         Literal::FormatString(_) => "f\"...\"".to_string(),
         Literal::Slice(_) => "[...]".to_string(),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1658,6 +1658,7 @@ pub enum Literal {
     Imaginary(f64),
     Boolean(bool),
     String(String),
+    RawString(String),
     FormatString(Vec<FormatStringPart>),
     Char(String),
     Slice(Vec<Expression>),

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -733,8 +733,6 @@ impl<'source> Lexer<'source> {
                 terminated = true;
                 self.next();
                 break;
-            } else if byte == b'\n' {
-                break;
             }
             self.next();
         }

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -123,6 +123,12 @@ impl<'source> Parser<'source> {
             } else {
                 text
             };
+            if value.contains('\n') {
+                self.track_error(
+                    "struct tags cannot contain newlines",
+                    "Raw strings used as struct tags must be a single line.",
+                );
+            }
             return Some(AttributeArg::Raw(value.to_string()));
         }
 

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -29,7 +29,7 @@ impl<'source> Parser<'source> {
         }
 
         match self.current_token().kind {
-            Integer | Imaginary | Boolean | Char | String | Float => self.parse_literal(),
+            Integer | Imaginary | Boolean | Char | String | Float | Backtick => self.parse_literal(),
             FormatStringStart => self.parse_format_string(),
             LeftParen => self.parse_parenthesized_expression(),
             LeftCurlyBrace => self.parse_block_expression(),
@@ -188,6 +188,17 @@ impl<'source> Parser<'source> {
                     c
                 };
                 Literal::Char(c_stripped.to_string())
+            }
+            Backtick => {
+                let s = self.current_token().text;
+                self.next();
+                let s_stripped = if s.len() >= 2 && s.starts_with('`') && s.ends_with('`') {
+                    &s[1..s.len() - 1]
+                } else {
+                    debug_assert!(false, "lexer produced Backtick token without backticks: {:?}", s);
+                    s
+                };
+                Literal::RawString(s_stripped.to_string())
             }
             _ => return self.unexpected_token("literal"),
         };

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -29,7 +29,9 @@ impl<'source> Parser<'source> {
         }
 
         match self.current_token().kind {
-            Integer | Imaginary | Boolean | Char | String | Float | Backtick => self.parse_literal(),
+            Integer | Imaginary | Boolean | Char | String | Float | Backtick => {
+                self.parse_literal()
+            }
             FormatStringStart => self.parse_format_string(),
             LeftParen => self.parse_parenthesized_expression(),
             LeftCurlyBrace => self.parse_block_expression(),
@@ -195,7 +197,11 @@ impl<'source> Parser<'source> {
                 let s_stripped = if s.len() >= 2 && s.starts_with('`') && s.ends_with('`') {
                     &s[1..s.len() - 1]
                 } else {
-                    debug_assert!(false, "lexer produced Backtick token without backticks: {:?}", s);
+                    debug_assert!(
+                        false,
+                        "lexer produced Backtick token without backticks: {:?}",
+                        s
+                    );
                     s
                 };
                 Literal::RawString(s_stripped.to_string())

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -79,6 +79,7 @@ impl<'source> Parser<'source> {
             Float => self.parse_float_pattern(),
             Boolean => self.parse_boolean_pattern(),
             String => self.parse_string_pattern(),
+            Backtick => self.parse_raw_string_pattern(),
             Char => self.parse_char_pattern(),
 
             Imaginary => {
@@ -247,6 +248,23 @@ impl<'source> Parser<'source> {
 
         Pattern::Literal {
             literal: Literal::String(s_stripped),
+            ty: Type::uninferred(),
+            span: self.span_from_tokens(start),
+        }
+    }
+
+    fn parse_raw_string_pattern(&mut self) -> Pattern {
+        let start = self.current_token();
+        let s = start.text;
+        self.next();
+        let s_stripped = if s.len() >= 2 && s.starts_with('`') && s.ends_with('`') {
+            s[1..s.len() - 1].to_string()
+        } else {
+            s.to_string()
+        };
+
+        Pattern::Literal {
+            literal: Literal::RawString(s_stripped),
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }

--- a/docs/reference/01-lexical-structure.md
+++ b/docs/reference/01-lexical-structure.md
@@ -96,6 +96,20 @@ Escape sequences:
 | `\r`     | Carriage return |
 | `\t`     | Tab             |
 
+### Raw string literals
+
+Raw string literals are enclosed in backticks. No escape sequences are processed — the content is taken verbatim. They support multiline content and are useful for regular expressions, file paths, and SQL queries. Type: `string`.
+
+```rust
+let path = `C:\Users\foo\bar`
+let pattern = `^\d{3}-\d{4}$`
+let query = `SELECT *
+  FROM users
+  WHERE active = true`
+```
+
+Raw strings cannot contain a backtick character (as it would end the literal).
+
 ### Format strings
 
 A format string begins with `f"` and can contain interpolated expressions in `{}`.

--- a/tests/spec/emit/literals.rs
+++ b/tests/spec/emit/literals.rs
@@ -515,3 +515,35 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn raw_string_simple() {
+    let input = r#"
+fn test() {
+  `hello world`
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn raw_string_with_backslashes() {
+    let input = "
+fn test() {
+  `C:\\Users\\foo\\bar`
+}
+";
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn raw_string_multiline() {
+    let input = "
+fn test() {
+  `line1
+line2
+line3`
+}
+";
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/raw_string_multiline.snap
+++ b/tests/spec/emit/snapshots/raw_string_multiline.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/literals.rs
+description: "input: \nfn test() {\n  `line1\nline2\nline3`\n}\n"
+---
+package main
+
+func test() {
+	_ = `line1
+line2
+line3`
+}

--- a/tests/spec/emit/snapshots/raw_string_simple.snap
+++ b/tests/spec/emit/snapshots/raw_string_simple.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/literals.rs
+description: "input: \nfn test() {\n  `hello world`\n}\n"
+---
+package main
+
+func test() {
+	_ = `hello world`
+}

--- a/tests/spec/emit/snapshots/raw_string_with_backslashes.snap
+++ b/tests/spec/emit/snapshots/raw_string_with_backslashes.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/literals.rs
+description: "input: \nfn test() {\n  `C:\\Users\\foo\\bar`\n}\n"
+---
+package main
+
+func test() {
+	_ = `C:\Users\foo\bar`
+}

--- a/tests/spec/lex/mod.rs
+++ b/tests/spec/lex/mod.rs
@@ -813,3 +813,27 @@ fn no_asi_before_closing_bracket() {
 ]";
     assert_lex_snapshot!(input);
 }
+
+#[test]
+fn raw_string_simple() {
+    let input = "`hello world`";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn raw_string_empty() {
+    let input = "``";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn raw_string_with_backslashes() {
+    let input = r#"`C:\Users\foo\bar`"#;
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn raw_string_multiline() {
+    let input = "`line1\nline2\nline3`";
+    assert_lex_snapshot!(input);
+}

--- a/tests/spec/lex/snapshots/raw_string_empty.snap
+++ b/tests/spec/lex/snapshots/raw_string_empty.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: ``"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Backtick,
+            text: "``",
+            byte_offset: 0,
+            byte_length: 2,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 2,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/raw_string_multiline.snap
+++ b/tests/spec/lex/snapshots/raw_string_multiline.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: `line1\nline2\nline3`"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Backtick,
+            text: "`line1\nline2\nline3`",
+            byte_offset: 0,
+            byte_length: 19,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 19,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/raw_string_simple.snap
+++ b/tests/spec/lex/snapshots/raw_string_simple.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: `hello world`"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Backtick,
+            text: "`hello world`",
+            byte_offset: 0,
+            byte_length: 13,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 13,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/lex/snapshots/raw_string_with_backslashes.snap
+++ b/tests/spec/lex/snapshots/raw_string_with_backslashes.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/lex/mod.rs
+description: "input: `C:\\Users\\foo\\bar`"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Backtick,
+            text: "`C:\\Users\\foo\\bar`",
+            byte_offset: 0,
+            byte_length: 18,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 18,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    trivia: Trivia {
+        comments: [],
+        doc_comments: [],
+        blank_lines: [],
+    },
+}

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -3516,3 +3516,24 @@ fn test() { func(a, b, ..xs,); }
 "#;
     assert_parse_snapshot!(input);
 }
+
+#[test]
+fn raw_string_literal() {
+    let input = "
+fn test() { `hello world` }
+";
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn match_raw_string() {
+    let input = "
+fn test(path: string) {
+  match path {
+    `C:\\` => print(\"windows\"),
+    _ => print(\"other\"),
+  }
+}
+";
+    assert_parse_snapshot!(input);
+}

--- a/tests/spec/parse/snapshots/match_raw_string.snap
+++ b/tests/spec/parse/snapshots/match_raw_string.snap
@@ -1,0 +1,144 @@
+---
+source: tests/spec/parse/mod.rs
+description: "input: \nfn test(path: string) {\n  match path {\n    `C:\\` => print(\"windows\"),\n    _ => print(\"other\"),\n  }\n}\n"
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "path",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 9,
+                        byte_length: 4,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "string",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 6,
+                        },
+                    },
+                ),
+                typed_pattern: None,
+                ty: Variable(
+                    -1,
+                ),
+            },
+        ],
+        return_annotation: Unknown,
+        return_type: Variable(
+            -1,
+        ),
+        visibility: Private,
+        body: Block {
+            items: [
+                Match {
+                    subject: Identifier {
+                        value: "path",
+                        ty: Variable(
+                            -1,
+                        ),
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 33,
+                            byte_length: 4,
+                        },
+                        binding_id: None,
+                        qualified: None,
+                    },
+                    arms: [
+                        MatchArm {
+                            pattern: WildCard {
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 75,
+                                    byte_length: 1,
+                                },
+                            },
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "print",
+                                    ty: Variable(
+                                        -1,
+                                    ),
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 80,
+                                        byte_length: 5,
+                                    },
+                                    binding_id: None,
+                                    qualified: None,
+                                },
+                                args: [
+                                    Literal {
+                                        literal: String(
+                                            "other",
+                                        ),
+                                        ty: Variable(
+                                            -1,
+                                        ),
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 86,
+                                            byte_length: 7,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_args: [],
+                                ty: Variable(
+                                    -1,
+                                ),
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 80,
+                                    byte_length: 14,
+                                },
+                            },
+                        },
+                    ],
+                    origin: Explicit,
+                    ty: Variable(
+                        -1,
+                    ),
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 27,
+                        byte_length: 72,
+                    },
+                },
+            ],
+            ty: Variable(
+                -1,
+            ),
+            span: Span {
+                file_id: 0,
+                byte_offset: 23,
+                byte_length: 78,
+            },
+        },
+        ty: Variable(
+            -1,
+        ),
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 100,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/raw_string_literal.snap
+++ b/tests/spec/parse/snapshots/raw_string_literal.snap
@@ -1,0 +1,56 @@
+---
+source: tests/spec/parse/mod.rs
+description: "input: \nfn test() { `hello world` }\n"
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [],
+        return_annotation: Unknown,
+        return_type: Variable(
+            -1,
+        ),
+        visibility: Private,
+        body: Block {
+            items: [
+                Literal {
+                    literal: RawString(
+                        "hello world",
+                    ),
+                    ty: Variable(
+                        -1,
+                    ),
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 13,
+                        byte_length: 13,
+                    },
+                },
+            ],
+            ty: Variable(
+                -1,
+            ),
+            span: Span {
+                file_id: 0,
+                byte_offset: 11,
+                byte_length: 17,
+            },
+        },
+        ty: Variable(
+            -1,
+        ),
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 27,
+        },
+    },
+]


### PR DESCRIPTION
This adds support for raw string literals, making it easier to write longer strings like SQL, or regular expressions.

```rust
let hello = `Hello`
let world = "World"

// Both have type string
fmt.Println(hello + " " + world)

// No need for double escape in regexp's
let re = regexp.MustCompile(`([a-zA-Z])(\d)`)

// Long strings like SQL can be written inline. No need for concat.
let sql = `
    SELECT
    orders.amount,
    orders.campaign,
    orders.created_at,
    FROM orders
    LEFT JOIN customer ON customer.id = orders.id
    LIMIT 100
`
```