### PR TITLE
chore: release v0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.1.19](https://github.com/ivov/lisette/compare/lisette-v0.1.18...lisette-v0.1.19) - 2026-04-24
+
+- ci: ship prebuilt binaries [#165](https://github.com/ivov/lisette/pull/165) [`a11eda1`](https://github.com/ivov/lisette/commit/a11eda1696aa2e0c9b3e7cc311d8031125a17529)
+- fix: suppress auto-stringer when user method uses Go casing [#171](https://github.com/ivov/lisette/pull/171) [`6c4bb49`](https://github.com/ivov/lisette/commit/6c4bb490bd5402b82677743e8dff28d45e0af5cc)
+- fix: place enum constructors beside their enum definition [#172](https://github.com/ivov/lisette/pull/172) [`e367406`](https://github.com/ivov/lisette/commit/e3674063d070d130d53be9b43525d4a7fcd41b86)
+- refactor: prep parallel semantics [#170](https://github.com/ivov/lisette/pull/170) [`54a2a0c`](https://github.com/ivov/lisette/commit/54a2a0cf07d34f1f9bea6205fb963114351790a1)
+
 ## [0.1.18](https://github.com/ivov/lisette/compare/lisette-v0.1.17...lisette-v0.1.18) - 2026-04-23
 
 - refactor: consolidate emit coercions and decision walkers [#157](https://github.com/ivov/lisette/pull/157) [`ed1cf48`](https://github.com/ivov/lisette/commit/ed1cf48f37b7f8c33f79bc660c636306d1fea27c)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "ecow",
  "lisette-syntax",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bincode",
  "ecow",
@@ -579,11 +579,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.1.18"
+version = "0.1.19"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,14 +18,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.1.18", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.18", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.1.18", path = "../format" }
-emit = { package = "lisette-emit", version = "0.1.18", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.1.18", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.18", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.1.18", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.1.19", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.19", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.1.19", path = "../format" }
+emit = { package = "lisette-emit", version = "0.1.19", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.1.19", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.19", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.1.19", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.1.18", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.1.19", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,6 +13,6 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.1.18", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.18", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.1.18", path = "../deps" }
-format = { package = "lisette-format", version = "0.1.18", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.1.19", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.19", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.1.19", path = "../deps" }
+format = { package = "lisette-format", version = "0.1.19", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.18", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.18", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.1.18", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.18", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.1.19", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.19", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.1.19", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.19", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION

## 0.1.19 (upcoming)

- ci: ship prebuilt binaries [#165](https://github.com/ivov/lisette/pull/165) [`a11eda1`](https://github.com/ivov/lisette/commit/a11eda1696aa2e0c9b3e7cc311d8031125a17529)
- fix: suppress auto-stringer when user method uses Go casing [#171](https://github.com/ivov/lisette/pull/171) [`6c4bb49`](https://github.com/ivov/lisette/commit/6c4bb490bd5402b82677743e8dff28d45e0af5cc)
- fix: place enum constructors beside their enum definition [#172](https://github.com/ivov/lisette/pull/172) [`e367406`](https://github.com/ivov/lisette/commit/e3674063d070d130d53be9b43525d4a7fcd41b86)
- refactor: prep parallel semantics [#170](https://github.com/ivov/lisette/pull/170) [`54a2a0c`](https://github.com/ivov/lisette/commit/54a2a0cf07d34f1f9bea6205fb963114351790a1)