### PR TITLE
fix: assign bindings in irrefutable let-else or-patterns

### DIFF
--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -615,13 +615,11 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
             .map(|alt| decision_tree::collect_pattern_info(self.emitter, alt, None))
             .collect();
 
-        if collected.iter().any(|(checks, _)| checks.is_empty()) {
-            return;
-        }
+        let irrefutable_idx = collected.iter().position(|(checks, _)| checks.is_empty());
+        let chain_len = irrefutable_idx.unwrap_or(collected.len());
 
-        for (i, (checks, bindings)) in collected.iter().enumerate() {
+        for (i, (checks, bindings)) in collected.iter().take(chain_len).enumerate() {
             let condition = decision_tree::render_condition(checks, subject_var);
-
             if i == 0 {
                 write_line!(output, "if {} {{", condition);
             } else {
@@ -629,6 +627,18 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
             }
 
             decision_tree::emit_tree_assignments(self.emitter, output, bindings, subject_var);
+        }
+
+        if let Some(idx) = irrefutable_idx {
+            let (_, bindings) = &collected[idx];
+            if idx == 0 {
+                decision_tree::emit_tree_assignments(self.emitter, output, bindings, subject_var);
+            } else {
+                output.push_str("} else {\n");
+                decision_tree::emit_tree_assignments(self.emitter, output, bindings, subject_var);
+                output.push_str("}\n");
+            }
+            return;
         }
 
         // Restore outer bindings for else body.

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -3000,6 +3000,19 @@ fn test() {
 }
 
 #[test]
+fn let_else_or_pattern_irrefutable_binding() {
+    let input = r#"
+fn test() -> int {
+  let x | x = 42 else {
+    return 0
+  }
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_complex_pattern_unused_item() {
     let input = r#"
 struct P { v: int }

--- a/tests/spec/emit/snapshots/let_else_or_pattern_irrefutable_binding.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_irrefutable_binding.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/emit/control_flow.rs
+assertion_line: 3012
+description: "input: \nfn test() -> int {\n  let x | x = 42 else {\n    return 0\n  }\n  x\n}\n"
+---
+package main
+
+func test() int {
+	return 42
+}


### PR DESCRIPTION
`let else` in combination with or-patterns with an irrefutable alternative now assign the subject to the bindings instead of leaving them at Go zero values. The whole `let` cannot fail, but the bindings still need to receive the value.

```rs
fn main() {
  let x | x = 42 else {
    return
  }
  fmt.Println(x)
}
```

Previously printed `0` but now prints `42`.