### PR TITLE
fix: hint as-cast for numeric type mismatches

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -869,6 +869,10 @@ impl TaskState<'_> {
             return "Wrap the value in a slice literal".to_string();
         }
 
+        if expected.is_numeric_compatible_with(actual) {
+            return format!("Cast with `as`, e.g. `value as {}`", expected);
+        }
+
         format!(
             "Change the type annotation to `{}` or convert the value to `{}`",
             actual, expected

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4096,6 +4096,30 @@ fn test() {
 }
 
 #[test]
+fn infer_named_numeric_expected_suggests_as_cast() {
+    let typedef_source = r#"
+pub enum Duration: int64 {
+  Second = 1000000000,
+}
+
+pub fn Sleep(d: Duration)
+"#;
+    let main_source = r#"
+import "time"
+
+fn test() {
+  time.Sleep(0);
+}
+"#;
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", typedef_source);
+    fs.add_file("main", "main.lis", main_source);
+    let result = infer_module("main", fs);
+
+    assert_multimodule_infer_error_snapshot!(result, main_source);
+}
+
+#[test]
 fn infer_taking_value_of_ufcs_method() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_named_numeric_expected_suggests_as_cast.snap
+++ b/tests/ui/errors/snapshots/infer_named_numeric_expected_suggests_as_cast.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[main.lis:5:14]
+ 4 │ fn test() {
+ 5 │   time.Sleep(0);
+   ·              ┬
+   ·              ╰── expected `Duration`, found `int`
+ 6 │ }
+   ╰────
+  help: Cast with `as`, e.g. `value as Duration` · code: [infer.type_mismatch]


### PR DESCRIPTION
The diagnostic for type mismatch now suggests `as` cast when the expected and actual types reduce to the same numeric family.
