### PR TITLE
fix: keep struct-field comments on their own line

### DIFF
--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -16,6 +16,8 @@ pub struct Comments<'a> {
 
     empty_lines: &'a [u32],
     empty_cursor: usize,
+
+    source: &'a str,
 }
 
 impl<'a> Comments<'a> {
@@ -47,7 +49,59 @@ impl<'a> Comments<'a> {
             doc_comments_cursor: 0,
             empty_lines: &trivia.blank_lines,
             empty_cursor: 0,
+            source,
         }
+    }
+
+    pub fn newline_between(&self, start: u32, end: u32) -> bool {
+        if start >= end {
+            return false;
+        }
+        let s = start as usize;
+        let e = (end as usize).min(self.source.len());
+        self.source.as_bytes()[s..e].contains(&b'\n')
+    }
+
+    pub fn take_split_by_newline_after(
+        &mut self,
+        anchor: u32,
+        before: u32,
+    ) -> (Option<Document<'a>>, Option<Document<'a>>) {
+        let comment_end = self.comments[self.comments_cursor..]
+            .iter()
+            .position(|c| c.start >= before)
+            .map(|i| self.comments_cursor + i)
+            .unwrap_or(self.comments.len());
+
+        let popped = &self.comments[self.comments_cursor..comment_end];
+        self.comments_cursor = comment_end;
+
+        let mut same_line: Vec<Option<&'a str>> = Vec::new();
+        let mut new_line: Vec<Option<&'a str>> = Vec::new();
+        let mut split_seen = false;
+
+        for c in popped {
+            if !split_seen && self.newline_between(anchor, c.start) {
+                split_seen = true;
+            }
+            if split_seen {
+                new_line.push(Some(c.content));
+            } else {
+                same_line.push(Some(c.content));
+            }
+        }
+
+        let empty_end = self.empty_lines[self.empty_cursor..]
+            .iter()
+            .position(|&l| l >= before)
+            .map(|i| self.empty_cursor + i)
+            .unwrap_or(self.empty_lines.len());
+        self.empty_cursor = empty_end;
+
+        (
+            comments_to_document(same_line),
+            comments_to_document(new_line),
+        )
     }
 
     pub fn take_comments_before(&mut self, position: u32) -> Option<Document<'a>> {

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -12,6 +12,8 @@ pub struct Formatter<'a> {
     comments: Comments<'a>,
 }
 
+type StructFieldEntry<'a> = (Option<Document<'a>>, Document<'a>, Option<Document<'a>>);
+
 impl<'a> Formatter<'a> {
     pub fn new(comments: Comments<'a>) -> Self {
         Self { comments }
@@ -1358,20 +1360,34 @@ impl<'a> Formatter<'a> {
             return self.empty_struct_body(header, struct_end);
         }
 
-        let (field_entries, with_comments) = self.struct_fields_with_comments(fields, struct_end);
+        let (field_entries, trailing, with_comments) =
+            self.struct_fields_with_comments(fields, struct_end);
 
         if with_comments || with_field_attrs || with_pub_fields {
-            let fields_docs: Vec<_> = field_entries
+            let mut fields_docs: Vec<Document<'a>> = field_entries
                 .into_iter()
-                .map(|(field, comment)| match comment {
-                    Some(c) => field.append(",").append(" ").append(c),
-                    None => field.append(","),
+                .map(|(leading, field, same_line_trailing)| {
+                    let mut doc = match leading {
+                        Some(c) => c.append(Document::Newline).append(field),
+                        None => field,
+                    };
+                    doc = doc.append(",");
+                    if let Some(t) = same_line_trailing {
+                        doc = doc.append(" ").append(t);
+                    }
+                    doc
                 })
                 .collect();
+            if let Some(t) = trailing {
+                fields_docs.push(t);
+            }
             return Self::braced_body(header, join(fields_docs, Document::Newline));
         }
 
-        let fields_docs: Vec<_> = field_entries.into_iter().map(|(field, _)| field).collect();
+        let fields_docs: Vec<_> = field_entries
+            .into_iter()
+            .map(|(_, field, _)| field)
+            .collect();
         Self::flexible_struct_body(header, fields_docs)
     }
 
@@ -1391,16 +1407,28 @@ impl<'a> Formatter<'a> {
         &mut self,
         fields: &'a [StructFieldDefinition],
         struct_end: u32,
-    ) -> (Vec<(Document<'a>, Option<Document<'a>>)>, bool) {
+    ) -> (Vec<StructFieldEntry<'a>>, Option<Document<'a>>, bool) {
         let mut entries = Vec::new();
         let mut with_comments = false;
+        let mut prev_anchor: Option<u32> = None;
 
-        for (i, field) in fields.iter().enumerate() {
-            let comment_limit = if i + 1 < fields.len() {
-                fields[i + 1].name_span.byte_offset
-            } else {
-                struct_end
+        for field in fields {
+            let field_start = field.name_span.byte_offset;
+            let (trailing_for_prev, leading) = match prev_anchor {
+                Some(anchor) => self
+                    .comments
+                    .take_split_by_newline_after(anchor, field_start),
+                None => (None, self.comments.take_comments_before(field_start)),
             };
+
+            with_comments = with_comments || trailing_for_prev.is_some() || leading.is_some();
+
+            if let Some(t) = trailing_for_prev
+                && let Some(last) = entries.last_mut()
+            {
+                let (_, _, slot): &mut (_, _, Option<Document<'a>>) = last;
+                *slot = Some(t);
+            }
 
             let field_attrs = Self::field_attributes(&field.attributes);
 
@@ -1415,15 +1443,26 @@ impl<'a> Formatter<'a> {
                     .append(Self::annotation(&field.annotation))
             };
 
-            let field_doc = field_attrs.append(field_definition);
+            entries.push((leading, field_attrs.append(field_definition), None));
 
-            let comment_doc = self.comments.take_comments_before(comment_limit);
-            with_comments = with_comments || comment_doc.is_some();
-
-            entries.push((field_doc, comment_doc));
+            let ann_span = field.annotation.get_span();
+            prev_anchor = Some(ann_span.byte_offset + ann_span.byte_length);
         }
 
-        (entries, with_comments)
+        let (last_trailing, struct_trailing) = match prev_anchor {
+            Some(anchor) => self
+                .comments
+                .take_split_by_newline_after(anchor, struct_end),
+            None => (None, self.comments.take_comments_before(struct_end)),
+        };
+        if let Some(t) = last_trailing
+            && let Some(last) = entries.last_mut()
+        {
+            last.2 = Some(t);
+        }
+        with_comments = with_comments || struct_trailing.is_some();
+
+        (entries, struct_trailing, with_comments)
     }
 
     fn field_attributes(attrs: &'a [Attribute]) -> Document<'a> {

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -213,6 +213,27 @@ fn comment_on_struct_field() {
 }
 
 #[test]
+fn leading_comment_on_struct_field() {
+    assert_format_snapshot!(
+        "struct Point {\n  // documentation for x\n  x: int,\n  // documentation for y\n  y: int,\n}"
+    );
+}
+
+#[test]
+fn standalone_comment_between_struct_fields() {
+    assert_format_snapshot!(
+        "struct Foo {\n  a: int,\n  // a standalone note about the missing field\n  c: string,\n}"
+    );
+}
+
+#[test]
+fn mixed_trailing_and_leading_struct_field_comments() {
+    assert_format_snapshot!(
+        "struct Mix {\n  a: int, // trailing on a\n  // leading for b\n  b: string,\n}"
+    );
+}
+
+#[test]
 fn comment_trailing() {
     assert_format_snapshot!(
         r#"fn test() {

--- a/tests/spec/format/snapshots/leading_comment_on_struct_field.snap
+++ b/tests/spec/format/snapshots/leading_comment_on_struct_field.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Point {\n  // documentation for x\n  x: int,\n  // documentation for y\n  y: int,\n}"
+---
+struct Point {
+  // documentation for x
+  x: int,
+  // documentation for y
+  y: int,
+}

--- a/tests/spec/format/snapshots/mixed_trailing_and_leading_struct_field_comments.snap
+++ b/tests/spec/format/snapshots/mixed_trailing_and_leading_struct_field_comments.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Mix {\n  a: int, // trailing on a\n  // leading for b\n  b: string,\n}"
+---
+struct Mix {
+  a: int, // trailing on a
+  // leading for b
+  b: string,
+}

--- a/tests/spec/format/snapshots/standalone_comment_between_struct_fields.snap
+++ b/tests/spec/format/snapshots/standalone_comment_between_struct_fields.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Foo {\n  a: int,\n  // a standalone note about the missing field\n  c: string,\n}"
+---
+struct Foo {
+  a: int,
+  // a standalone note about the missing field
+  c: string,
+}


### PR DESCRIPTION

Regular comments `//` on their own line between struct fields now stay on their own line, instead of being glued onto the previous field as a trailing comment. Same-line trailing comments are unaffected.  Doc comments `///` are handled by a separate path and were not affected by this bug.

```rs
struct Point {
  // line for x
  pub x: int,
  // line for y
  pub y: int,
}
```

Previously the formatter rewrote both leading comments as trailing comments on the previous field.