### PR TITLE
fix: handle escaped quotes in fmt.Println f-string collapse

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -21,6 +21,23 @@ struct CallArgsContext<'a> {
     combine_variadic: Option<VariadicCombine>,
 }
 
+/// Escape-aware close-quote search; plain `find` would collide with `\"` inside the literal.
+fn find_go_string_literal_close(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'"') {
+        return None;
+    }
+    let mut i = 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
 /// Collapse redundant fmt wrappers:
 /// - `fmt.Print{ln}(fmt.Sprintf(...))` → `fmt.Printf(..., "\n")`
 /// - `fmt.Print{ln}(fmt.Sprint(x))` → `fmt.Print{ln}(x)`
@@ -45,14 +62,10 @@ fn collapse_fmt_print(function_string: &str, args_strings: &[String], call_str: 
         if suffix.is_empty() {
             return format!("fmt.Printf({})", inner);
         }
-        if let Some(close_quote) = inner.find("\", ") {
-            let format_str = &inner[..close_quote];
-            let rest = &inner[close_quote + 1..];
-            return format!("fmt.Printf({}{}\"{})", format_str, suffix, rest);
-        }
-        if inner.starts_with('"') && inner.ends_with('"') {
-            let format_str = &inner[..inner.len() - 1];
-            return format!("fmt.Printf({}{}\")", format_str, suffix);
+        if let Some(close_quote) = find_go_string_literal_close(inner) {
+            let format_open = &inner[..close_quote];
+            let close_and_rest = &inner[close_quote..];
+            return format!("fmt.Printf({}{}{})", format_open, suffix, close_and_rest);
         }
         return call_str;
     }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -465,6 +465,19 @@ fn test() {
 }
 
 #[test]
+fn format_string_escaped_quote_before_interp() {
+    let input = r#"
+import "go:fmt"
+
+fn test() {
+  let x = 7;
+  fmt.Println(f"prefix \", {x}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn format_string_variable() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
+++ b/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 477
+description: "input: \nimport \"go:fmt\"\n\nfn test() {\n  let x = 7;\n  fmt.Println(f\"prefix \\\", {x}\")\n}\n"
+---
+package main
+
+import "fmt"
+
+func test() {
+	x := 7
+	fmt.Printf("prefix \", %v\n", x)
+}


### PR DESCRIPTION
Fixes the `fmt.Println(f"...")` collapse producing invalid Go when the format string contains an escaped `"` followed by comma.

```
import "go:fmt"

fn main() {
  let x = 7
  fmt.Println(f"prefix \", {x}")
}
```