### PR TITLE
fix: bridge Option<T> on scalar args to *scalar at callsites

### DIFF
--- a/bindgen/bindgen.external.json
+++ b/bindgen/bindgen.external.json
@@ -66,6 +66,17 @@
         ]
       },
       "nilable_param": {
+        "github.com/ilyakaznacheev/cleanenv": {
+          "FUsage": [
+            "headerText"
+          ],
+          "GetDescription": [
+            "headerText"
+          ],
+          "Usage": [
+            "headerText"
+          ]
+        },
         "go.mongodb.org/mongo-driver/v2/mongo": {
           "Client.Ping": [
             "rp"

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -390,8 +390,10 @@ impl Emitter<'_> {
         Some(self.emit_lisette_callback_wrapper(output, &value, &param_fn_ty))
     }
 
-    /// Bridge a Lisette `Option<Ref<T>>` argument to Go `*T` when the Go
-    /// parameter accepts nil.
+    /// Bridge a Lisette `Option<T>` argument to Go's nil-accepting form: `*T`
+    /// when the param is `Option<Ref<T>>` (`is_nullable_option`), and also `*T`
+    /// when the param is `Option<scalar>` (`is_non_nilable_option`, the
+    /// pointer-bridged shape produced by bindgen's `nilable_param` config).
     fn try_emit_go_pointer_param_unwrap(
         &mut self,
         output: &mut String,
@@ -399,14 +401,19 @@ impl Emitter<'_> {
         effective_param_ty: Option<&Type>,
     ) -> Option<String> {
         let param_ty = effective_param_ty?;
-        if !self.is_nullable_option(param_ty) {
-            return None;
-        }
         let arg_ty = arg.get_type();
-        if !self.is_nullable_option(&arg_ty) {
-            return None;
+        if self.is_nullable_option(param_ty) && self.is_nullable_option(&arg_ty) {
+            return Some(self.emit_unwrap_go_nullable_arg(output, arg, &arg_ty));
         }
-        Some(self.emit_unwrap_go_nullable_arg(output, arg, &arg_ty))
+        if self.is_non_nilable_option(param_ty) && self.is_non_nilable_option(&arg_ty) {
+            if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
+                return Some("nil".to_string());
+            }
+            let value = self.emit_value(output, arg);
+            let coercion = Coercion::resolve_unwrap_go_nullable(self, &arg_ty, Some(param_ty));
+            return Some(coercion.apply(self, output, value));
+        }
+        None
     }
 
     fn try_emit_nullable_coercion(

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1251,6 +1251,36 @@ pub struct Options {
 }
 
 #[test]
+fn interop_pointer_scalar_param_some() {
+    let input = r#"
+import "go:example.com/cfg"
+
+fn main() {
+  cfg.Configure(Some("custom"))
+}
+"#;
+    let typedef = r#"
+pub fn Configure(name: Option<string>) -> ()
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cfg", typedef)]);
+}
+
+#[test]
+fn interop_pointer_scalar_param_none() {
+    let input = r#"
+import "go:example.com/cfg"
+
+fn main() {
+  cfg.Configure(None)
+}
+"#;
+    let typedef = r#"
+pub fn Configure(name: Option<string>) -> ()
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cfg", typedef)]);
+}
+
+#[test]
 fn interop_struct_field_read_option_string_match() {
     let input = r#"
 import "go:example.com/aws"

--- a/tests/spec/emit/snapshots/interop_pointer_scalar_param_none.snap
+++ b/tests/spec/emit/snapshots/interop_pointer_scalar_param_none.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1280
+description: "input: \nimport \"go:example.com/cfg\"\n\nfn main() {\n  cfg.Configure(None)\n}\n"
+---
+package main
+
+import "example.com/cfg"
+
+func main() {
+	cfg.Configure(nil)
+}

--- a/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
+++ b/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 1265
+description: "input: \nimport \"go:example.com/cfg\"\n\nfn main() {\n  cfg.Configure(Some(\"custom\"))\n}\n"
+---
+package main
+
+import (
+	"example.com/cfg"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	opt_1 := lisette.MakeOptionSome("custom")
+	var ptr_2 *string
+	if opt_1.Tag == lisette.OptionSome {
+		ptr_2 = &opt_1.SomeVal
+	}
+	cfg.Configure(ptr_2)
+}


### PR DESCRIPTION
Adds support for calling Go functions whose `*T` parameter accepts `nil` (bound as `Option<T>` for a scalar T) with `None` from Lisette. The emit pass previously bridged only `Option<Ref<T>>` to `*T`, so `Option<scalar>` arguments type-checked but produced Go that failed to compile.