### PR TITLE
ci: pass missing expression to fix build

### DIFF
--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -38,7 +38,7 @@ impl Emitter<'_> {
         let temp_var = self.fresh_var(Some(prefix));
         self.declare(&temp_var);
         write_line!(setup, "{} := {}", temp_var, value_expr);
-        Staged::new(setup, temp_var)
+        Staged::new(setup, temp_var, expression)
     }
 
     pub(crate) fn emit_force_capture(

--- a/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
@@ -15,9 +15,10 @@ func make_range() lisette.Range[int] {
 
 func main() {
 	s := []int{1, 2, 3}
+	_base_2 := s
 	range_1 := make_range()
-	sub := s[range_1.Start:range_1.End:range_1.End]
-	range_1_2 := 7
+	sub := _base_2[range_1.Start:range_1.End:range_1.End]
+	range_1_3 := 7
 	_ = sub
-	_ = range_1_2
+	_ = range_1_3
 }

--- a/tests/spec/emit/snapshots/range_index_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/range_index_evaluated_once.snap
@@ -19,7 +19,8 @@ func make_range() lisette.Range[int] {
 
 func main() {
 	items := []int{0, 1, 2, 3, 4}
+	_base_2 := items
 	range_1 := make_range()
-	sub := items[range_1.Start:range_1.End:range_1.End]
+	sub := _base_2[range_1.Start:range_1.End:range_1.End]
 	fmt.Println(len(sub))
 }


### PR DESCRIPTION
Fix the build. #336 added a third `expression` parameter to `Staged::new` and updated three call sites, but I missed the one in `stage_or_capture`.