### PR TITLE
fix: skip arrays in bindgen

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -166,6 +166,9 @@ func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goV
 			continue
 		}
 		if result.SkipReason != nil {
+			if result.Kind == extract.ExportMethod && emitter.CollectSkippedMethod(result) {
+				continue
+			}
 			emitter.EmitSkipped(exports[i].Name, result.SkipReason)
 			continue
 		}

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -514,6 +514,10 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 
 			fieldType := ToLisetteNilable(field.Type(), c)
 			if fieldType.SkipReason != nil {
+				result.Fields = append(result.Fields, StructField{
+					Name:       field.Name(),
+					SkipReason: fieldType.SkipReason,
+				})
 				continue
 			}
 
@@ -537,6 +541,17 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 		result.LisetteType = basicToLisette(u)
 
 	default:
+		// `type UUID [16]byte` keeps its slice-shaped newtype body; this is
+		// the one position where an array lowers to a slice rather than skipping.
+		if arr := unwrapArray(underlying); arr != nil {
+			t := arraySliceTypeResult(arr, make(map[types.Type]bool), c)
+			if t.SkipReason != nil {
+				result.SkipReason = withOpaqueType(t.SkipReason)
+				return
+			}
+			result.LisetteType = t.LisetteType
+			return
+		}
 		t := ToLisette(underlying, c)
 		if t.SkipReason != nil {
 			result.SkipReason = withOpaqueType(t.SkipReason)

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -54,6 +54,7 @@ type StructField struct {
 	Name string
 	Type string
 	Doc  string
+	SkipReason *SkipReason
 }
 
 type InterfaceMethod struct {

--- a/bindgen/internal/convert/returns.go
+++ b/bindgen/internal/convert/returns.go
@@ -14,6 +14,13 @@ func ReturnsToLisette(signature *types.Signature, conv *Converter, qualifiedName
 	return returnsToLisetteRecursive(signature, make(map[types.Type]bool), conv, qualifiedName)
 }
 
+func returnElementToLisette(t types.Type, seen map[types.Type]bool, conv *Converter) TypeResult {
+	if arr := unwrapArray(t); arr != nil {
+		return arrayReturnTypeResult(arr, seen, conv)
+	}
+	return toLisetteRecursive(t, seen, conv)
+}
+
 // maybeWrapNilableFunction wraps function-typed returns in Option.
 //
 // Bare signatures are wrapped by default (opt-out via non_nilable_return).
@@ -67,7 +74,7 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 		if isPointerToErrorImpl(results.At(0).Type()) {
 			return TypeResult{LisetteType: "error", IsDirectError: true}
 		}
-		elem := toLisetteRecursive(results.At(0).Type(), seen, conv)
+		elem := returnElementToLisette(results.At(0).Type(), seen, conv)
 		if elem.SkipReason == nil {
 			wrapped, applied := maybeWrapNilableFunction(results.At(0).Type(), elem.LisetteType, conv, qualifiedName)
 			elem.LisetteType = wrapped
@@ -153,7 +160,7 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 	}
 
 	if count == 1 {
-		elem := toLisetteRecursive(results.At(start).Type(), seen, conv)
+		elem := returnElementToLisette(results.At(start).Type(), seen, conv)
 		if elem.SkipReason == nil {
 			wrapped, applied := maybeWrapNilableFunction(results.At(start).Type(), elem.LisetteType, conv, qualifiedName)
 			elem.LisetteType = wrapped
@@ -174,7 +181,7 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 	var elems []string
 	anyApplied := false
 	for i := start; i < end; i++ {
-		elem := toLisetteRecursive(results.At(i).Type(), seen, conv)
+		elem := returnElementToLisette(results.At(i).Type(), seen, conv)
 		if elem.SkipReason != nil {
 			return elem
 		}

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -67,14 +67,10 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		return TypeResult{LisetteType: fmt.Sprintf("Slice<%s>", elem.LisetteType)}
 
 	case *types.Array:
-		element := toLisetteRecursive(t.Elem(), seen, conv)
-		if element.SkipReason != nil {
-			return element
+		if elem := toLisetteRecursive(t.Elem(), seen, conv); elem.SkipReason != nil {
+			return elem
 		}
-		return TypeResult{
-			LisetteType: fmt.Sprintf("Slice<%s>", element.LisetteType),
-			ArrayReturn: true,
-		}
+		return TypeResult{SkipReason: arrayUnrepresentable()}
 
 	case *types.Map:
 		key := toLisetteRecursive(t.Key(), seen, conv)
@@ -351,14 +347,10 @@ func toLisetteNilableRecursive(t types.Type, seen map[types.Type]bool, conv *Con
 		return TypeResult{LisetteType: fmt.Sprintf("Slice<%s>", elem.LisetteType)}
 
 	case *types.Array:
-		elem := toLisetteNilableRecursive(t.Elem(), seen, conv)
-		if elem.SkipReason != nil {
+		if elem := toLisetteNilableRecursive(t.Elem(), seen, conv); elem.SkipReason != nil {
 			return elem
 		}
-		return TypeResult{
-			LisetteType: fmt.Sprintf("Slice<%s>", elem.LisetteType),
-			ArrayReturn: true,
-		}
+		return TypeResult{SkipReason: arrayUnrepresentable()}
 
 	case *types.Map:
 		key := toLisetteRecursive(t.Key(), seen, conv)
@@ -377,6 +369,52 @@ func toLisetteNilableRecursive(t types.Type, seen map[types.Type]bool, conv *Con
 	default:
 		return toLisetteRecursive(t, seen, conv)
 	}
+}
+
+func arrayUnrepresentable() *SkipReason {
+	return &SkipReason{
+		Code:    "array-currently-not-representable",
+		Message: "fixed-size array cannot currently be represented in Lisette",
+	}
+}
+
+func unwrapArray(t types.Type) *types.Array {
+	for {
+		switch v := t.(type) {
+		case *types.Array:
+			return v
+		case *types.Alias:
+			t = v.Rhs()
+		default:
+			return nil
+		}
+	}
+}
+
+func arrayReturnTypeResult(arr *types.Array, seen map[types.Type]bool, conv *Converter) TypeResult {
+	elem := arrayElementToLisette(arr.Elem(), seen, conv)
+	if elem.SkipReason != nil {
+		return elem
+	}
+	return TypeResult{
+		LisetteType: fmt.Sprintf("Slice<%s>", elem.LisetteType),
+		ArrayReturn: true,
+	}
+}
+
+func arraySliceTypeResult(arr *types.Array, seen map[types.Type]bool, conv *Converter) TypeResult {
+	elem := arrayElementToLisette(arr.Elem(), seen, conv)
+	if elem.SkipReason != nil {
+		return elem
+	}
+	return TypeResult{LisetteType: fmt.Sprintf("Slice<%s>", elem.LisetteType)}
+}
+
+func arrayElementToLisette(t types.Type, seen map[types.Type]bool, conv *Converter) TypeResult {
+	if inner := unwrapArray(t); inner != nil {
+		return arraySliceTypeResult(inner, seen, conv)
+	}
+	return toLisetteRecursive(t, seen, conv)
 }
 
 func isInternalPackagePath(path string) bool {

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -2,6 +2,7 @@ package emit
 
 import (
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -9,6 +10,10 @@ import (
 	"github.com/ivov/lisette/bindgen/internal/convert"
 	"github.com/ivov/lisette/bindgen/internal/extract"
 )
+
+func writeSkippedFieldComment(w io.Writer, indent string, f convert.StructField) {
+	fmt.Fprintf(w, "%s// SKIPPED field %q: %s — %s\n", indent, f.Name, f.SkipReason.Code, f.SkipReason.Message)
+}
 
 type stats struct {
 	functions int
@@ -181,6 +186,19 @@ func (e *Emitter) collectMethod(result convert.ConvertResult) bool {
 	return true
 }
 
+// CollectSkippedMethod buckets a skipped method under its receiver type so
+// the impl block renders a `// SKIPPED method` comment in place of the
+// unrepresentable signature. Returns false when the receiver could not be
+// established (in which case the caller falls back to a top-level skip).
+func (e *Emitter) CollectSkippedMethod(result convert.ConvertResult) bool {
+	if result.Receiver == nil || result.Receiver.BaseTypeName == "" {
+		return false
+	}
+	e.methods[result.Receiver.BaseTypeName] = append(e.methods[result.Receiver.BaseTypeName], result)
+	e.skipped++
+	return true
+}
+
 func (e *Emitter) EmitUnloadableNote(firstError string) {
 	e.buf.WriteString("// Status: UNLOADABLE — package could not be type-checked on this host\n")
 	fmt.Fprintf(&e.buf, "// First error: %s\n", firstError)
@@ -329,6 +347,11 @@ func (e *Emitter) shouldAllowUnusedResult(qualifiedName, methodName string, resu
 }
 
 func (e *Emitter) emitMethodInImpl(result convert.ConvertResult) {
+	if result.SkipReason != nil {
+		fmt.Fprintf(&e.buf, "  // SKIPPED method %q: %s — %s\n", result.Name, result.SkipReason.Code, result.SkipReason.Message)
+		return
+	}
+
 	e.emitDocWithIndent(result.Doc, "  ")
 
 	if result.CommaOk {
@@ -436,6 +459,22 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 	}
 
 	if len(result.Fields) > 0 {
+		allSkipped := true
+		for _, f := range result.Fields {
+			if f.SkipReason == nil {
+				allSkipped = false
+				break
+			}
+		}
+
+		if allSkipped {
+			for _, f := range result.Fields {
+				writeSkippedFieldComment(&e.buf, "", f)
+			}
+			fmt.Fprintf(&e.buf, "pub type %s%s\n\n", typeName, result.TypeParams.DeclBlock())
+			return
+		}
+
 		var sig strings.Builder
 		sig.WriteString("pub struct ")
 		sig.WriteString(typeName)
@@ -443,6 +482,10 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 
 		sig.WriteString(" {\n")
 		for _, f := range result.Fields {
+			if f.SkipReason != nil {
+				writeSkippedFieldComment(&sig, "  ", f)
+				continue
+			}
 			if f.Doc != "" {
 				for line := range strings.SplitSeq(f.Doc, "\n") {
 					sig.WriteString("  /// ")

--- a/bindgen/tests/testdata/fixtures/aliases/aliases.go
+++ b/bindgen/tests/testdata/fixtures/aliases/aliases.go
@@ -38,3 +38,11 @@ type Callback func()
 
 // Processor processes data.
 type Processor func(data []byte) []byte
+
+// Alias-to-array — return position must lower to Slice + #[go(array_return)]
+// after peeling the alias.
+type Digest = [32]byte
+
+func ComputeDigest() Digest {
+	return Digest{}
+}

--- a/bindgen/tests/testdata/fixtures/skipped/skipped.go
+++ b/bindgen/tests/testdata/fixtures/skipped/skipped.go
@@ -74,3 +74,42 @@ func MakeOpaqueFunc() OpaqueFunc  { return nil }
 func UseOpaqueFunc(fn OpaqueFunc) {}
 
 var DefaultOpaqueFunc OpaqueFunc
+
+// Should skip: bare fixed-size array param has no inverse-conversion machinery
+// in emit, so generated Go would receive []T where [N]T is required.
+func TakesArray(addr [4]byte) {}
+
+// Should skip: array param on the receiver method, same reason.
+type ArrayParamHolder struct{}
+
+func (a ArrayParamHolder) Set(addr [4]byte) {}
+
+// Should skip: array as map key produces an uncomparable Lisette type.
+type ArrayKeyHolder struct {
+	Pairs map[[2]uint16]int
+	Name  string
+}
+
+// Should skip: array used as map key in a parameter.
+func TakesArrayKeyMap(m map[[2]uint16]int) {}
+
+// Aliases collapse to bare arrays via *types.Alias RHS recursion. Both
+// the param and the map-key positions through an alias must skip.
+type AliasToArray = [4]byte
+
+func TakesAliasArray(addr AliasToArray) {}
+
+type AliasArrayKeyHolder struct {
+	Pairs map[AliasToArray]int
+	Name  string
+}
+
+// Arrays inside other structural positions: slice element, map value, and
+// pointer must all propagate the skip rather than leaking a slice-shaped
+// Lisette type.
+type ArrayInStructPositions struct {
+	SliceOfArr  [][3]int
+	MapValArr   map[string][3]int
+	PtrToArr    *[3]int
+	DirectField [3]int
+}

--- a/bindgen/tests/testdata/snapshots/aliases.d.lis
+++ b/bindgen/tests/testdata/snapshots/aliases.d.lis
@@ -3,6 +3,9 @@
 // Go: 0.0.0
 // Lisette: 0.0.0
 
+#[go(array_return)]
+pub fn ComputeDigest() -> Slice<uint8>
+
 pub fn GetMap() -> Map<string, int>
 
 pub fn TakeAlias(s: string) -> Slice<int>
@@ -15,6 +18,10 @@ pub type AliasStringMap = Map<string, int>
 
 /// Callback is a simple callback function.
 pub type Callback = fn() -> ()
+
+// SKIPPED: Digest - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
+pub type Digest
 
 /// Handler is a function that handles requests.
 pub type Handler = fn(string) -> Result<string, error>

--- a/bindgen/tests/testdata/snapshots/functions.d.lis
+++ b/bindgen/tests/testdata/snapshots/functions.d.lis
@@ -23,9 +23,11 @@ pub struct BadHandler {
 }
 
 /// Function type returning skipped type with ok - tests analyzeReturns skip in Option path
+// SKIPPED field "Check": anonymous-struct — anonymous struct types are not supported
 pub type BadOptionFn
 
 /// Function type returning skipped type with error - tests analyzeReturns skip in Result path
+// SKIPPED field "Run": anonymous-struct — anonymous struct types are not supported
 pub type BadResultFn
 
 /// Function type with just error return - tests single error path
@@ -57,6 +59,7 @@ pub struct Node {
 pub type SimpleCallback = fn() -> ()
 
 /// Function type returning multiple skipped types - tests collectReturnTypes skip in tuple path
+// SKIPPED field "GetPair": anonymous-struct — anonymous struct types are not supported
 pub type TupleSkip
 
 pub type Variadic = fn(string, VarArgs<int>) -> Result<(), error>

--- a/bindgen/tests/testdata/snapshots/internalref.d.lis
+++ b/bindgen/tests/testdata/snapshots/internalref.d.lis
@@ -13,6 +13,7 @@ pub fn GetInner() -> Option<Unknown>
 /// that still emits its remaining exported fields.
 pub struct Holder {
   pub Name: string,
+  // SKIPPED field "Inner": internal-package-ref — references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/internalref/internal/inner"
 }
 
 /// Should be unaffected by the internal-package check.

--- a/bindgen/tests/testdata/snapshots/methods.d.lis
+++ b/bindgen/tests/testdata/snapshots/methods.d.lis
@@ -10,6 +10,7 @@ pub type A
 pub type B
 
 /// Type with anonymous struct field - methods should skip due to receiver type
+// SKIPPED field "Data": anonymous-struct — anonymous struct types are not supported
 pub type BadReceiver
 
 pub struct Counter {

--- a/bindgen/tests/testdata/snapshots/skipped.d.lis
+++ b/bindgen/tests/testdata/snapshots/skipped.d.lis
@@ -19,6 +19,15 @@ pub fn MakeOpaqueFunc() -> OpaqueFunc
 // SKIPPED: SkippedMin - constraint:comparable
 // type constraint T cannot be represented
 
+// SKIPPED: TakesAliasArray - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
+
+// SKIPPED: TakesArray - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
+
+// SKIPPED: TakesArrayKeyMap - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
+
 /// Should be skipped: unsafe.Pointer
 pub fn UnsafeFunc(p: Unknown)
 
@@ -30,11 +39,44 @@ pub fn UnsafeReturn() -> Unknown
 
 pub fn UseOpaqueFunc(fn_: OpaqueFunc)
 
+pub struct AliasArrayKeyHolder {
+  // SKIPPED field "Pairs": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  pub Name: string,
+}
+
+// SKIPPED: AliasToArray - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
+pub type AliasToArray
+
+/// Arrays inside other structural positions: slice element, map value, and
+/// pointer must all propagate the skip rather than leaking a slice-shaped
+/// Lisette type.
+// SKIPPED field "SliceOfArr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+// SKIPPED field "MapValArr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+// SKIPPED field "PtrToArr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+// SKIPPED field "DirectField": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+pub type ArrayInStructPositions
+
+/// Should skip: array as map key produces an uncomparable Lisette type.
+pub struct ArrayKeyHolder {
+  // SKIPPED field "Pairs": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  pub Name: string,
+}
+
+/// Should skip: array param on the receiver method, same reason.
+pub type ArrayParamHolder
+
 pub struct HasUnsafe {
   pub Ptr: Unknown,
 }
 
 /// Nested anonymous structs - tests skip propagation in toLisetteInner
+// SKIPPED field "SliceAnon": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "ArrayAnon": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "MapKeyAnon": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "MapValAnon": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "PtrAnon": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "ChanAnon": anonymous-struct — anonymous struct types are not supported
 pub type NestedAnon
 
 // SKIPPED: OpaqueFunc - anonymous-struct
@@ -44,6 +86,7 @@ pub type OpaqueFunc
 /// Should be skipped: constrained generic (non-any)
 pub type Ordered
 
+// SKIPPED field "Field": anonymous-struct — anonymous struct types are not supported
 pub type Public
 
 /// Should NOT skip: normal struct
@@ -59,6 +102,10 @@ pub struct UnsafeStruct {
 }
 
 pub var DefaultOpaqueFunc: OpaqueFunc
+
+impl ArrayParamHolder {
+  // SKIPPED method "Set": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+}
 
 impl SafeStruct {
   /// Method on safe struct

--- a/crates/stdlib/typedefs/crypto/tls.d.lis
+++ b/crates/stdlib/typedefs/crypto/tls.d.lis
@@ -265,7 +265,7 @@ pub struct Config {
   pub CipherSuites: Slice<uint16>,
   pub PreferServerCipherSuites: bool,
   pub SessionTicketsDisabled: bool,
-  pub SessionTicketKey: Slice<uint8>,
+  // SKIPPED field "SessionTicketKey": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub ClientSessionCache: Option<ClientSessionCache>,
   pub UnwrapSession: Option<fn(Slice<uint8>, ConnectionState) -> Result<Ref<SessionState>, error>>,
   pub WrapSession: Option<fn(ConnectionState, Ref<SessionState>) -> Result<Slice<uint8>, error>>,
@@ -360,7 +360,7 @@ pub struct QUICSessionTicketOptions {
 /// RecordHeaderError is returned when a TLS record header is invalid.
 pub struct RecordHeaderError {
   pub Msg: string,
-  pub RecordHeader: Slice<uint8>,
+  // SKIPPED field "RecordHeader": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Conn: Option<net.Conn>,
 }
 
@@ -667,20 +667,7 @@ impl Config {
     ss: Ref<SessionState>,
   ) -> Result<Slice<uint8>, error>
 
-  /// SetSessionTicketKeys updates the session ticket keys for a server.
-  /// 
-  /// The first key will be used when creating new tickets, while all keys can be
-  /// used for decrypting tickets. It is safe to call this function while the
-  /// server is running in order to rotate the session ticket keys. The function
-  /// will panic if keys is empty.
-  /// 
-  /// Calling this function will turn off automatic session ticket key rotation.
-  /// 
-  /// If multiple servers are terminating connections for the same host they should
-  /// all have the same session ticket keys. If the session ticket keys leaks,
-  /// previously recorded and future TLS connections using those keys might be
-  /// compromised.
-  fn SetSessionTicketKeys(self: Ref<Config>, keys: Slice<Slice<uint8>>)
+  // SKIPPED method "SetSessionTicketKeys": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 impl Conn {

--- a/crates/stdlib/typedefs/debug/dwarf.d.lis
+++ b/crates/stdlib/typedefs/debug/dwarf.d.lis
@@ -1078,7 +1078,7 @@ impl Data {
   /// Ranges returns the PC ranges covered by e, a slice of [low,high) pairs.
   /// Only some entry types, such as [TagCompileUnit] or [TagSubprogram], have PC
   /// ranges; for others, this will return nil with no error.
-  fn Ranges(self: Ref<Data>, e: Ref<Entry>) -> Result<Slice<Slice<uint64>>, error>
+  fn Ranges(self: Ref<Data>, e: Ref<Entry>) -> Result<Unknown, error>
 
   /// Reader returns a new Reader for [Data].
   /// The reader is positioned at byte offset 0 in the DWARF “info” section.

--- a/crates/stdlib/typedefs/debug/elf.d.lis
+++ b/crates/stdlib/typedefs/debug/elf.d.lis
@@ -4390,7 +4390,7 @@ pub type FormatError
 
 /// ELF32 File header.
 pub struct Header32 {
-  pub Ident: Slice<uint8>,
+  // SKIPPED field "Ident": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Type: uint16,
   pub Machine: uint16,
   pub Version: uint32,
@@ -4408,7 +4408,7 @@ pub struct Header32 {
 
 /// ELF64 file header.
 pub struct Header64 {
-  pub Ident: Slice<uint8>,
+  // SKIPPED field "Ident": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Type: uint16,
   pub Machine: uint16,
   pub Version: uint32,

--- a/crates/stdlib/typedefs/debug/macho.d.lis
+++ b/crates/stdlib/typedefs/debug/macho.d.lis
@@ -388,8 +388,8 @@ pub struct Section {
 
 /// A Section32 is a 32-bit Mach-O section header.
 pub struct Section32 {
-  pub Name: Slice<uint8>,
-  pub Seg: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Seg": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Addr: uint32,
   pub Size: uint32,
   pub Offset: uint32,
@@ -403,8 +403,8 @@ pub struct Section32 {
 
 /// A Section64 is a 64-bit Mach-O section header.
 pub struct Section64 {
-  pub Name: Slice<uint8>,
-  pub Seg: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Seg": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Addr: uint64,
   pub Size: uint64,
   pub Offset: uint32,
@@ -440,7 +440,7 @@ pub struct Segment {
 pub struct Segment32 {
   pub Cmd: LoadCmd,
   pub Len: uint32,
-  pub Name: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Addr: uint32,
   pub Memsz: uint32,
   pub Offset: uint32,
@@ -455,7 +455,7 @@ pub struct Segment32 {
 pub struct Segment64 {
   pub Cmd: LoadCmd,
   pub Len: uint32,
-  pub Name: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Addr: uint64,
   pub Memsz: uint64,
   pub Offset: uint64,

--- a/crates/stdlib/typedefs/debug/pe.d.lis
+++ b/crates/stdlib/typedefs/debug/pe.d.lis
@@ -12,7 +12,7 @@ pub fn Open(name: string) -> Result<Ref<File>, error>
 
 /// COFFSymbol represents single COFF symbol table record.
 pub struct COFFSymbol {
-  pub Name: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Value: uint32,
   pub SectionNumber: int16,
   pub Type: uint16,
@@ -105,7 +105,7 @@ pub struct OptionalHeader32 {
   pub SizeOfHeapCommit: uint32,
   pub LoaderFlags: uint32,
   pub NumberOfRvaAndSizes: uint32,
-  pub DataDirectory: Slice<DataDirectory>,
+  // SKIPPED field "DataDirectory": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct OptionalHeader64 {
@@ -138,7 +138,7 @@ pub struct OptionalHeader64 {
   pub SizeOfHeapCommit: uint64,
   pub LoaderFlags: uint32,
   pub NumberOfRvaAndSizes: uint32,
-  pub DataDirectory: Slice<DataDirectory>,
+  // SKIPPED field "DataDirectory": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 /// Reloc represents a PE COFF relocation.
@@ -173,7 +173,7 @@ pub struct SectionHeader {
 
 /// SectionHeader32 represents real PE COFF section header.
 pub struct SectionHeader32 {
-  pub Name: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub VirtualSize: uint32,
   pub VirtualAddress: uint32,
   pub SizeOfRawData: uint32,

--- a/crates/stdlib/typedefs/math/rand/v2.d.lis
+++ b/crates/stdlib/typedefs/math/rand/v2.d.lis
@@ -52,7 +52,8 @@ pub fn IntN(n: int) -> int
 
 pub fn New(src: Source) -> Ref<Rand>
 
-pub fn NewChaCha8(seed: Slice<uint8>) -> Ref<ChaCha8>
+// SKIPPED: NewChaCha8 - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
 
 pub fn NewPCG(seed1: uint64, seed2: uint64) -> Ref<PCG>
 
@@ -140,9 +141,7 @@ impl ChaCha8 {
   /// the last call to Uint64.
   fn Read(self: Ref<ChaCha8>, mut p: Slice<uint8>) -> Partial<int, error>
 
-  /// Seed resets the ChaCha8 to behave the same way as NewChaCha8(seed).
-  fn Seed(self: Ref<ChaCha8>, seed: Slice<uint8>)
-
+  // SKIPPED method "Seed": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   /// Uint64 returns a uniformly distributed random uint64 value.
   fn Uint64(self: Ref<ChaCha8>) -> uint64
 

--- a/crates/stdlib/typedefs/net/netip.d.lis
+++ b/crates/stdlib/typedefs/net/netip.d.lis
@@ -3,9 +3,11 @@
 // Go: 1.25.5
 // Lisette: 0.1.20
 
-pub fn AddrFrom16(addr: Slice<uint8>) -> Addr
+// SKIPPED: AddrFrom16 - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
 
-pub fn AddrFrom4(addr: Slice<uint8>) -> Addr
+// SKIPPED: AddrFrom4 - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
 
 pub fn AddrFromSlice(slice: Slice<uint8>) -> Option<Addr>
 

--- a/crates/stdlib/typedefs/regexp/syntax.d.lis
+++ b/crates/stdlib/typedefs/regexp/syntax.d.lis
@@ -194,9 +194,9 @@ pub struct Regexp {
   pub Op: Op,
   pub Flags: Flags,
   pub Sub: Slice<Option<Ref<Regexp>>>,
-  pub Sub0: Slice<Option<Ref<Regexp>>>,
+  // SKIPPED field "Sub0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Rune: Slice<int32>,
-  pub Rune0: Slice<int32>,
+  // SKIPPED field "Rune0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Min: int,
   pub Max: int,
   pub Cap: int,

--- a/crates/stdlib/typedefs/runtime.d.lis
+++ b/crates/stdlib/typedefs/runtime.d.lis
@@ -649,7 +649,7 @@ pub struct MemProfileRecord {
   pub FreeBytes: int64,
   pub AllocObjects: int64,
   pub FreeObjects: int64,
-  pub Stack0: Slice<uint>,
+  // SKIPPED field "Stack0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 /// A MemStats records statistics about the memory allocator.
@@ -678,13 +678,14 @@ pub struct MemStats {
   pub NextGC: uint64,
   pub LastGC: uint64,
   pub PauseTotalNs: uint64,
-  pub PauseNs: Slice<uint64>,
-  pub PauseEnd: Slice<uint64>,
+  // SKIPPED field "PauseNs": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "PauseEnd": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub NumGC: uint32,
   pub NumForcedGC: uint32,
   pub GCCPUFraction: float64,
   pub EnableGC: bool,
   pub DebugGC: bool,
+  // SKIPPED field "BySize": anonymous-struct — anonymous struct types are not supported
 }
 
 /// A PanicNilError happens when code calls panic(nil).
@@ -699,10 +700,9 @@ pub type PanicNilError
 /// objects. See their comments for more information.
 pub type Pinner
 
+// SKIPPED field "Stack0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 /// A StackRecord describes a single execution stack.
-pub struct StackRecord {
-  pub Stack0: Slice<uint>,
-}
+pub type StackRecord
 
 /// A TypeAssertionError explains a failed type assertion.
 pub type TypeAssertionError

--- a/crates/stdlib/typedefs/syscall.d.lis
+++ b/crates/stdlib/typedefs/syscall.d.lis
@@ -959,7 +959,8 @@ pub fn SetsockoptIPMreq(fd: int, level: int, opt: int, mreq: Ref<IPMreq>) -> Res
 
 pub fn SetsockoptIPv6Mreq(fd: int, level: int, opt: int, mreq: Ref<IPv6Mreq>) -> Result<(), error>
 
-pub fn SetsockoptInet4Addr(fd: int, level: int, opt: int, value: Slice<uint8>) -> Result<(), error>
+// SKIPPED: SetsockoptInet4Addr - array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
 
 pub fn SetsockoptInt(fd: int, level: int, opt: int, value: int) -> Result<(), error>
 
@@ -1085,7 +1086,7 @@ pub struct BpfHdr {
   pub Caplen: uint32,
   pub Datalen: uint32,
   pub Hdrlen: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct BpfInsn {
@@ -1097,7 +1098,7 @@ pub struct BpfInsn {
 
 pub struct BpfProgram {
   pub Len: uint32,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Insns: Option<Ref<BpfInsn>>,
 }
 
@@ -1138,8 +1139,8 @@ pub struct Dirent {
   pub Reclen: uint16,
   pub Namlen: uint16,
   pub Type: uint8,
-  pub Name: Slice<int8>,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Name": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct Fbootstraptransfer_t {
@@ -1148,9 +1149,8 @@ pub struct Fbootstraptransfer_t {
   pub Buffer: Option<Ref<uint8>>,
 }
 
-pub struct FdSet {
-  pub Bits: Slice<int32>,
-}
+// SKIPPED field "Bits": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+pub type FdSet
 
 pub struct Flock_t {
   pub Start: int64,
@@ -1160,9 +1160,8 @@ pub struct Flock_t {
   pub Whence: int16,
 }
 
-pub struct Fsid {
-  pub Val: Slice<int32>,
-}
+// SKIPPED field "Val": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+pub type Fsid
 
 pub struct Fstore_t {
   pub Flags: uint32,
@@ -1172,14 +1171,12 @@ pub struct Fstore_t {
   pub Bytesalloc: int64,
 }
 
-pub struct ICMPv6Filter {
-  pub Filt: Slice<uint32>,
-}
+// SKIPPED field "Filt": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+pub type ICMPv6Filter
 
-pub struct IPMreq {
-  pub Multiaddr: Slice<uint8>,
-  pub Interface: Slice<uint8>,
-}
+// SKIPPED field "Multiaddr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+// SKIPPED field "Interface": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+pub type IPMreq
 
 pub struct IPv6MTUInfo {
   pub Addr: RawSockaddrInet6,
@@ -1187,7 +1184,7 @@ pub struct IPv6MTUInfo {
 }
 
 pub struct IPv6Mreq {
-  pub Multiaddr: Slice<uint8>,
+  // SKIPPED field "Multiaddr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Interface: uint32,
 }
 
@@ -1230,7 +1227,7 @@ pub struct IfMsghdr {
   pub Addrs: int32,
   pub Flags: int32,
   pub Index: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Data: IfData,
 }
 
@@ -1241,7 +1238,7 @@ pub struct IfaMsghdr {
   pub Addrs: int32,
   pub Flags: int32,
   pub Index: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Metric: int32,
 }
 
@@ -1252,7 +1249,7 @@ pub struct IfmaMsghdr {
   pub Addrs: int32,
   pub Flags: int32,
   pub Index: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct IfmaMsghdr2 {
@@ -1262,18 +1259,18 @@ pub struct IfmaMsghdr2 {
   pub Addrs: int32,
   pub Flags: int32,
   pub Index: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Refcount: int32,
 }
 
 pub struct Inet4Pktinfo {
   pub Ifindex: uint32,
-  pub Spec_dst: Slice<uint8>,
-  pub Addr: Slice<uint8>,
+  // SKIPPED field "Spec_dst": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct Inet6Pktinfo {
-  pub Addr: Slice<uint8>,
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Ifindex: uint32,
 }
 
@@ -1332,10 +1329,10 @@ pub struct Log2phys_t {
 pub struct Msghdr {
   pub Name: Option<Ref<uint8>>,
   pub Namelen: uint32,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Iov: Option<Ref<Iovec>>,
   pub Iovlen: int32,
-  pub Pad_cgo_1: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_1": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Control: Option<Ref<uint8>>,
   pub Controllen: uint32,
   pub Flags: int32,
@@ -1353,7 +1350,7 @@ pub struct ProcAttr {
 pub struct Radvisory_t {
   pub Offset: int64,
   pub Count: int32,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 /// A RawConn is a raw network connection.
@@ -1366,12 +1363,12 @@ pub interface RawConn {
 pub struct RawSockaddr {
   pub Len: uint8,
   pub Family: uint8,
-  pub Data: Slice<int8>,
+  // SKIPPED field "Data": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct RawSockaddrAny {
   pub Addr: RawSockaddr,
-  pub Pad: Slice<int8>,
+  // SKIPPED field "Pad": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct RawSockaddrDatalink {
@@ -1382,15 +1379,15 @@ pub struct RawSockaddrDatalink {
   pub Nlen: uint8,
   pub Alen: uint8,
   pub Slen: uint8,
-  pub Data: Slice<int8>,
+  // SKIPPED field "Data": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct RawSockaddrInet4 {
   pub Len: uint8,
   pub Family: uint8,
   pub Port: uint16,
-  pub Addr: Slice<uint8>,
-  pub Zero: Slice<int8>,
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Zero": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct RawSockaddrInet6 {
@@ -1398,14 +1395,14 @@ pub struct RawSockaddrInet6 {
   pub Family: uint8,
   pub Port: uint16,
   pub Flowinfo: uint32,
-  pub Addr: Slice<uint8>,
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Scope_id: uint32,
 }
 
 pub struct RawSockaddrUnix {
   pub Len: uint8,
   pub Family: uint8,
-  pub Path: Slice<int8>,
+  // SKIPPED field "Path": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct Rlimit {
@@ -1438,7 +1435,7 @@ pub struct RtMetrics {
   pub Rtt: uint32,
   pub Rttvar: uint32,
   pub Pksent: uint32,
-  pub Filler: Slice<uint32>,
+  // SKIPPED field "Filler": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct RtMsghdr {
@@ -1446,7 +1443,7 @@ pub struct RtMsghdr {
   pub Version: uint8,
   pub Type: uint8,
   pub Index: uint16,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Flags: int32,
   pub Addrs: int32,
   pub Pid: int32,
@@ -1486,18 +1483,18 @@ pub struct SockaddrDatalink {
   pub Nlen: uint8,
   pub Alen: uint8,
   pub Slen: uint8,
-  pub Data: Slice<int8>,
+  // SKIPPED field "Data": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct SockaddrInet4 {
   pub Port: int,
-  pub Addr: Slice<uint8>,
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct SockaddrInet6 {
   pub Port: int,
   pub ZoneId: uint32,
-  pub Addr: Slice<uint8>,
+  // SKIPPED field "Addr": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct SockaddrUnix {
@@ -1518,7 +1515,7 @@ pub struct Stat_t {
   pub Uid: uint32,
   pub Gid: uint32,
   pub Rdev: int32,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Atimespec: Timespec,
   pub Mtimespec: Timespec,
   pub Ctimespec: Timespec,
@@ -1529,7 +1526,7 @@ pub struct Stat_t {
   pub Flags: uint32,
   pub Gen: uint32,
   pub Lspare: int32,
-  pub Qspare: Slice<int64>,
+  // SKIPPED field "Qspare": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct Statfs_t {
@@ -1545,10 +1542,10 @@ pub struct Statfs_t {
   pub Type: uint32,
   pub Flags: uint32,
   pub Fssubtype: uint32,
-  pub Fstypename: Slice<int8>,
-  pub Mntonname: Slice<int8>,
-  pub Mntfromname: Slice<int8>,
-  pub Reserved: Slice<uint32>,
+  // SKIPPED field "Fstypename": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Mntonname": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Mntfromname": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Reserved": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct SysProcAttr {
@@ -1569,8 +1566,8 @@ pub struct Termios {
   pub Oflag: uint64,
   pub Cflag: uint64,
   pub Lflag: uint64,
-  pub Cc: Slice<uint8>,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Cc": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
   pub Ispeed: uint64,
   pub Ospeed: uint64,
 }
@@ -1583,7 +1580,7 @@ pub struct Timespec {
 pub struct Timeval {
   pub Sec: int64,
   pub Usec: int32,
-  pub Pad_cgo_0: Slice<uint8>,
+  // SKIPPED field "Pad_cgo_0": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 pub struct Timeval32 {

--- a/crates/stdlib/typedefs/unicode.d.lis
+++ b/crates/stdlib/typedefs/unicode.d.lis
@@ -115,7 +115,7 @@ pub fn ToUpper(r: int32) -> int32
 pub struct CaseRange {
   pub Lo: uint32,
   pub Hi: uint32,
-  pub Delta: Slice<int32>,
+  // SKIPPED field "Delta": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
 /// Range16 represents of a range of 16-bit Unicode code points. The range runs from Lo to Hi

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -53,10 +53,7 @@ impl<'source> Parser<'source> {
                     };
                 }
                 let span = self.span_from_tokens(start);
-                self.track_error(
-                    "unexpected `[` in type",
-                    "Use `Slice<T>` for slice types or `Array<T, N>` for fixed-size arrays.",
-                );
+                self.track_error("unexpected `[` in type", "Use `Slice<T>` for slice types.");
                 Annotation::Constructor {
                     name: "".into(),
                     params: vec![],

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -58,6 +58,8 @@ Compound types are different:
 | `VarArgs<T>`    | `...T` (call-site only)      |
 | `Unknown`       | `any` or `interface{}`       |
 
+Fixed-size arrays `[N]T` are not yet representable in Lisette. In return position they lower to `Slice<T>`. In any other position (e.g. parameters, struct fields, map keys, slice or map elements), bindgen currently skips the declaration. This may change in future.
+
 ### Named numeric types
 
 Go defines types like `time.Duration` as aliases for numeric primitives: `type Duration int64`. Go's nominal type system requires explicit casts for arithmetic between these types and their underlying type.


### PR DESCRIPTION
Bindgen now skips Go fixed-size arrays `[N]T` in non-return positions instead of lowering them to `Slice<T>`. This reflects the fact that Lisette cannot faithfully represent them yet.

The lowering on `main` was producing bindings incompatible with the actual Go type or rejected by the Lis type checker (slices are not comparable, so a `map[[N]T]V` key could not round-trip).

```rs
pub struct Holder {
  // SKIPPED field "Pairs": array-currently-not-representable
  pub Name: string,
}
```

Related: #223
