### PR TITLE
refactor: drop stale Nominal type uses in lsp

### DIFF
--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -19,9 +19,6 @@ use crate::state::{CachedSnapshot, SharedState};
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
 pub(crate) fn type_name(ty: &syntax::types::Type) -> Option<String> {
     match ty {
-        syntax::types::Type::Nominal { id, params, .. } if id == "prelude.Ref" => {
-            params.first().and_then(type_name)
-        }
         syntax::types::Type::Nominal {
             underlying_ty: Some(u),
             ..

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -128,11 +128,10 @@ pub(crate) fn get_hover_type_and_span(
                             && offset >= span.byte_offset
                             && offset < span.byte_offset + span.byte_length
                         {
-                            let slice_ty = syntax::types::Type::Nominal {
-                                id: "Slice".into(),
-                                params: vec![elem_type.clone()],
-                                underlying_ty: None,
-                            };
+                            let slice_ty = syntax::types::Type::compound(
+                                syntax::types::CompoundKind::Slice,
+                                vec![elem_type.clone()],
+                            );
                             Some((slice_ty, *span))
                         } else {
                             None


### PR DESCRIPTION
Follow-up to #161 