### PR TITLE
fix: detect colliding go imports at emit time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ name = "lisette-emit"
 version = "0.1.22"
 dependencies = [
  "ecow",
+ "lisette-diagnostics",
  "lisette-syntax",
  "rustc-hash",
 ]
@@ -998,6 +999,7 @@ name = "tests"
 version = "0.1.22"
 dependencies = [
  "bytes",
+ "ecow",
  "futures",
  "insta",
  "lisette-deps",

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -103,7 +103,7 @@ pub fn compile(
     }
 
     let failed = semantic_result.failed();
-    let errors = semantic_result.errors.clone();
+    let mut errors = semantic_result.errors.clone();
     let lints = semantic_result.lints.clone();
 
     if failed || config.target_phase == CompilePhase::Check {
@@ -116,13 +116,27 @@ pub fn compile(
         };
     }
 
-    let output = Emitter::emit(
+    let mut output = Emitter::emit(
         &semantic_result.into_emit_input(),
         &config.go_module,
         EmitOptions {
             debug: config.debug,
         },
     );
+
+    for file in &mut output {
+        errors.append(&mut file.diagnostics);
+    }
+
+    if errors.iter().any(|d| d.is_error()) {
+        return CompileResult {
+            output: vec![],
+            errors,
+            lints,
+            sources,
+            user_file_count,
+        };
+    }
 
     CompileResult {
         output,

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -402,6 +402,11 @@ impl LisetteDiagnostic {
         self
     }
 
+    pub fn with_emit_code(mut self, code: &str) -> Self {
+        self.code = Some(format!("emit.{}", code));
+        self
+    }
+
     pub fn with_code(mut self, code: impl Into<String>) -> Self {
         self.code = Some(code.into());
         self

--- a/crates/diagnostics/src/emit.rs
+++ b/crates/diagnostics/src/emit.rs
@@ -1,0 +1,24 @@
+use crate::LisetteDiagnostic;
+
+pub fn go_import_collision(alias: &str, paths: &[String]) -> LisetteDiagnostic {
+    let mut sorted = paths.to_vec();
+    sorted.sort();
+
+    let bullet_list = sorted
+        .iter()
+        .map(|p| format!("  - go:{}", p))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let suggestion_target = sorted.last().cloned().unwrap_or_default();
+
+    LisetteDiagnostic::error("Go import collision")
+        .with_emit_code("go_import_collision")
+        .with_help(format!(
+            "These Go packages all default to `{}` in generated code:\n{}\n\
+             Add an alias to at least one of them in your source: \
+             `import my_{} \"go:{}\"`. \
+             One of these may have been pulled in transitively by a typedef.",
+            alias, bullet_list, alias, suggestion_target,
+        ))
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -2,6 +2,7 @@ mod diagnostic;
 mod result;
 mod sink;
 
+pub mod emit;
 pub mod infer;
 pub mod lint;
 pub mod module_graph;

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -14,5 +14,6 @@ test = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "0.1.22", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.1.22", path = "../diagnostics" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/src/imports.rs
+++ b/crates/emit/src/imports.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::go_name;
+use diagnostics::{LisetteDiagnostic, emit as emit_diag};
 use ecow::EcoString;
 use syntax::ast::ImportAlias;
 use syntax::program::{File, FileImport, ModuleId};
@@ -101,22 +102,47 @@ impl<'a> ImportBuilder<'a> {
             if alias == "_" {
                 return true;
             }
-
-            let pkg_name = if alias.is_empty() {
-                // No alias — use last path component
-                path.rsplit('/').next().unwrap_or(path)
-            } else {
-                alias.as_str()
-            };
-
-            let escaped = go_name::escape_reserved(pkg_name);
+            let escaped = go_name::escape_reserved(effective_package_name(path, alias));
             let pattern = format!("{escaped}.");
             source.contains(&pattern)
         });
     }
 
-    pub fn build(self) -> HashMap<String, String> {
-        self.imports
+    pub fn build(self) -> (HashMap<String, String>, Vec<LisetteDiagnostic>) {
+        let diagnostics = self.detect_collisions();
+        (self.imports, diagnostics)
+    }
+
+    fn detect_collisions(&self) -> Vec<LisetteDiagnostic> {
+        if self.imports.len() < 2 {
+            return Vec::new();
+        }
+        let mut groups: HashMap<String, Vec<&str>> = HashMap::default();
+        for (path, alias) in &self.imports {
+            if alias == "_" {
+                continue;
+            }
+            let effective = effective_package_name(path, alias);
+            let sanitized = go_name::sanitize_package_name(effective).into_owned();
+            groups.entry(sanitized).or_default().push(path.as_str());
+        }
+        let mut groups: Vec<_> = groups.into_iter().filter(|(_, p)| p.len() > 1).collect();
+        groups.sort_by(|a, b| a.0.cmp(&b.0));
+        groups
+            .into_iter()
+            .map(|(alias, paths)| {
+                let owned: Vec<String> = paths.into_iter().map(str::to_string).collect();
+                emit_diag::go_import_collision(&alias, &owned)
+            })
+            .collect()
+    }
+}
+
+fn effective_package_name<'a>(path: &'a str, alias: &'a str) -> &'a str {
+    if alias.is_empty() {
+        path.rsplit('/').next().unwrap_or(path)
+    } else {
+        alias
     }
 }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -4,7 +4,7 @@ mod collectors;
 pub(crate) mod control_flow;
 pub(crate) mod definitions;
 pub(crate) mod expressions;
-mod imports;
+pub mod imports;
 pub(crate) mod names;
 mod output;
 pub(crate) mod patterns;
@@ -568,11 +568,13 @@ impl<'a> Emitter<'a> {
             let rendered_source = source.render();
             import_builder.filter_unreferenced(&rendered_source);
 
+            let (imports, diagnostics) = import_builder.build();
             output_files.push(OutputFile {
                 name: file.go_filename(),
-                imports: import_builder.build(),
+                imports,
                 source: rendered_source,
                 package_name: package_name.clone(),
+                diagnostics,
             });
         }
 

--- a/crates/emit/src/output.rs
+++ b/crates/emit/src/output.rs
@@ -2,6 +2,8 @@ use rustc_hash::FxHashMap as HashMap;
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
 
+use diagnostics::LisetteDiagnostic;
+
 use super::imports::format_import;
 
 #[derive(Clone, Debug)]
@@ -10,6 +12,7 @@ pub struct OutputFile {
     pub source: String,
     pub imports: HashMap<String, String>,
     pub package_name: String,
+    pub diagnostics: Vec<LisetteDiagnostic>,
 }
 
 impl OutputFile {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,7 @@ stdlib = { package = "lisette-stdlib", path = "../crates/stdlib" }
 deps = { package = "lisette-deps", path = "../crates/deps" }
 lsp = { package = "lisette-lsp", path = "../crates/lsp" }
 rustc-hash.workspace = true
+ecow.workspace = true
 insta.workspace = true
 miette.workspace = true
 tower-lsp = "0.20"

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4851,3 +4851,57 @@ fn main() {
 
     assert_build_snapshot!(fs, "github.com/user/myproject");
 }
+
+#[test]
+fn go_import_collision_flags_shared_last_segment() {
+    use ecow::EcoString;
+    use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+    let unused: HashSet<EcoString> = HashSet::default();
+    let go_package_names: HashMap<String, String> = HashMap::default();
+    let mut builder = emit::imports::ImportBuilder::new("project", &unused, &go_package_names);
+    builder.extend_with_modules(
+        &["database/sql", "entgo.io/ent/dialect/sql"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    );
+
+    let (_imports, diagnostics) = builder.build();
+    assert_eq!(diagnostics.len(), 1, "expected one collision diagnostic");
+    assert_eq!(diagnostics[0].code_str(), Some("emit.go_import_collision"));
+    let help = diagnostics[0].plain_help().unwrap_or_default();
+    assert!(
+        help.contains("database/sql") && help.contains("entgo.io/ent/dialect/sql"),
+        "help should name both colliding paths, got: {}",
+        help
+    );
+}
+
+#[test]
+fn go_import_collision_silent_when_aliases_differ() {
+    use ecow::EcoString;
+    use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+    let unused: HashSet<EcoString> = HashSet::default();
+    let mut go_package_names: HashMap<String, String> = HashMap::default();
+    go_package_names.insert(
+        "go:entgo.io/ent/dialect/sql".to_string(),
+        "entsql".to_string(),
+    );
+
+    let mut builder = emit::imports::ImportBuilder::new("project", &unused, &go_package_names);
+    builder.extend_with_modules(
+        &["database/sql", "entgo.io/ent/dialect/sql"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    );
+
+    let (_imports, diagnostics) = builder.build();
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics when aliases differ, got: {:?}",
+        diagnostics.iter().map(|d| d.code_str()).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Adds a diagnostic when two Go packages emitted into the same Go file default to the same package name. Previously the user saw a raw `go build` failure with `redeclared in this block` and no hint where it came from.

```rs
import "go:entgo.io/ent/dialect/sql"

fn main() {
  let driver = sql.Open(dialect.Postgres, dsn)?
}
```

Compiling this now reports the collision between `entgo.io/ent/dialect/sql` and `database/sql` (pulled in transitively by ent's typedefs) and suggests `import entsql "go:entgo.io/ent/dialect/sql"`.

Complements #212 and #217, which alias colliding imports inside generated typedefs. This catches the case those cannot see, i.e. a user's direct import colliding with a transitive one.
