### PR TITLE
fix: honor allow_unused_value config on bindgen methods

### DIFF
--- a/bindgen/bindgen.external.json
+++ b/bindgen/bindgen.external.json
@@ -27,6 +27,19 @@
           "SetStaticPath",
           "SetViewsPath",
           "UnregisterFixedRoute"
+        ],
+        "github.com/gobuffalo/buffalo": [
+          "App.DELETE",
+          "App.GET",
+          "App.Group",
+          "App.HEAD",
+          "App.OPTIONS",
+          "App.PATCH",
+          "App.POST",
+          "App.PUT",
+          "App.Redirect",
+          "App.Resource",
+          "App.VirtualHost"
         ]
       }
     },

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -400,7 +400,12 @@ func (e *Emitter) emitMethodInImpl(result convert.ConvertResult) {
 			e.buf.WriteString("  #[allow(unused_result)]\n")
 		}
 	}
-	if result.BuilderMethod {
+	allowUnusedValue := result.BuilderMethod
+	if !allowUnusedValue && result.Receiver != nil && result.HasReturn() {
+		qualifiedName := result.Receiver.BaseTypeName + "." + result.Name
+		allowUnusedValue = e.cfg.ShouldAllowUnusedValue(e.pkgPath, qualifiedName)
+	}
+	if allowUnusedValue {
 		e.buf.WriteString("  #[allow(unused_value)]\n")
 	}
 


### PR DESCRIPTION
Bindgen now honors `allow_unused_value` overrides on methods in `Type.Method` form, alongside the existing top-level function support.

```rs
import "go:net/http"
import "go:github.com/gobuffalo/buffalo"
import "go:github.com/gobuffalo/buffalo/render"

let app = buffalo.New(buffalo.NewOptions())

app.GET("/", |c| {
  c.Render(http.StatusOK, render.String("hello"))
})
```

Follow-up to #356