### PR TITLE
refactor: improve function type mismatch diagnostic

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -805,10 +805,27 @@ impl TaskState<'_> {
             return format!("Cast with `as`, e.g. `value as {}`", expected);
         }
 
+        if let Some(ret) = function_return_under_nominal(expected)
+            && ret == actual
+        {
+            return "Remove the `()` so that the type matches".to_string();
+        }
+
         format!(
             "Change the type annotation to `{}` or convert the value to `{}`",
             actual, expected
         )
+    }
+}
+
+fn function_return_under_nominal(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Function { return_type, .. } => Some(return_type),
+        Type::Nominal {
+            underlying_ty: Some(u),
+            ..
+        } => function_return_under_nominal(u),
+        _ => None,
     }
 }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1045,6 +1045,44 @@ fn test() {
 }
 
 #[test]
+fn infer_called_function_when_function_alias_expected() {
+    let input = r#"
+type Cmd = fn() -> int
+
+fn quit() -> int { 0 }
+
+fn test() {
+  let _x: Cmd = quit()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_called_function_when_bare_function_type_expected() {
+    let input = r#"
+fn quit() -> int { 0 }
+
+fn test() {
+  let _x: fn() -> int = quit()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_called_function_when_multi_arg_function_type_expected() {
+    let input = r#"
+fn add(a: int, b: int) -> int { a + b }
+
+fn test() {
+  let _x: fn(int, int) -> int = add(1, 2)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_nested_function() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/infer_called_function_when_bare_function_type_expected.snap
+++ b/tests/ui/errors/snapshots/infer_called_function_when_bare_function_type_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:25]
+ 4 │ fn test() {
+ 5 │   let _x: fn() -> int = quit()
+   ·                         ───┬──
+   ·                            ╰── expected `fn () -> int`, found `int`
+ 6 │ }
+   ╰────
+  help: Remove the `()` so that the type matches · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_called_function_when_function_alias_expected.snap
+++ b/tests/ui/errors/snapshots/infer_called_function_when_function_alias_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:7:17]
+ 6 │ fn test() {
+ 7 │   let _x: Cmd = quit()
+   ·                 ───┬──
+   ·                    ╰── expected `Cmd`, found `int`
+ 8 │ }
+   ╰────
+  help: Remove the `()` so that the type matches · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_called_function_when_multi_arg_function_type_expected.snap
+++ b/tests/ui/errors/snapshots/infer_called_function_when_multi_arg_function_type_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:33]
+ 4 │ fn test() {
+ 5 │   let _x: fn(int, int) -> int = add(1, 2)
+   ·                                 ────┬────
+   ·                                     ╰── expected `fn (int, int) -> int`, found `int`
+ 6 │ }
+   ╰────
+  help: Remove the `()` so that the type matches · code: [infer.type_mismatch]


### PR DESCRIPTION
Adds dedicated help text for the type mismatch diagnostic where the expected type is a function and the actual type is that function's return type.