### PR TITLE
refactor: improve ref qualifier misuse diagnostic

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2615,6 +2615,13 @@ pub fn type_alias_as_qualifier(
         ))
 }
 
+pub fn ref_qualifier(member: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid `Ref` construction")
+        .with_infer_code("ref_qualifier")
+        .with_span_label(&span, format!("`Ref` has no `{}`", member))
+        .with_help("To take a reference, use `&value`")
+}
+
 pub fn control_flow_in_expression(keyword: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`{}` cannot be used in expression position",

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -127,17 +127,24 @@ impl TaskState<'_> {
             let is_generic = matches!(alias_ty, Type::Forall { .. })
                 || matches!(underlying, Type::Nominal { params, .. } if !params.is_empty());
             if is_generic {
-                let type_name = if let Type::Nominal { id, .. } = underlying {
-                    unqualified_name(id).to_string()
+                if qualified_root == "prelude.Ref" {
+                    self.sink.push(diagnostics::infer::ref_qualifier(
+                        &member,
+                        expression.get_span(),
+                    ));
                 } else {
-                    "the original type".to_string()
-                };
-                self.sink.push(diagnostics::infer::type_alias_as_qualifier(
-                    root,
-                    &type_name,
-                    &member,
-                    expression.get_span(),
-                ));
+                    let type_name = if let Type::Nominal { id, .. } = underlying {
+                        unqualified_name(id).to_string()
+                    } else {
+                        "the original type".to_string()
+                    };
+                    self.sink.push(diagnostics::infer::type_alias_as_qualifier(
+                        root,
+                        &type_name,
+                        &member,
+                        expression.get_span(),
+                    ));
+                }
                 return Expression::DotAccess {
                     expression,
                     member,

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6756,6 +6756,18 @@ fn main() {
 }
 
 #[test]
+fn infer_ref_qualifier() {
+    let input = r#"
+fn main() {
+  let x = 42
+  let r = Ref.new(x)
+  let _ = r
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_parenthesized_type_qualifier() {
     let input = r#"
 struct Box {}

--- a/tests/ui/errors/snapshots/infer_ref_qualifier.snap
+++ b/tests/ui/errors/snapshots/infer_ref_qualifier.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid `Ref` construction
+   ╭─[test.lis:4:11]
+ 3 │   let x = 42
+ 4 │   let r = Ref.new(x)
+   ·           ─┬─
+   ·            ╰── `Ref` has no `new`
+ 5 │   let _ = r
+   ╰────
+  help: To take a reference, use `&value` · code: [infer.ref_qualifier]


### PR DESCRIPTION
`Ref.new(x)` previously triggered a diagnostic suggesting using the original type directly, which is meaningless for `Ref<T>`, hence adding a dedicated diagnostic pointing users to `&value`.