### PR TITLE
fix: suppress cascading diagnostics for error type

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -468,12 +468,16 @@ impl TaskState<'_> {
 
         let resolved_iterable_ty = store.peel_alias(&iterable_ty.resolve_in(&self.env));
 
+        let iterable_is_error = resolved_iterable_ty.is_error();
+
         let iterable_ty_name = match resolved_iterable_ty.get_name() {
             Some(name) => name,
             None => {
-                self.sink.push(diagnostics::infer::unknown_iterable_type(
-                    new_iterable.get_span(),
-                ));
+                if !iterable_is_error {
+                    self.sink.push(diagnostics::infer::unknown_iterable_type(
+                        new_iterable.get_span(),
+                    ));
+                }
                 "Slice"
             }
         };
@@ -482,7 +486,12 @@ impl TaskState<'_> {
         let iterable_ty_args = match resolved_iterable_ty.get_type_params() {
             Some(args) => args,
             None => {
-                fallback_args = [self.new_type_var(), self.new_type_var()];
+                let element = if iterable_is_error {
+                    Type::Error
+                } else {
+                    self.new_type_var()
+                };
+                fallback_args = [element.clone(), element];
                 &fallback_args
             }
         };

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -13,7 +13,7 @@ impl TaskState<'_> {
         index_ty: &Type,
         span: Span,
     ) -> bool {
-        if type_name != "Slice" || index_ty.is_variable() {
+        if type_name != "Slice" || index_ty.is_variable() || index_ty.is_error() {
             return true;
         }
         if index_ty.get_name().is_some_and(|n| n == "int") {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -132,8 +132,10 @@ impl TaskState<'_> {
                     self.check_negative_literal_overflow(&new_expression, &resolved, span);
                     operand_expected_ty.clone()
                 } else {
-                    self.sink
-                        .push(diagnostics::infer::not_numeric(&resolved, operand_span));
+                    if !resolved.is_error() {
+                        self.sink
+                            .push(diagnostics::infer::not_numeric(&resolved, operand_span));
+                    }
                     operand_expected_ty.clone()
                 }
             }
@@ -763,12 +765,18 @@ impl TaskState<'_> {
                 .push(diagnostics::infer::float_literal_int_cast(span));
         }
 
-        self.unify(store, expected_ty, &target_ty, &span);
+        let result_ty = if source_ty.contains_error() || target_ty.contains_error() {
+            Type::Error
+        } else {
+            target_ty.clone()
+        };
+
+        self.unify(store, expected_ty, &result_ty, &span);
 
         Expression::Cast {
             expression: new_expression.into(),
             target_type,
-            ty: target_ty,
+            ty: result_ty,
             span,
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -196,7 +196,11 @@ impl TaskState<'_> {
                     .unzip();
 
                 if let RestPattern::Bind { ref name, ref span } = rest {
-                    let rest_ty = self.type_slice(element_ty.clone());
+                    let rest_ty = if element_ty.shallow_resolve_in(&self.env).is_error() {
+                        Type::Error
+                    } else {
+                        self.type_slice(element_ty.clone())
+                    };
                     let is_typedef = self.is_d_lis(store);
                     let binding_id = self.facts.add_binding(
                         name.to_string(),
@@ -522,6 +526,8 @@ impl TaskState<'_> {
 
         self.unify(store, &expected_ty, &struct_ty, &span);
 
+        let scrutinee_is_error = expected_ty.shallow_resolve_in(&self.env).is_error();
+
         let struct_module = qualified_name.split('.').next().unwrap_or(&qualified_name);
         let is_cross_module = struct_module != self.cursor.module_id;
 
@@ -541,7 +547,11 @@ impl TaskState<'_> {
                                 field.value.get_span(),
                             ));
                         }
-                        substitute(&field_definition.ty, &map)
+                        if scrutinee_is_error {
+                            Type::Error
+                        } else {
+                            substitute(&field_definition.ty, &map)
+                        }
                     }
                     None => {
                         self.sink.push(diagnostics::infer::member_not_found(

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -55,7 +55,11 @@ impl TaskState<'_> {
             let ok_ty = ctx.ok_ty.clone();
             let err_ty = ctx.err_ty.clone();
 
-            if !is_result && !is_option && !resolved_tried_ty.is_partial() {
+            if !is_result
+                && !is_option
+                && !resolved_tried_ty.is_partial()
+                && !resolved_tried_ty.is_error()
+            {
                 self.sink
                     .push(diagnostics::infer::try_requires_result_or_option(span));
             }
@@ -90,6 +94,11 @@ impl TaskState<'_> {
         )
     }
 
+    fn propagate_as_error(&mut self, store: &Store, expected_ty: &Type, span: Span) -> Type {
+        self.unify(store, expected_ty, &Type::Error, &span);
+        Type::Error
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn infer_propagate_in_block(
         &mut self,
@@ -101,7 +110,9 @@ impl TaskState<'_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
-        let ty = if tried_ty.is_result() {
+        let ty = if tried_ty.is_error() {
+            self.propagate_as_error(store, expected_ty, span)
+        } else if tried_ty.is_result() {
             let ok_ty = tried_ty.ok_type();
             self.unify(store, try_err_ty, &tried_ty.err_type(), &span);
             if ok_ty.resolve_in(&self.env).is_variable() {
@@ -117,7 +128,7 @@ impl TaskState<'_> {
             self.unify(store, expected_ty, &some_ty, &span);
             some_ty
         } else {
-            Type::Error
+            self.propagate_as_error(store, expected_ty, span)
         };
 
         Expression::Propagate {
@@ -145,7 +156,9 @@ impl TaskState<'_> {
                 Type::Error
             });
 
-        let ty = if tried_ty.is_result() {
+        let ty = if tried_ty.is_error() {
+            self.propagate_as_error(store, expected_ty, span)
+        } else if tried_ty.is_result() {
             let ok_ty = tried_ty.ok_type();
             let err_ty = tried_ty.err_type();
             let new_ok = self.new_type_var();
@@ -179,11 +192,11 @@ impl TaskState<'_> {
             self.unify(store, expected_ty, &some_ty, &span);
             some_ty
         } else if tried_ty.is_partial() {
-            Type::Error
+            self.propagate_as_error(store, expected_ty, span)
         } else {
             self.sink
                 .push(diagnostics::infer::try_requires_result_or_option(span));
-            Type::Error
+            self.propagate_as_error(store, expected_ty, span)
         };
 
         Expression::Propagate {

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -103,8 +103,14 @@ impl TaskState<'_> {
             (Type::Var { id, .. }, _) => self.unify_type_variable(store, *id, &r2, span, false),
             (_, Type::Var { id, .. }) => self.unify_type_variable(store, *id, &r1, span, true),
 
-            // Non-variable vs Error succeeds silently; variables were handled above.
-            _ if matches!(r1, Type::Error) || matches!(r2, Type::Error) => Ok(()),
+            _ if matches!(r1, Type::Error) => {
+                self.collapse_vars_to_error(store, &r2, span);
+                Ok(())
+            }
+            _ if matches!(r2, Type::Error) => {
+                self.collapse_vars_to_error(store, &r1, span);
+                Ok(())
+            }
 
             (Type::Parameter(name1), Type::Parameter(name2)) if name1 == name2 => Ok(()),
 
@@ -234,8 +240,13 @@ impl TaskState<'_> {
         let both_concrete = !t1.is_variable() && !t2.is_variable();
         let neither_is_interface = !self.is_interface(store, t1) && !self.is_interface(store, t2);
         let neither_is_unknown = !r1.is_unknown() && !r2.is_unknown();
+        let neither_is_error = !r1.is_error() && !r2.is_error();
 
-        either_is_ref && both_concrete && neither_is_interface && neither_is_unknown
+        either_is_ref
+            && both_concrete
+            && neither_is_interface
+            && neither_is_unknown
+            && neither_is_error
     }
 
     fn is_interface(&self, store: &Store, ty: &Type) -> bool {
@@ -257,6 +268,44 @@ impl TaskState<'_> {
             (true, true) => self.try_unify(store, &t1.strip_refs(), &t2.strip_refs(), span),
             (true, false) | (false, true) => Err(UnifyError::TypeMismatch),
             (false, false) => unreachable!("unify_refs called without refs"),
+        }
+    }
+
+    fn collapse_vars_to_error(&mut self, store: &Store, ty: &Type, span: &Span) {
+        let resolved = self.env.shallow_resolve(ty);
+        match resolved {
+            Type::Var { id, .. } if !id.is_reserved() => {
+                let _ = self.unify_type_variable(store, id, &Type::Error, span, false);
+            }
+            Type::Nominal { params, .. } => {
+                for p in params {
+                    self.collapse_vars_to_error(store, &p, span);
+                }
+            }
+            Function {
+                params,
+                return_type,
+                ..
+            } => {
+                for p in params {
+                    self.collapse_vars_to_error(store, &p, span);
+                }
+                self.collapse_vars_to_error(store, &return_type, span);
+            }
+            Type::Tuple(elems) => {
+                for e in elems {
+                    self.collapse_vars_to_error(store, &e, span);
+                }
+            }
+            Type::Compound { args, .. } => {
+                for a in args {
+                    self.collapse_vars_to_error(store, &a, span);
+                }
+            }
+            Type::Forall { body, .. } => {
+                self.collapse_vars_to_error(store, &body, span);
+            }
+            _ => {}
         }
     }
 
@@ -433,6 +482,13 @@ impl TaskState<'_> {
                 _ if r1.is_ignored() || r2.is_ignored() => {}
                 _ if r1.is_receiver_placeholder() || r2.is_receiver_placeholder() => {}
                 (Type::Var { id: i1, .. }, Type::Var { id: i2, .. }) if i1 == i2 => {}
+
+                _ if matches!(r1, Type::Error) => {
+                    self.collapse_vars_to_error(store, &r2, span);
+                }
+                _ if matches!(r2, Type::Error) => {
+                    self.collapse_vars_to_error(store, &r1, span);
+                }
 
                 _ if r1_unk && r2_unk => {}
                 _ if r1_unk && !r2.is_variable() => {

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -27,6 +27,10 @@ impl TaskState<'_> {
         let source_ty = raw_source_ty.resolve_in(&self.env);
         let target_ty = raw_target_ty.resolve_in(&self.env);
 
+        if source_ty.contains_error() || target_ty.contains_error() {
+            return;
+        }
+
         if source_ty.is_complex() || target_ty.is_complex() {
             self.sink.push(diagnostics::infer::invalid_cast(
                 raw_source_ty,

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -939,6 +939,29 @@ impl Type {
         matches!(self, Type::Error)
     }
 
+    pub fn contains_error(&self) -> bool {
+        match self {
+            Type::Error => true,
+            Type::Nominal {
+                params,
+                underlying_ty,
+                ..
+            } => {
+                params.iter().any(Type::contains_error)
+                    || underlying_ty.as_deref().is_some_and(Type::contains_error)
+            }
+            Type::Compound { args, .. } => args.iter().any(Type::contains_error),
+            Type::Function {
+                params,
+                return_type,
+                ..
+            } => params.iter().any(Type::contains_error) || return_type.contains_error(),
+            Type::Tuple(elements) => elements.iter().any(Type::contains_error),
+            Type::Forall { body, .. } => body.contains_error(),
+            _ => false,
+        }
+    }
+
     pub fn has_unbound_variables(&self) -> bool {
         match self {
             Type::Var { hint, .. } => hint.is_some(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2546,6 +2546,41 @@ pub fn outer_fn() -> string {
 }
 
 #[test]
+fn module_graph_failed_import_suppresses_cascade() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"import "totally_missing"
+
+fn main() {
+  let value = totally_missing.SomeValue
+  match value.method() {
+    Ok((_, data)) => {
+      let _ = data as string
+    },
+    Err(_) => (),
+  }
+}"#,
+    );
+    let result = infer_module("main", fs);
+
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "Expected only the import error, got: {:#?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .code_str()
+            .is_some_and(|c| c.contains("module_not_found")),
+        "Expected module_not_found, got: {:?}",
+        result.errors[0].code_str()
+    );
+}
+
+#[test]
 fn module_graph_test_file_rejected() {
     let mut fs = MockFileSystem::new();
     fs.add_file(


### PR DESCRIPTION
Suppresses derivative diagnostics that appeared when an upstream error tainted the type of a downstream expression. A single broken expression now emits a single root diagnostic instead of a cascade.