### PR TITLE
fix: lower paired Go errors as tuple of Option<error>

### DIFF
--- a/bindgen/internal/convert/returns.go
+++ b/bindgen/internal/convert/returns.go
@@ -87,6 +87,14 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 
 	last := results.At(results.Len() - 1)
 
+	if allErrorResults(results) {
+		elems := make([]string, results.Len())
+		for i := range elems {
+			elems[i] = "Option<error>"
+		}
+		return TypeResult{LisetteType: fmt.Sprintf("(%s)", strings.Join(elems, ", "))}
+	}
+
 	if isErrorType(last.Type()) {
 		inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName)
 		innerType := inner.LisetteType
@@ -196,6 +204,18 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 		LisetteType:          fmt.Sprintf("(%s)", strings.Join(elems, ", ")),
 		NilableReturnApplied: anyApplied,
 	}
+}
+
+func allErrorResults(results *types.Tuple) bool {
+	if results.Len() < 2 {
+		return false
+	}
+	for v := range results.Variables() {
+		if !isErrorType(v.Type()) {
+			return false
+		}
+	}
+	return true
 }
 
 func isErrorType(t types.Type) bool {

--- a/bindgen/tests/testdata/fixtures/error_returns/error_returns.go
+++ b/bindgen/tests/testdata/fixtures/error_returns/error_returns.go
@@ -29,3 +29,9 @@ func ParseAppError() (*AppError, error) { return &AppError{}, nil }
 
 // Single error interface return (not *T) → Result<(), error>
 func Validate() error { return nil }
+
+// Two parallel errors → (Option<error>, Option<error>) — both can be nil for success.
+func ClosePair() (source error, database error) { return nil, nil }
+
+// Three parallel errors → (Option<error>, Option<error>, Option<error>).
+func CloseTriple() (a, b, c error) { return nil, nil, nil }

--- a/bindgen/tests/testdata/snapshots/error_returns.d.lis
+++ b/bindgen/tests/testdata/snapshots/error_returns.d.lis
@@ -3,6 +3,12 @@
 // Go: 0.0.0
 // Lisette: 0.0.0
 
+/// Two parallel errors → (Option<error>, Option<error>) — both can be nil for success.
+pub fn ClosePair() -> (Option<error>, Option<error>)
+
+/// Three parallel errors → (Option<error>, Option<error>, Option<error>).
+pub fn CloseTriple() -> (Option<error>, Option<error>, Option<error>)
+
 pub fn GetWidget() -> Option<Ref<Widget>>
 
 pub fn NewAppError() -> error

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -118,7 +118,11 @@ impl Emitter<'_> {
         let result_var = fe.emitter.fresh_var(Some("result"));
         fe.emitter.declare(&result_var);
 
-        let needs_nil_guard = ok_ty.is_ref() || self.as_interface(ok_ty).is_some();
+        let interface_id = self.as_interface(ok_ty);
+        let needs_nil_guard = ok_ty.is_ref()
+            || interface_id
+                .as_deref()
+                .is_some_and(|id| id != go_name::PRELUDE_ERROR_ID);
 
         write_line!(output, "var {} {}", result_var, result_ty_str);
         write_line!(output, "if {} != nil {{", err_var);

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -13,6 +13,8 @@ pub(crate) const PRELUDE_MODULE: &str = "prelude";
 
 pub(crate) const PRELUDE_PREFIX: &str = "prelude.";
 
+pub(crate) const PRELUDE_ERROR_ID: &str = "prelude.error";
+
 pub(crate) const GO_STDLIB_PKG: &str = "lisette";
 
 pub const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";

--- a/crates/emit/src/types/abi.rs
+++ b/crates/emit/src/types/abi.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::names::go_name::PRELUDE_ERROR_ID;
 use syntax::ast::{Annotation, Expression};
 use syntax::types::Type;
 
@@ -54,7 +55,7 @@ impl Emitter<'_> {
     /// nilable type, so `nil` typechecks as the no-error sentinel.
     fn err_slot_is_nilable(&self, fallible_ty: &Type) -> bool {
         let err = self.peel_alias(&fallible_ty.err_type());
-        matches!(&err, Type::Nominal { id, .. } if id.as_str() == "prelude.error")
+        matches!(&err, Type::Nominal { id, .. } if id.as_str() == PRELUDE_ERROR_ID)
             || self.is_nilable_go_type(&err)
     }
 

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1009,6 +1009,48 @@ fn main() {
 }
 
 #[test]
+fn interop_result_error_ok_skips_nil_guard() {
+    let input = r#"
+import "go:example.com/legacy"
+
+fn main() {
+  match legacy.Close() {
+    Ok(stored) => { let _ = stored },
+    Err(_) => { let _ = 0 },
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Close() -> Result<error, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/legacy", typedef)]);
+}
+
+#[test]
+fn interop_parallel_error_tuple_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/migrate"
+
+fn main() {
+  let (src, db) = migrate.Close()
+  match src {
+    Some(e) => fmt.Println("source:", e),
+    None => {},
+  }
+  match db {
+    Some(e) => fmt.Println("db:", e),
+    None => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Close() -> (Option<error>, Option<error>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/migrate", typedef)]);
+}
+
+#[test]
 fn interop_typed_nil_interface_collection() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
+++ b/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:fmt\"\nimport \"go:example.com/migrate\"\n\nfn main() {\n  let (src, db) = migrate.Close()\n  match src {\n    Some(e) => fmt.Println(\"source:\", e),\n    None => {},\n  }\n  match db {\n    Some(e) => fmt.Println(\"db:\", e),\n    None => {},\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/migrate"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	src, db := migrate.Close()
+	if src.Tag == lisette.OptionSome {
+		e := src.SomeVal
+		fmt.Println("source:", e)
+	}
+	if db.Tag == lisette.OptionSome {
+		e := db.SomeVal
+		fmt.Println("db:", e)
+	}
+}

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:example.com/legacy\"\n\nfn main() {\n  match legacy.Close() {\n    Ok(stored) => { let _ = stored },\n    Err(_) => { let _ = 0 },\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/legacy"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ret_2, ret_3 := legacy.Close()
+	var subject_1 lisette.Result[error, error]
+	if ret_3 != nil {
+		subject_1 = lisette.MakeResultErr[error, error](ret_3)
+	} else {
+		subject_1 = lisette.MakeResultOk[error, error](ret_2)
+	}
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal
+	} else {
+		_ = 0
+	}
+}


### PR DESCRIPTION
Go functions returning `(error, error)` now bind to a tuple of `Option<error>`, with each slot reporting its own error or `None` for success.

```rs
match m.Close() {
  (None, None) => fmt.Println("closed"),
  (src, db) => {
    if let Some(e) = src { fmt.Println("source:", e) }
    if let Some(e) = db { fmt.Println("db:", e) }
  },
}
```