### PR TITLE
feat: support Comparable and cmp.Ordered as type-parameter bounds

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -46,6 +46,18 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 		return
 	}
 
+	// Scan first: param/return processing must observe `S ~[]E` substitutions.
+	typeParams, substitutions, skip := collectTypeParams(signature.TypeParams(), false, c)
+	if skip != nil {
+		result.SkipReason = skip
+		return
+	}
+	result.TypeParams = typeParams
+
+	prevSubs := c.typeParamSubstitutions
+	c.typeParamSubstitutions = substitutions
+	defer func() { c.typeParamSubstitutions = prevSubs }()
+
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, result.Name)
 
 	params := signature.Params()
@@ -115,13 +127,6 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 	if (isSinglePointerReturn && !forceNonNilable) || (forceNilable && !returnType.NilableReturnApplied) {
 		result.ReturnType = fmt.Sprintf("Option<%s>", result.ReturnType)
 	}
-
-	typeParams, skip := collectTypeParams(signature.TypeParams(), false)
-	if skip != nil {
-		result.SkipReason = skip
-		return
-	}
-	result.TypeParams = typeParams
 }
 
 // applySentinelInt rewrites a bare `int` return into `Option<int>` when
@@ -148,7 +153,7 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	if symbolExport.ReceiverVariable != nil {
 		if symbolExport.IsPromoted {
 			typeName := symbolExport.BaseType.Obj().Name()
-			typeParams := extractReceiverTypeParams(symbolExport.BaseType)
+			typeParams := extractReceiverTypeParams(symbolExport.BaseType, c)
 			isPointerReceiver := symbolExport.NeedsPointerReceiver
 
 			recvLisetteType := typeName
@@ -172,16 +177,16 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 
 			isPointerReceiver := false
 			typeName := ""
-			var typeParams []string
+			var typeParams TypeParamSpecs
 			if pointer, ok := symbolExport.ReceiverVariable.Type().(*types.Pointer); ok {
 				isPointerReceiver = true
 				if named, ok := pointer.Elem().(*types.Named); ok {
 					typeName = named.Obj().Name()
-					typeParams = extractReceiverTypeParams(named)
+					typeParams = extractReceiverTypeParams(named, c)
 				}
 			} else if named, ok := symbolExport.ReceiverVariable.Type().(*types.Named); ok {
 				typeName = named.Obj().Name()
-				typeParams = extractReceiverTypeParams(named)
+				typeParams = extractReceiverTypeParams(named, c)
 			}
 
 			result.Receiver = &Receiver{
@@ -278,12 +283,19 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	}
 
 	if symbolExport.BaseType != nil {
-		_, skip := collectTypeParams(symbolExport.BaseType.TypeParams(), false)
+		_, _, skip := collectTypeParams(symbolExport.BaseType.TypeParams(), false, c)
 		if skip != nil {
 			result.SkipReason = skip
 			return
 		}
 	}
+
+	methodSpecs, _, skip := collectTypeParams(signature.TypeParams(), false, c)
+	if skip != nil {
+		result.SkipReason = skip
+		return
+	}
+	result.TypeParams = methodSpecs
 }
 
 func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport) {
@@ -305,7 +317,7 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 		return
 	}
 
-	typeParams, skip := collectTypeParams(named.TypeParams(), true)
+	typeParams, _, skip := collectTypeParams(named.TypeParams(), true, c)
 	if skip != nil {
 		result.SkipReason = skip
 		return
@@ -567,47 +579,86 @@ func formatConstantValue(val constant.Value) string {
 	}
 }
 
-func collectTypeParams(typeParams *types.TypeParamList, emitOpaque bool) ([]string, *SkipReason) {
+// `S ~[]E` shapes go into substitutions (caller rewrites `S` to `Slice<E>`)
+// rather than into specs. Recognized bounds register their imports on conv.
+func collectTypeParams(
+	typeParams *types.TypeParamList,
+	emitOpaque bool,
+	conv *Converter,
+) (specs TypeParamSpecs, substitutions map[string]string, skip *SkipReason) {
 	if typeParams == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	var names []string
 	for tp := range typeParams.TypeParams() {
+		name := tp.Obj().Name()
 		constraint := tp.Constraint()
-		if iface, ok := constraint.Underlying().(*types.Interface); ok {
-			if !isAnyConstraint(iface) {
-				return nil, &SkipReason{
-					Code:           "constraint:" + describeConstraint(iface),
-					Message:        fmt.Sprintf("type constraint %s cannot be represented", tp.Obj().Name()),
-					EmitOpaqueType: emitOpaque,
+
+		if elemName, ok := recognizeSliceShape(constraint); ok {
+			if substitutions == nil {
+				substitutions = make(map[string]string)
+			}
+			substitutions[name] = fmt.Sprintf("Slice<%s>", elemName)
+			continue
+		}
+
+		if isAnyConstraint(constraint) {
+			specs = append(specs, TypeParamSpec{Name: name})
+			continue
+		}
+
+		var currentPkg string
+		if conv != nil {
+			currentPkg = conv.currentPkgPath
+		}
+		if boundExpr, ok, imports := recognizeBound(constraint, currentPkg); ok {
+			for _, path := range imports {
+				if conv != nil {
+					conv.trackExternalPkg(path, path)
 				}
 			}
+			specs = append(specs, TypeParamSpec{Name: name, Bound: boundExpr})
+			continue
 		}
-		names = append(names, tp.Obj().Name())
+
+		iface, _ := constraint.Underlying().(*types.Interface)
+		return nil, nil, &SkipReason{
+			Code:           "constraint:" + describeConstraint(iface),
+			Message:        fmt.Sprintf("type constraint %s cannot be represented", name),
+			EmitOpaqueType: emitOpaque,
+		}
 	}
-	return names, nil
+	return specs, substitutions, nil
 }
 
-func extractReceiverTypeParams(named *types.Named) []string {
+func extractReceiverTypeParams(named *types.Named, conv *Converter) TypeParamSpecs {
 	origin := named.Origin()
 	typeParams := origin.TypeParams()
 	if typeParams == nil || typeParams.Len() == 0 {
 		return nil
 	}
 
-	var names []string
-	for tp := range typeParams.TypeParams() {
-		names = append(names, tp.Obj().Name())
+	specs, _, skip := collectTypeParams(typeParams, false, conv)
+	if skip != nil {
+		// Base type emits the skip; impl block falls back to bare names.
+		var fallback TypeParamSpecs
+		for tp := range typeParams.TypeParams() {
+			fallback = append(fallback, TypeParamSpec{Name: tp.Obj().Name()})
+		}
+		return fallback
 	}
-	return names
+	return specs
 }
 
-func isAnyConstraint(constraint *types.Interface) bool {
+func isAnyConstraint(constraint types.Type) bool {
 	if constraint == nil {
 		return true
 	}
-	return constraint.Empty()
+	iface, ok := constraint.Underlying().(*types.Interface)
+	if !ok {
+		return false
+	}
+	return iface.Empty()
 }
 
 func describeConstraint(constraint *types.Interface) string {

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -17,7 +17,7 @@ type ConvertResult struct {
 	Params           []FunctionParameter
 	ReturnType       string
 	Receiver         *Receiver // for methods
-	TypeParams       []string
+	TypeParams       TypeParamSpecs
 	Fields           []StructField     // for structs
 	InterfaceMethods []InterfaceMethod // for interfaces
 	Variants         []EnumVariant     // for enums (via iota)
@@ -45,7 +45,7 @@ type Receiver struct {
 	Type         string
 	IsPointer    bool
 	BaseTypeName string
-	TypeParams   []string // Type parameters of the receiver type (for generic types)
+	TypeParams   TypeParamSpecs // Type parameters of the receiver type (for generic types)
 }
 
 type StructField struct {
@@ -82,6 +82,8 @@ type Converter struct {
 	nonNilCache          map[token.Pos]nilCacheResult // lazily built; proven non-nil results
 	crossPkgConverters   map[string]*Converter        // lazily built; cached converters for imported packages
 	noCrossPkg           bool                         // when true, skip cross-package transitive analysis
+	// Set per-function-conversion: maps `S` to `Slice<E>` for the `S ~[]E` shape.
+	typeParamSubstitutions map[string]string
 }
 
 func NewConverter(pkgPath string, pkg *packages.Package, cfg *config.Config) *Converter {

--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -1,0 +1,116 @@
+package convert
+
+import (
+	"go/types"
+	"strings"
+)
+
+type TypeParamSpec struct {
+	Name  string
+	Bound string
+}
+
+type TypeParamSpecs []TypeParamSpec
+
+// `E: cmp.Ordered, V` for sites that introduce type parameters.
+func (ps TypeParamSpecs) FormatDecl() string {
+	if len(ps) == 0 {
+		return ""
+	}
+	parts := make([]string, len(ps))
+	for i, p := range ps {
+		if p.Bound != "" {
+			parts[i] = p.Name + ": " + p.Bound
+		} else {
+			parts[i] = p.Name
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// `E, V` for sites that reference an already-introduced parameter.
+func (ps TypeParamSpecs) FormatUse() string {
+	if len(ps) == 0 {
+		return ""
+	}
+	names := make([]string, len(ps))
+	for i, p := range ps {
+		names[i] = p.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+// `<E: cmp.Ordered, V>` or empty when there are no type parameters.
+func (ps TypeParamSpecs) DeclBlock() string {
+	if len(ps) == 0 {
+		return ""
+	}
+	return "<" + ps.FormatDecl() + ">"
+}
+
+// `<E, V>` or empty when there are no type parameters.
+func (ps TypeParamSpecs) UseBlock() string {
+	if len(ps) == 0 {
+		return ""
+	}
+	return "<" + ps.FormatUse() + ">"
+}
+
+// Named-type identity is checked before .Underlying(), which discards the
+// wrapper — afterwards cmp.Ordered's structural shape would short-circuit
+// as plain `comparable`. When the constraint lives in currentPkgPath, the
+// bound is rendered unqualified to avoid a self-import.
+func recognizeBound(constraint types.Type, currentPkgPath string) (boundExpr string, ok bool, requiresImports []string) {
+	if named, isNamed := constraint.(*types.Named); isNamed {
+		obj := named.Obj()
+		if obj.Pkg() != nil && obj.Pkg().Path() == "cmp" && obj.Name() == "Ordered" {
+			if currentPkgPath == "cmp" {
+				return "Ordered", true, nil
+			}
+			return "cmp.Ordered", true, []string{"cmp"}
+		}
+	}
+
+	iface, isIface := constraint.Underlying().(*types.Interface)
+	if !isIface {
+		return "", false, nil
+	}
+
+	// Type-set unions (e.g. `~int | ~string`) also report IsComparable, so
+	// the no-embeddeds check is essential to isolate the bare `comparable`.
+	if iface.IsComparable() && iface.NumEmbeddeds() == 0 && iface.NumMethods() == 0 {
+		return "Comparable", true, nil
+	}
+
+	return "", false, nil
+}
+
+// Detects `S ~[]E`: one embedded *types.Union with one tilde'd *types.Slice
+// term over a *types.TypeParam. Returns the inner E's name so callers can
+// rewrite `S` to `Slice<E>`.
+func recognizeSliceShape(constraint types.Type) (sliceElemTypeParamName string, ok bool) {
+	iface, isIface := constraint.Underlying().(*types.Interface)
+	if !isIface {
+		return "", false
+	}
+	if iface.NumEmbeddeds() != 1 {
+		return "", false
+	}
+	union, isUnion := iface.EmbeddedType(0).(*types.Union)
+	if !isUnion || union.Len() != 1 {
+		return "", false
+	}
+	term := union.Term(0)
+	if !term.Tilde() {
+		return "", false
+	}
+	slice, isSlice := term.Type().(*types.Slice)
+	if !isSlice {
+		return "", false
+	}
+	tp, isTp := slice.Elem().(*types.TypeParam)
+	if !isTp {
+		return "", false
+	}
+	return tp.Obj().Name(), true
+}

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -124,7 +124,13 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		return namedToLisette(t, seen, conv)
 
 	case *types.TypeParam:
-		return TypeResult{LisetteType: t.Obj().Name()}
+		name := t.Obj().Name()
+		if conv != nil && conv.typeParamSubstitutions != nil {
+			if substituted, ok := conv.typeParamSubstitutions[name]; ok {
+				return TypeResult{LisetteType: substituted}
+			}
+		}
+		return TypeResult{LisetteType: name}
 
 	case *types.Struct:
 		if t.NumFields() == 0 {

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -156,14 +156,13 @@ func (e *Emitter) EmitImplBlocks() {
 			continue
 		}
 
-		var typeParams []string
+		var typeParams convert.TypeParamSpecs
 		if methods[0].Receiver != nil {
 			typeParams = methods[0].Receiver.TypeParams
 		}
 
 		if len(typeParams) > 0 {
-			typeParamList := strings.Join(typeParams, ", ")
-			fmt.Fprintf(&e.buf, "impl<%s> %s<%s> {\n", typeParamList, typeName, typeParamList)
+			fmt.Fprintf(&e.buf, "impl<%s> %s<%s> {\n", typeParams.FormatDecl(), typeName, typeParams.FormatUse())
 		} else {
 			fmt.Fprintf(&e.buf, "impl %s {\n", typeName)
 		}
@@ -211,12 +210,7 @@ func (e *Emitter) emitFunction(result convert.ConvertResult) {
 	functionSignature.WriteString("pub fn ")
 	functionSignature.WriteString(result.Name)
 
-	if len(result.TypeParams) > 0 {
-		functionSignature.WriteString("<")
-		functionSignature.WriteString(strings.Join(result.TypeParams, ", "))
-		functionSignature.WriteString(">")
-	}
-
+	functionSignature.WriteString(result.TypeParams.DeclBlock())
 	functionSignature.WriteString("(")
 	var params []string
 	for _, p := range result.Params {
@@ -288,19 +282,11 @@ func (e *Emitter) emitMethodInImpl(result convert.ConvertResult) {
 	methodSignature.WriteString("  fn ")
 	methodSignature.WriteString(result.Name)
 
-	if len(result.TypeParams) > 0 {
-		methodSignature.WriteString("<")
-		methodSignature.WriteString(strings.Join(result.TypeParams, ", "))
-		methodSignature.WriteString(">")
-	}
-
+	methodSignature.WriteString(result.TypeParams.DeclBlock())
 	methodSignature.WriteString("(")
 	var params []string
 	if result.Receiver != nil && result.Receiver.IsPointer {
-		typeName := result.Receiver.BaseTypeName
-		if len(result.Receiver.TypeParams) > 0 {
-			typeName += "<" + strings.Join(result.Receiver.TypeParams, ", ") + ">"
-		}
+		typeName := result.Receiver.BaseTypeName + result.Receiver.TypeParams.UseBlock()
 		params = append(params, fmt.Sprintf("self: Ref<%s>", typeName))
 	} else {
 		params = append(params, "self")
@@ -335,12 +321,7 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 		var signature strings.Builder
 		signature.WriteString("pub interface ")
 		signature.WriteString(typeName)
-
-		if len(result.TypeParams) > 0 {
-			signature.WriteString("<")
-			signature.WriteString(strings.Join(result.TypeParams, ", "))
-			signature.WriteString(">")
-		}
+		signature.WriteString(result.TypeParams.DeclBlock())
 
 		if len(result.InterfaceMethods) == 0 {
 			signature.WriteString(" {}")
@@ -386,12 +367,7 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 		var sig strings.Builder
 		sig.WriteString("pub struct ")
 		sig.WriteString(typeName)
-
-		if len(result.TypeParams) > 0 {
-			sig.WriteString("<")
-			sig.WriteString(strings.Join(result.TypeParams, ", "))
-			sig.WriteString(">")
-		}
+		sig.WriteString(result.TypeParams.DeclBlock())
 
 		sig.WriteString(" {\n")
 		for _, f := range result.Fields {
@@ -421,25 +397,13 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 		if strings.HasPrefix(result.LisetteType, "fn(") || result.IsTypeAlias {
 			sig.WriteString("pub type ")
 			sig.WriteString(typeName)
-
-			if len(result.TypeParams) > 0 {
-				sig.WriteString("<")
-				sig.WriteString(strings.Join(result.TypeParams, ", "))
-				sig.WriteString(">")
-			}
-
+			sig.WriteString(result.TypeParams.DeclBlock())
 			sig.WriteString(" = ")
 			sig.WriteString(result.LisetteType)
 		} else {
 			sig.WriteString("pub struct ")
 			sig.WriteString(typeName)
-
-			if len(result.TypeParams) > 0 {
-				sig.WriteString("<")
-				sig.WriteString(strings.Join(result.TypeParams, ", "))
-				sig.WriteString(">")
-			}
-
+			sig.WriteString(result.TypeParams.DeclBlock())
 			sig.WriteString("(")
 			sig.WriteString(result.LisetteType)
 			sig.WriteString(")")
@@ -453,12 +417,7 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 	var signature strings.Builder
 	signature.WriteString("pub type ")
 	signature.WriteString(typeName)
-
-	if len(result.TypeParams) > 0 {
-		signature.WriteString("<")
-		signature.WriteString(strings.Join(result.TypeParams, ", "))
-		signature.WriteString(">")
-	}
+	signature.WriteString(result.TypeParams.DeclBlock())
 
 	e.buf.WriteString(signature.String())
 	e.buf.WriteString("\n\n")

--- a/bindgen/tests/testdata/fixtures/generics/generics.go
+++ b/bindgen/tests/testdata/fixtures/generics/generics.go
@@ -1,5 +1,7 @@
 package generics
 
+import "cmp"
+
 // Basic generic types
 
 type Box[T any] struct {
@@ -86,4 +88,17 @@ func Swap[T, U any](a T, b U) (U, T) {
 // Inline union constraint with non-comparable types
 func Either[T []int | []string](v T) T {
 	return v
+}
+
+// cmp.Ordered constraint (named-identity recognizer)
+func MinOrdered[T cmp.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Slice-shape rewrite: S ~[]E with E: cmp.Ordered
+func SortInts[S ~[]E, E cmp.Ordered](x S) S {
+	return x
 }

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -3,6 +3,8 @@
 // Go: 0.0.0
 // Lisette: 0.0.0
 
+import "go:cmp"
+
 /// Empty constraint (any)
 pub fn Clone<T>(v: T) -> T
 
@@ -11,11 +13,17 @@ pub fn Clone<T>(v: T) -> T
 
 pub fn Identity<T>(x: T) -> T
 
-// SKIPPED: Max - constraint:comparable
-// type constraint T cannot be represented
+/// Comparable constraint
+pub fn Max<T: Comparable>(a: T, b: T) -> T
 
 // SKIPPED: Min - constraint:comparable
 // type constraint T cannot be represented
+
+/// cmp.Ordered constraint (named-identity recognizer)
+pub fn MinOrdered<T: cmp.Ordered>(a: T, b: T) -> T
+
+/// Slice-shape rewrite: S ~[]E with E: cmp.Ordered
+pub fn SortInts<E: cmp.Ordered>(x: Slice<E>) -> Slice<E>
 
 /// Multiple constraints
 pub fn Swap<T, U>(a: T, b: U) -> (U, T)
@@ -24,9 +32,11 @@ pub struct Box<T> {
   pub Value: T,
 }
 
-// SKIPPED: ConstrainedPair - constraint:comparable
-// type constraint K cannot be represented
-pub type ConstrainedPair
+/// Multiple type parameters with different constraints
+pub struct ConstrainedPair<K: Comparable, V> {
+  pub Key: K,
+  pub Value: V,
+}
 
 pub type Container<T>
 
@@ -43,8 +53,10 @@ pub interface Transformer<T> {
   fn Transform(arg0: T) -> T
 }
 
-// SKIPPED: GetKey - constraint:comparable
-// type constraint K cannot be represented
+impl<K: Comparable, V> ConstrainedPair<K, V> {
+  /// Method on constrained generic
+  fn GetKey(self) -> K
+}
 
 impl<T> Container<T> {
   fn Add(self: Ref<Container<T>>, item: T)

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -708,6 +708,55 @@ pub fn not_comparable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic 
         ))
 }
 
+pub fn not_orderable_bound(param_name: &str, ty: &Type, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Bound not satisfied")
+        .with_infer_code("not_orderable_bound")
+        .with_span_label(
+            &span,
+            format!("`{}` does not satisfy `cmp.Ordered`", ty),
+        )
+        .with_help(format!(
+            "The type parameter `{}` requires `cmp.Ordered`; only integers, floats, and strings (and their named aliases) satisfy it",
+            param_name
+        ))
+}
+
+pub fn not_comparable_bound(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Bound not satisfied")
+        .with_infer_code("not_comparable_bound")
+        .with_span_label(&span, "does not satisfy `Comparable`")
+        .with_help(
+            "The parameter must be `Comparable` but the argument is not comparable. \
+             Relax the bound or pass an argument that satisfies it",
+        )
+}
+
+pub fn bound_only_in_value_position(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{}` is a bound, not a value type", name))
+        .with_infer_code("bound_only_in_value_position")
+        .with_span_label(&span, "not allowed here")
+        .with_help(format!(
+            "Use `{}` only as a bound to constrain a generic parameter, e.g. `fn f<T: {}>(x: T)`",
+            name, name
+        ))
+}
+
+pub fn missing_bound_on_param(
+    param_name: &str,
+    required_bound: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    let short = required_bound.rsplit('.').next().unwrap_or(required_bound);
+    LisetteDiagnostic::error("Missing bound on type parameter")
+        .with_infer_code("missing_bound_on_param")
+        .with_span_label(&span, format!("does not satisfy `{}`", short))
+        .with_help(format!(
+            "The parameter must be `{}` but the argument is unbounded. \
+             Add this bound to the enclosing function: `<{}: {}>`",
+            required_bound, param_name, required_bound
+        ))
+}
+
 pub fn division_by_zero(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Division by zero")
         .with_infer_code("division_by_zero")

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -7,6 +7,7 @@ use syntax::program::{CallKind, Definition, NativeTypeKind};
 use syntax::types::{Bound, SubstitutionMap, Symbol, Type, substitute, unqualified_name};
 
 use super::super::TaskState;
+use super::super::unify::Dispatched;
 use super::primitives::contains_deref;
 use crate::checker::scopes::UseContext;
 use crate::store::{ENTRY_MODULE_ID, Store};
@@ -138,7 +139,7 @@ impl TaskState<'_> {
             let qualified_name = self.qualify_name(&g.name);
 
             for b in &g.bounds {
-                let bound_ty = self.convert_to_type(store, b, &span);
+                let bound_ty = self.convert_bound_to_type(store, b, &span);
 
                 self.scopes
                     .current_mut()
@@ -870,6 +871,17 @@ impl TaskState<'_> {
                 continue;
             }
 
+            let span = args
+                .iter()
+                .find(|arg| arg.get_type().resolve_in(&self.env) == resolved_ty)
+                .map(|arg| arg.get_span())
+                .unwrap_or_else(|| *fallback_span);
+
+            if self.dispatch_builtin_bound(store, bound, &resolved_ty, &span) == Dispatched::Handled
+            {
+                continue;
+            }
+
             let interface_ty = bound.ty.resolve_in(&self.env);
             let Type::Nominal { id, params, .. } = interface_ty else {
                 continue;
@@ -878,12 +890,6 @@ impl TaskState<'_> {
             let Some(interface) = store.get_interface(&id).cloned() else {
                 continue;
             };
-
-            let span = args
-                .iter()
-                .find(|arg| arg.get_type().resolve_in(&self.env) == resolved_ty)
-                .map(|arg| arg.get_span())
-                .unwrap_or_else(|| *fallback_span);
 
             let _ = self.satisfies_interface(store, &resolved_ty, &interface, &params, &span);
         }

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -25,7 +25,7 @@ impl TaskState<'_> {
         for g in &generics {
             let qualified_name = self.qualify_name(&g.name);
             for b in &g.bounds {
-                let bound_ty = self.convert_to_type(store, b, &span);
+                let bound_ty = self.convert_bound_to_type(store, b, &span);
                 self.scopes
                     .current_mut()
                     .trait_bounds

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -1,4 +1,5 @@
 use crate::checker::EnvResolve;
+use crate::checker::TypeEnv;
 use crate::store::Store;
 use syntax::ast::{BinaryOperator, Expression, Literal, Span, UnaryOperator};
 use syntax::program::Definition;
@@ -8,6 +9,85 @@ use BinaryOperator::*;
 use UnaryOperator::*;
 
 use super::super::TaskState;
+
+/// Returns the first non-comparable shape per Go's `comparable` rules, or `None` if comparable.
+pub(crate) fn check_not_comparable(
+    env: &TypeEnv,
+    store: &Store,
+    ty: &Type,
+) -> Option<&'static str> {
+    if matches!(ty, Type::Function { .. }) {
+        return Some("functions");
+    }
+
+    if ty.has_name("Slice") {
+        return Some("slices");
+    }
+    if ty.has_name("Map") {
+        return Some("maps");
+    }
+
+    if ty.has_name("Ref") || ty.has_name("Channel") {
+        return None;
+    }
+
+    if matches!(ty, Type::Var { .. }) {
+        return None;
+    }
+
+    if matches!(ty, Type::Parameter(_)) {
+        return Some("type parameters (Go requires the `comparable` constraint)");
+    }
+
+    if let Some(name) = ty.get_qualified_id()
+        && let Some(definition) = store.get_definition(name)
+    {
+        let type_args = ty.get_type_params().unwrap_or_default();
+        let generics = match &definition {
+            Definition::Struct { generics, .. } | Definition::Enum { generics, .. } => {
+                generics.as_slice()
+            }
+            _ => &[],
+        };
+        let sub_map = generics
+            .iter()
+            .map(|g| g.name.clone())
+            .zip(type_args.iter().cloned())
+            .collect();
+
+        match definition {
+            Definition::Struct { fields, .. } => {
+                for f in fields {
+                    let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
+                    if check_not_comparable(env, store, &field_ty).is_some() {
+                        return Some("a struct containing non-comparable fields");
+                    }
+                }
+            }
+            Definition::Enum { variants, .. } => {
+                for v in variants {
+                    for f in v.fields.iter() {
+                        let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
+                        if check_not_comparable(env, store, &field_ty).is_some() {
+                            return Some("an enum containing non-comparable fields");
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Type::Tuple(elems) = ty {
+        for e in elems {
+            if check_not_comparable(env, store, &e.resolve_in(env)).is_some() {
+                return Some("a tuple containing non-comparable elements");
+            }
+        }
+    }
+
+    None
+}
 
 impl TaskState<'_> {
     pub(super) fn infer_unary(
@@ -497,6 +577,12 @@ impl TaskState<'_> {
             return;
         }
 
+        if let Type::Parameter(name) = &resolved_ty
+            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Ordered)
+        {
+            return;
+        }
+
         if !resolved_ty.is_ordered() && !resolved_ty.is_string() && !resolved_ty.is_boolean() {
             self.sink
                 .push(diagnostics::infer::not_orderable(&resolved_ty, *span));
@@ -508,92 +594,15 @@ impl TaskState<'_> {
         if resolved.is_error() {
             return;
         }
-        if let Some(reason) = self.check_not_comparable(store, &resolved) {
+        if let Type::Parameter(name) = &resolved
+            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+        {
+            return;
+        }
+        if let Some(reason) = check_not_comparable(&self.env, store, &resolved) {
             self.sink
                 .push(diagnostics::infer::not_comparable(&resolved, reason, *span));
         }
-    }
-
-    fn check_not_comparable(&self, store: &Store, ty: &Type) -> Option<&'static str> {
-        if matches!(ty, Type::Function { .. }) {
-            return Some("functions");
-        }
-
-        if ty.has_name("Slice") {
-            return Some("slices");
-        }
-        if ty.has_name("Map") {
-            return Some("maps");
-        }
-
-        // Ref and Channel are always comparable (pointer/reference equality) — don't recurse
-        if ty.has_name("Ref") || ty.has_name("Channel") {
-            return None;
-        }
-
-        if matches!(ty, Type::Var { .. }) {
-            return None;
-        }
-
-        // Type parameters (generic T) — Go requires `comparable` constraint
-        if matches!(ty, Type::Parameter(_)) {
-            return Some("type parameters (Go requires the `comparable` constraint)");
-        }
-
-        // Structs and enums: recurse into fields with generic substitution.
-        // For generic types like Option<Color>, the definition has fields with
-        // type parameter T — substitute T → Color before checking comparability.
-        if let Some(name) = ty.get_qualified_id()
-            && let Some(definition) = store.get_definition(name)
-        {
-            let type_args = ty.get_type_params().unwrap_or_default();
-            let generics = match &definition {
-                Definition::Struct { generics, .. } | Definition::Enum { generics, .. } => {
-                    generics.as_slice()
-                }
-                _ => &[],
-            };
-            let sub_map = generics
-                .iter()
-                .map(|g| g.name.clone())
-                .zip(type_args.iter().cloned())
-                .collect();
-
-            match definition {
-                Definition::Struct { fields, .. } => {
-                    for f in fields {
-                        let field_ty = substitute(&f.ty.resolve_in(&self.env), &sub_map);
-                        if self.check_not_comparable(store, &field_ty).is_some() {
-                            return Some("a struct containing non-comparable fields");
-                        }
-                    }
-                }
-                Definition::Enum { variants, .. } => {
-                    for v in variants {
-                        for f in v.fields.iter() {
-                            let field_ty = substitute(&f.ty.resolve_in(&self.env), &sub_map);
-                            if self.check_not_comparable(store, &field_ty).is_some() {
-                                return Some("an enum containing non-comparable fields");
-                            }
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        if let Type::Tuple(elems) = ty {
-            for e in elems {
-                if self
-                    .check_not_comparable(store, &e.resolve_in(&self.env))
-                    .is_some()
-                {
-                    return Some("a tuple containing non-comparable elements");
-                }
-            }
-        }
-
-        None
     }
 
     fn unify_binary_operands(

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -4,6 +4,8 @@ mod interface;
 mod unify;
 mod validation;
 
+pub(crate) use unify::BuiltinBound;
+
 use rustc_hash::FxHashMap as HashMap;
 
 use super::TaskState;

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -8,6 +8,35 @@ use syntax::types::{Bound, Type, TypeVarId};
 use super::super::TaskState;
 use crate::checker::type_env::VarState;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BuiltinBound {
+    Ordered,
+    Comparable,
+}
+
+impl BuiltinBound {
+    pub(crate) fn from_qualified_id(qualified: &str) -> Option<Self> {
+        match qualified {
+            "go:cmp.Ordered" => Some(Self::Ordered),
+            "prelude.Comparable" => Some(Self::Comparable),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Ordered => "cmp.Ordered",
+            Self::Comparable => "Comparable",
+        }
+    }
+
+    /// True when a parameter declared `T: self` satisfies a callee that
+    /// requires `T: target`. Encodes Go's `cmp.Ordered ⊂ Comparable`.
+    pub(crate) fn satisfies(self, target: Self) -> bool {
+        self == target || (self == Self::Ordered && target == Self::Comparable)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum UnifyError {
     TypeMismatch,
@@ -16,6 +45,12 @@ pub enum UnifyError {
     #[allow(clippy::box_collection)] // Intentional: shrinks Result<(), UnifyError> on hot path
     Multiple(Box<Vec<UnifyError>>),
     AlreadyReported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dispatched {
+    Handled,
+    Fallthrough,
 }
 
 impl TaskState<'_> {
@@ -629,6 +664,10 @@ impl TaskState<'_> {
             return;
         }
 
+        if self.dispatch_builtin_bound(store, bound, &resolved_ty, span) == Dispatched::Handled {
+            return;
+        }
+
         let interface_ty = bound.ty.resolve_in(&self.env);
         let Type::Nominal { id, params, .. } = interface_ty else {
             return;
@@ -639,6 +678,76 @@ impl TaskState<'_> {
         };
 
         let _ = self.satisfies_interface(store, &resolved_ty, &interface, &params, span);
+    }
+
+    /// Built-in bound recognition; falls through to the interface path on miss.
+    pub(super) fn dispatch_builtin_bound(
+        &mut self,
+        store: &Store,
+        bound: &Bound,
+        resolved_generic: &Type,
+        span: &Span,
+    ) -> Dispatched {
+        let bound_ty = bound.ty.resolve_in(&self.env);
+        let Some(builtin) = bound_ty
+            .get_qualified_id()
+            .and_then(BuiltinBound::from_qualified_id)
+        else {
+            return Dispatched::Fallthrough;
+        };
+
+        if let Type::Parameter(param_name) = resolved_generic {
+            if !self.parameter_satisfies_bound(param_name, builtin) {
+                self.sink.push(diagnostics::infer::missing_bound_on_param(
+                    param_name,
+                    builtin.label(),
+                    *span,
+                ));
+            }
+            return Dispatched::Handled;
+        }
+
+        match builtin {
+            BuiltinBound::Ordered if !resolved_generic.satisfies_ordered_constraint() => {
+                self.sink.push(diagnostics::infer::not_orderable_bound(
+                    bound.param_name.as_str(),
+                    resolved_generic,
+                    *span,
+                ));
+            }
+            BuiltinBound::Comparable => {
+                if super::expressions::operators::check_not_comparable(
+                    &self.env,
+                    store,
+                    resolved_generic,
+                )
+                .is_some()
+                {
+                    self.sink
+                        .push(diagnostics::infer::not_comparable_bound(*span));
+                }
+            }
+            BuiltinBound::Ordered => {}
+        }
+        Dispatched::Handled
+    }
+
+    pub(super) fn parameter_satisfies_bound(&self, param_name: &str, target: BuiltinBound) -> bool {
+        let mut found = false;
+        self.scopes.for_each_bound_on_param(param_name, |bound_ty| {
+            if found {
+                return;
+            }
+            if let Some(declared) = bound_ty
+                .resolve_in(&self.env)
+                .get_qualified_id()
+                .and_then(BuiltinBound::from_qualified_id)
+                && declared.satisfies(target)
+            {
+                found = true;
+            }
+        });
+        found
     }
 
     fn unification_diagnostic(

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -97,6 +97,10 @@ pub struct TaskState<'s> {
     pub ufcs_methods: HashSet<(String, String)>,
     /// Typed files produced by inference.
     pub typed_files: Vec<(String, File)>,
+    /// Reentrancy counter: > 0 while resolving a generic bound annotation.
+    /// Lets `convert_to_type` admit bound-only markers (e.g. `Comparable`)
+    /// without flagging them as misuse in value positions.
+    pub bound_position_depth: u32,
 }
 
 impl<'s> TaskState<'s> {
@@ -113,6 +117,7 @@ impl<'s> TaskState<'s> {
             method_cache: RefCell::new(HashMap::default()),
             ufcs_methods: HashSet::default(),
             typed_files: Vec::new(),
+            bound_position_depth: 0,
         }
     }
 
@@ -214,7 +219,7 @@ impl<'s> TaskState<'s> {
     ) {
         for g in generics {
             for b in &g.bounds {
-                self.convert_to_type(store, b, span);
+                self.convert_bound_to_type(store, b, span);
             }
         }
     }
@@ -715,6 +720,7 @@ fn is_reserved_import_alias(name: &str) -> bool {
         // Lisette prelude types and constructors
         | "Option"
         | "Result"
+        | "Comparable"
         | "Some"
         | "None"
         | "Ok"

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -10,6 +10,21 @@ use crate::checker::TaskState;
 use crate::store::Store;
 
 impl TaskState<'_> {
+    /// Resolves a generic-bound annotation. Bound-only markers like
+    /// `Comparable` are admitted here; the same names in value position
+    /// are flagged inside `convert_to_type`.
+    pub fn convert_bound_to_type(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+        span: &Span,
+    ) -> Type {
+        self.bound_position_depth += 1;
+        let result = self.convert_to_type(store, annotation, span);
+        self.bound_position_depth -= 1;
+        result
+    }
+
     pub fn convert_to_type(&mut self, store: &Store, annotation: &Annotation, span: &Span) -> Type {
         match annotation {
             Annotation::Unknown => self.new_type_var(),
@@ -91,6 +106,18 @@ impl TaskState<'_> {
                     self.sink.push(diagnostics::infer::unknown_outside_typedef(
                         *annotation_span,
                     ));
+                }
+
+                if self.bound_position_depth == 0
+                    && let Some(builtin) =
+                        crate::checker::infer::BuiltinBound::from_qualified_id(&qualified_name)
+                {
+                    self.sink
+                        .push(diagnostics::infer::bound_only_in_value_position(
+                            builtin.label(),
+                            *annotation_span,
+                        ));
+                    return Type::Error;
                 }
 
                 let (generics, body) = match &ty {

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -171,7 +171,7 @@ impl TaskState<'_> {
         let mut impl_bounds: Vec<syntax::types::Bound> = Vec::new();
         for g in generics {
             for b in &g.bounds {
-                let bound_ty = self.convert_to_type(&*store, b, span);
+                let bound_ty = self.convert_bound_to_type(&*store, b, span);
                 impl_bounds.push(syntax::types::Bound {
                     param_name: g.name.clone(),
                     generic: Type::Parameter(g.name.clone()),

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -787,7 +787,7 @@ impl TaskState<'_> {
             let qualified_name = self.qualify_name(&g.name);
 
             for b in &g.bounds {
-                let bound_ty = self.convert_to_type(store, b, span);
+                let bound_ty = self.convert_bound_to_type(store, b, span);
 
                 self.scopes
                     .current_mut()

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -304,6 +304,28 @@ impl Scopes {
         all_bounds
     }
 
+    pub fn for_each_bound_on_param<F: FnMut(&Type)>(&self, param_name: &str, mut visit: F) {
+        for scope in self.stack.iter().rev() {
+            let introduces = scope
+                .type_params
+                .as_ref()
+                .is_some_and(|tp| tp.contains_key(param_name));
+            if !introduces {
+                continue;
+            }
+            if let Some(ref bounds) = scope.trait_bounds {
+                for (key, types) in bounds {
+                    if key.last_segment() == param_name {
+                        for ty in types {
+                            visit(ty);
+                        }
+                    }
+                }
+            }
+            return;
+        }
+    }
+
     pub fn increment_loop_depth(&self) {
         self.current().loop_depth.increment();
     }

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -524,6 +524,11 @@ type Unknown
 ///   }
 type Never
 
+/// Marker for Go's `comparable` constraint. A type satisfies `Comparable`
+/// when it admits `==` and `!=` (everything except slices, maps, functions,
+/// and aggregates that contain them). Only usable as a type-parameter bound.
+type Comparable
+
 /// Zero or more arguments of type `T`. Only valid as the last parameter
 /// of a function. Corresponds to Go's `...T` syntax.
 ///

--- a/crates/stdlib/typedefs/cmp.d.lis
+++ b/crates/stdlib/typedefs/cmp.d.lis
@@ -3,14 +3,24 @@
 // Go: 1.25.5
 // Lisette: 0.1.20
 
-// SKIPPED: Compare - constraint:comparable
-// type constraint T cannot be represented
+/// Compare returns
+/// 
+/// 	-1 if x is less than y,
+/// 	 0 if x equals y,
+/// 	+1 if x is greater than y.
+/// 
+/// For floating-point types, a NaN is considered less than any non-NaN,
+/// a NaN is considered equal to a NaN, and -0.0 is equal to 0.0.
+pub fn Compare<T: Ordered>(x: T, y: T) -> int
 
-// SKIPPED: Less - constraint:comparable
-// type constraint T cannot be represented
+/// Less reports whether x is less than y.
+/// For floating-point types, a NaN is considered less than any non-NaN,
+/// and -0.0 is not less than (is equal to) 0.0.
+pub fn Less<T: Ordered>(x: T, y: T) -> bool
 
-// SKIPPED: Or - constraint:comparable
-// type constraint T cannot be represented
+/// Or returns the first of its arguments that is not equal to the zero value.
+/// If no argument is non-zero, it returns the zero value.
+pub fn Or<T: Comparable>(vals: VarArgs<T>) -> T
 
 /// Ordered is a constraint that permits any ordered type: any type
 /// that supports the operators < <= >= >.

--- a/crates/stdlib/typedefs/hash/maphash.d.lis
+++ b/crates/stdlib/typedefs/hash/maphash.d.lis
@@ -15,8 +15,10 @@ import "go:hash"
 /// 	return h.Sum64()
 pub fn Bytes(seed: Seed, b: Slice<uint8>) -> uint64
 
-// SKIPPED: Comparable - constraint:comparable
-// type constraint T cannot be represented
+/// Comparable returns the hash of comparable value v with the given seed
+/// such that Comparable(s, v1) == Comparable(s, v2) if v1 == v2.
+/// If v != v, then the resulting hash is randomly distributed.
+pub fn Comparable<T: Comparable>(seed: Seed, v: T) -> uint64
 
 pub fn MakeSeed() -> Seed
 
@@ -30,8 +32,8 @@ pub fn MakeSeed() -> Seed
 /// 	return h.Sum64()
 pub fn String(seed: Seed, s: string) -> uint64
 
-// SKIPPED: WriteComparable - constraint:comparable
-// type constraint T cannot be represented
+/// WriteComparable adds x to the data hashed by h.
+pub fn WriteComparable<T: Comparable>(h: Ref<Hash>, x: T)
 
 /// A Hash computes a seeded hash of a byte sequence.
 /// 

--- a/crates/stdlib/typedefs/maps.d.lis
+++ b/crates/stdlib/typedefs/maps.d.lis
@@ -11,8 +11,9 @@ import "go:iter"
 // SKIPPED: Clone - constraint:union
 // type constraint M cannot be represented
 
-// SKIPPED: Collect - constraint:comparable
-// type constraint K cannot be represented
+/// Collect collects key-value pairs from seq into a new map
+/// and returns it.
+pub fn Collect<K: Comparable, V>(seq: iter.Seq2<K, V>) -> Map<K, V>
 
 // SKIPPED: Copy - constraint:union
 // type constraint M1 cannot be represented

--- a/crates/stdlib/typedefs/slices.d.lis
+++ b/crates/stdlib/typedefs/slices.d.lis
@@ -3,119 +3,220 @@
 // Go: 1.25.5
 // Lisette: 0.1.20
 
+import "go:cmp"
 import "go:iter"
 
-// SKIPPED: All - constraint:union
-// type constraint Slice cannot be represented
+/// All returns an iterator over index-value pairs in the slice
+/// in the usual order.
+pub fn All<E>(s: Slice<E>) -> iter.Seq2<int, E>
 
-// SKIPPED: AppendSeq - constraint:union
-// type constraint Slice cannot be represented
+/// AppendSeq appends the values from seq to the slice and
+/// returns the extended slice.
+/// If seq is empty, the result preserves the nilness of s.
+pub fn AppendSeq<E>(s: Slice<E>, seq: iter.Seq<E>) -> Slice<E>
 
-// SKIPPED: Backward - constraint:union
-// type constraint Slice cannot be represented
+/// Backward returns an iterator over index-value pairs in the slice,
+/// traversing it backward with descending indices.
+pub fn Backward<E>(s: Slice<E>) -> iter.Seq2<int, E>
 
-// SKIPPED: BinarySearch - constraint:union
-// type constraint S cannot be represented
+/// BinarySearch searches for target in a sorted slice and returns the earliest
+/// position where target is found, or the position where target would appear
+/// in the sort order; it also returns a bool saying whether the target is
+/// really found in the slice. The slice must be sorted in increasing order.
+pub fn BinarySearch<E: cmp.Ordered>(x: Slice<E>, target: E) -> Option<int>
 
-// SKIPPED: BinarySearchFunc - constraint:union
-// type constraint S cannot be represented
+/// BinarySearchFunc works like [BinarySearch], but uses a custom comparison
+/// function. The slice must be sorted in increasing order, where "increasing"
+/// is defined by cmp. cmp should return 0 if the slice element matches
+/// the target, a negative number if the slice element precedes the target,
+/// or a positive number if the slice element follows the target.
+/// cmp must implement the same ordering as the slice, such that if
+/// cmp(a, t) < 0 and cmp(b, t) >= 0, then a must precede b in the slice.
+pub fn BinarySearchFunc<E, T>(x: Slice<E>, target: T, cmp: fn(E, T) -> int) -> Option<int>
 
-// SKIPPED: Chunk - constraint:union
-// type constraint Slice cannot be represented
+/// Chunk returns an iterator over consecutive sub-slices of up to n elements of s.
+/// All but the last sub-slice will have size n.
+/// All sub-slices are clipped to have no capacity beyond the length.
+/// If s is empty, the sequence is empty: there is no empty slice in the sequence.
+/// Chunk panics if n is less than 1.
+pub fn Chunk<E>(s: Slice<E>, n: int) -> iter.Seq<Slice<E>>
 
-// SKIPPED: Clip - constraint:union
-// type constraint S cannot be represented
+/// Clip removes unused capacity from the slice, returning s[:len(s):len(s)].
+/// The result preserves the nilness of s.
+pub fn Clip<E>(s: Slice<E>) -> Slice<E>
 
-// SKIPPED: Clone - constraint:union
-// type constraint S cannot be represented
+/// Clone returns a copy of the slice.
+/// The elements are copied using assignment, so this is a shallow clone.
+/// The result may have additional unused capacity.
+/// The result preserves the nilness of s.
+pub fn Clone<E>(s: Slice<E>) -> Slice<E>
 
 /// Collect collects values from seq into a new slice and returns it.
 /// If seq is empty, the result is nil.
 pub fn Collect<E>(seq: iter.Seq<E>) -> Slice<E>
 
-// SKIPPED: Compact - constraint:union
-// type constraint S cannot be represented
+/// Compact replaces consecutive runs of equal elements with a single copy.
+/// This is like the uniq command found on Unix.
+/// Compact modifies the contents of the slice s and returns the modified slice,
+/// which may have a smaller length.
+/// Compact zeroes the elements between the new length and the original length.
+/// The result preserves the nilness of s.
+pub fn Compact<E: Comparable>(s: Slice<E>) -> Slice<E>
 
-// SKIPPED: CompactFunc - constraint:union
-// type constraint S cannot be represented
+/// CompactFunc is like [Compact] but uses an equality function to compare elements.
+/// For runs of elements that compare equal, CompactFunc keeps the first one.
+/// CompactFunc zeroes the elements between the new length and the original length.
+/// The result preserves the nilness of s.
+pub fn CompactFunc<E>(s: Slice<E>, eq: fn(E, E) -> bool) -> Slice<E>
 
-// SKIPPED: Compare - constraint:union
-// type constraint S cannot be represented
+/// Compare compares the elements of s1 and s2, using [cmp.Compare] on each pair
+/// of elements. The elements are compared sequentially, starting at index 0,
+/// until one element is not equal to the other.
+/// The result of comparing the first non-matching elements is returned.
+/// If both slices are equal until one of them ends, the shorter slice is
+/// considered less than the longer one.
+/// The result is 0 if s1 == s2, -1 if s1 < s2, and +1 if s1 > s2.
+pub fn Compare<E: cmp.Ordered>(s1: Slice<E>, s2: Slice<E>) -> int
 
-// SKIPPED: CompareFunc - constraint:union
-// type constraint S1 cannot be represented
+/// CompareFunc is like [Compare] but uses a custom comparison function on each
+/// pair of elements.
+/// The result is the first non-zero result of cmp; if cmp always
+/// returns 0 the result is 0 if len(s1) == len(s2), -1 if len(s1) < len(s2),
+/// and +1 if len(s1) > len(s2).
+pub fn CompareFunc<E1, E2>(s1: Slice<E1>, s2: Slice<E2>, cmp: fn(E1, E2) -> int) -> int
 
-// SKIPPED: Concat - constraint:union
-// type constraint S cannot be represented
+/// Concat returns a new slice concatenating the passed in slices.
+/// If the concatenation is empty, the result is nil.
+pub fn Concat<E>(slices: VarArgs<Slice<E>>) -> Slice<E>
 
-// SKIPPED: Contains - constraint:union
-// type constraint S cannot be represented
+/// Contains reports whether v is present in s.
+pub fn Contains<E: Comparable>(s: Slice<E>, v: E) -> bool
 
-// SKIPPED: ContainsFunc - constraint:union
-// type constraint S cannot be represented
+/// ContainsFunc reports whether at least one
+/// element e of s satisfies f(e).
+pub fn ContainsFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> bool
 
-// SKIPPED: Delete - constraint:union
-// type constraint S cannot be represented
+/// Delete removes the elements s[i:j] from s, returning the modified slice.
+/// Delete panics if j > len(s) or s[i:j] is not a valid slice of s.
+/// Delete is O(len(s)-i), so if many items must be deleted, it is better to
+/// make a single call deleting them all together than to delete one at a time.
+/// Delete zeroes the elements s[len(s)-(j-i):len(s)].
+/// If the result is empty, it has the same nilness as s.
+pub fn Delete<E>(s: Slice<E>, i: int, j: int) -> Slice<E>
 
-// SKIPPED: DeleteFunc - constraint:union
-// type constraint S cannot be represented
+/// DeleteFunc removes any elements from s for which del returns true,
+/// returning the modified slice.
+/// DeleteFunc zeroes the elements between the new length and the original length.
+/// If the result is empty, it has the same nilness as s.
+pub fn DeleteFunc<E>(s: Slice<E>, del: fn(E) -> bool) -> Slice<E>
 
-// SKIPPED: Equal - constraint:union
-// type constraint S cannot be represented
+/// Equal reports whether two slices are equal: the same length and all
+/// elements equal. If the lengths are different, Equal returns false.
+/// Otherwise, the elements are compared in increasing index order, and the
+/// comparison stops at the first unequal pair.
+/// Empty and nil slices are considered equal.
+/// Floating point NaNs are not considered equal.
+pub fn Equal<E: Comparable>(s1: Slice<E>, s2: Slice<E>) -> bool
 
-// SKIPPED: EqualFunc - constraint:union
-// type constraint S1 cannot be represented
+/// EqualFunc reports whether two slices are equal using an equality
+/// function on each pair of elements. If the lengths are different,
+/// EqualFunc returns false. Otherwise, the elements are compared in
+/// increasing index order, and the comparison stops at the first index
+/// for which eq returns false.
+pub fn EqualFunc<E1, E2>(s1: Slice<E1>, s2: Slice<E2>, eq: fn(E1, E2) -> bool) -> bool
 
-// SKIPPED: Grow - constraint:union
-// type constraint S cannot be represented
+/// Grow increases the slice's capacity, if necessary, to guarantee space for
+/// another n elements. After Grow(n), at least n elements can be appended
+/// to the slice without another allocation. If n is negative or too large to
+/// allocate the memory, Grow panics.
+/// The result preserves the nilness of s.
+pub fn Grow<E>(s: Slice<E>, n: int) -> Slice<E>
 
-// SKIPPED: Index - constraint:union
-// type constraint S cannot be represented
+/// Index returns the index of the first occurrence of v in s,
+/// or -1 if not present.
+pub fn Index<E: Comparable>(s: Slice<E>, v: E) -> int
 
-// SKIPPED: IndexFunc - constraint:union
-// type constraint S cannot be represented
+/// IndexFunc returns the first index i satisfying f(s[i]),
+/// or -1 if none do.
+pub fn IndexFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> int
 
-// SKIPPED: Insert - constraint:union
-// type constraint S cannot be represented
+/// Insert inserts the values v... into s at index i,
+/// returning the modified slice.
+/// The elements at s[i:] are shifted up to make room.
+/// In the returned slice r, r[i] == v[0],
+/// and, if i < len(s), r[i+len(v)] == value originally at r[i].
+/// Insert panics if i > len(s).
+/// This function is O(len(s) + len(v)).
+/// If the result is empty, it has the same nilness as s.
+pub fn Insert<E>(s: Slice<E>, i: int, v: VarArgs<E>) -> Slice<E>
 
-// SKIPPED: IsSorted - constraint:union
-// type constraint S cannot be represented
+/// IsSorted reports whether x is sorted in ascending order.
+pub fn IsSorted<E: cmp.Ordered>(x: Slice<E>) -> bool
 
-// SKIPPED: IsSortedFunc - constraint:union
-// type constraint S cannot be represented
+/// IsSortedFunc reports whether x is sorted in ascending order, with cmp as the
+/// comparison function as defined by [SortFunc].
+pub fn IsSortedFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int) -> bool
 
-// SKIPPED: Max - constraint:union
-// type constraint S cannot be represented
+/// Max returns the maximal value in x. It panics if x is empty.
+/// For floating-point E, Max propagates NaNs (any NaN value in x
+/// forces the output to be NaN).
+pub fn Max<E: cmp.Ordered>(x: Slice<E>) -> E
 
-// SKIPPED: MaxFunc - constraint:union
-// type constraint S cannot be represented
+/// MaxFunc returns the maximal value in x, using cmp to compare elements.
+/// It panics if x is empty. If there is more than one maximal element
+/// according to the cmp function, MaxFunc returns the first one.
+pub fn MaxFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int) -> E
 
-// SKIPPED: Min - constraint:union
-// type constraint S cannot be represented
+/// Min returns the minimal value in x. It panics if x is empty.
+/// For floating-point numbers, Min propagates NaNs (any NaN value in x
+/// forces the output to be NaN).
+pub fn Min<E: cmp.Ordered>(x: Slice<E>) -> E
 
-// SKIPPED: MinFunc - constraint:union
-// type constraint S cannot be represented
+/// MinFunc returns the minimal value in x, using cmp to compare elements.
+/// It panics if x is empty. If there is more than one minimal element
+/// according to the cmp function, MinFunc returns the first one.
+pub fn MinFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int) -> E
 
-// SKIPPED: Repeat - constraint:union
-// type constraint S cannot be represented
+/// Repeat returns a new slice that repeats the provided slice the given number of times.
+/// The result has length and capacity (len(x) * count).
+/// The result is never nil.
+/// Repeat panics if count is negative or if the result of (len(x) * count)
+/// overflows.
+pub fn Repeat<E>(x: Slice<E>, count: int) -> Slice<E>
 
-// SKIPPED: Replace - constraint:union
-// type constraint S cannot be represented
+/// Replace replaces the elements s[i:j] by the given v, and returns the
+/// modified slice.
+/// Replace panics if j > len(s) or s[i:j] is not a valid slice of s.
+/// When len(v) < (j-i), Replace zeroes the elements between the new length and the original length.
+/// If the result is empty, it has the same nilness as s.
+pub fn Replace<E>(s: Slice<E>, i: int, j: int, v: VarArgs<E>) -> Slice<E>
 
-// SKIPPED: Reverse - constraint:union
-// type constraint S cannot be represented
+/// Reverse reverses the elements of the slice in place.
+pub fn Reverse<E>(s: Slice<E>)
 
-// SKIPPED: Sort - constraint:union
-// type constraint S cannot be represented
+/// Sort sorts a slice of any ordered type in ascending order.
+/// When sorting floating-point numbers, NaNs are ordered before other values.
+pub fn Sort<E: cmp.Ordered>(x: Slice<E>)
 
-// SKIPPED: SortFunc - constraint:union
-// type constraint S cannot be represented
+/// SortFunc sorts the slice x in ascending order as determined by the cmp
+/// function. This sort is not guaranteed to be stable.
+/// cmp(a, b) should return a negative number when a < b, a positive number when
+/// a > b and zero when a == b or a and b are incomparable in the sense of
+/// a strict weak ordering.
+/// 
+/// SortFunc requires that cmp is a strict weak ordering.
+/// See https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings.
+/// The function should return 0 for incomparable items.
+pub fn SortFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int)
 
-// SKIPPED: SortStableFunc - constraint:union
-// type constraint S cannot be represented
+/// SortStableFunc sorts the slice x while keeping the original order of equal
+/// elements, using cmp to compare elements in the same way as [SortFunc].
+pub fn SortStableFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int)
 
-// SKIPPED: Sorted - constraint:comparable
-// type constraint E cannot be represented
+/// Sorted collects values from seq into a new slice, sorts the slice,
+/// and returns it.
+/// If seq is empty, the result is nil.
+pub fn Sorted<E: cmp.Ordered>(seq: iter.Seq<E>) -> Slice<E>
 
 /// SortedFunc collects values from seq into a new slice, sorts the slice
 /// using the comparison function, and returns it.
@@ -129,5 +230,5 @@ pub fn SortedFunc<E>(seq: iter.Seq<E>, cmp: fn(E, E) -> int) -> Slice<E>
 /// If seq is empty, the result is nil.
 pub fn SortedStableFunc<E>(seq: iter.Seq<E>, cmp: fn(E, E) -> int) -> Slice<E>
 
-// SKIPPED: Values - constraint:union
-// type constraint Slice cannot be represented
+/// Values returns an iterator that yields the slice elements in order.
+pub fn Values<E>(s: Slice<E>) -> iter.Seq<E>

--- a/crates/stdlib/typedefs/unique.d.lis
+++ b/crates/stdlib/typedefs/unique.d.lis
@@ -3,12 +3,17 @@
 // Go: 1.25.5
 // Lisette: 0.1.20
 
-// SKIPPED: Make - constraint:comparable
-// type constraint T cannot be represented
+pub fn Make<T: Comparable>(value: T) -> Handle<T>
 
-// SKIPPED: Handle - constraint:comparable
-// type constraint T cannot be represented
-pub type Handle
+/// Handle is a globally unique identity for some value of type T.
+/// 
+/// Two handles compare equal exactly if the two values used to create the handles
+/// would have also compared equal. The comparison of two handles is trivial and
+/// typically much more efficient than comparing the values used to create them.
+pub type Handle<T: Comparable>
 
-// SKIPPED: Value - constraint:comparable
-// type constraint T cannot be represented
+impl<T: Comparable> Handle<T> {
+  /// Value returns a shallow copy of the T value that produced the Handle.
+  /// Value is safe for concurrent use by multiple goroutines.
+  fn Value(self) -> T
+}

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -891,6 +891,38 @@ impl Type {
         self.as_simple().is_some_and(SimpleKind::is_ordered)
     }
 
+    /// True for Go's `cmp.Ordered` set: ints, floats, strings, and named aliases over them.
+    pub fn satisfies_ordered_constraint(&self) -> bool {
+        if let Some(kind) = self.as_simple() {
+            return matches!(
+                kind,
+                SimpleKind::Int
+                    | SimpleKind::Int8
+                    | SimpleKind::Int16
+                    | SimpleKind::Int32
+                    | SimpleKind::Int64
+                    | SimpleKind::Uint
+                    | SimpleKind::Uint8
+                    | SimpleKind::Uint16
+                    | SimpleKind::Uint32
+                    | SimpleKind::Uint64
+                    | SimpleKind::Uintptr
+                    | SimpleKind::Byte
+                    | SimpleKind::Rune
+                    | SimpleKind::Float32
+                    | SimpleKind::Float64
+                    | SimpleKind::String
+            );
+        }
+        match self {
+            Type::Nominal { underlying_ty, .. } => underlying_ty
+                .as_deref()
+                .is_some_and(Type::satisfies_ordered_constraint),
+            Type::Parameter(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_complex(&self) -> bool {
         self.as_simple().is_some_and(SimpleKind::is_complex)
     }

--- a/docs/reference/05-functions.md
+++ b/docs/reference/05-functions.md
@@ -82,6 +82,18 @@ fn combine<T: Display, U: Debug>(a: T, b: U) -> string {
 }
 ```
 
+Two built-in bounds are predeclared:
+
+- `Comparable` (in the prelude) for types that admit `==` and `!=`.
+- `cmp.Ordered` (in `go:cmp`) for types that admit `<`, `>`, etc.
+
+```rust
+import "go:cmp"
+
+fn dedupe<T: Comparable>(xs: Slice<T>) -> Slice<T> { /* ... */ }
+fn sort<T: cmp.Ordered>(xs: Slice<T>) { /* ... */ }
+```
+
 ## Mutable parameters
 
 Parameters are immutable by default. If a function mutates a parameter (e.g. sorting a slice in place), mark it with `mut`:

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4712,6 +4712,174 @@ fn test() {
 }
 
 #[test]
+fn infer_comparable_bound_rejects_slice() {
+    let input = r#"
+fn requires_comparable<T: Comparable>(_x: T) {}
+
+fn test() {
+  requires_comparable([1, 2, 3])
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_ordered_bound_rejects_bool() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_ordered<T: cmp.Ordered>(_x: T) {}
+
+fn test() {
+  requires_ordered(true)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_bound_on_param_for_comparable() {
+    let input = r#"
+fn requires_comparable<T: Comparable>(_x: T) {}
+
+fn wrapper<T>(x: T) {
+  requires_comparable(x)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_bound_on_param_for_ordered() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_ordered<T: cmp.Ordered>(_x: T) {}
+
+fn wrapper<T>(x: T) {
+  requires_ordered(x)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_propagated_bound_no_error() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_ordered<T: cmp.Ordered>(_x: T) {}
+
+fn wrapper<T: cmp.Ordered>(x: T) {
+  requires_ordered(x)
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_ordered_bound_allows_lt_in_body() {
+    let input = r#"
+import "go:cmp"
+
+fn less<T: cmp.Ordered>(a: T, b: T) -> bool { a < b }
+fn user() -> bool { less(1, 2) }
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_comparable_bound_allows_eq_in_body() {
+    let input = r#"
+fn eq<T: Comparable>(a: T, b: T) -> bool { a == b }
+fn user() -> bool { eq(1, 1) }
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_shadowed_inner_generic_does_not_inherit_bound() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_ordered<T: cmp.Ordered>(_x: T) {}
+
+struct Box<T> {}
+
+impl<T: cmp.Ordered> Box<T> {
+  fn bad<T>(self, x: T) { requires_ordered(x) }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_comparable_in_param_position_rejected() {
+    let input = r#"
+fn takes(_x: Comparable) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_ordered_in_param_position_rejected() {
+    let input = r#"
+import "go:cmp"
+
+fn takes(_x: cmp.Ordered) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_ordered_satisfies_comparable_in_wrapper() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_comparable<T: Comparable>(_x: T) {}
+
+fn wrapper<T: cmp.Ordered>(x: T) {
+  requires_comparable(x)
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_comparable_does_not_satisfy_ordered_in_wrapper() {
+    let input = r#"
+import "go:cmp"
+
+fn requires_ordered<T: cmp.Ordered>(_x: T) {}
+
+fn wrapper<T: Comparable>(x: T) {
+  requires_ordered(x)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_impl_on_type_alias() {
     let source = r#"
 type UserId = int

--- a/tests/ui/errors/snapshots/infer_comparable_bound_rejects_slice.snap
+++ b/tests/ui/errors/snapshots/infer_comparable_bound_rejects_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Bound not satisfied
+   ╭─[test.lis:5:23]
+ 4 │ fn test() {
+ 5 │   requires_comparable([1, 2, 3])
+   ·                       ────┬────
+   ·                           ╰── does not satisfy `Comparable`
+ 6 │ }
+   ╰────
+  help: The parameter must be `Comparable` but the argument is not comparable. Relax the bound or pass an argument that satisfies it · code: [infer.not_comparable_bound]

--- a/tests/ui/errors/snapshots/infer_comparable_does_not_satisfy_ordered_in_wrapper.snap
+++ b/tests/ui/errors/snapshots/infer_comparable_does_not_satisfy_ordered_in_wrapper.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing bound on type parameter
+   ╭─[test.lis:7:20]
+ 6 │ fn wrapper<T: Comparable>(x: T) {
+ 7 │   requires_ordered(x)
+   ·                    ┬
+   ·                    ╰── does not satisfy `Ordered`
+ 8 │ }
+   ╰────
+  help: The parameter must be `cmp.Ordered` but the argument is unbounded. Add this bound to the enclosing function: `<T: cmp.Ordered>` · code: [infer.missing_bound_on_param]

--- a/tests/ui/errors/snapshots/infer_comparable_in_param_position_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_comparable_in_param_position_rejected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `Comparable` is a bound, not a value type
+   ╭─[test.lis:2:14]
+ 1 │ 
+ 2 │ fn takes(_x: Comparable) {}
+   ·              ─────┬────
+   ·                   ╰── not allowed here
+   ╰────
+  help: Use `Comparable` only as a bound to constrain a generic parameter, e.g. `fn f<T: Comparable>(x: T)` · code: [infer.bound_only_in_value_position]

--- a/tests/ui/errors/snapshots/infer_missing_bound_on_param_for_comparable.snap
+++ b/tests/ui/errors/snapshots/infer_missing_bound_on_param_for_comparable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing bound on type parameter
+   ╭─[test.lis:5:23]
+ 4 │ fn wrapper<T>(x: T) {
+ 5 │   requires_comparable(x)
+   ·                       ┬
+   ·                       ╰── does not satisfy `Comparable`
+ 6 │ }
+   ╰────
+  help: The parameter must be `Comparable` but the argument is unbounded. Add this bound to the enclosing function: `<T: Comparable>` · code: [infer.missing_bound_on_param]

--- a/tests/ui/errors/snapshots/infer_missing_bound_on_param_for_ordered.snap
+++ b/tests/ui/errors/snapshots/infer_missing_bound_on_param_for_ordered.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing bound on type parameter
+   ╭─[test.lis:7:20]
+ 6 │ fn wrapper<T>(x: T) {
+ 7 │   requires_ordered(x)
+   ·                    ┬
+   ·                    ╰── does not satisfy `Ordered`
+ 8 │ }
+   ╰────
+  help: The parameter must be `cmp.Ordered` but the argument is unbounded. Add this bound to the enclosing function: `<T: cmp.Ordered>` · code: [infer.missing_bound_on_param]

--- a/tests/ui/errors/snapshots/infer_ordered_bound_rejects_bool.snap
+++ b/tests/ui/errors/snapshots/infer_ordered_bound_rejects_bool.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Bound not satisfied
+   ╭─[test.lis:7:20]
+ 6 │ fn test() {
+ 7 │   requires_ordered(true)
+   ·                    ──┬─
+   ·                      ╰── `bool` does not satisfy `cmp.Ordered`
+ 8 │ }
+   ╰────
+  help: The type parameter `T` requires `cmp.Ordered`; only integers, floats, and strings (and their named aliases) satisfy it · code: [infer.not_orderable_bound]

--- a/tests/ui/errors/snapshots/infer_ordered_in_param_position_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_ordered_in_param_position_rejected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `cmp.Ordered` is a bound, not a value type
+   ╭─[test.lis:4:14]
+ 3 │ 
+ 4 │ fn takes(_x: cmp.Ordered) {}
+   ·              ─────┬─────
+   ·                   ╰── not allowed here
+   ╰────
+  help: Use `cmp.Ordered` only as a bound to constrain a generic parameter, e.g. `fn f<T: cmp.Ordered>(x: T)` · code: [infer.bound_only_in_value_position]

--- a/tests/ui/errors/snapshots/infer_shadowed_inner_generic_does_not_inherit_bound.snap
+++ b/tests/ui/errors/snapshots/infer_shadowed_inner_generic_does_not_inherit_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing bound on type parameter
+    ╭─[test.lis:9:44]
+  8 │ impl<T: cmp.Ordered> Box<T> {
+  9 │   fn bad<T>(self, x: T) { requires_ordered(x) }
+    ·                                            ┬
+    ·                                            ╰── does not satisfy `Ordered`
+ 10 │ }
+    ╰────
+  help: The parameter must be `cmp.Ordered` but the argument is unbounded. Add this bound to the enclosing function: `<T: cmp.Ordered>` · code: [infer.missing_bound_on_param]


### PR DESCRIPTION
Adds support for Go's `Comparable` and `cmp.Ordered` as type param bounds in Lisette. 

This unlocks ~50 stdlib functions that were previously skipped during bindgen, including `slices.Sort`, `slices.Min`/`Max`, `cmp.Compare`, `maps.Keys`, `unique.Make`, `hash/maphash.Comparable`. User code can declare `fn foo<T: Comparable>` or `fn foo<T: cmp.Ordered>` and use `==` / `<` on `T` inside the body.