### PR TITLE
fix: emit never-bodied lambda as func() into unknown arg

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -326,12 +326,15 @@ impl Emitter<'_> {
             return format!("&{}", temp);
         }
 
+        let unwrapped_param_ty = effective_param_ty.map(|p| p.unwrap_forall());
         let suppress = ctx.is_prelude_dispatch
-            && effective_param_ty
-                .is_some_and(|p| matches!(p.unwrap_forall(), Type::Function { .. }));
+            && unwrapped_param_ty.is_some_and(|p| matches!(p, Type::Function { .. }));
+        let flows_to_unknown = unwrapped_param_ty.is_some_and(|p| p.resolves_to_unknown());
         let saved = std::mem::replace(&mut self.suppress_go_fn_short_circuit, suppress);
+        let saved_flows = std::mem::replace(&mut self.arg_flows_to_unknown, flows_to_unknown);
         let value = self.emit_composite_value(output, arg);
         self.suppress_go_fn_short_circuit = saved;
+        self.arg_flows_to_unknown = saved_flows;
         match effective_param_ty {
             Some(target) => {
                 let coercion = Coercion::resolve(self, &arg.get_type(), target);

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -167,7 +167,9 @@ impl Emitter<'_> {
             .collect();
 
         let has_return = matches!(ty, Type::Function { return_type, .. }
-            if !return_type.is_unit() && !return_type.is_variable());
+            if !(return_type.is_unit()
+                || return_type.is_variable()
+                || (self.arg_flows_to_unknown && return_type.is_never())));
 
         // When the lambda flows into a Go-prelude generic callback that
         // expects the unlowered single-return form, suppress the lambda's
@@ -201,6 +203,7 @@ impl Emitter<'_> {
             });
         }
         let saved_suppress = std::mem::replace(&mut self.suppress_go_fn_short_circuit, false);
+        let saved_flows = std::mem::replace(&mut self.arg_flows_to_unknown, false);
 
         let mut body_string = String::new();
 
@@ -217,6 +220,7 @@ impl Emitter<'_> {
 
         self.current_return_context = saved_return_context;
         self.suppress_go_fn_short_circuit = saved_suppress;
+        self.arg_flows_to_unknown = saved_flows;
 
         format!(
             "func({}){} {{\n{}}}",

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -163,6 +163,10 @@ pub struct Emitter<'a> {
     /// Set when the destination is a Go-side function (e.g. a generic
     /// `func(T) U` callback) that needs the unlowered single-return form.
     suppress_go_fn_short_circuit: bool,
+    /// True while emitting an argument into an `Unknown` (`any`) param;
+    /// makes `emit_lambda` render `Never`-returning lambdas as `func()`
+    /// (not `func() struct{}`).
+    arg_flows_to_unknown: bool,
 }
 
 /// `force_tagged` is set inside try-block IIFEs whose outer signature is
@@ -312,6 +316,7 @@ impl<'a> Emitter<'a> {
             skip_array_return_wrap: false,
             current_slot_expected_ty: None,
             suppress_go_fn_short_circuit: false,
+            arg_flows_to_unknown: false,
         }
     }
 

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -715,6 +715,33 @@ fn test() -> string {
 }
 
 #[test]
+fn never_bodied_lambda_into_unknown_emits_unit_return() {
+    let input = r#"
+fn take_any(x: Unknown) {}
+
+fn test() {
+  take_any(|| { panic("boom") })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn never_bodied_lambda_into_generic_keeps_struct_return() {
+    let input = r#"
+fn run<T>(f: fn() -> T) -> int {
+  let _ = f
+  0
+}
+
+fn test() -> int {
+  run(|| { panic("boom") })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn doc_comment_on_public_function() {
     let input = r#"
 /// A publicly exported function.

--- a/tests/spec/emit/snapshots/never_bodied_lambda_into_generic_keeps_struct_return.snap
+++ b/tests/spec/emit/snapshots/never_bodied_lambda_into_generic_keeps_struct_return.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/functions.rs
+description: "input: \nfn run<T>(f: fn() -> T) -> int {\n  let _ = f\n  0\n}\n\nfn test() -> int {\n  run(|| { panic(\"boom\") })\n}\n"
+---
+package main
+
+func run[T any](f func() T) int {
+	_ = f
+	return 0
+}
+
+func test() int {
+	return run(func() struct{} {
+		panic("boom")
+	})
+}

--- a/tests/spec/emit/snapshots/never_bodied_lambda_into_unknown_emits_unit_return.snap
+++ b/tests/spec/emit/snapshots/never_bodied_lambda_into_unknown_emits_unit_return.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: "input: \nfn take_any(x: Unknown) {}\n\nfn test() {\n  take_any(|| { panic(\"boom\") })\n}\n"
+---
+package main
+
+func take_any(_ any) {}
+
+func test() {
+	take_any(func() {
+		panic("boom")
+	})
+}


### PR DESCRIPTION
A `Never` bodied lambda like `|| { panic(...) }` passed to an `Unknown` typed parameter now emits as Go `func()` instead of `func() struct{}`, so reflection-based libraries recognize the signature. Previously, `gomega.Panic()` rejected the closure because Lis lowered its inferred `Never` return type to Go's empty struct.