### PR TITLE
fix: sequence receiver before range value in substring and slice

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -409,11 +409,10 @@ impl Emitter<'_> {
             .and_then(|t| t.get_name())
             .expect("substring arg should resolve to a known range type");
         let receiver_staged = self.stage_operand(receiver_expr);
-        output.push_str(&receiver_staged.setup);
-        let recv = receiver_staged.value;
-        let range_var = self.emit_or_capture(output, arg, "range");
-        let (start, end) = range_var_bounds(&range_var, range_kind);
-        format_substring_call(&recv, start.as_deref(), end.as_deref())
+        let range_staged = self.stage_or_capture(arg, "range");
+        let values = self.sequence(output, vec![receiver_staged, range_staged], "_arg");
+        let (start, end) = range_var_bounds(&values[1], range_kind);
+        format_substring_call(&values[0], start.as_deref(), end.as_deref())
     }
 }
 

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -35,14 +35,9 @@ impl Emitter<'_> {
         let index_ty = index.get_type();
         if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
             let needs_cap = expression.get_type().has_name("Slice");
-            output.push_str(&base_staged.setup);
-            let index_string = self.emit_or_capture(output, index, "range");
-            return self.emit_range_var_slice(
-                &base_staged.value,
-                &index_string,
-                range_kind,
-                needs_cap,
-            );
+            let index_staged = self.stage_or_capture(index, "range");
+            let values = self.sequence(output, vec![base_staged, index_staged], "_base");
+            return self.emit_range_var_slice(&values[0], &values[1], range_kind, needs_cap);
         }
 
         let index_staged = self.stage_composite(index);

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -20,20 +20,25 @@ impl Emitter<'_> {
         expression: &Expression,
         prefix: &str,
     ) -> String {
-        let emit_directly = matches!(
+        let staged = self.stage_or_capture(expression, prefix);
+        output.push_str(&staged.setup);
+        staged.value
+    }
+
+    pub(crate) fn stage_or_capture(&mut self, expression: &Expression, prefix: &str) -> Staged {
+        if matches!(
             expression,
             Expression::Literal { .. } | Expression::Identifier { .. }
-        );
-
-        if emit_directly {
-            return self.emit_operand(output, expression);
+        ) {
+            return self.stage_operand(expression);
         }
 
+        let mut setup = String::new();
+        let value_expr = self.emit_operand(&mut setup, expression);
         let temp_var = self.fresh_var(Some(prefix));
         self.declare(&temp_var);
-        let expression_string = self.emit_operand(output, expression);
-        write_line!(output, "{} := {}", temp_var, expression_string);
-        temp_var
+        write_line!(setup, "{} := {}", temp_var, value_expr);
+        Staged::new(setup, temp_var)
     }
 
     pub(crate) fn emit_force_capture(

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1729,6 +1729,29 @@ fn main() {
 }
 
 #[test]
+fn slice_range_value_eval_order() {
+    let input = r#"
+import "go:fmt"
+
+fn make_items() -> Slice<int> {
+  fmt.Println("receiver")
+  [10, 20, 30, 40]
+}
+
+fn make_range() -> Range<int> {
+  fmt.Println("range")
+  1..3
+}
+
+fn main() {
+  let xs = make_items()[make_range()]
+  fmt.Println(xs.length())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_field_assignment_expression_position() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -869,6 +869,28 @@ fn test(s: string, r: RangeTo<int>) -> string {
 }
 
 #[test]
+fn string_substring_range_value_eval_order() {
+    let input = r#"
+import "go:fmt"
+
+fn make_s() -> string {
+  fmt.Println("receiver")
+  "hello"
+}
+
+fn make_range() -> Range<int> {
+  fmt.Println("range")
+  1..4
+}
+
+fn main() {
+  fmt.Println(make_s().substring(make_range()))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn string_substring_ufcs() {
     let input = r#"
 fn test(s: string) -> string {

--- a/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 1751
+description: "input: \nimport \"go:fmt\"\n\nfn make_items() -> Slice<int> {\n  fmt.Println(\"receiver\")\n  [10, 20, 30, 40]\n}\n\nfn make_range() -> Range<int> {\n  fmt.Println(\"range\")\n  1..3\n}\n\nfn main() {\n  let xs = make_items()[make_range()]\n  fmt.Println(xs.length())\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func make_items() []int {
+	fmt.Println("receiver")
+	return []int{10, 20, 30, 40}
+}
+
+func make_range() lisette.Range[int] {
+	fmt.Println("range")
+	return lisette.Range[int]{
+		Start: 1,
+		End:   3,
+	}
+}
+
+func main() {
+	_base_2 := make_items()
+	range_1 := make_range()
+	xs := _base_2[range_1.Start:range_1.End:range_1.End]
+	fmt.Println(len(xs))
+}

--- a/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 890
+description: "input: \nimport \"go:fmt\"\n\nfn make_s() -> string {\n  fmt.Println(\"receiver\")\n  \"hello\"\n}\n\nfn make_range() -> Range<int> {\n  fmt.Println(\"range\")\n  1..4\n}\n\nfn main() {\n  fmt.Println(make_s().substring(make_range()))\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func make_s() string {
+	fmt.Println("receiver")
+	return "hello"
+}
+
+func make_range() lisette.Range[int] {
+	fmt.Println("range")
+	return lisette.Range[int]{
+		Start: 1,
+		End:   4,
+	}
+}
+
+func main() {
+	_arg_2 := make_s()
+	range_1 := make_range()
+	fmt.Println(lisette.Substring(_arg_2, range_1.Start, range_1.End))
+}


### PR DESCRIPTION
A `string.substring(r)` or `slice[r]` call where `r` is a range value now evaluates the receiver before the range, matching the order of the range-literal forms.

```rs
fn make_s() -> string {
  fmt.Println("receiver")
  "hello"
}

fn make_range() -> Range<int> {
  fmt.Println("range")
  1..4
}

fn main() {
  fmt.Println(make_s().substring(make_range()))
}
```