### PR TITLE
fix: reach pointer-receiver methods on package-var struct fields

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -509,25 +509,7 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 
 	switch u := underlying.(type) {
 	case *types.Struct:
-		for field := range u.Fields() {
-			if !field.Exported() {
-				continue
-			}
-
-			fieldType := ToLisetteNilable(field.Type(), c)
-			if fieldType.SkipReason != nil {
-				result.Fields = append(result.Fields, StructField{
-					Name:       field.Name(),
-					SkipReason: fieldType.SkipReason,
-				})
-				continue
-			}
-
-			result.Fields = append(result.Fields, StructField{
-				Name: field.Name(),
-				Type: fieldType.LisetteType,
-			})
-		}
+		result.Fields = convertStructFields(u, c)
 
 	case *types.Interface:
 		if isErrorInterface(u) {
@@ -603,6 +585,11 @@ func (c *Converter) convertConstant(result *ConvertResult, exp extract.SymbolExp
 }
 
 func (c *Converter) convertVariable(result *ConvertResult, exp extract.SymbolExport) {
+	if anon, ok := exp.GoType.(*types.Struct); ok {
+		c.synthesizeAnonStructVar(result, anon)
+		return
+	}
+
 	t := ToLisette(exp.GoType, c)
 	if t.SkipReason != nil {
 		result.SkipReason = t.SkipReason
@@ -618,6 +605,40 @@ func (c *Converter) convertVariable(result *ConvertResult, exp extract.SymbolExp
 	if isNilable && !forceNonNilable {
 		result.LisetteType = fmt.Sprintf("Option<%s>", result.LisetteType)
 	}
+}
+
+const anonStructSuffix = "_struct"
+
+func (c *Converter) synthesizeAnonStructVar(result *ConvertResult, anon *types.Struct) {
+	typeName := result.Name + anonStructSuffix
+	result.LisetteType = typeName
+	result.SyntheticType = &ConvertResult{
+		Name:   typeName,
+		Kind:   extract.ExportType,
+		Fields: convertStructFields(anon, c),
+	}
+}
+
+func convertStructFields(s *types.Struct, c *Converter) []StructField {
+	var fields []StructField
+	for field := range s.Fields() {
+		if !field.Exported() {
+			continue
+		}
+		fieldType := ToLisetteNilable(field.Type(), c)
+		if fieldType.SkipReason != nil {
+			fields = append(fields, StructField{
+				Name:       field.Name(),
+				SkipReason: fieldType.SkipReason,
+			})
+			continue
+		}
+		fields = append(fields, StructField{
+			Name: field.Name(),
+			Type: fieldType.LisetteType,
+		})
+	}
+	return fields
 }
 
 func (c *Converter) getOriginalLiteral(constObj *types.Const) string {

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -34,6 +34,9 @@ type ConvertResult struct {
 	SentinelInt *int
 	// BuilderMethod suppresses unused_value on fluent-chain returns the caller typically discards.
 	BuilderMethod bool
+	// SyntheticType holds a typedef bindgen mints to give an otherwise-skipped
+	// var a referenceable type.
+	SyntheticType *ConvertResult
 }
 
 type FunctionParameter struct {

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -151,6 +151,9 @@ func sanitizeIdent(s string) string {
 }
 
 func (e *Emitter) EmitExport(result convert.ConvertResult) {
+	if result.SyntheticType != nil {
+		e.EmitExport(*result.SyntheticType)
+	}
 	switch result.Kind {
 	case extract.ExportFunction:
 		e.emitFunction(result)

--- a/bindgen/tests/testdata/fixtures/variables/variables.go
+++ b/bindgen/tests/testdata/fixtures/variables/variables.go
@@ -29,3 +29,10 @@ var Counter int
 
 // ConfigMap holds configuration.
 var ConfigMap map[string]string
+
+// Counters has anonymous-struct type. Bindgen synthesizes Counters_struct so
+// the var (and its field types' methods) stay reachable from Lisette.
+var Counters struct {
+	Hits   int64
+	Misses int64
+}

--- a/bindgen/tests/testdata/snapshots/structs.d.lis
+++ b/bindgen/tests/testdata/snapshots/structs.d.lis
@@ -97,8 +97,10 @@ pub struct Wrapper {
   pub Label: string,
 }
 
-// SKIPPED: AnonField - anonymous-struct
-// anonymous struct types are not supported
+// SKIPPED field "Nested": anonymous-struct — anonymous struct types are not supported
+pub type AnonField_struct
+
+pub var AnonField: AnonField_struct
 
 impl Base {
   /// GetID returns the ID

--- a/bindgen/tests/testdata/snapshots/variables.d.lis
+++ b/bindgen/tests/testdata/snapshots/variables.d.lis
@@ -19,6 +19,15 @@ pub var ConfigMap: Map<string, string>
 /// Counter is a simple counter.
 pub var Counter: int
 
+pub struct Counters_struct {
+  pub Hits: int64,
+  pub Misses: int64,
+}
+
+/// Counters has anonymous-struct type. Bindgen synthesizes Counters_struct so
+/// the var (and its field types' methods) stay reachable from Lisette.
+pub var Counters: Counters_struct
+
 /// EOF marks end of file.
 pub var EOF: error
 

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -796,7 +796,11 @@ impl TaskState<'_> {
             .lookup_value(&var_name)
             .map(|t| t.resolve_in(&self.env).is_ref())
             .unwrap_or(false);
-        if !is_deref && !binding_is_ref && !self.scopes.lookup_mutable(&var_name) {
+        if !is_deref
+            && !binding_is_ref
+            && !self.scopes.lookup_mutable(&var_name)
+            && !self.imports.imported_modules.contains_key(&var_name)
+        {
             let self_type_name = if var_name == "self" {
                 self.lookup_type(store, "self")
                     .and_then(|t| t.get_name().map(str::to_owned))

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1296,7 +1296,11 @@ impl TaskState<'_> {
             .lookup_value(&var_name)
             .map(|t| t.resolve_in(&self.env).is_ref())
             .unwrap_or(false);
-        if !is_deref && !binding_is_ref && !self.scopes.lookup_mutable(&var_name) {
+        if !is_deref
+            && !binding_is_ref
+            && !self.scopes.lookup_mutable(&var_name)
+            && !self.imports.imported_modules.contains_key(&var_name)
+        {
             let is_match_arm = self
                 .scopes
                 .lookup_binding_id(&var_name)

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4271,3 +4271,39 @@ fn main() {
     );
     infer_module("main", fs).assert_no_errors();
 }
+
+#[test]
+fn ref_self_method_call_through_imported_pub_var_succeeds() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "metrics",
+        "lib.d.lis",
+        r#"
+pub struct Counter {
+  pub n: int64,
+}
+
+impl Counter {
+  fn Value(self: Ref<Counter>) -> int64
+}
+
+pub struct Counters_struct {
+  pub Hits: Counter,
+}
+
+pub var Counters: Counters_struct
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "metrics"
+
+fn main() {
+  let _ = metrics.Counters.Hits.Value()
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}


### PR DESCRIPTION
Imported package-level vars whose Go type is an anonymous struct (e.g. `glog.Stats`, declared in Go as `var Stats struct { Info, Warning, Error OutputStats }`) now resolve to a synthesized named typedef, and pointer-receiver methods on their fields are callable directly through the import path.

```rs
import "go:github.com/golang/glog"

fn main() {
  glog.Info("hello")
  glog.Flush()
  let n = glog.Stats.Info.Lines()
}
```