### PR TITLE
fix: fixes to lsp and formatting

### DIFF
--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -268,9 +268,20 @@ impl<'a> Formatter<'a> {
 
         let mut entries: Vec<SiblingEntry<'a>> = Vec::with_capacity(variants.len());
         for variant in variants {
+            let doc_leading = self
+                .comments
+                .take_doc_comments_before(variant.name_span.byte_offset);
             self.push_sibling_entry(&mut entries, variant.name_span.byte_offset, |s| {
                 s.enum_variant_body(variant)
             });
+            if let Some(doc) = doc_leading {
+                if let Some(last) = entries.last_mut() {
+                    last.leading = Some(match last.leading.take() {
+                        Some(reg) => doc.append(Document::Newline).append(reg),
+                        None => doc,
+                    });
+                }
+            }
         }
         let body = self.join_sibling_body(entries, span.end());
         Self::braced_body(header, body)
@@ -298,6 +309,9 @@ impl<'a> Formatter<'a> {
 
         let mut entries: Vec<SiblingEntry<'a>> = Vec::with_capacity(variants.len());
         for variant in variants {
+            let doc_leading = self
+                .comments
+                .take_doc_comments_before(variant.name_span.byte_offset);
             self.push_sibling_entry(&mut entries, variant.name_span.byte_offset, |s| {
                 let value_doc = s.literal(&variant.value);
                 Document::string(variant.name.to_string())
@@ -305,6 +319,14 @@ impl<'a> Formatter<'a> {
                     .append(value_doc)
                     .append(",")
             });
+            if let Some(doc) = doc_leading {
+                if let Some(last) = entries.last_mut() {
+                    last.leading = Some(match last.leading.take() {
+                        Some(reg) => doc.append(Document::Newline).append(reg),
+                        None => doc,
+                    });
+                }
+            }
         }
         let body = self.join_sibling_body(entries, span.end());
         Self::braced_body(header, body)

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -274,13 +274,13 @@ impl<'a> Formatter<'a> {
             self.push_sibling_entry(&mut entries, variant.name_span.byte_offset, |s| {
                 s.enum_variant_body(variant)
             });
-            if let Some(doc) = doc_leading {
-                if let Some(last) = entries.last_mut() {
-                    last.leading = Some(match last.leading.take() {
-                        Some(reg) => doc.append(Document::Newline).append(reg),
-                        None => doc,
-                    });
-                }
+            if let Some(doc) = doc_leading
+                && let Some(last) = entries.last_mut()
+            {
+                last.leading = Some(match last.leading.take() {
+                    Some(reg) => doc.append(Document::Newline).append(reg),
+                    None => doc,
+                });
             }
         }
         let body = self.join_sibling_body(entries, span.end());
@@ -319,13 +319,13 @@ impl<'a> Formatter<'a> {
                     .append(value_doc)
                     .append(",")
             });
-            if let Some(doc) = doc_leading {
-                if let Some(last) = entries.last_mut() {
-                    last.leading = Some(match last.leading.take() {
-                        Some(reg) => doc.append(Document::Newline).append(reg),
-                        None => doc,
-                    });
-                }
+            if let Some(doc) = doc_leading
+                && let Some(last) = entries.last_mut()
+            {
+                last.leading = Some(match last.leading.take() {
+                    Some(reg) => doc.append(Document::Newline).append(reg),
+                    None => doc,
+                });
             }
         }
         let body = self.join_sibling_body(entries, span.end());

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -381,32 +381,6 @@ fn resolve_dot_access_doc(
         .cloned()
 }
 
-/// If `expression` is a zero-field enum variant identifier, returns a display
-/// label of the form `"EnumName.VariantName"`. Otherwise returns `None`.
-///
-/// Zero-field variants have the enum type itself (e.g. `Color`) as their
-/// inferred type, so without this the hover would only show `"Color"` for
-/// both `Color.R` and `Color.G`.
-pub(crate) fn enum_variant_label(
-    expression: &Expression,
-    ty: &syntax::types::Type,
-) -> Option<String> {
-    let Expression::Identifier {
-        qualified: Some(q), ..
-    } = expression
-    else {
-        return None;
-    };
-    // qualified looks like "module.EnumName.VariantName"; split off the last segment
-    let (parent, variant_name) = q.rsplit_once('.')?;
-    // parent must match the type's qualified id (e.g. "module.EnumName")
-    if ty.get_qualified_id() != Some(parent) {
-        return None;
-    }
-    let enum_name = parent.rsplit('.').next()?;
-    Some(format!("{}.{}", enum_name, variant_name))
-}
-
 /// Resolve the doc comment for the hovered expression.
 pub(crate) fn get_hover_doc(
     expression: &Expression,

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -58,18 +58,28 @@ pub(crate) fn get_hover_type_and_span(
                     field_types,
                     ..
                 }),
-            ) => fields.iter().enumerate().find_map(|(i, field)| {
-                let field_ty = field_types.get(i).unwrap_or(fallback_ty);
-                get_pattern_element_type(field, typed_fields.get(i), field_ty, offset)
-            }),
+            ) => fields
+                .iter()
+                .enumerate()
+                .find_map(|(i, field)| {
+                    let field_ty = field_types.get(i).unwrap_or(fallback_ty);
+                    get_pattern_element_type(field, typed_fields.get(i), field_ty, offset)
+                })
+                .or_else(|| Some((fallback_ty.clone(), span))),
 
             (
                 Pattern::EnumVariant { fields, .. },
                 Some(TypedPattern::EnumStructVariant { variant_fields, .. }),
-            ) => fields.iter().enumerate().find_map(|(i, field)| {
-                let field_ty = variant_fields.get(i).map(|f| &f.ty).unwrap_or(fallback_ty);
-                get_pattern_element_type(field, None, field_ty, offset)
-            }),
+            ) => fields
+                .iter()
+                .enumerate()
+                .find_map(|(i, field)| {
+                    let field_ty = variant_fields.get(i).map(|f| &f.ty).unwrap_or(fallback_ty);
+                    get_pattern_element_type(field, None, field_ty, offset)
+                })
+                .or_else(|| Some((fallback_ty.clone(), span))),
+
+            (Pattern::EnumVariant { .. }, _) => Some((fallback_ty.clone(), span)),
 
             (Pattern::Struct { fields, .. }, Some(typed)) => {
                 let (field_defs, pattern_fields): (Vec<_>, _) = match typed {
@@ -162,6 +172,10 @@ pub(crate) fn get_hover_type_and_span(
                     );
                     Some((binding_ty, name_span))
                 })
+            }
+
+            (Pattern::Literal { .. }, _) | (Pattern::WildCard { .. }, _) => {
+                Some((fallback_ty.clone(), span))
             }
 
             _ => None,

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -367,6 +367,32 @@ fn resolve_dot_access_doc(
         .cloned()
 }
 
+/// If `expression` is a zero-field enum variant identifier, returns a display
+/// label of the form `"EnumName.VariantName"`. Otherwise returns `None`.
+///
+/// Zero-field variants have the enum type itself (e.g. `Color`) as their
+/// inferred type, so without this the hover would only show `"Color"` for
+/// both `Color.R` and `Color.G`.
+pub(crate) fn enum_variant_label(
+    expression: &Expression,
+    ty: &syntax::types::Type,
+) -> Option<String> {
+    let Expression::Identifier {
+        qualified: Some(q), ..
+    } = expression
+    else {
+        return None;
+    };
+    // qualified looks like "module.EnumName.VariantName"; split off the last segment
+    let (parent, variant_name) = q.rsplit_once('.')?;
+    // parent must match the type's qualified id (e.g. "module.EnumName")
+    if ty.get_qualified_id() != Some(parent) {
+        return None;
+    }
+    let enum_name = parent.rsplit('.').next()?;
+    Some(format!("{}.{}", enum_name, variant_name))
+}
+
 /// Resolve the doc comment for the hovered expression.
 pub(crate) fn get_hover_doc(
     expression: &Expression,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -212,11 +212,9 @@ impl LanguageServer for Backend {
             snapshot.definitions().get(type_id)?.doc().cloned()
         });
 
-        let ty_label = hover::enum_variant_label(expression, &ty).unwrap_or_else(|| ty.to_string());
-
         let content = match doc {
-            Some(doc) => format!("```lisette\n{ty_label}\n```\n\n---\n\n{doc}"),
-            None => format!("```lisette\n{ty_label}\n```"),
+            Some(doc) => format!("```lisette\n{ty}\n```\n\n---\n\n{doc}"),
+            None => format!("```lisette\n{ty}\n```"),
         };
 
         Ok(Some(Hover {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -207,11 +207,16 @@ impl LanguageServer for Backend {
             return Ok(None);
         }
 
-        let doc = hover::get_hover_doc(expression, offset, file, &snapshot);
+        let doc = hover::get_hover_doc(expression, offset, file, &snapshot).or_else(|| {
+            let type_id = ty.get_qualified_id()?;
+            snapshot.definitions().get(type_id)?.doc().cloned()
+        });
+
+        let ty_label = hover::enum_variant_label(expression, &ty).unwrap_or_else(|| ty.to_string());
 
         let content = match doc {
-            Some(doc) => format!("```lisette\n{ty}\n```\n\n---\n\n{doc}"),
-            None => format!("```lisette\n{ty}\n```"),
+            Some(doc) => format!("```lisette\n{ty_label}\n```\n\n---\n\n{doc}"),
+            None => format!("```lisette\n{ty_label}\n```"),
         };
 
         Ok(Some(Hover {

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -1120,6 +1120,94 @@ fn main() {
 }
 
 #[tokio::test]
+async fn hover_match_arm_enum_variant_shows_enum_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+enum Color { Red, Green, Blue(string) }
+fn main() {
+  let c: Color = Color.Green
+  match c {
+    Color.Red => 0,
+    Color.Green => 1,
+    Color.Blue(_) => 2,
+  }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Hover on "Color" part of "Color.Red" in match arm pattern — should show
+    // the enum type, not the match expression's return type.
+    let hover = client.hover(TEST_URI, 4, 6).await;
+    assert!(
+        hover.is_some(),
+        "hover on match arm enum variant should return something"
+    );
+    let content = hover_content(&hover.unwrap());
+    assert!(
+        content.contains("Color"),
+        "match arm enum variant should show enum type 'Color', got: {content}"
+    );
+
+    // Same check for a variant with a field payload — hover on the variant name.
+    let hover = client.hover(TEST_URI, 6, 6).await;
+    assert!(
+        hover.is_some(),
+        "hover on match arm enum variant with payload should return something"
+    );
+    let content = hover_content(&hover.unwrap());
+    assert!(
+        content.contains("Color"),
+        "match arm enum variant with payload should show enum type 'Color', got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_match_arm_literal_pattern_shows_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+fn main() {
+  let x = 1
+  match x {
+    1 => 10,
+    2 => 20,
+    _ => 0,
+  }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Hover on literal `1` in match arm pattern.
+    let hover = client.hover(TEST_URI, 3, 4).await;
+    assert!(
+        hover.is_some(),
+        "hover on literal pattern should return something"
+    );
+    let content = hover_content(&hover.unwrap());
+    assert!(
+        content.contains("int"),
+        "literal pattern should show 'int', got: {content}"
+    );
+
+    // Hover on wildcard `_` in match arm pattern.
+    let hover = client.hover(TEST_URI, 5, 4).await;
+    assert!(
+        hover.is_some(),
+        "hover on wildcard pattern should return something"
+    );
+    let content = hover_content(&hover.unwrap());
+    assert!(
+        content.contains("int"),
+        "wildcard pattern should show 'int', got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn diagnostics_type_error() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1487,6 +1487,20 @@ fn comment_trailing_in_value_enum_body() {
 }
 
 #[test]
+fn doc_comment_on_enum_variant() {
+    assert_format_snapshot!(
+        "/// Enum doc\nenum Color {\n  /// Doc for R\n  R,\n  /// Doc for G\n  G,\n  /// Doc for B\n  B,\n}"
+    );
+}
+
+#[test]
+fn doc_comment_on_value_enum_variant() {
+    assert_format_snapshot!(
+        "pub enum E: int {\n  /// Doc for A\n  A = 1,\n  /// Doc for B\n  B = 2,\n}"
+    );
+}
+
+#[test]
 fn comment_between_interface_methods() {
     assert_format_snapshot!("interface I {\n  fn first()\n  // between methods\n  fn second()\n}");
 }

--- a/tests/spec/format/snapshots/doc_comment_on_enum_variant.snap
+++ b/tests/spec/format/snapshots/doc_comment_on_enum_variant.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: /// Enum doc\nenum Color {\n  /// Doc for R\n  R,\n  /// Doc for G\n  G,\n  /// Doc for B\n  B,\n}"
+---
+/// Enum doc
+enum Color {
+  /// Doc for R
+  R,
+  /// Doc for G
+  G,
+  /// Doc for B
+  B,
+}

--- a/tests/spec/format/snapshots/doc_comment_on_value_enum_variant.snap
+++ b/tests/spec/format/snapshots/doc_comment_on_value_enum_variant.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: pub enum E: int {\n  /// Doc for A\n  A = 1,\n  /// Doc for B\n  B = 2,\n}"
+---
+pub enum E: int {
+  /// Doc for A
+  A = 1,
+  /// Doc for B
+  B = 2,
+}


### PR DESCRIPTION
A few fixes to lsp / formatting.

- Currently hover inside a match expression matches the entire expression, not the individual arms, as an example when hovering on `Color.G` the entire match block is targeted. This change allows hover on individual arms.

```rust 
match color {
  Color.R => fmt.Println("red"),
  Color.G => fmt.Println("green"), // Allow to hover on Color.G
  Color.B => fmt.Println("blue"),
}
```

- Enum constructors could not have any doc comments, as the formatter pushed them all to the bottom of the next code block. The formatter now formats the doc comments like in the snippet below.

```rust 
/// General doc
enum Color {
  /// This is the doc for R
  R,
  /// This is the doc for G
  G,
  /// This is the doc for B
  B,
}
```
- If a variable was bound to a enum constructor the hover did not show any docs at all.

```rust 
let red = Color.R // hover on `red` to see Color docs.
```