### PR TITLE
refactor: consolidate checker cursor and scope setup

### DIFF
--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -187,13 +187,8 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                 continue;
             }
 
-            let prev_module_id = checker.cursor.module_id.clone();
-            checker.cursor.module_id = module_id.to_string();
-
             store.store_module(&module_id, files);
             checker.register_module(&mut store, &module_id);
-
-            checker.cursor.module_id = prev_module_id;
 
             if cache_enabled && !is_entry {
                 compiled_modules.push(CompiledModule {
@@ -207,12 +202,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
         }
 
         for module_id in &to_infer {
-            let prev_module_id = checker.cursor.module_id.clone();
-            checker.cursor.module_id = module_id.clone();
-
             checker.infer_module(&mut store, module_id);
-
-            checker.cursor.module_id = prev_module_id;
         }
 
         for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -8,63 +8,71 @@ pub(crate) use unify::BuiltinBound;
 
 use rustc_hash::FxHashMap as HashMap;
 
-use super::TaskState;
 use super::freeze::FreezeFolder;
+use super::{FileContextKind, TaskState};
 use crate::store::Store;
 use syntax::ast::Expression;
 use syntax::program::{File, FileImport};
 
 impl TaskState<'_> {
     pub fn infer_module(&mut self, store: &mut Store, module_id: &str) {
-        self.cursor.module_id = module_id.to_string();
-
-        let files: Vec<File> = {
-            let module = store
-                .get_module_mut(module_id)
-                .expect("module must exist for inference");
-            std::mem::take(&mut module.files).into_values().collect()
-        };
-
+        let files = self.take_module_files(store, module_id);
         let items_per_file: Vec<&[Expression]> = files.iter().map(|f| f.items.as_slice()).collect();
         self.check_const_cycles(&*store, &items_per_file);
 
         for file in files {
-            let imports = file.imports();
-
-            self.reset_scopes();
-            self.cursor.file_id = Some(file.id);
-            self.put_prelude_in_scope(&*store);
-            self.put_unprefixed_module_in_scope(&*store, module_id);
-            self.put_imported_modules_in_scope(&*store, &imports);
-            self.check_definition_module_collisions(&*store, &file.items, &imports);
-
-            let inferred_items: Vec<_> = file
-                .items
-                .into_iter()
-                .map(|item| {
-                    let type_var = self.new_type_var();
-                    self.infer_expression(store, item, &type_var)
-                })
-                .collect();
-
-            self.check_reference_sibling_aliasing(&inferred_items);
-
-            let folder = FreezeFolder::new(&self.env);
-            folder.freeze_facts(&mut self.facts);
-            let frozen_items = FreezeFolder::new(&self.env).freeze_items(inferred_items);
-
-            let typed_file = File {
-                id: file.id,
-                module_id: file.module_id,
-                name: file.name,
-                source: file.source,
-                items: frozen_items,
-            };
-
-            self.typed_files.push((module_id.to_string(), typed_file));
+            self.infer_file(store, module_id, file);
         }
+    }
 
-        self.cursor.file_id = None;
+    fn take_module_files(&mut self, store: &mut Store, module_id: &str) -> Vec<File> {
+        self.with_module_cursor(module_id, |_this| {
+            let module = store
+                .get_module_mut(module_id)
+                .expect("module must exist for inference");
+            std::mem::take(&mut module.files).into_values().collect()
+        })
+    }
+
+    fn infer_file(&mut self, store: &mut Store, module_id: &str, file: File) {
+        let file_id = file.id;
+        let imports = file.imports();
+
+        self.with_file_context(
+            store,
+            module_id,
+            file_id,
+            &imports,
+            FileContextKind::Standard,
+            |this, store| {
+                this.check_definition_module_collisions(&*store, &file.items, &imports);
+
+                let inferred_items: Vec<_> = file
+                    .items
+                    .into_iter()
+                    .map(|item| {
+                        let type_var = this.new_type_var();
+                        this.infer_expression(store, item, &type_var)
+                    })
+                    .collect();
+
+                this.check_reference_sibling_aliasing(&inferred_items);
+
+                let folder = FreezeFolder::new(&this.env);
+                folder.freeze_facts(&mut this.facts);
+                let frozen_items = FreezeFolder::new(&this.env).freeze_items(inferred_items);
+
+                let typed_file = File {
+                    id: file_id,
+                    module_id: file.module_id,
+                    name: file.name,
+                    source: file.source,
+                    items: frozen_items,
+                };
+
+                this.typed_files.push((module_id.to_string(), typed_file));
+            },
+        );
     }
 
     fn check_definition_module_collisions(

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -76,6 +76,13 @@ impl ImportState {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FileContextKind {
+    Standard,
+    ImportedTypedef,
+    Prelude,
+}
+
 /// Cache for builtin types (int, bool, string, etc.) resolved from the prelude.
 /// These never change once populated, so no invalidation needed.
 type BuiltinCache = HashMap<String, Type>;
@@ -501,6 +508,58 @@ impl<'s> TaskState<'s> {
     pub fn reset_scopes(&mut self) {
         self.scopes.reset();
         self.imports.clear();
+    }
+
+    pub(crate) fn with_module_cursor<T>(
+        &mut self,
+        module_id: &str,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        if self.cursor.module_id == module_id {
+            return f(self);
+        }
+
+        let previous_module_id = std::mem::replace(&mut self.cursor.module_id, module_id.into());
+        let result = f(self);
+        self.cursor.module_id = previous_module_id;
+        result
+    }
+
+    pub(crate) fn with_file_context<T>(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+        kind: FileContextKind,
+        f: impl FnOnce(&mut Self, &mut Store) -> T,
+    ) -> T {
+        self.with_module_cursor(module_id, |this| {
+            let previous_file_id = this.cursor.file_id.replace(file_id);
+            let previous_scopes = std::mem::take(&mut this.scopes);
+            let previous_imports = std::mem::take(&mut this.imports);
+
+            match kind {
+                FileContextKind::Standard => {
+                    this.put_prelude_in_scope(&*store);
+                    this.put_unprefixed_module_in_scope(&*store, module_id);
+                }
+                FileContextKind::ImportedTypedef => {
+                    this.put_prelude_in_scope(&*store);
+                }
+                FileContextKind::Prelude => {
+                    this.put_unprefixed_module_in_scope(&*store, module_id);
+                }
+            }
+            this.put_imported_modules_in_scope(&*store, imports);
+
+            let result = f(this, store);
+
+            this.scopes = previous_scopes;
+            this.imports = previous_imports;
+            this.cursor.file_id = previous_file_id;
+            result
+        })
     }
 
     pub fn failed(&self) -> bool {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -10,10 +10,10 @@ use syntax::ast::{
     Annotation, Attribute, AttributeArg, EnumVariant, Expression, FunctionDefinition, Generic,
     Span, StructKind, Visibility as SyntacticVisibility,
 };
-use syntax::program::{Definition, File, Visibility};
+use syntax::program::{Definition, File, FileImport, Visibility};
 use syntax::types::{Symbol, Type};
 
-use super::TaskState;
+use super::{FileContextKind, TaskState};
 use crate::store::Store;
 
 pub(crate) fn extract_package_directive(source: &str) -> Option<String> {
@@ -90,99 +90,19 @@ impl TaskState<'_> {
     }
 
     pub fn register_module(&mut self, store: &mut Store, id: &str) {
-        self.cursor.module_id = id.to_string();
+        let type_name_entries =
+            self.with_module_cursor(id, |this| this.collect_module_type_name_entries(store, id));
+        self.insert_type_name_entries(store, id, type_name_entries);
 
-        let type_name_entries = {
-            let module = store
-                .get_module(id)
-                .expect("module must exist for declaration");
-            let mut entries = Vec::new();
-            for file in module.files.values() {
-                entries.extend(self.collect_type_name_entries(
-                    &file.items,
-                    &Visibility::Private,
-                    false,
-                ));
-            }
-            for file in module.all_typedefs() {
-                entries.extend(self.collect_type_name_entries(
-                    &file.items,
-                    &Visibility::Private,
-                    true,
-                ));
-            }
-            entries
-        };
-        let module = store
-            .get_module_mut(id)
-            .expect("module must exist for declaration");
-        for (qualified_name, definition) in type_name_entries {
-            module
-                .definitions
-                .entry(qualified_name)
-                .or_insert(definition);
-        }
-
-        let file_data: Vec<_> = {
-            let module = store
-                .get_module(id)
-                .expect("module must exist for declaration");
-            module
-                .files
-                .iter()
-                .chain(module.typedefs.iter())
-                .map(|(file_id, f)| (*file_id, f.imports()))
-                .collect()
-        };
+        let file_data = self.module_file_data(store, id);
 
         for (file_id, imports) in &file_data {
-            self.reset_scopes();
-            self.cursor.file_id = Some(*file_id);
-
-            self.put_prelude_in_scope(&*store);
-            self.put_unprefixed_module_in_scope(&*store, id);
-            self.put_imported_modules_in_scope(&*store, imports);
-
-            let items = std::mem::take(
-                &mut store
-                    .get_file_mut(*file_id)
-                    .expect("file must exist for registration")
-                    .items,
-            );
-
-            self.register_type_definitions(store, &items);
-
-            store
-                .get_file_mut(*file_id)
-                .expect("file must exist after registration")
-                .items = items;
+            self.register_file_type_definitions(store, id, *file_id, imports);
         }
 
         for (file_id, imports) in &file_data {
-            self.reset_scopes();
-            self.cursor.file_id = Some(*file_id);
-
-            self.put_prelude_in_scope(&*store);
-            self.put_unprefixed_module_in_scope(&*store, id);
-            self.put_imported_modules_in_scope(&*store, imports);
-
-            let items = std::mem::take(
-                &mut store
-                    .get_file_mut(*file_id)
-                    .expect("file must exist for registration")
-                    .items,
-            );
-
-            self.register_impl_blocks(store, &items);
-            self.register_values(store, &items, &Visibility::Private);
-
-            store
-                .get_file_mut(*file_id)
-                .expect("file must exist after registration")
-                .items = items;
+            self.register_file_values(store, id, *file_id, imports);
         }
-
-        self.cursor.file_id = None;
 
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = crate::call_classification::compute_module_ufcs(module, id);
@@ -248,24 +168,136 @@ impl TaskState<'_> {
 
         store.store_file(module_id, file);
 
-        let prev_module_id = self.cursor.module_id.clone();
-        self.cursor.module_id = module_id.to_string();
-
-        self.reset_scopes();
-        self.cursor.file_id = Some(file_id);
-        self.put_prelude_in_scope(&*store);
-        self.put_imported_modules_in_scope(&*store, &imports);
-
-        let items = std::mem::take(
-            &mut store
-                .get_file_mut(file_id)
-                .expect("file must exist after store_file")
-                .items,
+        self.with_file_context(
+            store,
+            module_id,
+            file_id,
+            &imports,
+            FileContextKind::ImportedTypedef,
+            |this, store| {
+                let items = std::mem::take(
+                    &mut store
+                        .get_file_mut(file_id)
+                        .expect("file must exist after store_file")
+                        .items,
+                );
+                this.register_types_and_values(store, &items, &Visibility::Public);
+            },
         );
-        self.register_types_and_values(store, &items, &Visibility::Public);
+    }
 
-        self.cursor.file_id = None;
-        self.cursor.module_id = prev_module_id;
+    fn collect_module_type_name_entries(
+        &self,
+        store: &Store,
+        module_id: &str,
+    ) -> Vec<(Symbol, Definition)> {
+        let module = store
+            .get_module(module_id)
+            .expect("module must exist for declaration");
+        let mut entries = Vec::new();
+        for file in module.files.values() {
+            entries.extend(self.collect_type_name_entries(
+                &file.items,
+                &Visibility::Private,
+                false,
+            ));
+        }
+        for file in module.all_typedefs() {
+            entries.extend(self.collect_type_name_entries(&file.items, &Visibility::Private, true));
+        }
+        entries
+    }
+
+    fn insert_type_name_entries(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        type_name_entries: Vec<(Symbol, Definition)>,
+    ) {
+        let module = store
+            .get_module_mut(module_id)
+            .expect("module must exist for declaration");
+        for (qualified_name, definition) in type_name_entries {
+            module
+                .definitions
+                .entry(qualified_name)
+                .or_insert(definition);
+        }
+    }
+
+    fn module_file_data(&self, store: &Store, module_id: &str) -> Vec<(u32, Vec<FileImport>)> {
+        let module = store
+            .get_module(module_id)
+            .expect("module must exist for declaration");
+        module
+            .files
+            .iter()
+            .chain(module.typedefs.iter())
+            .map(|(file_id, f)| (*file_id, f.imports()))
+            .collect()
+    }
+
+    fn register_file_type_definitions(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+    ) {
+        self.with_file_context(
+            store,
+            module_id,
+            file_id,
+            imports,
+            FileContextKind::Standard,
+            |this, store| {
+                let items = std::mem::take(
+                    &mut store
+                        .get_file_mut(file_id)
+                        .expect("file must exist for registration")
+                        .items,
+                );
+
+                this.register_type_definitions(store, &items);
+
+                store
+                    .get_file_mut(file_id)
+                    .expect("file must exist after registration")
+                    .items = items;
+            },
+        );
+    }
+
+    fn register_file_values(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+    ) {
+        self.with_file_context(
+            store,
+            module_id,
+            file_id,
+            imports,
+            FileContextKind::Standard,
+            |this, store| {
+                let items = std::mem::take(
+                    &mut store
+                        .get_file_mut(file_id)
+                        .expect("file must exist for registration")
+                        .items,
+                );
+
+                this.register_impl_blocks(store, &items);
+                this.register_values(store, &items, &Visibility::Private);
+
+                store
+                    .get_file_mut(file_id)
+                    .expect("file must exist after registration")
+                    .items = items;
+            },
+        );
     }
 
     pub fn register_types_and_values(

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -3,7 +3,7 @@ use stdlib::LIS_PRELUDE_SOURCE;
 use syntax::program::{File, Visibility};
 
 use crate::call_classification::compute_module_ufcs;
-use crate::checker::TaskState;
+use crate::checker::{FileContextKind, TaskState};
 use crate::store::Store;
 
 pub const PRELUDE_MODULE_ID: &str = "prelude";
@@ -27,28 +27,29 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
     );
 
     let mut checker = TaskState::with_fresh_allocator(sink);
-    checker.cursor.module_id = PRELUDE_MODULE_ID.to_string();
-    checker.cursor.file_id = Some(PRELUDE_FILE_ID);
-
     let module = store
         .get_module(PRELUDE_MODULE_ID)
         .cloned()
         .expect("prelude module must exist");
 
-    for file in module.all_typedefs() {
-        checker.register_type_names(store, &file.items, &Visibility::Public);
-    }
+    checker.with_file_context(
+        store,
+        PRELUDE_MODULE_ID,
+        PRELUDE_FILE_ID,
+        &[],
+        FileContextKind::Prelude,
+        |checker, store| {
+            for file in module.all_typedefs() {
+                checker.register_type_names(store, &file.items, &Visibility::Public);
+            }
 
-    checker.reset_scopes();
-    checker.put_unprefixed_module_in_scope(&*store, PRELUDE_MODULE_ID);
-
-    for file in module.all_typedefs() {
-        checker.register_type_definitions(store, &file.items);
-        checker.register_impl_blocks(store, &file.items);
-        checker.register_values(store, &file.items, &Visibility::Public);
-    }
-
-    checker.cursor.file_id = None;
+            for file in module.all_typedefs() {
+                checker.register_type_definitions(store, &file.items);
+                checker.register_impl_blocks(store, &file.items);
+                checker.register_values(store, &file.items, &Visibility::Public);
+            }
+        },
+    );
 }
 
 pub fn compute_prelude_ufcs(store: &Store) -> Vec<(String, String)> {


### PR DESCRIPTION
Reduce the boilerplate for saving the cursor, resetting scopes, setting up imports boilerplate across `register_module`, `register_imported_typedef`, `infer_module`, and `parse_and_register_prelude`.