### PR TITLE
fix: suppress auto-stringer when user method uses Go casing

### DIFF
--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
 use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::names::generics::receiver_generics_string;
 use crate::names::go_name;
@@ -224,11 +225,12 @@ impl Emitter<'_> {
     }
 
     /// Returns the name for the auto-generated stringer method, or `None` if no
-    /// auto-generated method should be emitted.
+    /// auto-generated method should be emitted. Both Lisette casing (`string`,
+    /// `goString`) and Go casing (`String`, `GoString`) count as user-defined.
     ///
-    /// - No user `string` → auto-generated method is `"String"`
-    /// - User `string` only → auto-generated method is `"GoString"`
-    /// - User `string` + `goString` → `None` (skip, user covers both)
+    /// - No user stringer → auto-generated method is `"String"`
+    /// - User stringer only → auto-generated method is `"GoString"`
+    /// - User stringer + go-stringer → `None` (skip, user covers both)
     pub(super) fn stringer_method_name(&self, name: &str) -> Option<&'static str> {
         let qualified = format!("{}.{}", self.current_module, name);
         let methods = self
@@ -242,10 +244,14 @@ impl Emitter<'_> {
                 | Definition::TypeAlias { methods, .. } => Some(methods),
                 _ => None,
             });
-        match methods {
-            Some(m) if m.contains_key("string") && m.contains_key("goString") => None,
-            Some(m) if m.contains_key("string") => Some("GoString"),
-            _ => Some("String"),
+        let has_stringer = methods
+            .is_some_and(|m| m.contains_key("string") || m.contains_key(ENUM_STRINGER_METHOD));
+        let has_go_stringer = methods
+            .is_some_and(|m| m.contains_key("goString") || m.contains_key(ENUM_GO_STRINGER_METHOD));
+        match (has_stringer, has_go_stringer) {
+            (true, true) => None,
+            (true, false) => Some(ENUM_GO_STRINGER_METHOD),
+            _ => Some(ENUM_STRINGER_METHOD),
         }
     }
 }

--- a/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nenum Color {\n  Red,\n  Blue,\n}\n\nimpl Color {\n  fn String(self) -> string {\n    \"custom\"\n  }\n}\n\nfn main() {\n  let c = Color.Red\n  let _ = c\n}\n"
+---
+package main
+
+import "fmt"
+
+func MakeColorRed() Color {
+	return Color{Tag: ColorRed}
+}
+
+func MakeColorBlue() Color {
+	return Color{Tag: ColorBlue}
+}
+
+type ColorTag int
+
+const (
+	ColorRed ColorTag = iota
+	ColorBlue
+)
+
+type Color struct {
+	Tag ColorTag
+}
+
+func (c Color) GoString() string {
+	switch c.Tag {
+	case ColorRed:
+		return "Color.Red"
+	case ColorBlue:
+		return "Color.Blue"
+	default:
+		return fmt.Sprintf("Color(%d)", c.Tag)
+	}
+}
+
+func (c Color) String() string {
+	return "custom"
+}
+
+func main() {
+	_ = MakeColorRed()
+}

--- a/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
@@ -13,7 +13,7 @@ type Counter struct {
 	count int
 }
 
-func (c Counter) String() string {
+func (c Counter) GoString() string {
 	return fmt.Sprintf("Counter { count: %v }", c.count)
 }
 

--- a/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
@@ -13,7 +13,7 @@ type Counter struct {
 	count int
 }
 
-func (c Counter) String() string {
+func (c Counter) GoString() string {
 	return fmt.Sprintf("Counter { count: %v }", c.count)
 }
 

--- a/tests/spec/emit/snapshots/struct_user_pascal_string_and_go_string_methods.snap
+++ b/tests/spec/emit/snapshots/struct_user_pascal_string_and_go_string_methods.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn String(self) -> string {\n    \"custom display\"\n  }\n\n  fn GoString(self) -> string {\n    \"custom debug\"\n  }\n}\n\nfn main() {\n  let p = Point { x: 1, y: 2 }\n  let _ = p\n}\n"
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) String() string {
+	return "custom display"
+}
+
+func (p Point) GoString() string {
+	return "custom debug"
+}
+
+func main() {
+	p := Point{
+		x: 1,
+		y: 2,
+	}
+	_ = p
+}

--- a/tests/spec/emit/snapshots/struct_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/struct_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct A { a: string }\n\nimpl A {\n  fn String(self) -> string {\n    self.a + \"asdf\"\n  }\n}\n\nfn main() {\n  let a = A { a: \"text\" }\n  let _ = a\n}\n"
+---
+package main
+
+import "fmt"
+
+type A struct {
+	a string
+}
+
+func (a A) GoString() string {
+	return fmt.Sprintf("A { a: %v }", a.a)
+}
+
+func (a A) String() string {
+	return a.a + "asdf"
+}
+
+func main() {
+	_ = A{a: "text"}
+}

--- a/tests/spec/emit/snapshots/tuple_struct_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct UserId(int)\n\nimpl UserId {\n  fn String(self) -> string {\n    \"custom\"\n  }\n}\n\nfn main() {\n  let u = UserId(1)\n  let _ = u\n}\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) GoString() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+func (u UserId) String() string {
+	return "custom"
+}
+
+func main() {
+	_ = UserId(1)
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2631,6 +2631,89 @@ fn main() {
 }
 
 #[test]
+fn struct_user_pascal_string_method_suppresses_auto_stringer() {
+    let input = r#"
+struct A { a: string }
+
+impl A {
+  fn String(self) -> string {
+    self.a + "asdf"
+  }
+}
+
+fn main() {
+  let a = A { a: "text" }
+  let _ = a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_struct_user_pascal_string_method_suppresses_auto_stringer() {
+    let input = r#"
+struct UserId(int)
+
+impl UserId {
+  fn String(self) -> string {
+    "custom"
+  }
+}
+
+fn main() {
+  let u = UserId(1)
+  let _ = u
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn enum_user_pascal_string_method_suppresses_auto_stringer() {
+    let input = r#"
+enum Color {
+  Red,
+  Blue,
+}
+
+impl Color {
+  fn String(self) -> string {
+    "custom"
+  }
+}
+
+fn main() {
+  let c = Color.Red
+  let _ = c
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_user_pascal_string_and_go_string_methods() {
+    let input = r#"
+struct Point { x: int, y: int }
+
+impl Point {
+  fn String(self) -> string {
+    "custom display"
+  }
+
+  fn GoString(self) -> string {
+    "custom debug"
+  }
+}
+
+fn main() {
+  let p = Point { x: 1, y: 2 }
+  let _ = p
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn impl_methods_share_local_variable_name() {
     let input = r#"
 pub struct Calc {}


### PR DESCRIPTION
Fix #169