### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.0](https://github.com/ivov/lisette/compare/lisette-v0.1.26...lisette-v0.2.0) - 2026-05-06
+
+- refactor!: reject positional access on string [#323](https://github.com/ivov/lisette/pull/323) [`a7c7245`](https://github.com/ivov/lisette/commit/a7c7245aab153ad88d44ef5ea93529c26cad2d8c)
+- feat: add substring, bytes, and runes methods on string [#320](https://github.com/ivov/lisette/pull/320) [`ebd679d`](https://github.com/ivov/lisette/commit/ebd679deed12383da5cbeffc9b60b0b3770c3104)
+- refactor!: switch variadic spread to postfix syntax [#322](https://github.com/ivov/lisette/pull/322) [`8f597b2`](https://github.com/ivov/lisette/commit/8f597b2ae00b68a6cf48df63077d66e382496865)
+- fix: allow rune to string cast, block rune to byte cast [#318](https://github.com/ivov/lisette/pull/318) [`3ce2fb6`](https://github.com/ivov/lisette/commit/3ce2fb6b8c8859ee10ef9508b093fff1bc62cb3c)
+- docs: add snippet sharing to playground [#319](https://github.com/ivov/lisette/pull/319) [`0234b42`](https://github.com/ivov/lisette/commit/0234b42056f50951226d60d76735bc33945886a0)
+- docs: add link to WASM playground in index.html [#310](https://github.com/ivov/lisette/pull/310) [`38d46b6`](https://github.com/ivov/lisette/commit/38d46b648b9678b94fe4a4bef7189648b985d02b)
+- refactor: add rune-indexed string access to prelude [#317](https://github.com/ivov/lisette/pull/317) [`5395a8d`](https://github.com/ivov/lisette/commit/5395a8db2fbd2e85826cfbe11e5ea3c168b9449d)
+- refactor: move third-party typedefs into project [#315](https://github.com/ivov/lisette/pull/315) [`d7d8adc`](https://github.com/ivov/lisette/commit/d7d8adcfaf5c87e109ba3bc135e49876c9793d53)
+- refactor: thread target through third-party typedef cache paths [#314](https://github.com/ivov/lisette/pull/314) [`e3d6ed2`](https://github.com/ivov/lisette/commit/e3d6ed2bb8324144a188de7baf55846dd1addf16)
+- ci: lint bindgen and prelude with golangci-lint [#313](https://github.com/ivov/lisette/pull/313) [`48e57b8`](https://github.com/ivov/lisette/commit/48e57b8eab6d034242173b5d1651fb640db11b46)
+- fix: disambiguate bindgen aliases on shared trailing segments [#312](https://github.com/ivov/lisette/pull/312) [`cc2f820`](https://github.com/ivov/lisette/commit/cc2f820039f6c8dd0551dbc27b922eb91eef1295)
+- fix: suggest `..` zero-fill in missing-fields help [#311](https://github.com/ivov/lisette/pull/311) [`219cf0a`](https://github.com/ivov/lisette/commit/219cf0ab8f5f062320eabbf6fd4d5e195d328dc2)
+- fix: preserve all returns when trailing bool is a flag [#307](https://github.com/ivov/lisette/pull/307) [`227e61e`](https://github.com/ivov/lisette/commit/227e61e7e23246ee08e69e671d2df53be5708c17)
 ## [0.1.26](https://github.com/ivov/lisette/compare/lisette-v0.1.25...lisette-v0.1.26) - 2026-05-04
 
 - fix: tailor nil and member-not-found help to context [#306](https://github.com/ivov/lisette/pull/306) [`aa12647`](https://github.com/ivov/lisette/commit/aa12647673d779dad69b6142b3b61b681611a205)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -582,11 +582,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.1.26"
+version = "0.2.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.26"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.26"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.1.26", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.26", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.1.26", path = "../format" }
-emit = { package = "lisette-emit", version = "0.1.26", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.1.26", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.26", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.1.26", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.0", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.0", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.0", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.1.26", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.26", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.1.26", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.26", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.1.26", path = "../deps" }
-format = { package = "lisette-format", version = "0.1.26", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.0", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.0", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.1.26", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.1.26", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.1.26", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.1.26", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.0 (upcoming)

- refactor!: reject positional access on string [#323](https://github.com/ivov/lisette/pull/323) [`a7c7245`](https://github.com/ivov/lisette/commit/a7c7245aab153ad88d44ef5ea93529c26cad2d8c)
- feat: add substring, bytes, and runes methods on string [#320](https://github.com/ivov/lisette/pull/320) [`ebd679d`](https://github.com/ivov/lisette/commit/ebd679deed12383da5cbeffc9b60b0b3770c3104)
- refactor!: switch variadic spread to postfix syntax [#322](https://github.com/ivov/lisette/pull/322) [`8f597b2`](https://github.com/ivov/lisette/commit/8f597b2ae00b68a6cf48df63077d66e382496865)
- fix: allow rune to string cast, block rune to byte cast [#318](https://github.com/ivov/lisette/pull/318) [`3ce2fb6`](https://github.com/ivov/lisette/commit/3ce2fb6b8c8859ee10ef9508b093fff1bc62cb3c)
- docs: add snippet sharing to playground [#319](https://github.com/ivov/lisette/pull/319) [`0234b42`](https://github.com/ivov/lisette/commit/0234b42056f50951226d60d76735bc33945886a0)
- docs: add link to WASM playground in index.html [#310](https://github.com/ivov/lisette/pull/310) [`38d46b6`](https://github.com/ivov/lisette/commit/38d46b648b9678b94fe4a4bef7189648b985d02b)
- refactor: add rune-indexed string access to prelude [#317](https://github.com/ivov/lisette/pull/317) [`5395a8d`](https://github.com/ivov/lisette/commit/5395a8db2fbd2e85826cfbe11e5ea3c168b9449d)
- refactor: move third-party typedefs into project [#315](https://github.com/ivov/lisette/pull/315) [`d7d8adc`](https://github.com/ivov/lisette/commit/d7d8adcfaf5c87e109ba3bc135e49876c9793d53)
- refactor: thread target through third-party typedef cache paths [#314](https://github.com/ivov/lisette/pull/314) [`e3d6ed2`](https://github.com/ivov/lisette/commit/e3d6ed2bb8324144a188de7baf55846dd1addf16)
- ci: lint bindgen and prelude with golangci-lint [#313](https://github.com/ivov/lisette/pull/313) [`48e57b8`](https://github.com/ivov/lisette/commit/48e57b8eab6d034242173b5d1651fb640db11b46)
- fix: disambiguate bindgen aliases on shared trailing segments [#312](https://github.com/ivov/lisette/pull/312) [`cc2f820`](https://github.com/ivov/lisette/commit/cc2f820039f6c8dd0551dbc27b922eb91eef1295)
- fix: suggest `..` zero-fill in missing-fields help [#311](https://github.com/ivov/lisette/pull/311) [`219cf0a`](https://github.com/ivov/lisette/commit/219cf0ab8f5f062320eabbf6fd4d5e195d328dc2)
- fix: preserve all returns when trailing bool is a flag [#307](https://github.com/ivov/lisette/pull/307) [`227e61e`](https://github.com/ivov/lisette/commit/227e61e7e23246ee08e69e671d2df53be5708c17)
