### PR TITLE
ci: fix release-publish iteration on workspace crates

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,12 +47,11 @@ jobs:
           RELEASES: ${{ steps.release.outputs.releases }}
         run: |
           set -euo pipefail
-          for release in $(echo "$RELEASES" | jq -r -c '.[]'); do
-            TAG=$(echo "$release" | jq -er '.tag')
-            git-cliff --config cliff.toml --tag "$TAG" --unreleased --strip all > /tmp/notes.md
-            gh release edit "$TAG" --notes-file /tmp/notes.md
-            { grep -oE 'pull/[0-9]+' /tmp/notes.md || true; } | cut -d/ -f2 | sort -u > "/tmp/prs-${TAG}.txt"
-          done
+          TAG=$(echo "$RELEASES" | jq -er '.[] | select(.package_name == "lisette") | .tag')
+          git fetch --tags origin
+          git-cliff --config cliff.toml --latest --strip all | tail -n +3 > /tmp/notes.md
+          gh release edit "$TAG" --notes-file /tmp/notes.md
+          { grep -oE 'pull/[0-9]+' /tmp/notes.md || true; } | cut -d/ -f2 | sort -u > "/tmp/prs-${TAG}.txt"
 
       # Tags are created via the GitHub REST API with GITHUB_TOKEN (not git push with the PAT)
       # so they do not trigger the cargo-dist release workflow.
@@ -79,18 +78,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ steps.release.outputs.releases }}
         run: |
-          for release in $(echo "$RELEASES" | jq -r -c '.[]'); do
-            TAG=$(echo "$release" | jq -r '.tag')
-            RELEASE_LINK="[\`${TAG}\`](https://github.com/ivov/lisette/releases/tag/${TAG})"
-            declare -A COMMENTED_ISSUES
-            while IFS= read -r pr; do
-              [ -z "$pr" ] && continue
-              gh pr comment "$pr" --body "Released in ${RELEASE_LINK}" || true
-              for issue in $(gh pr view "$pr" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true); do
-                if [[ -z "${COMMENTED_ISSUES[$issue]:-}" ]]; then
-                  gh issue comment "$issue" --body "Addressed in ${RELEASE_LINK}" || true
-                  COMMENTED_ISSUES[$issue]=1
-                fi
-              done
-            done < "/tmp/prs-${TAG}.txt"
-          done
+          TAG=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "lisette") | .tag')
+          RELEASE_LINK="[\`${TAG}\`](https://github.com/ivov/lisette/releases/tag/${TAG})"
+          declare -A COMMENTED_ISSUES
+          while IFS= read -r pr; do
+            [ -z "$pr" ] && continue
+            gh pr comment "$pr" --body "Released in ${RELEASE_LINK}" || true
+            for issue in $(gh pr view "$pr" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true); do
+              if [[ -z "${COMMENTED_ISSUES[$issue]:-}" ]]; then
+                gh issue comment "$issue" --body "Addressed in ${RELEASE_LINK}" || true
+                COMMENTED_ISSUES[$issue]=1
+              fi
+            done
+          done < "/tmp/prs-${TAG}.txt"


### PR DESCRIPTION
#235 broke the release. The new release notes step iterated on every workspace crate from the `release-plz` output, failed on the first one (no GH release exists for internal crates), and aborted before tagging Go modules.

This PR scopes the faulty step to the `lisette` package and switches `git-cliff` to `--latest` so it works after the release tag exists. Same scoping applied to the comment step.