### PR TITLE
fix: report tail-position return-value mismatches

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -139,33 +139,42 @@ pub fn pattern_issue(span: &Span, kind: IssueKind) -> LisetteDiagnostic {
         .with_help(help)
 }
 
-pub fn discarded_result_in_tail(span: &Span, return_type: &str) -> LisetteDiagnostic {
-    LisetteDiagnostic::warn("`Result` is silently discarded")
-        .with_lint_code("unused_result")
-        .with_span_label(span, "failure will go unnoticed")
-        .with_help(format!(
-            "Handle this `Result` with `?` or `match`, explicitly discard it with `let _ = ...`, or return it by adding `-> {}` to the function signature",
-            return_type
-        ))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MismatchedTailKind {
+    Result,
+    Option,
+    Partial,
+    Value,
 }
 
-pub fn discarded_option_in_tail(span: &Span, return_type: &str) -> LisetteDiagnostic {
-    LisetteDiagnostic::warn("Unused Option")
-        .with_lint_code("unused_option")
-        .with_span_label(span, "this `Option` is discarded")
-        .with_help(format!(
-            "Handle this `Option`, explicitly discard it with `let _ = ...`, or return it by adding `-> {}` to the function signature",
-            return_type
-        ))
+impl MismatchedTailKind {
+    pub fn lint_code(&self) -> &'static str {
+        match self {
+            Self::Result => "unused_result",
+            Self::Option => "unused_option",
+            Self::Partial => "unused_partial",
+            Self::Value => "unused_value",
+        }
+    }
 }
 
-pub fn discarded_partial_in_tail(span: &Span, return_type: &str) -> LisetteDiagnostic {
-    LisetteDiagnostic::warn("`Partial` is silently discarded")
-        .with_lint_code("unused_partial")
-        .with_span_label(span, "partial result will go unnoticed")
+pub fn mismatched_tail_value(
+    actual_span: &Span,
+    actual_ty: &str,
+    expected_span: &Span,
+    expected_ty: &str,
+    kind: MismatchedTailKind,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Mismatch between return type and return value")
+        .with_lint_code(kind.lint_code())
+        .with_span_primary_label(actual_span, format!("returns `{}`", actual_ty))
+        .with_span_label(
+            expected_span,
+            format!("has `{}` as implicit return type", expected_ty),
+        )
         .with_help(format!(
-            "Handle this `Partial` with `match`, explicitly discard it with `let _ = ...`, or return it by adding `-> {}` to the function signature",
-            return_type
+            "If the `{}` return type is intended, discard the return value with `let _ = ...`. If the `{}` return value is intended, add `-> {}` to the function signature.",
+            expected_ty, actual_ty, actual_ty
         ))
 }
 
@@ -322,15 +331,6 @@ pub fn empty_match_arm(span: &Span) -> LisetteDiagnostic {
         .with_lint_code("empty_match_arm")
         .with_span_label(span, "forgotten stub?")
         .with_help("Return `()` to indicate an intentional no-op in a match arm")
-}
-
-pub fn discarded_lambda_value(span: &Span, body_ty: &str) -> LisetteDiagnostic {
-    LisetteDiagnostic::warn("Discarded lambda value")
-        .with_lint_code("discarded_lambda_value")
-        .with_span_label(span, format!("value of type `{}` is discarded", body_ty))
-        .with_help(
-            "The lambda signature requires `()`, which does not match the value it is returning. End the lambda body with `()` or bind the value with `let _ = expr`.",
-        )
 }
 
 pub fn unnecessary_parens(span: &Span, keyword: &str) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -149,6 +149,10 @@ pub enum MismatchedTailKind {
 
 impl MismatchedTailKind {
     pub fn lint_code(&self) -> &'static str {
+        "mismatched_return_value"
+    }
+
+    pub fn allow_alias(&self) -> &'static str {
         match self {
             Self::Result => "unused_result",
             Self::Option => "unused_option",

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -139,25 +139,22 @@ impl Emitter<'_> {
                 output.push('\n');
             }
             _ => {
-                let is_call = matches!(
-                    expression.unwrap_parens(),
-                    Expression::Call { .. } | Expression::Task { .. } | Expression::Defer { .. }
-                );
                 let unwrapped = expression.unwrap_parens();
-                let emitted = if let Expression::Call { .. } = unwrapped
-                    && let Some(raw) = self.emit_go_call_discarded(output, unwrapped)
-                {
-                    raw
-                } else if is_call {
-                    self.emit_operand(output, unwrapped)
-                } else {
-                    self.emit_operand(output, expression)
-                };
-                if !emitted.is_empty() {
-                    if is_call && !emitted.starts_with("append(") {
-                        write_line!(output, "{}", emitted);
-                    } else if emitted != "struct{}{}" {
-                        write_line!(output, "_ = {}", emitted);
+                match unwrapped {
+                    Expression::Task { .. } | Expression::Defer { .. } => {
+                        let emitted = self.emit_operand(output, unwrapped);
+                        if !emitted.is_empty() {
+                            write_line!(output, "{}", emitted);
+                        }
+                    }
+                    Expression::Call { .. } => {
+                        self.emit_discard(output, unwrapped);
+                    }
+                    _ => {
+                        let emitted = self.emit_operand(output, expression);
+                        if !emitted.is_empty() && emitted != "struct{}{}" {
+                            write_line!(output, "_ = {}", emitted);
+                        }
                     }
                 }
             }

--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -781,17 +781,19 @@ impl Emitter<'_> {
         LetEmitter::new(self, binding, value, else_block, mutable).emit(output);
     }
 
-    /// Handles Go multi-value returns correctly.
     pub(crate) fn emit_discard(&mut self, output: &mut String, value: &Expression) {
-        if let Expression::Propagate { expression, .. } = value.unwrap_parens() {
+        let unwrapped = value.unwrap_parens();
+
+        if let Expression::Propagate { expression, .. } = unwrapped {
             self.emit_propagate(output, expression, Some("_"));
             return;
         }
+
         let value_ty = value.get_type();
-        if value_ty.is_unit() || value_ty.is_variable() {
+        if value_ty.is_unit() || value_ty.is_variable() || value_ty.is_never() {
             let value_expression = self.emit_operand(output, value);
             if !value_expression.is_empty() {
-                if matches!(value.unwrap_parens(), Expression::Call { .. }) {
+                if matches!(unwrapped, Expression::Call { .. }) {
                     write_line!(output, "{}", value_expression);
                 } else {
                     write_line!(output, "_ = {}", value_expression);
@@ -800,23 +802,28 @@ impl Emitter<'_> {
             return;
         }
 
-        let is_go_multi_return = self
-            .resolve_go_call_strategy(value)
-            .is_some_and(|s| s.is_multi_return());
+        if let Expression::Call { .. } = unwrapped
+            && let Some(raw) = self.emit_go_call_discarded(output, unwrapped)
+        {
+            write_line!(output, "{}", raw);
+            return;
+        }
+
         let is_lowered_lisette_call = if let Expression::Call {
             expression: callee, ..
-        } = value
+        } = unwrapped
         {
             self.classify_callee_abi(callee).is_some()
         } else {
             false
         };
-        if is_go_multi_return || is_lowered_lisette_call {
+        if is_lowered_lisette_call {
             let call_str = self.emit_call(output, value, None);
             write_line!(output, "{}", call_str);
-        } else {
-            let value_expression = self.emit_operand(output, value);
-            write_line!(output, "_ = {}", value_expression);
+            return;
         }
+
+        let value_expression = self.emit_operand(output, value);
+        write_line!(output, "_ = {}", value_expression);
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -267,9 +267,6 @@ impl TaskState<'_> {
         };
         let new_body =
             self.infer_function_body(store, body, &body_ty, &return_annotation, &return_ty);
-        if relax_body_to_unit {
-            self.warn_discarded_lambda_tail(&new_body);
-        }
         self.scopes.restore_loop_depth(saved_loop_depth);
 
         self.scopes.pop();
@@ -907,26 +904,6 @@ impl TaskState<'_> {
 
             let _ = self.satisfies_interface(store, &resolved_ty, &interface, &params, &span);
         }
-    }
-
-    /// Warn when a `()` lambda's trailing expression is a non-call value the user likely meant to return.
-    fn warn_discarded_lambda_tail(&mut self, body: &Expression) {
-        let trailing = match body {
-            Expression::Block { items, .. } => items.last(),
-            other => Some(other),
-        };
-        let Some(expr) = trailing else { return };
-        if matches!(expr, Expression::Call { .. }) {
-            return;
-        }
-        let ty = expr.get_type().resolve_in(&self.env);
-        if ty.is_unit() || ty.is_ignored() || ty.is_never() || ty.is_variable() {
-            return;
-        }
-        self.sink.push(diagnostics::lint::discarded_lambda_value(
-            &expr.get_span(),
-            &ty.to_string(),
-        ));
     }
 
     fn infer_function_body(

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -2,6 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use diagnostics::lint::MismatchedTailKind;
 use diagnostics::{PatternIssue, UnusedExpressionKind};
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
 use syntax::types::Type;
@@ -149,11 +150,20 @@ impl Facts {
             .push(UnusedExpressionFact { span, kind });
     }
 
-    pub fn add_discarded_tail(&mut self, span: Span, kind: DiscardedTailKind, return_type: String) {
+    pub fn add_discarded_tail(
+        &mut self,
+        span: Span,
+        kind: MismatchedTailKind,
+        return_type: String,
+        expected_span: Span,
+        expected_type: String,
+    ) {
         self.discarded_tail_expressions.push(DiscardedTailFact {
             span,
             kind,
             return_type,
+            expected_span,
+            expected_type,
         });
     }
 
@@ -292,18 +302,13 @@ pub struct UnusedExpressionFact {
     pub kind: UnusedExpressionKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DiscardedTailKind {
-    Result,
-    Option,
-    Partial,
-}
-
 #[derive(Debug, Clone)]
 pub struct DiscardedTailFact {
     pub span: Span,
-    pub kind: DiscardedTailKind,
+    pub kind: MismatchedTailKind,
     pub return_type: String,
+    pub expected_span: Span,
+    pub expected_type: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/semantics/src/validators/lints.rs
+++ b/crates/semantics/src/validators/lints.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::context::AnalysisContext;
-use crate::facts::{DiscardedTailKind, Facts};
+use crate::facts::Facts;
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use syntax::ast::Expression;
@@ -226,26 +226,13 @@ fn collect_unused_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
 
 fn collect_discarded_tail_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
     for fact in &facts.discarded_tail_expressions {
-        match fact.kind {
-            DiscardedTailKind::Partial => {
-                out.push(diagnostics::lint::discarded_partial_in_tail(
-                    &fact.span,
-                    &fact.return_type,
-                ));
-            }
-            DiscardedTailKind::Result => {
-                out.push(diagnostics::lint::discarded_result_in_tail(
-                    &fact.span,
-                    &fact.return_type,
-                ));
-            }
-            DiscardedTailKind::Option => {
-                out.push(diagnostics::lint::discarded_option_in_tail(
-                    &fact.span,
-                    &fact.return_type,
-                ));
-            }
-        }
+        out.push(diagnostics::lint::mismatched_tail_value(
+            &fact.span,
+            &fact.return_type,
+            &fact.expected_span,
+            &fact.expected_type,
+            fact.kind,
+        ));
     }
 }
 

--- a/crates/semantics/src/validators/unused_expressions.rs
+++ b/crates/semantics/src/validators/unused_expressions.rs
@@ -1,9 +1,15 @@
 use diagnostics::UnusedExpressionKind;
-use syntax::ast::{Expression, Span, UnaryOperator};
+use syntax::ast::{Annotation, Expression, SelectArmPattern, Span, UnaryOperator};
 use syntax::types::{Symbol, Type};
 
-use crate::facts::{DiscardedTailKind, Facts};
+use crate::facts::Facts;
 use crate::store::Store;
+use diagnostics::lint::MismatchedTailKind;
+
+struct TailContext<'a> {
+    expected_span: Span,
+    expected_ty: &'a Type,
+}
 
 pub(super) fn run(typed_ast: &[Expression], module_id: &str, store: &Store, facts: &mut Facts) {
     for item in typed_ast {
@@ -13,12 +19,7 @@ pub(super) fn run(typed_ast: &[Expression], module_id: &str, store: &Store, fact
 
 fn visit_expression(
     expression: &Expression,
-    // `Some(ty)` when `expression` is a block whose last-item result is
-    // passed through as the block's value and subsequently discarded —
-    // e.g. a function body whose return type is ignored/unit/never, or a
-    // block in statement position. `None` means the block's result is
-    // consumed as a value, so the tail is not a discarded-tail candidate.
-    discarded_block_ty: Option<&syntax::types::Type>,
+    tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
     facts: &mut Facts,
@@ -28,33 +29,62 @@ fn visit_expression(
         | Expression::TryBlock { items, ty, .. }
         | Expression::RecoverBlock { items, ty, .. } => {
             let tail_is_discarded =
-                discarded_block_ty.is_some() || ty.is_unit() || ty.is_ignored() || ty.is_never();
-            visit_block_items(items, tail_is_discarded, module_id, store, facts);
+                tail_ctx.is_some() || ty.is_unit() || ty.is_ignored() || ty.is_never();
+            visit_block_items(items, tail_is_discarded, tail_ctx, module_id, store, facts);
         }
         Expression::Function {
-            body, return_type, ..
+            body,
+            return_type,
+            return_annotation,
+            ..
         } => {
+            let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
             let body_ty = body.get_type();
-            let tail_is_discarded =
-                return_type.is_unit() || body_ty.is_ignored() || body_ty.is_never();
-            let discard = if tail_is_discarded {
-                Some(return_type)
-            } else {
-                None
-            };
-            visit_expression(body, discard, module_id, store, facts);
+            let tail_is_discarded = is_implicit_return
+                && (return_type.is_unit() || body_ty.is_ignored() || body_ty.is_never());
+            let ctx = tail_is_discarded.then(|| TailContext {
+                expected_span: signature_marker_span(body.get_span()),
+                expected_ty: return_type,
+            });
+            visit_expression(body, ctx.as_ref(), module_id, store, facts);
             return;
         }
-        Expression::Lambda { body, .. } => {
+        Expression::Lambda {
+            body,
+            ty,
+            span,
+            return_annotation,
+            ..
+        } => {
+            let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
+            let lambda_returns_unit =
+                matches!(ty, Type::Function { return_type, .. } if return_type.is_unit());
             let body_ty = body.get_type();
-            let tail_is_discarded = body_ty.is_unit() || body_ty.is_ignored() || body_ty.is_never();
-            let discard_anchor = body.get_type();
-            let discard = if tail_is_discarded {
-                Some(&discard_anchor)
-            } else {
-                None
+            let tail_is_discarded = is_implicit_return
+                && (lambda_returns_unit
+                    || body_ty.is_unit()
+                    || body_ty.is_ignored()
+                    || body_ty.is_never());
+            let lambda_return_ty: &Type = match ty {
+                Type::Function { return_type, .. } => return_type,
+                _ => &body_ty,
             };
-            visit_expression(body, discard, module_id, store, facts);
+            let ctx = tail_is_discarded.then(|| TailContext {
+                expected_span: signature_marker_span(*span),
+                expected_ty: lambda_return_ty,
+            });
+
+            if tail_is_discarded && !matches!(body.as_ref(), Expression::Block { .. }) {
+                descend_discarded(
+                    body,
+                    &DiscardMode::Tail(ctx.as_ref()),
+                    module_id,
+                    store,
+                    facts,
+                );
+            }
+
+            visit_expression(body, ctx.as_ref(), module_id, store, facts);
             return;
         }
         _ => {}
@@ -65,9 +95,17 @@ fn visit_expression(
     }
 }
 
+/// 1-byte span at the start of `span`. Anchors the "expected" label when
+/// there is no explicit return-type annotation. Lands on the body's `{` for
+/// functions and the leading `|` for lambdas.
+fn signature_marker_span(span: Span) -> Span {
+    Span::new(span.file_id, span.byte_offset, 1)
+}
+
 fn visit_block_items(
     items: &[Expression],
     tail_is_discarded: bool,
+    tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
     facts: &mut Facts,
@@ -76,45 +114,180 @@ fn visit_block_items(
     for (i, item) in items.iter().enumerate() {
         let is_last = i == len - 1;
         let is_statement_only = is_statement_only(item);
-        let suppress_unused_check = item.is_control_flow();
 
-        if !is_statement_only && !suppress_unused_check && !is_last {
-            let item_span = item.get_span();
-            let is_literal = is_literal_or_negated_literal(item);
-            let ty = item.get_type();
-
-            let mut allowed_lints = callee_allowed_lints(item, module_id, store);
-            if is_channel_send(item) {
-                allowed_lints.push("unused_value".to_string());
-            }
-
-            emit_unused_expression(item_span, &ty, is_literal, &allowed_lints, facts);
+        if !is_statement_only && !is_last {
+            descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
         }
 
-        if is_last
-            && !is_statement_only
-            && !suppress_unused_check
-            && tail_is_discarded
-            && let Some(call_return) = get_call_return_type(item)
-        {
-            let classification = if call_return.is_result() {
-                Some(("unused_result", DiscardedTailKind::Result))
-            } else if call_return.is_option() {
-                Some(("unused_option", DiscardedTailKind::Option))
-            } else if call_return.is_partial() {
-                Some(("unused_partial", DiscardedTailKind::Partial))
-            } else {
-                None
-            };
+        if is_last && !is_statement_only && tail_is_discarded {
+            descend_discarded(item, &DiscardMode::Tail(tail_ctx), module_id, store, facts);
+        }
+    }
+}
 
-            if let Some((lint_name, kind)) = classification {
-                let allowed_lints = callee_allowed_lints(item, module_id, store);
-                if !allowed_lints.contains(&lint_name.to_string()) {
-                    facts.add_discarded_tail(item.get_span(), kind, call_return.to_string());
+/// Whether the descent is checking a tail-position discard (function/lambda
+/// return value type-mismatch, hard error) or a non-tail discard (statement-
+/// position unused expression, warning). Same structural walk; different
+/// fact emitted at value leaves.
+enum DiscardMode<'a> {
+    Tail(Option<&'a TailContext<'a>>),
+    NonTail,
+}
+
+fn descend_discarded(
+    expression: &Expression,
+    mode: &DiscardMode<'_>,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Facts,
+) {
+    match expression.unwrap_parens() {
+        Expression::Block { items, .. }
+        | Expression::TryBlock { items, .. }
+        | Expression::RecoverBlock { items, .. } => {
+            if let Some(last) = items.last()
+                && !is_statement_only(last)
+            {
+                descend_discarded(last, mode, module_id, store, facts);
+            }
+        }
+        Expression::If {
+            consequence,
+            alternative,
+            ..
+        } => {
+            descend_discarded(consequence, mode, module_id, store, facts);
+            descend_discarded(alternative, mode, module_id, store, facts);
+        }
+        Expression::Match { arms, .. } => {
+            for arm in arms {
+                descend_discarded(&arm.expression, mode, module_id, store, facts);
+            }
+        }
+        Expression::Select { arms, .. } => {
+            for arm in arms {
+                match &arm.pattern {
+                    SelectArmPattern::Receive { body, .. }
+                    | SelectArmPattern::Send { body, .. }
+                    | SelectArmPattern::WildCard { body } => {
+                        descend_discarded(body, mode, module_id, store, facts);
+                    }
+                    SelectArmPattern::MatchReceive {
+                        arms: match_arms, ..
+                    } => {
+                        for match_arm in match_arms {
+                            descend_discarded(&match_arm.expression, mode, module_id, store, facts);
+                        }
+                    }
                 }
             }
         }
+        Expression::Loop { body, .. } => {
+            descend_loop_break_values(body, mode, module_id, store, facts);
+        }
+        Expression::Let { .. }
+        | Expression::Const { .. }
+        | Expression::Assignment { .. }
+        | Expression::Return { .. }
+        | Expression::Break { .. }
+        | Expression::Continue { .. }
+        | Expression::Defer { .. }
+        | Expression::Task { .. }
+        | Expression::While { .. }
+        | Expression::WhileLet { .. }
+        | Expression::For { .. } => {}
+        unwrapped => match mode {
+            DiscardMode::Tail(tail_ctx) => {
+                check_discarded_tail(expression, *tail_ctx, module_id, store, facts)
+            }
+            DiscardMode::NonTail => emit_unused_at_leaf(unwrapped, module_id, store, facts),
+        },
     }
+}
+
+fn descend_loop_break_values(
+    expression: &Expression,
+    mode: &DiscardMode<'_>,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Facts,
+) {
+    match expression {
+        Expression::Break {
+            value: Some(value), ..
+        } => {
+            descend_discarded(value, mode, module_id, store, facts);
+        }
+        Expression::Loop { .. }
+        | Expression::While { .. }
+        | Expression::WhileLet { .. }
+        | Expression::For { .. }
+        | Expression::Function { .. }
+        | Expression::Lambda { .. }
+        | Expression::Task { .. }
+        | Expression::Defer { .. } => {}
+        _ => {
+            for child in expression.children() {
+                descend_loop_break_values(child, mode, module_id, store, facts);
+            }
+        }
+    }
+}
+
+fn emit_unused_at_leaf(leaf: &Expression, module_id: &str, store: &Store, facts: &mut Facts) {
+    let span = leaf.get_span();
+    let is_literal = is_literal_or_negated_literal(leaf);
+    let ty = leaf.get_type();
+    let mut allowed_lints = callee_allowed_lints(leaf, module_id, store);
+    if is_channel_send(leaf) {
+        allowed_lints.push("unused_value".to_string());
+    }
+    emit_unused_expression(span, &ty, is_literal, &allowed_lints, facts);
+}
+
+fn check_discarded_tail(
+    item: &Expression,
+    tail_ctx: Option<&TailContext<'_>>,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Facts,
+) {
+    let unwrapped = item.unwrap_parens();
+    let reported_ty = get_call_return_type(unwrapped).unwrap_or_else(|| unwrapped.get_type());
+
+    let kind = if reported_ty.is_result() {
+        MismatchedTailKind::Result
+    } else if reported_ty.is_option() {
+        MismatchedTailKind::Option
+    } else if reported_ty.is_partial() {
+        MismatchedTailKind::Partial
+    } else if reported_ty.is_unit()
+        || reported_ty.is_ignored()
+        || reported_ty.is_never()
+        || reported_ty.is_variable()
+    {
+        return;
+    } else {
+        MismatchedTailKind::Value
+    };
+
+    let allowed_lints = callee_allowed_lints(unwrapped, module_id, store);
+    if allowed_lints.iter().any(|s| s == kind.lint_code()) {
+        return;
+    }
+
+    let (expected_span, expected_ty) = match tail_ctx {
+        Some(ctx) => (ctx.expected_span, ctx.expected_ty.to_string()),
+        None => (item.get_span(), reported_ty.to_string()),
+    };
+
+    facts.add_discarded_tail(
+        item.get_span(),
+        kind,
+        reported_ty.to_string(),
+        expected_span,
+        expected_ty,
+    );
 }
 
 fn emit_unused_expression(
@@ -139,7 +312,7 @@ fn emit_unused_expression(
     };
 
     if let Some(kind) = kind
-        && !allowed_lints.contains(&kind.lint_name().to_string())
+        && !allowed_lints.iter().any(|s| s == kind.lint_name())
     {
         facts.add_unused_expression(span, kind);
     }
@@ -264,12 +437,9 @@ fn get_call_return_type(expression: &Expression) -> Option<Type> {
     else {
         return None;
     };
-    match callee.get_type() {
-        Type::Function { return_type, .. } => Some((*return_type).clone()),
-        Type::Forall { body, .. } => match body.as_ref() {
-            Type::Function { return_type, .. } => Some((**return_type).clone()),
-            _ => None,
-        },
-        _ => None,
-    }
+    callee
+        .get_type()
+        .unwrap_forall()
+        .get_function_ret()
+        .cloned()
 }

--- a/crates/semantics/src/validators/unused_expressions.rs
+++ b/crates/semantics/src/validators/unused_expressions.rs
@@ -272,7 +272,8 @@ fn check_discarded_tail(
     };
 
     let allowed_lints = callee_allowed_lints(unwrapped, module_id, store);
-    if allowed_lints.iter().any(|s| s == kind.lint_code()) {
+    let alias = kind.allow_alias();
+    if allowed_lints.iter().any(|s| s == alias) {
         return;
     }
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -1928,7 +1928,7 @@ struct User {
 
 fn main() {
   let u = User { first_name: "Alice", middle_name: "" }
-  json.Marshal(u)
+  let _ = json.Marshal(u)
 }
 "#,
     );

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1569,3 +1569,13 @@ fn run() -> Result<int, error> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn discarded_tail_call_to_go_builtin_uses_underscore() {
+    let input = r#"
+fn test() {
+  "test".length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/blocking_send.snap
+++ b/tests/spec/emit/snapshots/blocking_send.snap
@@ -8,5 +8,5 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
 	ch := make(chan int)
-	lisette.ChannelSend(ch, 42)
+	_ = lisette.ChannelSend(ch, 42)
 }

--- a/tests/spec/emit/snapshots/channel_split_destructure.snap
+++ b/tests/spec/emit/snapshots/channel_split_destructure.snap
@@ -10,5 +10,5 @@ func test() {
 	ch := make(chan int)
 	tmp_1 := lisette.ChannelSplit(ch)
 	tx := tmp_1.First
-	lisette.SenderSend(tx, 42)
+	_ = lisette.SenderSend(tx, 42)
 }

--- a/tests/spec/emit/snapshots/discarded_tail_call_to_go_builtin_uses_underscore.snap
+++ b/tests/spec/emit/snapshots/discarded_tail_call_to_go_builtin_uses_underscore.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/functions.rs
+description: "input: \nfn test() {\n  \"test\".length()\n}\n"
+---
+package main
+
+func test() {
+	_ = len("test")
+}

--- a/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
@@ -28,5 +28,5 @@ func greet_ref[T Greetable](item T) string {
 
 func test() {
 	p := Person{name: "Alice"}
-	greet_ref(&p)
+	_ = greet_ref(&p)
 }

--- a/tests/spec/emit/snapshots/ref_channel_auto_deref_select.snap
+++ b/tests/spec/emit/snapshots/ref_channel_auto_deref_select.snap
@@ -8,7 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
 	ch := make(chan int, 1)
-	lisette.ChannelSend(ch, 42)
+	_ = lisette.ChannelSend(ch, 42)
 	r := &ch
 	var tmp_1 int
 	ch_2 := *r

--- a/tests/spec/emit/snapshots/select_arm_binding_does_not_leak.snap
+++ b/tests/spec/emit/snapshots/select_arm_binding_does_not_leak.snap
@@ -14,7 +14,7 @@ func main() {
 	fmt.Println(x)
 	x_1 := 200
 	ch := make(chan int, 1)
-	lisette.ChannelSend(ch, 99)
+	_ = lisette.ChannelSend(ch, 99)
 	ch_2 := ch
 	for {
 		select {

--- a/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	ch := make(chan string, 1)
-	lisette.ChannelSend(ch, "hello")
+	_ = lisette.ChannelSend(ch, "hello")
 loop_1:
 	for {
 		ch_2 := ch

--- a/tests/spec/emit/snapshots/select_complex_channel_expression_hoisted.snap
+++ b/tests/spec/emit/snapshots/select_complex_channel_expression_hoisted.snap
@@ -9,8 +9,8 @@ import lisette "github.com/ivov/lisette/prelude"
 func main() {
 	ch1 := make(chan int, 1)
 	ch2 := make(chan int, 1)
-	lisette.ChannelSend(ch1, 1)
-	lisette.ChannelSend(ch2, 2)
+	_ = lisette.ChannelSend(ch1, 1)
+	_ = lisette.ChannelSend(ch2, 2)
 	flag := true
 	var ch_1 chan int
 	if flag {

--- a/tests/spec/emit/snapshots/select_match_receive_before_shorthand_eval_order.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_before_shorthand_eval_order.snap
@@ -13,8 +13,8 @@ func choose(_ int, ch chan int) chan int {
 func main() {
 	ch1 := make(chan int, 1)
 	ch2 := make(chan int, 1)
-	lisette.ChannelSend(ch1, 10)
-	lisette.ChannelSend(ch2, 20)
+	_ = lisette.ChannelSend(ch1, 10)
+	_ = lisette.ChannelSend(ch2, 20)
 	var tmp_1 int
 	ch_2 := choose(1, ch1)
 	ch_3 := choose(2, ch2)

--- a/tests/spec/emit/snapshots/select_match_receive_binding_no_leak.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_binding_no_leak.snap
@@ -15,7 +15,7 @@ func main() {
 	x_1 := 2
 	ch := make(chan int)
 	go func() {
-		lisette.ChannelSend(ch, 1)
+		_ = lisette.ChannelSend(ch, 1)
 	}()
 	select {
 	case recv_2, ok := <-ch:

--- a/tests/spec/emit/snapshots/select_match_receive_complex_unused_recv.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_complex_unused_recv.snap
@@ -19,7 +19,7 @@ func (p P) String() string {
 
 func test() {
 	ch := make(chan P, 1)
-	lisette.ChannelSend(ch, P{v: 1})
+	_ = lisette.ChannelSend(ch, P{v: 1})
 	select {
 	case recv_1, ok := <-ch:
 		_ = ok

--- a/tests/spec/emit/snapshots/select_match_receive_propagate_channel_call.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_propagate_channel_call.snap
@@ -12,7 +12,7 @@ func g() lisette.Result[chan int, string] {
 
 func f() lisette.Result[int, string] {
 	ch := make(chan int, 1)
-	lisette.ChannelSend(ch, 7)
+	_ = lisette.ChannelSend(ch, 7)
 	var x int
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {

--- a/tests/spec/emit/snapshots/select_raw_receive_before_shorthand_eval_order.snap
+++ b/tests/spec/emit/snapshots/select_raw_receive_before_shorthand_eval_order.snap
@@ -13,8 +13,8 @@ func choose(_ int, ch chan int) chan int {
 func main() {
 	ch1 := make(chan int, 1)
 	ch2 := make(chan int, 1)
-	lisette.ChannelSend(ch1, 10)
-	lisette.ChannelSend(ch2, 20)
+	_ = lisette.ChannelSend(ch1, 10)
+	_ = lisette.ChannelSend(ch2, 20)
 	var tmp_1 int
 	ch_2 := choose(1, ch1)
 	ch_3 := choose(2, ch2)

--- a/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
+++ b/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
@@ -12,7 +12,7 @@ import (
 func test() {
 	ok := "everything is fine"
 	ch := make(chan int, 1)
-	lisette.ChannelSend(ch, 42)
+	_ = lisette.ChannelSend(ch, 42)
 	select {
 	case val, ok_1 := <-ch:
 		if ok_1 {

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
@@ -12,7 +12,7 @@ func g() lisette.Result[chan int, string] {
 
 func f() lisette.Result[int, string] {
 	ch := make(chan int, 1)
-	lisette.ChannelSend(ch, 7)
+	_ = lisette.ChannelSend(ch, 7)
 	var x int
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
@@ -12,7 +12,7 @@ func g() lisette.Result[int, string] {
 
 func f() lisette.Result[int, string] {
 	chans := []chan int{make(chan int, 1)}
-	lisette.ChannelSend(chans[0], 7)
+	_ = lisette.ChannelSend(chans[0], 7)
 	var x int
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {

--- a/tests/spec/emit/snapshots/select_retry_loop_hoists_send_values.snap
+++ b/tests/spec/emit/snapshots/select_retry_loop_hoists_send_values.snap
@@ -7,7 +7,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func mark(log chan int, tag int) int {
-	lisette.ChannelSend(log, tag)
+	_ = lisette.ChannelSend(log, tag)
 	return tag
 }
 

--- a/tests/spec/emit/snapshots/select_send_before_shorthand_receive_eval_order.snap
+++ b/tests/spec/emit/snapshots/select_send_before_shorthand_receive_eval_order.snap
@@ -7,7 +7,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func mark(log chan int, tag int) int {
-	lisette.ChannelSend(log, tag)
+	_ = lisette.ChannelSend(log, tag)
 	return tag
 }
 
@@ -20,7 +20,7 @@ func main() {
 	log := make(chan int, 8)
 	send_ch := make(chan int, 1)
 	recv_ch := make(chan int, 1)
-	lisette.ChannelSend(recv_ch, 42)
+	_ = lisette.ChannelSend(recv_ch, 42)
 	var tmp_1 int
 	send_val_2 := mark(log, 1)
 	ch_3 := choose(log, 2, recv_ch)

--- a/tests/spec/emit/snapshots/select_shorthand_receive_complex_unused_recv.snap
+++ b/tests/spec/emit/snapshots/select_shorthand_receive_complex_unused_recv.snap
@@ -19,7 +19,7 @@ func (p P) String() string {
 
 func test() {
 	ch := make(chan P, 1)
-	lisette.ChannelSend(ch, P{v: 1})
+	_ = lisette.ChannelSend(ch, P{v: 1})
 	ch_1 := ch
 	for {
 		select {

--- a/tests/spec/emit/snapshots/task_parallel_same_variable_name.snap
+++ b/tests/spec/emit/snapshots/task_parallel_same_variable_name.snap
@@ -11,11 +11,11 @@ func test() {
 	go func() {
 		found := 0
 		found = 1
-		lisette.ChannelSend(ch, found)
+		_ = lisette.ChannelSend(ch, found)
 	}()
 	go func() {
 		found := 0
 		found = 2
-		lisette.ChannelSend(ch, found)
+		_ = lisette.ChannelSend(ch, found)
 	}()
 }

--- a/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
@@ -11,5 +11,5 @@ func noop() {}
 func test() {
 	ch := make(chan struct{}, 1)
 	noop()
-	lisette.ChannelSend(ch, struct{}{})
+	_ = lisette.ChannelSend(ch, struct{}{})
 }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3830,7 +3830,7 @@ fn main() {
     );
     let count = warnings
         .iter()
-        .filter(|w| w.code_str() == Some("lint.unused_value"))
+        .filter(|w| w.code_str() == Some("lint.mismatched_return_value"))
         .count();
     assert_eq!(count, 2, "expected one diagnostic per break value");
 }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -396,9 +396,10 @@ fn main() {
 }
 
 #[test]
-fn match_in_statement_position_no_unused_result_warning() {
+fn match_in_statement_position_with_unit_arms_no_warning() {
     assert_no_lint_warnings!(
         r#"
+import "go:fmt"
 fn get_result() -> Result<int, string> {
   Ok(42)
 }
@@ -406,8 +407,8 @@ fn get_result() -> Result<int, string> {
 fn main() {
   let r = get_result();
   match r {
-    Ok(_) => "ok",
-    Err(_) => "err",
+    Ok(_) => fmt.Println("ok"),
+    Err(_) => fmt.Println("err"),
   }
   ()
 }
@@ -416,14 +417,15 @@ fn main() {
 }
 
 #[test]
-fn match_in_statement_position_no_unused_value_warning() {
+fn match_in_statement_position_with_unit_arms_no_value_warning() {
     assert_no_lint_warnings!(
         r#"
+import "go:fmt"
 fn main() {
   let x = 1;
   match x {
-    1 => "one",
-    _ => "other",
+    1 => fmt.Println("one"),
+    _ => fmt.Println("other"),
   }
   ()
 }
@@ -432,15 +434,16 @@ fn main() {
 }
 
 #[test]
-fn if_in_statement_position_no_unused_value_warning() {
+fn if_in_statement_position_with_unit_branches_no_warning() {
     assert_no_lint_warnings!(
         r#"
+import "go:fmt"
 fn main() {
   let x = 1;
   if x > 0 {
-    "positive"
+    fmt.Println("positive")
   } else {
-    "negative"
+    fmt.Println("negative")
   }
   ()
 }
@@ -3630,6 +3633,220 @@ import "go:fmt"
 fn take(f: fn() -> ()) { f() }
 fn main() {
   take(|| { fmt.Println("hi") })
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_function_value_bare_literal() {
+    assert_lint_snapshot!(
+        r#"
+fn test() {
+  42
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_function_value_native_call_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn test() {
+  "test".length()
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_function_value_user_call_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn make_int() -> int { 42 }
+fn test() {
+  make_int()
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_function_value_silent_on_result_tail() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+fn test(cond: bool) {
+  if cond { fmt.Print("yes") } else { fmt.Print("no") }
+}
+fn main() {
+  test(true)
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_function_value_silent_with_allow_attr() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(unused_value)]
+fn advance_rng() -> int { 42 }
+fn test() {
+  advance_rng()
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_lambda_value_expression_body_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn take(f: fn() -> ()) { f() }
+fn main() {
+  take(|| 42)
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_paren_call_returning_result_errors_as_unused_result() {
+    assert_lint_snapshot!(
+        r#"
+fn might_fail() -> Result<int, string> { Ok(1) }
+fn test() {
+  (might_fail())
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_paren_call_silent_with_allow_attr() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+fn test() {
+  (fmt.Println("hi"))
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_loop_with_break_value_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn test() {
+  loop { break 1 }
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_infinite_loop_silent() {
+    assert_no_lint_warnings!(
+        r#"
+fn test() {
+  loop { let _ = 1 }
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_non_call_result_tail_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn get_result() -> Result<int, string> { Ok(1) }
+fn test() {
+  let r = get_result()
+  r
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_loop_break_value_silent_with_allow_attr() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(unused_value)]
+fn allowed() -> int { 42 }
+fn test() {
+  loop { break allowed() }
+}
+fn main() {
+  test()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_loop_two_branches_two_diagnostics() {
+    let warnings = crate::_harness::lint::lint(
+        r#"
+fn test() {
+  loop {
+    if true { break 1 } else { break 2 }
+  }
+}
+fn main() {
+  test()
+}
+"#,
+    );
+    let count = warnings
+        .iter()
+        .filter(|w| w.code_str() == Some("lint.unused_value"))
+        .count();
+    assert_eq!(count, 2, "expected one diagnostic per break value");
+}
+
+#[test]
+fn discarded_non_call_option_in_if_branches_errors() {
+    assert_lint_snapshot!(
+        r#"
+fn get_option() -> Option<int> { Some(1) }
+fn test(c: bool) {
+  let a = get_option()
+  let b = get_option()
+  if c { a } else { b }
+}
+fn main() {
+  test(true)
 }
 "#
     );

--- a/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
@@ -2,12 +2,14 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:4:13]
- 3 │ fn main() {
- 4 │   take(|| { 42 })
-   ·        ┬    ─┬
-   ·        │     ╰── returns `int`
-   ·        ╰── has `()` as implicit return type
- 5 │ }
+   ╭─[test.lis:3:3]
+ 1 │ 
+ 2 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 3 │   42
+   ·   ─┬
+   ·    ╰── returns `int`
+ 4 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
@@ -2,12 +2,14 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:4:13]
- 3 │ fn main() {
- 4 │   take(|| { 42 })
-   ·        ┬    ─┬
-   ·        │     ╰── returns `int`
-   ·        ╰── has `()` as implicit return type
- 5 │ }
+   ╭─[test.lis:3:3]
+ 1 │ 
+ 2 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 3 │   "test".length()
+   ·   ───────┬───────
+   ·          ╰── returns `int`
+ 4 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
@@ -2,12 +2,14 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:4:13]
- 3 │ fn main() {
- 4 │   take(|| { 42 })
-   ·        ┬    ─┬
-   ·        │     ╰── returns `int`
-   ·        ╰── has `()` as implicit return type
+   ╭─[test.lis:4:3]
+ 2 │ fn make_int() -> int { 42 }
+ 3 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 4 │   make_int()
+   ·   ─────┬────
+   ·        ╰── returns `int`
  5 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── returns `int`
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_lambda_value_bare_literal.snap
+++ b/tests/ui/lint/snapshots/discarded_lambda_value_bare_literal.snap
@@ -10,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── has `()` as implicit return type
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
@@ -2,11 +2,11 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:4:13]
+   ╭─[test.lis:4:11]
  3 │ fn main() {
- 4 │   take(|| { 42 })
-   ·        ┬    ─┬
-   ·        │     ╰── returns `int`
+ 4 │   take(|| 42)
+   ·        ┬  ─┬
+   ·        │   ╰── returns `int`
    ·        ╰── has `()` as implicit return type
  5 │ }
    ╰────

--- a/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
@@ -10,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── has `()` as implicit return type
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
@@ -2,12 +2,14 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:4:13]
- 3 │ fn main() {
- 4 │   take(|| { 42 })
-   ·        ┬    ─┬
-   ·        │     ╰── returns `int`
-   ·        ╰── has `()` as implicit return type
- 5 │ }
+   ╭─[test.lis:3:16]
+ 1 │ 
+ 2 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 3 │   loop { break 1 }
+   ·                ┬
+   ·                ╰── returns `int`
+ 4 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]

--- a/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·                ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.unused_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
@@ -14,4 +14,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `Option<int>`
  7 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.unused_option]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Mismatch between return type and return value
+   ╭─[test.lis:6:10]
+ 2 │ fn get_option() -> Option<int> { Some(1) }
+ 3 │ fn test(c: bool) {
+   ·                  ┬
+   ·                  ╰── has `()` as implicit return type
+ 4 │   let a = get_option()
+ 5 │   let b = get_option()
+ 6 │   if c { a } else { b }
+   ·          ┬
+   ·          ╰── returns `Option<int>`
+ 7 │ }
+   ╰────
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.unused_option]

--- a/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
@@ -2,14 +2,15 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:7:3]
- 5 │ 
- 6 │ fn do_work() {
-   ·              ┬
-   ·              ╰── has `()` as implicit return type
- 7 │   get_result()
-   ·   ──────┬─────
-   ·         ╰── returns `Result<int, string>`
- 8 │ }
+   ╭─[test.lis:5:3]
+ 2 │ fn get_result() -> Result<int, string> { Ok(1) }
+ 3 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 4 │   let r = get_result()
+ 5 │   r
+   ·   ┬
+   ·   ╰── returns `Result<int, string>`
+ 6 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
@@ -13,4 +13,4 @@ source: tests/ui/lint/mod.rs
    ·   ╰── returns `Result<int, string>`
  6 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.unused_result]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
+++ b/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `Result<int, string>`
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.unused_result]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
+++ b/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
@@ -2,14 +2,14 @@
 source: tests/ui/lint/mod.rs
 ---
   [error] Mismatch between return type and return value
-   ╭─[test.lis:7:3]
- 5 │ 
- 6 │ fn do_work() {
-   ·              ┬
-   ·              ╰── has `()` as implicit return type
- 7 │   get_result()
-   ·   ──────┬─────
-   ·         ╰── returns `Result<int, string>`
- 8 │ }
+   ╭─[test.lis:4:3]
+ 2 │ fn might_fail() -> Result<int, string> { Ok(1) }
+ 3 │ fn test() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
+ 4 │   (might_fail())
+   ·   ───────┬──────
+   ·          ╰── returns `Result<int, string>`
+ 5 │ }
    ╰────
   help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
@@ -1,12 +1,15 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Unused Option
+  [error] Mismatch between return type and return value
    ╭─[test.lis:7:3]
+ 5 │ 
  6 │ fn do_search() {
+   ·                ┬
+   ·                ╰── has `()` as implicit return type
  7 │   find_item()
    ·   ─────┬─────
-   ·        ╰── this `Option` is discarded
+   ·        ╰── returns `Option<int>`
  8 │ }
    ╰────
-  help: Handle this `Option`, explicitly discard it with `let _ = ...`, or return it by adding `-> Option<int>` to the function signature · code: [lint.unused_option]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.unused_option]

--- a/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── returns `Option<int>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.unused_option]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
@@ -1,12 +1,15 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] `Partial` is silently discarded
+  [error] Mismatch between return type and return value
    ╭─[test.lis:7:3]
+ 5 │ 
  6 │ fn main() {
+   ·           ┬
+   ·           ╰── has `()` as implicit return type
  7 │   get_partial()
    ·   ──────┬──────
-   ·         ╰── partial result will go unnoticed
+   ·         ╰── returns `Partial<int, string>`
  8 │ }
    ╰────
-  help: Handle this `Partial` with `match`, explicitly discard it with `let _ = ...`, or return it by adding `-> Partial<int, string>` to the function signature · code: [lint.unused_partial]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Partial<int, string>` return value is intended, add `-> Partial<int, string>` to the function signature · code: [lint.unused_partial]

--- a/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·         ╰── returns `Partial<int, string>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Partial<int, string>` return value is intended, add `-> Partial<int, string>` to the function signature · code: [lint.unused_partial]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Partial<int, string>` return value is intended, add `-> Partial<int, string>` to the function signature · code: [lint.mismatched_return_value]

--- a/tests/ui/lint/snapshots/unused_result_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_result_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·         ╰── returns `Result<int, string>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.unused_result]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]


### PR DESCRIPTION
Tail-position type mismatches in `fn` and lambda bodies are now reported as errors, not silently discarded, matching Rust semantics and preventing invalid Go output for cases like `fn test() { "test".length() }`

```rs
fn test() {
  42
}
```

```
[error] Mismatch between return type and return value
  ╭─[test.lis:3:3]
1 │
2 │ fn test() {
  ·           ┬
  ·           ╰── has `()` as implicit return type
3 │   42
  ·   ─┬
  ·    ╰── returns `int`
4 │ }
  ╰────
help: If the `()` return type is intended, discard the return value with `let _ = ...`. 
If the `int` return value is intended, add `-> int` to the function signature · code:
[lint.mismatched_return_value]
```

Fix #252
