### PR TITLE
ci: skip release gates on release-plz tmp branches

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -2,7 +2,9 @@ name: Release gates
 
 on:
   push:
-    branches: ['release-plz-*']
+    branches:
+      - 'release-plz-*'
+      - '!release-plz-*-tmp-*'
 
 concurrency:
   group: release-gates-${{ github.ref }}


### PR DESCRIPTION
`release-plz` creates ephemeral `release-plz-<ts-tmp-<random>` branches as a workaround for committing verified bot-signed commits via the GraphQL API, which cannot force-push. The branches are deleted within seconds, but their creation triggers `release-gates.yml`, causing the changelog tripwire to fail.
