### PR TITLE
refactor: extend fn-as-lambda diagnostic to expressions

### DIFF
--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -39,6 +39,9 @@ impl<'source> Parser<'source> {
             LeftCurlyBrace => self.parse_block_expression(),
             LeftSquareBracket => self.parse_slice_literal(),
             Identifier => self.parse_identifier(),
+            Function if self.stream.peek_ahead(1).kind == LeftParen => {
+                self.parse_fn_as_lambda_recovery()
+            }
             Function => self.parse_function(None, vec![]),
             Match => self.parse_match(),
             If => self.parse_if(),
@@ -454,18 +457,46 @@ impl<'source> Parser<'source> {
         if !(self.is(Function) && self.stream.peek_ahead(1).kind == LeftParen) {
             return false;
         }
-        let start = self.current_token();
-        let span = Span::new(self.file_id, start.byte_offset, start.byte_length + 1);
-        let error = ParseError::new("Syntax error", span, "expected a lambda")
-            .with_parse_code("fn_as_lambda")
-            .with_help("Use a lambda instead: `|x| x * 2`");
-        self.errors.push(error);
+        let span = self.track_fn_as_lambda_error();
         self.resync_on_error();
         args.push(Expression::Unit {
             ty: Type::uninferred(),
             span,
         });
         true
+    }
+
+    fn parse_fn_as_lambda_recovery(&mut self) -> Expression {
+        let start = self.current_token();
+        self.track_fn_as_lambda_error();
+
+        self.ensure(Function);
+        let params = self.parse_function_params();
+        let return_annotation = self.parse_function_return_annotation();
+
+        let body = if self.is(LeftCurlyBrace) {
+            self.parse_block_expression()
+        } else {
+            Expression::NoOp
+        };
+
+        Expression::Lambda {
+            params,
+            return_annotation,
+            body: body.into(),
+            ty: Type::uninferred(),
+            span: self.span_from_tokens(start),
+        }
+    }
+
+    fn track_fn_as_lambda_error(&mut self) -> Span {
+        let start = self.current_token();
+        let span = Span::new(self.file_id, start.byte_offset, start.byte_length + 1);
+        let error = ParseError::new("Syntax error", span, "expected a lambda")
+            .with_parse_code("fn_as_lambda")
+            .with_help("Use a lambda instead: `|x| x * 2`");
+        self.errors.push(error);
+        span
     }
 
     pub fn parse_type_args(&mut self) -> Vec<Annotation> {
@@ -796,12 +827,7 @@ impl<'source> Parser<'source> {
             }
 
             if self.is(Function) && self.stream.peek_ahead(1).kind == LeftParen {
-                let start = self.current_token();
-                let span = Span::new(self.file_id, start.byte_offset, start.byte_length + 1);
-                let error = ParseError::new("Syntax error", span, "expected a lambda")
-                    .with_parse_code("fn_as_lambda")
-                    .with_help("Use a lambda instead: `|x| x * 2`");
-                self.errors.push(error);
+                let span = self.track_fn_as_lambda_error();
                 self.resync_on_error();
                 expressions.push(Expression::Unit {
                     ty: Type::uninferred(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4447,6 +4447,22 @@ fn main() {
 }
 
 #[test]
+fn parse_fn_as_lambda_in_let_rhs() {
+    let input = r#"
+fn main() {
+  let op = fn() -> Result<(), error> {
+    Ok(())
+  }
+  match op() {
+    Ok(()) => 0,
+    Err(_) => 1,
+  };
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_go_slice_syntax_in_type() {
     let input = r#"
 fn test(arr: []int) {}

--- a/tests/ui/errors/snapshots/parse_fn_as_lambda_in_let_rhs.snap
+++ b/tests/ui/errors/snapshots/parse_fn_as_lambda_in_let_rhs.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:12]
+ 2 │ fn main() {
+ 3 │   let op = fn() -> Result<(), error> {
+   ·            ─┬─
+   ·             ╰── expected a lambda
+ 4 │     Ok(())
+   ╰────
+  help: Use a lambda instead: `|x| x * 2` · code: [parse.fn_as_lambda]


### PR DESCRIPTION
Writing a Go-style `fn(...) -> ...` as a lambda now emits the `parse.fn_as_lambda` hint at `fn` in any expression position. Previously this only fired inside call argument lists and delimited literals, so cases like a `let` right-hand side produced a cascade of misleading `parse.expected_declaration` errors.