### PR TITLE
feat: add nilable_param bindgen override

### DIFF
--- a/bindgen/README.md
+++ b/bindgen/README.md
@@ -230,6 +230,15 @@ Bindgen accepts a config file with per-package overrides:
           "CopyBuffer": ["buf"],
         },
       },
+
+      // Turn `Ref<T>` parameter into `Option<Ref<T>>` for Go APIs that accept
+      // nil to mean "use the default"
+      // e.g. `rp` in `mongo.Client.Ping(ctx, rp)` accepts nil
+      "nilable_param": {
+        "go.mongodb.org/mongo-driver/v2/mongo": {
+          "Client.Ping": ["rp"],
+        },
+      },
     },
   },
 }

--- a/bindgen/bindgen.external.json
+++ b/bindgen/bindgen.external.json
@@ -62,6 +62,13 @@
           "NewEmptyConfigError"
         ]
       },
+      "nilable_param": {
+        "go.mongodb.org/mongo-driver/v2/mongo": {
+          "Client.Ping": [
+            "rp"
+          ]
+        }
+      },
       "mutates_param": {
         "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob": {
           "Client.DownloadBuffer": [

--- a/bindgen/internal/config/config.go
+++ b/bindgen/internal/config/config.go
@@ -35,6 +35,10 @@ type TypeOverrides struct {
 	NeverReturn      map[string][]string            `json:"never_return"`
 	PartialResult    map[string][]string            `json:"partial_result"`
 	MutatesParam     map[string]map[string][]string `json:"mutates_param"`
+	// NilableParam declares pointer/interface parameters that accept nil in Go
+	// (e.g. `nil` means "use the default"), so they should be `Option<Ref<T>>`
+	// instead of `Ref<T>`.
+	NilableParam map[string]map[string][]string `json:"nilable_param"`
 	// SentinelMinusOne declares int-returning functions that signal
 	// "absent" with `-1`. Bindgen rewrites the return to `Option<int>`
 	// and emits `#[go(sentinel_minus_one)]`.
@@ -152,6 +156,19 @@ func (c *Config) MutatingParams(pkg, name string) []string {
 		return nil
 	}
 	return funcs[name] // nil if not found
+}
+
+// NilableParams returns the list of parameter names that should be wrapped in
+// `Option<>` for the given function or method, or nil if none are configured.
+func (c *Config) NilableParams(pkg, name string) []string {
+	if c == nil {
+		return nil
+	}
+	funcs, ok := lookupWithGlobNested(c.Overrides.Types.NilableParam, pkg)
+	if !ok {
+		return nil
+	}
+	return funcs[name]
 }
 
 // IsPartialResult returns true if the given function or method in the given

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -118,11 +118,18 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 	result.TypeParams = liftedSpecs
 
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, result.Name)
+	nilableParams := c.cfg.NilableParams(c.currentPkgPath, result.Name)
 
 	params := signature.Params()
 	for i := 0; i < params.Len(); i++ {
 		param := params.At(i)
-		paramType := ToLisette(param.Type(), c)
+		name := param.Name()
+		if name == "" {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		name = sanitizeParamName(name)
+
+		paramType := convertParamType(param.Type(), name, nilableParams, c)
 		if paramType.SkipReason != nil {
 			result.SkipReason = paramType.SkipReason
 			return
@@ -135,12 +142,6 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 		if override, ok := paramOverrides[i]; ok {
 			typeStr = override
 		}
-
-		name := param.Name()
-		if name == "" {
-			name = fmt.Sprintf("arg%d", i)
-		}
-		name = sanitizeParamName(name)
 
 		result.Params = append(result.Params, FunctionParameter{
 			Name:    name,
@@ -274,11 +275,18 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	liftedSpecs, paramOverrides := c.liftReflectionDecodeParams(signature, qualifiedName, methodSpecs)
 
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, qualifiedName)
+	nilableParams := c.cfg.NilableParams(c.currentPkgPath, qualifiedName)
 
 	params := signature.Params()
 	for i := 0; i < params.Len(); i++ {
 		param := params.At(i)
-		paramType := ToLisette(param.Type(), c)
+		name := param.Name()
+		if name == "" {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		name = sanitizeParamName(name)
+
+		paramType := convertParamType(param.Type(), name, nilableParams, c)
 		if paramType.SkipReason != nil {
 			result.SkipReason = paramType.SkipReason
 			return
@@ -291,12 +299,6 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 		if override, ok := paramOverrides[i]; ok {
 			typeStr = override
 		}
-
-		name := param.Name()
-		if name == "" {
-			name = fmt.Sprintf("arg%d", i)
-		}
-		name = sanitizeParamName(name)
 
 		result.Params = append(result.Params, FunctionParameter{
 			Name:    name,
@@ -1311,12 +1313,20 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 			return nil, false
 		}
 
-		mutParams := c.cfg.MutatingParams(c.currentPkgPath, typeName+"."+method.Name())
+		qualifiedName := typeName + "." + method.Name()
+		mutParams := c.cfg.MutatingParams(c.currentPkgPath, qualifiedName)
+		nilableParams := c.cfg.NilableParams(c.currentPkgPath, qualifiedName)
 
 		var params []FunctionParameter
 		for j := 0; j < signature.Params().Len(); j++ {
 			param := signature.Params().At(j)
-			paramType := ToLisette(param.Type(), c)
+			name := param.Name()
+			if name == "" {
+				name = fmt.Sprintf("arg%d", j)
+			}
+			name = sanitizeParamName(name)
+
+			paramType := convertParamType(param.Type(), name, nilableParams, c)
 			if paramType.SkipReason != nil {
 				return nil, false
 			}
@@ -1325,12 +1335,6 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 			if signature.Variadic() && j == signature.Params().Len()-1 {
 				typeStr = sliceToVarArgs(typeStr)
 			}
-
-			name := param.Name()
-			if name == "" {
-				name = fmt.Sprintf("arg%d", j)
-			}
-			name = sanitizeParamName(name)
 
 			params = append(params, FunctionParameter{
 				Name:    name,

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"fmt"
 	"go/types"
+	"slices"
 	"strings"
 )
 
@@ -30,6 +31,15 @@ func ToLisette(t types.Type, conv *Converter) TypeResult {
 // where Go pointers/interfaces can be nil.
 func ToLisetteNilable(t types.Type, conv *Converter) TypeResult {
 	return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv)
+}
+
+// convertParamType wraps a `*T` parameter in `Option<>` when the param's name
+// appears in `nilable` — used for Go APIs where passing nil means "use default".
+func convertParamType(t types.Type, name string, nilable []string, conv *Converter) TypeResult {
+	if slices.Contains(nilable, name) {
+		return ToLisetteNilable(t, conv)
+	}
+	return ToLisette(t, conv)
 }
 
 // isNilableGoType returns true if the Go type is a pointer or a named

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -268,6 +268,13 @@ impl Emitter<'_> {
             return result;
         }
 
+        if ctx.is_go_call
+            && let Some(result) =
+                self.try_emit_go_pointer_param_unwrap(output, arg, effective_param_ty)
+        {
+            return result;
+        }
+
         if ctx.pointer_indices.contains(&index) {
             let value = self.emit_value(output, arg);
             if matches!(arg, Expression::Reference { .. }) || arg.get_type().is_ref() {
@@ -343,6 +350,25 @@ impl Emitter<'_> {
         Some(self.emit_lisette_callback_wrapper(output, &value, &param_fn_ty))
     }
 
+    /// Bridge a Lisette `Option<Ref<T>>` argument to Go `*T` when the Go
+    /// parameter accepts nil.
+    fn try_emit_go_pointer_param_unwrap(
+        &mut self,
+        output: &mut String,
+        arg: &Expression,
+        effective_param_ty: Option<&Type>,
+    ) -> Option<String> {
+        let param_ty = effective_param_ty?;
+        if !self.is_nullable_option(param_ty) {
+            return None;
+        }
+        let arg_ty = arg.get_type();
+        if !self.is_nullable_option(&arg_ty) {
+            return None;
+        }
+        Some(self.emit_unwrap_go_nullable_arg(output, arg, &arg_ty))
+    }
+
     fn try_emit_nullable_coercion(
         &mut self,
         output: &mut String,
@@ -372,11 +398,20 @@ impl Emitter<'_> {
             return None;
         }
 
+        Some(self.emit_unwrap_go_nullable_arg(output, arg, &arg_ty))
+    }
+
+    fn emit_unwrap_go_nullable_arg(
+        &mut self,
+        output: &mut String,
+        arg: &Expression,
+        arg_ty: &Type,
+    ) -> String {
         if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
-            return Some("nil".to_string());
+            return "nil".to_string();
         }
         let value = self.emit_value(output, arg);
-        let coercion = Coercion::resolve_unwrap_go_nullable(self, &arg.get_type());
-        Some(coercion.apply(self, output, value))
+        let coercion = Coercion::resolve_unwrap_go_nullable(self, arg_ty);
+        coercion.apply(self, output, value)
     }
 }


### PR DESCRIPTION
Adds a bindgen config override that binds specific Go pointer parameters as `Option<Ref<T>>` instead of `Ref<T>`, so Lisette can pass `None` to Go APIs that treat `nil` as "use the default".

```rs
let client = mongo.Connect(client_opts)?
client.Ping(ctx, None)?
```