### PR TITLE
fix: exempt tag-attributed fields from unused_struct_field lint

### DIFF
--- a/crates/semantics/src/validators/ref_lints/mod.rs
+++ b/crates/semantics/src/validators/ref_lints/mod.rs
@@ -201,12 +201,15 @@ fn collect_items(
 
                     for struct_field in fields {
                         let field_id = StructFieldId::new(name, &struct_field.name);
+                        let has_tag_attribute =
+                            struct_field.attributes.iter().any(|a| a.name == "tag");
                         graph.add_struct_field(
                             field_id,
                             StructFieldInfo {
                                 span: struct_field.name_span,
                                 parent_is_public: is_public,
                                 parent_has_serialization_attr: has_serialization_attr,
+                                has_tag_attribute,
                             },
                         );
                     }

--- a/crates/semantics/src/validators/ref_lints/reference_graph.rs
+++ b/crates/semantics/src/validators/ref_lints/reference_graph.rs
@@ -37,6 +37,7 @@ pub struct StructFieldInfo {
     pub span: Span,
     pub parent_is_public: bool,
     pub parent_has_serialization_attr: bool,
+    pub has_tag_attribute: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -162,6 +163,7 @@ impl ReferenceGraph {
             .filter(|(id, info)| {
                 !info.parent_is_public
                     && !info.parent_has_serialization_attr
+                    && !info.has_tag_attribute
                     && !self.used_struct_fields.contains(*id)
                     && !id.field_name.starts_with('_')
             })

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1112,6 +1112,24 @@ fn main() {
 }
 
 #[test]
+fn field_with_tag_attribute_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+struct User {
+  #[tag(`validate:"required,email"`)]
+  email: string,
+  #[tag(`validate:"gte=0"`)]
+  age: int,
+}
+
+fn main() {
+  let _u = User { email: "a@b.c", age: 1 }
+}
+"#
+    );
+}
+
+#[test]
 fn struct_field_used_in_pattern() {
     assert_no_lint_warnings!(
         r#"


### PR DESCRIPTION
A field with a `#[tag(...)]` attribute is no longer flagged by `unused_struct_field`. The attribute itself declares that the field is consumed via Go struct tags, so the existing `pub struct` and `#[json]`, `#[xml]`, `#[db]`, etc. exemptions now extend to any per-field tag, including reflection-driven libraries.

```rs
struct User {
  #[tag(`validate:"required,min=2"`)]
  name: string,
  #[tag(`validate:"required,email"`)]
  email: string,
}
```