### PR TITLE
fix: declare local const in go scope for let/const shadowing

### DIFF
--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -69,7 +69,15 @@ impl Emitter<'_> {
         expression: &Expression,
         ty: &Type,
     ) -> String {
-        let go_identifier = self.scope.bindings.add(identifier, identifier);
+        let initial_go_name = self.scope.bindings.add(identifier, identifier);
+        let go_identifier = if self.try_declare(&initial_go_name) {
+            initial_go_name
+        } else {
+            let fresh = self.fresh_var(Some(identifier));
+            self.scope.bindings.add(identifier, &fresh);
+            self.try_declare(&fresh);
+            fresh
+        };
         let ty_str = self.go_type_as_string(ty);
 
         let mut output = String::new();

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1260,6 +1260,36 @@ fn parse(s: string) -> Result<int, error> {
 }
 
 #[test]
+fn local_const_shadows_let_binding() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let x = 1
+  fmt.Println(x)
+  const x = 2
+  fmt.Println(x)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn local_let_shadows_const_binding() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  const x = 1
+  fmt.Println(x)
+  let x = 2
+  fmt.Println(x)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn let_discard_empty_block() {
     let input = r#"
 fn test() {

--- a/tests/spec/emit/snapshots/local_const_shadows_let_binding.snap
+++ b/tests/spec/emit/snapshots/local_const_shadows_let_binding.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 1274
+description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  let x = 1\n  fmt.Println(x)\n  const x = 2\n  fmt.Println(x)\n}\n"
+---
+package main
+
+import "fmt"
+
+func main() {
+	x := 1
+	fmt.Println(x)
+	const x_1 int = 2
+	fmt.Println(x_1)
+}

--- a/tests/spec/emit/snapshots/local_let_shadows_const_binding.snap
+++ b/tests/spec/emit/snapshots/local_let_shadows_const_binding.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/expressions.rs
+assertion_line: 1289
+description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  const x = 1\n  fmt.Println(x)\n  let x = 2\n  fmt.Println(x)\n}\n"
+---
+package main
+
+import "fmt"
+
+func main() {
+	const x int = 1
+	fmt.Println(x)
+	x_1 := 2
+	fmt.Println(x_1)
+}


### PR DESCRIPTION
A local `const` declaration now participates in Go-scope name tracking, so it can shadow a preceding `let` binding (and a later `let` can shadow it) without producing invalid Go.

```rs
fn main() {
  let x = 1
  fmt.Println(x)
  const x = 2
  fmt.Println(x)
}
```

Previously this emitted a Go program that failed to compile with `x redeclared in this block`.