### PR TITLE
fix: bridge option<T> backed by go *T across reads and writes

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -193,6 +193,27 @@ impl Emitter<'_> {
         unwrapped_var
     }
 
+    /// Wrap a Go `*T` (T value-typed) into Lisette `Option<T>`.
+    pub(crate) fn emit_pointer_to_option_wrap(
+        &mut self,
+        output: &mut String,
+        ptr_value: &str,
+        option_ty: &Type,
+    ) -> String {
+        self.flags.needs_stdlib = true;
+        let inner_ty_str = self.go_type_as_string(&option_ty.ok_type());
+        let option_var = self.fresh_var(Some("option"));
+        self.declare(&option_var);
+        write_line!(
+            output,
+            "{} := lisette.OptionFromPointer[{}]({})",
+            option_var,
+            inner_ty_str,
+            ptr_value
+        );
+        option_var
+    }
+
     /// Bridge `Option<T>` to Go `*T` when T is not naturally nilable.
     pub(crate) fn emit_option_unwrap_to_go_pointer(
         &mut self,
@@ -256,6 +277,7 @@ impl Emitter<'_> {
         );
 
         let fallible = Fallible::from_type(elem_option_ty).expect("Option type expected");
+        let is_pointer_bridged = self.is_non_nilable_option(elem_option_ty);
 
         let is_interface = self.is_interface_option(elem_option_ty);
         if is_interface {
@@ -263,8 +285,13 @@ impl Emitter<'_> {
         } else {
             write_line!(output, "if {} != nil {{", val_var);
         }
+        let some_input = if is_pointer_bridged {
+            format!("*{}", val_var)
+        } else {
+            val_var.clone()
+        };
         let mut fe = FallibleEmitter::new(self, &fallible);
-        let some_wrapper = fe.emit_success(&val_var);
+        let some_wrapper = fe.emit_success(&some_input);
         write_line!(output, "{}[{}] = {}", wrapped_var, idx_var, some_wrapper);
         output.push_str("} else {\n");
         let mut fe = FallibleEmitter::new(self, &fallible);
@@ -287,17 +314,23 @@ impl Emitter<'_> {
         self.flags.needs_stdlib = true;
 
         let is_map = collection_ty.has_name("Map");
+        let is_pointer_bridged = self.is_non_nilable_option(elem_option_ty);
 
         let inner_ty = elem_option_ty.ok_type();
-        let go_inner_ty = self.go_type_as_string(&inner_ty);
+        let inner_ty_str = self.go_type_as_string(&inner_ty);
+        let raw_elem_ty = if is_pointer_bridged {
+            format!("*{}", inner_ty_str)
+        } else {
+            inner_ty_str
+        };
         let raw_collection_ty = if is_map {
             let params = collection_ty
                 .get_type_params()
                 .expect("Map should have type params");
             let key_ty = self.go_type_as_string(&params[0]);
-            format!("map[{}]{}", key_ty, go_inner_ty)
+            format!("map[{}]{}", key_ty, raw_elem_ty)
         } else {
-            format!("[]{}", go_inner_ty)
+            format!("[]{}", raw_elem_ty)
         };
 
         let src_var = self.fresh_var(Some("src"));
@@ -326,29 +359,25 @@ impl Emitter<'_> {
             src_var
         );
 
-        if is_map {
-            write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
-            write_line!(
-                output,
-                "{}[{}] = {}.SomeVal",
-                unwrapped_var,
-                idx_var,
-                val_var
-            );
+        let some_assignment = if is_pointer_bridged {
+            format!("&{}.SomeVal", val_var)
+        } else {
+            format!("{}.SomeVal", val_var)
+        };
+
+        write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
+        write_line!(
+            output,
+            "{}[{}] = {}",
+            unwrapped_var,
+            idx_var,
+            some_assignment
+        );
+        if is_map || is_pointer_bridged {
             output.push_str("} else {\n");
             write_line!(output, "{}[{}] = nil", unwrapped_var, idx_var);
-            output.push_str("}\n");
-        } else {
-            write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
-            write_line!(
-                output,
-                "{}[{}] = {}.SomeVal",
-                unwrapped_var,
-                idx_var,
-                val_var
-            );
-            output.push_str("}\n");
         }
+        output.push_str("}\n");
 
         output.push_str("}\n");
 

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -411,7 +411,7 @@ impl Emitter<'_> {
             return "nil".to_string();
         }
         let value = self.emit_value(output, arg);
-        let coercion = Coercion::resolve_unwrap_go_nullable(self, arg_ty);
+        let coercion = Coercion::resolve_unwrap_go_nullable(self, arg_ty, None);
         coercion.apply(self, output, value)
     }
 }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -70,12 +70,9 @@ impl Emitter<'_> {
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
             if is_go_struct {
-                if self.needs_go_pointer_bridge(&value_ty, field_ty.as_ref()) {
-                    value = self.emit_option_unwrap_to_go_pointer(output, &value, &value_ty);
-                } else {
-                    let coercion = Coercion::resolve_unwrap_go_nullable(self, &value_ty);
-                    value = coercion.apply(self, output, value);
-                }
+                let coercion =
+                    Coercion::resolve_unwrap_go_nullable(self, &value_ty, field_ty.as_ref());
+                value = coercion.apply(self, output, value);
             }
             if let Some(field_ty) = field_ty.as_ref() {
                 let coercion = Coercion::resolve(self, &value_ty, field_ty);

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -535,7 +535,7 @@ impl Emitter<'_> {
             && Self::is_go_imported_type(&receiver.get_type())
             && self.is_go_nullable(ty)
         {
-            let coercion = Coercion::resolve_unwrap_go_nullable(self, &value.get_type());
+            let coercion = Coercion::resolve_unwrap_go_nullable(self, &value.get_type(), Some(ty));
             let unwrapped = coercion.apply(self, output, rhs_staged.value);
             write_line!(output, "{} = {}", target_str, unwrapped);
         } else {

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -227,12 +227,19 @@ impl Emitter<'_> {
         ty.is_option() && self.is_nilable_go_type(&ty.ok_type())
     }
 
-    /// True when a Go-imported struct field declared `Option<T>` (T non-nilable)
-    /// receives a value of the same shape — the field is `*T` underneath, so
-    /// the value must be bridged with address-of.
-    pub(crate) fn needs_go_pointer_bridge(&self, value_ty: &Type, field_ty: Option<&Type>) -> bool {
-        let is_non_nullable_option = |t: &Type| t.is_option() && !self.is_nullable_option(t);
-        is_non_nullable_option(value_ty) && field_ty.is_some_and(is_non_nullable_option)
+    /// True for `Option<T>` where T is a concrete non-nilable Go value type
+    /// (string, int32, named scalar, named struct). This is the bindgen's
+    /// pointer-bridged shape: the corresponding Go layout is `*T`. Excludes
+    /// `Option<Unknown>` / `Option<any>` (Go layout `interface{}`, not bridged).
+    pub(crate) fn is_non_nilable_option(&self, ty: &Type) -> bool {
+        if !ty.is_option() {
+            return false;
+        }
+        let inner = ty.ok_type();
+        if inner.contains_unknown() || inner.has_name("any") {
+            return false;
+        }
+        !self.is_nilable_go_type(&inner)
     }
 
     /// Returns true if the Option wraps a Go interface type (not a pointer).
@@ -246,19 +253,23 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn is_go_nullable(&self, ty: &Type) -> bool {
-        self.is_nullable_option(ty) || self.nullable_collection_element_ty(ty).is_some()
+        self.is_nullable_option(ty)
+            || self.is_non_nilable_option(ty)
+            || self.nullable_collection_element_ty(ty).is_some()
     }
 
     pub(crate) fn nullable_collection_element_ty(&self, ty: &Type) -> Option<Type> {
+        let is_pointer_bridged_option =
+            |t: &Type| self.is_nullable_option(t) || self.is_non_nilable_option(t);
         if ty.has_name("Slice") {
             let elem_ty = ty.inner()?;
-            if self.is_nullable_option(&elem_ty) {
+            if is_pointer_bridged_option(&elem_ty) {
                 return Some(elem_ty);
             }
         } else if ty.has_name("Map") {
             let params = ty.get_type_params()?;
             let val_ty = params.get(1)?.clone();
-            if self.is_nullable_option(&val_ty) {
+            if is_pointer_bridged_option(&val_ty) {
                 return Some(val_ty);
             }
         }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -260,9 +260,14 @@ impl Emitter<'_> {
             return;
         }
 
-        let is_go_nullable = matches!(target, Expression::DotAccess { expression, ty, .. }
-                if Self::is_go_imported_type(&expression.get_type())
-                    && self.is_go_nullable(ty));
+        let go_field_ty: Option<Type> = match target {
+            Expression::DotAccess { expression, ty, .. }
+                if Self::is_go_imported_type(&expression.get_type()) && self.is_go_nullable(ty) =>
+            {
+                Some(ty.clone())
+            }
+            _ => None,
+        };
 
         let rhs_staged = self.stage_composite(value);
         let rhs_has_setup = !rhs_staged.setup.is_empty();
@@ -274,8 +279,9 @@ impl Emitter<'_> {
         };
         output.push_str(&rhs_staged.setup);
 
-        if is_go_nullable {
-            let coercion = Coercion::resolve_unwrap_go_nullable(self, &value.get_type());
+        if let Some(target_ty) = go_field_ty {
+            let coercion =
+                Coercion::resolve_unwrap_go_nullable(self, &value.get_type(), Some(&target_ty));
             let unwrapped = coercion.apply(self, output, rhs_staged.value);
             write_line!(output, "{} = {}", target_str, unwrapped);
         } else {

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -18,11 +18,17 @@ pub(crate) enum CoercionKind {
     UnwrapNullableOption {
         ty: Type,
     },
+    UnwrapPointerOption {
+        ty: Type,
+    },
     UnwrapNullableCollection {
         ty: Type,
         elem_option_ty: Type,
     },
     WrapNullableOption {
+        ty: Type,
+    },
+    WrapPointerOption {
         ty: Type,
     },
     WrapNullableCollection {
@@ -48,7 +54,23 @@ impl Coercion {
         }
     }
 
-    pub(crate) fn resolve_unwrap_go_nullable(emitter: &Emitter, value_ty: &Type) -> Self {
+    pub(crate) fn resolve_unwrap_go_nullable(
+        emitter: &Emitter,
+        value_ty: &Type,
+        target_ty: Option<&Type>,
+    ) -> Self {
+        if let Some(target_ty) = target_ty
+            && emitter.is_non_nilable_option(value_ty)
+            && emitter.is_non_nilable_option(target_ty)
+        {
+            return Self {
+                from: value_ty.clone(),
+                to: target_ty.clone(),
+                kind: CoercionKind::UnwrapPointerOption {
+                    ty: value_ty.clone(),
+                },
+            };
+        }
         let kind = if emitter.is_nullable_option(value_ty) {
             CoercionKind::UnwrapNullableOption {
                 ty: value_ty.clone(),
@@ -87,6 +109,10 @@ impl Coercion {
             CoercionKind::WrapNullableOption {
                 ty: value_ty.clone(),
             }
+        } else if emitter.is_non_nilable_option(value_ty) {
+            CoercionKind::WrapPointerOption {
+                ty: value_ty.clone(),
+            }
         } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
             CoercionKind::WrapNullableCollection {
                 ty: value_ty.clone(),
@@ -112,11 +138,17 @@ impl Coercion {
             CoercionKind::UnwrapNullableOption { ty } => {
                 emitter.emit_option_unwrap_to_nullable(output, &value, &ty)
             }
+            CoercionKind::UnwrapPointerOption { ty } => {
+                emitter.emit_option_unwrap_to_go_pointer(output, &value, &ty)
+            }
             CoercionKind::UnwrapNullableCollection { ty, elem_option_ty } => {
                 emitter.emit_collection_nullable_unwrap(output, &value, &ty, &elem_option_ty)
             }
             CoercionKind::WrapNullableOption { ty } => {
                 emitter.emit_nil_check_option_wrap(output, &value, &ty)
+            }
+            CoercionKind::WrapPointerOption { ty } => {
+                emitter.emit_pointer_to_option_wrap(output, &value, &ty)
             }
             CoercionKind::WrapNullableCollection { ty, elem_option_ty } => {
                 emitter.emit_collection_nullable_wrap(output, &value, &ty, &elem_option_ty)

--- a/prelude/option.go
+++ b/prelude/option.go
@@ -45,6 +45,16 @@ func OptionFromNilable[T any](val T, isNil bool) Option[T] {
 	return Option[T]{Tag: OptionSome, SomeVal: val}
 }
 
+// OptionFromPointer wraps a Go `*T` into an `Option[T]`, dereferencing the
+// pointer for the Some branch. Used when reading Go-imported struct fields
+// declared `*T` (T value-typed) — the Lisette typedef is `Option<T>`.
+func OptionFromPointer[T any](ptr *T) Option[T] {
+	if ptr == nil {
+		return Option[T]{Tag: OptionNone}
+	}
+	return Option[T]{Tag: OptionSome, SomeVal: *ptr}
+}
+
 func (opt Option[T]) IsSome() bool {
 	return opt.Tag == OptionSome
 }

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1249,3 +1249,148 @@ pub struct Options {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cb", typedef)]);
 }
+
+#[test]
+fn interop_struct_field_read_option_string_match() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let bucket = aws.Bucket { .. }
+  match bucket.Name {
+    Some(name) => { let _ = name },
+    None => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Bucket {
+  pub Name: Option<string>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_read_option_int32_let_binding() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let input = aws.ListInput { .. }
+  let n = input.MaxItems
+  let _ = n
+}
+"#;
+    let typedef = r#"
+pub struct ListInput {
+  pub MaxItems: Option<int32>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_read_option_string_in_loop() {
+    let input = r#"
+import "go:example.com/aws"
+import "go:fmt"
+
+fn main() {
+  let buckets: Slice<aws.Bucket> = []
+  for bucket in buckets {
+    match bucket.Name {
+      Some(name) => fmt.Println(name),
+      None => {},
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Bucket {
+  pub Name: Option<string>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_read_slice_option_string_iter() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let b = aws.Bucket { .. }
+  for tag in b.Tags {
+    match tag {
+      Some(v) => { let _ = v },
+      None => {},
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Bucket {
+  pub Tags: Slice<Option<string>>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_read_map_option_string_index() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let b = aws.Bucket { .. }
+  match b.Annotations["k"] {
+    Some(v) => { let _ = v },
+    None => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Bucket {
+  pub Annotations: Map<string, Option<string>>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_assign_option_string() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let mut b = aws.Bucket { .. }
+  b.Name = Some("hi")
+}
+"#;
+    let typedef = r#"
+pub struct Bucket {
+  pub Name: Option<string>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_struct_field_assign_option_int32() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let mut b = aws.ListInput { .. }
+  b.MaxItems = Some(5 as int32)
+  b.MaxItems = None
+}
+"#;
+    let typedef = r#"
+pub struct ListInput {
+  pub MaxItems: Option<int32>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1395
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let mut b = aws.ListInput { .. }\n  b.MaxItems = Some(5 as int32)\n  b.MaxItems = None\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	b := aws.ListInput{}
+	opt_1 := lisette.MakeOptionSome(int32(5))
+	var ptr_2 *int32
+	if opt_1.Tag == lisette.OptionSome {
+		ptr_2 = &opt_1.SomeVal
+	}
+	b.MaxItems = ptr_2
+	opt_3 := lisette.MakeOptionNone[int32]()
+	var ptr_4 *int32
+	if opt_3.Tag == lisette.OptionSome {
+		ptr_4 = &opt_3.SomeVal
+	}
+	b.MaxItems = ptr_4
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1376
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let mut b = aws.Bucket { .. }\n  b.Name = Some(\"hi\")\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	b := aws.Bucket{}
+	opt_1 := lisette.MakeOptionSome("hi")
+	var ptr_2 *string
+	if opt_1.Tag == lisette.OptionSome {
+		ptr_2 = &opt_1.SomeVal
+	}
+	b.Name = ptr_2
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1358
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let b = aws.Bucket { .. }\n  match b.Annotations[\"k\"] {\n    Some(v) => { let _ = v },\n    None => {},\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	b := aws.Bucket{}
+	raw_2 := b.Annotations
+	src_3 := raw_2
+	wrapped_4 := make(map[string]lisette.Option[string], len(src_3))
+	for i_5, v_6 := range src_3 {
+		if v_6 != nil {
+			wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+		} else {
+			wrapped_4[i_5] = lisette.MakeOptionNone[string]()
+		}
+	}
+	subject_1 := wrapped_4["k"]
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1290
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let input = aws.ListInput { .. }\n  let n = input.MaxItems\n  let _ = n\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	input := aws.ListInput{}
+	raw_1 := input.MaxItems
+	option_2 := lisette.OptionFromPointer[int32](raw_1)
+	_ = option_2
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1314
+description: "input: \nimport \"go:example.com/aws\"\nimport \"go:fmt\"\n\nfn main() {\n  let buckets: Slice<aws.Bucket> = []\n  for bucket in buckets {\n    match bucket.Name {\n      Some(name) => fmt.Println(name),\n      None => {},\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	buckets := []aws.Bucket{}
+	for _, bucket := range buckets {
+		raw_2 := bucket.Name
+		option_3 := lisette.OptionFromPointer[string](raw_2)
+		subject_1 := option_3
+		if subject_1.Tag == lisette.OptionSome {
+			name := subject_1.SomeVal
+			fmt.Println(name)
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1271
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let bucket = aws.Bucket { .. }\n  match bucket.Name {\n    Some(name) => { let _ = name },\n    None => {},\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	bucket := aws.Bucket{}
+	raw_2 := bucket.Name
+	option_3 := lisette.OptionFromPointer[string](raw_2)
+	subject_1 := option_3
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1337
+description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let b = aws.Bucket { .. }\n  for tag in b.Tags {\n    match tag {\n      Some(v) => { let _ = v },\n      None => {},\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	b := aws.Bucket{}
+	raw_1 := b.Tags
+	src_2 := raw_1
+	wrapped_3 := make([]lisette.Option[string], len(src_2))
+	for i_4, v_5 := range src_2 {
+		if v_5 != nil {
+			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+		} else {
+			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+		}
+	}
+	for _, tag := range wrapped_3 {
+		if tag.Tag == lisette.OptionSome {
+			_ = tag.SomeVal
+		}
+	}
+}


### PR DESCRIPTION
Optional value-typed struct fields backed by Go `*T` now read and write correctly. 

Bindgen for `aws-sdk-go-v2` and similar SDKs lowers fields like `Name *string` and `Size *int64` to `Option<string>` and `Option<int64>`. Previously, the read path emitted Go that referenced `.Tag` on a raw pointer, and the write path stored the wrong shape.

```rs
let bucket = s3.Bucket { Name: Some("photos"), .. }
match bucket.Name {
  Some(name) => fmt.Println(name),
  None => fmt.Println("<unnamed>"),
}
```

The same bridge applies when iterating slice or map fields whose elements have this shape, direct field assignment, and struct-literal updates that pass these fields through.