### PR TITLE
docs: add link to WASM playground in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1165,6 +1165,7 @@
       <div class="examples-header">
         <h2>Learn more</h2>
         <p>By visiting the repository:<span class="mobile-br"></span> <a href="https://github.com/ivov/lisette" target="_blank" rel="noopener"><code>github.com/ivov/lisette</code></a></p>
+        <p>By visiting the WASM playground:<span class="mobile-br"></span> <a href="https://lisette.run/play/" target="_blank" rel="noopener"><code>lisette.run/play</code></a></p>
       </div>
     </section>
 


### PR DESCRIPTION
Hi,

Originally, I wanted to vibecode a WASM playground, so I downloaded the source code. Then I noticed the `WASM` folder and figured out that it's possible to run it locally via `python -m http.server` and opening http://localhost:8000/play/. Finally, I found a link to the deployed version of this WASM app, so it might make sense to surface it more explicitly.