### PR TITLE
fix: align select arm type inference with match

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -6,8 +6,7 @@ use syntax::types::Type;
 
 use super::super::TaskState;
 
-/// Result of reconciling branch types. `Widened` means the common type is a
-/// later branch's type (a supertype of the first), not the first branch's type.
+/// Outcome of unifying branch types: kept first, widened to a supertype, or failed.
 enum BranchReconciliation {
     FirstBranch,
     Widened(Type),
@@ -15,6 +14,31 @@ enum BranchReconciliation {
 }
 
 impl TaskState<'_> {
+    pub(crate) fn reconcile_and_unify(
+        &mut self,
+        store: &mut Store,
+        result_ty: &Type,
+        branch_types: &[Type],
+        span: &Span,
+    ) {
+        if branch_types.is_empty() {
+            return;
+        }
+        match self.reconcile_branch_types(store, branch_types, span) {
+            BranchReconciliation::FirstBranch => {
+                self.unify(store, result_ty, &branch_types[0], span);
+            }
+            BranchReconciliation::Widened(ty) => {
+                self.unify(store, result_ty, &ty, span);
+            }
+            BranchReconciliation::Failed => {
+                debug_assert!(branch_types.len() >= 2);
+                let _ = self.try_unify(store, &branch_types[0], &branch_types[1], span);
+                self.unify(store, result_ty, &branch_types[0], span);
+            }
+        }
+    }
+
     fn reconcile_branch_types(
         &mut self,
         store: &Store,
@@ -287,22 +311,7 @@ impl TaskState<'_> {
 
         if needs_reconciliation {
             let arm_types: Vec<Type> = new_arms.iter().map(|a| a.expression.get_type()).collect();
-
-            match self.reconcile_branch_types(store, &arm_types, &span) {
-                BranchReconciliation::FirstBranch => {
-                    if let Some(first) = arm_types.first() {
-                        self.unify(store, &result_ty, first, &span);
-                    }
-                }
-                BranchReconciliation::Widened(ty) => {
-                    self.unify(store, &result_ty, &ty, &span);
-                }
-                BranchReconciliation::Failed => {
-                    debug_assert!(arm_types.len() >= 2);
-                    let _ = self.try_unify(store, &arm_types[0], &arm_types[1], &span);
-                    self.unify(store, &result_ty, &arm_types[0], &span);
-                }
-            }
+            self.reconcile_and_unify(store, &result_ty, &arm_types, &span);
         } else if is_statement && let Some(first_arm) = new_arms.first() {
             // In statement position, set the match's type from the first arm so the
             // expression still has a well-defined type for inspection, even though

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -28,11 +28,28 @@ impl TaskState<'_> {
         self.check_duplicate_select_defaults(&arms);
 
         let result_ty = self.new_type_var();
+        self.unify(store, expected_ty, &result_ty, &span);
+
+        let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
+
+        let mut arm_target_types: Vec<Type> = if needs_reconciliation {
+            Vec::with_capacity(arms.len())
+        } else {
+            Vec::new()
+        };
 
         let new_arms: Vec<SelectArm> = arms
             .into_iter()
             .map(|arm| {
                 self.scopes.push();
+
+                let independent_ty;
+                let arm_target = if needs_reconciliation {
+                    independent_ty = self.new_type_var();
+                    &independent_ty
+                } else {
+                    &result_ty
+                };
 
                 let new_arm_pattern = match arm.pattern {
                     SelectArmPattern::Receive {
@@ -45,13 +62,13 @@ impl TaskState<'_> {
                         binding,
                         receive_expression,
                         body,
-                        &result_ty,
+                        arm_target,
                     ),
 
                     SelectArmPattern::Send {
                         send_expression,
                         body,
-                    } => self.infer_select_send(store, send_expression, body, &result_ty),
+                    } => self.infer_select_send(store, send_expression, body, arm_target),
 
                     SelectArmPattern::MatchReceive {
                         receive_expression,
@@ -60,13 +77,17 @@ impl TaskState<'_> {
                         store,
                         receive_expression,
                         match_arms,
-                        &result_ty,
+                        arm_target,
                     ),
 
                     SelectArmPattern::WildCard { body } => {
-                        self.infer_select_wildcard(store, body, &result_ty)
+                        self.infer_select_wildcard(store, body, arm_target)
                     }
                 };
+
+                if needs_reconciliation {
+                    arm_target_types.push(arm_target.clone());
+                }
 
                 self.scopes.pop();
 
@@ -76,23 +97,26 @@ impl TaskState<'_> {
             })
             .collect();
 
-        self.unify(store, expected_ty, &result_ty, &span);
+        if needs_reconciliation {
+            self.reconcile_and_unify(store, &result_ty, &arm_target_types, &span);
+        }
 
-        // Reject non-exhaustive select expressions in value position:
-        // shorthand receive arms without a default arm can silently return
-        // a zero value when the channel is closed or the pattern doesn't match.
         let resolved_result = result_ty.resolve_in(&self.env);
-        if !resolved_result.is_unit() && !resolved_result.is_variable() {
-            let has_shorthand_receive = new_arms
-                .iter()
-                .any(|arm| matches!(arm.pattern, SelectArmPattern::Receive { .. }));
-            let has_default = new_arms
-                .iter()
-                .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
-            if has_shorthand_receive && !has_default {
-                self.sink
-                    .push(diagnostics::infer::non_exhaustive_select_expression(span));
-            }
+        let shorthand_receive_count = new_arms
+            .iter()
+            .filter(|arm| matches!(arm.pattern, SelectArmPattern::Receive { .. }))
+            .count();
+        let has_default = new_arms
+            .iter()
+            .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
+        if !expected_ty.is_ignored()
+            && !resolved_result.is_unit()
+            && !resolved_result.is_variable()
+            && shorthand_receive_count == 1
+            && !has_default
+        {
+            self.sink
+                .push(diagnostics::infer::non_exhaustive_select_expression(span));
         }
 
         Expression::Select {
@@ -247,7 +271,15 @@ impl TaskState<'_> {
 
         let pattern_ty = receive_ty.resolve_in(&self.env);
 
-        let new_match_arms = match_arms
+        let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
+
+        let mut arm_expression_types: Vec<Type> = if needs_reconciliation {
+            Vec::with_capacity(match_arms.len())
+        } else {
+            Vec::new()
+        };
+
+        let new_match_arms: Vec<MatchArm> = match_arms
             .into_iter()
             .map(|match_arm| {
                 self.scopes.push();
@@ -265,9 +297,23 @@ impl TaskState<'_> {
                     Box::new(guard_expression)
                 });
 
+                let independent_ty;
+                let arm_expected = if needs_reconciliation {
+                    independent_ty = self.new_type_var();
+                    &independent_ty
+                } else {
+                    result_ty
+                };
+
                 let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-                let new_expression = self.infer_expression(store, *match_arm.expression, result_ty);
+                self.scopes.set_in_subexpression(false);
+                let new_expression =
+                    self.infer_expression(store, *match_arm.expression, arm_expected);
                 self.scopes.set_in_match_arm(saved_in_match_arm);
+
+                if needs_reconciliation {
+                    arm_expression_types.push(arm_expected.clone());
+                }
 
                 self.scopes.pop();
 
@@ -279,6 +325,11 @@ impl TaskState<'_> {
                 }
             })
             .collect();
+
+        if needs_reconciliation {
+            let span = new_receive_expression.get_span();
+            self.reconcile_and_unify(store, result_ty, &arm_expression_types, &span);
+        }
 
         SelectArmPattern::MatchReceive {
             receive_expression: Box::new(new_receive_expression),

--- a/crates/semantics/src/checker/infer/validation/select.rs
+++ b/crates/semantics/src/checker/infer/validation/select.rs
@@ -129,9 +129,7 @@ impl TaskState<'_> {
         }
     }
 
-    /// Check for multiple shorthand receive arms in select.
-    /// Multiple `let Some(v) = ch.receive()` arms can lead to unexpected behavior
-    /// when one channel is closed - it may be selected over channels with values.
+    /// Reject multiple `let Some(v) = ch.receive()` arms in one select.
     pub(crate) fn check_multiple_select_receives(&mut self, arms: &[syntax::ast::SelectArm]) {
         use syntax::ast::SelectArmPattern;
 

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -1036,12 +1036,15 @@ fn select_wildcard_only() {
 #[test]
 fn select_arm_type_mismatch() {
     infer(
-        r#"{
-    select {
-      _ => 42,
-      _ => "wrong",
+        r#"
+    fn test() -> int {
+      let ch = Channel.new<int>();
+      select {
+        let Some(x) = ch.receive() => x,
+        _ => "wrong",
+      }
     }
-  }"#,
+  "#,
     )
     .assert_type_mismatch();
 }


### PR DESCRIPTION
Brings `select` arm inference in line with plain `match`, i.e. arm bodies with differing types reconcile when the result type is unconstrained, `break` is accepted inside `match ch.receive()` arms, and `infer.non_exhaustive_select_expression` is suppressed in statement position.

```rs
loop {
  select {
    match ch.receive() {
      Some(v) => fmt.Println(f"got {v}"),
      None => break,
    },
    let Some(_) = timeout.receive() => break,
  }
}
```
