### PR TITLE
feat: add beginner-friendly diagnostics

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -174,7 +174,7 @@ impl TaskState<'_> {
         self.scopes.set_dot_access_base(prior_dot_access_base);
         let resolved_expression_ty = expression_ty.resolve_in(&self.env);
 
-        if resolved_expression_ty.is_error() {
+        if resolved_expression_ty.is_error() || resolved_expression_ty.is_variable() {
             self.unify(store, expected_ty, &Type::Error, &span);
             return Expression::DotAccess {
                 expression: new_expression.into(),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -858,6 +858,10 @@ impl Expression {
         matches!(self, Expression::NoOp)
     }
 
+    pub fn is_block(&self) -> bool {
+        matches!(self, Expression::Block { .. })
+    }
+
     pub fn is_range(&self) -> bool {
         matches!(self, Expression::Range { .. })
     }

--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -17,10 +17,20 @@ impl<'source> Parser<'source> {
 
         while self.is_not(RightCurlyBrace) {
             let start_position = self.stream.position;
-            if let Some(arm) = self.parse_match_arm() {
+            let arm = self.parse_match_arm();
+            let block_bodied = arm.as_ref().is_some_and(|a| a.expression.is_block());
+            if let Some(arm) = arm {
                 arms.push(arm);
             }
-            self.expect_comma_or(RightCurlyBrace);
+
+            if block_bodied && !self.at_match_arm_terminator() {
+                let span = self.span_from_token(self.previous_token);
+                self.error_match_arm_missing_comma(span);
+                self.recover_to_comma_or(RightCurlyBrace);
+            } else {
+                self.expect_comma_or(RightCurlyBrace);
+            }
+
             self.ensure_progress(start_position, RightCurlyBrace);
         }
 

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -944,16 +944,30 @@ impl<'source> Parser<'source> {
         self.next();
 
         let raw = name_token.text;
-        let name: EcoString = if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
-            raw[1..raw.len() - 1].into()
+        let unquoted: &str = if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
+            &raw[1..raw.len() - 1]
         } else {
             debug_assert!(
                 false,
                 "lexer produced String token without quotes: {:?}",
                 raw
             );
-            raw.into()
+            raw
         };
+
+        if alias.is_none() && self.is(As) && self.stream.peek_ahead(1).kind == Identifier {
+            let as_token = self.current_token();
+            let alias_identifier = self.stream.peek_ahead(1);
+            self.next();
+            self.next();
+            self.error_import_alias_after_path(
+                self.span_from_tokens(as_token),
+                alias_identifier.text,
+                unquoted,
+            );
+        }
+
+        let name: EcoString = unquoted.into();
         let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
 
         Expression::ModuleImport {

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -292,10 +292,11 @@ impl<'source> Parser<'source> {
             "Add a comma between elements.",
         );
 
-        loop {
-            if self.at_eof() || self.is(Comma) || self.is(closing) || self.at_item_boundary() {
-                break;
-            }
+        self.recover_to_comma_or(closing);
+    }
+
+    pub(super) fn recover_to_comma_or(&mut self, closing: TokenKind) {
+        while !self.at_eof() && !self.is(Comma) && !self.is(closing) && !self.at_item_boundary() {
             self.next();
         }
 
@@ -540,6 +541,10 @@ impl<'source> Parser<'source> {
         )
     }
 
+    fn at_match_arm_terminator(&self) -> bool {
+        self.at_eof() || self.is(Comma) || self.is(RightCurlyBrace) || self.at_item_boundary()
+    }
+
     fn resync_on_error(&mut self) {
         if !self.at_eof() {
             self.next();
@@ -572,6 +577,30 @@ impl<'source> Parser<'source> {
         let error = ParseError::new("Syntax error", span, label.into())
             .with_parse_code("syntax_error")
             .with_help(help.into());
+
+        self.errors.push(error);
+    }
+
+    fn error_import_alias_after_path(&mut self, span: ast::Span, alias: &str, path: &str) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new("Syntax error", span, "import alias goes before the path")
+            .with_parse_code("import_alias_position")
+            .with_help(format!(
+                "Use Go-style alias syntax: `import {alias} \"{path}\"`"
+            ));
+
+        self.errors.push(error);
+    }
+
+    fn error_match_arm_missing_comma(&mut self, span: ast::Span) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new("Syntax error", span, "missing comma after match arm")
+            .with_parse_code("match_arm_missing_comma")
+            .with_help("Match arms must be separated by commas, even when the body is a block.");
 
         self.errors.push(error);
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2294,6 +2294,14 @@ import foo.bar;
 }
 
 #[test]
+fn parse_error_import_alias_after_path() {
+    let input = r#"
+import "go:fmt" as f
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_error_recovery_unclosed_type_args() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/parse_error_import_alias_after_path.snap
+++ b/tests/ui/errors/snapshots/parse_error_import_alias_after_path.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:2:17]
+ 1 │ 
+ 2 │ import "go:fmt" as f
+   ·                 ──┬─
+   ·                   ╰── import alias goes before the path
+   ╰────
+  help: Use Go-style alias syntax: `import f "go:fmt"` · code: [parse.import_alias_position]

--- a/tests/ui/errors/snapshots/parse_match_arm_block_missing_comma.snap
+++ b/tests/ui/errors/snapshots/parse_match_arm_block_missing_comma.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   [error] Syntax error
-   ╭─[test.lis:6:6]
+   ╭─[test.lis:6:5]
  5 │       let _ = 10
  6 │     }
-   ·      ▲
-   ·      ╰── expected `,` or `}`
+   ·     ┬
+   ·     ╰── missing comma after match arm
  7 │     2 => {
    ╰────
-  help: Add a comma between elements · code: [parse.syntax_error]
+  help: Match arms must be separated by commas, even when the body is a block · code: [parse.match_arm_missing_comma]


### PR DESCRIPTION
- Match arm with a block body and no trailing comma now produces a dedicated diagnostic
- Rust-style `import "<path>" as <alias>` now produces a dedicated diagnostic