### PR TITLE
feat: recognize named-interface bounds in bindgen generics

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -795,16 +795,7 @@ func collectTypeParams(
 			continue
 		}
 
-		var currentPkg string
-		if conv != nil {
-			currentPkg = conv.currentPkgPath
-		}
-		if boundExpr, ok, imports := recognizeBound(constraint, currentPkg); ok {
-			for _, path := range imports {
-				if conv != nil {
-					conv.trackExternalPkg(path, path)
-				}
-			}
+		if boundExpr, ok := recognizeBound(constraint, conv); ok {
 			specs = append(specs, TypeParamSpec{Name: name, Bound: boundExpr})
 			continue
 		}
@@ -854,12 +845,12 @@ func describeConstraint(constraint *types.Interface) string {
 		return "any"
 	}
 
-	if constraint.IsComparable() {
-		return "comparable"
-	}
-
 	if constraint.NumMethods() > 0 {
 		return "interface-method"
+	}
+
+	if constraint.IsComparable() {
+		return "comparable"
 	}
 
 	if constraint.NumEmbeddeds() > 0 {

--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -58,31 +58,53 @@ func (ps TypeParamSpecs) UseBlock() string {
 
 // Named-type identity is checked before .Underlying(), which discards the
 // wrapper — afterwards cmp.Ordered's structural shape would short-circuit
-// as plain `comparable`. When the constraint lives in currentPkgPath, the
-// bound is rendered unqualified to avoid a self-import.
-func recognizeBound(constraint types.Type, currentPkgPath string) (boundExpr string, ok bool, requiresImports []string) {
+// as plain `comparable`.
+func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, ok bool) {
 	if named, isNamed := constraint.(*types.Named); isNamed {
 		obj := named.Obj()
 		if obj.Pkg() != nil && obj.Pkg().Path() == "cmp" && obj.Name() == "Ordered" {
-			if currentPkgPath == "cmp" {
-				return "Ordered", true, nil
-			}
-			return "cmp.Ordered", true, []string{"cmp"}
+			return qualifyNamedBound(named, conv)
 		}
 	}
 
 	iface, isIface := constraint.Underlying().(*types.Interface)
 	if !isIface {
-		return "", false, nil
+		return "", false
 	}
 
 	// Type-set unions (e.g. `~int | ~string`) also report IsComparable, so
 	// the no-embeddeds check is essential to isolate the bare `comparable`.
 	if iface.IsComparable() && iface.NumEmbeddeds() == 0 && iface.NumMethods() == 0 {
-		return "Comparable", true, nil
+		return "Comparable", true
 	}
 
-	return "", false, nil
+	// Single named method-only interface (e.g. `T fmt.Stringer`). Excludes
+	// inline interface literals (which are *types.Interface, not *types.Named)
+	// and type-set unions (which embed a *types.Union — NumEmbeddeds > 0).
+	if named, isNamed := constraint.(*types.Named); isNamed &&
+		iface.NumMethods() > 0 && iface.NumEmbeddeds() == 0 {
+		return qualifyNamedBound(named, conv)
+	}
+
+	return "", false
+}
+
+// Renders a Named bound, qualifying with the package alias when external and
+// tracking the external package on conv. Bounds in the current package render
+// unqualified to avoid a self-import.
+func qualifyNamedBound(named *types.Named, conv *Converter) (string, bool) {
+	obj := named.Obj()
+	pkg := obj.Pkg()
+	if pkg == nil || isInternalPackagePath(pkg.Path()) {
+		return "", false
+	}
+	if conv != nil && pkg.Path() == conv.currentPkgPath {
+		return obj.Name(), true
+	}
+	if conv != nil {
+		conv.trackExternalPkg(pkg.Path(), pkg.Name())
+	}
+	return PkgRef(pkg.Path()) + "." + obj.Name(), true
 }
 
 // Unwraps `interface { ~T }` to its inner T, the shared shape of every

--- a/bindgen/tests/testdata/fixtures/generics/generics.go
+++ b/bindgen/tests/testdata/fixtures/generics/generics.go
@@ -1,6 +1,28 @@
 package generics
 
-import "cmp"
+import (
+	"cmp"
+	"fmt"
+)
+
+// Local method-only interface for cross-package and self-package bound tests.
+type Greeter interface {
+	Greet() string
+}
+
+// Bound by an external method-only interface (fmt.Stringer).
+func Shout[T fmt.Stringer](x T) string {
+	return "!" + x.String() + "!"
+}
+
+// Bound by a method-only interface declared in this package.
+func GreetAll[T Greeter](xs []T) string {
+	out := ""
+	for _, x := range xs {
+		out += x.Greet()
+	}
+	return out
+}
 
 // Basic generic types
 

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -4,12 +4,16 @@
 // Lisette: 0.0.0
 
 import "go:cmp"
+import "go:fmt"
 
 /// Empty constraint (any)
 pub fn Clone<T>(v: T) -> T
 
 // SKIPPED: Either - constraint:union
 // type constraint T cannot be represented
+
+/// Bound by a method-only interface declared in this package.
+pub fn GreetAll<T: Greeter>(xs: Slice<T>) -> string
 
 pub fn Identity<T>(x: T) -> T
 
@@ -34,6 +38,9 @@ pub fn Max<T: Comparable>(a: T, b: T) -> T
 /// cmp.Ordered constraint (named-identity recognizer)
 pub fn MinOrdered<T: cmp.Ordered>(a: T, b: T) -> T
 
+/// Bound by an external method-only interface (fmt.Stringer).
+pub fn Shout<T: fmt.Stringer>(x: T) -> string
+
 /// Slice-shape rewrite: S ~[]E with E: cmp.Ordered
 pub fn SortInts<E: cmp.Ordered>(x: Slice<E>) -> Slice<E>
 
@@ -51,6 +58,11 @@ pub struct ConstrainedPair<K: Comparable, V> {
 }
 
 pub type Container<T>
+
+/// Local method-only interface for cross-package and self-package bound tests.
+pub interface Greeter {
+  fn Greet() -> string
+}
 
 /// Ordered constraint (type union)
 pub type Ordered


### PR DESCRIPTION
Adds bindgen support for Go generic functions whose type-parameter is constrained to an interface. These were previously skipped.

 ```rs
pub fn Stringers<T: fmt.Stringer>(key: string, values: Slice<T>) -> zapcore.Field
```