### PR TITLE
refactor: thread target through third-party typedef cache paths

### DIFF
--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -8,7 +8,7 @@ use deps::TypedefLocator;
 use emit::{OutputFile, PRELUDE_IMPORT_PATH};
 use stdlib::Target;
 
-pub fn go_command(_target: Target) -> Command {
+pub fn go_command(target: Target) -> Command {
     let mut c = Command::new("go");
     // Isolate from any user-side env that would change Go's mode against
     // lisette's `target/`: a stray `go.work` (workspace mode) or a stray
@@ -16,6 +16,8 @@ pub fn go_command(_target: Target) -> Command {
     // for unrelated `lis add` invocations otherwise.
     c.env("GOWORK", "off");
     c.env("GOFLAGS", "");
+    c.env("GOOS", target.goos);
+    c.env("GOARCH", target.goarch);
     c
 }
 

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -8,6 +8,7 @@ use crate::output::{print_add_success, print_preview_notice, print_progress, pri
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
 use deps::{GoModule, remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep};
+use stdlib::Target;
 
 struct ParsedDependency {
     module_path: String,
@@ -75,7 +76,11 @@ pub fn add(dep_string: &str) -> i32 {
         Err(code) => return code,
     };
 
-    let workspace = GoWorkspace::new(&project_ctx.target_dir, &project_ctx.typedef_cache_dir);
+    let workspace = GoWorkspace::new(
+        &project_ctx.target_dir,
+        &project_ctx.typedef_cache_dir,
+        Target::host(),
+    );
 
     let module_graph = match reconcile_module_graph(&dep, &workspace) {
         Ok(v) => v,
@@ -200,7 +205,7 @@ fn parse_dep_string(input: &str) -> Result<ParsedDependency, String> {
         ));
     }
 
-    let host = stdlib::Target::host();
+    let host = Target::host();
     if stdlib::get_go_stdlib_typedef(path, host).is_some() {
         return Err(format!(
             "`{}` is a Go standard library package; stdlib packages do not need `lis add` (just `import \"go:{}\"`)",
@@ -440,7 +445,7 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         manifest.go_deps(),
         Some(project_root.clone()),
         std::env::var("HOME").ok(),
-        stdlib::Target::host(),
+        Target::host(),
     );
 
     if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
@@ -459,7 +464,7 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         }
     };
 
-    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir);
+    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir, Target::host());
 
     let dep_version = if dep.version == "latest" {
         print_progress(&format!("Resolving {}@latest", dep.module_path));

--- a/crates/cli/src/handlers/bindgen.rs
+++ b/crates/cli/src/handlers/bindgen.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
+use stdlib::Target;
+
 use crate::cli_error;
 
 pub fn bindgen(
@@ -43,7 +45,8 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
     }
 
     // lis bindgen writes to a user-specified path, not the typedef cache
-    let workspace = crate::workspace::GoWorkspace::new(Path::new("."), Path::new(""));
+    let workspace =
+        crate::workspace::GoWorkspace::new(Path::new("."), Path::new(""), Target::host());
 
     match workspace.run_bindgen(target_pkg) {
         Ok(content) => {

--- a/crates/cli/src/typedef_regen.rs
+++ b/crates/cli/src/typedef_regen.rs
@@ -9,6 +9,7 @@ use crate::output::{print_progress, print_warning};
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
 use deps::{GoModule, Manifest, TypedefLocator};
+use stdlib::Target;
 
 /// Generate any Go typedefs declared in the manifest but missing from the cache:
 /// `~/.lisette/cache/typedefs/lis@v{version}/{module}@{version}/*.d.lis`
@@ -29,11 +30,12 @@ pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Re
         }
     };
     let typedef_cache_dir = deps::typedef_cache_dir(&home);
+    let target = Target::host();
 
     let missing_modules: Vec<(String, String)> = go_deps
         .iter()
         .filter(|(module_path, dep)| {
-            !module_dir_populated(&typedef_cache_dir, module_path, &dep.version)
+            !module_dir_populated(&typedef_cache_dir, target, module_path, &dep.version)
         })
         .map(|(module_path, dep)| (module_path.clone(), dep.version.clone()))
         .collect();
@@ -75,7 +77,7 @@ pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Re
     let still_missing: Vec<(String, String)> = missing_modules
         .into_iter()
         .filter(|(module_path, version)| {
-            !module_dir_populated(&typedef_cache_dir, module_path, version)
+            !module_dir_populated(&typedef_cache_dir, target, module_path, version)
         })
         .collect();
 
@@ -87,14 +89,14 @@ pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Re
         go_deps.clone(),
         Some(project_root.to_path_buf()),
         Some(home),
-        stdlib::Target::host(),
+        target,
     );
     if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
         error!("failed to write target/go.mod", msg);
         return Err(1);
     }
 
-    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir);
+    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir, target);
 
     let lis_version = env!("CARGO_PKG_VERSION");
     print_progress(&format!(
@@ -117,8 +119,15 @@ pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Re
     Ok(())
 }
 
-fn module_dir_populated(cache_dir: &Path, module_path: &str, version: &str) -> bool {
-    let module_dir = cache_dir.join(format!("{}@{}", module_path, version));
+fn module_dir_populated(
+    cache_dir: &Path,
+    target: Target,
+    module_path: &str,
+    version: &str,
+) -> bool {
+    let module_dir = cache_dir
+        .join(target.cache_segment())
+        .join(format!("{}@{}", module_path, version));
     match fs::read_dir(&module_dir) {
         Ok(mut entries) => entries.next().is_some(),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -44,20 +44,22 @@ pub struct GoWorkspace<'a> {
     root: &'a Path,
     /// The typedef cache root, e.g. `~/.lisette/cache/typedefs/lis@v0.1.7`.
     pub typedef_cache_dir: &'a Path,
+    target: stdlib::Target,
 }
 
 impl<'a> GoWorkspace<'a> {
-    pub fn new(root: &'a Path, typedef_cache_dir: &'a Path) -> Self {
+    pub fn new(root: &'a Path, typedef_cache_dir: &'a Path, target: stdlib::Target) -> Self {
         Self {
             root,
             typedef_cache_dir,
+            target,
         }
     }
 
     /// Run a `go` subcommand and return its stdout on success.
     fn run_go(&self, args: &[&str]) -> Result<String, String> {
         let cmd_display = format!("go {}", args.join(" "));
-        let output = crate::go_cli::go_command(stdlib::Target::host())
+        let output = crate::go_cli::go_command(self.target)
             .args(args)
             .current_dir(self.root)
             .output()
@@ -188,7 +190,7 @@ impl<'a> GoWorkspace<'a> {
             c
         } else {
             let bindgen_at_version = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
-            let mut c = crate::go_cli::go_command(stdlib::Target::host());
+            let mut c = crate::go_cli::go_command(self.target);
             c.args(["run", &bindgen_at_version, sub]);
             c
         };
@@ -277,7 +279,8 @@ impl<'a> GoWorkspace<'a> {
                     module,
                     package: pkg_path,
                 };
-                !pkg.typedef_path(self.typedef_cache_dir).exists()
+                !pkg.typedef_path(self.typedef_cache_dir, self.target)
+                    .exists()
             })
             .cloned()
             .collect();
@@ -288,7 +291,7 @@ impl<'a> GoWorkspace<'a> {
 
         let manifest = self.run_bindgen_batch(&uncached)?;
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module, self.typedef_cache_dir);
+        let outcome = self.apply_batch_manifest(&manifest, module);
 
         for stubbed in &outcome.stubbed {
             crate::output::print_warning(&format!(
@@ -318,7 +321,7 @@ impl<'a> GoWorkspace<'a> {
                 module,
                 package: pkg_path,
             };
-            let pkg_typedef_path = pkg.typedef_path(self.typedef_cache_dir);
+            let pkg_typedef_path = pkg.typedef_path(self.typedef_cache_dir, self.target);
 
             let typedef = fs::read_to_string(&pkg_typedef_path)
                 .map_err(|e| format!("Failed to read cached typedef for `{}`: {}", pkg_path, e))?;
@@ -565,55 +568,57 @@ pub(crate) struct BatchOutcome {
     pub(crate) failures: Vec<String>,
 }
 
-pub(crate) fn apply_batch_manifest_to_cache(
-    manifest: &BatchManifest,
-    module: GoModule,
-    typedef_cache_dir: &Path,
-) -> BatchOutcome {
-    let mut outcome = BatchOutcome::default();
+impl GoWorkspace<'_> {
+    pub(crate) fn apply_batch_manifest(
+        &self,
+        manifest: &BatchManifest,
+        module: GoModule,
+    ) -> BatchOutcome {
+        let mut outcome = BatchOutcome::default();
 
-    for e in &manifest.errors {
+        for e in &manifest.errors {
+            outcome
+                .failures
+                .push(format!("{}: {} ({})", e.package, e.message, e.kind));
+        }
+
+        for entry in &manifest.ok {
+            if let Err(msg) = validate_typedef_parses(&entry.package, &entry.content) {
+                outcome.failures.push(msg);
+                continue;
+            }
+
+            let pkg = GoPackage {
+                module,
+                package: &entry.package,
+            };
+            let pkg_typedef_path = pkg.typedef_path(self.typedef_cache_dir, self.target);
+
+            if let Some(parent_dir) = pkg_typedef_path.parent()
+                && let Err(e) = fs::create_dir_all(parent_dir)
+            {
+                outcome.failures.push(format!(
+                    "Failed to create cache directory for `{}`: {}",
+                    entry.package, e
+                ));
+                continue;
+            }
+
+            if let Err(e) = fs::write(&pkg_typedef_path, &entry.content) {
+                outcome.failures.push(format!(
+                    "Failed to cache typedef for `{}`: {}",
+                    entry.package, e
+                ));
+                continue;
+            }
+
+            if entry.stubbed {
+                outcome.stubbed.push(entry.package.clone());
+            }
+        }
+
         outcome
-            .failures
-            .push(format!("{}: {} ({})", e.package, e.message, e.kind));
     }
-
-    for entry in &manifest.ok {
-        if let Err(msg) = validate_typedef_parses(&entry.package, &entry.content) {
-            outcome.failures.push(msg);
-            continue;
-        }
-
-        let pkg = GoPackage {
-            module,
-            package: &entry.package,
-        };
-        let pkg_typedef_path = pkg.typedef_path(typedef_cache_dir);
-
-        if let Some(parent_dir) = pkg_typedef_path.parent()
-            && let Err(e) = fs::create_dir_all(parent_dir)
-        {
-            outcome.failures.push(format!(
-                "Failed to create cache directory for `{}`: {}",
-                entry.package, e
-            ));
-            continue;
-        }
-
-        if let Err(e) = fs::write(&pkg_typedef_path, &entry.content) {
-            outcome.failures.push(format!(
-                "Failed to cache typedef for `{}`: {}",
-                entry.package, e
-            ));
-            continue;
-        }
-
-        if entry.stubbed {
-            outcome.stubbed.push(entry.package.clone());
-        }
-    }
-
-    outcome
 }
 
 fn validate_typedef_parses(pkg_path: &str, typedef: &str) -> Result<(), String> {
@@ -703,12 +708,20 @@ mod tests {
         }
     }
 
+    fn test_target() -> stdlib::Target {
+        stdlib::Target::new("linux", "amd64")
+    }
+
+    fn workspace_for(cache_dir: &Path) -> GoWorkspace<'_> {
+        GoWorkspace::new(cache_dir, cache_dir, test_target())
+    }
+
     fn cache_path_for(cache_dir: &Path, pkg: &str) -> std::path::PathBuf {
         let go_pkg = GoPackage {
             module: module(),
             package: pkg,
         };
-        go_pkg.typedef_path(cache_dir)
+        go_pkg.typedef_path(cache_dir, test_target())
     }
 
     #[test]
@@ -724,7 +737,7 @@ mod tests {
             errors: vec![],
         };
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module(), tmp.path());
+        let outcome = workspace_for(tmp.path()).apply_batch_manifest(&manifest, module());
 
         assert!(outcome.failures.is_empty());
         assert!(outcome.stubbed.is_empty());
@@ -749,7 +762,7 @@ mod tests {
             )],
         };
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module(), tmp.path());
+        let outcome = workspace_for(tmp.path()).apply_batch_manifest(&manifest, module());
 
         assert_eq!(outcome.failures.len(), 1);
         assert!(outcome.failures[0].contains("broken"));
@@ -770,7 +783,7 @@ mod tests {
             errors: vec![],
         };
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module(), tmp.path());
+        let outcome = workspace_for(tmp.path()).apply_batch_manifest(&manifest, module());
 
         assert_eq!(outcome.failures.len(), 1);
         assert!(outcome.failures[0].contains("bad"));
@@ -790,7 +803,7 @@ mod tests {
             errors: vec![],
         };
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module(), tmp.path());
+        let outcome = workspace_for(tmp.path()).apply_batch_manifest(&manifest, module());
 
         assert!(outcome.failures.is_empty());
         assert_eq!(outcome.stubbed, vec![format!("{}/stub", MODULE_PATH)]);
@@ -806,7 +819,7 @@ mod tests {
             errors: vec![],
         };
 
-        let outcome = apply_batch_manifest_to_cache(&manifest, module(), tmp.path());
+        let outcome = workspace_for(tmp.path()).apply_batch_manifest(&manifest, module());
 
         assert!(outcome.stubbed.is_empty());
         assert!(outcome.failures.is_empty());

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -3,6 +3,8 @@ mod typedef_locator;
 
 use std::path::{Path, PathBuf};
 
+use stdlib::Target;
+
 pub use project_manifest::{
     GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
     check_toolchain_version, parse_manifest, remove_go_dep, resolve_empty_via,
@@ -46,11 +48,13 @@ impl GoPackage<'_> {
     /// Build the path to a `.d.lis` file under a base directory.
     ///
     /// ```text
-    /// ~/.lisette/cache/typedefs/lis@v0.1.6/github.com/gorilla/mux@v1.8.0/mux.d.lis
-    /// ~/.lisette/cache/typedefs/lis@v0.1.6/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
+    /// ~/.lisette/cache/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/mux.d.lis
+    /// ~/.lisette/cache/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
     /// ```
-    pub fn typedef_path(&self, base_dir: &Path) -> PathBuf {
-        let module_dir = base_dir.join(format!("{}@{}", self.module.path, self.module.version));
+    pub fn typedef_path(&self, base_dir: &Path, target: Target) -> PathBuf {
+        let module_dir = base_dir
+            .join(target.cache_segment())
+            .join(format!("{}@{}", self.module.path, self.module.version));
 
         let relative = if self.package == self.module.path {
             ""

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -126,7 +126,7 @@ impl TypedefLocator {
             package: package_path,
         };
         let typedef_cache_dir = typedef_cache_dir(home_path);
-        let typedef_path = pkg.typedef_path(&typedef_cache_dir);
+        let typedef_path = pkg.typedef_path(&typedef_cache_dir, self.target);
 
         match std::fs::read_to_string(&typedef_path) {
             Ok(source) => TypedefLocatorResult::Found {

--- a/crates/stdlib/src/target.rs
+++ b/crates/stdlib/src/target.rs
@@ -11,6 +11,10 @@ impl Target {
         Self { goos, goarch }
     }
 
+    pub fn cache_segment(self) -> String {
+        format!("{}_{}", self.goos, self.goarch)
+    }
+
     pub fn host() -> Self {
         let goos = match std::env::consts::OS {
             "macos" => "darwin",

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -11,6 +11,12 @@ fn default_resolver() -> deps::TypedefLocator {
     deps::TypedefLocator::default()
 }
 
+fn host_module_cache_dir(home: &str, module: &str) -> std::path::PathBuf {
+    deps::typedef_cache_dir(home)
+        .join(stdlib::Target::host().cache_segment())
+        .join(module)
+}
+
 fn has_diagnostic_code(sink: &LocalSink, code: &str) -> bool {
     sink.take().iter().any(|d| d.code_str() == Some(code))
 }
@@ -414,7 +420,7 @@ fn resolver_root_vs_subpackage_typedef_lookup() {
 
     // Set up cache with root package and subpackage
     let home = tmp.path().join("home").to_string_lossy().to_string();
-    let root_dir = deps::typedef_cache_dir(&home).join("github.com/gorilla/mux@v1.8.0");
+    let root_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
     let sub_dir = root_dir.join("middleware");
     std::fs::create_dir_all(&sub_dir).unwrap();
     std::fs::write(root_dir.join("mux.d.lis"), "// root\n").unwrap();
@@ -466,7 +472,7 @@ fn third_party_go_struct_impl_methods_registered() {
 
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home").to_string_lossy().to_string();
-    let cache_dir = deps::typedef_cache_dir(&home).join("github.com/gorilla/mux@v1.8.0");
+    let cache_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
     std::fs::create_dir_all(&cache_dir).unwrap();
     std::fs::write(
         cache_dir.join("mux.d.lis"),
@@ -555,7 +561,7 @@ fn stdlib_cache_save_load_excludes_third_party() {
 
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home").to_string_lossy().to_string();
-    let cache_dir = deps::typedef_cache_dir(&home).join("github.com/gorilla/mux@v1.8.0");
+    let cache_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
     std::fs::create_dir_all(&cache_dir).unwrap();
     std::fs::write(cache_dir.join("mux.d.lis"), "pub const VERSION: string\n").unwrap();
 


### PR DESCRIPTION
Cache paths for third-party typedefs now include a `<goos>_<goarch>` segment, so projects on different targets do not share third-party typedef entries that bindgen produces differently per target.