### PR TITLE
refactor: add rune-indexed string access to prelude

### DIFF
--- a/prelude/string.go
+++ b/prelude/string.go
@@ -1,0 +1,78 @@
+package lisette
+
+import "unicode/utf8"
+
+// RuneAt returns the rune at rune-index i in s. Panics on out-of-range i.
+func RuneAt(s string, i int) rune {
+	if i < 0 {
+		panic("rune index out of range")
+	}
+	runeCount := 0
+	for byteIdx := 0; byteIdx < len(s); {
+		r, size := utf8.DecodeRuneInString(s[byteIdx:])
+		if runeCount == i {
+			return r
+		}
+		byteIdx += size
+		runeCount++
+	}
+	panic("rune index out of range")
+}
+
+// Substring returns s[start:end] in rune indices. Panics on bad bounds.
+func Substring(s string, start, end int) string {
+	if start < 0 || end < 0 {
+		panic("substring index out of range")
+	}
+	if start > end {
+		panic("substring: start > end")
+	}
+	return s[byteOffsetOrPanic(s, start):byteOffsetOrPanic(s, end)]
+}
+
+// SubstringFrom returns s[start:] in rune indices. Panics on bad bounds.
+func SubstringFrom(s string, start int) string {
+	if start < 0 {
+		panic("substring index out of range")
+	}
+	return s[byteOffsetOrPanic(s, start):]
+}
+
+// SubstringTo returns s[:end] in rune indices. Panics on bad bounds.
+func SubstringTo(s string, end int) string {
+	if end < 0 {
+		panic("substring index out of range")
+	}
+	return s[:byteOffsetOrPanic(s, end)]
+}
+
+func byteOffsetOrPanic(s string, i int) int {
+	off, ok := byteOffsetAtRune(s, i)
+	if !ok {
+		panic("substring index out of range")
+	}
+	return off
+}
+
+// byteOffsetAtRune returns the byte offset corresponding to rune index i,
+// where i is in [0, runeCount(s)]. ok is false if i exceeds that range.
+func byteOffsetAtRune(s string, i int) (int, bool) {
+	if i == 0 {
+		// i == 0 is before any rune; loop only matches post-increment.
+		return 0, true
+	}
+	runeCount := 0
+	for byteIdx := 0; byteIdx < len(s); {
+		if s[byteIdx] < utf8.RuneSelf {
+			byteIdx++
+		} else {
+			_, size := utf8.DecodeRuneInString(s[byteIdx:])
+			byteIdx += size
+		}
+		runeCount++
+		if runeCount == i {
+			return byteIdx, true
+		}
+	}
+	return 0, false
+}

--- a/prelude/string_test.go
+++ b/prelude/string_test.go
@@ -1,0 +1,176 @@
+package lisette
+
+import "testing"
+
+func TestRuneAtASCII(t *testing.T) {
+	s := "hello"
+	want := []rune{'h', 'e', 'l', 'l', 'o'}
+	for i, w := range want {
+		if got := RuneAt(s, i); got != w {
+			t.Errorf("RuneAt(%q, %d) = %q, want %q", s, i, got, w)
+		}
+	}
+}
+
+func TestRuneAtMultibyte(t *testing.T) {
+	s := "héllo"
+	want := []rune{'h', 'é', 'l', 'l', 'o'}
+	for i, w := range want {
+		if got := RuneAt(s, i); got != w {
+			t.Errorf("RuneAt(%q, %d) = %q, want %q", s, i, got, w)
+		}
+	}
+}
+
+func TestRuneAtInvalidUTF8(t *testing.T) {
+	s := "h\xc3"
+	if got := RuneAt(s, 1); got != '�' {
+		t.Errorf("expected RuneError for invalid byte, got %q", got)
+	}
+}
+
+func TestRuneAtPanics(t *testing.T) {
+	assertPanic(t, "rune index out of range", func() { RuneAt("hello", 5) })
+	assertPanic(t, "rune index out of range", func() { RuneAt("hello", -1) })
+	assertPanic(t, "rune index out of range", func() { RuneAt("", 0) })
+}
+
+func TestSubstring(t *testing.T) {
+	cases := []struct {
+		s          string
+		start, end int
+		want       string
+	}{
+		{"hello", 0, 5, "hello"},
+		{"hello", 1, 4, "ell"},
+		{"hello", 0, 0, ""},
+		{"hello", 5, 5, ""},
+		{"hello", 2, 2, ""},
+		{"héllo", 0, 2, "hé"},
+		{"héllo", 1, 4, "éll"},
+		{"héllo", 0, 5, "héllo"},
+		{"", 0, 0, ""},
+	}
+	for _, c := range cases {
+		got := Substring(c.s, c.start, c.end)
+		if got != c.want {
+			t.Errorf("Substring(%q, %d, %d) = %q, want %q", c.s, c.start, c.end, got, c.want)
+		}
+	}
+}
+
+func TestSubstringPanics(t *testing.T) {
+	assertPanic(t, "substring index out of range", func() { Substring("hello", -1, 3) })
+	assertPanic(t, "substring index out of range", func() { Substring("hello", 0, -1) })
+	assertPanic(t, "substring: start > end", func() { Substring("hello", 3, 1) })
+	assertPanic(t, "substring index out of range", func() { Substring("hello", 6, 6) })
+	assertPanic(t, "substring index out of range", func() { Substring("hello", 0, 6) })
+}
+
+func TestSubstringFrom(t *testing.T) {
+	cases := []struct {
+		s     string
+		start int
+		want  string
+	}{
+		{"hello", 0, "hello"},
+		{"hello", 2, "llo"},
+		{"hello", 5, ""},
+		{"héllo", 1, "éllo"},
+		{"héllo", 5, ""},
+	}
+	for _, c := range cases {
+		got := SubstringFrom(c.s, c.start)
+		if got != c.want {
+			t.Errorf("SubstringFrom(%q, %d) = %q, want %q", c.s, c.start, got, c.want)
+		}
+	}
+}
+
+func TestSubstringFromPanics(t *testing.T) {
+	assertPanic(t, "substring index out of range", func() { SubstringFrom("hello", -1) })
+	assertPanic(t, "substring index out of range", func() { SubstringFrom("hello", 6) })
+}
+
+func TestSubstringTo(t *testing.T) {
+	cases := []struct {
+		s    string
+		end  int
+		want string
+	}{
+		{"hello", 0, ""},
+		{"hello", 3, "hel"},
+		{"hello", 5, "hello"},
+		{"héllo", 2, "hé"},
+		{"héllo", 5, "héllo"},
+	}
+	for _, c := range cases {
+		got := SubstringTo(c.s, c.end)
+		if got != c.want {
+			t.Errorf("SubstringTo(%q, %d) = %q, want %q", c.s, c.end, got, c.want)
+		}
+	}
+}
+
+func TestSubstringToPanics(t *testing.T) {
+	assertPanic(t, "substring index out of range", func() { SubstringTo("hello", -1) })
+	assertPanic(t, "substring index out of range", func() { SubstringTo("hello", 6) })
+}
+
+func TestRuneAtZeroAlloc(t *testing.T) {
+	s := "héllo world!"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = RuneAt(s, 5)
+	})
+	if allocs != 0 {
+		t.Fatalf("RuneAt: expected 0 allocs, got %v", allocs)
+	}
+}
+
+func TestSubstringZeroAlloc(t *testing.T) {
+	s := "héllo world!"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = Substring(s, 1, 4)
+	})
+	if allocs != 0 {
+		t.Fatalf("Substring: expected 0 allocs, got %v", allocs)
+	}
+}
+
+func TestSubstringFromZeroAlloc(t *testing.T) {
+	s := "héllo world!"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = SubstringFrom(s, 5)
+	})
+	if allocs != 0 {
+		t.Fatalf("SubstringFrom: expected 0 allocs, got %v", allocs)
+	}
+}
+
+func TestSubstringToZeroAlloc(t *testing.T) {
+	s := "héllo world!"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = SubstringTo(s, 5)
+	})
+	if allocs != 0 {
+		t.Fatalf("SubstringTo: expected 0 allocs, got %v", allocs)
+	}
+}
+
+func assertPanic(t *testing.T, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+		if msg != want {
+			t.Fatalf("expected panic %q, got %q", want, msg)
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
Adds `RuneAt`, `Substring`, `SubstringFrom`, `SubstringTo` to the `prelude` runtime package, as targets for upcoming rune-indexed `string` methods.

Prep for #316