### PR TITLE
fix: preserve & on UFCS composite literal receivers

### DIFF
--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -6,7 +6,7 @@ use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::types::native::NativeGoType;
 use crate::utils::Staged;
-use syntax::ast::{Annotation, Expression};
+use syntax::ast::{Annotation, Expression, Literal};
 use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
 
@@ -202,7 +202,11 @@ impl Emitter<'_> {
         let type_args_string = self.format_type_args_from_annotations(type_args);
 
         let receiver = if let Some(stripped) = receiver.strip_prefix('&') {
-            stripped.to_string()
+            if Self::is_address_of_composite_literal(args.first()) {
+                format!("(&{})", stripped)
+            } else {
+                stripped.to_string()
+            }
         } else if receiver.starts_with('*') {
             format!("({})", receiver)
         } else {
@@ -215,6 +219,23 @@ impl Emitter<'_> {
             go_method,
             type_args_string,
             emitted_rest.join(", ")
+        )
+    }
+
+    fn is_address_of_composite_literal(arg: Option<&Expression>) -> bool {
+        let Some(Expression::Reference {
+            expression: inner, ..
+        }) = arg.map(Expression::unwrap_parens)
+        else {
+            return false;
+        };
+        matches!(
+            inner.unwrap_parens(),
+            Expression::StructCall { .. }
+                | Expression::Literal {
+                    literal: Literal::Slice(_),
+                    ..
+                }
         )
     }
 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2655,6 +2655,25 @@ fn main() {
 }
 
 #[test]
+fn ufcs_address_of_struct_literal_receiver() {
+    let input = r#"
+struct Counter { x: int }
+
+impl Counter {
+  fn inc(self: Ref<Counter>) -> int {
+    self.x = self.x + 1
+    self.x
+  }
+}
+
+fn main() {
+  let _ = Counter.inc(&Counter { x: 0 })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn private_field_not_capitalized_by_method_export() {
     let input = r#"
 pub interface IFoo {

--- a/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 2673
+description: "input: \nstruct Counter { x: int }\n\nimpl Counter {\n  fn inc(self: Ref<Counter>) -> int {\n    self.x = self.x + 1\n    self.x\n  }\n}\n\nfn main() {\n  let _ = Counter.inc(&Counter { x: 0 })\n}\n"
+---
+package main
+
+import "fmt"
+
+type Counter struct {
+	x int
+}
+
+func (c Counter) String() string {
+	return fmt.Sprintf("Counter { x: %v }", c.x)
+}
+
+func (c *Counter) inc() int {
+	c.x++
+	return c.x
+}
+
+func main() {
+	_ = (&Counter{x: 0}).inc()
+}


### PR DESCRIPTION
Calling a pointer-receiver method via UFCS with an address of composite literal argument no longer emits invalid Go.

```rs
struct Counter { x: int }

impl Counter {
  fn inc(self: Ref<Counter>) -> int {
    self.x = self.x + 1
    self.x
  }
}

fn main() {
  let _ = Counter.inc(&Counter { x: 0 })
}
```