### PR TITLE
fix: hint unwrap for member access on Option/Result

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -727,10 +727,35 @@ pub fn member_not_found(
     field: &str,
     span: Span,
     available_fields: Option<&[String]>,
+    unwrap_hint: Option<UnwrapHint>,
 ) -> LisetteDiagnostic {
     let mut diagnostic = LisetteDiagnostic::error("Member not found")
         .with_infer_code("member_not_found")
         .with_span_label(&span, format!("no member `{}` on type `{}`", field, ty));
+
+    if let Some(hint) = unwrap_hint {
+        let (wrapper_name, pattern) = match hint.wrapper {
+            UnwrapWrapper::Option => (
+                "Option",
+                format!(
+                    "match <expr> {{ Some(x) => x.{}(...), None => ... }}",
+                    field
+                ),
+            ),
+            UnwrapWrapper::Result => (
+                "Result",
+                format!(
+                    "match <expr> {{ Ok(x) => x.{}(...), Err(e) => ... }}",
+                    field
+                ),
+            ),
+        };
+        diagnostic = diagnostic.with_help(format!(
+            "Unwrap the `{}` to extract the `{}` value, then call `{}` on it, e.g. `{}`",
+            wrapper_name, hint.inner_ty, field, pattern
+        ));
+        return diagnostic;
+    }
 
     let suggestion = available_fields.and_then(|fields| find_similar_name(field, fields));
 
@@ -741,6 +766,18 @@ pub fn member_not_found(
     }
 
     diagnostic
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum UnwrapWrapper {
+    Option,
+    Result,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnwrapHint {
+    pub wrapper: UnwrapWrapper,
+    pub inner_ty: Type,
 }
 
 pub fn not_numeric(ty: &Type, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -229,6 +229,7 @@ impl TaskState<'_> {
         }
 
         let available_members = self.get_available_member_names(store, &resolved_expression_ty);
+        let unwrap_hint = self.compute_unwrap_hint(store, &resolved_expression_ty, &member);
         self.sink.push(diagnostics::infer::member_not_found(
             &resolved_expression_ty,
             &member,
@@ -238,6 +239,7 @@ impl TaskState<'_> {
             } else {
                 Some(&available_members)
             },
+            unwrap_hint,
         ));
 
         Expression::DotAccess {
@@ -294,6 +296,44 @@ impl TaskState<'_> {
         names.extend(methods.into_keys().map(|k| k.to_string()));
 
         names
+    }
+
+    fn compute_unwrap_hint(
+        &self,
+        store: &Store,
+        ty: &Type,
+        member: &str,
+    ) -> Option<diagnostics::infer::UnwrapHint> {
+        let wrapper = if ty.is_option() {
+            diagnostics::infer::UnwrapWrapper::Option
+        } else if ty.is_result() {
+            diagnostics::infer::UnwrapWrapper::Result
+        } else {
+            return None;
+        };
+
+        let inner = ty.inner()?.strip_refs();
+        if self.has_member(store, &inner, member) {
+            Some(diagnostics::infer::UnwrapHint {
+                wrapper,
+                inner_ty: inner,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn has_member(&self, store: &Store, ty: &Type, member: &str) -> bool {
+        let deref_ty = ty.strip_refs();
+
+        if let Type::Nominal { .. } = deref_ty
+            && let Some(fields) = store.fields_of(&deref_ty.get_qualified_name())
+            && fields.iter().any(|f| f.name == member)
+        {
+            return true;
+        }
+
+        self.get_all_methods(store, &deref_ty).contains_key(member)
     }
 
     fn as_struct_field(

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -559,6 +559,7 @@ impl TaskState<'_> {
                             &field.name,
                             span,
                             Some(&available),
+                            None,
                         ));
                         Type::Error
                     }
@@ -833,6 +834,7 @@ impl TaskState<'_> {
                             &field.name,
                             *span,
                             Some(&available),
+                            None,
                         ));
                         Type::Error
                     }

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -429,6 +429,7 @@ impl TaskState<'_> {
                             &field.name,
                             ctx.span,
                             Some(&available),
+                            None,
                         ));
                         self.new_type_var()
                     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1268,6 +1268,48 @@ fn test(s: Slice<int>) -> int {
 }
 
 #[test]
+fn infer_member_not_found_unwrap_option() {
+    let input = r#"
+fn test(opt: Option<string>) -> int {
+  opt.contains("h")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_unwrap_result() {
+    let input = r#"
+fn test(res: Result<string, error>) -> int {
+  res.contains("h")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_unwrap_option_ref_struct() {
+    let input = r#"
+struct Url { Path: string }
+
+fn test(u: Option<Ref<Url>>) -> string {
+  u.Path
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_unwrap_option_no_inner_match() {
+    let input = r#"
+fn test(opt: Option<string>) {
+  opt.bogus
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_struct_missing_fields() {
     let input = r#"
 struct Person {

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(opt: Option<string>) -> int {
+ 3 │   opt.contains("h")
+   ·   ──────┬─────
+   ·         ╰── no member `contains` on type `Option<string>`
+ 4 │ }
+   ╰────
+  help: Unwrap the `Option` to extract the `string` value, then call `contains` on it, e.g. `match <expr> { Some(x) => x.contains(...), None => ... }` · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option_no_inner_match.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option_no_inner_match.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(opt: Option<string>) {
+ 3 │   opt.bogus
+   ·   ────┬────
+   ·       ╰── no member `bogus` on type `Option<string>`
+ 4 │ }
+   ╰────
+  help: Ensure the field or method is defined on this type · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option_ref_struct.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_option_ref_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:5:3]
+ 4 │ fn test(u: Option<Ref<Url>>) -> string {
+ 5 │   u.Path
+   ·   ───┬──
+   ·      ╰── no member `Path` on type `Option<Ref<Url>>`
+ 6 │ }
+   ╰────
+  help: Unwrap the `Option` to extract the `Url` value, then call `Path` on it, e.g. `match <expr> { Some(x) => x.Path(...), None => ... }` · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_result.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_result.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(res: Result<string, error>) -> int {
+ 3 │   res.contains("h")
+   ·   ──────┬─────
+   ·         ╰── no member `contains` on type `Result<string, error>`
+ 4 │ }
+   ╰────
+  help: Unwrap the `Result` to extract the `string` value, then call `contains` on it, e.g. `match <expr> { Ok(x) => x.contains(...), Err(e) => ... }` · code: [infer.member_not_found]


### PR DESCRIPTION
Adds an unwrap hint to the member-not-found diagnostic when the receiver is `Option` or `Result` and the missing member exists on the inner `T`.

```rs
fn handle(r: Ref<http.Request>) -> string {
  r.URL.Path
}
```

```
  [error] Member not found
   ╭─[test.lis:5:3]
 4 │ fn test(u: Option<Ref<Url>>) -> string {
 5 │   u.Path
   ·   ───┬──
   ·      ╰── no member `Path` on type `Option<Ref<Url>>`
 6 │ }
   ╰────
  help: Unwrap the `Option` to extract the `Url` value, then call `Path` on it, e.g. `match <expr> 
  { Some(x) => x.Path(...), None => ... }` · code: [infer.member_not_found]
```