### PR TITLE
fix: snapshot bytes-loop receiver to survive body reassignment

### DIFF
--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -324,16 +324,7 @@ impl Emitter<'_> {
     ) {
         self.enter_scope();
 
-        let can_skip_copy = if let Expression::Identifier {
-            binding_id: Some(id),
-            ..
-        } = iterable
-        {
-            !self.ctx.mutations.is_mutated(*id)
-        } else {
-            false
-        };
-        let range_var = if can_skip_copy {
+        let range_var = if self.is_unmutated_identifier(iterable) {
             self.emit_operand(output, iterable)
         } else {
             self.emit_force_capture(output, iterable, "_range")
@@ -411,8 +402,8 @@ impl Emitter<'_> {
     }
 
     /// `for b in s.bytes()` lowers to a C-style byte-indexed loop, bypassing
-    /// the `[]byte(s)` allocation. Captures the receiver if it has side
-    /// effects, since `len(s)` and `s[i]` reference it twice.
+    /// the `[]byte(s)` allocation. Snapshots the receiver unless it is an
+    /// unmutated identifier, since `len(s)` and `s[i]` reference it twice.
     fn emit_bytes_for_loop(
         &mut self,
         output: &mut String,
@@ -421,7 +412,11 @@ impl Emitter<'_> {
         body: &Expression,
     ) {
         self.enter_scope();
-        let recv_var = self.emit_or_capture(output, receiver, "_s");
+        let recv_var = if self.is_unmutated_identifier(receiver) {
+            self.emit_operand(output, receiver)
+        } else {
+            self.emit_force_capture(output, receiver, "_s")
+        };
         if let Some(label) = self.current_loop_label() {
             write_line!(output, "{}:", label);
         }
@@ -441,6 +436,18 @@ impl Emitter<'_> {
         self.emit_block(output, body);
         output.push_str("}\n");
         self.exit_scope();
+    }
+
+    fn is_unmutated_identifier(&self, expression: &Expression) -> bool {
+        if let Expression::Identifier {
+            binding_id: Some(id),
+            ..
+        } = expression
+        {
+            !self.ctx.mutations.is_mutated(*id)
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -14,17 +14,6 @@ pub(crate) struct VariadicCombine {
 }
 
 impl Emitter<'_> {
-    pub(crate) fn emit_or_capture(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        prefix: &str,
-    ) -> String {
-        let staged = self.stage_or_capture(expression, prefix);
-        output.push_str(&staged.setup);
-        staged.value
-    }
-
     pub(crate) fn stage_or_capture(&mut self, expression: &Expression, prefix: &str) -> Staged {
         if matches!(
             expression,

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -97,6 +97,25 @@ fn test(s: string) {
 }
 
 #[test]
+fn for_bytes_loop_captures_mutated_receiver() {
+    let input = r#"
+fn main() {
+  let mut s = "ab"
+  let mut count = 0
+  for b in s.bytes() {
+    count += 1
+    s = ""
+    let _ = b
+  }
+  if count != 2 {
+    panic("expected count 2 — bytes loop must iterate over the original string")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_new() {
     let input = r#"
 fn test() -> Slice<int> {

--- a/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
+++ b/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 115
+description: "input: \nfn main() {\n  let mut s = \"ab\"\n  let mut count = 0\n  for b in s.bytes() {\n    count += 1\n    s = \"\"\n    let _ = b\n  }\n  if count != 2 {\n    panic(\"expected count 2 — bytes loop must iterate over the original string\")\n  }\n}\n"
+---
+package main
+
+func main() {
+	s := "ab"
+	count := 0
+	_s_1 := s
+	for _i_2 := 0; _i_2 < len(_s_1); _i_2++ {
+		b := _s_1[_i_2]
+		count++
+		s = ""
+		_ = b
+	}
+	if count != 2 {
+		panic("expected count 2 — bytes loop must iterate over the original string")
+	}
+}


### PR DESCRIPTION
A `for b in s.bytes()` loop now iterates over the receiver value at loop entry, so reassigning the loop variable in the body does not truncate the iteration. This matches the semantics of `for r in s.runes()` and Go's `for range` form.