### PR TITLE
fix: camel-case snake_case names in receiver-method UFCS calls

### DIFF
--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -182,11 +182,7 @@ impl Emitter<'_> {
         spread: Option<&Expression>,
     ) -> String {
         let go_method = if is_public {
-            let mut chars = method.chars();
-            match chars.next() {
-                Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
-                None => method.to_string(),
-            }
+            go_name::snake_to_camel(method)
         } else {
             go_name::escape_keyword(method).into_owned()
         };

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2312,6 +2312,23 @@ fn main() {
 }
 
 #[test]
+fn ufcs_call_to_public_snake_case_receiver_method() {
+    let input = r#"
+pub struct Service {}
+
+impl Service {
+  pub fn get_session(self) -> int { 42 }
+}
+
+fn main() {
+  let s = Service {};
+  let _ = Service.get_session(s);
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn ufcs_call_return_only_type_args() {
     let input = r#"
 struct Box<T> { value: T }

--- a/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 2328
+description: "input: \npub struct Service {}\n\nimpl Service {\n  pub fn get_session(self) -> int { 42 }\n}\n\nfn main() {\n  let s = Service {};\n  let _ = Service.get_session(s);\n}\n"
+---
+package main
+
+type Service struct{}
+
+func (s Service) String() string {
+	return "Service"
+}
+
+func (s Service) GetSession() int {
+	return 42
+}
+
+func main() {
+	s := Service{}
+	_ = s.GetSession()
+}


### PR DESCRIPTION
Receiver-method UFCS calls now camel-case snake case public method names, matching how those methods are emitted at their definition site. Previously the callsite only uppercased the first character, so the call failed to compile.

```rs
pub struct Service {}

impl Service {
  pub fn get_session(self) -> int { 42 }
}

fn main() {
  let s = Service {};
  Service.get_session(s);
}
```