### PR TITLE
fix: allow assignment to pub var through import alias

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -341,7 +341,7 @@ impl TaskState<'_> {
 
             let can_mutate = is_mutable || is_deref || binding_is_ref;
 
-            if !can_mutate {
+            if !can_mutate && !self.imports.imported_modules.contains_key(&var_name) {
                 let self_type_name = if var_name == "self" {
                     self.lookup_type(store, "self")
                         .and_then(|t| t.get_name().map(str::to_owned))

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4223,3 +4223,51 @@ fn main() {
     )
     .assert_infer_code("invalid_cast");
 }
+
+#[test]
+fn assign_to_imported_pub_var_succeeds() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "config",
+        "lib.d.lis",
+        r#"
+pub var Threshold: int
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "config"
+
+fn main() {
+  config.Threshold = 42
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn assign_to_aliased_imported_pub_var_succeeds() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "config",
+        "lib.d.lis",
+        r#"
+pub var Threshold: int
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import c "config"
+
+fn main() {
+  c.Threshold = 99
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5646,6 +5646,44 @@ fn main() {
 }
 
 #[test]
+fn infer_assign_to_imported_pub_var_wrong_type() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "config",
+        "lib.d.lis",
+        r#"
+pub var Threshold: int
+"#,
+    );
+    let source = r#"
+import "config"
+
+fn main() {
+  config.Threshold = "not an int"
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+
+    assert!(
+        result
+            .errors
+            .iter()
+            .all(|e| e.code_str() != Some("infer.immutable")),
+        "import-alias receivers must not trigger infer.immutable; got: {:?}",
+        result
+            .errors
+            .iter()
+            .map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "expected a type-mismatch error for wrong-typed RHS"
+    );
+}
+
+#[test]
 fn infer_mutate_const_shows_const_hint() {
     let input = r#"
 const N = 5


### PR DESCRIPTION
Assigning to a `pub var` declaration through an import alias now compiles. Previously the compiler rejected the assignment with `infer.immutable` and suggested `let mut <alias>`, which was inapplicable since the receiver is an import, not a local binding.