### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.1](https://github.com/ivov/lisette/compare/lisette-v0.2.0...lisette-v0.2.1) - 2026-05-07
+
+- fix: snapshot bytes-loop receiver to survive body reassignment [#344](https://github.com/ivov/lisette/pull/344) [`1eda7c8`](https://github.com/ivov/lisette/commit/1eda7c83360ca712eabfe0ec081878ea647c5d94)
+- fix: freshen rest binding in let-else or-pattern [#343](https://github.com/ivov/lisette/pull/343) [`f88c1ef`](https://github.com/ivov/lisette/commit/f88c1efc04ec425748004e2e955ad5dbae639f60)
+- fix: freshen go-escaped names that clash with siblings [#342](https://github.com/ivov/lisette/pull/342) [`36b6de2`](https://github.com/ivov/lisette/commit/36b6de2eac3ed929c3acd02235cba8bb77928d52)
+- fix: declare local const in go scope for let/const shadowing [#341](https://github.com/ivov/lisette/pull/341) [`f7d8afb`](https://github.com/ivov/lisette/commit/f7d8afb898060786ec8ee944baae19e379fa637e)
+- fix: ignore string literal contents in emit text scans [#337](https://github.com/ivov/lisette/pull/337) [`eaa4e69`](https://github.com/ivov/lisette/commit/eaa4e696d7badb625eb5632d6c8f7ae5d697bda0)
+- fix: assign bindings in irrefutable let-else or-patterns [#338](https://github.com/ivov/lisette/pull/338) [`6362b34`](https://github.com/ivov/lisette/commit/6362b344ef9a4b17245d4ecdea92c553819867fc)
+- ci: pass missing expression to fix build [#340](https://github.com/ivov/lisette/pull/340) [`495a95b`](https://github.com/ivov/lisette/commit/495a95bf8fc73b735b2a9a7977b30abc6d93e7e9)
+- ci: skip pr-specific checks on release-plz prs [#339](https://github.com/ivov/lisette/pull/339) [`1b0a0ec`](https://github.com/ivov/lisette/commit/1b0a0ec0508c14239f642885a06894a324cacc5a)
+- fix: capture mutable reads before later sibling setup runs [#336](https://github.com/ivov/lisette/pull/336) [`ead1048`](https://github.com/ivov/lisette/commit/ead1048e55e08eb0bb9f8bf840912cf9d048e38b)
+- docs: show project layout in lis new and lis learn help [#335](https://github.com/ivov/lisette/pull/335) [`e16d7cf`](https://github.com/ivov/lisette/commit/e16d7cfc1138350b28a35add04e1f5155351c36e)
+- fix: sequence receiver before range value in substring and slice [#334](https://github.com/ivov/lisette/pull/334) [`4559d27`](https://github.com/ivov/lisette/commit/4559d27f0d433fd18b5ebf8cfa036bf0b0b60884)
+- fix: dereference Ref<string> receiver in substring call [#333](https://github.com/ivov/lisette/pull/333) [`855ae00`](https://github.com/ivov/lisette/commit/855ae00886ddb88b543b8ca5de16ef717a0041d3)
+- fix: preserve & on UFCS composite literal receivers [#331](https://github.com/ivov/lisette/pull/331) [`589a9fa`](https://github.com/ivov/lisette/commit/589a9fad527778f17e89de446876406828677ecf)
+- fix: parenthesize pointer newtype cast in match patterns [#332](https://github.com/ivov/lisette/pull/332) [`4035606`](https://github.com/ivov/lisette/commit/403560667e43c4b7d74ac311114ea81d6e790133)
+- fix: camel-case snake_case names in receiver-method UFCS calls [#330](https://github.com/ivov/lisette/pull/330) [`06d098e`](https://github.com/ivov/lisette/commit/06d098e148ffa23642b185f8d9b3799666f62207)
+- fix: export camel-case method names in interface adapters [#329](https://github.com/ivov/lisette/pull/329) [`d35f8d3`](https://github.com/ivov/lisette/commit/d35f8d3113ff9c9089f3f90719e206a669be0a51)
+- fix: handle escaped quotes in fmt.Println f-string collapse [#328](https://github.com/ivov/lisette/pull/328) [`a798d21`](https://github.com/ivov/lisette/commit/a798d218279b08e0d201fc5e05a830bf9dc9590e)
+- fix: preserve short-circuit when && or || RHS needs setup [#326](https://github.com/ivov/lisette/pull/326) [`4126b50`](https://github.com/ivov/lisette/commit/4126b50af7cd378fdc0730fe3ca8ef23e0a7ff75)
 ## [0.2.0](https://github.com/ivov/lisette/compare/lisette-v0.1.26...lisette-v0.2.0) - 2026-05-06
 
 - refactor!: reject positional access on string [#323](https://github.com/ivov/lisette/pull/323) [`a7c7245`](https://github.com/ivov/lisette/commit/a7c7245aab153ad88d44ef5ea93529c26cad2d8c)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "ecow",
@@ -582,11 +582,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.0", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.0", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.0", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.0", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.1", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.1", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.1", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.1", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.1", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.1", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.1", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.1", path = "../diagnostics" }
 ecow.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.0", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.0", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.1", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.1", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.1", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.1", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.0", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.0", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.0", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.1", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.1", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.1 (upcoming)

- fix: snapshot bytes-loop receiver to survive body reassignment [#344](https://github.com/ivov/lisette/pull/344) [`1eda7c8`](https://github.com/ivov/lisette/commit/1eda7c83360ca712eabfe0ec081878ea647c5d94)
- fix: freshen rest binding in let-else or-pattern [#343](https://github.com/ivov/lisette/pull/343) [`f88c1ef`](https://github.com/ivov/lisette/commit/f88c1efc04ec425748004e2e955ad5dbae639f60)
- fix: freshen go-escaped names that clash with siblings [#342](https://github.com/ivov/lisette/pull/342) [`36b6de2`](https://github.com/ivov/lisette/commit/36b6de2eac3ed929c3acd02235cba8bb77928d52)
- fix: declare local const in go scope for let/const shadowing [#341](https://github.com/ivov/lisette/pull/341) [`f7d8afb`](https://github.com/ivov/lisette/commit/f7d8afb898060786ec8ee944baae19e379fa637e)
- fix: ignore string literal contents in emit text scans [#337](https://github.com/ivov/lisette/pull/337) [`eaa4e69`](https://github.com/ivov/lisette/commit/eaa4e696d7badb625eb5632d6c8f7ae5d697bda0)
- fix: assign bindings in irrefutable let-else or-patterns [#338](https://github.com/ivov/lisette/pull/338) [`6362b34`](https://github.com/ivov/lisette/commit/6362b344ef9a4b17245d4ecdea92c553819867fc)
- ci: pass missing expression to fix build [#340](https://github.com/ivov/lisette/pull/340) [`495a95b`](https://github.com/ivov/lisette/commit/495a95bf8fc73b735b2a9a7977b30abc6d93e7e9)
- ci: skip pr-specific checks on release-plz prs [#339](https://github.com/ivov/lisette/pull/339) [`1b0a0ec`](https://github.com/ivov/lisette/commit/1b0a0ec0508c14239f642885a06894a324cacc5a)
- fix: capture mutable reads before later sibling setup runs [#336](https://github.com/ivov/lisette/pull/336) [`ead1048`](https://github.com/ivov/lisette/commit/ead1048e55e08eb0bb9f8bf840912cf9d048e38b)
- docs: show project layout in lis new and lis learn help [#335](https://github.com/ivov/lisette/pull/335) [`e16d7cf`](https://github.com/ivov/lisette/commit/e16d7cfc1138350b28a35add04e1f5155351c36e)
- fix: sequence receiver before range value in substring and slice [#334](https://github.com/ivov/lisette/pull/334) [`4559d27`](https://github.com/ivov/lisette/commit/4559d27f0d433fd18b5ebf8cfa036bf0b0b60884)
- fix: dereference Ref<string> receiver in substring call [#333](https://github.com/ivov/lisette/pull/333) [`855ae00`](https://github.com/ivov/lisette/commit/855ae00886ddb88b543b8ca5de16ef717a0041d3)
- fix: preserve & on UFCS composite literal receivers [#331](https://github.com/ivov/lisette/pull/331) [`589a9fa`](https://github.com/ivov/lisette/commit/589a9fad527778f17e89de446876406828677ecf)
- fix: parenthesize pointer newtype cast in match patterns [#332](https://github.com/ivov/lisette/pull/332) [`4035606`](https://github.com/ivov/lisette/commit/403560667e43c4b7d74ac311114ea81d6e790133)
- fix: camel-case snake_case names in receiver-method UFCS calls [#330](https://github.com/ivov/lisette/pull/330) [`06d098e`](https://github.com/ivov/lisette/commit/06d098e148ffa23642b185f8d9b3799666f62207)
- fix: export camel-case method names in interface adapters [#329](https://github.com/ivov/lisette/pull/329) [`d35f8d3`](https://github.com/ivov/lisette/commit/d35f8d3113ff9c9089f3f90719e206a669be0a51)
- fix: handle escaped quotes in fmt.Println f-string collapse [#328](https://github.com/ivov/lisette/pull/328) [`a798d21`](https://github.com/ivov/lisette/commit/a798d218279b08e0d201fc5e05a830bf9dc9590e)
- fix: preserve short-circuit when && or || RHS needs setup [#326](https://github.com/ivov/lisette/pull/326) [`4126b50`](https://github.com/ivov/lisette/commit/4126b50af7cd378fdc0730fe3ca8ef23e0a7ff75)
