### PR TITLE
fix: capture mutable reads before later sibling setup runs

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -243,7 +243,7 @@ impl Emitter<'_> {
             .map(|(i, arg)| {
                 let mut setup = String::new();
                 let value = self.emit_call_arg(&mut setup, arg, i, ctx);
-                Staged::new(setup, value)
+                Staged::new(setup, value, arg)
             })
             .collect();
         self.sequence_with_spread(

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -5,7 +5,7 @@ use crate::control_flow::fallible::{
 };
 use crate::types::abi::AbiShape;
 use crate::types::emitter::Position;
-use crate::utils::{inline_trivial_bindings, optimize_region};
+use crate::utils::{Staged, inline_trivial_bindings, optimize_region};
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -314,16 +314,21 @@ impl Emitter<'_> {
                 .ty
                 .clone();
             let slot_tys = crate::types::abi::tuple_element_types(&self.peel_alias(&return_ty));
-            let parts: Vec<String> = elements
+            let stages: Vec<Staged> = elements
                 .iter()
                 .enumerate()
-                .map(|(i, e)| match slot_tys.get(i) {
-                    Some(slot_ty) if self.is_nullable_option(slot_ty) => {
-                        self.emit_nullable_slot_value(output, e, slot_ty)
-                    }
-                    _ => self.emit_composite_value(output, e),
+                .map(|(i, e)| {
+                    let mut setup = String::new();
+                    let value = match slot_tys.get(i) {
+                        Some(slot_ty) if self.is_nullable_option(slot_ty) => {
+                            self.emit_nullable_slot_value(&mut setup, e, slot_ty)
+                        }
+                        _ => self.emit_composite_value(&mut setup, e),
+                    };
+                    Staged::new(setup, value, e)
                 })
                 .collect();
+            let parts = self.sequence(output, stages, "_ret");
             write_line!(output, "return {}", parts.join(", "));
             return true;
         }

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -65,7 +65,7 @@ impl Emitter<'_> {
         Staged {
             value: format!("(*{})", s.value),
             setup: s.setup,
-            has_side_effects: s.has_side_effects,
+            needs_capture: s.needs_capture,
         }
     }
 

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -7,9 +7,8 @@ use syntax::types::{CompoundKind, SimpleKind, Type, unqualified_name};
 use crate::Emitter;
 use crate::definitions::enum_layout;
 use crate::go_name;
-use crate::is_order_sensitive;
 use crate::types::coercion::Coercion;
-use crate::utils::Staged;
+use crate::utils::{Staged, observable_after_mutation};
 use crate::write_line;
 
 /// Context for emitting a struct literal or enum variant construction.
@@ -104,7 +103,7 @@ impl Emitter<'_> {
                 field_side_effects.extend(
                     field_assignments
                         .iter()
-                        .map(|f| is_order_sensitive(&f.value)),
+                        .map(|f| observable_after_mutation(&f.value)),
                 );
                 self.emit_struct_update(output, base, &field_pairs, &field_side_effects)
             }

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -1,6 +1,6 @@
 use crate::Emitter;
 use crate::names::go_name;
-use crate::utils::Staged;
+use crate::utils::{Staged, observable_after_mutation};
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -42,7 +42,7 @@ impl Emitter<'_> {
         expression: &Expression,
         prefix: &str,
     ) -> String {
-        if matches!(expression.unwrap_parens(), Expression::Literal { .. }) {
+        if !observable_after_mutation(expression) {
             return self.emit_operand(output, expression);
         }
 
@@ -57,14 +57,14 @@ impl Emitter<'_> {
     pub(crate) fn stage_operand(&mut self, expression: &Expression) -> Staged {
         let mut setup = String::new();
         let value = self.emit_operand(&mut setup, expression);
-        Staged::new(setup, value)
+        Staged::new(setup, value, expression)
     }
 
     /// Emit an expression as a composite value to a separate buffer.
     pub(crate) fn stage_composite(&mut self, expression: &Expression) -> Staged {
         let mut setup = String::new();
         let value = self.emit_composite_value(&mut setup, expression);
-        Staged::new(setup, value)
+        Staged::new(setup, value, expression)
     }
 
     /// Suppresses the Go-fn identity short-circuit when the formal param
@@ -93,7 +93,7 @@ impl Emitter<'_> {
             self.declare(&cb_var);
             write_line!(setup, "{} := {}", cb_var, staged.value);
             let tagged = self.lower_arg_to_tagged(&mut setup, &cb_var, param_ty);
-            return Staged::new(setup, tagged);
+            return Staged::new(setup, tagged, expression);
         }
 
         staged
@@ -176,7 +176,7 @@ impl Emitter<'_> {
 
             output.push_str(&s.setup);
 
-            if later_has_setup && s.has_side_effects {
+            if later_has_setup && s.needs_capture {
                 let tmp = self.fresh_var(Some(prefix));
                 self.declare(&tmp);
                 write_line!(output, "{} := {}", tmp, s.value);

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -144,24 +144,29 @@ pub(crate) fn is_order_sensitive(expression: &Expression) -> bool {
     )
 }
 
+/// True for any expression except a pure literal — i.e. one whose value can
+/// be invalidated by a later sibling's setup, or is a call we should not
+/// re-evaluate.
+pub(crate) fn observable_after_mutation(expression: &Expression) -> bool {
+    !matches!(expression.unwrap_parens(), Expression::Literal { .. })
+}
+
 /// Result of emitting a sub-expression to a separate buffer.
-/// `setup` contains any statements the emitter produced (temp vars, etc.).
-/// `value` is the final expression string.
 pub(crate) struct Staged {
     pub setup: String,
     pub value: String,
-    /// Whether the emitted value contains a call (side-effectful).
-    /// Detected via `value.contains('(')` on the Go output string.
-    pub has_side_effects: bool,
+    /// Recapture before later sibling setup runs. Only set for inline values
+    /// (empty setup); a non-empty setup already bound `value` to a temp.
+    pub needs_capture: bool,
 }
 
 impl Staged {
-    pub(crate) fn new(setup: String, value: String) -> Self {
-        let has_side_effects = value.contains('(');
+    pub(crate) fn new(setup: String, value: String, expression: &Expression) -> Self {
+        let needs_capture = setup.is_empty() && observable_after_mutation(expression);
         Self {
             setup,
             value,
-            has_side_effects,
+            needs_capture,
         }
     }
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/prelude.rs
+assertion_line: 794
 description: "input: \nfn main() {\n  let g = Some\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(g)\n  let _ = r\n}\n"
 ---
 package main
@@ -16,9 +17,10 @@ func main() {
 		return *new(int), false
 	}
 	opt := lisette.MakeOptionSome(1)
+	_arg_6 := opt
 	cb_3 := g
 	tagged_5 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_3(arg0))
 	}
-	_ = lisette.OptionAndThen(opt, tagged_5)
+	_ = lisette.OptionAndThen(_arg_6, tagged_5)
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/prelude.rs
+assertion_line: 808
 description: "input: \nfn doubler(x: int) -> Option<int> { Some(x * 2) }\nfn main() {\n  let g = doubler\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(g)\n  let _ = r\n}\n"
 ---
 package main
@@ -13,9 +14,10 @@ func doubler(x int) (int, bool) {
 func main() {
 	g := doubler
 	opt := lisette.MakeOptionSome(1)
+	_arg_4 := opt
 	cb_1 := g
 	tagged_3 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	_ = lisette.OptionAndThen(opt, tagged_3)
+	_ = lisette.OptionAndThen(_arg_4, tagged_3)
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/prelude.rs
+assertion_line: 781
 description: "input: \nfn doubler(x: int) -> Option<int> { Some(x * 2) }\nfn main() {\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(doubler)\n  let _ = r\n}\n"
 ---
 package main
@@ -12,9 +13,10 @@ func doubler(x int) (int, bool) {
 
 func main() {
 	opt := lisette.MakeOptionSome(1)
+	_arg_4 := opt
 	cb_1 := doubler
 	tagged_3 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	_ = lisette.OptionAndThen(opt, tagged_3)
+	_ = lisette.OptionAndThen(_arg_4, tagged_3)
 }

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/control_flow.rs
+assertion_line: 2665
 description: "input: \nfn g() -> Result<int, string> { Ok(0) }\n\nfn f() -> Result<int, string> {\n  let chans = [Channel.buffered<int>(1)]\n  chans[0].send(7)\n  let x = select {\n    let Some(v) = chans[g()?].receive() => v,\n    _ => 0,\n  }\n  Ok(x)\n}\n\nfn main() { let _ = f() }\n"
 ---
 package main
@@ -14,19 +15,20 @@ func f() lisette.Result[int, string] {
 	chans := []chan int{make(chan int, 1)}
 	_ = lisette.ChannelSend(chans[0], 7)
 	var x int
+	_base_3 := chans
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
 	result_2 := check_1.OkVal
-	ch_3 := chans[result_2]
+	ch_4 := _base_3[result_2]
 	for {
 		select {
-		case v, ok := <-ch_3:
+		case v, ok := <-ch_4:
 			if ok {
 				x = v
 			} else {
-				ch_3 = nil
+				ch_4 = nil
 				continue
 			}
 		default:

--- a/tests/spec/emit/snapshots/try_block_nested.snap
+++ b/tests/spec/emit/snapshots/try_block_nested.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/control_flow.rs
+assertion_line: 1737
 description: "input: \nfn risky_a() -> Result<int, string> { Ok(1) }\nfn risky_b() -> Result<int, string> { Ok(2) }\n\nfn test() -> int {\n  let outer = try {\n    let inner: Result<int, string> = try {\n      risky_a()?\n    };\n    let inner_val = match inner {\n      Ok(x) => x,\n      Err(_) => 0,\n    };\n    inner_val + risky_b()?\n  };\n  match outer {\n    Ok(x) => x,\n    Err(_) => -1,\n  }\n}\n"
 ---
 package main
@@ -27,18 +28,18 @@ func test() int {
 			return lisette.MakeResultOk[int, string](result_4)
 		}()
 		inner = tryResult_2
-		var inner_val int
+		var _left_7 int
 		if inner.Tag == lisette.ResultOk {
-			inner_val = inner.OkVal
+			_left_7 = inner.OkVal
 		} else {
-			inner_val = 0
+			_left_7 = 0
 		}
 		check_5 := risky_b()
 		if check_5.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_5.ErrVal)
 		}
 		result_6 := check_5.OkVal
-		return lisette.MakeResultOk[int, string](inner_val + result_6)
+		return lisette.MakeResultOk[int, string](_left_7 + result_6)
 	}()
 	outer = tryResult_1
 	if outer.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
+++ b/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
+assertion_line: 3491
 description: "input: \nfn noop() {}\n\nfn main() {\n  let mut m = Map.new<(), int>()\n  m[()] = 7\n  let x = m[noop()]\n  let _ = x\n}\n"
 ---
 package main
@@ -10,6 +11,7 @@ func main() {
 	m := make(map[struct{}]int)
 	idx_1 := struct{}{}
 	m[idx_1] = 7
+	_base_2 := m
 	noop()
-	_ = m[struct{}{}]
+	_ = _base_2[struct{}{}]
 }

--- a/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/concurrency.rs
+assertion_line: 881
 description: "input: \nfn noop() {}\n\nfn test() {\n  let ch = Channel.buffered<()>(1)\n  ch.send(noop())\n}\n"
 ---
 package main
@@ -10,6 +11,7 @@ func noop() {}
 
 func test() {
 	ch := make(chan struct{}, 1)
+	_arg_1 := ch
 	noop()
-	_ = lisette.ChannelSend(ch, struct{}{})
+	_ = lisette.ChannelSend(_arg_1, struct{}{})
 }

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
+assertion_line: 3463
 description: "input: \nfn noop() {}\n\nfn main() {\n  let xs: Slice<()> = []\n  let y = Slice.append(xs, noop())\n  let _ = y\n}\n"
 ---
 package main
@@ -8,6 +9,7 @@ func noop() {}
 
 func main() {
 	xs := []struct{}{}
+	_arg_1 := xs
 	noop()
-	_ = append(xs, struct{}{})
+	_ = append(_arg_1, struct{}{})
 }

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
+assertion_line: 3410
 description: "input: \nfn noop() {}\n\nfn test() {\n  let mut xs: Slice<()> = []\n  xs.append(noop())\n}\n"
 ---
 package main
@@ -8,6 +9,7 @@ func noop() {}
 
 func test() {
 	xs := []struct{}{}
+	_arg_1 := xs
 	noop()
-	_ = append(xs, struct{}{})
+	_ = append(_arg_1, struct{}{})
 }

--- a/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/spec/emit/functions.rs
+assertion_line: 1428
 description: "input: \nfn noop() {}\n\nstruct Box {}\n\nimpl Box {\n  fn ping(self, _x: ()) {}\n}\n\nfn test() {\n  let b = Box {}\n  Box.ping(b, noop())\n}\n"
 ---
 package main
@@ -16,6 +17,7 @@ func (b Box) ping(_ struct{}) {}
 
 func test() {
 	b := Box{}
+	_arg_1 := b
 	noop()
-	b.ping(struct{}{})
+	_arg_1.ping(struct{}{})
 }


### PR DESCRIPTION
Sibling sub-expressions now evaluate left-to-right even when a later sibling needs a lowered setup that mutates state read by an earlier sibling. Previously, the later setup ran first and the earlier read observed the post-mutation value.

```rs
fn bump(mut xs: Slice<int>) -> Result<int, error> {
  xs[0] = 2
  Ok(0)
}

fn main() {
  let mut xs = [1]
  fmt.Println(xs[0], bump(xs).is_ok())
}
```

Previously printed `2 true`; now prints `1 true`.