### PR TITLE
feat: add lis sync to reconcile manifest with source

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -31,6 +31,7 @@ pub enum Command {
     Add {
         dependency: String,
     },
+    Sync,
     Lsp,
     Bindgen {
         package: String,
@@ -196,6 +197,17 @@ impl Command {
                 }),
             },
 
+            "sync" => {
+                if let Some(extra) = arguments.next() {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: format!("unexpected argument `{}`", extra),
+                        reason: "`lis sync` takes no arguments".to_string(),
+                        hint: "Run `lis sync` from the project root".to_string(),
+                    });
+                }
+                Ok(Command::Sync)
+            }
+
             "lsp" => Ok(Command::Lsp),
 
             "learn" => Ok(Command::Learn),
@@ -294,6 +306,7 @@ impl Command {
             "help",
             "version",
             "add",
+            "sync",
             "learn",
             "doc",
             "completions",

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -2,13 +2,12 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
-
 use crate::go_cli;
+use crate::lock::acquire_mutation_lock;
 use crate::output::{print_add_success, print_preview_notice, print_progress};
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
-use deps::{GoModule, remove_go_dep, upsert_go_dep};
+use deps::{GoModule, remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep};
 
 struct ParsedDependency {
     module_path: String,
@@ -318,7 +317,7 @@ fn miscased_known_host(path: &str) -> Option<String> {
     None
 }
 
-fn find_project_root() -> Option<PathBuf> {
+pub(crate) fn find_project_root() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let mut current: &Path = &cwd;
     loop {
@@ -368,7 +367,7 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         return Err(1);
     }
 
-    print_preview_notice();
+    print_preview_notice("lis add");
 
     let project_target_dir = project_root.join("target");
     if project_target_dir.is_file() {
@@ -387,7 +386,7 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         return Err(1);
     }
 
-    let lock = acquire_add_lock(&project_target_dir)?;
+    let lock = acquire_mutation_lock(&project_target_dir)?;
 
     let locator = deps::TypedefLocator::new(
         manifest.go_deps(),
@@ -444,35 +443,6 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         resolved_version: dep_version,
         _lock: lock,
     })
-}
-
-fn acquire_add_lock(target_dir: &Path) -> Result<File, i32> {
-    let lock_path = target_dir.join(".lis-add.lock");
-    let file = match File::create(&lock_path) {
-        Ok(f) => f,
-        Err(e) => {
-            error!(
-                "failed to create lock file",
-                format!("Failed to create `{}`: {}", lock_path.display(), e)
-            );
-            return Err(1);
-        }
-    };
-
-    if let Err(e) = file.try_lock_exclusive() {
-        if e.kind() == std::io::ErrorKind::WouldBlock {
-            cli_error!(
-                "Another `lis add` is in progress",
-                "A concurrent `lis add` holds the project lock",
-                "Wait for the other invocation to finish, then retry"
-            );
-        } else {
-            error!("failed to acquire lock", format!("{}", e));
-        }
-        return Err(1);
-    }
-
-    Ok(file)
 }
 
 /// Walk the dependency tree reachable from `dep` and cache typedefs for every
@@ -706,56 +676,14 @@ fn apply_graph_to_manifest(
         })?;
     }
 
-    prune_stale_via(project_root)?;
+    trim_dead_via_parents(project_root).map_err(|msg| {
+        error!("failed to update manifest", msg);
+        1
+    })?;
+    resolve_empty_via(project_root, &[]).map_err(|msg| {
+        error!("failed to update manifest", msg);
+        1
+    })?;
 
     Ok(upgraded)
-}
-
-/// Drop `via` entries that point to parents no longer present in the manifest,
-/// and remove transitives left with an empty `via` list.
-fn prune_stale_via(project_root: &Path) -> Result<(), i32> {
-    let manifest = match deps::parse_manifest(project_root) {
-        Ok(m) => m,
-        Err(msg) => {
-            error!("failed to re-read manifest for hygiene pass", msg);
-            return Err(1);
-        }
-    };
-    let live_deps = manifest.go_deps();
-    let live_paths: std::collections::HashSet<&str> =
-        live_deps.keys().map(|s| s.as_str()).collect();
-
-    let mut sorted: Vec<(&String, &deps::GoDependency)> = live_deps.iter().collect();
-    sorted.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (dep_path, dep) in &sorted {
-        let Some(ref via) = dep.via else { continue };
-
-        let mut canonical: Vec<String> = via
-            .iter()
-            .filter(|parent| live_paths.contains(parent.as_str()))
-            .cloned()
-            .collect();
-        canonical.sort();
-        canonical.dedup();
-
-        if canonical.iter().eq(via.iter()) {
-            continue;
-        }
-
-        if canonical.is_empty() {
-            remove_go_dep(project_root, dep_path).map_err(|msg| {
-                error!("failed to update manifest", msg);
-                1
-            })?;
-            continue;
-        }
-
-        upsert_go_dep(project_root, dep_path, &dep.version, Some(canonical)).map_err(|msg| {
-            error!("failed to update manifest", msg);
-            1
-        })?;
-    }
-
-    Ok(())
 }

--- a/crates/cli/src/handlers/mod.rs
+++ b/crates/cli/src/handlers/mod.rs
@@ -11,6 +11,7 @@ mod learn;
 mod lsp;
 mod new;
 mod run;
+mod sync;
 
 pub use add::add;
 pub use bindgen::bindgen;
@@ -24,3 +25,4 @@ pub use learn::learn;
 pub use lsp::lsp;
 pub use new::new_project;
 pub use run::run;
+pub use sync::sync;

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -1,0 +1,158 @@
+use std::path::{Path, PathBuf};
+
+use syntax::ast::Expression;
+use syntax::parse::Parser;
+
+use lisette::fs::collect_lis_filepaths_recursive;
+
+use crate::handlers::add::find_project_root;
+use crate::lock::acquire_mutation_lock;
+use crate::output::{print_preview_notice, print_sync_summary};
+use crate::{cli_error, error};
+
+pub fn sync() -> i32 {
+    let project_root = match find_project_root() {
+        Some(root) => root,
+        None => {
+            cli_error!(
+                "No project found",
+                "No `lisette.toml` in current directory or in any parent",
+                "Run `lis new <name>` to create a project"
+            );
+            return 1;
+        }
+    };
+
+    let manifest = match deps::parse_manifest(&project_root) {
+        Ok(m) => m,
+        Err(msg) => {
+            cli_error!("Failed to read manifest", msg, "Fix `lisette.toml`");
+            return 1;
+        }
+    };
+
+    if let Err(msg) = deps::check_toolchain_version(&manifest) {
+        let trimmed = msg
+            .strip_prefix("Toolchain mismatch: ")
+            .unwrap_or(&msg)
+            .to_string();
+        error!("toolchain mismatch", trimmed);
+        return 1;
+    }
+
+    if let Err(msg) = deps::validate_project_name(&manifest.project.name) {
+        cli_error!(
+            "Invalid project name",
+            msg,
+            "Rename `project.name` in `lisette.toml`"
+        );
+        return 1;
+    }
+
+    print_preview_notice("lis sync");
+
+    let target_dir = project_root.join("target");
+    if target_dir.is_file() {
+        cli_error!(
+            "Failed to set up target directory",
+            "`target/` exists but is a file, not a directory",
+            "Remove or move `target/` and retry"
+        );
+        return 1;
+    }
+    if let Err(e) = std::fs::create_dir_all(&target_dir) {
+        error!(
+            "failed to set up target directory",
+            format!("Failed to create target directory: {}", e)
+        );
+        return 1;
+    }
+
+    let _lock = match acquire_mutation_lock(&target_dir) {
+        Ok(f) => f,
+        Err(code) => return code,
+    };
+
+    let imported_pkgs = match scan_source_imports(&project_root.join("src")) {
+        Ok(pkgs) => pkgs,
+        Err(SourceScanError::Parse { path, message }) => {
+            cli_error!(
+                "Source parse error",
+                format!("Failed to parse `{}`: {}", path.display(), message),
+                "Fix the parse error and rerun `lis sync`"
+            );
+            return 1;
+        }
+        Err(SourceScanError::Read { path, error }) => {
+            error!(
+                "failed to read source file",
+                format!("Failed to read `{}`: {}", path.display(), error)
+            );
+            return 1;
+        }
+    };
+
+    let trimmed = match deps::trim_dead_via_parents(&project_root) {
+        Ok(t) => t,
+        Err(msg) => {
+            error!("failed to update manifest", msg);
+            return 1;
+        }
+    };
+
+    let report = match deps::resolve_empty_via(&project_root, &imported_pkgs) {
+        Ok(r) => r,
+        Err(msg) => {
+            error!("failed to update manifest", msg);
+            return 1;
+        }
+    };
+
+    print_sync_summary(&trimmed, &report.promoted, &report.removed);
+
+    0
+}
+
+enum SourceScanError {
+    Parse {
+        path: PathBuf,
+        message: String,
+    },
+    Read {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+}
+
+/// Collect every third-party Go package path imported via `import "go:..."`
+/// across `src/**/*.lis`. Aborts on the first parse or read error.
+fn scan_source_imports(src_dir: &Path) -> Result<Vec<String>, SourceScanError> {
+    let mut imports = Vec::new();
+    if !src_dir.is_dir() {
+        return Ok(imports);
+    }
+
+    for path in collect_lis_filepaths_recursive(src_dir) {
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => return Err(SourceScanError::Read { path, error: e }),
+        };
+        let parse_result = Parser::lex_and_parse_file(&source, 0);
+        if parse_result.failed() {
+            return Err(SourceScanError::Parse {
+                path,
+                message: parse_result.errors[0].message.clone(),
+            });
+        }
+        for expr in &parse_result.ast {
+            if let Expression::ModuleImport { name, .. } = expr
+                && let Some(pkg) = name.strip_prefix("go:")
+                && deps::is_third_party(pkg)
+            {
+                imports.push(pkg.to_string());
+            }
+        }
+    }
+
+    Ok(imports)
+}

--- a/crates/cli/src/lock.rs
+++ b/crates/cli/src/lock.rs
@@ -1,0 +1,35 @@
+use std::fs::File;
+use std::path::Path;
+
+use fs2::FileExt;
+
+use crate::{cli_error, error};
+
+pub fn acquire_mutation_lock(target_dir: &Path) -> Result<File, i32> {
+    let lock_path = target_dir.join(".lis-mutate.lock");
+    let file = match File::create(&lock_path) {
+        Ok(f) => f,
+        Err(e) => {
+            error!(
+                "failed to create lock file",
+                format!("Failed to create `{}`: {}", lock_path.display(), e)
+            );
+            return Err(1);
+        }
+    };
+
+    if let Err(e) = file.try_lock_exclusive() {
+        if e.kind() == std::io::ErrorKind::WouldBlock {
+            cli_error!(
+                "Another manifest mutation is in progress",
+                "A concurrent `lis add` or `lis sync` holds the project lock",
+                "Wait for the other invocation to finish, then retry"
+            );
+        } else {
+            error!("failed to acquire lock", format!("{}", e));
+        }
+        return Err(1);
+    }
+
+    Ok(file)
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ mod agents_md;
 mod command;
 mod go_cli;
 mod handlers;
+mod lock;
 mod output;
 mod panic;
 mod typedef_regen;
@@ -81,6 +82,7 @@ fn main() {
             0
         }
         Command::Add { dependency } => handlers::add(&dependency),
+        Command::Sync => handlers::sync(),
         Command::Lsp => handlers::lsp(),
         Command::Bindgen {
             package,

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -176,20 +176,20 @@ pub fn capitalize_first(s: &str) -> String {
     }
 }
 
-pub fn print_preview_notice() {
+pub fn print_preview_notice(command: &str) {
     eprintln!();
     if use_color() {
         eprintln!(
             "  ! You are running an unfinished feature: {}",
-            "lis add".bright_magenta()
+            command.bright_magenta()
         );
         eprintln!(
             "  ! Support for third-party Go dependencies is {}",
             "not yet stable".yellow().underline()
         );
     } else {
-        eprintln!("  ! You are running an unfinished feature: lis add");
-        eprintln!("  ! Support for third-party Go dependencies is not yet stable");
+        eprintln!("  ! You are running an unfinished feature: {}", command);
+        eprintln!("  ! Support for third-party Go dependencies is experimental");
     }
     eprintln!("  ! Bug reports are welcome: https://github.com/ivov/lisette/issues");
     eprintln!();
@@ -300,6 +300,62 @@ fn print_tree_node(
             colored,
             visited,
         );
+    }
+}
+
+pub fn print_sync_summary(trimmed: &[deps::TrimmedVia], promoted: &[String], removed: &[String]) {
+    eprintln!();
+
+    if trimmed.is_empty() && promoted.is_empty() && removed.is_empty() {
+        if use_color() {
+            eprintln!("  {} Manifest already in sync", "✓".green());
+        } else {
+            eprintln!("  ✓ Manifest already in sync");
+        }
+        return;
+    }
+
+    let colored = use_color();
+
+    let promoted_set: std::collections::HashSet<&str> =
+        promoted.iter().map(String::as_str).collect();
+    let removed_set: std::collections::HashSet<&str> = removed.iter().map(String::as_str).collect();
+
+    for entry in trimmed {
+        if promoted_set.contains(entry.module_path.as_str())
+            || removed_set.contains(entry.module_path.as_str())
+        {
+            continue;
+        }
+        let parents = entry.removed_parents.join(", ");
+        if colored {
+            eprintln!(
+                "  ↓ Trimmed via for {} (removed: {})",
+                entry.module_path.green(),
+                parents.blue()
+            );
+        } else {
+            eprintln!(
+                "  ↓ Trimmed via for {} (removed: {})",
+                entry.module_path, parents
+            );
+        }
+    }
+
+    for path in promoted {
+        if colored {
+            eprintln!("  ↑ Promoted {} to direct", path.green());
+        } else {
+            eprintln!("  ↑ Promoted {} to direct", path);
+        }
+    }
+
+    for path in removed {
+        if colored {
+            eprintln!("  − Removed {}", path.green());
+        } else {
+            eprintln!("  − Removed {}", path);
+        }
     }
 }
 

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -4,8 +4,8 @@ mod typedef_locator;
 use std::path::{Path, PathBuf};
 
 pub use project_manifest::{
-    GoDependency, Manifest, check_toolchain_version, parse_manifest, remove_go_dep, upsert_go_dep,
-    validate_project_name,
+    GoDependency, Manifest, ResolveReport, TrimmedVia, check_toolchain_version, parse_manifest,
+    remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep, validate_project_name,
 };
 pub use typedef_locator::{TypedefLocator, TypedefLocatorResult, TypedefOrigin};
 

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -229,6 +229,121 @@ pub fn remove_go_dep(project_root: &Path, go_dep_path: &str) -> Result<(), Strin
     }
 
     save_manifest(&path, &encoding, &manifest)
+}
+
+/// Trimmed transitive dep. `removed_parents` are parents dropped from `via`.
+pub struct TrimmedVia {
+    pub module_path: String,
+    pub removed_parents: Vec<String>,
+}
+
+pub struct ResolveReport {
+    pub promoted: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+/// Drop `via` parents that are no longer manifest keys. Never deletes entries.
+/// `resolve_empty_via` handles entries left with `via = []`.
+pub fn trim_dead_via_parents(project_root: &Path) -> Result<Vec<TrimmedVia>, String> {
+    let manifest = parse_manifest(project_root)?;
+    let live_deps = manifest.go_deps();
+    let live_paths: HashSet<&str> = live_deps.keys().map(|s| s.as_str()).collect();
+
+    let mut trimmed = Vec::new();
+
+    for (dep_path, dep) in &live_deps {
+        let Some(ref via) = dep.via else { continue };
+
+        let removed_parents: Vec<String> = via
+            .iter()
+            .filter(|parent| !live_paths.contains(parent.as_str()))
+            .cloned()
+            .collect();
+
+        if removed_parents.is_empty() {
+            continue;
+        }
+
+        let mut canonical: Vec<String> = via
+            .iter()
+            .filter(|parent| live_paths.contains(parent.as_str()))
+            .cloned()
+            .collect();
+        canonical.sort();
+        canonical.dedup();
+
+        upsert_go_dep(project_root, dep_path, &dep.version, Some(canonical))?;
+        trimmed.push(TrimmedVia {
+            module_path: dep_path.clone(),
+            removed_parents,
+        });
+    }
+
+    Ok(trimmed)
+}
+
+/// For each entry with `via = []`, promote (drop the `via` field) if any
+/// `imported_pkgs` path maps to it by longest-declared-prefix; otherwise
+/// remove the entry.
+///
+/// Each import maps to a single best key — its longest declared prefix. E.g.
+/// `k8s.io/api/core/v1` maps to `k8s.io/api` (not `k8s.io`) when both are
+/// declared, preventing double-counting against nested keys.
+pub fn resolve_empty_via(
+    project_root: &Path,
+    imported_pkgs: &[String],
+) -> Result<ResolveReport, String> {
+    let manifest = parse_manifest(project_root)?;
+    let live_deps = manifest.go_deps();
+
+    let mut matched: HashSet<String> = HashSet::new();
+    for pkg in imported_pkgs {
+        if let Some((module, _)) = find_module_for_pkg(&live_deps, pkg) {
+            matched.insert(module.to_string());
+        }
+    }
+
+    let mut promoted = Vec::new();
+    let mut removed = Vec::new();
+
+    for (dep_path, dep) in &live_deps {
+        let Some(ref via) = dep.via else { continue };
+        if !via.is_empty() {
+            continue;
+        }
+
+        if matched.contains(dep_path.as_str()) {
+            upsert_go_dep(project_root, dep_path, &dep.version, None)?;
+            promoted.push(dep_path.clone());
+        } else {
+            remove_go_dep(project_root, dep_path)?;
+            removed.push(dep_path.clone());
+        }
+    }
+
+    Ok(ResolveReport { promoted, removed })
+}
+
+/// Longest declared module path that is a prefix of `pkg_path`, matching the
+/// full key or a key followed by `/`.
+pub(crate) fn find_module_for_pkg<'a>(
+    deps: &'a BTreeMap<String, GoDependency>,
+    pkg_path: &str,
+) -> Option<(&'a str, &'a GoDependency)> {
+    let mut best: Option<(&str, &GoDependency)> = None;
+    for (module_path, dep) in deps {
+        let is_match = pkg_path == module_path.as_str()
+            || (pkg_path.starts_with(module_path.as_str())
+                && pkg_path.as_bytes().get(module_path.len()) == Some(&b'/'));
+        if is_match
+            && best
+                .as_ref()
+                .is_none_or(|(prev, _)| module_path.len() > prev.len())
+        {
+            best = Some((module_path.as_str(), dep));
+        }
+    }
+    best
 }
 
 fn ensure_go_deps_table(

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use crate::project_manifest::{GoDependency, Manifest, check_toolchain_version, parse_manifest};
+use crate::project_manifest::{
+    GoDependency, Manifest, check_toolchain_version, find_module_for_pkg, parse_manifest,
+};
 use crate::{GoModule, GoPackage, typedef_cache_dir};
 
 #[derive(Debug)]
@@ -87,7 +89,7 @@ impl TypedefLocator {
             };
         }
 
-        let Some((module_path, dep)) = self.find_module_for_pkg(package_path) else {
+        let Some((module_path, dep)) = find_module_for_pkg(&self.deps, package_path) else {
             return TypedefLocatorResult::UndeclaredImport;
         };
 
@@ -126,26 +128,5 @@ impl TypedefLocator {
                 version: version.clone(),
             },
         }
-    }
-
-    /// Find the longest declared module path that is a prefix of the package path.
-    fn find_module_for_pkg(&self, pkg_path: &str) -> Option<(&str, &GoDependency)> {
-        let mut best: Option<(&str, &GoDependency)> = None;
-
-        for (module_path, dep) in &self.deps {
-            let is_match = pkg_path == module_path.as_str()
-                || (pkg_path.starts_with(module_path.as_str())
-                    && pkg_path.as_bytes().get(module_path.len()) == Some(&b'/'));
-
-            if is_match
-                && best
-                    .as_ref()
-                    .is_none_or(|(prev, _)| module_path.len() > prev.len())
-            {
-                best = Some((module_path.as_str(), dep));
-            }
-        }
-
-        best
     }
 }

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -69,13 +69,22 @@ pub fn missing_go_typedef(
     version: &str,
     span: Span,
 ) -> LisetteDiagnostic {
+    let help = if go_pkg == module {
+        format!(
+            "Module `{}` {} is declared but no typedef was found. Run `lis check` to regenerate all typedefs, or `lis add {}@{}` to regenerate this one.",
+            module, version, module, version
+        )
+    } else {
+        format!(
+            "Subpackage `{}` of module `{}` {} has no typedef. Run `lis add {}@{}` to regenerate the module's typedefs, including any subpackages.",
+            go_pkg, module, version, module, version
+        )
+    };
+
     LisetteDiagnostic::error("Missing Go typedef")
         .with_resolve_code("missing_go_typedef")
         .with_span_label(&span, "no .d.lis file found")
-        .with_help(format!(
-            "Package `{}` is declared via `{}` {} but no typedef was found. Run `lis check` to regenerate all typedefs, or `lis add {}@{}` to regenerate this one.",
-            go_pkg, module, version, module, version
-        ))
+        .with_help(help)
 }
 
 pub fn unreadable_go_typedef(path: &std::path::Path, error: &str, span: Span) -> LisetteDiagnostic {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -245,6 +245,55 @@ fn graph_declared_dep_missing_typedef() {
 }
 
 #[test]
+fn graph_subpackage_missing_typedef_points_at_add() {
+    use std::collections::BTreeMap;
+
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "go:k8s.io/api/core/v1""#);
+
+    let mut store = Store::new();
+    store.module_ids.push("main".to_string());
+
+    let mut go_deps = BTreeMap::new();
+    go_deps.insert(
+        "k8s.io/api".to_string(),
+        deps::GoDependency {
+            version: "v0.30.0".to_string(),
+            via: None,
+        },
+    );
+    let resolver = deps::TypedefLocator::new(go_deps, None, None);
+
+    let sink = LocalSink::new();
+    let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver);
+
+    assert!(sink.has_errors());
+
+    let diags = sink.take();
+    let missing = diags
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.missing_go_typedef"))
+        .expect("missing_go_typedef diagnostic");
+    let help = missing.plain_help().unwrap_or("");
+    assert!(
+        help.contains("Subpackage"),
+        "subpackage variant should mention `Subpackage`, got: {help}",
+    );
+    assert!(
+        help.contains("k8s.io/api/core/v1"),
+        "subpackage variant should reference the imported package path, got: {help}",
+    );
+    assert!(
+        help.contains("lis add k8s.io/api@v0.30.0"),
+        "subpackage variant should suggest `lis add <module>@<version>` (which runs reconcile and writes missing subpackage typedefs), got: {help}",
+    );
+    assert!(
+        !help.contains("lis sync") && !help.contains("lis check"),
+        "subpackage variant must not suggest `lis sync` or `lis check` — neither regenerates a missing subpackage typedef when the module dir already contains the root .d.lis, got: {help}",
+    );
+}
+
+#[test]
 fn store_get_definition_domain_style_go_module() {
     let mut store = Store::new();
     store.add_module("go:github.com/gorilla/mux");

--- a/tests/spec/mod.rs
+++ b/tests/spec/mod.rs
@@ -8,3 +8,4 @@ pub mod infer;
 mod lex;
 mod parse;
 mod pattern_analysis;
+mod sync;

--- a/tests/spec/sync.rs
+++ b/tests/spec/sync.rs
@@ -1,0 +1,224 @@
+use std::path::Path;
+use std::process::Command;
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
+}
+
+fn run_sync(project_dir: &Path) -> std::process::Output {
+    let manifest_path = repo_root().join("Cargo.toml");
+    Command::new("cargo")
+        .args(["run", "--quiet", "-p", "lisette", "--manifest-path"])
+        .arg(&manifest_path)
+        .args(["--", "sync"])
+        .current_dir(project_dir)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run lis sync")
+}
+
+fn write_project(dir: &Path, manifest: &str, sources: &[(&str, &str)]) {
+    std::fs::write(dir.join("lisette.toml"), manifest).unwrap();
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    for (name, body) in sources {
+        let path = src.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
+    }
+}
+
+fn read_manifest(dir: &Path) -> String {
+    std::fs::read_to_string(dir.join("lisette.toml")).unwrap()
+}
+
+#[test]
+fn sync_promotes_transitive_still_imported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux"] }
+"#;
+    let source = r#"import "go:github.com/gorilla/context"
+
+fn main() {}
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", source)]);
+
+    let output = run_sync(tmp.path());
+    assert!(
+        output.status.success(),
+        "lis sync failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after = read_manifest(tmp.path());
+    assert!(
+        after.contains(r#""github.com/gorilla/context" = "v1.1.1""#),
+        "expected context promoted to a bare version string, got:\n{}",
+        after
+    );
+    assert!(
+        !after.contains("via"),
+        "expected via field gone, got:\n{}",
+        after
+    );
+}
+
+#[test]
+fn sync_removes_transitive_no_longer_imported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux"] }
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", "fn main() {}\n")]);
+
+    let output = run_sync(tmp.path());
+    assert!(output.status.success());
+
+    let after = read_manifest(tmp.path());
+    assert!(
+        !after.contains("gorilla/context"),
+        "expected context removed, got:\n{}",
+        after
+    );
+}
+
+#[test]
+fn sync_keeps_transitive_with_remaining_parents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/mux" = "v1.8.0"
+"github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux", "github.com/old/dead"] }
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", "fn main() {}\n")]);
+
+    let output = run_sync(tmp.path());
+    assert!(output.status.success());
+
+    let after = read_manifest(tmp.path());
+    assert!(
+        after.contains("gorilla/context"),
+        "expected context kept, got:\n{}",
+        after
+    );
+    assert!(
+        after.contains("gorilla/mux") && !after.contains("old/dead"),
+        "expected via shortened to drop dead parent only, got:\n{}",
+        after
+    );
+}
+
+#[test]
+fn sync_promotes_subpackage_via_longest_prefix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"k8s.io/api" = { version = "v0.30.0", via = ["k8s.io/client-go"] }
+"#;
+    let source = r#"import "go:k8s.io/api/core/v1"
+
+fn main() {}
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", source)]);
+
+    let output = run_sync(tmp.path());
+    assert!(output.status.success());
+
+    let after = read_manifest(tmp.path());
+    assert!(
+        after.contains(r#""k8s.io/api" = "v0.30.0""#),
+        "expected k8s.io/api promoted via longest-prefix subpackage match, got:\n{}",
+        after
+    );
+}
+
+#[test]
+fn sync_no_op_on_clean_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/mux" = "v1.8.0"
+"#;
+    let source = r#"import "go:github.com/gorilla/mux"
+
+fn main() {}
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", source)]);
+
+    let before = read_manifest(tmp.path());
+    let output = run_sync(tmp.path());
+    assert!(output.status.success());
+
+    let after = read_manifest(tmp.path());
+    assert_eq!(
+        before, after,
+        "manifest must be byte-identical on no-op sync"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Manifest already in sync"),
+        "expected already-in-sync message, got stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn sync_aborts_on_source_parse_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux"] }
+"#;
+    let bad_source = "fn broken( {\n";
+    write_project(tmp.path(), manifest, &[("main.lis", bad_source)]);
+
+    let before = read_manifest(tmp.path());
+    let output = run_sync(tmp.path());
+    assert!(
+        !output.status.success(),
+        "lis sync must fail on parse error"
+    );
+
+    let after = read_manifest(tmp.path());
+    assert_eq!(
+        before, after,
+        "manifest must be unchanged when sync aborts on parse error"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.to_lowercase().contains("parse"),
+        "expected parse-error message, got stderr:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("main.lis"),
+        "error must point at the failing file, got stderr:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
Introduces `lis sync` to reconcile the manifest against Lis source after a manual edit. Drops dead `via` parents, and for each transitive left without a parent: promotes it to a direct dep if Lis source still imports it, or removes it otherwise. Subpackage imports (e.g. `go:k8s.io/api/core/v1`) match their longest declared prefix (`k8s.io/api`).