### PR TITLE
fix: bind unexported error sentinels as error

### DIFF
--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -277,6 +277,9 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 		if conv != nil && !conv.hasReachableUnexportedType(t) {
 			return TypeResult{LisetteType: "Unknown"}
 		}
+		if namedImplementsError(t) {
+			return TypeResult{LisetteType: "error"}
+		}
 		return toLisetteRecursive(t.Underlying(), seen, conv)
 	}
 
@@ -439,6 +442,14 @@ func isInternalPackagePath(path string) bool {
 	}
 
 	return strings.Contains(path, "/internal/")
+}
+
+func namedImplementsError(t *types.Named) bool {
+	errorIface := universeErrorInterface()
+	if errorIface == nil {
+		return false
+	}
+	return types.Implements(t, errorIface) || types.Implements(types.NewPointer(t), errorIface)
 }
 
 func isErrorInterface(_interface *types.Interface) bool {

--- a/bindgen/tests/testdata/fixtures/unexported_type_leak/unexported_type_leak.go
+++ b/bindgen/tests/testdata/fixtures/unexported_type_leak/unexported_type_leak.go
@@ -35,3 +35,13 @@ type band uint8
 
 func GetVisitor() func() band { return nil }
 func PromoteBand(b band)      {}
+
+// Sentinel of an unexported type that satisfies error via value-receiver
+// methods (mirrors cmpopts.AnyError). Without the implementsError check, the
+// empty-struct underlying would leak as Lisette's unit type `()`.
+type anyError struct{}
+
+func (anyError) Error() string     { return "any error" }
+func (anyError) Is(err error) bool { return err != nil }
+
+var AnyError anyError

--- a/bindgen/tests/testdata/snapshots/unexported_type_leak.d.lis
+++ b/bindgen/tests/testdata/snapshots/unexported_type_leak.d.lis
@@ -24,4 +24,6 @@ pub const LevelInfo = 1
 
 pub const LevelWarn = 2
 
+pub var AnyError: error
+
 pub var DefaultTier: int


### PR DESCRIPTION
Bindgen now emits `error` for exported vars whose Go type is an unexported named type satisfying `error`. The most visible case is `cmpopts.AnyError`, whose underlying `anyError` is `struct{}` and previously surfaced as Lisette's unit type `()`, leaving the var unusable without a manual cast.

```rs
import "go:errors"
import "go:github.com/google/go-cmp/cmp"
import "go:github.com/google/go-cmp/cmp/cmpopts"

let err: error = errors.New("boom")
cmp.Equal(err, cmpopts.AnyError, cmpopts.EquateErrors()) // true
```