### PR TITLE
fix: preserve comments between method chain segments

### DIFF
--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -113,10 +113,20 @@ impl<'a> Comments<'a> {
         found
     }
 
+    pub fn cursor_snapshot(&self) -> (usize, usize, usize) {
+        (self.comments_cursor, self.doc_comments_cursor, self.empty_cursor)
+    }
+
+    pub fn restore_cursor(&mut self, snapshot: (usize, usize, usize)) {
+        self.comments_cursor = snapshot.0;
+        self.doc_comments_cursor = snapshot.1;
+        self.empty_cursor = snapshot.2;
+    }
+
     pub fn has_comments_before(&self, position: u32) -> bool {
         self.comments[self.comments_cursor..]
-            .iter()
-            .any(|c| c.start < position)
+            .first()
+            .is_some_and(|c| c.start < position)
     }
 
     pub fn has_comments_in_range(&self, span: syntax::ast::Span) -> bool {

--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -113,6 +113,12 @@ impl<'a> Comments<'a> {
         found
     }
 
+    pub fn has_comments_before(&self, position: u32) -> bool {
+        self.comments[self.comments_cursor..]
+            .iter()
+            .any(|c| c.start < position)
+    }
+
     pub fn has_comments_in_range(&self, span: syntax::ast::Span) -> bool {
         let start = span.byte_offset;
         let end = span.byte_offset + span.byte_length;

--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -114,7 +114,11 @@ impl<'a> Comments<'a> {
     }
 
     pub fn cursor_snapshot(&self) -> (usize, usize, usize) {
-        (self.comments_cursor, self.doc_comments_cursor, self.empty_cursor)
+        (
+            self.comments_cursor,
+            self.doc_comments_cursor,
+            self.empty_cursor,
+        )
     }
 
     pub fn restore_cursor(&mut self, snapshot: (usize, usize, usize)) {

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -928,12 +928,20 @@ impl<'a> Formatter<'a> {
                 spread,
                 type_args,
             });
-            let has_inter_segment_comments = chain_segments
-                .iter()
-                .any(|s| self.comments.has_comments_before(s.member_start));
-            if chain_segments.len() >= 2 || has_inter_segment_comments {
+            if chain_segments.len() >= 2 {
                 return self.format_method_chain(root, &chain_segments);
             }
+            // Single-segment chain: probe-format the root to drain any inner-receiver
+            // comments, then check if comments remain before the member. If so, there
+            // are genuine inter-segment comments and we should use chain formatting.
+            let snapshot = self.comments.cursor_snapshot();
+            let root_doc = self.expression(root);
+            let has_inter_segment_comments =
+                self.comments.has_comments_before(chain_segments[0].member_start);
+            if has_inter_segment_comments {
+                return self.format_method_chain_with_root(root_doc, &chain_segments);
+            }
+            self.comments.restore_cursor(snapshot);
         }
 
         let head = self
@@ -1036,7 +1044,14 @@ impl<'a> Formatter<'a> {
         segments: &[MethodChainSegment<'a>],
     ) -> Document<'a> {
         let root_doc = self.expression(root);
+        self.format_method_chain_with_root(root_doc, segments)
+    }
 
+    fn format_method_chain_with_root(
+        &mut self,
+        root_doc: Document<'a>,
+        segments: &[MethodChainSegment<'a>],
+    ) -> Document<'a> {
         let segment_docs: Vec<Document<'a>> = segments
             .iter()
             .map(|seg| {

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -915,17 +915,23 @@ impl<'a> Formatter<'a> {
         if let Expression::DotAccess {
             expression: inner,
             member,
+            span,
             ..
         } = callee
         {
             let (root, mut chain_segments) = collect_method_chain(inner);
+            let member_start = span.byte_offset + span.byte_length - member.len() as u32;
             chain_segments.push(MethodChainSegment {
                 member,
+                member_start,
                 args,
                 spread,
                 type_args,
             });
-            if chain_segments.len() >= 2 {
+            let has_inter_segment_comments = chain_segments
+                .iter()
+                .any(|s| self.comments.has_comments_before(s.member_start));
+            if chain_segments.len() >= 2 || has_inter_segment_comments {
                 return self.format_method_chain(root, &chain_segments);
             }
         }
@@ -1034,10 +1040,19 @@ impl<'a> Formatter<'a> {
         let segment_docs: Vec<Document<'a>> = segments
             .iter()
             .map(|seg| {
+                let comments = self.comments.take_comments_before(seg.member_start);
                 let head = Document::str(".")
                     .append(seg.member)
                     .append(Self::format_type_args(seg.type_args));
-                strict_break("", "").append(self.format_call_with_head(head, seg.args, seg.spread))
+                let call_doc = strict_break("", "")
+                    .append(self.format_call_with_head(head, seg.args, seg.spread));
+                match comments {
+                    Some(c) => strict_break("", "")
+                        .append(c)
+                        .force_break()
+                        .append(call_doc),
+                    None => call_doc,
+                }
             })
             .collect();
 
@@ -1902,6 +1917,7 @@ impl<'a> Formatter<'a> {
 
 struct MethodChainSegment<'a> {
     member: &'a str,
+    member_start: u32,
     args: &'a [Expression],
     spread: &'a Option<Expression>,
     type_args: &'a [Annotation],
@@ -1922,13 +1938,16 @@ fn collect_method_chain(expression: &Expression) -> (&Expression, Vec<MethodChai
         let Expression::DotAccess {
             expression: inner,
             member,
+            span,
             ..
         } = expression.as_ref()
         else {
             break;
         };
+        let member_start = span.byte_offset + span.byte_length - member.len() as u32;
         segments.push(MethodChainSegment {
             member,
+            member_start,
             args,
             spread,
             type_args,

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -936,8 +936,9 @@ impl<'a> Formatter<'a> {
             // are genuine inter-segment comments and we should use chain formatting.
             let snapshot = self.comments.cursor_snapshot();
             let root_doc = self.expression(root);
-            let has_inter_segment_comments =
-                self.comments.has_comments_before(chain_segments[0].member_start);
+            let has_inter_segment_comments = self
+                .comments
+                .has_comments_before(chain_segments[0].member_start);
             if has_inter_segment_comments {
                 return self.format_method_chain_with_root(root_doc, &chain_segments);
             }

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1332,6 +1332,13 @@ fn method_chain_comment_before_single_segment() {
 }
 
 #[test]
+fn method_chain_comment_inside_receiver_slice() {
+    assert_format_snapshot!(
+        "fn test() { [\"Lilian\", // comment\n\"Lisette\", // comment\n\"Lisa\"].length() }"
+    );
+}
+
+#[test]
 fn unit_return_type_annotation() {
     assert_format_snapshot!("fn do_nothing() -> () { () }");
 }

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1318,6 +1318,20 @@ fn method_chain_short_stays_inline() {
 }
 
 #[test]
+fn method_chain_comment_between_segments() {
+    assert_format_snapshot!(
+        "fn test() { let foo = [5, 5, 5].map(|x| x * 2) // .filter(|x| x % 2 == 0)\n.fold(0, |acc, x| acc + x) }"
+    );
+}
+
+#[test]
+fn method_chain_comment_before_single_segment() {
+    assert_format_snapshot!(
+        "fn test() { let foo = [5, 5, 5] // .map(|x| x * 2)\n// .filter(|x| x % 2 == 0)\n.fold(0, |acc, x| acc + x) }"
+    );
+}
+
+#[test]
 fn unit_return_type_annotation() {
     assert_format_snapshot!("fn do_nothing() -> () { () }");
 }

--- a/tests/spec/format/snapshots/method_chain_comment_before_single_segment.snap
+++ b/tests/spec/format/snapshots/method_chain_comment_before_single_segment.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/format/mod.rs
+assertion_line: 1329
+description: "input: fn test() { let foo = [5, 5, 5] // .map(|x| x * 2)\n// .filter(|x| x % 2 == 0)\n.fold(0, |acc, x| acc + x) }"
+---
+fn test() {
+  let foo = [5, 5, 5]
+    // .map(|x| x * 2)
+    // .filter(|x| x % 2 == 0)
+    .fold(0, |acc, x| acc + x)
+}

--- a/tests/spec/format/snapshots/method_chain_comment_between_segments.snap
+++ b/tests/spec/format/snapshots/method_chain_comment_between_segments.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/format/mod.rs
+assertion_line: 1322
+description: "input: fn test() { let foo = [5, 5, 5].map(|x| x * 2) // .filter(|x| x % 2 == 0)\n.fold(0, |acc, x| acc + x) }"
+---
+fn test() {
+  let foo = [5, 5, 5]
+    .map(|x| x * 2)
+    // .filter(|x| x % 2 == 0)
+    .fold(0, |acc, x| acc + x)
+}

--- a/tests/spec/format/snapshots/method_chain_comment_inside_receiver_slice.snap
+++ b/tests/spec/format/snapshots/method_chain_comment_inside_receiver_slice.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/format/mod.rs
+assertion_line: 1336
+description: "input: fn test() { [\"Lilian\", // comment\n\"Lisette\", // comment\n\"Lisa\"].length() }"
+---
+fn test() {
+  [
+    "Lilian",
+    // comment
+    "Lisette",
+    // comment
+    "Lisa",
+  ].length()
+}


### PR DESCRIPTION
I noticed a few issues with the formatter, when using method chaining.

Comments placed between method chain steps were being incorrectly moved inside the argument list of the next call.

This code:
```rust
let foo = [5, 5, 5]
  .map(|x| x * 2)
  // .filter(|x| x % 2 == 0)
  .fold(0, |acc, x| acc + x)

```

Gets formatted as:

```rust
let foo = [5, 5, 5]
  .map(|x| x * 2)
  .fold(
    0,
    // .filter(|x| x % 2 == 0)
    |acc, x| acc + x,
  )
```

Also this: (the first chain is commented out)

```rust
let foo = [5, 5, 5]
  // .map(|x| x * 2)
  // .filter(|x| x % 2 == 0)
  .fold(0, |acc, x| acc + x)
```

Formats as:

```rust
let foo = [5, 5, 5].fold(
  0,
  // .map(|x| x * 2)
  // .filter(|x| x % 2 == 0)
  |acc, x| acc + x,
)
```

If the last method is commented it still "falls" off (is moved to a own line below the chain block),  but i think thats a lesser issue, so its not included in this change.