### PR TITLE
fix: lead native_method_value help with call-direct form

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2389,14 +2389,24 @@ pub fn specialized_impl_cannot_satisfy_interface(
         ))
 }
 
-pub fn native_method_value(method: &str, span: Span) -> LisetteDiagnostic {
+pub enum NativeMethodForm {
+    Instance,
+    Static,
+}
+
+pub fn native_method_value(method: &str, form: NativeMethodForm, span: Span) -> LisetteDiagnostic {
+    let help = match form {
+        NativeMethodForm::Instance => format!(
+            "Call it directly: `receiver.{method}()`. To use it as a value, wrap in a closure: `|args| receiver.{method}(args)`"
+        ),
+        NativeMethodForm::Static => {
+            format!("Use a closure instead: `|args| receiver.{method}(args)`")
+        }
+    };
     LisetteDiagnostic::error("Cannot use native method as a value")
         .with_infer_code("native_method_value")
         .with_span_label(&span, "native methods must be called directly")
-        .with_help(format!(
-            "Use a closure instead: `|args| receiver.{}(args)`",
-            method
-        ))
+        .with_help(help)
 }
 
 pub fn native_constructor_value(name: &str, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -235,8 +235,11 @@ impl TaskState<'_> {
                 )
                 && NativeTypeKind::from_type(&resolved_expression_ty).is_some()
             {
-                self.sink
-                    .push(diagnostics::infer::native_method_value(&member, span));
+                self.sink.push(diagnostics::infer::native_method_value(
+                    &member,
+                    diagnostics::infer::NativeMethodForm::Instance,
+                    span,
+                ));
             }
             return expression;
         }

--- a/crates/semantics/src/validators/native_value_usage.rs
+++ b/crates/semantics/src/validators/native_value_usage.rs
@@ -112,7 +112,11 @@ fn check_one(
         if matches!(method_part, "new" | "buffered") {
             sink.push(diagnostics::infer::native_constructor_value(value, span));
         } else {
-            sink.push(diagnostics::infer::native_method_value(method_part, span));
+            sink.push(diagnostics::infer::native_method_value(
+                method_part,
+                diagnostics::infer::NativeMethodForm::Static,
+                span,
+            ));
         }
         return;
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5761,6 +5761,21 @@ fn main() {
 }
 
 #[test]
+fn infer_native_method_value_on_struct_field() {
+    let input = r#"
+import "go:fmt"
+
+struct Box { items: Slice<int> }
+
+fn main() {
+  let b = Box { items: [1, 2] }
+  fmt.Printf("count=%d\n", b.items.length)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_private_method_expression() {
     let input = r#"
 struct Box { value: int }

--- a/tests/ui/errors/snapshots/infer_native_method_value_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/infer_native_method_value_on_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use native method as a value
+   ╭─[test.lis:8:28]
+ 7 │   let b = Box { items: [1, 2] }
+ 8 │   fmt.Printf("count=%d\n", b.items.length)
+   ·                            ───────┬──────
+   ·                                   ╰── native methods must be called directly
+ 9 │ }
+   ╰────
+  help: Call it directly: `receiver.length()`. To use it as a value, wrap in a closure: `|args| receiver.length(args)` · code: [infer.native_method_value]

--- a/tests/ui/errors/snapshots/infer_native_receiver_method_value.snap
+++ b/tests/ui/errors/snapshots/infer_native_receiver_method_value.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·               ╰── native methods must be called directly
  5 │   let _ = f
    ╰────
-  help: Use a closure instead: `|args| receiver.length(args)` · code: [infer.native_method_value]
+  help: Call it directly: `receiver.length()`. To use it as a value, wrap in a closure: `|args| receiver.length(args)` · code: [infer.native_method_value]


### PR DESCRIPTION
When a slice method or other native-typed method is referenced without parens through a receiver, the `infer.native_method_value` help now leads with the call-direct form and demotes the closure suggestion. The closure-only suggestion still applies to the static UFCS form (e.g. `Slice.append`), where there is no receiver to call against.