### PR TITLE
fix: reject unknown vs concrete inside invariant generic positions

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -369,10 +369,14 @@ impl TaskState<'_> {
 
         let new_spread = (*spread).map(|spread_expr| match variadic_elem_ty {
             Some(elem_ty) => {
-                let expected_slice = self.type_slice(elem_ty);
-                let inferred = self.with_value_context(|s| {
-                    s.infer_expression(store, spread_expr, &expected_slice)
-                });
+                let expected = if elem_ty.is_unknown() {
+                    let var = self.new_type_var();
+                    self.type_slice(var)
+                } else {
+                    self.type_slice(elem_ty)
+                };
+                let inferred =
+                    self.with_value_context(|s| s.infer_expression(store, spread_expr, &expected));
                 if param_mutability.last().copied().unwrap_or(false) {
                     let is_external = self.is_external_callee(&callee_expression);
                     self.check_arg_against_mut_param(&inferred, is_external);

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -78,6 +78,8 @@ impl TaskState<'_> {
     ) -> Result<(), UnifyError> {
         let r1 = self.env.shallow_resolve(t1);
         let r2 = self.env.shallow_resolve(t2);
+        let r1_unk = r1.is_unknown();
+        let r2_unk = r2.is_unknown();
 
         match (&r1, &r2) {
             _ if r1.is_ignored() || r2.is_ignored() => Ok(()),
@@ -88,8 +90,12 @@ impl TaskState<'_> {
 
             (Type::Var { id: i1, .. }, Type::Var { id: i2, .. }) if i1 == i2 => Ok(()),
 
-            _ if r1.is_unknown() => Ok(()),
-            _ if r2.is_unknown() && !r1.is_variable() => Err(UnifyError::TypeMismatch),
+            _ if r1_unk && r2_unk => Ok(()),
+            _ if r1_unk && !r2.is_variable() && self.scopes.is_inside_type_param() => {
+                Err(UnifyError::TypeMismatch)
+            }
+            _ if r1_unk => Ok(()),
+            _ if r2_unk && !r1.is_variable() => Err(UnifyError::TypeMismatch),
 
             _ if matches!(r2, Type::Never) => Ok(()),
             _ if matches!(r1, Type::Never) => Err(UnifyError::TypeMismatch),
@@ -420,14 +426,19 @@ impl TaskState<'_> {
         for (t1, t2) in pairs {
             let r1 = self.env.shallow_resolve(&t1);
             let r2 = self.env.shallow_resolve(&t2);
+            let r1_unk = r1.is_unknown();
+            let r2_unk = r2.is_unknown();
 
             match (&r1, &r2) {
                 _ if r1.is_ignored() || r2.is_ignored() => {}
                 _ if r1.is_receiver_placeholder() || r2.is_receiver_placeholder() => {}
                 (Type::Var { id: i1, .. }, Type::Var { id: i2, .. }) if i1 == i2 => {}
 
-                _ if r1.is_unknown() => {}
-                _ if r2.is_unknown() && !r1.is_variable() => {
+                _ if r1_unk && r2_unk => {}
+                _ if r1_unk && !r2.is_variable() => {
+                    return Err(UnifyError::TypeMismatch);
+                }
+                _ if r2_unk && !r1.is_variable() => {
                     return Err(UnifyError::TypeMismatch);
                 }
 

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -21,7 +21,7 @@ use semantics::checker::TaskState;
 use semantics::prelude::parse_and_register_prelude;
 use semantics::store::Store;
 use syntax::program::{Definition, Visibility};
-use syntax::types::Type;
+use syntax::types::{CompoundKind, Type};
 
 pub fn init_prelude(store: &mut Store) {
     let sink = LocalSink::new();
@@ -29,52 +29,46 @@ pub fn init_prelude(store: &mut Store) {
 }
 
 pub fn register_test_builtins(store: &mut Store, _checker: &mut TaskState) {
-    let module_id = "prelude";
     let module = store
         .modules
-        .get_mut(module_id)
+        .get_mut("prelude")
         .expect("prelude module must exist");
 
-    let unknown_type = Type::Nominal {
+    let mut define = |name: &str, params: Vec<Type>, return_type: Type| {
+        let param_mutability = vec![false; params.len()];
+        module.definitions.insert(
+            format!("prelude.{name}").into(),
+            Definition::Value {
+                visibility: Visibility::Public,
+                ty: Type::Function {
+                    params,
+                    param_mutability,
+                    bounds: vec![],
+                    return_type: Box::new(return_type),
+                },
+                name_span: None,
+                allowed_lints: vec![],
+                go_hints: vec![],
+                go_name: None,
+                doc: None,
+            },
+        );
+    };
+
+    let unknown = Type::Nominal {
         id: "prelude.Unknown".into(),
         params: vec![],
         underlying_ty: None,
     };
-    let get_unknown_ty = Type::Function {
-        params: vec![],
-        param_mutability: vec![],
-        bounds: vec![],
-        return_type: Box::new(unknown_type.clone()),
+    let unknown_map = Type::Compound {
+        kind: CompoundKind::Map,
+        args: vec![string_type(), unknown.clone()],
     };
-    module.definitions.insert(
-        "prelude.get_unknown".into(),
-        Definition::Value {
-            visibility: Visibility::Public,
-            ty: get_unknown_ty,
-            name_span: None,
-            allowed_lints: vec![],
-            go_hints: vec![],
-            go_name: None,
-            doc: None,
-        },
-    );
+    let unknown_slice = slice_type(unknown.clone());
 
-    let takes_unknown_ty = Type::Function {
-        params: vec![unknown_type],
-        param_mutability: vec![false],
-        bounds: vec![],
-        return_type: Box::new(Type::unit()),
-    };
-    module.definitions.insert(
-        "prelude.takes_unknown".into(),
-        Definition::Value {
-            visibility: Visibility::Public,
-            ty: takes_unknown_ty,
-            name_span: None,
-            allowed_lints: vec![],
-            go_hints: vec![],
-            go_name: None,
-            doc: None,
-        },
-    );
+    define("get_unknown", vec![], unknown.clone());
+    define("takes_unknown", vec![unknown], Type::unit());
+    define("get_unknown_map", vec![], unknown_map.clone());
+    define("takes_unknown_map", vec![unknown_map], Type::unit());
+    define("takes_unknown_slice", vec![unknown_slice], Type::unit());
 }

--- a/tests/spec/infer/equality.rs
+++ b/tests/spec/infer/equality.rs
@@ -1430,6 +1430,44 @@ fn unknown_rejects_downcast_to_concrete() {
 }
 
 #[test]
+fn unknown_map_accepts_matching_unknown_map() {
+    infer(
+        r#"
+    fn test() {
+      let m = get_unknown_map();
+      takes_unknown_map(m)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn unknown_map_rejects_concrete_value_type() {
+    infer(
+        r#"
+    fn test() {
+      takes_unknown_map(Map.from([("k", "v")]))
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn unknown_slice_rejects_concrete_element_type() {
+    infer(
+        r#"
+    fn test() {
+      let xs: Slice<int> = [1, 2, 3]
+      takes_unknown_slice(xs)
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
 fn explicit_type_arg() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1608,6 +1608,27 @@ fn test() {
 }
 
 #[test]
+fn infer_unknown_map_invariant() {
+    let input = r#"
+fn test() {
+  takes_unknown_map(Map.from([("k", "v")]))
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_unknown_slice_invariant() {
+    let input = r#"
+fn test() {
+  let xs: Slice<int> = [1, 2, 3]
+  takes_unknown_slice(xs)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_match_on_unconstrained_type() {
     let input = r#"
 fn get_something<T>() -> T {

--- a/tests/ui/errors/snapshots/infer_unknown_map_invariant.snap
+++ b/tests/ui/errors/snapshots/infer_unknown_map_invariant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:3:21]
+ 2 │ fn test() {
+ 3 │   takes_unknown_map(Map.from([("k", "v")]))
+   ·                     ───────────┬──────────
+   ·                                ╰── expected `Map<string, Unknown>`, found `Map<string, string>`
+ 4 │ }
+   ╰────
+  help: Change the type annotation to `Map<string, string>` or convert the value to `Map<string, Unknown>` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_unknown_slice_invariant.snap
+++ b/tests/ui/errors/snapshots/infer_unknown_slice_invariant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:4:23]
+ 3 │   let xs: Slice<int> = [1, 2, 3]
+ 4 │   takes_unknown_slice(xs)
+   ·                       ─┬
+   ·                        ╰── expected `Slice<Unknown>`, found `Slice<int>`
+ 5 │ }
+   ╰────
+  help: Change the type annotation to `Slice<int>` or convert the value to `Slice<Unknown>` · code: [infer.type_mismatch]


### PR DESCRIPTION

`Map<string, string>` no longer typechecks where `Map<string, Unknown>` is expected. Generics in Go are invariant (i.e. the conversion `map[string]string` → `map[string]any` does not exist) so the mismatch now surfaces at `lis check` instead of in the middle of `go build`.

```rs
import "go:github.com/sirupsen/logrus"

fn main() {
  logrus.Fields(Map.from([("k", "v")]))
  // error: expected `Map<string, Unknown>`, found `Map<string, string>`
}
```
