### PR TITLE
fix: alias empty named interfaces to Unknown

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -515,7 +515,8 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 		if isErrorInterface(u) {
 			result.LisetteType = "error"
 		} else if u.Empty() {
-			result.IsInterface = true
+			result.LisetteType = "Unknown"
+			result.IsTypeAlias = true
 		} else if methods, ok := c.extractInterfaceMethods(u, result.Name); ok {
 			result.IsInterface = true
 			result.InterfaceMethods = methods

--- a/bindgen/tests/testdata/fixtures/interfaces/interfaces.go
+++ b/bindgen/tests/testdata/fixtures/interfaces/interfaces.go
@@ -37,6 +37,12 @@ type ReadWriteSeeker interface {
 // Empty interface alias
 type Any interface{}
 
+// Empty named interface used as a struct field — alias must resolve to
+// Unknown end-to-end so any value can be assigned.
+type Holder struct {
+	Hook Any
+}
+
 // Custom error types
 
 // Custom error type implementing error interface

--- a/bindgen/tests/testdata/snapshots/interfaces.d.lis
+++ b/bindgen/tests/testdata/snapshots/interfaces.d.lis
@@ -7,7 +7,7 @@
 pub fn Validate(s: string) -> Result<(), error>
 
 /// Empty interface alias
-pub interface Any {}
+pub type Any = Unknown
 
 /// Nilable comma-ok method on interface
 pub interface Cache {
@@ -16,7 +16,13 @@ pub interface Cache {
   fn Set(key: string, value: Ref<Node>)
 }
 
-pub interface Empty {}
+pub type Empty = Unknown
+
+/// Empty named interface used as a struct field — alias must resolve to
+/// Unknown end-to-end so any value can be assigned.
+pub struct Holder {
+  pub Hook: Any,
+}
 
 /// Variadic method on interface
 pub interface Logger {

--- a/crates/stdlib/typedefs/crypto.d.lis
+++ b/crates/stdlib/typedefs/crypto.d.lis
@@ -89,7 +89,7 @@ pub interface Decrypter {
   fn Public() -> PublicKey
 }
 
-pub interface DecrypterOpts {}
+pub type DecrypterOpts = Unknown
 
 /// MessageSigner is an interface for an opaque private key that can be used for
 /// signing operations where the message is not pre-hashed by the caller.
@@ -121,7 +121,7 @@ pub interface MessageSigner {
 /// 
 /// as well as purpose-specific interfaces such as [Signer] and [Decrypter], which
 /// can be used for increased type safety within applications.
-pub interface PrivateKey {}
+pub type PrivateKey = Unknown
 
 /// PublicKey represents a public key using an unspecified algorithm.
 /// 
@@ -133,7 +133,7 @@ pub interface PrivateKey {}
 /// 	}
 /// 
 /// which can be used for increased type safety within applications.
-pub interface PublicKey {}
+pub type PublicKey = Unknown
 
 /// Signer is an interface for an opaque private key that can be used for
 /// signing operations. For example, an RSA key kept in a hardware module.

--- a/crates/stdlib/typedefs/database/sql/driver.d.lis
+++ b/crates/stdlib/typedefs/database/sql/driver.d.lis
@@ -344,7 +344,7 @@ pub interface Validator {
 /// in this package. This is used, for example, when a user selects a cursor
 /// such as "select cursor(select * from my_table) from dual". If the [Rows]
 /// from the select is closed, the cursor [Rows] will also be closed.
-pub interface Value {}
+pub type Value = Unknown
 
 /// ValueConverter is the interface providing the ConvertValue method.
 /// 

--- a/crates/stdlib/typedefs/encoding/json.d.lis
+++ b/crates/stdlib/typedefs/encoding/json.d.lis
@@ -330,7 +330,7 @@ pub struct SyntaxError {
 ///   - [Number], for JSON numbers
 ///   - string, for JSON string literals
 ///   - nil, for JSON null
-pub interface Token {}
+pub type Token = Unknown
 
 /// An UnmarshalFieldError describes a JSON object key that
 /// led to an unexported (and therefore unwritable) struct field.

--- a/crates/stdlib/typedefs/encoding/xml.d.lis
+++ b/crates/stdlib/typedefs/encoding/xml.d.lis
@@ -308,7 +308,7 @@ pub struct TagPathError {
 
 /// A Token is an interface holding one of the token types:
 /// [StartElement], [EndElement], [CharData], [Comment], [ProcInst], or [Directive].
-pub interface Token {}
+pub type Token = Unknown
 
 /// A TokenReader is anything that can decode a stream of XML tokens, including a
 /// [Decoder].

--- a/crates/stdlib/typedefs/plugin.d.lis
+++ b/crates/stdlib/typedefs/plugin.d.lis
@@ -37,7 +37,7 @@ pub type Plugin
 /// 	}
 /// 	*v.(*int) = 7
 /// 	f.(func())() // prints "Hello, number 7"
-pub interface Symbol {}
+pub type Symbol = Unknown
 
 impl Plugin {
   /// Lookup searches for a symbol named symName in plugin p.


### PR DESCRIPTION
Empty named Go interfaces (`type Foo interface{}`) now bind as `pub type Foo = Unknown` instead of `pub interface Foo {}`, matching Go's semantics that `interface{}` accepts any value. Function values, scalars, and other types assign directly without an `as` cast.