### PR TITLE
feat: recognize M ~map[K]V as type-parameter shape

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -215,6 +215,10 @@
           "Level.AppendText": ["b"],
           "LevelVar.AppendText": ["b"]
         },
+        "maps": {
+          "DeleteFunc": ["m"],
+          "Insert": ["m"]
+        },
         "math/big": {
           "Float.Append": ["buf"],
           "Float.AppendText": ["b"],

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -579,8 +579,9 @@ func formatConstantValue(val constant.Value) string {
 	}
 }
 
-// `S ~[]E` shapes go into substitutions (caller rewrites `S` to `Slice<E>`)
-// rather than into specs. Recognized bounds register their imports on conv.
+// `S ~[]E` and `M ~map[K]V` shapes go into substitutions (caller rewrites `S`
+// to `Slice<E>` or `M` to `Map<K, V>`) rather than into specs. Recognized
+// bounds register their imports on conv.
 func collectTypeParams(
 	typeParams *types.TypeParamList,
 	emitOpaque bool,
@@ -599,6 +600,14 @@ func collectTypeParams(
 				substitutions = make(map[string]string)
 			}
 			substitutions[name] = fmt.Sprintf("Slice<%s>", elemName)
+			continue
+		}
+
+		if keyName, valName, ok := recognizeMapShape(constraint); ok {
+			if substitutions == nil {
+				substitutions = make(map[string]string)
+			}
+			substitutions[name] = fmt.Sprintf("Map<%s, %s>", keyName, valName)
 			continue
 		}
 

--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -85,26 +85,35 @@ func recognizeBound(constraint types.Type, currentPkgPath string) (boundExpr str
 	return "", false, nil
 }
 
-// Detects `S ~[]E`: one embedded *types.Union with one tilde'd *types.Slice
-// term over a *types.TypeParam. Returns the inner E's name so callers can
-// rewrite `S` to `Slice<E>`.
-func recognizeSliceShape(constraint types.Type) (sliceElemTypeParamName string, ok bool) {
+// Unwraps `interface { ~T }` to its inner T, the shared shape of every
+// type-set-as-shape recognizer below.
+func singleTildeTerm(constraint types.Type) (types.Type, bool) {
 	iface, isIface := constraint.Underlying().(*types.Interface)
 	if !isIface {
-		return "", false
+		return nil, false
 	}
 	if iface.NumEmbeddeds() != 1 {
-		return "", false
+		return nil, false
 	}
 	union, isUnion := iface.EmbeddedType(0).(*types.Union)
 	if !isUnion || union.Len() != 1 {
-		return "", false
+		return nil, false
 	}
 	term := union.Term(0)
 	if !term.Tilde() {
+		return nil, false
+	}
+	return term.Type(), true
+}
+
+// Detects `S ~[]E` over a *types.TypeParam. Returns the inner E's name so
+// callers can rewrite `S` to `Slice<E>`.
+func recognizeSliceShape(constraint types.Type) (sliceElemTypeParamName string, ok bool) {
+	inner, ok := singleTildeTerm(constraint)
+	if !ok {
 		return "", false
 	}
-	slice, isSlice := term.Type().(*types.Slice)
+	slice, isSlice := inner.(*types.Slice)
 	if !isSlice {
 		return "", false
 	}
@@ -113,4 +122,23 @@ func recognizeSliceShape(constraint types.Type) (sliceElemTypeParamName string, 
 		return "", false
 	}
 	return tp.Obj().Name(), true
+}
+
+// Detects `M ~map[K]V` over *types.TypeParam key and value. Returns the inner
+// K's and V's names so callers can rewrite `M` to `Map<K, V>`.
+func recognizeMapShape(constraint types.Type) (keyName, valName string, ok bool) {
+	inner, ok := singleTildeTerm(constraint)
+	if !ok {
+		return "", "", false
+	}
+	m, isMap := inner.(*types.Map)
+	if !isMap {
+		return "", "", false
+	}
+	k, kIsTp := m.Key().(*types.TypeParam)
+	v, vIsTp := m.Elem().(*types.TypeParam)
+	if !kIsTp || !vIsTp {
+		return "", "", false
+	}
+	return k.Obj().Name(), v.Obj().Name(), true
 }

--- a/bindgen/tests/testdata/fixtures/generics/generics.go
+++ b/bindgen/tests/testdata/fixtures/generics/generics.go
@@ -102,3 +102,22 @@ func MinOrdered[T cmp.Ordered](a, b T) T {
 func SortInts[S ~[]E, E cmp.Ordered](x S) S {
 	return x
 }
+
+// Map-shape rewrite: single map, V any.
+func MapClone[M ~map[K]V, K comparable, V any](m M) M {
+	return m
+}
+
+// Map-shape rewrite: two maps, shared V (V any).
+func MapCopy[M1, M2 ~map[K]V, K comparable, V any](dst M1, src M2) {
+}
+
+// Map-shape rewrite: two maps, shared V (V comparable).
+func MapEqual[M1, M2 ~map[K]V, K, V comparable](m1 M1, m2 M2) bool {
+	return false
+}
+
+// Map-shape rewrite: two maps, distinct V.
+func MapEqualFunc[M1 ~map[K]V1, M2 ~map[K]V2, K comparable, V1, V2 any](m1 M1, m2 M2, eq func(V1, V2) bool) bool {
+	return false
+}

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -13,6 +13,18 @@ pub fn Clone<T>(v: T) -> T
 
 pub fn Identity<T>(x: T) -> T
 
+/// Map-shape rewrite: single map, V any.
+pub fn MapClone<K: Comparable, V>(m: Map<K, V>) -> Map<K, V>
+
+/// Map-shape rewrite: two maps, shared V (V any).
+pub fn MapCopy<K: Comparable, V>(mut dst: Map<K, V>, src: Map<K, V>)
+
+/// Map-shape rewrite: two maps, shared V (V comparable).
+pub fn MapEqual<K: Comparable, V: Comparable>(m1: Map<K, V>, m2: Map<K, V>) -> bool
+
+/// Map-shape rewrite: two maps, distinct V.
+pub fn MapEqualFunc<K: Comparable, V1, V2>(m1: Map<K, V1>, m2: Map<K, V2>, eq: fn(V1, V2) -> bool) -> bool
+
 /// Comparable constraint
 pub fn Max<T: Comparable>(a: T, b: T) -> T
 

--- a/crates/stdlib/typedefs/maps.d.lis
+++ b/crates/stdlib/typedefs/maps.d.lis
@@ -5,33 +5,50 @@
 
 import "go:iter"
 
-// SKIPPED: All - constraint:union
-// type constraint Map cannot be represented
+/// All returns an iterator over key-value pairs from m.
+/// The iteration order is not specified and is not guaranteed
+/// to be the same from one call to the next.
+pub fn All<K: Comparable, V>(m: Map<K, V>) -> iter.Seq2<K, V>
 
-// SKIPPED: Clone - constraint:union
-// type constraint M cannot be represented
+/// Clone returns a copy of m.  This is a shallow clone:
+/// the new keys and values are set using ordinary assignment.
+pub fn Clone<K: Comparable, V>(m: Map<K, V>) -> Map<K, V>
 
 /// Collect collects key-value pairs from seq into a new map
 /// and returns it.
 pub fn Collect<K: Comparable, V>(seq: iter.Seq2<K, V>) -> Map<K, V>
 
-// SKIPPED: Copy - constraint:union
-// type constraint M1 cannot be represented
+/// Copy copies all key/value pairs in src adding them to dst.
+/// When a key in src is already present in dst,
+/// the value in dst will be overwritten by the value associated
+/// with the key in src.
+pub fn Copy<K: Comparable, V>(mut dst: Map<K, V>, src: Map<K, V>)
 
-// SKIPPED: DeleteFunc - constraint:union
-// type constraint M cannot be represented
+/// DeleteFunc deletes any key/value pairs from m for which del returns true.
+pub fn DeleteFunc<K: Comparable, V>(mut m: Map<K, V>, del: fn(K, V) -> bool)
 
-// SKIPPED: Equal - constraint:union
-// type constraint M1 cannot be represented
+/// Equal reports whether two maps contain the same key/value pairs.
+/// Values are compared using ==.
+pub fn Equal<K: Comparable, V: Comparable>(m1: Map<K, V>, m2: Map<K, V>) -> bool
 
-// SKIPPED: EqualFunc - constraint:union
-// type constraint M1 cannot be represented
+/// EqualFunc is like Equal, but compares values using eq.
+/// Keys are still compared with ==.
+pub fn EqualFunc<K: Comparable, V1, V2>(
+  m1: Map<K, V1>,
+  m2: Map<K, V2>,
+  eq: fn(V1, V2) -> bool,
+) -> bool
 
-// SKIPPED: Insert - constraint:union
-// type constraint Map cannot be represented
+/// Insert adds the key-value pairs from seq to m.
+/// If a key in seq already exists in m, its value will be overwritten.
+pub fn Insert<K: Comparable, V>(mut m: Map<K, V>, seq: iter.Seq2<K, V>)
 
-// SKIPPED: Keys - constraint:union
-// type constraint Map cannot be represented
+/// Keys returns an iterator over keys in m.
+/// The iteration order is not specified and is not guaranteed
+/// to be the same from one call to the next.
+pub fn Keys<K: Comparable, V>(m: Map<K, V>) -> iter.Seq<K>
 
-// SKIPPED: Values - constraint:union
-// type constraint Map cannot be represented
+/// Values returns an iterator over values in m.
+/// The iteration order is not specified and is not guaranteed
+/// to be the same from one call to the next.
+pub fn Values<K: Comparable, V>(m: Map<K, V>) -> iter.Seq<V>


### PR DESCRIPTION
Go's stdlib `maps` package writes its functions with a generic constraint `M ~map[K]V`. Bindgen now recognizes this shape and translates it to `Map<K, V>` in Lisette, so `All`, `Clone`, `Copy`, `DeleteFunc`, `Equal`, `EqualFunc`, `Insert`, `Keys`, `Values` are now usable.

Follow-up to #197