### PR TITLE
feat: add substring, bytes, and runes methods on string

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -1,9 +1,11 @@
 use super::NativeCallContext;
 use crate::Emitter;
+use crate::expressions::access::index_access::range_var_bounds;
 use crate::names::go_name;
 use crate::types::native::NativeGoType;
 use crate::utils::Staged;
 use syntax::ast::Expression;
+use syntax::types::peel_to_range_type;
 
 #[derive(Clone, Copy)]
 pub(super) enum InlineImport {
@@ -11,6 +13,7 @@ pub(super) enum InlineImport {
     Slices,
     Strings,
     Maps,
+    Stdlib,
 }
 
 struct InlineRule {
@@ -81,6 +84,20 @@ static INLINE_METHODS: &[InlineRule] = &[
         template: "maps.Clone({r})",
         import: InlineImport::Maps,
     },
+    InlineRule {
+        types: &[N::String],
+        method: "bytes",
+        arity: 0,
+        template: "[]byte({r})",
+        import: InlineImport::None,
+    },
+    InlineRule {
+        types: &[N::String],
+        method: "runes",
+        arity: 0,
+        template: "[]rune({r})",
+        import: InlineImport::None,
+    },
     // Single-arg methods
     InlineRule {
         types: &[N::Map],
@@ -149,8 +166,8 @@ static INLINE_METHODS: &[InlineRule] = &[
         types: &[N::String],
         method: "rune_at",
         arity: 1,
-        template: "[]rune({r})[{0}]",
-        import: InlineImport::None,
+        template: "lisette.RuneAt({r}, {0})",
+        import: InlineImport::Stdlib,
     },
     InlineRule {
         types: &[N::Slice],
@@ -228,6 +245,7 @@ impl Emitter<'_> {
             InlineImport::Slices => self.flags.needs_slices = true,
             InlineImport::Strings => self.flags.needs_strings = true,
             InlineImport::Maps => self.flags.needs_maps = true,
+            InlineImport::Stdlib => self.flags.needs_stdlib = true,
             InlineImport::None => {}
         }
     }
@@ -240,6 +258,10 @@ impl Emitter<'_> {
         let Expression::DotAccess { expression, .. } = ctx.function else {
             unreachable!("expected DotAccess for native method call")
         };
+
+        if matches!(ctx.native_type, NativeGoType::String) && ctx.method == "substring" {
+            return self.emit_string_substring(output, expression, ctx.args);
+        }
 
         let mut all_stages: Vec<Staged> =
             Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
@@ -305,6 +327,13 @@ impl Emitter<'_> {
         output: &mut String,
         ctx: &NativeCallContext,
     ) -> String {
+        if matches!(ctx.native_type, NativeGoType::String)
+            && ctx.method == "substring"
+            && ctx.args.len() >= 2
+        {
+            return self.emit_string_substring(output, &ctx.args[0], &ctx.args[1..]);
+        }
+
         let stages = self.stage_native_method_args(ctx.function, ctx.args);
 
         let combine = Self::variadic_combine_for(ctx.function, ctx.spread, 0);
@@ -336,5 +365,64 @@ impl Emitter<'_> {
             type_args_string,
             emitted_args.join(", ")
         )
+    }
+
+    fn emit_string_substring(
+        &mut self,
+        output: &mut String,
+        receiver_expr: &Expression,
+        args: &[Expression],
+    ) -> String {
+        self.flags.needs_stdlib = true;
+        let arg = &args[0];
+
+        if let Expression::Range {
+            start,
+            end,
+            inclusive,
+            ..
+        } = arg
+        {
+            let mut stages = vec![self.stage_operand(receiver_expr)];
+            if let Some(s) = start.as_deref() {
+                stages.push(self.stage_operand(s));
+            }
+            if let Some(e) = end.as_deref() {
+                stages.push(self.stage_operand(e));
+            }
+            let values = self.sequence(output, stages, "_arg");
+            let mut bounds = values.iter().skip(1);
+            let start_bound = start.is_some().then(|| bounds.next().unwrap().clone());
+            let end_bound = end.is_some().then(|| {
+                let e = bounds.next().unwrap();
+                if *inclusive {
+                    format!("{}+1", e)
+                } else {
+                    e.clone()
+                }
+            });
+            return format_substring_call(&values[0], start_bound.as_deref(), end_bound.as_deref());
+        }
+
+        let arg_ty = arg.get_type();
+        let range_kind = peel_to_range_type(&arg_ty)
+            .and_then(|t| t.get_name())
+            .expect("substring arg should resolve to a known range type");
+        let receiver_staged = self.stage_operand(receiver_expr);
+        output.push_str(&receiver_staged.setup);
+        let recv = receiver_staged.value;
+        let range_var = self.emit_or_capture(output, arg, "range");
+        let (start, end) = range_var_bounds(&range_var, range_kind);
+        format_substring_call(&recv, start.as_deref(), end.as_deref())
+    }
+}
+
+fn format_substring_call(recv: &str, start: Option<&str>, end: Option<&str>) -> String {
+    let pkg = go_name::GO_STDLIB_PKG;
+    match (start, end) {
+        (Some(s), Some(e)) => format!("{}.Substring({}, {}, {})", pkg, recv, s, e),
+        (Some(s), None) => format!("{}.SubstringFrom({}, {})", pkg, recv, s),
+        (None, Some(e)) => format!("{}.SubstringTo({}, {})", pkg, recv, e),
+        (None, None) => unreachable!("`s.substring(..)` is rejected upstream"),
     }
 }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -54,6 +54,14 @@ impl Emitter<'_> {
             return;
         }
 
+        if let Some((kind, receiver)) = recognize_string_view_loop(binding, iterable) {
+            match kind {
+                StringViewKind::Runes => self.emit_runes_for_loop(output, binding, receiver, body),
+                StringViewKind::Bytes => self.emit_bytes_for_loop(output, binding, receiver, body),
+            }
+            return;
+        }
+
         let iter_expression = self.emit_operand(output, iterable);
         let iter_expression = if iterable.get_type().is_ref() {
             format!("*{}", iter_expression)
@@ -375,5 +383,112 @@ impl Emitter<'_> {
         output.push_str("}\n");
 
         self.exit_scope();
+    }
+
+    /// `for r in s.runes()` lowers to Go's native rune-range over the string,
+    /// bypassing the `[]rune(s)` allocation.
+    fn emit_runes_for_loop(
+        &mut self,
+        output: &mut String,
+        binding: &Binding,
+        receiver: &Expression,
+        body: &Expression,
+    ) {
+        self.enter_scope();
+        let recv_str = self.emit_operand(output, receiver);
+        if let Some(label) = self.current_loop_label() {
+            write_line!(output, "{}:", label);
+        }
+        let loop_var = self.bind_loop_pattern(&binding.pattern, None);
+        if loop_var == "_" {
+            write_line!(output, "for range {} {{", recv_str);
+        } else {
+            write_line!(output, "for _, {} := range {} {{", loop_var, recv_str);
+        }
+        self.emit_block(output, body);
+        output.push_str("}\n");
+        self.exit_scope();
+    }
+
+    /// `for b in s.bytes()` lowers to a C-style byte-indexed loop, bypassing
+    /// the `[]byte(s)` allocation. Captures the receiver if it has side
+    /// effects, since `len(s)` and `s[i]` reference it twice.
+    fn emit_bytes_for_loop(
+        &mut self,
+        output: &mut String,
+        binding: &Binding,
+        receiver: &Expression,
+        body: &Expression,
+    ) {
+        self.enter_scope();
+        let recv_var = self.emit_or_capture(output, receiver, "_s");
+        if let Some(label) = self.current_loop_label() {
+            write_line!(output, "{}:", label);
+        }
+        let idx_var = self.fresh_var(Some("_i"));
+        let loop_var = self.bind_loop_pattern(&binding.pattern, None);
+        write_line!(
+            output,
+            "for {} := 0; {} < len({}); {}++ {{",
+            idx_var,
+            idx_var,
+            recv_var,
+            idx_var
+        );
+        if loop_var != "_" {
+            write_line!(output, "{} := {}[{}]", loop_var, recv_var, idx_var);
+        }
+        self.emit_block(output, body);
+        output.push_str("}\n");
+        self.exit_scope();
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StringViewKind {
+    Bytes,
+    Runes,
+}
+
+/// Recognise `for x in s.bytes()` / `for x in s.runes()` for zero-alloc lowering.
+fn recognize_string_view_loop<'a>(
+    binding: &'a Binding,
+    iterable: &'a Expression,
+) -> Option<(StringViewKind, &'a Expression)> {
+    if !matches!(
+        &binding.pattern,
+        Pattern::Identifier { .. } | Pattern::WildCard { .. }
+    ) {
+        return None;
+    }
+
+    let Expression::Call {
+        expression, args, ..
+    } = iterable
+    else {
+        return None;
+    };
+
+    if !args.is_empty() {
+        return None;
+    }
+
+    let Expression::DotAccess {
+        expression: receiver,
+        member,
+        ..
+    } = expression.as_ref()
+    else {
+        return None;
+    };
+
+    if !receiver.get_type().has_name("string") {
+        return None;
+    }
+
+    match member.as_str() {
+        "bytes" => Some((StringViewKind::Bytes, receiver.as_ref())),
+        "runes" => Some((StringViewKind::Runes, receiver.as_ref())),
+        _ => None,
     }
 }

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -1,4 +1,5 @@
 use syntax::ast::{Expression, UnaryOperator};
+use syntax::types::peel_to_range_type;
 
 use crate::Emitter;
 use crate::utils::Staged;
@@ -29,14 +30,10 @@ impl Emitter<'_> {
 
         let base_staged = self.stage_base_with_deref(expression);
 
-        // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`).
+        // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`,
+        // or `r: Prefix` where `type Prefix = RangeTo<int>`).
         let index_ty = index.get_type();
-        if let Some(range_kind) = index_ty.get_name()
-            && matches!(
-                range_kind,
-                "Range" | "RangeInclusive" | "RangeFrom" | "RangeTo" | "RangeToInclusive"
-            )
-        {
+        if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
             let needs_cap = expression.get_type().has_name("Slice");
             output.push_str(&base_staged.setup);
             let index_string = self.emit_or_capture(output, index, "range");
@@ -142,26 +139,41 @@ impl Emitter<'_> {
         range_kind: &str,
         needs_cap: bool,
     ) -> String {
-        let (start, end) = match range_kind {
-            "Range" => (format!("{}.Start", range), format!("{}.End", range)),
-            "RangeInclusive" => (format!("{}.Start", range), format!("{}.End+1", range)),
-            "RangeFrom" => (format!("{}.Start", range), String::new()),
-            "RangeTo" => (String::new(), format!("{}.End", range)),
-            "RangeToInclusive" => (String::new(), format!("{}.End+1", range)),
-            _ => unreachable!("unexpected range kind: {}", range_kind),
-        };
+        let (start, end) = range_var_bounds(range, range_kind);
+        let start_str = start.as_deref().unwrap_or("");
+        let end_str = end.as_deref().unwrap_or("");
 
         if !needs_cap {
-            return format!("{}[{}:{}]", base, start, end);
+            return format!("{}[{}:{}]", base, start_str, end_str);
         }
 
         // For open-ended ranges, cap at len(base).
-        let cap = if end.is_empty() {
+        let cap = if end_str.is_empty() {
             format!("len({})", base)
         } else {
-            end.clone()
+            end_str.to_string()
         };
 
-        format!("{}[{}:{}:{}]", base, start, end, cap)
+        format!("{}[{}:{}:{}]", base, start_str, end_str, cap)
+    }
+}
+
+pub(crate) fn range_var_bounds(
+    range_var: &str,
+    range_kind: &str,
+) -> (Option<String>, Option<String>) {
+    match range_kind {
+        "Range" => (
+            Some(format!("{}.Start", range_var)),
+            Some(format!("{}.End", range_var)),
+        ),
+        "RangeInclusive" => (
+            Some(format!("{}.Start", range_var)),
+            Some(format!("{}.End+1", range_var)),
+        ),
+        "RangeFrom" => (Some(format!("{}.Start", range_var)), None),
+        "RangeTo" => (None, Some(format!("{}.End", range_var))),
+        "RangeToInclusive" => (None, Some(format!("{}.End+1", range_var))),
+        _ => unreachable!("unexpected range kind: {}", range_kind),
     }
 }

--- a/crates/emit/src/expressions/access/mod.rs
+++ b/crates/emit/src/expressions/access/mod.rs
@@ -1,3 +1,3 @@
 mod dot_access;
-mod index_access;
+pub(crate) mod index_access;
 mod struct_call;

--- a/crates/emit/src/expressions/mod.rs
+++ b/crates/emit/src/expressions/mod.rs
@@ -1,4 +1,4 @@
-mod access;
+pub(crate) mod access;
 mod dot_classify;
 mod identifiers;
 pub(crate) mod literals;

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -1,5 +1,5 @@
 use syntax::ast::{Expression, UnaryOperator};
-use syntax::types::Type;
+use syntax::types::{Type, peel_to_range_type};
 
 use crate::Emitter;
 use crate::definitions::interface_adapter::AdapterPlan;
@@ -195,12 +195,7 @@ fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
     };
 
     let is_range_index = matches!(**index, Expression::Range { .. })
-        || index.get_type().get_name().is_some_and(|n| {
-            matches!(
-                n,
-                "Range" | "RangeInclusive" | "RangeFrom" | "RangeTo" | "RangeToInclusive"
-            )
-        });
+        || peel_to_range_type(&index.get_type()).is_some();
 
     if !is_range_index {
         return false;

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -4,7 +4,9 @@ use crate::checker::EnvResolve;
 use syntax::ast::BindingKind;
 use syntax::ast::{Annotation, Binding, Expression, Pattern, Span, StructKind};
 use syntax::program::{CallKind, Definition, DefinitionBody, NativeTypeKind};
-use syntax::types::{Bound, SubstitutionMap, Symbol, Type, substitute, unqualified_name};
+use syntax::types::{
+    Bound, SubstitutionMap, Symbol, Type, peel_to_range_type, substitute, unqualified_name,
+};
 
 use super::super::TaskState;
 use super::super::unify::Dispatched;
@@ -366,10 +368,28 @@ impl TaskState<'_> {
             let _ = self.speculatively(|this| this.try_unify(store, &peeled, &return_ty, &span));
         }
 
-        let new_args = self.infer_call_arguments(store, args, &param_types);
+        let call_kind = self.classify_call(store, &callee_expression);
+
+        let substring_range_idx =
+            self.substring_carve_out_param_idx(call_kind, &callee_expression, &param_types);
+        let effective_param_types = if let Some(idx) = substring_range_idx {
+            let mut adjusted = param_types.clone();
+            adjusted[idx] = self.new_type_var();
+            adjusted
+        } else {
+            param_types.clone()
+        };
+
+        let new_args = self.infer_call_arguments(store, args, &effective_param_types);
         self.check_call_arity(&param_types, &new_args, &callee_expression, &span);
         self.check_mut_param_arguments(&new_args, &param_mutability, &callee_expression);
         self.check_range_to_for_variadic(&new_args, &variadic_elem_ty);
+
+        if let Some(idx) = substring_range_idx
+            && let Some(arg) = new_args.get(idx)
+        {
+            self.validate_substring_range_arg(store, arg);
+        }
 
         let new_spread = (*spread).map(|spread_expr| match variadic_elem_ty {
             Some(elem_ty) => {
@@ -440,8 +460,6 @@ impl TaskState<'_> {
         } else {
             return_ty.clone()
         };
-
-        let call_kind = self.classify_call(store, &callee_expression);
 
         Expression::Call {
             expression: callee_expression.into(),
@@ -1096,7 +1114,8 @@ impl TaskState<'_> {
                 }
 
                 // Native method: receiver.method() on Slice/Map/Channel/etc.
-                if let Some(kind) = NativeTypeKind::from_type(&receiver_ty) {
+                let peeled = store.deep_resolve_alias(&receiver_ty);
+                if let Some(kind) = NativeTypeKind::from_type(&peeled) {
                     return CallKind::NativeMethod(kind);
                 }
 
@@ -1398,5 +1417,52 @@ impl TaskState<'_> {
         if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
             self.facts.mark_mutated(binding_id);
         }
+    }
+
+    /// Verify the substring arg is a range type over `int`; emit a `Range<int>` mismatch otherwise.
+    fn validate_substring_range_arg(&mut self, store: &mut Store, arg: &Expression) {
+        let arg_ty = arg.get_type().resolve_in(&self.env);
+        let arg_span = arg.get_span();
+        let int_ty = self.type_int();
+
+        if let Some(peeled) = peel_to_range_type(&arg_ty) {
+            if let Some(inner) = peeled.get_type_params().and_then(|p| p.first()) {
+                self.unify(store, &int_ty, inner, &arg_span);
+            }
+        } else {
+            let expected = self.type_range(store, int_ty);
+            self.unify(store, &expected, &arg_ty, &arg_span);
+        }
+    }
+
+    /// Index of the `Range` param to relax for a native-string `substring` call, or `None`.
+    fn substring_carve_out_param_idx(
+        &self,
+        call_kind: CallKind,
+        callee: &Expression,
+        param_types: &[Type],
+    ) -> Option<usize> {
+        if !matches!(
+            call_kind,
+            CallKind::NativeMethod(NativeTypeKind::String)
+                | CallKind::NativeMethodIdentifier(NativeTypeKind::String)
+        ) {
+            return None;
+        }
+        let is_substring = match callee {
+            Expression::DotAccess { member, .. } => member.as_str() == "substring",
+            Expression::Identifier { value, .. } => value
+                .rsplit_once('.')
+                .is_some_and(|(_, method)| method == "substring"),
+            _ => false,
+        };
+        if !is_substring {
+            return None;
+        }
+        param_types.iter().position(|p| {
+            p.resolve_in(&self.env)
+                .get_name()
+                .is_some_and(|n| n == "Range")
+        })
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::types::{CompoundKind, Type};
+use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
 use super::super::super::TaskState;
 
@@ -81,16 +81,14 @@ impl TaskState<'_> {
         // Handle range-typed variables used as slice indices (e.g. `let r = 2..5; items[r]`).
         // Inline ranges are caught by `index.is_range()` above; this handles the case where
         // the range is stored in a variable.
-        let is_range_index = (type_name == "Slice" || type_name == "string")
-            && resolved_index_ty.get_name().is_some_and(|n| {
-                matches!(
-                    n,
-                    "Range" | "RangeInclusive" | "RangeFrom" | "RangeTo" | "RangeToInclusive"
-                )
-            });
+        let peeled_range = if type_name == "Slice" || type_name == "string" {
+            peel_to_range_type(&resolved_index_ty)
+        } else {
+            None
+        };
 
-        if is_range_index {
-            if let Some(bound_ty) = resolved_index_ty.get_type_params().and_then(|p| p.first()) {
+        if let Some(peeled) = peeled_range {
+            if let Some(bound_ty) = peeled.get_type_params().and_then(|p| p.first()) {
                 let int_ty = self.type_int();
                 self.unify(store, &int_ty, bound_ty, &span);
             }

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -89,6 +89,15 @@ impl string {
 
   /// Returns the rune at index `i`.
   fn rune_at(self, i: int) -> rune
+
+  /// Returns the bytes of the string as a `Slice<byte>`.
+  fn bytes(self) -> Slice<byte>
+
+  /// Returns the runes of the string as a `Slice<rune>`.
+  fn runes(self) -> Slice<rune>
+
+  /// Returns the substring at the given rune-indexed range.
+  fn substring(self, r: Range<int>) -> string
 }
 
 // -----------------------

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -157,6 +157,24 @@ pub fn module_part(id: &str) -> &str {
     id.split('.').next().unwrap_or(id)
 }
 
+pub fn is_range_type_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Range" | "RangeInclusive" | "RangeFrom" | "RangeTo" | "RangeToInclusive"
+    )
+}
+
+pub fn peel_to_range_type(ty: &Type) -> Option<&Type> {
+    std::iter::successors(Some(ty), |t| match t {
+        Type::Nominal {
+            underlying_ty: Some(u),
+            ..
+        } => Some(u.as_ref()),
+        _ => None,
+    })
+    .find(|t| t.get_name().is_some_and(is_range_type_name))
+}
+
 /// type param name -> type variable
 pub type SubstitutionMap = HashMap<EcoString, Type>;
 

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -51,6 +51,52 @@ fn test(s: string, i: int) -> rune {
 }
 
 #[test]
+fn string_bytes() {
+    let input = r#"
+fn test(s: string) -> Slice<byte> {
+  s.bytes()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_runes() {
+    let input = r#"
+fn test(s: string) -> Slice<rune> {
+  s.runes()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_runes_zero_alloc() {
+    let input = r#"
+import "go:fmt"
+fn test(s: string) {
+  for r in s.runes() {
+    fmt.Println(r)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_bytes_zero_alloc() {
+    let input = r#"
+import "go:fmt"
+fn test(s: string) {
+  for b in s.bytes() {
+    fmt.Println(b)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_new() {
     let input = r#"
 fn test() -> Slice<int> {
@@ -757,6 +803,135 @@ fn main() {
   let opt: Option<int> = Some(1)
   let r = opt.and_then(g)
   let _ = r
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_range() {
+    let input = r#"
+fn test(s: string) -> string {
+  s.substring(0..5)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_range_inclusive() {
+    let input = r#"
+fn test(s: string) -> string {
+  s.substring(0..=4)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_range_from() {
+    let input = r#"
+fn test(s: string) -> string {
+  s.substring(6..)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_range_to() {
+    let input = r#"
+fn test(s: string) -> string {
+  s.substring(..5)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_range_to_inclusive() {
+    let input = r#"
+fn test(s: string) -> string {
+  s.substring(..=4)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_stored_range_to() {
+    let input = r#"
+fn test(s: string, r: RangeTo<int>) -> string {
+  s.substring(r)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_ufcs() {
+    let input = r#"
+fn test(s: string) -> string {
+  string.substring(s, 0..5)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_alias_receiver() {
+    let input = r#"
+type MyString = string
+
+fn test(s: MyString, r: RangeTo<int>) -> string {
+  s.substring(r)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_native_method_on_alias() {
+    let input = r#"
+type MyString = string
+
+fn test(s: MyString) -> bool {
+  s.contains("foo")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_aliased_range() {
+    let input = r#"
+type Prefix = RangeTo<int>
+fn test(s: string, r: Prefix) -> string {
+  s.substring(r)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_index_aliased_range() {
+    let input = r#"
+type Prefix = RangeTo<int>
+fn test(xs: Slice<int>, r: Prefix) -> Slice<int> {
+  xs[r]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn mut_subslice_clones_for_aliased_range() {
+    let input = r#"
+type Prefix = Range<int>
+fn test(arr: Slice<int>, r: Prefix) -> Slice<int> {
+  let mut owned = arr[r]
+  owned[0] = 99
+  owned
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
+++ b/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 96
+description: "input: \nimport \"go:fmt\"\nfn test(s: string) {\n  for b in s.bytes() {\n    fmt.Println(b)\n  }\n}\n"
+---
+package main
+
+import "fmt"
+
+func test(s string) {
+	for _i_1 := 0; _i_1 < len(s); _i_1++ {
+		b := s[_i_1]
+		fmt.Println(b)
+	}
+}

--- a/tests/spec/emit/snapshots/for_runes_zero_alloc.snap
+++ b/tests/spec/emit/snapshots/for_runes_zero_alloc.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 83
+description: "input: \nimport \"go:fmt\"\nfn test(s: string) {\n  for r in s.runes() {\n    fmt.Println(r)\n  }\n}\n"
+---
+package main
+
+import "fmt"
+
+func test(s string) {
+	for _, r := range s {
+		fmt.Println(r)
+	}
+}

--- a/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
+++ b/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 917
+description: "input: \ntype Prefix = Range<int>\nfn test(arr: Slice<int>, r: Prefix) -> Slice<int> {\n  let mut owned = arr[r]\n  owned[0] = 99\n  owned\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
+
+type Prefix = lisette.Range[int]
+
+func test(arr []int, r Prefix) []int {
+	owned := slices.Clone(arr[r.Start:r.End:r.End])
+	owned[0] = 99
+	return owned
+}

--- a/tests/spec/emit/snapshots/slice_index_aliased_range.snap
+++ b/tests/spec/emit/snapshots/slice_index_aliased_range.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 904
+description: "input: \ntype Prefix = RangeTo<int>\nfn test(xs: Slice<int>, r: Prefix) -> Slice<int> {\n  xs[r]\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Prefix = lisette.RangeTo[int]
+
+func test(xs []int, r Prefix) []int {
+	return xs[:r.End:r.End]
+}

--- a/tests/spec/emit/snapshots/string_bytes.snap
+++ b/tests/spec/emit/snapshots/string_bytes.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 60
+description: "input: \nfn test(s: string) -> Slice<byte> {\n  s.bytes()\n}\n"
+---
+package main
+
+func test(s string) []byte {
+	return []byte(s)
+}

--- a/tests/spec/emit/snapshots/string_native_method_on_alias.snap
+++ b/tests/spec/emit/snapshots/string_native_method_on_alias.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 882
+description: "input: \ntype MyString = string\n\nfn test(s: MyString) -> bool {\n  s.contains(\"foo\")\n}\n"
+---
+package main
+
+import "strings"
+
+type MyString = string
+
+func test(s MyString) bool {
+	return strings.Contains(s, "foo")
+}

--- a/tests/spec/emit/snapshots/string_rune_at.snap
+++ b/tests/spec/emit/snapshots/string_rune_at.snap
@@ -4,6 +4,8 @@ description: "input: \nfn test(s: string, i: int) -> rune {\n  s.rune_at(i)\n}\n
 ---
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 func test(s string, i int) rune {
-	return []rune(s)[i]
+	return lisette.RuneAt(s, i)
 }

--- a/tests/spec/emit/snapshots/string_runes.snap
+++ b/tests/spec/emit/snapshots/string_runes.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 70
+description: "input: \nfn test(s: string) -> Slice<rune> {\n  s.runes()\n}\n"
+---
+package main
+
+func test(s string) []rune {
+	return []rune(s)
+}

--- a/tests/spec/emit/snapshots/string_substring_alias_receiver.snap
+++ b/tests/spec/emit/snapshots/string_substring_alias_receiver.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 870
+description: "input: \ntype MyString = string\n\nfn test(s: MyString, r: RangeTo<int>) -> string {\n  s.substring(r)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyString = string
+
+func test(s MyString, r lisette.RangeTo[int]) string {
+	return lisette.SubstringTo(s, r.End)
+}

--- a/tests/spec/emit/snapshots/string_substring_aliased_range.snap
+++ b/tests/spec/emit/snapshots/string_substring_aliased_range.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 893
+description: "input: \ntype Prefix = RangeTo<int>\nfn test(s: string, r: Prefix) -> string {\n  s.substring(r)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Prefix = lisette.RangeTo[int]
+
+func test(s string, r Prefix) string {
+	return lisette.SubstringTo(s, r.End)
+}

--- a/tests/spec/emit/snapshots/string_substring_range.snap
+++ b/tests/spec/emit/snapshots/string_substring_range.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 818
+description: "input: \nfn test(s: string) -> string {\n  s.substring(0..5)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.Substring(s, 0, 5)
+}

--- a/tests/spec/emit/snapshots/string_substring_range_from.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_from.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 838
+description: "input: \nfn test(s: string) -> string {\n  s.substring(6..)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.SubstringFrom(s, 6)
+}

--- a/tests/spec/emit/snapshots/string_substring_range_inclusive.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_inclusive.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 828
+description: "input: \nfn test(s: string) -> string {\n  s.substring(0..=4)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.Substring(s, 0, 4+1)
+}

--- a/tests/spec/emit/snapshots/string_substring_range_to.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_to.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 848
+description: "input: \nfn test(s: string) -> string {\n  s.substring(..5)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.SubstringTo(s, 5)
+}

--- a/tests/spec/emit/snapshots/string_substring_range_to_inclusive.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_to_inclusive.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 858
+description: "input: \nfn test(s: string) -> string {\n  s.substring(..=4)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.SubstringTo(s, 4+1)
+}

--- a/tests/spec/emit/snapshots/string_substring_stored_range_to.snap
+++ b/tests/spec/emit/snapshots/string_substring_stored_range_to.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 848
+description: "input: \nfn test(s: string, r: RangeTo<int>) -> string {\n  s.substring(r)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string, r lisette.RangeTo[int]) string {
+	return lisette.SubstringTo(s, r.End)
+}

--- a/tests/spec/emit/snapshots/string_substring_ufcs.snap
+++ b/tests/spec/emit/snapshots/string_substring_ufcs.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 858
+description: "input: \nfn test(s: string) -> string {\n  string.substring(s, 0..5)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s string) string {
+	return lisette.Substring(s, 0, 5)
+}


### PR DESCRIPTION
Adds `substring`, `bytes`, and `runes` methods on `string`.

```rs
let s = "héllo world"

s.substring(0..5) // "héllo"
s.substring(6..) // "world"
s.substring(..=4) // "héllo"

for r in s.runes() { ... } // codepoint iteration
for b in s.bytes() { ... } // byte iteration
```

`substring` is rune-indexed and accepts any of the five range shapes. `s.bytes()` and `s.runes()` return `Slice<byte>` and `Slice<rune>` respectively, and iteration over them lowers without allocating an intermediate slice.

Relates to #316