### PR TITLE
fix: pascalcase exported go names

### DIFF
--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -134,7 +134,7 @@ impl EnumLayout {
         enum_name: &str,
     ) -> String {
         if is_struct {
-            let base = go_name::capitalize_first(field_name);
+            let base = go_name::snake_to_camel(field_name);
             if base == ENUM_TAG_FIELD
                 || base == ENUM_STRINGER_METHOD
                 || base == ENUM_GO_STRINGER_METHOD

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -270,7 +270,7 @@ impl Emitter<'_> {
         }
 
         let function_name = if is_public {
-            go_name::capitalize_first(&function_definition.name)
+            go_name::snake_to_camel(&function_definition.name)
         } else if receiver.is_some() {
             go_name::escape_keyword(&function_definition.name).into_owned()
         } else {

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -67,7 +67,7 @@ impl Emitter<'_> {
         let code = if is_free_function {
             let mut free_function = function.clone();
             let method_name = if should_export {
-                go_name::capitalize_first(&function.name)
+                go_name::snake_to_camel(&function.name)
             } else {
                 function.name.to_string()
             };
@@ -75,7 +75,7 @@ impl Emitter<'_> {
             let mut combined_generics = ctx.generics.to_vec();
             combined_generics.extend(free_function.generics.iter().cloned());
             free_function.generics = combined_generics;
-            self.emit_function(&free_function, None, should_export)
+            self.emit_function(&free_function, None, false)
         } else {
             self.emit_function(
                 &function,

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -95,7 +95,7 @@ impl Emitter<'_> {
         };
 
         let method_name = if is_public || self.method_needs_export(&func.name) {
-            go_name::capitalize_first(&func.name)
+            go_name::snake_to_camel(&func.name)
         } else {
             go_name::escape_keyword(&func.name).into_owned()
         };

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -342,20 +342,10 @@ impl Emitter<'_> {
             if is_enum && parts.len() == 3 {
                 // Enum variant via type alias: "module.TypeAlias.Variant"
                 // Emit as "module.TypeAlias" (the variant fields are handled separately)
-                return format!(
-                    "{}.{}{}",
-                    pkg,
-                    go_name::capitalize_first(parts[1]),
-                    type_args
-                );
+                return format!("{}.{}{}", pkg, go_name::snake_to_camel(parts[1]), type_args);
             } else if !is_enum && parts.len() == 2 {
                 // Cross-module struct reference
-                return format!(
-                    "{}.{}{}",
-                    pkg,
-                    go_name::capitalize_first(parts[1]),
-                    type_args
-                );
+                return format!("{}.{}{}", pkg, go_name::snake_to_camel(parts[1]), type_args);
             }
         }
 

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -236,7 +236,7 @@ impl Emitter<'_> {
         let literal = format!(
             "{}.{}{}{{ Tag: {} }}",
             alias_pkg,
-            go_name::capitalize_first(type_alias_name),
+            go_name::snake_to_camel(type_alias_name),
             type_args,
             tag_value
         );
@@ -302,35 +302,25 @@ impl Emitter<'_> {
 
         let inner_ty = inner_expression.get_type();
 
-        let (module_name, id_for_prelude_check) =
-            if let Some(synthetic_module) = inner_ty.as_import_namespace() {
-                (synthetic_module.to_string(), synthetic_module.to_string())
-            } else if let Type::Nominal { id, .. } = &inner_ty {
-                let module_name =
-                    if let Expression::Identifier { value, .. } = inner_expression.as_ref() {
-                        value.to_string()
-                    } else {
-                        return None;
-                    };
-                (module_name, id.to_string())
-            } else {
-                return None;
-            };
+        let module_name = if let Some(synthetic_module) = inner_ty.as_import_namespace() {
+            synthetic_module.to_string()
+        } else if matches!(&inner_ty, Type::Nominal { .. })
+            && let Expression::Identifier { value, .. } = inner_expression.as_ref()
+        {
+            value.to_string()
+        } else {
+            return None;
+        };
         let module_name = module_name.as_str();
 
-        let is_prelude = id_for_prelude_check.starts_with(go_name::PRELUDE_PREFIX);
         let go_method = if is_exported {
-            if is_prelude {
-                go_name::snake_to_camel(member)
-            } else {
-                go_name::capitalize_first(member)
-            }
+            go_name::snake_to_camel(member)
         } else {
             go_name::escape_keyword(member).into_owned()
         };
 
         let pkg = self.go_pkg_qualifier(module_name);
-        let go_type_name = go_name::capitalize_first(type_name);
+        let go_type_name = go_name::snake_to_camel(type_name);
 
         // Extract type args from the receiver parameter
         let type_args = if let Type::Function { params, .. } = result_ty.unwrap_forall()

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -273,7 +273,7 @@ impl Emitter<'_> {
             .unwrap_or(false)
             || self.method_needs_export(method_part);
         let go_method = if should_export {
-            go_name::capitalize_first(method_part)
+            go_name::snake_to_camel(method_part)
         } else {
             go_name::escape_keyword(method_part).into_owned()
         };
@@ -385,6 +385,6 @@ impl Emitter<'_> {
             return None;
         }
 
-        Some(go_name::capitalize_first(name))
+        Some(go_name::snake_to_camel(name))
     }
 }

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -27,8 +27,11 @@ pub(crate) fn capitalize_first(s: &str) -> String {
     }
 }
 
+/// Convert a Lisette identifier to its exported Go form: snake_case becomes
+/// PascalCase (`user_id` → `UserId`), already-Pascal names pass through, and
+/// the result is escaped if it collides with a Go keyword.
 pub(crate) fn make_exported(name: &str) -> String {
-    escape_keyword(&capitalize_first(name)).into_owned()
+    escape_keyword(&snake_to_camel(name)).into_owned()
 }
 
 pub(crate) fn snake_to_camel(s: &str) -> String {
@@ -285,7 +288,7 @@ pub(crate) fn qualify_method(
 ) -> ResolvedName {
     let Some((module, type_name)) = type_id.split_once('.') else {
         let method_name = if is_public {
-            capitalize_first(method)
+            snake_to_camel(method)
         } else {
             method.to_string()
         };
@@ -301,18 +304,13 @@ pub(crate) fn qualify_method(
         ))
     } else if module == current_module {
         let method_name = if is_public {
-            capitalize_first(method)
+            snake_to_camel(method)
         } else {
             method.to_string()
         };
         ResolvedName::local(format!("{}_{}", type_name, method_name))
     } else {
         let pkg = module_alias.unwrap_or_else(|| go_package_name(module));
-        ResolvedName::local(format!(
-            "{}.{}_{}",
-            pkg,
-            type_name,
-            capitalize_first(method)
-        ))
+        ResolvedName::local(format!("{}.{}_{}", pkg, type_name, snake_to_camel(method)))
     }
 }

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -71,7 +71,7 @@ impl Emitter<'_> {
         };
 
         if is_public {
-            format!("{}.{}", type_part, go_name::capitalize_first(method_part))
+            format!("{}.{}", type_part, go_name::snake_to_camel(method_part))
         } else {
             name.to_string()
         }

--- a/crates/semantics/src/validators/ast_lints/casing.rs
+++ b/crates/semantics/src/validators/ast_lints/casing.rs
@@ -15,17 +15,33 @@ pub fn to_pascal_case(s: &str) -> String {
 }
 
 pub fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let chars: Vec<char> = s.chars().collect();
+    let mut result = String::with_capacity(s.len() + 4);
+
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' {
+            result.push('_');
+            continue;
+        }
+
         if c.is_uppercase() {
-            if i > 0 {
+            let prev_upper = i > 0 && chars[i - 1].is_uppercase();
+            let next_lower = i + 1 < chars.len() && chars[i + 1].is_lowercase();
+
+            if (i > 0 && !prev_upper) || (i > 1 && prev_upper && next_lower) {
                 result.push('_');
             }
+
             result.push(c.to_ascii_lowercase());
         } else {
             result.push(c);
         }
     }
+
     result
 }
 
@@ -57,4 +73,29 @@ pub fn is_screaming_snake_case(s: &str) -> bool {
     let s = s.strip_prefix('_').unwrap_or(s);
     s.chars()
         .all(|c| c.is_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_snake_case_handles_acronyms() {
+        assert_eq!(to_snake_case("ID"), "id");
+        assert_eq!(to_snake_case("URL"), "url");
+        assert_eq!(to_snake_case("HTTP"), "http");
+
+        assert_eq!(to_snake_case("HTMLParser"), "html_parser");
+        assert_eq!(to_snake_case("XMLHttpRequest"), "xml_http_request");
+
+        assert_eq!(to_snake_case("UserID"), "user_id");
+        assert_eq!(to_snake_case("APIKey"), "api_key");
+
+        assert_eq!(to_snake_case("oddsAndEnds"), "odds_and_ends");
+        assert_eq!(to_snake_case("FooBar"), "foo_bar");
+
+        assert_eq!(to_snake_case("user_id"), "user_id");
+        assert_eq!(to_snake_case("hello"), "hello");
+        assert_eq!(to_snake_case(""), "");
+    }
 }

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	raw := store.Get_value("count")
+	raw := store.GetValue("count")
 	subject_1 := lisette.AssertType[int](raw)
 	if subject_1.Tag == lisette.OptionSome {
 		n := subject_1.SomeVal

--- a/tests/spec/build/snapshots/cross_module_generic_return_only_string_vs_int.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_return_only_string_vs_int.snap
@@ -39,27 +39,27 @@ func (v Validated[T]) String() string {
 }
 
 type ValidationResult[T any] struct {
-	Value      Validated[T]
-	Field_name string
+	Value     Validated[T]
+	FieldName string
 }
 
 func (v ValidationResult[T]) String() string {
-	return fmt.Sprintf("ValidationResult { value: %v, field_name: %v }", v.Value, v.Field_name)
+	return fmt.Sprintf("ValidationResult { value: %v, field_name: %v }", v.Value, v.FieldName)
 }
 
-func ValidationResult_New_invalid[T any](field, msg string) ValidationResult[T] {
+func ValidationResult_NewInvalid[T any](field, msg string) ValidationResult[T] {
 	return ValidationResult[T]{
-		Value:      MakeValidatedInvalid[T](msg),
-		Field_name: field,
+		Value:     MakeValidatedInvalid[T](msg),
+		FieldName: field,
 	}
 }
 
-func Validate_positive(field string, _ int) ValidationResult[int] {
-	return ValidationResult_New_invalid[int](field, "must be positive")
+func ValidatePositive(field string, _ int) ValidationResult[int] {
+	return ValidationResult_NewInvalid[int](field, "must be positive")
 }
 
-func Validate_non_empty(field, _ string) ValidationResult[string] {
-	return ValidationResult_New_invalid[string](field, "must not be empty")
+func ValidateNonEmpty(field, _ string) ValidationResult[string] {
+	return ValidationResult_NewInvalid[string](field, "must not be empty")
 }
 
 
@@ -72,8 +72,8 @@ import (
 )
 
 func main() {
-	r1 := lib.Validate_positive("age", -1)
-	r2 := lib.Validate_non_empty("name", "")
-	fmt.Println(r1.Field_name)
-	fmt.Println(r2.Field_name)
+	r1 := lib.ValidatePositive("age", -1)
+	r2 := lib.ValidateNonEmpty("name", "")
+	fmt.Println(r1.FieldName)
+	fmt.Println(r2.FieldName)
 }

--- a/tests/spec/build/snapshots/cross_module_interface_impl_in_main.snap
+++ b/tests/spec/build/snapshots/cross_module_interface_impl_in_main.snap
@@ -8,7 +8,7 @@ type Printable interface {
 	Display() string
 }
 
-func Print_all[T Printable](items []T) string {
+func PrintAll[T Printable](items []T) string {
 	return items[0].Display()
 }
 
@@ -35,5 +35,5 @@ func (n Name) Display() string {
 
 func main() {
 	names := []Name{Name{value: "alice"}}
-	fmt.Println(lib.Print_all(names))
+	fmt.Println(lib.PrintAll(names))
 }

--- a/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
+++ b/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
@@ -13,7 +13,7 @@ func Process(item models.Item) string {
 	return fmt.Sprintf("%v: %v", item.Name, item.Value)
 }
 
-func Create_item(name string, value int) models.Item {
+func CreateItem(name string, value int) models.Item {
 	return models.Item{
 		Name:  name,
 		Value: value,
@@ -36,7 +36,7 @@ func main() {
 		Value: 42,
 	}
 	fmt.Println(logic.Process(item))
-	created := logic.Create_item("created", 100)
+	created := logic.CreateItem("created", 100)
 	fmt.Printf("%v: %v\n", created.Name, created.Value)
 }
 

--- a/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
+++ b/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
@@ -7,7 +7,7 @@ package main
 import "fmt"
 
 type Mapper[T any] interface {
-	Map_val() T
+	MapVal() T
 }
 
 type Filter interface {
@@ -28,7 +28,7 @@ func (s Score) String() string {
 	return fmt.Sprintf("Score { name: %v, val: %v }", s.name, s.val)
 }
 
-func (s Score) Map_val() string {
+func (s Score) MapVal() string {
 	return s.name
 }
 
@@ -38,7 +38,7 @@ func (s Score) Keep() bool {
 
 func process_score(item Score) string {
 	if item.Keep() {
-		return item.Map_val()
+		return item.MapVal()
 	}
 	return "filtered"
 }

--- a/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
+++ b/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
@@ -7,7 +7,7 @@ package main
 import "fmt"
 
 type Printable interface {
-	To_string() string
+	ToString() string
 }
 
 type Box[T any] struct {
@@ -19,7 +19,7 @@ func (b Box[T]) String() string {
 }
 
 func Box_print[T Printable](self Box[T]) {
-	fmt.Println(self.value.To_string())
+	fmt.Println(self.value.ToString())
 }
 
 func (b Box[T]) get() T {
@@ -34,7 +34,7 @@ func (n Name) String() string {
 	return fmt.Sprintf("Name { name: %v }", n.name)
 }
 
-func (n Name) To_string() string {
+func (n Name) ToString() string {
 	return n.name
 }
 

--- a/tests/spec/build/snapshots/multi_file_module_bootstrap_imports.snap
+++ b/tests/spec/build/snapshots/multi_file_module_bootstrap_imports.snap
@@ -128,6 +128,6 @@ package types
 
 import "github.com/user/myproject/foo"
 
-func Make_something() foo.Foo {
+func MakeSomething() foo.Foo {
 	return foo.Foo_New(99)
 }

--- a/tests/spec/build/snapshots/multimodule_if_let_in_dependency.snap
+++ b/tests/spec/build/snapshots/multimodule_if_let_in_dependency.snap
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	_ = utils.Unwrap_or_default(lisette.MakeOptionSome(42))
+	_ = utils.UnwrapOrDefault(lisette.MakeOptionSome(42))
 }
 
 
@@ -19,7 +19,7 @@ package utils
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func Unwrap_or_default(opt lisette.Option[int]) int {
+func UnwrapOrDefault(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
 		return opt.SomeVal
 	}

--- a/tests/spec/build/snapshots/multimodule_import_between_local_modules.snap
+++ b/tests/spec/build/snapshots/multimodule_import_between_local_modules.snap
@@ -15,7 +15,7 @@ func main() {
 		X: 0,
 		Y: 0,
 	}
-	_ = p1.Manhattan_distance(p2)
+	_ = p1.ManhattanDistance(p2)
 }
 
 
@@ -47,6 +47,6 @@ func (p Point) String() string {
 	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
-func (p Point) Manhattan_distance(other Point) int {
+func (p Point) ManhattanDistance(other Point) int {
 	return mymath.Abs(p.X-other.X) + mymath.Abs(p.Y-other.Y)
 }

--- a/tests/spec/build/snapshots/multimodule_intra_module_function_call.snap
+++ b/tests/spec/build/snapshots/multimodule_intra_module_function_call.snap
@@ -7,7 +7,7 @@ package main
 import "github.com/user/myproject/math_utils"
 
 func main() {
-	_ = math_utils.Double_square(3.0)
+	_ = math_utils.DoubleSquare(3.0)
 }
 
 
@@ -18,6 +18,6 @@ func Square(x float64) float64 {
 	return x * x
 }
 
-func Double_square(x float64) float64 {
+func DoubleSquare(x float64) float64 {
 	return Square(x) * 2.0
 }

--- a/tests/spec/build/snapshots/multimodule_static_method_call.snap
+++ b/tests/spec/build/snapshots/multimodule_static_method_call.snap
@@ -8,7 +8,7 @@ import "github.com/user/myproject/shapes"
 
 func main() {
 	p := shapes.Point_New(3, 4)
-	_ = p.Squared_distance()
+	_ = p.SquaredDistance()
 }
 
 
@@ -33,6 +33,6 @@ func Point_New(x, y int) Point {
 	}
 }
 
-func (p Point) Squared_distance() int {
+func (p Point) SquaredDistance() int {
 	return p.X*p.X + p.Y*p.Y
 }

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
@@ -7,11 +7,11 @@ package main
 import "fmt"
 
 type Printable interface {
-	Print_val() string
+	PrintVal() string
 }
 
 type Summable interface {
-	Sum_val() int
+	SumVal() int
 }
 
 type Container[T any] struct {
@@ -24,11 +24,11 @@ func (c Container[T]) String() string {
 }
 
 func Container_display[T Printable](self Container[T]) string {
-	return fmt.Sprintf("[%v] %v", self.label, self.value.Print_val())
+	return fmt.Sprintf("[%v] %v", self.label, self.value.PrintVal())
 }
 
 func Container_total[T Summable](self Container[T]) int {
-	return self.value.Sum_val()
+	return self.value.SumVal()
 }
 
 type Item struct {
@@ -40,11 +40,11 @@ func (i Item) String() string {
 	return fmt.Sprintf("Item { name: %v, count: %v }", i.name, i.count)
 }
 
-func (i Item) Print_val() string {
+func (i Item) PrintVal() string {
 	return i.name
 }
 
-func (i Item) Sum_val() int {
+func (i Item) SumVal() int {
 	return i.count
 }
 

--- a/tests/spec/build/snapshots/multiple_json_attributes_merge.snap
+++ b/tests/spec/build/snapshots/multiple_json_attributes_merge.snap
@@ -10,18 +10,18 @@ import (
 )
 
 type User struct {
-	First_name  string `json:"firstName,omitempty"`
-	Middle_name string `json:"middleName,omitempty"`
+	FirstName  string `json:"firstName,omitempty"`
+	MiddleName string `json:"middleName,omitempty"`
 }
 
 func (u User) String() string {
-	return fmt.Sprintf("User { first_name: %v, middle_name: %v }", u.First_name, u.Middle_name)
+	return fmt.Sprintf("User { first_name: %v, middle_name: %v }", u.FirstName, u.MiddleName)
 }
 
 func main() {
 	u := User{
-		First_name:  "Alice",
-		Middle_name: "",
+		FirstName:  "Alice",
+		MiddleName: "",
 	}
 	json.Marshal(u)
 }

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -33,7 +33,7 @@ func main() {
 		Value: inner_pair,
 		Label: "coords",
 	}
-	fmt.Println(ops.Describe_tagged_pair(tagged_pair))
+	fmt.Println(ops.DescribeTaggedPair(tagged_pair))
 }
 
 
@@ -46,7 +46,7 @@ import (
 	"github.com/user/myproject/types"
 )
 
-func Describe_tagged_pair[A traits.Showable, B traits.Showable](tp types.Tagged[types.Pair[A, B]]) string {
+func DescribeTaggedPair[A traits.Showable, B traits.Showable](tp types.Tagged[types.Pair[A, B]]) string {
 	return fmt.Sprintf("tagged_pair: %v", tp.Display())
 }
 

--- a/tests/spec/build/snapshots/nested_submodule_type_reference.snap
+++ b/tests/spec/build/snapshots/nested_submodule_type_reference.snap
@@ -17,7 +17,7 @@ func (c Container) String() string {
 	return fmt.Sprintf("Container { items: %v }", c.Items)
 }
 
-func First_item(c Container) sub.Item {
+func FirstItem(c Container) sub.Item {
 	return c.Items[0]
 }
 
@@ -52,5 +52,5 @@ func main() {
 		Score: 42,
 	}
 	c := lib.Container{Items: []sub.Item{item}}
-	fmt.Println(lib.First_item(c).Name)
+	fmt.Println(lib.FirstItem(c).Name)
 }

--- a/tests/spec/build/snapshots/same_module_cross_file_method_casing.snap
+++ b/tests/spec/build/snapshots/same_module_cross_file_method_casing.snap
@@ -7,7 +7,7 @@ package main
 import "github.com/user/myproject/shapes"
 
 func main() {
-	_ = shapes.Test_local_static()
+	_ = shapes.TestLocalStatic()
 }
 
 
@@ -48,7 +48,7 @@ func Builder_New() Builder {
 	}
 }
 
-func (b Builder) With_x(x float64) Builder {
+func (b Builder) WithX(x float64) Builder {
 	return Builder{
 		X: x,
 		Y: b.Y,
@@ -59,8 +59,8 @@ func (b Builder) With_x(x float64) Builder {
 // === shapes/use_types.go ===
 package shapes
 
-func Test_local_static() float64 {
+func TestLocalStatic() float64 {
 	p := Point_New(1.0, 2.0)
-	b := Builder_New().With_x(5.0)
+	b := Builder_New().WithX(5.0)
 	return p.X + b.X
 }

--- a/tests/spec/emit/snapshots/mutable_interface_var_uses_var_declaration.snap
+++ b/tests/spec/emit/snapshots/mutable_interface_var_uses_var_declaration.snap
@@ -7,7 +7,7 @@ package main
 import "fmt"
 
 type Printable interface {
-	To_string() string
+	ToString() string
 }
 
 type Box struct {
@@ -18,7 +18,7 @@ func (b Box) String() string {
 	return fmt.Sprintf("Box { label: %v }", b.label)
 }
 
-func (b Box) To_string() string {
+func (b Box) ToString() string {
 	return b.label
 }
 

--- a/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
+++ b/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
@@ -7,7 +7,7 @@ package main
 import "fmt"
 
 type Printable interface {
-	To_string() string
+	ToString() string
 }
 
 type Box struct {
@@ -18,7 +18,7 @@ func (b Box) String() string {
 	return fmt.Sprintf("Box { label: %v }", b.label)
 }
 
-func (b Box) To_string() string {
+func (b Box) ToString() string {
 	return b.label
 }
 
@@ -30,7 +30,7 @@ func (c Circle) String() string {
 	return fmt.Sprintf("Circle { radius: %v }", c.radius)
 }
 
-func (c Circle) To_string() string {
+func (c Circle) ToString() string {
 	return "circle"
 }
 

--- a/tests/spec/emit/snapshots/ref_receiver_camel_cases_public_snake_case_field.snap
+++ b/tests/spec/emit/snapshots/ref_receiver_camel_cases_public_snake_case_field.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/types.rs
-assertion_line: 1538
 description: "input: \nstruct Foo {\n  pub bar_baz: string,\n}\n\nimpl Foo {\n  fn show(self: Ref<Foo>) -> string {\n    self.bar_baz\n  }\n}\n\nfn test() {\n  let mut foo = Foo { bar_baz: \"quux\" }\n  let _ = foo.show()\n}\n"
 ---
 package main
@@ -8,18 +7,18 @@ package main
 import "fmt"
 
 type Foo struct {
-	Bar_baz string
+	BarBaz string
 }
 
 func (f Foo) String() string {
-	return fmt.Sprintf("Foo { bar_baz: %v }", f.Bar_baz)
+	return fmt.Sprintf("Foo { bar_baz: %v }", f.BarBaz)
 }
 
 func (f *Foo) show() string {
-	return f.Bar_baz
+	return f.BarBaz
 }
 
 func test() {
-	foo := Foo{Bar_baz: "quux"}
+	foo := Foo{BarBaz: "quux"}
 	_ = foo.show()
 }

--- a/tests/spec/emit/snapshots/struct_with_json_snake_case.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_snake_case.snap
@@ -7,10 +7,10 @@ package main
 import "fmt"
 
 type User struct {
-	First_name string `json:"first_name"`
-	Last_name  string `json:"last_name"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
 }
 
 func (u User) String() string {
-	return fmt.Sprintf("User { first_name: %v, last_name: %v }", u.First_name, u.Last_name)
+	return fmt.Sprintf("User { first_name: %v, last_name: %v }", u.FirstName, u.LastName)
 }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1600,7 +1600,7 @@ fn test() {
 }
 
 #[test]
-fn ref_receiver_preserves_snake_case_in_public_field() {
+fn ref_receiver_camel_cases_public_snake_case_field() {
     let input = r#"
 struct Foo {
   pub bar_baz: string,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2475,6 +2475,34 @@ fn main() {
 }
 
 #[test]
+fn non_snake_case_struct_field_initialism() {
+    assert_lint_snapshot!(
+        r#"
+struct Resource { ID: uint }
+
+fn main() {
+  let r = Resource { ID: 1 };
+  let _ = r.ID;
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_struct_field_trailing_initialism() {
+    assert_lint_snapshot!(
+        r#"
+struct User { UserID: int }
+
+fn main() {
+  let u = User { UserID: 1 };
+  let _ = u.UserID;
+}
+"#
+    );
+}
+
+#[test]
 fn non_screaming_snake_case_constant() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/non_snake_case_struct_field_initialism.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_struct_field_initialism.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Miscased name
+   ╭─[test.lis:2:19]
+ 1 │ 
+ 2 │ struct Resource { ID: uint }
+   ·                   ─┬
+   ·                    ╰── expected snake_case
+ 3 │ 
+   ╰────
+  help: Rename to `id` · code: [lint.non_snake_case_struct_field]

--- a/tests/ui/lint/snapshots/non_snake_case_struct_field_trailing_initialism.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_struct_field_trailing_initialism.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Miscased name
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ struct User { UserID: int }
+   ·               ───┬──
+   ·                  ╰── expected snake_case
+ 3 │ 
+   ╰────
+  help: Rename to `user_id` · code: [lint.non_snake_case_struct_field]


### PR DESCRIPTION

Exported names from snake_case Lisette identifiers now use PascalCase in Go.

```rs
struct User {
  pub id: uint,
  pub user_id: int,
  pub api_key: string,
}
```

emits

```rs
type User struct {
  Id     uint
  UserId int
  ApiKey string
}
```

Also, the lint for non-snake_case fields is now acronym-aware, i.e. `ID` suggests `id`, `UserID` suggests `user_id` instead of `i_d` and `user_i_d`.