### PR TITLE
fix: freshen go-escaped names that clash with siblings

### DIFF
--- a/crates/emit/src/collectors.rs
+++ b/crates/emit/src/collectors.rs
@@ -1,7 +1,8 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::names::go_name;
 use crate::Emitter;
+use syntax::ast::{Expression, Visibility};
 use syntax::program::{DefinitionBody, File};
 use syntax::types::Type;
 
@@ -62,6 +63,50 @@ impl Emitter<'_> {
                 }
                 _ => {}
             }
+        }
+    }
+
+    /// Detect free top-level private Lisette names (free functions and
+    /// constants) whose natural Go form would collide after `escape_reserved`
+    /// — e.g. `len` escapes to `len_` and clashes with a sibling `len_`. The
+    /// verbatim name claims its Go form; each escaped collider is remapped
+    /// to `name_2`, `name_3`, etc. until unique. Public functions go through
+    /// `snake_to_camel` and a separate identifier path, so they are not
+    /// considered here.
+    pub(crate) fn collect_escape_remap(&mut self, files: &[&File]) {
+        let entries: Vec<(&str, String)> = files
+            .iter()
+            .flat_map(|f| &f.items)
+            .filter_map(|item| match item {
+                Expression::Function {
+                    name,
+                    visibility: Visibility::Private,
+                    ..
+                } => Some((name.as_str(), go_name::escape_reserved(name).into_owned())),
+                Expression::Const { identifier, .. } => Some((
+                    identifier.as_str(),
+                    go_name::escape_reserved(identifier).into_owned(),
+                )),
+                _ => None,
+            })
+            .collect();
+
+        let mut taken: HashSet<String> = entries
+            .iter()
+            .filter(|(name, natural)| *name == natural)
+            .map(|(_, natural)| natural.clone())
+            .collect();
+
+        for (name, natural) in &entries {
+            if *name == natural || taken.insert(natural.clone()) {
+                continue;
+            }
+            let fresh = (2..)
+                .map(|n| format!("{}_{}", name, n))
+                .find(|c| !taken.contains(c))
+                .expect("freshening counter is unbounded");
+            taken.insert(fresh.clone());
+            self.module.escape_remap.insert((*name).to_string(), fresh);
         }
     }
 

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -145,9 +145,7 @@ impl Emitter<'_> {
             .map(|p| {
                 let name = if let Pattern::Identifier { identifier, .. } = &p.pattern {
                     if let Some(go_name) = self.go_name_for_binding(&p.pattern) {
-                        let go_id = self.scope.bindings.add(identifier, go_name);
-                        self.declare(&go_id);
-                        go_id
+                        self.declare_param(identifier, go_name)
                     } else {
                         self.scope.bindings.add(identifier, "_");
                         "_".to_string()
@@ -228,6 +226,20 @@ impl Emitter<'_> {
         )
     }
 
+    /// Bind and declare a parameter. If the natural post-escape Go name is
+    /// already declared in this scope, pick a fresh Go name so later identifier lookups in the body resolve to the renamed slot.
+    fn declare_param(&mut self, lisette_name: &str, raw_go_name: impl Into<String>) -> String {
+        let go_id = self.scope.bindings.add(lisette_name, raw_go_name);
+        let go_id = if self.is_declared(&go_id) {
+            let fresh = self.fresh_var(Some(lisette_name));
+            self.scope.bindings.add(lisette_name, fresh)
+        } else {
+            go_id
+        };
+        self.declare(&go_id);
+        go_id
+    }
+
     pub(crate) fn is_go_never(expression: &Expression) -> bool {
         match expression {
             Expression::Return { .. } => true,
@@ -273,6 +285,12 @@ impl Emitter<'_> {
             go_name::snake_to_camel(&function_definition.name)
         } else if receiver.is_some() {
             go_name::escape_keyword(&function_definition.name).into_owned()
+        } else if let Some(remapped) = self
+            .module
+            .escape_remap
+            .get(function_definition.name.as_str())
+        {
+            remapped.clone()
         } else {
             go_name::escape_reserved(&function_definition.name).into_owned()
         };
@@ -460,9 +478,7 @@ impl Emitter<'_> {
             let name = match &param.pattern {
                 Pattern::Identifier { identifier, .. } => {
                     if let Some(go_name) = self.go_name_for_binding(&param.pattern) {
-                        let go_id = self.scope.bindings.add(identifier, go_name);
-                        self.declare(&go_id);
-                        go_id
+                        self.declare_param(identifier, go_name)
                     } else {
                         "_".to_string()
                     }

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -69,7 +69,11 @@ impl Emitter<'_> {
         expression: &Expression,
         ty: &Type,
     ) -> String {
-        let go_identifier = self.scope.bindings.add(identifier, identifier);
+        let target_name = match self.module.escape_remap.get(identifier) {
+            Some(remapped) => remapped.clone(),
+            None => identifier.to_string(),
+        };
+        let go_identifier = self.scope.bindings.add(identifier, target_name);
         let ty_str = self.go_type_as_string(ty);
 
         let mut output = String::new();

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -95,6 +95,10 @@ struct ModuleData {
     absorbed_ref_generics: HashSet<String>,
     /// Pre-computed wrapping strategy per Go function.
     go_call_strategies: HashMap<String, GoCallStrategy>,
+    /// Lisette name → freshened Go name when `escape_reserved` would collide
+    /// with a sibling top-level definition (e.g. `fn len` and `fn len_` both
+    /// targeting `len_`). Consulted at definition and call sites.
+    escape_remap: HashMap<String, String>,
 }
 
 struct ScopeState {
@@ -284,6 +288,7 @@ impl<'a> Emitter<'a> {
                 reverse_module_aliases: HashMap::default(),
                 absorbed_ref_generics: HashSet::default(),
                 go_call_strategies: HashMap::default(),
+                escape_remap: HashMap::default(),
             },
             scope: ScopeState {
                 next_var: 0,
@@ -499,6 +504,7 @@ impl<'a> Emitter<'a> {
         self.collect_exported_method_names(files);
         self.collect_impl_bounds(files);
         self.collect_enum_layouts();
+        self.collect_escape_remap(files);
         let mut make_functions_by_file = self.collect_make_functions();
 
         let mut output_files = Vec::new();

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -5,6 +5,13 @@ use crate::names::go_name;
 
 impl Emitter<'_> {
     pub(crate) fn resolve_go_name(&mut self, name: &str) -> String {
+        if !self.module.escape_remap.is_empty()
+            && !name.contains('.')
+            && let Some(remapped) = self.module.escape_remap.get(name)
+        {
+            return remapped.clone();
+        }
+
         if let Some(go_call) = self.try_resolve_cross_module_static_method(name) {
             return go_call;
         }


### PR DESCRIPTION
Lisette names that escape to a Go-builtin form (e.g. `len` → `len_`) no longer collide with sibling declarations that already use the escaped form.

Previously, this produced invalid Go:

```rs
fn len() -> int { 1 }
fn len_() -> int { 2 }

fn main() {
  fmt.Println(len(), len_())
}
```