### PR TITLE
fix: preserve substitution through generic alias peeling

### DIFF
--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -155,43 +155,26 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn peel_alias(&self, ty: &Type) -> Type {
-        let mut current = ty.unwrap_forall().clone();
-        let mut seen: Vec<String> = Vec::new();
-        loop {
-            let Type::Nominal { id, .. } = &current else {
-                return current;
-            };
-            if seen.iter().any(|s| s == id.as_str()) {
-                return current;
-            }
-            let Some(Definition::TypeAlias { ty: alias_ty, .. }) =
-                self.ctx.definitions.get(id.as_str())
-            else {
-                return current;
-            };
-            seen.push(id.to_string());
-            current = alias_ty.unwrap_forall().clone();
-        }
+        syntax::types::peel_alias(ty, |id| {
+            self.ctx
+                .definitions
+                .get(id)
+                .is_some_and(Definition::is_type_alias)
+        })
     }
 
     pub(crate) fn peel_alias_id(&self, id: &str) -> String {
-        let mut current = id.to_string();
-        let mut seen: Vec<String> = Vec::new();
-        loop {
-            if seen.iter().any(|s| s == &current) {
-                return current;
-            }
+        syntax::types::peel_alias_id(id, |current| {
             let Some(Definition::TypeAlias { ty: alias_ty, .. }) =
-                self.ctx.definitions.get(current.as_str())
+                self.ctx.definitions.get(current)
             else {
-                return current;
+                return None;
             };
             let Type::Nominal { id: next, .. } = alias_ty.unwrap_forall() else {
-                return current;
+                return None;
             };
-            seen.push(current);
-            current = next.to_string();
-        }
+            Some(next.to_string())
+        })
     }
 
     pub(crate) fn as_enum(&self, ty: &Type) -> Option<String> {

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -246,22 +246,10 @@ impl Store {
     }
 
     pub fn peel_alias(&self, ty: &Type) -> Type {
-        let mut current = ty.clone();
-        while let Type::Nominal {
-            id,
-            underlying_ty: Some(u),
-            ..
-        } = &current
-        {
-            if !self
-                .get_definition(id)
-                .is_some_and(|d| matches!(d, Definition::TypeAlias { .. }))
-            {
-                break;
-            }
-            current = *u.clone();
-        }
-        current
+        syntax::types::peel_alias(ty, |id| {
+            self.get_definition(id)
+                .is_some_and(Definition::is_type_alias)
+        })
     }
 
     pub fn peel_alias_deep(&self, ty: &Type) -> Type {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -149,6 +149,10 @@ impl Definition {
         )
     }
 
+    pub fn is_type_alias(&self) -> bool {
+        matches!(self, Definition::TypeAlias { .. })
+    }
+
     pub fn name_span(&self) -> Option<Span> {
         match self {
             Definition::TypeAlias { name_span, .. } => Some(*name_span),

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1144,6 +1144,52 @@ impl Type {
     }
 }
 
+/// Walk an alias chain via `underlying_ty` (preserves substitution); cycle
+/// guard defends against chains that slip past `circular_type_alias`.
+pub fn peel_alias<F>(ty: &Type, is_alias: F) -> Type
+where
+    F: Fn(&str) -> bool,
+{
+    let mut current = ty.unwrap_forall().clone();
+    let mut seen: Vec<String> = Vec::new();
+    while let Type::Nominal {
+        id,
+        underlying_ty: Some(u),
+        ..
+    } = &current
+    {
+        if !is_alias(id.as_str()) {
+            break;
+        }
+        if seen.iter().any(|s| s == id.as_str()) {
+            break;
+        }
+        seen.push(id.to_string());
+        current = u.unwrap_forall().clone();
+    }
+    current
+}
+
+/// Walk an alias chain by id alone; used when no `Type` with
+/// `underlying_ty` is available (e.g. Go-name resolution).
+pub fn peel_alias_id<F>(id: &str, next_alias: F) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut current = id.to_string();
+    let mut seen: Vec<String> = Vec::new();
+    loop {
+        if seen.iter().any(|s| s == &current) {
+            return current;
+        }
+        let Some(next) = next_alias(&current) else {
+            return current;
+        };
+        seen.push(current);
+        current = next;
+    }
+}
+
 impl Type {
     pub fn unwrap_forall(&self) -> &Type {
         match self {

--- a/tests/spec/emit/snapshots/generic_alias_of_option_in_return_position.snap
+++ b/tests/spec/emit/snapshots/generic_alias_of_option_in_return_position.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Maybe<T> = Option<T>\n\nfn test() -> Maybe<int> {\n  Some(42)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Maybe[T any] = lisette.Option[T]
+
+func test() (int, bool) {
+	return 42, true
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1228,6 +1228,18 @@ struct User {
 }
 
 #[test]
+fn generic_alias_of_option_in_return_position() {
+    let input = r#"
+type Maybe<T> = Option<T>
+
+fn test() -> Maybe<int> {
+  Some(42)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn prelude_type_shadowing_struct_and_methods() {
     let input = r#"
 struct Span {


### PR DESCRIPTION
Generic alias instantiations now retain their type args when peeled. Previously a function returning a generic alias of `Option`/`Result`/`Partial` lowered with the alias's bare type parameter, producing uncompilable Go.

```rs
type Maybe<T> = Option<T>

fn first() -> Maybe<int> {
  Some(42)
}
```

Before: `func first() (T, bool)`. After: `func first() (int, bool)`.