### PR TITLE
chore: release v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Lisette is under active development. Any version before 1.0.0 may include breaki
 - feat: zero-fill spread [#210](https://github.com/ivov/lisette/pull/210) [`9681887`](https://github.com/ivov/lisette/commit/9681887c997b4c3d6e63e4107d883294edf3e679)
 - fix: avoid cloning lhs on compound assign with invalid target [#209](https://github.com/ivov/lisette/pull/209) [`e481af2`](https://github.com/ivov/lisette/commit/e481af2e5562e96cbb788b696aec5b600407eb30)
 - feat: multi-line string literals [#208](https://github.com/ivov/lisette/pull/208) [`05127d9`](https://github.com/ivov/lisette/commit/05127d9af9a29c60eadde2b9856ec3cce6bd1179)
+- ci: pin workflow actions to immutable SHAs [#220](https://github.com/ivov/lisette/pull/220) [`30c05ea`](https://github.com/ivov/lisette/commit/30c05ead8613c3435c79da9bc27023adc8b17650)
+- fix: alias single-segment paths colliding with longer external paths [#217](https://github.com/ivov/lisette/pull/217) [`efd89d3`](https://github.com/ivov/lisette/commit/efd89d330115c0a3dbab95b8c30562d74f7973b9)
+- fix: alias bindgen imports that collide on package name [#212](https://github.com/ivov/lisette/pull/212) [`fbf4f74`](https://github.com/ivov/lisette/commit/fbf4f746c9b0e45f78bd362f8674b69b01a1ce8b)
+- feat: support sql.Scanner and driver.Valuer on option [#206](https://github.com/ivov/lisette/pull/206) [`6091db8`](https://github.com/ivov/lisette/commit/6091db8e03b00bb0d765f52586a483c9da29a8de)
 
 ## [0.1.21](https://github.com/ivov/lisette/compare/lisette-v0.1.20...lisette-v0.1.21) - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.1.22](https://github.com/ivov/lisette/compare/lisette-v0.1.21...lisette-v0.1.22) - 2026-04-28
+
+- fix: bind variadic interface methods to VarArgs [#211](https://github.com/ivov/lisette/pull/211) [`500865b`](https://github.com/ivov/lisette/commit/500865be30ad6b3c33a16c66bcd3b965c7a30375)
+- feat: silence unused_value on fluent-builder method returns [#218](https://github.com/ivov/lisette/pull/218) [`1266fde`](https://github.com/ivov/lisette/commit/1266fdebdfc8dc3fff6cbd0ae4de570c167852d7)
+- feat: lift interface{} params to Ref<T> for reflection decoders [#219](https://github.com/ivov/lisette/pull/219) [`6f7b04a`](https://github.com/ivov/lisette/commit/6f7b04a4b6e0f00145c011dbe05609f5893fd67f)
+- feat: suggest go prefix for unprefixed declared go deps [#215](https://github.com/ivov/lisette/pull/215) [`490709e`](https://github.com/ivov/lisette/commit/490709ef90048cc525c014bea04e20a4048bd744)
+- feat: do not require trailing () in unit-context lambdas [#216](https://github.com/ivov/lisette/pull/216) [`49e44be`](https://github.com/ivov/lisette/commit/49e44be0bfc47578dd63a803694bb4a5dfa30fbb)
+- feat: zero-fill spread [#210](https://github.com/ivov/lisette/pull/210) [`9681887`](https://github.com/ivov/lisette/commit/9681887c997b4c3d6e63e4107d883294edf3e679)
+- fix: avoid cloning lhs on compound assign with invalid target [#209](https://github.com/ivov/lisette/pull/209) [`e481af2`](https://github.com/ivov/lisette/commit/e481af2e5562e96cbb788b696aec5b600407eb30)
+- feat: multi-line string literals [#208](https://github.com/ivov/lisette/pull/208) [`05127d9`](https://github.com/ivov/lisette/commit/05127d9af9a29c60eadde2b9856ec3cce6bd1179)
+
 ## [0.1.21](https://github.com/ivov/lisette/compare/lisette-v0.1.20...lisette-v0.1.21) - 2026-04-26
 
 - feat: recognize M ~map[K]V as type-parameter shape [#198](https://github.com/ivov/lisette/pull/198) [`b22621e`](https://github.com/ivov/lisette/commit/b22621e2e44b9d7b661e624f2c9337a3d387016e)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "ecow",
  "lisette-syntax",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "bincode",
  "ecow",
@@ -579,11 +579,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.1.21"
+version = "0.1.22"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,14 +18,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.1.21", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.21", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.1.21", path = "../format" }
-emit = { package = "lisette-emit", version = "0.1.21", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.1.21", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.21", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.1.21", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.1.22", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.22", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.1.22", path = "../format" }
+emit = { package = "lisette-emit", version = "0.1.22", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.1.22", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.22", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.1.22", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.1.21", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.1.22", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,6 +13,6 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.1.21", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.21", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.1.21", path = "../deps" }
-format = { package = "lisette-format", version = "0.1.21", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.1.22", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.22", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.1.22", path = "../deps" }
+format = { package = "lisette-format", version = "0.1.22", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.21", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.21", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.1.21", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.21", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.22", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.1.22", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.1.22", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.1.22 (upcoming)

- fix: bind variadic interface methods to VarArgs [#211](https://github.com/ivov/lisette/pull/211) [`500865b`](https://github.com/ivov/lisette/commit/500865be30ad6b3c33a16c66bcd3b965c7a30375)
- feat: silence unused_value on fluent-builder method returns [#218](https://github.com/ivov/lisette/pull/218) [`1266fde`](https://github.com/ivov/lisette/commit/1266fdebdfc8dc3fff6cbd0ae4de570c167852d7)
- feat: lift interface{} params to Ref<T> for reflection decoders [#219](https://github.com/ivov/lisette/pull/219) [`6f7b04a`](https://github.com/ivov/lisette/commit/6f7b04a4b6e0f00145c011dbe05609f5893fd67f)
- feat: suggest go prefix for unprefixed declared go deps [#215](https://github.com/ivov/lisette/pull/215) [`490709e`](https://github.com/ivov/lisette/commit/490709ef90048cc525c014bea04e20a4048bd744)
- feat: do not require trailing () in unit-context lambdas [#216](https://github.com/ivov/lisette/pull/216) [`49e44be`](https://github.com/ivov/lisette/commit/49e44be0bfc47578dd63a803694bb4a5dfa30fbb)
- feat: zero-fill spread [#210](https://github.com/ivov/lisette/pull/210) [`9681887`](https://github.com/ivov/lisette/commit/9681887c997b4c3d6e63e4107d883294edf3e679)
- fix: avoid cloning lhs on compound assign with invalid target [#209](https://github.com/ivov/lisette/pull/209) [`e481af2`](https://github.com/ivov/lisette/commit/e481af2e5562e96cbb788b696aec5b600407eb30)
- feat: multi-line string literals [#208](https://github.com/ivov/lisette/pull/208) [`05127d9`](https://github.com/ivov/lisette/commit/05127d9af9a29c60eadde2b9856ec3cce6bd1179)
- ci: pin workflow actions to immutable SHAs [#220](https://github.com/ivov/lisette/pull/220) [`30c05ea`](https://github.com/ivov/lisette/commit/30c05ead8613c3435c79da9bc27023adc8b17650)
- fix: alias single-segment paths colliding with longer external paths [#217](https://github.com/ivov/lisette/pull/217) [`efd89d3`](https://github.com/ivov/lisette/commit/efd89d330115c0a3dbab95b8c30562d74f7973b9)
- fix: alias bindgen imports that collide on package name [#212](https://github.com/ivov/lisette/pull/212) [`fbf4f74`](https://github.com/ivov/lisette/commit/fbf4f746c9b0e45f78bd362f8674b69b01a1ce8b)
- feat: support sql.Scanner and driver.Valuer on option [#206](https://github.com/ivov/lisette/pull/206) [`6091db8`](https://github.com/ivov/lisette/commit/6091db8e03b00bb0d765f52586a483c9da29a8de)