### PR TITLE
perf: parallelize inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +170,12 @@ checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -576,6 +601,7 @@ dependencies = [
  "lisette-diagnostics",
  "lisette-stdlib",
  "lisette-syntax",
+ "rayon",
  "rustc-hash",
  "serde",
 ]
@@ -777,6 +803,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ owo-colors = "4.0"
 insta = "1.39.0"
 ecow = "0.2"
 rustc-hash = "2"
+rayon = "1"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -446,4 +446,12 @@ impl LisetteDiagnostic {
     pub fn is_warning(&self) -> bool {
         self.severity == Severity::Warning
     }
+
+    pub fn sort_key(a: &Self, b: &Self) -> std::cmp::Ordering {
+        a.file_id()
+            .cmp(&b.file_id())
+            .then_with(|| a.primary_offset().cmp(&b.primary_offset()))
+            .then_with(|| a.code_str().cmp(&b.code_str()))
+            .then_with(|| a.plain_message().cmp(b.plain_message()))
+    }
 }

--- a/crates/diagnostics/src/sink.rs
+++ b/crates/diagnostics/src/sink.rs
@@ -53,7 +53,7 @@ impl LocalSink {
 
     pub fn merge(sinks: Vec<LocalSink>) -> Vec<LisetteDiagnostic> {
         let mut all: Vec<LisetteDiagnostic> = sinks.into_iter().flat_map(|s| s.take()).collect();
-        all.sort_by_key(|d| d.primary_offset());
+        all.sort_by(LisetteDiagnostic::sort_key);
         all
     }
 }

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -20,4 +20,5 @@ serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"
 rustc-hash.workspace = true
+rayon.workspace = true
 

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -1,3 +1,4 @@
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -209,8 +210,41 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
             })
             .collect();
 
-        for (module_id, files) in module_files {
-            checker.infer_module(&store, &module_id, files);
+        // Single-file or tiny multi-module projects stay serial to avoid rayon
+        // overhead. This threshold is a conservative starting point, not a
+        // measured inflection point. To be tuned in future.
+        const PARALLEL_THRESHOLD: usize = 4;
+
+        if module_files.len() < PARALLEL_THRESHOLD {
+            for (module_id, files) in module_files {
+                checker.infer_module(&store, &module_id, files);
+            }
+        } else {
+            let allocator = binding_ids.clone();
+            let ufcs_snapshot = checker.ufcs_methods.clone();
+            let store_ref: &Store = &store;
+
+            type WorkerOutput = (Vec<(String, File)>, Facts, LocalSink);
+            let outputs: Vec<WorkerOutput> = module_files
+                .into_par_iter()
+                .map(|(module_id, files)| {
+                    let local_sink = LocalSink::new();
+                    let mut worker = TaskState::new(&local_sink, allocator.clone());
+                    worker.ufcs_methods = ufcs_snapshot.clone();
+                    worker.infer_module(store_ref, &module_id, files);
+                    let typed_files = std::mem::take(&mut worker.typed_files);
+                    let facts = std::mem::replace(&mut worker.facts, Facts::new(allocator.clone()));
+                    (typed_files, facts, local_sink)
+                })
+                .collect();
+
+            let mut worker_sinks: Vec<LocalSink> = Vec::with_capacity(outputs.len());
+            for (typed_files, facts, sink_local) in outputs {
+                checker.typed_files.extend(typed_files);
+                checker.facts.merge(facts);
+                worker_sinks.push(sink_local);
+            }
+            sink.extend(LocalSink::merge(worker_sinks));
         }
 
         for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {

--- a/crates/semantics/src/validators/lints.rs
+++ b/crates/semantics/src/validators/lints.rs
@@ -157,7 +157,7 @@ fn lint_module(
     }
     diagnostics.extend(ref_result.diagnostics);
 
-    diagnostics.sort_by_key(|d| d.primary_offset());
+    diagnostics.sort_by(LisetteDiagnostic::sort_key);
     sink.extend(diagnostics);
 }
 
@@ -175,18 +175,23 @@ pub fn lint_all_facts(facts: &Facts, unused: &mut UnusedInfo, sink: &LocalSink) 
     collect_always_failing_try_blocks(facts, &mut diagnostics);
     collect_expression_only_fstrings(facts, &mut diagnostics);
 
-    diagnostics.sort_by_key(|d| d.primary_offset());
+    diagnostics.sort_by(LisetteDiagnostic::sort_key);
     sink.extend(diagnostics);
 }
 
 fn collect_bindings(facts: &Facts, unused: &mut UnusedInfo, out: &mut Vec<LisetteDiagnostic>) {
     for b in facts.bindings.values() {
         let is_anon = b.name.starts_with('_');
+        let written_but_not_read = b.kind.is_mutable() && b.mutated && !b.used && !is_anon;
 
         if !b.used {
             if !is_anon && b.kind.is_param() && !b.is_typedef && b.name != "self" {
                 out.push(diagnostics::lint::unused_parameter(&b.span, &b.name));
-            } else if !is_anon && !b.kind.is_param() && (!b.kind.is_match_arm() || b.is_as_alias) {
+            } else if !written_but_not_read
+                && !is_anon
+                && !b.kind.is_param()
+                && (!b.kind.is_match_arm() || b.is_as_alias)
+            {
                 out.push(diagnostics::lint::unused_variable(
                     &b.span,
                     &b.name,
@@ -200,7 +205,7 @@ fn collect_bindings(facts: &Facts, unused: &mut UnusedInfo, out: &mut Vec<Lisett
             out.push(diagnostics::lint::unused_mut(&b.span));
         }
 
-        if b.kind.is_mutable() && b.mutated && !b.used && !is_anon {
+        if written_but_not_read {
             out.push(diagnostics::lint::written_but_not_read(&b.span, &b.name));
         }
     }

--- a/tests/ui/lint/snapshots/written_but_not_read_in_match.snap
+++ b/tests/ui/lint/snapshots/written_but_not_read_in_match.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Unused variable
+  [warning] Variable assigned but never read
    ╭─[test.lis:3:11]
  2 │ fn main() {
  3 │   let mut status = "init"
    ·           ───┬──
-   ·              ╰── never used
+   ·              ╰── `status` is assigned but never read
  4 │   let opt: Option<int> = None
    ╰────
-  help: Use this variable or prefix it with an underscore: `_status` · code: [lint.unused_variable]
+  help: Read the variable after assigning it, or explicitly discard it with `let _ = ...` · code: [lint.assigned_but_never_read]

--- a/tests/ui/lint/snapshots/written_but_not_read_simple.snap
+++ b/tests/ui/lint/snapshots/written_but_not_read_simple.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Unused variable
+  [warning] Variable assigned but never read
    ╭─[test.lis:3:11]
  2 │ fn main() {
  3 │   let mut x = 0
    ·           ┬
-   ·           ╰── never used
+   ·           ╰── `x` is assigned but never read
  4 │   x = 42
    ╰────
-  help: Use this variable or prefix it with an underscore: `_x` · code: [lint.unused_variable]
+  help: Read the variable after assigning it, or explicitly discard it with `let _ = ...` · code: [lint.assigned_but_never_read]

--- a/tests/ui/lint/snapshots/written_but_not_read_simple_reassignment.snap
+++ b/tests/ui/lint/snapshots/written_but_not_read_simple_reassignment.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Unused variable
+  [warning] Variable assigned but never read
    ╭─[test.lis:3:11]
  2 │ fn main() {
  3 │   let mut a = 0
    ·           ┬
-   ·           ╰── never used
+   ·           ╰── `a` is assigned but never read
  4 │   a = 42
    ╰────
-  help: Use this variable or prefix it with an underscore: `_a` · code: [lint.unused_variable]
+  help: Read the variable after assigning it, or explicitly discard it with `let _ = ...` · code: [lint.assigned_but_never_read]


### PR DESCRIPTION

Inference now runs in parallel across modules. Projects with <4 modules stay on the serial path.

Cold-cache `lis check` on synthetic multi-module projects:

| Modules | Before | After | Delta |
| ------- | -----: | -----: | -----: |
| 10      |  51 ms |  41 ms |    -20% |
| 30      | 145 ms | 113 ms |    -22% |
| 100     | 454 ms | 344 ms |    -24% |

> `n` modules ~660 LOC each, `LISETTE_NO_CACHE=1`, hyperfine with `--warmup 5 --runs 25`, M1 MBP

Diagnostic sink merging now sorts by `(file_id, primary_offset, code, message)` to keep order deterministic regardless of worker scheduling. This also surfaced an accidental overlap between `unused_variable` and `assigned_but_never_read`, fixed here as well.

Follow-up to #363