### PR TITLE
fix: tailor nil and member-not-found help to context

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -252,12 +252,14 @@ pub fn name_not_found(
     variable_name: &str,
     span: Span,
     available_names: &[String],
+    expected_ty: Option<&Type>,
 ) -> LisetteDiagnostic {
     if matches!(variable_name, "nil" | "null" | "Nil" | "undefined") {
+        let help = nil_help_for(expected_ty);
         return LisetteDiagnostic::error(format!("`{}` is not supported", variable_name))
             .with_resolve_code("nil_not_supported")
             .with_span_label(&span, "does not exist")
-            .with_help("Absence is encoded with `Option<T>` in Lisette. Use `None` to represent absent values.");
+            .with_help(help);
     }
 
     if let Some(hint) = go_builtin_hint(variable_name) {
@@ -287,6 +289,18 @@ pub fn name_not_found(
     }
 
     diagnostic
+}
+
+/// Pick a `nil`-replacement hint tailored to the expected type.
+fn nil_help_for(expected_ty: Option<&Type>) -> String {
+    match expected_ty {
+        Some(ty) if ty.is_slice() => format!("For an empty `{}`, use `[]`.", ty),
+        Some(ty) if ty.is_map() => format!("For an empty `{}`, use `Map.new()`.", ty),
+        _ => {
+            "Absence is encoded with `Option<T>` in Lisette. Use `None` to represent absent values."
+                .to_string()
+        }
+    }
 }
 
 pub fn self_in_static_method(span: Span) -> LisetteDiagnostic {
@@ -730,6 +744,7 @@ pub fn member_not_found(
     span: Span,
     available_fields: Option<&[String]>,
     unwrap_hint: Option<UnwrapHint>,
+    is_call_target: bool,
 ) -> LisetteDiagnostic {
     let mut diagnostic = LisetteDiagnostic::error("Member not found")
         .with_infer_code("member_not_found")
@@ -791,7 +806,12 @@ pub fn member_not_found(
     let suggestion = available_fields.and_then(|fields| find_similar_name(field, fields));
 
     if let Some(suggestion) = suggestion {
-        diagnostic = diagnostic.with_help(format!("Did you mean `{}`?", suggestion));
+        let rendered = if is_call_target {
+            format!("{}()", suggestion)
+        } else {
+            suggestion
+        };
+        diagnostic = diagnostic.with_help(format!("Did you mean `{}`?", rendered));
     } else {
         diagnostic = diagnostic.with_help("Ensure the field or method is defined on this type");
     }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -256,6 +256,7 @@ impl TaskState<'_> {
                 Some(&available_members)
             },
             unwrap_hint,
+            self.scopes.is_callee_context(),
         ));
 
         args.build_dot_access(Type::Error, None, None)

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -564,6 +564,7 @@ impl TaskState<'_> {
                             span,
                             Some(&available),
                             None,
+                            false,
                         ));
                         Type::Error
                     }
@@ -840,6 +841,7 @@ impl TaskState<'_> {
                             *span,
                             Some(&available),
                             None,
+                            false,
                         ));
                         Type::Error
                     }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -263,7 +263,7 @@ impl TaskState<'_> {
                     self.sink
                         .push(diagnostics::infer::self_in_static_method(span));
                 } else {
-                    self.error_name_not_found(store, &value, span);
+                    self.error_name_not_found(store, &value, span, expected_ty);
                 }
                 Type::Error
             }
@@ -509,7 +509,13 @@ impl TaskState<'_> {
         new_items
     }
 
-    pub(super) fn error_name_not_found(&mut self, store: &Store, variable_name: &str, span: Span) {
+    pub(super) fn error_name_not_found(
+        &mut self,
+        store: &Store,
+        variable_name: &str,
+        span: Span,
+        expected_ty: &Type,
+    ) {
         if self.imports.failed_imports.contains(variable_name) {
             return;
         }
@@ -528,10 +534,18 @@ impl TaskState<'_> {
             }
         }
 
+        let hint_ty = if matches!(variable_name, "nil" | "null" | "Nil" | "undefined") {
+            let resolved = expected_ty.resolve_in(&self.env);
+            (!resolved.is_variable() && !resolved.is_error()).then_some(resolved)
+        } else {
+            None
+        };
+
         self.sink.push(diagnostics::infer::name_not_found(
             variable_name,
             span,
             &available_names,
+            hint_ty.as_ref(),
         ));
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -453,6 +453,7 @@ impl TaskState<'_> {
                             ctx.span,
                             Some(&available),
                             None,
+                            false,
                         ));
                         self.new_type_var()
                     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -21,6 +21,26 @@ fn test() -> Option<int> {
 }
 
 #[test]
+fn infer_nil_not_supported_for_slice() {
+    let input = r#"
+fn test() -> Slice<int> {
+  nil
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_nil_not_supported_for_map() {
+    let input = r#"
+fn test() -> Map<string, int> {
+  nil
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_go_builtin_len() {
     let input = r#"
 fn test(items: Slice<int>) -> int {

--- a/tests/ui/errors/snapshots/infer_method_not_found_with_prefix_suggestion.snap
+++ b/tests/ui/errors/snapshots/infer_method_not_found_with_prefix_suggestion.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·     ╰── no member `len` on type `string`
  4 │ }
    ╰────
-  help: Did you mean `length`? · code: [infer.member_not_found]
+  help: Did you mean `length()`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_method_not_found_with_prefix_suggestion_on_slice.snap
+++ b/tests/ui/errors/snapshots/infer_method_not_found_with_prefix_suggestion_on_slice.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·     ╰── no member `len` on type `Slice<int>`
  4 │ }
    ╰────
-  help: Did you mean `length`? · code: [infer.member_not_found]
+  help: Did you mean `length()`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_method_not_found_with_typo_suggestion.snap
+++ b/tests/ui/errors/snapshots/infer_method_not_found_with_typo_suggestion.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·       ╰── no member `cntains` on type `string`
  4 │ }
    ╰────
-  help: Did you mean `contains`? · code: [infer.member_not_found]
+  help: Did you mean `contains()`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_nil_not_supported_for_map.snap
+++ b/tests/ui/errors/snapshots/infer_nil_not_supported_for_map.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `nil` is not supported
+   ╭─[test.lis:3:3]
+ 2 │ fn test() -> Map<string, int> {
+ 3 │   nil
+   ·   ─┬─
+   ·    ╰── does not exist
+ 4 │ }
+   ╰────
+  help: For an empty `Map<string, int>`, use `Map.new()` · code: [resolve.nil_not_supported]

--- a/tests/ui/errors/snapshots/infer_nil_not_supported_for_slice.snap
+++ b/tests/ui/errors/snapshots/infer_nil_not_supported_for_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `nil` is not supported
+   ╭─[test.lis:3:3]
+ 2 │ fn test() -> Slice<int> {
+ 3 │   nil
+   ·   ─┬─
+   ·    ╰── does not exist
+ 4 │ }
+   ╰────
+  help: For an empty `Slice<int>`, use `[]` · code: [resolve.nil_not_supported]


### PR DESCRIPTION
In diagnostics, `nil` in a context expecting `Slice<T>` or `Map<K,V>` now points at the empty literal.