### PR TITLE
fix: lsp completion for built-in prelude types

### DIFF
--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -17,7 +17,7 @@ use crate::snapshot::AnalysisSnapshot;
 use crate::state::{CachedSnapshot, SharedState};
 
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
-pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<&str> {
+pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<String> {
     match ty {
         syntax::types::Type::Nominal { id, params, .. } if id == "prelude.Ref" => {
             params.first().and_then(type_name)
@@ -26,7 +26,9 @@ pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<&str> {
             underlying_ty: Some(u),
             ..
         } => type_name(u),
-        syntax::types::Type::Nominal { id, .. } => Some(id.as_str()),
+        syntax::types::Type::Nominal { id, .. } => Some(id.to_string()),
+        syntax::types::Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
+        syntax::types::Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
         _ => None,
     }
 }

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -54,17 +54,14 @@ pub(crate) fn definition_to_completion_kind(
     }
 }
 
-/// Extract the element type from a collection type (Slice<T>, Array<T>, Map<K, V>).
-fn element_type_name(ty: &syntax::types::Type) -> Option<&str> {
-    match ty {
-        syntax::types::Type::Nominal { id, params, .. }
-            if id == "prelude.Slice" || id == "prelude.Array" =>
-        {
-            params.first().and_then(type_name)
+/// Extract the element type from a collection type (Slice<T>, EnumeratedSlice<T>, Map<K, V>).
+fn element_type_name(ty: &syntax::types::Type) -> Option<String> {
+    use syntax::types::CompoundKind;
+    match ty.as_compound()? {
+        (CompoundKind::Slice | CompoundKind::EnumeratedSlice, args) => {
+            args.first().and_then(type_name)
         }
-        syntax::types::Type::Nominal { id, params, .. } if id == "prelude.Map" => {
-            params.get(1).and_then(type_name)
-        }
+        (CompoundKind::Map, args) => args.get(1).and_then(type_name),
         _ => None,
     }
 }
@@ -129,9 +126,9 @@ pub(crate) fn resolve_variable_type(
     let ty = &resolved[0];
 
     if indexed {
-        element_type_name(ty).map(|s| s.to_string())
+        element_type_name(ty)
     } else {
-        type_name(ty).map(|s| s.to_string())
+        type_name(ty)
     }
 }
 
@@ -160,7 +157,7 @@ pub(crate) fn detect_dot_context(
             }
         ) {
             let ty = expression.get_type();
-            return type_name(&ty).map(|type_id| DotContext::Instance(type_id.to_string()));
+            return type_name(&ty).map(DotContext::Instance);
         }
         return None;
     }
@@ -178,7 +175,7 @@ pub(crate) fn detect_dot_context(
 
     let ty = expression.get_type();
     if let Some(type_id) = type_name(&ty) {
-        return Some(DotContext::Instance(type_id.to_string()));
+        return Some(DotContext::Instance(type_id));
     }
 
     if let Expression::Identifier { value, .. } = expression.as_ref()

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -45,10 +45,16 @@ pub(crate) fn resolve_struct_call_field(
     field_assignments
         .iter()
         .find(|fa| offset_in_span(offset, &fa.name_span))
-        .and_then(|fa| type_id.and_then(|tid| find_struct_field_span(tid, &fa.name, snapshot)))
+        .and_then(|fa| {
+            type_id
+                .as_deref()
+                .and_then(|tid| find_struct_field_span(tid, &fa.name, snapshot))
+        })
         .or_else(|| {
             lookup_definition_span(name, file, snapshot).or_else(|| {
-                type_id.and_then(|tid| snapshot.definitions().get(tid).and_then(|d| d.name_span()))
+                type_id
+                    .as_deref()
+                    .and_then(|tid| snapshot.definitions().get(tid).and_then(|d| d.name_span()))
             })
         })
 }
@@ -93,7 +99,7 @@ pub(crate) fn resolve_dot_access_definition(
     let resolve_by_type = || {
         type_name(&expression.get_type()).and_then(|type_id| {
             let name = format!("{}.{}", type_id, member);
-            try_lookup(&name).or_else(|| find_struct_field_span(type_id, member, snapshot))
+            try_lookup(&name).or_else(|| find_struct_field_span(&type_id, member, snapshot))
         })
     };
 

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -410,7 +410,8 @@ pub(crate) fn get_hover_doc(
                 .iter()
                 .find(|fa| offset_in_span(offset, &fa.name_span))
             {
-                if let Some(Definition::Struct { fields, .. }) = snapshot.definitions().get(type_id)
+                if let Some(Definition::Struct { fields, .. }) =
+                    snapshot.definitions().get(type_id.as_str())
                 {
                     return fields
                         .iter()
@@ -420,7 +421,7 @@ pub(crate) fn get_hover_doc(
                 return None;
             }
 
-            let span = snapshot.definitions().get(type_id)?.name_span()?;
+            let span = snapshot.definitions().get(type_id.as_str())?.name_span()?;
             find_doc_at_definition_span(span, snapshot)
         }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -698,7 +698,7 @@ impl LanguageServer for Backend {
                 .iter()
                 .find(|fa| offset_in_span(offset, &fa.name_span))
             && type_name(ty)
-                .and_then(|type_id| find_struct_field_span(type_id, &fa.name, &snapshot))
+                .and_then(|type_id| find_struct_field_span(&type_id, &fa.name, &snapshot))
                 .is_some()
         {
             return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -751,6 +751,62 @@ fn main() {
 }
 
 #[tokio::test]
+async fn completion_dot_on_slice_variable() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+fn main() {
+  let names = [\"Lisette\", \"Lilian\", \"Lisa\"]
+  names.length()
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 8).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "length"),
+        "should include 'length' from prelude Slice, got: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "is_empty"),
+        "should include 'is_empty' from prelude Slice, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_dot_on_string_variable() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+fn main() {
+  let s = \"hello\"
+  s.length()
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 4).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "length"),
+        "should include 'length' from prelude string, got: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "contains"),
+        "should include 'contains' from prelude string, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_no_globals_after_dot() {
     let mut client = TestClient::new().await;
     client.initialize().await;


### PR DESCRIPTION
Currently the lsp does not provide completions for some compound (eg slice) and primitive (eg string) prelude types.

As an example: 

```rust 
let names = ["Lisette", "Lisa", "Lilian"]
```

Then type: ```names.``` <- after the dot there is no completion.

After this change you get autocomplete like:

```text 
LSP dropdown in editor of choise:
   >  get        Method
   >  fold       Method
   >  capacity   Method
   >  contains   Method
   >  append     Method
   >  all        Method
   >  map        Method
   >  any        Method
   >  join       Method
   >  find       Method
   >  clone      Method
   >  filter     Method
   >  extend     Method
```

**NOTE** 

I also found a error message in the source code for prelude.Array (Array<T, N> for fixed-size arrays), 
but it seems the type is either deleted, or not implemented on the Lisette side (in prelude). Its located in: [crates/syntax/src/parse/annotations.rs:58](https://github.com/ivov/lisette/blob/main/crates/syntax/src/parse/annotations.rs#L58)

So im a bit unsure about the Array, as currently you can only construct slices on the Lisette side, and i assume arrays can only come from bindgen via Go source. If this assumption is correct this PR may still need some tweaking.


