### PR TITLE
fix: show lsp completions through ref types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 .DS_Store
-tests/e2e/target/
 tests/e2e_smoke_project/target/
 bindgen/bin/*
 !bindgen/bin/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .DS_Store
+tests/e2e/target/
 tests/e2e_smoke_project/target/
 bindgen/bin/*
 !bindgen/bin/.gitkeep

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -27,6 +27,9 @@ pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<String> {
             ..
         } => type_name(u),
         syntax::types::Type::Nominal { id, .. } => Some(id.to_string()),
+        syntax::types::Type::Compound { kind: syntax::types::CompoundKind::Ref, args } => {
+            args.first().and_then(type_name)
+        }
         syntax::types::Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
         syntax::types::Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
         _ => None,

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -27,9 +27,10 @@ pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<String> {
             ..
         } => type_name(u),
         syntax::types::Type::Nominal { id, .. } => Some(id.to_string()),
-        syntax::types::Type::Compound { kind: syntax::types::CompoundKind::Ref, args } => {
-            args.first().and_then(type_name)
-        }
+        syntax::types::Type::Compound {
+            kind: syntax::types::CompoundKind::Ref,
+            args,
+        } => args.first().and_then(type_name),
         syntax::types::Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
         syntax::types::Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
         _ => None,

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -9986,3 +9986,35 @@ async fn diagnostics_toolchain_mismatch_surfaces_error() {
 
     client.shutdown().await;
 }
+
+#[tokio::test]
+async fn completion_dot_on_ref_variable() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+impl Point {
+  pub fn dist(self) -> int { self.x + self.y }
+}
+fn main() {
+  let p = &Point { x: 1, y: 2 }
+  p.dist()
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 6, 4).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "dist"),
+        "should include 'dist' method through ref, got: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "x"),
+        "should include 'x' field through ref, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}


### PR DESCRIPTION
Go stdlib packages like `bufio.NewReader` returns a `Ref<Reader>`. Currently lsp autocomplete did not show completions for any compound reference. This should probably also fix #281, even if the given code sample did not actually use a `Ref<T>` anywhere.

**PS**.

I gitignored `tests/e2e/target/` i assume it was removed from gitignore by mistake?

Edit by maintainer: Close #281