### PR TITLE
fix: stop double-wrapping callbacks bound to Go fn aliases

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -312,32 +312,23 @@ impl Emitter<'_> {
         arg: &Expression,
         effective_param_ty: Option<&Type>,
     ) -> Option<String> {
-        let param_fn_ty = effective_param_ty.and_then(|param_ty| {
-            let unwrapped = param_ty.unwrap_forall();
-            let fn_ty = match unwrapped {
-                Type::Function { .. } => unwrapped.clone(),
-                Type::Nominal {
-                    underlying_ty: Some(inner),
-                    ..
-                } => inner.unwrap_forall().clone(),
-                _ => return None,
-            };
-            if let Type::Function { return_type, .. } = &fn_ty
-                && (return_type.is_result()
+        let param_fn_ty = effective_param_ty
+            .and_then(|param_ty| self.resolve_to_function_type(param_ty.unwrap_forall()))
+            .filter(|fn_ty| {
+                let Type::Function { return_type, .. } = fn_ty else {
+                    return false;
+                };
+                return_type.is_result()
                     || return_type.is_option()
-                    || return_type.tuple_arity().is_some_and(|a| a >= 2))
-            {
-                return Some(fn_ty);
-            }
-            None
-        })?;
+                    || return_type.tuple_arity().is_some_and(|a| a >= 2)
+            })?;
 
-        // Identity wrapper when both ends already lower.
         let arg_ty = arg.get_type();
-        if let Type::Function {
+        let arg_fn_ty = self.resolve_to_function_type(arg_ty.unwrap_forall());
+        if let Some(Type::Function {
             return_type: arg_ret,
             ..
-        } = arg_ty.unwrap_forall()
+        }) = arg_fn_ty.as_ref()
             && let Type::Function {
                 return_type: param_ret,
                 ..

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1358,6 +1358,22 @@ fn main() {
 }
 
 #[test]
+fn go_callback_bound_to_aliased_fn_type() {
+    let input = r#"
+import "go:path/filepath"
+import "go:io/fs"
+
+fn main() {
+  let walker: filepath.WalkFunc = |_path: string, _info: fs.FileInfo, _err: error| -> Result<(), error> {
+    Ok(())
+  }
+  let _ = filepath.Walk("/tmp", walker)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unit_call_as_function_argument() {
     let input = r#"
 fn noop() {}

--- a/tests/spec/emit/snapshots/go_callback_bound_to_aliased_fn_type.snap
+++ b/tests/spec/emit/snapshots/go_callback_bound_to_aliased_fn_type.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1373
+description: "input: \nimport \"go:path/filepath\"\nimport \"go:io/fs\"\n\nfn main() {\n  let walker: filepath.WalkFunc = |_path: string, _info: fs.FileInfo, _err: error| -> Result<(), error> {\n    Ok(())\n  }\n  let _ = filepath.Walk(\"/tmp\", walker)\n}\n"
+---
+package main
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+func main() {
+	var walker filepath.WalkFunc = func(_ string, _ fs.FileInfo, _ error) error {
+		return nil
+	}
+	filepath.Walk("/tmp", walker)
+}


### PR DESCRIPTION
Lambdas bound to a Go fn-type alias and then passed to a Go function now emit valid Go. Previously the binding was double-wrapped at the call site, so the generated Go failed to compile.

```rs
import "go:path/filepath"
import "go:io/fs"

fn main() {
  let walker: filepath.WalkFunc = |_path: string, _info: fs.FileInfo, _err: error| -> Result<(), error> {
    Ok(())
  }
  let _ = filepath.Walk("/tmp", walker)
}
```