### PR TITLE
refactor: clean up diagnostics taxonomy

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -1,0 +1,33 @@
+use crate::LisetteDiagnostic;
+use syntax::ast::Span;
+
+pub fn field_attribute_without_struct_attribute(
+    field_span: &Span,
+    attribute_name: &str,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Orphan field attribute")
+        .with_attribute_code("orphan_field_attribute")
+        .with_span_label(field_span, "field has attribute but struct does not")
+        .with_help(format!(
+            "Add `#[{}]` atop the struct definition to enable field-level attributes",
+            attribute_name
+        ))
+}
+
+pub fn duplicate_tag_key(span: &Span, key: &str, first_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Duplicate tag")
+        .with_attribute_code("duplicate_tag")
+        .with_span_label(span, "duplicate")
+        .with_span_label(first_span, "first occurrence")
+        .with_help(format!(
+            "Remove one of the `{}` attributes - each tag key may appear only once per field",
+            key
+        ))
+}
+
+pub fn conflicting_case_transforms(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Conflicting case transforms")
+        .with_attribute_code("conflicting_case_transforms")
+        .with_span_label(span, "conflicting")
+        .with_help("Choose either `snake_case` or `camel_case`, not both")
+}

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -398,7 +398,18 @@ impl LisetteDiagnostic {
     }
 
     pub fn with_lint_code(mut self, code: &str) -> Self {
+        debug_assert!(
+            matches!(self.severity, Severity::Warning),
+            "with_lint_code requires Warning severity (got {:?}); \
+             use a phase-specific code constructor for errors",
+            self.severity,
+        );
         self.code = Some(format!("lint.{}", code));
+        self
+    }
+
+    pub fn with_attribute_code(mut self, code: &str) -> Self {
+        self.code = Some(format!("attribute.{}", code));
         self
     }
 

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2,6 +2,44 @@ use crate::LisetteDiagnostic;
 use syntax::ast::{Annotation, BinaryOperator, Span};
 use syntax::types::{SimpleKind, Type};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MismatchedTailKind {
+    Result,
+    Option,
+    Partial,
+    Value,
+}
+
+impl MismatchedTailKind {
+    pub fn allow_alias(&self) -> &'static str {
+        match self {
+            Self::Result => "unused_result",
+            Self::Option => "unused_option",
+            Self::Partial => "unused_partial",
+            Self::Value => "unused_value",
+        }
+    }
+}
+
+pub fn mismatched_tail_value(
+    actual_span: &Span,
+    actual_ty: &str,
+    expected_span: &Span,
+    expected_ty: &str,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Mismatch between return type and return value")
+        .with_infer_code("mismatched_return_value")
+        .with_span_primary_label(actual_span, format!("returns `{}`", actual_ty))
+        .with_span_label(
+            expected_span,
+            format!("has `{}` as implicit return type", expected_ty),
+        )
+        .with_help(format!(
+            "If the `{}` return type is intended, discard the return value with `let _ = ...`. If the `{}` return value is intended, add `-> {}` to the function signature.",
+            expected_ty, actual_ty, actual_ty
+        ))
+}
+
 pub fn blank_import_non_go(blank_span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid import")
         .with_resolve_code("blank_import_non_go")

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -2,6 +2,7 @@ mod diagnostic;
 mod result;
 mod sink;
 
+pub mod attribute;
 pub mod emit;
 pub mod infer;
 pub mod lint;

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -139,49 +139,6 @@ pub fn pattern_issue(span: &Span, kind: IssueKind) -> LisetteDiagnostic {
         .with_help(help)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MismatchedTailKind {
-    Result,
-    Option,
-    Partial,
-    Value,
-}
-
-impl MismatchedTailKind {
-    pub fn lint_code(&self) -> &'static str {
-        "mismatched_return_value"
-    }
-
-    pub fn allow_alias(&self) -> &'static str {
-        match self {
-            Self::Result => "unused_result",
-            Self::Option => "unused_option",
-            Self::Partial => "unused_partial",
-            Self::Value => "unused_value",
-        }
-    }
-}
-
-pub fn mismatched_tail_value(
-    actual_span: &Span,
-    actual_ty: &str,
-    expected_span: &Span,
-    expected_ty: &str,
-    kind: MismatchedTailKind,
-) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Mismatch between return type and return value")
-        .with_lint_code(kind.lint_code())
-        .with_span_primary_label(actual_span, format!("returns `{}`", actual_ty))
-        .with_span_label(
-            expected_span,
-            format!("has `{}` as implicit return type", expected_ty),
-        )
-        .with_help(format!(
-            "If the `{}` return type is intended, discard the return value with `let _ = ...`. If the `{}` return value is intended, add `-> {}` to the function signature.",
-            expected_ty, actual_ty, actual_ty
-        ))
-}
-
 pub fn unused_expression(span: &Span, kind: UnusedExpressionKind) -> LisetteDiagnostic {
     let (code, msg, label, help) = match kind {
         UnusedExpressionKind::Literal => (
@@ -487,37 +444,6 @@ pub fn unknown_attribute(span: &Span, name: &str) -> LisetteDiagnostic {
             "`{}` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[msgpack]`, `#[mapstructure]`, `#[tag]`",
             name
         ))
-}
-
-pub fn field_attribute_without_struct_attribute(
-    field_span: &Span,
-    attribute_name: &str,
-) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Orphan field attribute")
-        .with_lint_code("orphan_field_attribute")
-        .with_span_label(field_span, "field has attribute but struct does not")
-        .with_help(format!(
-            "Add `#[{}]` atop the struct definition to enable field-level attributes",
-            attribute_name
-        ))
-}
-
-pub fn duplicate_tag_key(span: &Span, key: &str, first_span: &Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Duplicate tag")
-        .with_lint_code("duplicate_tag")
-        .with_span_label(span, "duplicate")
-        .with_span_label(first_span, "first occurrence")
-        .with_help(format!(
-            "Remove one of the `{}` attributes - each tag key may appear only once per field",
-            key
-        ))
-}
-
-pub fn conflicting_case_transforms(span: &Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Conflicting case transforms")
-        .with_lint_code("conflicting_case_transforms")
-        .with_span_label(span, "conflicting")
-        .with_help("Choose either `snake_case` or `camel_case`, not both")
 }
 
 pub fn tag_has_alias(span: &Span, key: &str) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -179,6 +179,8 @@ impl TaskState<'_> {
             return_type: return_ty.clone().into(),
         };
 
+        // `Type::ignored()` defers the tail-position check to
+        // `validators/unused_expressions.rs`, which honors `#[allow(unused_*)]`.
         let has_implicit_unit_return = return_annotation == Annotation::Unknown;
         let body_ty = if has_implicit_unit_return {
             Type::ignored()
@@ -259,6 +261,8 @@ impl TaskState<'_> {
         // `defer` inside a closure body should not be flagged as "defer in loop"
         // even when the closure is lexically inside a loop.
         let saved_loop_depth = self.scopes.reset_loop_depth();
+        // `Type::ignored()` defers the tail-position check to
+        // `validators/unused_expressions.rs`, which honors `#[allow(unused_*)]`.
         let relax_body_to_unit = return_annotation == Annotation::Unknown && return_ty.is_unit();
         let body_ty = if relax_body_to_unit {
             Type::ignored()

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -2,7 +2,6 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use diagnostics::lint::MismatchedTailKind;
 use diagnostics::{PatternIssue, UnusedExpressionKind};
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
 use syntax::types::Type;
@@ -153,14 +152,12 @@ impl Facts {
     pub fn add_discarded_tail(
         &mut self,
         span: Span,
-        kind: MismatchedTailKind,
         return_type: String,
         expected_span: Span,
         expected_type: String,
     ) {
         self.discarded_tail_expressions.push(DiscardedTailFact {
             span,
-            kind,
             return_type,
             expected_span,
             expected_type,
@@ -305,7 +302,6 @@ pub struct UnusedExpressionFact {
 #[derive(Debug, Clone)]
 pub struct DiscardedTailFact {
     pub span: Span,
-    pub kind: MismatchedTailKind,
     pub return_type: String,
     pub expected_span: Span,
     pub expected_type: String,

--- a/crates/semantics/src/validators/ast_lints/attributes.rs
+++ b/crates/semantics/src/validators/ast_lints/attributes.rs
@@ -76,15 +76,17 @@ fn check_field_attributes(
             && is_serialization_key(key)
             && !struct_keys.contains(key)
         {
-            diagnostics.push(diagnostics::lint::field_attribute_without_struct_attribute(
-                &attribute.span,
-                key,
-            ));
+            diagnostics.push(
+                diagnostics::attribute::field_attribute_without_struct_attribute(
+                    &attribute.span,
+                    key,
+                ),
+            );
         }
 
         if let Some(key) = attribute_key {
             if let Some((_, first_attribute)) = seen_keys.iter().find(|(k, _)| *k == key) {
-                diagnostics.push(diagnostics::lint::duplicate_tag_key(
+                diagnostics.push(diagnostics::attribute::duplicate_tag_key(
                     &attribute.span,
                     key,
                     &first_attribute.span,
@@ -190,7 +192,7 @@ fn check_conflicting_case_transforms(
     }
 
     if has_snake_case && has_camel_case {
-        diagnostics.push(diagnostics::lint::conflicting_case_transforms(
+        diagnostics.push(diagnostics::attribute::conflicting_case_transforms(
             &attribute.span,
         ));
     }

--- a/crates/semantics/src/validators/lints.rs
+++ b/crates/semantics/src/validators/lints.rs
@@ -226,12 +226,11 @@ fn collect_unused_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
 
 fn collect_discarded_tail_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
     for fact in &facts.discarded_tail_expressions {
-        out.push(diagnostics::lint::mismatched_tail_value(
+        out.push(diagnostics::infer::mismatched_tail_value(
             &fact.span,
             &fact.return_type,
             &fact.expected_span,
             &fact.expected_type,
-            fact.kind,
         ));
     }
 }

--- a/crates/semantics/src/validators/unused_expressions.rs
+++ b/crates/semantics/src/validators/unused_expressions.rs
@@ -4,7 +4,7 @@ use syntax::types::{Symbol, Type};
 
 use crate::facts::Facts;
 use crate::store::Store;
-use diagnostics::lint::MismatchedTailKind;
+use diagnostics::infer::MismatchedTailKind;
 
 struct TailContext<'a> {
     expected_span: Span,
@@ -284,7 +284,6 @@ fn check_discarded_tail(
 
     facts.add_discarded_tail(
         item.get_span(),
-        kind,
         reported_ty.to_string(),
         expected_span,
         expected_ty,

--- a/crates/syntax/src/parse/error.rs
+++ b/crates/syntax/src/parse/error.rs
@@ -44,9 +44,4 @@ impl ParseError {
         self.code = format!("parse.{}", code);
         self
     }
-
-    pub fn with_lint_code(mut self, code: &str) -> Self {
-        self.code = format!("lint.{}", code);
-        self
-    }
 }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3830,7 +3830,7 @@ fn main() {
     );
     let count = warnings
         .iter()
-        .filter(|w| w.code_str() == Some("lint.mismatched_return_value"))
+        .filter(|w| w.code_str() == Some("infer.mismatched_return_value"))
         .count();
     assert_eq!(count, 2, "expected one diagnostic per break value");
 }

--- a/tests/ui/lint/snapshots/conflicting_case_transforms.snap
+++ b/tests/ui/lint/snapshots/conflicting_case_transforms.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·                ╰── conflicting
  3 │ pub struct User {
    ╰────
-  help: Choose either `snake_case` or `camel_case`, not both · code: [lint.conflicting_case_transforms]
+  help: Choose either `snake_case` or `camel_case`, not both · code: [attribute.conflicting_case_transforms]

--- a/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_bare_literal.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_native_call_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_function_value_user_call_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── returns `int`
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_lambda_value_bare_literal.snap
+++ b/tests/ui/lint/snapshots/discarded_lambda_value_bare_literal.snap
@@ -10,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── has `()` as implicit return type
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_lambda_value_expression_body_errors.snap
@@ -10,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── has `()` as implicit return type
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_loop_with_break_value_errors.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·                ╰── returns `int`
  4 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `int` return value is intended, add `-> int` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_option_in_if_branches_errors.snap
@@ -14,4 +14,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `Option<int>`
  7 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
+++ b/tests/ui/lint/snapshots/discarded_non_call_result_tail_errors.snap
@@ -13,4 +13,4 @@ source: tests/ui/lint/mod.rs
    ·   ╰── returns `Result<int, string>`
  6 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
+++ b/tests/ui/lint/snapshots/discarded_paren_call_returning_result_errors_as_unused_result.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·          ╰── returns `Result<int, string>`
  5 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/duplicate_tag_key.snap
+++ b/tests/ui/lint/snapshots/duplicate_tag_key.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·         ╰── duplicate
  6 │   name: string,
    ╰────
-  help: Remove one of the `json` attributes - each tag key may appear only once per field · code: [lint.duplicate_tag]
+  help: Remove one of the `json` attributes - each tag key may appear only once per field · code: [attribute.duplicate_tag]

--- a/tests/ui/lint/snapshots/field_attribute_without_struct_attribute.snap
+++ b/tests/ui/lint/snapshots/field_attribute_without_struct_attribute.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·            ╰── field has attribute but struct does not
  4 │   name: string,
    ╰────
-  help: Add `#[json]` atop the struct definition to enable field-level attributes · code: [lint.orphan_field_attribute]
+  help: Add `#[json]` atop the struct definition to enable field-level attributes · code: [attribute.orphan_field_attribute]

--- a/tests/ui/lint/snapshots/field_tag_requires_struct_opt_in.snap
+++ b/tests/ui/lint/snapshots/field_tag_requires_struct_opt_in.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·              ╰── field has attribute but struct does not
  4 │   name: string,
    ╰────
-  help: Add `#[bson]` atop the struct definition to enable field-level attributes · code: [lint.orphan_field_attribute]
+  help: Add `#[bson]` atop the struct definition to enable field-level attributes · code: [attribute.orphan_field_attribute]

--- a/tests/ui/lint/snapshots/raw_tag_plus_alias_same_key_duplicate.snap
+++ b/tests/ui/lint/snapshots/raw_tag_plus_alias_same_key_duplicate.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·                ╰── duplicate
  6 │   name: string,
    ╰────
-  help: Remove one of the `validate` attributes - each tag key may appear only once per field · code: [lint.duplicate_tag]
+  help: Remove one of the `validate` attributes - each tag key may appear only once per field · code: [attribute.duplicate_tag]

--- a/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_option_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·        ╰── returns `Option<int>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Option<int>` return value is intended, add `-> Option<int>` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_partial_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·         ╰── returns `Partial<int, string>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Partial<int, string>` return value is intended, add `-> Partial<int, string>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Partial<int, string>` return value is intended, add `-> Partial<int, string>` to the function signature · code: [infer.mismatched_return_value]

--- a/tests/ui/lint/snapshots/unused_result_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/unused_result_in_tail_position.snap
@@ -12,4 +12,4 @@ source: tests/ui/lint/mod.rs
    ·         ╰── returns `Result<int, string>`
  8 │ }
    ╰────
-  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [lint.mismatched_return_value]
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Result<int, string>` return value is intended, add `-> Result<int, string>` to the function signature · code: [infer.mismatched_return_value]


### PR DESCRIPTION
- Split error diagnostics out of the `lint.` prefix so it stays warning-only
- Move attribute-validation errors move to a new `attribute.` prefix
- Move `mismatched_return_value` from `lint.` to `infer.`