### PR TITLE
refactor: make inference borrow the store immutably

### DIFF
--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -201,8 +201,16 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
             to_infer.push(module_id);
         }
 
-        for module_id in &to_infer {
-            checker.infer_module(&mut store, module_id);
+        let module_files: Vec<(String, Vec<File>)> = to_infer
+            .iter()
+            .map(|module_id| {
+                let files = checker.take_module_files(&mut store, module_id);
+                (module_id.clone(), files)
+            })
+            .collect();
+
+        for (module_id, files) in module_files {
+            checker.infer_module(&store, &module_id, files);
         }
 
         for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -34,7 +34,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_const_binding(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         doc: Option<String>,
         annotation: Option<Annotation>,
         expression: Box<Expression>,
@@ -92,7 +92,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_let_binding(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         binding: Binding,
         value: Box<Expression>,
         mutable: bool,

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -16,7 +16,7 @@ enum BranchReconciliation {
 impl TaskState<'_> {
     pub(crate) fn reconcile_and_unify(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         result_ty: &Type,
         branch_types: &[Type],
         span: &Span,
@@ -142,7 +142,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_if(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         condition: Box<Expression>,
         consequence: Box<Expression>,
         alternative: Box<Expression>,
@@ -236,7 +236,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_match(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         subject: Box<Expression>,
         arms: Vec<MatchArm>,
         origin: MatchOrigin,
@@ -331,7 +331,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_loop(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         body: Box<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -376,7 +376,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_while(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         condition: Box<Expression>,
         body: Box<Expression>,
         span: Span,
@@ -412,7 +412,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_while_let(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         pattern: Pattern,
         scrutinee: Box<Expression>,
         body: Box<Expression>,
@@ -462,7 +462,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_for(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         binding: Binding,
         iterable: Box<Expression>,
         body: Box<Expression>,
@@ -618,7 +618,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_return_statement(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         parent_is_subexpression: bool,
@@ -655,7 +655,7 @@ impl TaskState<'_> {
 
     fn infer_return(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
     ) -> Expression {
@@ -681,7 +681,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_defer(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -728,7 +728,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_break(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         value: Option<Box<Expression>>,
         span: Span,
         parent_is_subexpression: bool,
@@ -811,7 +811,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_task(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -14,7 +14,7 @@ use super::primitives::contains_deref;
 impl TaskState<'_> {
     pub(super) fn infer_dot_access_or_qualified_path(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         member: EcoString,
         span: Span,
@@ -192,7 +192,7 @@ impl DotAccessResolutionArgs<'_> {
 impl TaskState<'_> {
     pub(super) fn infer_dot_access(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         member: EcoString,
         span: Span,

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -97,7 +97,7 @@ fn has_numeric_member_in_chain(expression: &Expression) -> bool {
 impl TaskState<'_> {
     pub(super) fn infer_function(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Expression,
         expected_ty: &Type,
     ) -> Expression {
@@ -226,7 +226,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_lambda(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         params: Vec<Binding>,
         return_annotation: Annotation,
         body: Box<Expression>,
@@ -293,7 +293,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_function_call(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         args: Vec<Expression>,
         spread: Box<Option<Expression>>,
@@ -545,7 +545,7 @@ impl TaskState<'_> {
 
     fn instantiate_callee_type(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         forall_ty: &Type,
         type_args: &[Annotation],
         callee_expression: &Expression,
@@ -825,7 +825,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_type_conversion_call(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         callee_expression: Expression,
         named_ty: Type,
         underlying_fn: Type,
@@ -886,7 +886,7 @@ impl TaskState<'_> {
 
     fn infer_call_arguments(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         args: Vec<Expression>,
         param_types: &[Type],
     ) -> Vec<Expression> {
@@ -982,7 +982,7 @@ impl TaskState<'_> {
 
     fn infer_function_body(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         body: Box<Expression>,
         body_ty: &Type,
         return_annotation: &Annotation,
@@ -1014,7 +1014,7 @@ impl TaskState<'_> {
 
     fn infer_function_params(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         params: Vec<Binding>,
         expected_params: &[Type],
         handle_self_receiver: bool,
@@ -1420,7 +1420,7 @@ impl TaskState<'_> {
     }
 
     /// Verify the substring arg is a range type over `int`; emit a `Range<int>` mismatch otherwise.
-    fn validate_substring_range_arg(&mut self, store: &mut Store, arg: &Expression) {
+    fn validate_substring_range_arg(&mut self, store: &Store, arg: &Expression) {
         let arg_ty = arg.get_type().resolve_in(&self.env);
         let arg_span = arg.get_span();
         let int_ty = self.type_int();

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -11,7 +11,7 @@ use crate::store::Store;
 impl TaskState<'_> {
     pub(super) fn infer_impl_block(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         annotation: Annotation,
         methods: Vec<Expression>,
         receiver_name: EcoString,
@@ -94,11 +94,7 @@ impl TaskState<'_> {
         }
     }
 
-    pub(super) fn infer_interface(
-        &mut self,
-        store: &mut Store,
-        expression: Expression,
-    ) -> Expression {
+    pub(super) fn infer_interface(&mut self, store: &Store, expression: Expression) -> Expression {
         let Expression::Interface {
             doc,
             name,

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -28,7 +28,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_indexed_access(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         index: Box<Expression>,
         span: syntax::ast::Span,
@@ -200,7 +200,7 @@ impl TaskState<'_> {
     /// Emits a type-aware diagnostic for Go-style `expr[a:b]` colon syntax.
     pub(super) fn infer_colon_subscript(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         index: Box<Expression>,
         span: syntax::ast::Span,
@@ -228,7 +228,7 @@ impl TaskState<'_> {
 
     fn infer_slice_range_access(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         range: Box<Expression>,
         span: syntax::ast::Span,
@@ -345,7 +345,7 @@ impl TaskState<'_> {
         }
     }
 
-    fn infer_range_bounds_only(&mut self, store: &mut Store, range: Box<Expression>) -> Expression {
+    fn infer_range_bounds_only(&mut self, store: &Store, range: Box<Expression>) -> Expression {
         match *range {
             Expression::Range {
                 start,

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -10,7 +10,7 @@ use super::super::TaskState;
 impl TaskState<'_> {
     pub(super) fn infer_literal(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         literal: Literal,
         expected_ty: &Type,
         span: Span,
@@ -183,7 +183,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_unit(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         span: Span,
         expected_ty: &Type,
     ) -> Expression {

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -22,7 +22,7 @@ use crate::store::Store;
 impl TaskState<'_> {
     pub fn infer_expression(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Expression,
         expected_ty: &Type,
     ) -> Expression {
@@ -39,7 +39,7 @@ impl TaskState<'_> {
 
     fn infer_expression_inner(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Expression,
         expected_ty: &Type,
         parent_is_subexpression: bool,

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -92,7 +92,7 @@ pub(crate) fn check_not_comparable(
 impl TaskState<'_> {
     pub(super) fn infer_unary(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         operator: UnaryOperator,
         operand: Box<Expression>,
         expected_ty: &Type,
@@ -164,7 +164,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_binary(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         operator: BinaryOperator,
         left_operand: Box<Expression>,
         right_operand: Box<Expression>,
@@ -223,7 +223,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_binary_with_left(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         operator: BinaryOperator,
         left_inferred: Expression,
         left_ty: Type,
@@ -298,7 +298,7 @@ impl TaskState<'_> {
 
     fn infer_binary_impl(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         operator: BinaryOperator,
         left_operand: Box<Expression>,
         right_operand: Box<Expression>,
@@ -395,7 +395,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn resolve_binary_type(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         operator: &BinaryOperator,
         left_operand_ty: &Type,
         right_operand_ty: &Type,
@@ -691,7 +691,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_range(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         start: Option<Box<Expression>>,
         end: Option<Box<Expression>>,
         inclusive: bool,
@@ -735,7 +735,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_cast(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         target_type: syntax::ast::Annotation,
         span: Span,

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -53,7 +53,7 @@ pub(crate) fn collect_pattern_bindings(pattern: &Pattern) -> Vec<(String, Span)>
 impl TaskState<'_> {
     pub(super) fn infer_pattern(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
@@ -63,7 +63,7 @@ impl TaskState<'_> {
 
     fn infer_pattern_inner(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
@@ -333,7 +333,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_enum_variant_pattern(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         identifier: EcoString,
         fields: Vec<Pattern>,
         rest: bool,
@@ -469,7 +469,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_struct_pattern(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         identifier: EcoString,
         fields: Vec<StructFieldPattern>,
         rest: bool,
@@ -627,7 +627,7 @@ impl TaskState<'_> {
 
     fn infer_or_pattern(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         patterns: Vec<Pattern>,
         span: Span,
         expected_ty: Type,
@@ -785,7 +785,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn try_infer_enum_struct_variant(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         identifier: &str,
         fields: &[StructFieldPattern],
         rest: bool,

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -3,7 +3,6 @@ use crate::store::Store;
 use syntax::EcoString;
 use syntax::ast::DeadCodeCause;
 use syntax::ast::{BinaryOperator, Expression, Span, UnaryOperator};
-use syntax::program::Visibility;
 use syntax::types::Type;
 
 use super::super::TaskState;
@@ -90,7 +89,7 @@ fn contains_stored_reference_to(expression: &Expression, var_name: &str) -> bool
 impl TaskState<'_> {
     pub(super) fn infer_paren(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -129,7 +128,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_block(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         items: Vec<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -155,7 +154,7 @@ impl TaskState<'_> {
         }
 
         self.scopes.push();
-        self.register_types_and_values(store, &items, &Visibility::Local);
+        self.register_block_local_items(store, &items);
 
         let new_items = self.infer_block_items(store, items, expected_ty.clone());
 
@@ -173,7 +172,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_reference(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -225,7 +224,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_identifier(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         value: EcoString,
         span: Span,
         expected_ty: &Type,
@@ -284,7 +283,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_assignment(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         target: Box<Expression>,
         value: Box<Expression>,
         compound_operator: Option<BinaryOperator>,
@@ -389,7 +388,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_tuple(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         elements: Vec<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -422,7 +421,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_block_items(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         items: Vec<Expression>,
         last_item_expected_ty: Type,
     ) -> Vec<Expression> {

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -4,7 +4,6 @@ use crate::checker::EnvResolve;
 use crate::checker::scopes::{CarrierKind, DepthCounter, RecoverBlockContext, TryBlockContext};
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::program::Visibility;
 use syntax::types::Type;
 
 use super::super::TaskState;
@@ -12,7 +11,7 @@ use super::super::TaskState;
 impl TaskState<'_> {
     pub(super) fn infer_propagate(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,
@@ -102,7 +101,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_propagate_in_block(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         new_expression: Expression,
         tried_ty: &Type,
         try_ok_ty: &Type,
@@ -140,7 +139,7 @@ impl TaskState<'_> {
 
     fn infer_propagate_in_function(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         new_expression: Expression,
         tried_ty: &Type,
         span: Span,
@@ -212,7 +211,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_try_block(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         items: Vec<Expression>,
         try_keyword_span: Span,
         span: Span,
@@ -249,7 +248,7 @@ impl TaskState<'_> {
             });
         }
 
-        self.register_types_and_values(store, &items, &Visibility::Local);
+        self.register_block_local_items(store, &items);
 
         let new_items = self.infer_block_items(store, items, ok_ty.clone());
 
@@ -338,7 +337,7 @@ impl TaskState<'_> {
 
     pub(super) fn infer_recover_block(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         items: Vec<Expression>,
         recover_keyword_span: Span,
         span: Span,
@@ -372,7 +371,7 @@ impl TaskState<'_> {
             });
         }
 
-        self.register_types_and_values(store, &items, &Visibility::Local);
+        self.register_block_local_items(store, &items);
 
         let new_items = self.infer_block_items(store, items, inner_ty.clone());
 

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -9,7 +9,7 @@ use crate::validators::temp_producing::is_temp_producing;
 impl TaskState<'_> {
     pub(super) fn infer_select(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         arms: Vec<SelectArm>,
         span: Span,
         expected_ty: &Type,
@@ -128,7 +128,7 @@ impl TaskState<'_> {
 
     fn infer_select_receive(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         binding: Box<Pattern>,
         receive_expression: Box<Expression>,
         body: Box<Expression>,
@@ -219,7 +219,7 @@ impl TaskState<'_> {
 
     fn infer_select_send(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         send_expression: Box<Expression>,
         body: Box<Expression>,
         result_ty: &Type,
@@ -250,7 +250,7 @@ impl TaskState<'_> {
 
     fn infer_select_match_receive(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         receive_expression: Box<Expression>,
         match_arms: Vec<MatchArm>,
         result_ty: &Type,
@@ -339,7 +339,7 @@ impl TaskState<'_> {
 
     fn infer_select_wildcard(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         body: Box<Expression>,
         result_ty: &Type,
     ) -> SelectArmPattern {

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -50,7 +50,7 @@ pub(crate) enum NoZeroReason {
 impl TaskState<'_> {
     pub(super) fn infer_struct_call(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         struct_name: EcoString,
         field_assignments: Vec<StructFieldAssignment>,
         spread: StructSpread,
@@ -243,7 +243,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_struct_call_for_struct(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         struct_name: EcoString,
         qualified_name: String,
         struct_ty: Type,
@@ -355,7 +355,7 @@ impl TaskState<'_> {
     #[allow(clippy::too_many_arguments)]
     fn infer_struct_call_for_enum_variant(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         variant_name: EcoString,
         variant_fields: Vec<syntax::ast::EnumFieldDefinition>,
         map: SubstitutionMap,
@@ -410,7 +410,7 @@ impl TaskState<'_> {
 
     fn infer_struct_spread(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         spread: StructSpread,
         target_ty: &Type,
     ) -> StructSpread {
@@ -427,7 +427,7 @@ impl TaskState<'_> {
 
     fn infer_structish_fields<'a, FindDef>(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         ctx: StructishCtx<'a, '_, impl Iterator<Item = (&'a EcoString, &'a Type)> + Clone>,
         mut find_def: FindDef,
     ) -> (Vec<StructFieldAssignment>, HashSet<EcoString>)

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -6,7 +6,7 @@ mod validation;
 
 pub(crate) use unify::BuiltinBound;
 
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::freeze::FreezeFolder;
 use super::{FileContextKind, TaskState};
@@ -15,17 +15,18 @@ use syntax::ast::Expression;
 use syntax::program::{File, FileImport};
 
 impl TaskState<'_> {
-    pub fn infer_module(&mut self, store: &mut Store, module_id: &str) {
-        let files = self.take_module_files(store, module_id);
+    /// Infer types for `files` belonging to `module_id`.
+    pub fn infer_module(&mut self, store: &Store, module_id: &str, files: Vec<File>) {
         let items_per_file: Vec<&[Expression]> = files.iter().map(|f| f.items.as_slice()).collect();
-        self.check_const_cycles(&*store, &items_per_file);
+        self.check_const_cycles(store, &items_per_file);
 
         for file in files {
             self.infer_file(store, module_id, file);
         }
     }
 
-    fn take_module_files(&mut self, store: &mut Store, module_id: &str) -> Vec<File> {
+    /// Extract a module's `.lis` files from the store.
+    pub fn take_module_files(&mut self, store: &mut Store, module_id: &str) -> Vec<File> {
         self.with_module_cursor(module_id, |_this| {
             let module = store
                 .get_module_mut(module_id)
@@ -34,7 +35,7 @@ impl TaskState<'_> {
         })
     }
 
-    fn infer_file(&mut self, store: &mut Store, module_id: &str, file: File) {
+    fn infer_file(&mut self, store: &Store, module_id: &str, file: File) {
         let file_id = file.id;
         let imports = file.imports();
 
@@ -45,7 +46,7 @@ impl TaskState<'_> {
             &imports,
             FileContextKind::Standard,
             |this, store| {
-                this.check_definition_module_collisions(&*store, &file.items, &imports);
+                this.check_definition_module_collisions(store, &file.items, &imports);
 
                 let inferred_items: Vec<_> = file
                     .items
@@ -126,5 +127,72 @@ impl TaskState<'_> {
                     ));
             }
         }
+    }
+
+    pub(crate) fn register_block_local_items(&mut self, store: &Store, items: &[Expression]) {
+        for item in items {
+            match item {
+                Expression::Const { .. } => self.register_block_local_const(store, item),
+                Expression::Function { .. } => self.register_block_local_fn(store, item),
+                _ => {}
+            }
+        }
+    }
+
+    fn register_block_local_const(&mut self, store: &Store, item: &Expression) {
+        let Expression::Const {
+            identifier,
+            identifier_span,
+            annotation,
+            expression,
+            span,
+            ..
+        } = item
+        else {
+            return;
+        };
+
+        let qualified_name = self.qualify_name(identifier);
+        let is_duplicate = self.scopes.lookup_const(identifier)
+            || self.is_const_name(store, qualified_name.as_str());
+        if is_duplicate && self.is_lis(store) {
+            self.sink.push(diagnostics::infer::duplicate_definition(
+                "constant",
+                identifier,
+                *identifier_span,
+            ));
+            return;
+        }
+
+        let before = self.sink.len();
+        let const_ty = if let Some(annotation) = annotation {
+            self.convert_to_type(store, annotation, span)
+        } else {
+            self.type_from_literal_expression(expression)
+                .unwrap_or_else(|| self.new_type_var())
+        };
+        self.sink.truncate(before);
+
+        let scope = self.scopes.current_mut();
+        scope.values.insert(identifier.to_string(), const_ty);
+        scope
+            .consts
+            .get_or_insert_with(HashSet::default)
+            .insert(identifier.to_string());
+    }
+
+    fn register_block_local_fn(&mut self, store: &Store, item: &Expression) {
+        let Expression::Function { name, span, .. } = item else {
+            return;
+        };
+
+        let fn_sig = item.to_function_signature();
+
+        let before = self.sink.len();
+        let fn_ty = self.extract_function_signature(store, &fn_sig, span);
+        self.sink.truncate(before);
+
+        let scope = self.scopes.current_mut();
+        scope.values.insert(name.to_string(), fn_ty);
     }
 }

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -83,6 +83,12 @@ pub(crate) enum FileContextKind {
     Prelude,
 }
 
+struct SavedFileContext {
+    file_id: Option<u32>,
+    scopes: Scopes,
+    imports: ImportState,
+}
+
 /// Cache for builtin types (int, bool, string, etc.) resolved from the prelude.
 /// These never change once populated, so no invalidation needed.
 type BuiltinCache = HashMap<String, Type>;
@@ -350,10 +356,14 @@ impl<'s> TaskState<'s> {
     }
 
     pub(crate) fn is_const_var(&self, store: &Store, var_name: &str) -> bool {
-        self.scopes.lookup_binding_id(var_name).is_none()
-            && self
-                .lookup_qualified_name(store, var_name)
-                .is_some_and(|qname| self.is_const_name(store, &qname))
+        if self.scopes.lookup_binding_id(var_name).is_some() {
+            return false;
+        }
+        if self.scopes.lookup_const(var_name) {
+            return true;
+        }
+        self.lookup_qualified_name(store, var_name)
+            .is_some_and(|qname| self.is_const_name(store, &qname))
     }
 
     /// Track that `name` (at the start of `span`) refers to the definition at `qualified_name`.
@@ -544,6 +554,23 @@ impl<'s> TaskState<'s> {
 
     pub(crate) fn with_file_context<T>(
         &mut self,
+        store: &Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+        kind: FileContextKind,
+        f: impl FnOnce(&mut Self, &Store) -> T,
+    ) -> T {
+        self.with_module_cursor(module_id, |this| {
+            let saved = this.enter_file_context(store, module_id, file_id, imports, kind);
+            let result = f(this, store);
+            this.exit_file_context(saved);
+            result
+        })
+    }
+
+    pub(crate) fn with_file_context_mut<T>(
+        &mut self,
         store: &mut Store,
         module_id: &str,
         file_id: u32,
@@ -552,31 +579,48 @@ impl<'s> TaskState<'s> {
         f: impl FnOnce(&mut Self, &mut Store) -> T,
     ) -> T {
         self.with_module_cursor(module_id, |this| {
-            let previous_file_id = this.cursor.file_id.replace(file_id);
-            let previous_scopes = std::mem::take(&mut this.scopes);
-            let previous_imports = std::mem::take(&mut this.imports);
-
-            match kind {
-                FileContextKind::Standard => {
-                    this.put_prelude_in_scope(&*store);
-                    this.put_unprefixed_module_in_scope(&*store, module_id);
-                }
-                FileContextKind::ImportedTypedef => {
-                    this.put_prelude_in_scope(&*store);
-                }
-                FileContextKind::Prelude => {
-                    this.put_unprefixed_module_in_scope(&*store, module_id);
-                }
-            }
-            this.put_imported_modules_in_scope(&*store, imports);
-
+            let saved = this.enter_file_context(&*store, module_id, file_id, imports, kind);
             let result = f(this, store);
-
-            this.scopes = previous_scopes;
-            this.imports = previous_imports;
-            this.cursor.file_id = previous_file_id;
+            this.exit_file_context(saved);
             result
         })
+    }
+
+    fn enter_file_context(
+        &mut self,
+        store: &Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+        kind: FileContextKind,
+    ) -> SavedFileContext {
+        let saved = SavedFileContext {
+            file_id: self.cursor.file_id.replace(file_id),
+            scopes: std::mem::take(&mut self.scopes),
+            imports: std::mem::take(&mut self.imports),
+        };
+
+        match kind {
+            FileContextKind::Standard => {
+                self.put_prelude_in_scope(store);
+                self.put_unprefixed_module_in_scope(store, module_id);
+            }
+            FileContextKind::ImportedTypedef => {
+                self.put_prelude_in_scope(store);
+            }
+            FileContextKind::Prelude => {
+                self.put_unprefixed_module_in_scope(store, module_id);
+            }
+        }
+        self.put_imported_modules_in_scope(store, imports);
+
+        saved
+    }
+
+    fn exit_file_context(&mut self, saved: SavedFileContext) {
+        self.scopes = saved.scopes;
+        self.imports = saved.imports;
+        self.cursor.file_id = saved.file_id;
     }
 
     pub fn failed(&self) -> bool {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -164,7 +164,7 @@ impl TaskState<'_> {
 
         store.store_file(module_id, file);
 
-        self.with_file_context(
+        self.with_file_context_mut(
             store,
             module_id,
             file_id,
@@ -240,7 +240,7 @@ impl TaskState<'_> {
         file_id: u32,
         imports: &[FileImport],
     ) {
-        self.with_file_context(
+        self.with_file_context_mut(
             store,
             module_id,
             file_id,
@@ -271,7 +271,7 @@ impl TaskState<'_> {
         file_id: u32,
         imports: &[FileImport],
     ) {
-        self.with_file_context(
+        self.with_file_context_mut(
             store,
             module_id,
             file_id,

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -73,6 +73,7 @@ pub struct Scope {
     /// variable name -> type
     pub values: HashMap<String, Type>,
     pub mutables: Option<HashSet<String>>,
+    pub consts: Option<HashSet<String>>,
     pub type_params: Option<HashMap<String, usize>>,
     pub trait_bounds: Option<HashMap<Symbol, Vec<Type>>>,
     pub fn_return_type: Option<Type>,
@@ -99,6 +100,7 @@ impl Scope {
         Scope {
             values: HashMap::default(),
             mutables: None,
+            consts: None,
             type_params: None,
             trait_bounds: None,
             fn_return_type: None,
@@ -169,28 +171,14 @@ impl Scopes {
 
     pub fn push(&mut self) {
         let current = self.current();
-        let loop_depth = current.loop_depth.get();
-        let defer_block_depth = current.defer_block_depth.get();
-        let negation_depth = current.negation_depth.get();
-        let type_param_depth = current.type_param_depth.get();
-        let use_context = current.use_context.get();
-        let loop_break_type = current.loop_break_type.clone();
-        self.stack.push(Scope {
-            values: HashMap::default(),
-            mutables: None,
-            type_params: None,
-            trait_bounds: None,
-            fn_return_type: None,
-            try_block_context: None,
-            recover_block_context: None,
-            loop_break_type,
-            loop_depth: DepthCounter::with_value(loop_depth),
-            defer_block_depth: DepthCounter::with_value(defer_block_depth),
-            negation_depth: DepthCounter::with_value(negation_depth),
-            type_param_depth: DepthCounter::with_value(type_param_depth),
-            use_context: Cell::new(use_context),
-            name_to_binding: HashMap::default(),
-        });
+        let mut scope = Scope::new();
+        scope.loop_break_type = current.loop_break_type.clone();
+        scope.loop_depth = DepthCounter::with_value(current.loop_depth.get());
+        scope.defer_block_depth = DepthCounter::with_value(current.defer_block_depth.get());
+        scope.negation_depth = DepthCounter::with_value(current.negation_depth.get());
+        scope.type_param_depth = DepthCounter::with_value(current.type_param_depth.get());
+        scope.use_context = Cell::new(current.use_context.get());
+        self.stack.push(scope);
     }
 
     pub fn pop(&mut self) {
@@ -225,6 +213,14 @@ impl Scopes {
             .iter()
             .rev()
             .any(|s| s.mutables.as_ref().is_some_and(|m| m.contains(name)))
+    }
+
+    /// Whether `name` is a block-local `const` in any enclosing scope.
+    pub fn lookup_const(&self, name: &str) -> bool {
+        self.stack
+            .iter()
+            .rev()
+            .any(|s| s.consts.as_ref().is_some_and(|c| c.contains(name)))
     }
 
     /// Look up a binding ID by walking the scope stack from top to bottom.

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -32,7 +32,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         .cloned()
         .expect("prelude module must exist");
 
-    checker.with_file_context(
+    checker.with_file_context_mut(
         store,
         PRELUDE_MODULE_ID,
         PRELUDE_FILE_ID,

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -72,7 +72,8 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
 
             store.store_module(&module_id, files);
             checker.register_module(&mut store, &module_id);
-            checker.infer_module(&mut store, &module_id);
+            let module_files = checker.take_module_files(&mut store, &module_id);
+            checker.infer_module(&store, &module_id, module_files);
 
             checker.cursor.module_id = prev_module_id;
         }

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -55,7 +55,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
 
     for expression in ast {
         let type_var = checker.new_type_var();
-        let typed_expression = checker.infer_expression(&mut store, expression, &type_var);
+        let typed_expression = checker.infer_expression(&store, expression, &type_var);
         typed_ast.push(typed_expression);
 
         if checker.failed() {

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -172,7 +172,7 @@ impl CompiledTest {
 
             for expression in self.ast {
                 let type_var = checker.new_type_var();
-                let typed_expression = checker.infer_expression(&mut store, expression, &type_var);
+                let typed_expression = checker.infer_expression(&store, expression, &type_var);
                 typed_ast.push(typed_expression);
 
                 if checker.failed() {


### PR DESCRIPTION
Inference now borrows the store immutably, as preparation for parallelizing semantic analysis.