### PR TITLE
fix: parenthesize pointer newtype cast in match patterns

### DIFF
--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -59,7 +59,13 @@ impl AccessPath {
                         result = format!("(*{})", result);
                     }
                 }
-                PathSegment::NewtypeCast(ty) => result = format!("{}({})", ty, result),
+                PathSegment::NewtypeCast(ty) => {
+                    result = if ty.starts_with('*') {
+                        format!("({})({})", ty, result)
+                    } else {
+                        format!("{}({})", ty, result)
+                    }
+                }
             }
         }
         result

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -524,6 +524,20 @@ fn test(uid: UserId) -> int {
 }
 
 #[test]
+fn newtype_ref_struct_pattern_match() {
+    let input = r#"
+struct Wrap(Ref<int>)
+
+fn test(w: Wrap) -> int {
+  match w {
+    Wrap(r) => r.*,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn pattern_unicode_escape_conversion() {
     let input = r#"
 fn test(s: string) -> int {

--- a/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nstruct Wrap(Ref<int>)\n\nfn test(w: Wrap) -> int {\n  match w {\n    Wrap(r) => r.*,\n  }\n}\n"
+---
+package main
+
+type Wrap *int
+
+func test(w Wrap) int {
+	r := (*int)(w)
+	return *r
+}


### PR DESCRIPTION
Matching a newtype over `Ref<T>` failed to compile because the destructuring path emitted an unparenthesized pointer cast like `*int(w)`, which Go parses as multiplication. The non-pattern form `w.0` already parenthesizes pointer types; pattern emission now does the same, producing `(*int)(w)`.

```rs
struct Wrap(Ref<int>)

fn main() {
  let mut x = 5
  let w = Wrap(&x)
  match w {
    Wrap(r) => fmt.Println(r.*),
  }
}
```