### PR TITLE
fix: skip subpackage check for multi-module monorepo siblings

### DIFF
--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -134,17 +134,24 @@ pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
 
 pub fn check_no_subpackage_deps(manifest: &Manifest) -> Result<(), String> {
     let deps = manifest.go_deps();
+    let has_via = |d: &GoDependency| d.via.as_ref().is_some_and(|v| !v.is_empty());
 
-    for key in deps.keys() {
-        if let Some(parent) = deps
-            .keys()
-            .find(|other| other.as_str() != key.as_str() && is_pkg_under(key, other))
-        {
-            return Err(format!(
-                "`{}` in `[dependencies.go]` is a subpackage of `{}`; remove this entry and rely on the parent module pin",
-                key, parent
-            ));
+    for (key, dep) in &deps {
+        let Some((parent, parent_dep)) = deps
+            .iter()
+            .find(|(other, _)| other.as_str() != key.as_str() && is_pkg_under(key, other))
+        else {
+            continue;
+        };
+
+        if has_via(dep) || has_via(parent_dep) {
+            continue;
         }
+
+        return Err(format!(
+            "`{}` in `[dependencies.go]` is a subpackage of `{}`; remove this entry and rely on the parent module pin",
+            key, parent
+        ));
     }
 
     Ok(())

--- a/tests/spec/sync.rs
+++ b/tests/spec/sync.rs
@@ -255,3 +255,26 @@ version = "0.1.0"
         stderr
     );
 }
+
+#[test]
+fn sync_accepts_multi_module_monorepo_siblings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = r#"[project]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.go]
+"go.opentelemetry.io/otel" = { version = "v1.37.0", via = ["go.opentelemetry.io/contrib"] }
+"go.opentelemetry.io/otel/sdk" = { version = "v1.37.0", via = ["go.opentelemetry.io/contrib"] }
+"go.opentelemetry.io/otel/sdk/metric" = { version = "v1.36.0", via = ["go.opentelemetry.io/otel/sdk"] }
+"#;
+    write_project(tmp.path(), manifest, &[("main.lis", "fn main() {}\n")]);
+
+    let output = run_sync(tmp.path());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("subpackage of"),
+        "multi-module monorepo siblings must not be flagged as subpackages, got stderr:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
Allows separately versioned siblings in Go multi-module monorepos to coexist in `[dependencies.go]`. Previously the subpackage check flagged any pair where one path was a string prefix of the other, blocking common transitive sets like `cloud.google.com/go` + `cloud.google.com/go/spanner`, `go.opentelemetry.io/otel` + `.../otel/sdk`, and `google.golang.org/genproto` + `.../genproto/googleapis/api`.

Follow-up to #278
