### PR TITLE
refactor: move third-party typedefs into project

### DIFF
--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -444,7 +444,6 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
     let locator = deps::TypedefLocator::new(
         manifest.go_deps(),
         Some(project_root.clone()),
-        std::env::var("HOME").ok(),
         Target::host(),
     );
 
@@ -453,16 +452,7 @@ fn setup_project(dep: &ParsedDependency) -> Result<ProjectContext, i32> {
         return Err(1);
     }
 
-    let typedef_cache_dir = match std::env::var("HOME") {
-        Ok(h) => deps::typedef_cache_dir(&h),
-        Err(_) => {
-            error!(
-                "failed to add dependency",
-                "HOME environment variable not set".to_string()
-            );
-            return Err(1);
-        }
-    };
+    let typedef_cache_dir = deps::typedef_cache_dir(&project_root);
 
     let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir, Target::host());
 

--- a/crates/cli/src/typedef_regen.rs
+++ b/crates/cli/src/typedef_regen.rs
@@ -12,24 +12,14 @@ use deps::{GoModule, Manifest, TypedefLocator};
 use stdlib::Target;
 
 /// Generate any Go typedefs declared in the manifest but missing from the cache:
-/// `~/.lisette/cache/typedefs/lis@v{version}/{module}@{version}/*.d.lis`
+/// `<project>/target/.lisette/typedefs/lis@v{version}/<target>/{module}@{version}/*.d.lis`
 pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Result<(), i32> {
     let go_deps = manifest.go_deps();
     if go_deps.is_empty() {
         return Ok(());
     }
 
-    let home = match std::env::var("HOME") {
-        Ok(h) => h,
-        Err(_) => {
-            error!(
-                "failed to regenerate Go typedefs",
-                "HOME environment variable not set".to_string()
-            );
-            return Err(1);
-        }
-    };
-    let typedef_cache_dir = deps::typedef_cache_dir(&home);
+    let typedef_cache_dir = deps::typedef_cache_dir(project_root);
     let target = Target::host();
 
     let missing_modules: Vec<(String, String)> = go_deps
@@ -85,12 +75,7 @@ pub fn generate_missing_typedefs(project_root: &Path, manifest: &Manifest) -> Re
         return Ok(());
     }
 
-    let locator = TypedefLocator::new(
-        go_deps.clone(),
-        Some(project_root.to_path_buf()),
-        Some(home),
-        target,
-    );
+    let locator = TypedefLocator::new(go_deps, Some(project_root.to_path_buf()), target);
     if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
         error!("failed to write target/go.mod", msg);
         return Err(1);

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -42,7 +42,7 @@ pub struct GoModuleInfo {
 pub struct GoWorkspace<'a> {
     /// The dir with the `go.mod` that `go` commands run against.
     root: &'a Path,
-    /// The typedef cache root, e.g. `~/.lisette/cache/typedefs/lis@v0.1.7`.
+    /// The typedef cache root, e.g. `<project>/target/.lisette/typedefs/lis@v0.1.7`.
     pub typedef_cache_dir: &'a Path,
     target: stdlib::Target,
 }

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -22,9 +22,11 @@ pub fn is_stdlib(pkg: &str) -> bool {
     !is_third_party(pkg)
 }
 
-pub fn typedef_cache_dir(home: &str) -> PathBuf {
+pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
     let lis_version = env!("CARGO_PKG_VERSION");
-    PathBuf::from(home).join(format!(".lisette/cache/typedefs/lis@v{}", lis_version))
+    project_root
+        .join("target/.lisette/typedefs")
+        .join(format!("lis@v{}", lis_version))
 }
 
 #[derive(Clone, Copy)]
@@ -48,8 +50,8 @@ impl GoPackage<'_> {
     /// Build the path to a `.d.lis` file under a base directory.
     ///
     /// ```text
-    /// ~/.lisette/cache/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/mux.d.lis
-    /// ~/.lisette/cache/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
+    /// <project>/target/.lisette/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/mux.d.lis
+    /// <project>/target/.lisette/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
     /// ```
     pub fn typedef_path(&self, base_dir: &Path, target: Target) -> PathBuf {
         let module_dir = base_dir

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -36,7 +36,6 @@ pub enum TypedefOrigin {
 pub struct TypedefLocator {
     deps: BTreeMap<String, GoDependency>,
     project_root: Option<PathBuf>,
-    home: Option<String>,
     target: Target,
 }
 
@@ -44,13 +43,11 @@ impl TypedefLocator {
     pub fn new(
         deps: BTreeMap<String, GoDependency>,
         project_root: Option<PathBuf>,
-        home: Option<String>,
         target: Target,
     ) -> Self {
         Self {
             deps,
             project_root,
-            home,
             target,
         }
     }
@@ -69,7 +66,6 @@ impl TypedefLocator {
         let locator = Self::new(
             manifest.go_deps(),
             Some(project_root.to_path_buf()),
-            std::env::var("HOME").ok(),
             Target::host(),
         );
 
@@ -111,7 +107,7 @@ impl TypedefLocator {
 
         let version = &dep.version;
 
-        let Some(home_path) = &self.home else {
+        let Some(project_root) = &self.project_root else {
             return TypedefLocatorResult::MissingTypedef {
                 module: module_path.to_string(),
                 version: version.clone(),
@@ -125,7 +121,7 @@ impl TypedefLocator {
             },
             package: package_path,
         };
-        let typedef_cache_dir = typedef_cache_dir(home_path);
+        let typedef_cache_dir = typedef_cache_dir(project_root);
         let typedef_path = pkg.typedef_path(&typedef_cache_dir, self.target);
 
         match std::fs::read_to_string(&typedef_path) {

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -85,7 +85,7 @@ pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLoc
             via: None,
         },
     );
-    deps::TypedefLocator::new(go_deps, None, None, stdlib::Target::host())
+    deps::TypedefLocator::new(go_deps, None, stdlib::Target::host())
 }
 
 pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -11,8 +11,8 @@ fn default_resolver() -> deps::TypedefLocator {
     deps::TypedefLocator::default()
 }
 
-fn host_module_cache_dir(home: &str, module: &str) -> std::path::PathBuf {
-    deps::typedef_cache_dir(home)
+fn host_module_cache_dir(project_root: &std::path::Path, module: &str) -> std::path::PathBuf {
+    deps::typedef_cache_dir(project_root)
         .join(stdlib::Target::host().cache_segment())
         .join(module)
 }
@@ -227,7 +227,7 @@ fn graph_declared_dep_missing_typedef() {
             via: None,
         },
     );
-    let resolver = deps::TypedefLocator::new(go_deps, None, None, stdlib::Target::host());
+    let resolver = deps::TypedefLocator::new(go_deps, None, stdlib::Target::host());
 
     let sink = LocalSink::new();
     let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver);
@@ -268,7 +268,7 @@ fn graph_subpackage_missing_typedef_points_at_add() {
             via: None,
         },
     );
-    let resolver = deps::TypedefLocator::new(go_deps, None, None, stdlib::Target::host());
+    let resolver = deps::TypedefLocator::new(go_deps, None, stdlib::Target::host());
 
     let sink = LocalSink::new();
     let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver);
@@ -417,10 +417,10 @@ fn resolver_root_vs_subpackage_typedef_lookup() {
     use std::collections::BTreeMap;
 
     let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path();
 
     // Set up cache with root package and subpackage
-    let home = tmp.path().join("home").to_string_lossy().to_string();
-    let root_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
+    let root_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
     let sub_dir = root_dir.join("middleware");
     std::fs::create_dir_all(&sub_dir).unwrap();
     std::fs::write(root_dir.join("mux.d.lis"), "// root\n").unwrap();
@@ -436,8 +436,7 @@ fn resolver_root_vs_subpackage_typedef_lookup() {
     );
     let resolver = deps::TypedefLocator::new(
         go_deps,
-        None,
-        Some(tmp.path().join("home").to_string_lossy().to_string()),
+        Some(project_root.to_path_buf()),
         stdlib::Target::host(),
     );
 
@@ -471,8 +470,8 @@ fn third_party_go_struct_impl_methods_registered() {
     use semantics::loader::Loader;
 
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().join("home").to_string_lossy().to_string();
-    let cache_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
+    let project_root = tmp.path();
+    let cache_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
     std::fs::create_dir_all(&cache_dir).unwrap();
     std::fs::write(
         cache_dir.join("mux.d.lis"),
@@ -488,7 +487,11 @@ fn third_party_go_struct_impl_methods_registered() {
             via: None,
         },
     );
-    let resolver = deps::TypedefLocator::new(go_deps, None, Some(home), stdlib::Target::host());
+    let resolver = deps::TypedefLocator::new(
+        go_deps,
+        Some(project_root.to_path_buf()),
+        stdlib::Target::host(),
+    );
 
     let source = r#"
 import "go:github.com/gorilla/mux"
@@ -560,8 +563,8 @@ fn stdlib_cache_save_load_excludes_third_party() {
     use semantics::loader::Loader;
 
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().join("home").to_string_lossy().to_string();
-    let cache_dir = host_module_cache_dir(&home, "github.com/gorilla/mux@v1.8.0");
+    let project_root = tmp.path();
+    let cache_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
     std::fs::create_dir_all(&cache_dir).unwrap();
     std::fs::write(cache_dir.join("mux.d.lis"), "pub const VERSION: string\n").unwrap();
 
@@ -573,7 +576,11 @@ fn stdlib_cache_save_load_excludes_third_party() {
             via: None,
         },
     );
-    let resolver = deps::TypedefLocator::new(go_deps, None, Some(home), stdlib::Target::host());
+    let resolver = deps::TypedefLocator::new(
+        go_deps,
+        Some(project_root.to_path_buf()),
+        stdlib::Target::host(),
+    );
 
     let source = r#"
 import "go:github.com/gorilla/mux"


### PR DESCRIPTION
Third-party typedefs move from `~/.lisette/cache/typedefs/` to `<project>/target/.lisette/typedefs/`.

Done to:

- eliminate the risk of cross-project bindgen leakage (method-set promotion, nilability checks)
- simplify the upcoming introduction of lazy typedef generation, to speed up `lis add`

Follow-up to #314