### PR TITLE
fix: avoid cloning lhs on compound assign with invalid target

### DIFF
--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -983,6 +983,9 @@ impl<'source> Parser<'source> {
                     "invalid assignment target",
                     "Only variables, fields, and indices can be assigned to.",
                 );
+                self.next();
+                let _rhs = self.parse_expression();
+                return lhs;
             }
             self.next();
             let rhs = self.parse_expression();

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -2921,6 +2921,42 @@ fn test() {
 }
 
 #[test]
+fn compound_assignment_on_block_no_exponential_blowup() {
+    use std::fmt::Write;
+    use syntax::lex::Lexer;
+    use syntax::parse::Parser;
+
+    let levels = 20;
+    let mut input = String::from("fn test() {\n");
+    for _ in 0..levels {
+        input.push('{');
+    }
+    input.push('a');
+    for _ in 0..levels {
+        input.push_str(" } -= 0");
+    }
+    input.push_str("\n}\n");
+
+    let lex = Lexer::new(&input, 0).lex();
+    let parse_result = Parser::new(lex.tokens, &input).parse();
+
+    struct Counter(usize);
+    impl Write for Counter {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            self.0 += s.len();
+            if self.0 >= 100_000 {
+                Err(std::fmt::Error)
+            } else {
+                Ok(())
+            }
+        }
+    }
+    let mut counter = Counter(0);
+    let result = write!(counter, "{:?}", parse_result.ast);
+    assert!(result.is_ok(), "AST debug output exceeded 100 KiB");
+}
+
+#[test]
 fn range_exclusive() {
     let input = r#"
 fn test() { let r = 0..10; }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6513,3 +6513,13 @@ fn main() {
 "#;
     assert_parse_error_snapshot!(input);
 }
+
+#[test]
+fn parse_compound_assignment_invalid_target() {
+    let input = r#"
+fn main() {
+  { 1 } -= 2;
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/parse_compound_assignment_invalid_target.snap
+++ b/tests/ui/errors/snapshots/parse_compound_assignment_invalid_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:9]
+ 2 │ fn main() {
+ 3 │   { 1 } -= 2;
+   ·         ─┬
+   ·          ╰── invalid assignment target
+ 4 │ }
+   ╰────
+  help: Only variables, fields, and indices can be assigned to · code: [parse.syntax_error]


### PR DESCRIPTION
Fix #207