### PR TITLE
fix: emit address-of for option fields at go struct literals

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -193,6 +193,32 @@ impl Emitter<'_> {
         unwrapped_var
     }
 
+    /// Bridge `Option<T>` to Go `*T` when T is not naturally nilable.
+    pub(crate) fn emit_option_unwrap_to_go_pointer(
+        &mut self,
+        output: &mut String,
+        option_value: &str,
+        option_ty: &Type,
+    ) -> String {
+        let inner_ty = option_ty.ok_type();
+        let go_inner_ty = self.go_type_as_string(&inner_ty);
+
+        let opt_var = self.fresh_var(Some("opt"));
+        self.declare(&opt_var);
+        let ptr_var = self.fresh_var(Some("ptr"));
+        self.declare(&ptr_var);
+
+        self.flags.needs_stdlib = true;
+
+        write_line!(output, "{} := {}", opt_var, option_value);
+        write_line!(output, "var {} *{}", ptr_var, go_inner_ty);
+        write_line!(output, "if {}.Tag == {} {{", opt_var, OPTION_SOME_TAG);
+        write_line!(output, "{} = &{}.SomeVal", ptr_var, opt_var);
+        output.push_str("}\n");
+
+        ptr_var
+    }
+
     pub(crate) fn emit_collection_nullable_wrap(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -66,12 +66,18 @@ impl Emitter<'_> {
             let field_name = self.resolve_struct_call_field_name(&f.name, ty, &ctx);
             let mut value = emitted_values[fi].clone();
             value = self.wrap_recursive_enum_field(output, value, f, &ctx);
+            let value_ty = f.value.get_type();
+            let field_ty = self.lookup_struct_field_ty(ty, &f.name);
             if is_go_struct {
-                let coercion = Coercion::resolve_unwrap_go_nullable(self, &f.value.get_type());
-                value = coercion.apply(self, output, value);
+                if self.needs_go_pointer_bridge(&value_ty, field_ty.as_ref()) {
+                    value = self.emit_option_unwrap_to_go_pointer(output, &value, &value_ty);
+                } else {
+                    let coercion = Coercion::resolve_unwrap_go_nullable(self, &value_ty);
+                    value = coercion.apply(self, output, value);
+                }
             }
-            if let Some(field_ty) = self.lookup_struct_field_ty(ty, &f.name) {
-                let coercion = Coercion::resolve(self, &f.value.get_type(), &field_ty);
+            if let Some(field_ty) = field_ty.as_ref() {
+                let coercion = Coercion::resolve(self, &value_ty, field_ty);
                 value = coercion.apply(self, output, value);
             }
             field_names.push(field_name);

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -244,6 +244,14 @@ impl Emitter<'_> {
         ty.is_option() && self.is_nilable_go_type(&ty.ok_type())
     }
 
+    /// True when a Go-imported struct field declared `Option<T>` (T non-nilable)
+    /// receives a value of the same shape — the field is `*T` underneath, so
+    /// the value must be bridged with address-of.
+    pub(crate) fn needs_go_pointer_bridge(&self, value_ty: &Type, field_ty: Option<&Type>) -> bool {
+        let is_non_nullable_option = |t: &Type| t.is_option() && !self.is_nullable_option(t);
+        is_non_nullable_option(value_ty) && field_ty.is_some_and(is_non_nullable_option)
+    }
+
     /// Returns true if the Option wraps a Go interface type (not a pointer).
     /// These need `IsNilInterface` instead of `!= nil` to catch typed nils.
     pub(crate) fn is_interface_option(&self, ty: &Type) -> bool {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1139,3 +1139,71 @@ pub fn Peek() -> Option<Msg>
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/evts", typedef)]);
 }
+
+#[test]
+fn interop_struct_literal_option_to_pointer_named_scalar() {
+    let input = r#"
+import "go:example.com/cb"
+
+fn main() {
+  let _ = cb.Options {
+    Direction: Some(cb.DirectionDefault),
+  }
+}
+"#;
+    let typedef = r#"
+pub type Direction = int
+
+pub const DirectionDefault: Direction = 0
+
+pub struct Options {
+  pub Direction: Option<Direction>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cb", typedef)]);
+}
+
+#[test]
+fn interop_struct_literal_option_to_pointer_struct() {
+    let input = r#"
+import "go:example.com/cb"
+
+fn main() {
+  let inner = cb.Inner { Tag: "x" }
+  let _ = cb.Outer {
+    Slot: Some(&inner),
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Inner {
+  pub Tag: string,
+}
+
+pub struct Outer {
+  pub Slot: Option<Ref<Inner>>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cb", typedef)]);
+}
+
+#[test]
+fn interop_struct_literal_option_none_to_pointer() {
+    let input = r#"
+import "go:example.com/cb"
+
+fn main() {
+  let _ = cb.Options {
+    Direction: None,
+  }
+}
+"#;
+    let typedef = r#"
+pub type Direction = int
+
+pub struct Options {
+  pub Direction: Option<Direction>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cb", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_none_to_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_none_to_pointer.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:example.com/cb\"\n\nfn main() {\n  let _ = cb.Options {\n    Direction: None,\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/cb"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	opt_1 := lisette.MakeOptionNone[cb.Direction]()
+	var ptr_2 *cb.Direction
+	if opt_1.Tag == lisette.OptionSome {
+		ptr_2 = &opt_1.SomeVal
+	}
+	_ = cb.Options{Direction: ptr_2}
+}

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_named_scalar.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_named_scalar.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:example.com/cb\"\n\nfn main() {\n  let _ = cb.Options {\n    Direction: Some(cb.DirectionDefault),\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/cb"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	opt_1 := lisette.MakeOptionSome(cb.DirectionDefault)
+	var ptr_2 *cb.Direction
+	if opt_1.Tag == lisette.OptionSome {
+		ptr_2 = &opt_1.SomeVal
+	}
+	_ = cb.Options{Direction: ptr_2}
+}

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_struct.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_struct.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:example.com/cb\"\n\nfn main() {\n  let inner = cb.Inner { Tag: \"x\" }\n  let _ = cb.Outer {\n    Slot: Some(&inner),\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/cb"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	inner := cb.Inner{Tag: "x"}
+	opt_1 := lisette.MakeOptionSome(&inner)
+	var unwrap_2 *cb.Inner
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	_ = cb.Outer{Slot: unwrap_2}
+}


### PR DESCRIPTION
Fix #195