### PR TITLE
fix: preserve short-circuit when && or || RHS needs setup

### DIFF
--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -71,6 +71,15 @@ impl Emitter<'_> {
             }
         }
 
+        if matches!(operator, BinaryOperator::And | BinaryOperator::Or) {
+            return self.emit_short_circuit_binary(
+                output,
+                operator,
+                left_expression,
+                right_expression,
+            );
+        }
+
         let stages = vec![
             self.stage_composite(left_expression),
             self.stage_composite(right_expression),
@@ -80,6 +89,31 @@ impl Emitter<'_> {
         let right_string = values[1].clone();
 
         format!("{} {} {}", left_string, operator, right_string)
+    }
+
+    fn emit_short_circuit_binary(
+        &mut self,
+        output: &mut String,
+        operator: &BinaryOperator,
+        left_expression: &Expression,
+        right_expression: &Expression,
+    ) -> String {
+        let left_staged = self.stage_composite(left_expression);
+        output.push_str(&left_staged.setup);
+
+        // Wrap RHS setup in an IIFE so it runs only when control reaches the
+        // RHS — hoisting it before the operator would defeat short-circuit.
+        let right_staged = self.stage_composite(right_expression);
+        let right_string = if right_staged.setup.is_empty() {
+            right_staged.value
+        } else {
+            format!(
+                "func() bool {{\n{}return {}\n}}()",
+                right_staged.setup, right_staged.value
+            )
+        };
+
+        format!("{} {} {}", left_staged.value, operator, right_string)
     }
 
     pub(crate) fn emit_unary_expression(

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -142,6 +142,49 @@ fn test() -> bool {
 }
 
 #[test]
+fn binary_logical_and_short_circuits_rhs_with_setup() {
+    let input = r#"
+fn track(flag: Ref<bool>) -> Result<int, error> {
+  flag.* = true
+  Ok(1)
+}
+
+fn test() {
+  let mut ran = false
+  if false && track(&ran).is_ok() {
+    panic("body should not run")
+  }
+  if ran {
+    panic("rhs evaluated despite short-circuit")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn binary_logical_or_short_circuits_rhs_with_setup() {
+    let input = r#"
+fn track(flag: Ref<bool>) -> Result<int, error> {
+  flag.* = true
+  Ok(1)
+}
+
+fn test() {
+  let mut ran = false
+  if true || track(&ran).is_ok() {
+    if ran {
+      panic("rhs evaluated despite short-circuit")
+    }
+    return
+  }
+  panic("if-body should run")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unary_negation() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 162
+description: "input: \nfn track(flag: Ref<bool>) -> Result<int, error> {\n  flag.* = true\n  Ok(1)\n}\n\nfn test() {\n  let mut ran = false\n  if false && track(&ran).is_ok() {\n    panic(\"body should not run\")\n  }\n  if ran {\n    panic(\"rhs evaluated despite short-circuit\")\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func track(flag *bool) (int, error) {
+	*flag = true
+	return 1, nil
+}
+
+func test() {
+	ran := false
+	if false && func() bool {
+		ret_1, ret_2 := track(&ran)
+		var result_3 lisette.Result[int, error]
+		if ret_2 != nil {
+			result_3 = lisette.MakeResultErr[int, error](ret_2)
+		} else {
+			result_3 = lisette.MakeResultOk[int, error](ret_1)
+		}
+		return result_3.IsOk()
+	}() {
+		panic("body should not run")
+	}
+	if ran {
+		panic("rhs evaluated despite short-circuit")
+	}
+}

--- a/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 184
+description: "input: \nfn track(flag: Ref<bool>) -> Result<int, error> {\n  flag.* = true\n  Ok(1)\n}\n\nfn test() {\n  let mut ran = false\n  if true || track(&ran).is_ok() {\n    if ran {\n      panic(\"rhs evaluated despite short-circuit\")\n    }\n    return\n  }\n  panic(\"if-body should run\")\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func track(flag *bool) (int, error) {
+	*flag = true
+	return 1, nil
+}
+
+func test() {
+	ran := false
+	if true || func() bool {
+		ret_1, ret_2 := track(&ran)
+		var result_3 lisette.Result[int, error]
+		if ret_2 != nil {
+			result_3 = lisette.MakeResultErr[int, error](ret_2)
+		} else {
+			result_3 = lisette.MakeResultOk[int, error](ret_1)
+		}
+		return result_3.IsOk()
+	}() {
+		if ran {
+			panic("rhs evaluated despite short-circuit")
+		}
+		return
+	}
+	panic("if-body should run")
+}


### PR DESCRIPTION
Fix `&&` and `||` evaluating the RHS even when the LHS already decided the result, in cases where the RHS needs setup statements, such as a `Result` returning call followed by `.is_ok()`. Previously the emitter hoisted that setup before the operator, defeating Go's native short-circuit; now the RHS setup is wrapped in an IIFE so it runs only when control reaches the RHS.

```rs
import "go:fmt"

fn check() -> Result<int, error> {
  fmt.Println("right side ran")
  Ok(1)
}

fn main() {
  if false && check().is_ok() {
    fmt.Println("body")
  }
}
```

Before this change the program printed `right side ran`. Now it prints nothing.