### PR TITLE
fix: export camel-case method names in interface adapters

### DIFF
--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::write_line;
 use ecow::EcoString;
@@ -323,7 +324,12 @@ impl Emitter<'_> {
             .map(|(n, t)| format!("{} {}", n, t))
             .collect();
 
-        let inner_call = format!("a.inner.{}({})", method.name, param_names.join(", "));
+        let go_method_name = if self.method_needs_export(&method.name) {
+            go_name::snake_to_camel(&method.name)
+        } else {
+            go_name::escape_keyword(&method.name).into_owned()
+        };
+        let inner_call = format!("a.inner.{}({})", go_method_name, param_names.join(", "));
 
         let user_shape = method.user_shape.clone();
         let interface_shape = method.interface_shape.clone();
@@ -333,7 +339,7 @@ impl Emitter<'_> {
             && let Some(shape) = user_shape
         {
             let go_ret = self.render_lowered_return_ty(&shape, &method.return_type);
-            write_method_header(decl, adapter_name, &method.name, &params_str, &go_ret);
+            write_method_header(decl, adapter_name, &go_method_name, &params_str, &go_ret);
             decl.push_str(&format!("return {}\n", inner_call));
             write_line!(decl, "}}");
             self.exit_scope();
@@ -345,7 +351,7 @@ impl Emitter<'_> {
             && let Some((go_ret, body)) =
                 self.emit_hint_shift_bridge(&inner_call, &method.return_type, &user, &interface)
         {
-            write_method_header(decl, adapter_name, &method.name, &params_str, &go_ret);
+            write_method_header(decl, adapter_name, &go_method_name, &params_str, &go_ret);
             decl.push_str(&body);
             write_line!(decl, "}}");
             self.exit_scope();
@@ -373,7 +379,7 @@ impl Emitter<'_> {
             decl,
             "func (a {}) {}({}){} {{",
             adapter_name,
-            method.name,
+            go_method_name,
             params_decl.join(", "),
             ret_suffix
         );

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4802,6 +4802,41 @@ fn main() {
 }
 
 #[test]
+fn user_iface_adapter_uses_exported_go_method_name_for_snake_case() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub struct Entry { name: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn get_session(key: string) -> Option<Ref<Entry>>
+}
+
+struct MyCache {}
+
+impl MyCache {
+  fn get_session(self, _key: string) -> Option<Ref<Entry>> {
+    None
+  }
+}
+
+fn use_cache(_c: Cache) {}
+
+fn main() {
+  let c = MyCache {}
+  use_cache(c)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn result_with_pointer_error_lowers_to_native_tuple() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
+++ b/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+type Entry struct {
+	name string
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf("Entry { name: %v }", e.name)
+}
+
+type Cache interface {
+	GetSession(string) (*Entry, bool)
+}
+
+type MyCache struct{}
+
+func (m MyCache) String() string {
+	return "MyCache"
+}
+
+func (m MyCache) GetSession(_ string) *Entry {
+	return nil
+}
+
+func use_cache(_ Cache) {}
+
+func main() {
+	c := MyCache{}
+	use_cache(_lisAdapter_MyCache_Cache_0{inner: c})
+}
+
+type _lisAdapter_MyCache_Cache_0 struct {
+	inner MyCache
+}
+
+func (a _lisAdapter_MyCache_Cache_0) GetSession(arg0 string) (*Entry, bool) {
+	val_1 := a.inner.GetSession(arg0)
+	return val_1, val_1 != nil
+}


### PR DESCRIPTION
Fixes a Go compile error when a synthesized interface adapter is needed for a public Lisette interface with a snake_case method. The interface and the impl method both emit as `GetSession`, but the adapter previously declared and called `get_session`, so the adapter neither implemented the interface nor resolved the inner method.

```rs
pub interface Cache {
  #[go(comma_ok)]
  fn get_session(key: string) -> Option<Ref<Entry>>
}

struct MyCache {}
impl MyCache {
  fn get_session(self, _key: string) -> Option<Ref<Entry>> { None }
}

fn use_cache(_c: Cache) {}

fn main() {
  use_cache(MyCache {})
}
```