### PR TITLE
fix: preserve underscores in go-imported member names

### DIFF
--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -359,6 +359,13 @@ impl Emitter<'_> {
 /// convention); exported members elsewhere get first-letter capitalization;
 /// non-exported members are escaped to avoid Go keywords.
 fn go_field_name(expression_ty: &Type, member: &str, is_exported: bool) -> String {
+    if expression_ty
+        .as_import_namespace()
+        .is_some_and(go_name::is_go_import)
+    {
+        return member.to_string();
+    }
+
     let is_prelude_type = expression_ty
         .strip_refs()
         .get_qualified_id()

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -344,6 +344,21 @@ pub interface Event {}
 }
 
 #[test]
+fn go_imported_const_underscore_preserved() {
+    let input = r#"
+import "go:example.com/grpc_health_v1"
+
+fn main() {
+  let _ = grpc_health_v1.HealthCheckResponse_SERVING
+}
+"#;
+    let typedef = r#"
+pub const HealthCheckResponse_SERVING: int = 1
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/grpc_health_v1", typedef)]);
+}
+
+#[test]
 fn package_local_option_alias_does_not_collide_with_prelude_option() {
     // Regression: a Go module that declares its own `type Option = ...`
     // (e.g. the functional-options pattern) would trip `Type::is_option`

--- a/tests/spec/emit/snapshots/go_imported_const_underscore_preserved.snap
+++ b/tests/spec/emit/snapshots/go_imported_const_underscore_preserved.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/imports.rs
+assertion_line: 358
+description: "input: \nimport \"go:example.com/grpc_health_v1\"\n\nfn main() {\n  let _ = grpc_health_v1.HealthCheckResponse_SERVING\n}\n"
+---
+package main
+
+import "example.com/grpc_health_v1"
+
+func main() {
+	_ = grpc_health_v1.HealthCheckResponse_SERVING
+}


### PR DESCRIPTION
For members accessed through a Go-imported package, underscores are no longer stripped in the emit phase.

```rs
import "go:google.golang.org/grpc/health/grpc_health_v1"

fn main() {
  let _ = grpc_health_v1.HealthCheckResponse_SERVING // _ no longer missing
}
```

Fix #233
