### PR TITLE
fix: tolerate transitive bindgen failures in lis add

### DIFF
--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use crate::go_cli;
 use crate::lock::acquire_mutation_lock;
-use crate::output::{print_add_success, print_preview_notice, print_progress};
+use crate::output::{print_add_success, print_preview_notice, print_progress, print_warning};
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
 use deps::{GoModule, remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep};
@@ -358,6 +358,15 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         return Err(1);
     }
 
+    if let Err(msg) = deps::check_no_subpackage_deps(&manifest) {
+        cli_error!(
+            "Invalid `lisette.toml`",
+            msg,
+            "Fix `lisette.toml` and retry"
+        );
+        return Err(1);
+    }
+
     if let Err(msg) = deps::validate_project_name(&manifest.project.name) {
         cli_error!(
             "Invalid project name",
@@ -467,14 +476,26 @@ fn reconcile_module_graph(
 ) -> Result<GraphResult, i32> {
     let mut module_versions: HashMap<String, String> = HashMap::new();
     let mut edges: HashMap<String, Vec<String>> = HashMap::new();
+    let mut failed_transitives: HashSet<String> = HashSet::new();
     let mut queue: Vec<String> = vec![dep.module_path.clone()];
 
     loop {
         while let Some(module_path) = queue.pop() {
-            let module_version = workspace.query_version(&module_path).map_err(|msg| {
-                error!("failed to resolve module version", msg);
-                1
-            })?;
+            let is_explicit = module_path == dep.module_path;
+
+            let module_version = match workspace.query_version(&module_path) {
+                Ok(v) => v,
+                Err(msg) => {
+                    if is_explicit {
+                        error!("failed to resolve module version", msg);
+                        return Err(1);
+                    }
+                    if failed_transitives.insert(module_path.clone()) {
+                        print_warning(&format!("skipping transitive {}: {}", module_path, msg));
+                    }
+                    continue;
+                }
+            };
 
             if module_versions
                 .get(&module_path)
@@ -483,7 +504,7 @@ fn reconcile_module_graph(
                 continue;
             }
 
-            if module_path != dep.module_path && !module_versions.contains_key(&module_path) {
+            if !is_explicit && !module_versions.contains_key(&module_path) {
                 print_progress(&format!("Resolving transitive dep {}", module_path));
             }
 
@@ -495,16 +516,28 @@ fn reconcile_module_graph(
             let packages = match workspace.reconcile(module) {
                 Ok(p) => p,
                 Err(msg) => {
-                    error!("failed to reconcile dependency", msg);
-                    return Err(1);
+                    if is_explicit {
+                        error!("failed to reconcile dependency", msg);
+                        return Err(1);
+                    }
+                    if failed_transitives.insert(module_path.clone()) {
+                        print_warning(&format!("skipping transitive {}: {}", module_path, msg));
+                    }
+                    continue;
                 }
             };
 
             let dep_modules = match workspace.find_third_party_deps(module, &packages) {
                 Ok(t) => t,
                 Err(msg) => {
-                    error!("failed to scan transitive imports", msg);
-                    return Err(1);
+                    if is_explicit {
+                        error!("failed to scan transitive imports", msg);
+                        return Err(1);
+                    }
+                    if failed_transitives.insert(module_path.clone()) {
+                        print_warning(&format!("skipping transitive {}: {}", module_path, msg));
+                    }
+                    continue;
                 }
             };
 
@@ -536,6 +569,13 @@ fn reconcile_module_graph(
         if !more_work {
             break;
         }
+    }
+
+    if !failed_transitives.is_empty() {
+        print_warning(&format!(
+            "{} transitive dep(s) skipped; importing them later will fail until they are bindable",
+            failed_transitives.len()
+        ));
     }
 
     Ok(GraphResult {

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -40,6 +40,15 @@ pub fn sync() -> i32 {
         return 1;
     }
 
+    if let Err(msg) = deps::check_no_subpackage_deps(&manifest) {
+        cli_error!(
+            "Invalid `lisette.toml`",
+            msg,
+            "Fix `lisette.toml` and retry"
+        );
+        return 1;
+    }
+
     if let Err(msg) = deps::validate_project_name(&manifest.project.name) {
         cli_error!(
             "Invalid project name",

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -4,8 +4,9 @@ mod typedef_locator;
 use std::path::{Path, PathBuf};
 
 pub use project_manifest::{
-    GoDependency, Manifest, ResolveReport, TrimmedVia, check_toolchain_version, parse_manifest,
-    remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep, validate_project_name,
+    GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
+    check_toolchain_version, parse_manifest, remove_go_dep, resolve_empty_via,
+    trim_dead_via_parents, upsert_go_dep, validate_project_name,
 };
 pub use typedef_locator::{TypedefLocator, TypedefLocatorResult, TypedefOrigin};
 

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -132,6 +132,24 @@ pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
     Ok(())
 }
 
+pub fn check_no_subpackage_deps(manifest: &Manifest) -> Result<(), String> {
+    let deps = manifest.go_deps();
+
+    for key in deps.keys() {
+        if let Some(parent) = deps
+            .keys()
+            .find(|other| other.as_str() != key.as_str() && is_pkg_under(key, other))
+        {
+            return Err(format!(
+                "`{}` in `[dependencies.go]` is a subpackage of `{}`; remove this entry and rely on the parent module pin",
+                key, parent
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
 
 fn strip_bom_to_str(bytes: &[u8]) -> Result<&str, std::str::Utf8Error> {
@@ -324,6 +342,14 @@ pub fn resolve_empty_via(
     Ok(ResolveReport { promoted, removed })
 }
 
+/// Whether `pkg_path` equals `module_path` or is a path nested under it
+/// (`module_path` followed by `/`).
+fn is_pkg_under(pkg_path: &str, module_path: &str) -> bool {
+    pkg_path == module_path
+        || (pkg_path.starts_with(module_path)
+            && pkg_path.as_bytes().get(module_path.len()) == Some(&b'/'))
+}
+
 /// Longest declared module path that is a prefix of `pkg_path`, matching the
 /// full key or a key followed by `/`.
 pub(crate) fn find_module_for_pkg<'a>(
@@ -332,10 +358,7 @@ pub(crate) fn find_module_for_pkg<'a>(
 ) -> Option<(&'a str, &'a GoDependency)> {
     let mut best: Option<(&str, &GoDependency)> = None;
     for (module_path, dep) in deps {
-        let is_match = pkg_path == module_path.as_str()
-            || (pkg_path.starts_with(module_path.as_str())
-                && pkg_path.as_bytes().get(module_path.len()) == Some(&b'/'));
-        if is_match
+        if is_pkg_under(pkg_path, module_path)
             && best
                 .as_ref()
                 .is_none_or(|(prev, _)| module_path.len() > prev.len())

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::project_manifest::{
-    GoDependency, Manifest, check_toolchain_version, find_module_for_pkg, parse_manifest,
+    GoDependency, Manifest, check_no_subpackage_deps, check_toolchain_version, find_module_for_pkg,
+    parse_manifest,
 };
 use crate::{GoModule, GoPackage, typedef_cache_dir};
 
@@ -58,6 +59,7 @@ impl TypedefLocator {
         let manifest = parse_manifest(project_root)?;
 
         check_toolchain_version(&manifest)?;
+        check_no_subpackage_deps(&manifest)?;
 
         let locator = Self::new(
             manifest.go_deps(),

--- a/tests/spec/sync.rs
+++ b/tests/spec/sync.rs
@@ -222,3 +222,36 @@ version = "0.1.0"
         stderr
     );
 }
+
+#[test]
+fn sync_aborts_with_clear_message_on_subpackage_dep() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"github.com/gorilla/mux" = "v1.8.0"
+"github.com/gorilla/mux/middleware" = "v1.8.0"
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", "fn main() {}\n")]);
+
+    let output = run_sync(tmp.path());
+    assert!(
+        !output.status.success(),
+        "lis sync must fail when a subpackage is declared as a dep"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`github.com/gorilla/mux/middleware`")
+            && stderr.contains("subpackage of `github.com/gorilla/mux`"),
+        "expected targeted subpackage diagnostic, got stderr:\n{}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("invalid Go version"),
+        "subpackage error must not be misframed as a version problem, got stderr:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
`lis add` no longer aborts when a transitive dependency fails to bind. The explicit module is still written to `lisette.toml`; each failed transitive surfaces as a warning, and a summary line reports the skipped count. Importing a skipped transitive later will still error, but the rest of the project can build.