### PR TITLE
fix: tailor diagnostics for `Self` in impl and `mut` struct fields

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -128,14 +128,16 @@ pub fn invalid_map_initialization(key: &Type, value: &Type, span: Span) -> Liset
         ))
 }
 
-pub fn self_type_not_supported(span: Span) -> LisetteDiagnostic {
+pub fn self_type_not_supported(span: Span, impl_receiver: Option<&str>) -> LisetteDiagnostic {
     let name_span = Span::new(span.file_id, span.byte_offset, 4); // "Self" is 4 chars
+    let help = match impl_receiver {
+        Some(name) => format!("Replace `Self` with `{}`.", name),
+        None => "Use a type parameter instead, e.g. `interface Comparable<T> { fn compare(self, other: T) -> int }`".to_string(),
+    };
     LisetteDiagnostic::error("Use of `Self` type")
         .with_resolve_code("self_type_not_supported")
         .with_span_label(&name_span, "invalid type")
-        .with_help(
-            "Use a type parameter instead, e.g. `interface Comparable<T> { fn compare(self, other: T) -> int }`",
-        )
+        .with_help(help)
 }
 
 pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -83,8 +83,10 @@ impl TaskState<'_> {
                     self.resolve_type_with_arity(store, type_name, params.len())
                 else {
                     if type_name == "Self" {
+                        let receiver = self.scopes.impl_receiver_type().map(|ty| ty.stringify());
                         self.sink.push(diagnostics::infer::self_type_not_supported(
                             *annotation_span,
+                            receiver.as_deref(),
                         ));
                     } else {
                         self.sink.push(diagnostics::infer::type_not_found(

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -664,6 +664,14 @@ impl<'source> Parser<'source> {
             Visibility::Private
         };
 
+        if self.is(Mut) {
+            self.track_error(
+                "fields cannot be marked `mut`",
+                "Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`).",
+            );
+            self.next();
+        }
+
         if self.is_not(Identifier) {
             self.track_error("expected field name", "Field names must be identifiers.");
             return None;

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -570,6 +570,26 @@ struct Foo {
 }
 
 #[test]
+fn parse_struct_field_pub_mut() {
+    let input = r#"
+struct Foo {
+  pub mut diffs: Slice<string>,
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_struct_field_mut() {
+    let input = r#"
+struct Foo {
+  mut diffs: Slice<string>,
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_enum_variant_invalid_token() {
     let input = r#"
 enum Foo {
@@ -5605,6 +5625,36 @@ fn infer_self_type_in_interface() {
     let input = r#"
 interface Comparable {
   fn compare(self, other: Self) -> int
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_in_impl_block() {
+    let input = r#"
+struct DiffReporter {
+  pub diffs: Slice<string>,
+}
+impl DiffReporter {
+  pub fn PushStep(self: Ref<Self>, step: string) {
+    let _ = step
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_in_generic_impl_block() {
+    let input = r#"
+struct Stack<T> {
+  pub items: Slice<T>,
+}
+impl<T> Stack<T> {
+  pub fn Peek(self: Ref<Self>) -> T {
+    self.items[0]
+  }
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_self_type_in_generic_impl_block.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_in_generic_impl_block.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 5660
+---
+  [error] Use of `Self` type
+   ╭─[test.lis:6:25]
+ 5 │ impl<T> Stack<T> {
+ 6 │   pub fn Peek(self: Ref<Self>) -> T {
+   ·                         ──┬─
+   ·                           ╰── invalid type
+ 7 │     self.items[0]
+   ╰────
+  help: Replace `Self` with `Stack<T>` · code: [resolve.self_type_not_supported]

--- a/tests/ui/errors/snapshots/infer_self_type_in_impl_block.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_in_impl_block.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 5645
+---
+  [error] Use of `Self` type
+   ╭─[test.lis:6:29]
+ 5 │ impl DiffReporter {
+ 6 │   pub fn PushStep(self: Ref<Self>, step: string) {
+   ·                             ──┬─
+   ·                               ╰── invalid type
+ 7 │     let _ = step
+   ╰────
+  help: Replace `Self` with `DiffReporter` · code: [resolve.self_type_not_supported]

--- a/tests/ui/errors/snapshots/parse_struct_field_mut.snap
+++ b/tests/ui/errors/snapshots/parse_struct_field_mut.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 589
+---
+  [error] Syntax error
+   ╭─[test.lis:3:3]
+ 2 │ struct Foo {
+ 3 │   mut diffs: Slice<string>,
+   ·   ─┬─
+   ·    ╰── fields cannot be marked `mut`
+ 4 │ }
+   ╰────
+  help: Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`) · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_struct_field_pub_mut.snap
+++ b/tests/ui/errors/snapshots/parse_struct_field_pub_mut.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 579
+---
+  [error] Syntax error
+   ╭─[test.lis:3:7]
+ 2 │ struct Foo {
+ 3 │   pub mut diffs: Slice<string>,
+   ·       ─┬─
+   ·        ╰── fields cannot be marked `mut`
+ 4 │ }
+   ╰────
+  help: Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`) · code: [parse.syntax_error]


### PR DESCRIPTION
- `resolve.self_type_not_supported` inside an `impl` block now produces a useful suggestion.
- `pub mut diffs: Slice<string>` now produces a single error at the `mut` token.
