### PR TITLE
ci: cut redundancy and speed up PR checks

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,5 +31,3 @@ runs:
         cache-dependency-path: '**/go.sum'
     - if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # ratchet:Swatinem/rust-cache@v2
-      with:
-        shared-key: ci

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -27,6 +27,9 @@ runs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
       with:
         go-version-file: go-version
-        cache: false
+        cache: true
+        cache-dependency-path: '**/go.sum'
     - if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # ratchet:Swatinem/rust-cache@v2
+      with:
+        shared-key: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go-version
-          cache: false
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
       - run: cd bindgen && golangci-lint run
       - run: cd prelude && golangci-lint run
@@ -87,18 +88,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           go: 'true'
-      - run: cargo test -p tests --test suite -- --format terse
-
-  build:
-    name: Build
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: ./.github/actions/setup-rust
+      - uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # ratchet:taiki-e/install-action@v2
         with:
-          just: 'true'
-      - run: just build
+          tool: cargo-nextest@0.9.133
+      - run: cargo nextest run -p tests --test suite
 
   stdlib-check:
     name: Stdlib check
@@ -145,7 +138,8 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go-version
-          cache: false
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - run: cd prelude && go test ./...
 
   shear:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           go: 'true'
-      - uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # ratchet:taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest@0.9.133
-      - run: cargo nextest run -p tests --test suite
+      - run: cargo test -p tests --test suite -- --format terse
 
   stdlib-check:
     name: Stdlib check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ opt-level = 3
 inherits = "release"
 debug = true
 
+[profile.bindgen]
+inherits = "release"
+opt-level = 1
+codegen-units = 256
+
 [profile.dist]
 inherits = "release"
 lto = "thin"

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ build-debug:
     cargo build
 
 test:
-    cargo nextest run -p tests --test suite --test lsp
+    cargo test -p tests --test suite --test lsp
 
 test-infer:
     cargo test -p tests --test suite infer_tests

--- a/justfile
+++ b/justfile
@@ -18,8 +18,7 @@ build-debug:
     cargo build
 
 test:
-    cargo test -p tests --test suite
-    cargo test -p tests --test lsp
+    cargo nextest run -p tests --test suite --test lsp
 
 test-infer:
     cargo test -p tests --test suite infer_tests
@@ -95,7 +94,12 @@ _stdlib-typedef-version:
     @grep '// Lisette:' crates/stdlib/typedefs/fmt.d.lis | awk '{print $3}'
 
 check-stdlib-drift:
-    just generate-stdlib-typedefs "$(just _stdlib-typedef-version)"
+    cd bindgen && just build
+    just build
+    ./target/release/lis check crates/stdlib/typedefs/
+    BINDGEN_TARGETS={{_supported-targets}} ./target/release/lis bindgen stdlib "$(just _stdlib-typedef-version)"
+    ./target/release/lis format crates/stdlib/typedefs/
+    just format
     git diff --exit-code crates/stdlib/
 
 # Build the playground and write output to docs/play/ (served at lisette.run/play)

--- a/justfile
+++ b/justfile
@@ -95,10 +95,10 @@ _stdlib-typedef-version:
 
 check-stdlib-drift:
     cd bindgen && just build
-    just build
-    ./target/release/lis check crates/stdlib/typedefs/
-    BINDGEN_TARGETS={{_supported-targets}} ./target/release/lis bindgen stdlib "$(just _stdlib-typedef-version)"
-    ./target/release/lis format crates/stdlib/typedefs/
+    cargo build --profile bindgen
+    ./target/bindgen/lis check crates/stdlib/typedefs/
+    BINDGEN_TARGETS={{_supported-targets}} ./target/bindgen/lis bindgen stdlib "$(just _stdlib-typedef-version)"
+    ./target/bindgen/lis format crates/stdlib/typedefs/
     just format
     git diff --exit-code crates/stdlib/
 


### PR DESCRIPTION
- Remove the redundant build job
- Refactor `check-stdlib-drift` to save a build
- Merge sequential `cargo test` calls in `just test`
- Enable the setup-go cache
- Use a low-opt cargo profile for `check-stdlib-drift`