### PR TITLE
fix: redirect unwrap/expect diagnostic on Option/Result/Partial

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -733,6 +733,35 @@ pub fn member_not_found(
         .with_infer_code("member_not_found")
         .with_span_label(&span, format!("no member `{}` on type `{}`", field, ty));
 
+    if matches!(field, "unwrap" | "expect") && (ty.is_option() || ty.is_result() || ty.is_partial())
+    {
+        let help = if ty.is_option() {
+            format!(
+                "Lisette does not provide `{}()`. Use `?` to propagate, `match` to handle both \
+                 cases (e.g. `match <expr> {{ Some(x) => x, None => ... }}`), `let else` for \
+                 early exit, or `unwrap_or(default)` for a fallback.",
+                field
+            )
+        } else if ty.is_result() {
+            format!(
+                "Lisette does not provide `{}()`. Use `?` to propagate, `match` to handle both \
+                 cases (e.g. `match <expr> {{ Ok(x) => x, Err(e) => ... }}`), `let else` for \
+                 early exit, or `unwrap_or(default)` for a fallback.",
+                field
+            )
+        } else {
+            format!(
+                "Lisette does not provide `{}()`. The `?` operator is not supported on \
+                 `Partial`; use `match` to handle all three cases (e.g. `match <expr> \
+                 {{ Ok(x) => ..., Err(e) => ..., Both(x, e) => ... }}`) or `unwrap_or(default)` \
+                 for a fallback.",
+                field
+            )
+        };
+        diagnostic = diagnostic.with_help(help);
+        return diagnostic;
+    }
+
     if let Some(hint) = unwrap_hint {
         let (wrapper_name, pattern) = match hint.wrapper {
             UnwrapWrapper::Option => (

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1310,6 +1310,56 @@ fn test(opt: Option<string>) {
 }
 
 #[test]
+fn infer_member_not_found_unwrap_method_on_option() {
+    let input = r#"
+fn test(opt: Option<int>) -> int {
+  opt.unwrap()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_unwrap_method_on_result() {
+    let input = r#"
+fn test(res: Result<int, error>) -> int {
+  res.unwrap()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_expect_method_on_option() {
+    let input = r#"
+fn test(opt: Option<int>) -> int {
+  opt.expect("must be set")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_unwrap_method_on_partial() {
+    let input = r#"
+fn test(p: Partial<int, error>) -> int {
+  p.unwrap()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_member_not_found_expect_method_on_partial() {
+    let input = r#"
+fn test(p: Partial<int, error>) -> int {
+  p.expect("must be ok")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_struct_missing_fields() {
     let input = r#"
 struct Person {

--- a/tests/ui/errors/snapshots/infer_member_not_found_expect_method_on_option.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_expect_method_on_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(opt: Option<int>) -> int {
+ 3 │   opt.expect("must be set")
+   ·   ─────┬────
+   ·        ╰── no member `expect` on type `Option<int>`
+ 4 │ }
+   ╰────
+  help: Lisette does not provide `expect()`. Use `?` to propagate, `match` to handle both cases (e.g. `match <expr> { Some(x) => x, None => ... }`), `let else` for early exit, or `unwrap_or(default)` for a fallback · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_expect_method_on_partial.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_expect_method_on_partial.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(p: Partial<int, error>) -> int {
+ 3 │   p.expect("must be ok")
+   ·   ────┬───
+   ·       ╰── no member `expect` on type `Partial<int, error>`
+ 4 │ }
+   ╰────
+  help: Lisette does not provide `expect()`. The `?` operator is not supported on `Partial`; use `match` to handle all three cases (e.g. `match <expr> { Ok(x) => ..., Err(e) => ..., Both(x, e) => ... }`) or `unwrap_or(default)` for a fallback · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_option.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(opt: Option<int>) -> int {
+ 3 │   opt.unwrap()
+   ·   ─────┬────
+   ·        ╰── no member `unwrap` on type `Option<int>`
+ 4 │ }
+   ╰────
+  help: Lisette does not provide `unwrap()`. Use `?` to propagate, `match` to handle both cases (e.g. `match <expr> { Some(x) => x, None => ... }`), `let else` for early exit, or `unwrap_or(default)` for a fallback · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_partial.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_partial.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(p: Partial<int, error>) -> int {
+ 3 │   p.unwrap()
+   ·   ────┬───
+   ·       ╰── no member `unwrap` on type `Partial<int, error>`
+ 4 │ }
+   ╰────
+  help: Lisette does not provide `unwrap()`. The `?` operator is not supported on `Partial`; use `match` to handle all three cases (e.g. `match <expr> { Ok(x) => ..., Err(e) => ..., Both(x, e) => ... }`) or `unwrap_or(default)` for a fallback · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_result.snap
+++ b/tests/ui/errors/snapshots/infer_member_not_found_unwrap_method_on_result.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Member not found
+   ╭─[test.lis:3:3]
+ 2 │ fn test(res: Result<int, error>) -> int {
+ 3 │   res.unwrap()
+   ·   ─────┬────
+   ·        ╰── no member `unwrap` on type `Result<int, error>`
+ 4 │ }
+   ╰────
+  help: Lisette does not provide `unwrap()`. Use `?` to propagate, `match` to handle both cases (e.g. `match <expr> { Ok(x) => x, Err(e) => ... }`), `let else` for early exit, or `unwrap_or(default)` for a fallback · code: [infer.member_not_found]


### PR DESCRIPTION
Calling `.unwrap()` or `.expect()` on `Option<T>`, `Result<T, E>`, or `Partial<T, E>` previously fell through to a similarity-based hint suggesting `unwrap_or`, which unhelpful when the inner type has no constructible default, e.g. an interface. The diagnostic now points at the canonical idioms instead.