### PR TITLE
fix: dereference Ref<string> receiver in substring call

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -375,6 +375,14 @@ impl Emitter<'_> {
     ) -> String {
         self.flags.needs_stdlib = true;
         let arg = &args[0];
+        let is_ref_receiver = receiver_expr.get_type().is_ref();
+        let deref = |raw: &str| -> String {
+            if is_ref_receiver {
+                format!("*{}", raw)
+            } else {
+                raw.to_string()
+            }
+        };
 
         if let Expression::Range {
             start,
@@ -401,7 +409,11 @@ impl Emitter<'_> {
                     e.clone()
                 }
             });
-            return format_substring_call(&values[0], start_bound.as_deref(), end_bound.as_deref());
+            return format_substring_call(
+                &deref(&values[0]),
+                start_bound.as_deref(),
+                end_bound.as_deref(),
+            );
         }
 
         let arg_ty = arg.get_type();
@@ -410,7 +422,7 @@ impl Emitter<'_> {
             .expect("substring arg should resolve to a known range type");
         let receiver_staged = self.stage_operand(receiver_expr);
         output.push_str(&receiver_staged.setup);
-        let recv = receiver_staged.value;
+        let recv = deref(&receiver_staged.value);
         let range_var = self.emit_or_capture(output, arg, "range");
         let (start, end) = range_var_bounds(&range_var, range_kind);
         format_substring_call(&recv, start.as_deref(), end.as_deref())

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -903,6 +903,26 @@ fn test(s: MyString) -> bool {
 }
 
 #[test]
+fn string_substring_ref_receiver_range_literal() {
+    let input = r#"
+fn test(r: Ref<string>) -> string {
+  r.substring(1..4)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_substring_ref_receiver_range_value() {
+    let input = r#"
+fn test(r: Ref<string>, range: Range<int>) -> string {
+  r.substring(range)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn string_substring_aliased_range() {
     let input = r#"
 type Prefix = RangeTo<int>

--- a/tests/spec/emit/snapshots/string_substring_ref_receiver_range_literal.snap
+++ b/tests/spec/emit/snapshots/string_substring_ref_receiver_range_literal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 912
+description: "input: \nfn test(r: Ref<string>) -> string {\n  r.substring(1..4)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(r *string) string {
+	return lisette.Substring(*r, 1, 4)
+}

--- a/tests/spec/emit/snapshots/string_substring_ref_receiver_range_value.snap
+++ b/tests/spec/emit/snapshots/string_substring_ref_receiver_range_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 922
+description: "input: \nfn test(r: Ref<string>, range: Range<int>) -> string {\n  r.substring(range)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(r *string, range_ lisette.Range[int]) string {
+	return lisette.Substring(*r, range_.Start, range_.End)
+}


### PR DESCRIPTION
Fixes `r.substring(...)` on a `Ref<string>` receiver producing invalid Go.

```rs
import "go:fmt"

fn main() {
  let s = "hello"
  let r = &s
  fmt.Println(r.substring(1..4))
}
```