### PR TITLE
fix: freshen rest binding in let-else or-pattern

### DIFF
--- a/crates/emit/src/patterns/bindings.rs
+++ b/crates/emit/src/patterns/bindings.rs
@@ -261,6 +261,18 @@ impl Emitter<'_> {
             self.scope.bindings.add(lisette_name, "_");
             return;
         };
+        self.declare_var_decl(output, lisette_name, go_name, resolved);
+    }
+
+    /// Freshen `go_name` against the current scope, register the binding, and
+    /// emit `var X T`. Used for both identifier and slice-rest declarations.
+    fn declare_var_decl(
+        &mut self,
+        output: &mut String,
+        lisette_name: &EcoString,
+        go_name: String,
+        resolved: &Type,
+    ) {
         let go_name = if self.is_declared(&go_name) {
             self.fresh_var(Some(lisette_name))
         } else {
@@ -542,9 +554,7 @@ impl Emitter<'_> {
         if let RestPattern::Bind { name, .. } = rest
             && let Some(go_name) = self.go_name_for_rest_binding(rest)
         {
-            let go_name = self.scope.bindings.add(name, go_name);
-            let go_ty = self.go_type_as_string(resolved);
-            write_line!(output, "var {} {}", go_name, go_ty);
+            self.declare_var_decl(output, name, go_name, resolved);
         }
     }
 

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -580,6 +580,23 @@ fn main() {
 }
 
 #[test]
+fn or_pattern_let_else_rest_shadow() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let rest = [99]
+  fmt.Println(rest[0])
+  let [x, ..rest] | [x, ..rest] = [1, 2] else {
+    return
+  }
+  fmt.Println(x, rest[0])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn match_on_go_interface_emits_type_switch() {
     let input = r#"
 import "go:example.com/events"

--- a/tests/spec/emit/snapshots/or_pattern_let_else_rest_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_rest_shadow.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/patterns.rs
+assertion_line: 596
+description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  let rest = [99]\n  fmt.Println(rest[0])\n  let [x, ..rest] | [x, ..rest] = [1, 2] else {\n    return\n  }\n  fmt.Println(x, rest[0])\n}\n"
+---
+package main
+
+import "fmt"
+
+func main() {
+	rest := []int{99}
+	fmt.Println(rest[0])
+	subject_1 := []int{1, 2}
+	var x int
+	var rest_2 []int
+	if len(subject_1) >= 1 {
+		x = subject_1[0]
+		rest_2 = subject_1[1:]
+	} else if len(subject_1) >= 1 {
+		x = subject_1[0]
+		rest_2 = subject_1[1:]
+	} else {
+		return
+	}
+	fmt.Println(x, rest_2[0])
+}


### PR DESCRIPTION
Fixes a `let else` or-pattern with a `..rest` slice binding emitting Go that does not compile when the rest name shadows an outer binding.

```rs
let rest = [99]
let [x, ..rest] | [x, ..rest] = [1, 2] else {
  return
}
```