### PR TITLE
perf: parallelize post-inference checks

### DIFF
--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -149,39 +149,9 @@ impl Facts {
         self.dead_code.push(DeadCodeFact { span, cause });
     }
 
-    pub fn add_unused_expression(&mut self, span: Span, kind: UnusedExpressionKind) {
-        self.unused_expressions
-            .push(UnusedExpressionFact { span, kind });
-    }
-
-    pub fn add_discarded_tail(
-        &mut self,
-        span: Span,
-        return_type: String,
-        expected_span: Span,
-        expected_type: String,
-    ) {
-        self.discarded_tail_expressions.push(DiscardedTailFact {
-            span,
-            return_type,
-            expected_span,
-            expected_type,
-        });
-    }
-
     pub fn add_overused_reference(&mut self, span: Span, name: Option<String>) {
         self.overused_references
             .push(OverusedReferenceFact { span, name });
-    }
-
-    pub fn add_unused_type_param(&mut self, name: String, span: Span) {
-        self.unused_type_params
-            .push(UnusedTypeParamFact { name, span });
-    }
-
-    pub fn add_type_param_only_in_bound(&mut self, name: String, span: Span) {
-        self.type_params_only_in_bound
-            .push(TypeParamOnlyInBoundFact { name, span });
     }
 
     pub fn add_always_failing_try_block(&mut self, span: Span) {
@@ -211,6 +181,21 @@ impl Facts {
             .entry((module_id, method_name))
             .or_default()
             .push(usage_span);
+    }
+
+    pub fn absorb_local_facts(&mut self, local: LocalFacts) {
+        let LocalFacts {
+            unused_expressions,
+            discarded_tail_expressions,
+            unused_type_params,
+            type_params_only_in_bound,
+        } = local;
+        self.unused_expressions.extend(unused_expressions);
+        self.discarded_tail_expressions
+            .extend(discarded_tail_expressions);
+        self.unused_type_params.extend(unused_type_params);
+        self.type_params_only_in_bound
+            .extend(type_params_only_in_bound);
     }
 
     pub fn merge(&mut self, other: Facts) {
@@ -275,6 +260,46 @@ impl Facts {
                 .or_default()
                 .extend(spans);
         }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct LocalFacts {
+    pub unused_expressions: Vec<UnusedExpressionFact>,
+    pub discarded_tail_expressions: Vec<DiscardedTailFact>,
+    pub unused_type_params: Vec<UnusedTypeParamFact>,
+    pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
+}
+
+impl LocalFacts {
+    pub fn add_unused_expression(&mut self, span: Span, kind: UnusedExpressionKind) {
+        self.unused_expressions
+            .push(UnusedExpressionFact { span, kind });
+    }
+
+    pub fn add_discarded_tail(
+        &mut self,
+        span: Span,
+        return_type: String,
+        expected_span: Span,
+        expected_type: String,
+    ) {
+        self.discarded_tail_expressions.push(DiscardedTailFact {
+            span,
+            return_type,
+            expected_span,
+            expected_type,
+        });
+    }
+
+    pub fn add_unused_type_param(&mut self, name: String, span: Span) {
+        self.unused_type_params
+            .push(UnusedTypeParamFact { name, span });
+    }
+
+    pub fn add_type_param_only_in_bound(&mut self, name: String, span: Span) {
+        self.type_params_only_in_bound
+            .push(TypeParamOnlyInBoundFact { name, span });
     }
 }
 
@@ -417,6 +442,25 @@ mod tests {
 
         a.merge(b);
         assert_eq!(a.or_pattern_error_spans.len(), 2);
+    }
+
+    #[test]
+    fn absorb_local_facts_extends_all_four_streams() {
+        let allocator = Arc::new(BindingIdAllocator::new());
+        let mut facts = Facts::new(allocator);
+
+        let mut local = LocalFacts::default();
+        local.add_unused_expression(span(0), UnusedExpressionKind::Value);
+        local.add_discarded_tail(span(1), "Int".into(), span(2), "Unit".into());
+        local.add_unused_type_param("T".into(), span(3));
+        local.add_type_param_only_in_bound("U".into(), span(4));
+
+        facts.absorb_local_facts(local);
+
+        assert_eq!(facts.unused_expressions.len(), 1);
+        assert_eq!(facts.discarded_tail_expressions.len(), 1);
+        assert_eq!(facts.unused_type_params.len(), 1);
+        assert_eq!(facts.type_params_only_in_bound.len(), 1);
     }
 
     #[test]

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -11,33 +11,87 @@ pub(crate) mod stringer_signature;
 pub(crate) mod temp_producing;
 pub(crate) mod visibility;
 
-use diagnostics::LocalSink;
+use diagnostics::{LocalSink, PatternIssue};
+use rayon::prelude::*;
+use syntax::program::{File, Module};
 
 use crate::context::AnalysisContext;
 use crate::facts::Facts;
+use crate::store::Store;
+
+use super::PARALLEL_THRESHOLD;
 
 pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &LocalSink) {
     let store = analysis.store;
-    let pattern_ctx = pattern_analysis::Context::new(analysis, &facts.or_pattern_error_spans);
 
-    for module in store.modules.values() {
-        visibility::run_module(&module.id, store, sink);
-        for file in module.files.values() {
-            duplicate_bindings::run(&file.items, sink);
-            irrefutable_patterns::run(&file.items, sink);
-            receivers::run(&file.items, sink);
-            stringer_signature::run(&file.items, sink);
-            prelude_shadowing::run(&file.items, store, sink);
-            generics::run(&file.items, &module.id, store, sink);
-            newtype::run(&file.items, store, sink);
-            native_value_usage::run(&file.items, &module.id, store, sink);
-            enum_variant_value::run(&file.items, store, sink);
-            temp_producing::run(&file.items, sink);
-            for expression in &file.items {
-                pattern_analysis::check(expression, &pattern_ctx, sink);
-            }
-        }
+    let mut module_ids: Vec<&str> = store.modules.keys().map(String::as_str).collect();
+    module_ids.sort_unstable();
+    for module_id in &module_ids {
+        visibility::run_module(module_id, store, sink);
     }
 
-    facts.pattern_issues = pattern_ctx.take_issues();
+    let mut work: Vec<(&Module, &File)> = store
+        .modules
+        .values()
+        .flat_map(|m| m.files.values().map(move |f| (m, f)))
+        .collect();
+    work.sort_unstable_by(|a, b| {
+        a.0.id
+            .cmp(&b.0.id)
+            .then_with(|| a.1.name.cmp(&b.1.name))
+            .then_with(|| a.1.id.cmp(&b.1.id))
+    });
+
+    let or_spans = &facts.or_pattern_error_spans;
+
+    if work.len() < PARALLEL_THRESHOLD {
+        let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
+        for (module, file) in &work {
+            run_file_checks(module, file, store, sink, &pattern_ctx);
+        }
+        facts.pattern_issues = pattern_ctx.take_issues();
+        return;
+    }
+
+    type WorkerOutput = (LocalSink, Vec<PatternIssue>);
+    let outputs: Vec<WorkerOutput> = work
+        .par_iter()
+        .map(|(module, file)| {
+            let local_sink = LocalSink::new();
+            let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
+            run_file_checks(module, file, store, &local_sink, &pattern_ctx);
+            (local_sink, pattern_ctx.take_issues())
+        })
+        .collect();
+
+    let mut worker_sinks = Vec::with_capacity(outputs.len());
+    let mut all_issues = Vec::new();
+    for (worker_sink, issues) in outputs {
+        worker_sinks.push(worker_sink);
+        all_issues.extend(issues);
+    }
+    sink.extend(LocalSink::merge(worker_sinks));
+    facts.pattern_issues = all_issues;
+}
+
+fn run_file_checks(
+    module: &Module,
+    file: &File,
+    store: &Store,
+    sink: &LocalSink,
+    pattern_ctx: &pattern_analysis::Context,
+) {
+    duplicate_bindings::run(&file.items, sink);
+    irrefutable_patterns::run(&file.items, sink);
+    receivers::run(&file.items, sink);
+    stringer_signature::run(&file.items, sink);
+    prelude_shadowing::run(&file.items, store, sink);
+    generics::run(&file.items, &module.id, store, sink);
+    newtype::run(&file.items, store, sink);
+    native_value_usage::run(&file.items, &module.id, store, sink);
+    enum_variant_value::run(&file.items, store, sink);
+    temp_producing::run(&file.items, sink);
+    for expression in &file.items {
+        pattern_analysis::check(expression, pattern_ctx, sink);
+    }
 }

--- a/crates/semantics/src/passes/fact_producers/generics.rs
+++ b/crates/semantics/src/passes/fact_producers/generics.rs
@@ -1,25 +1,25 @@
 //! Generic-parameter fact producers for the lint layer.
 //!
-//! Records facts on `Facts`; rendering happens later in `lints::from_facts`.
+//! Records facts via `LocalFacts`; rendering happens later in `lints::from_facts`.
 
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Annotation, Binding, Expression, Generic};
 use syntax::types::Type;
 
-use crate::facts::Facts;
+use crate::facts::LocalFacts;
 
-pub(crate) fn run(typed_ast: &[Expression], facts: &mut Facts) {
+pub(crate) fn run(typed_ast: &[Expression], local: &mut LocalFacts) {
     for item in typed_ast {
-        visit_expression(item, facts);
+        visit_expression(item, local);
     }
 }
 
-fn visit_expression(expression: &Expression, facts: &mut Facts) {
+fn visit_expression(expression: &Expression, local: &mut LocalFacts) {
     match expression {
         Expression::ImplBlock { methods, .. } => {
             for method in methods {
-                visit_expression(method, facts);
+                visit_expression(method, local);
             }
             return;
         }
@@ -29,14 +29,14 @@ fn visit_expression(expression: &Expression, facts: &mut Facts) {
             return_type,
             ..
         } => {
-            check_unused_type_parameters(generics, params, return_type, facts);
-            check_type_params_only_in_bound(generics, params, return_type, facts);
+            check_unused_type_parameters(generics, params, return_type, local);
+            check_type_params_only_in_bound(generics, params, return_type, local);
         }
         _ => {}
     }
 
     for child in expression.children() {
-        visit_expression(child, facts);
+        visit_expression(child, local);
     }
 }
 
@@ -44,7 +44,7 @@ fn check_unused_type_parameters(
     generics: &[Generic],
     params: &[Binding],
     return_type: &Type,
-    facts: &mut Facts,
+    local: &mut LocalFacts,
 ) {
     if generics.is_empty() {
         return;
@@ -67,7 +67,7 @@ fn check_unused_type_parameters(
         }
 
         if remaining.contains(&generic.name) {
-            facts.add_unused_type_param(generic.name.to_string(), generic.span);
+            local.add_unused_type_param(generic.name.to_string(), generic.span);
         }
     }
 }
@@ -76,7 +76,7 @@ fn check_type_params_only_in_bound(
     generics: &[Generic],
     params: &[Binding],
     return_type: &Type,
-    facts: &mut Facts,
+    local: &mut LocalFacts,
 ) {
     if generics.is_empty() {
         return;
@@ -94,7 +94,7 @@ fn check_type_params_only_in_bound(
         if generic.name.starts_with('_') || !only_in_bound.contains(&generic.name) {
             continue;
         }
-        facts.add_type_param_only_in_bound(generic.name.to_string(), generic.span);
+        local.add_type_param_only_in_bound(generic.name.to_string(), generic.span);
     }
 }
 

--- a/crates/semantics/src/passes/fact_producers/mod.rs
+++ b/crates/semantics/src/passes/fact_producers/mod.rs
@@ -1,15 +1,50 @@
 pub(crate) mod generics;
 pub(crate) mod unused_expressions;
 
+use rayon::prelude::*;
+use syntax::program::{File, Module};
+
 use crate::context::AnalysisContext;
-use crate::facts::Facts;
+use crate::facts::{Facts, LocalFacts};
+
+use super::PARALLEL_THRESHOLD;
 
 pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts) {
     let store = analysis.store;
-    for module in store.modules.values() {
-        for file in module.files.values() {
-            generics::run(&file.items, facts);
-            unused_expressions::run(&file.items, &module.id, store, facts);
+
+    let mut work: Vec<(&Module, &File)> = store
+        .modules
+        .values()
+        .flat_map(|m| m.files.values().map(move |f| (m, f)))
+        .collect();
+    work.sort_unstable_by(|a, b| {
+        a.0.id
+            .cmp(&b.0.id)
+            .then_with(|| a.1.name.cmp(&b.1.name))
+            .then_with(|| a.1.id.cmp(&b.1.id))
+    });
+
+    if work.len() < PARALLEL_THRESHOLD {
+        let mut local = LocalFacts::default();
+        for (module, file) in &work {
+            generics::run(&file.items, &mut local);
+            unused_expressions::run(&file.items, &module.id, store, &mut local);
         }
+        facts.absorb_local_facts(local);
+        return;
+    }
+
+    let locals: Vec<LocalFacts> = work
+        .par_iter()
+        .map(|(module, file)| {
+            let mut local = LocalFacts::default();
+            generics::run(&file.items, &mut local);
+            unused_expressions::run(&file.items, &module.id, store, &mut local);
+            local
+        })
+        .collect();
+
+    for local in locals {
+        facts.absorb_local_facts(local);
     }
 }

--- a/crates/semantics/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/semantics/src/passes/fact_producers/unused_expressions.rs
@@ -2,7 +2,7 @@ use diagnostics::UnusedExpressionKind;
 use syntax::ast::{Annotation, Expression, SelectArmPattern, Span, UnaryOperator};
 use syntax::types::{Symbol, Type};
 
-use crate::facts::Facts;
+use crate::facts::LocalFacts;
 use crate::store::Store;
 use diagnostics::infer::MismatchedTailKind;
 
@@ -11,7 +11,12 @@ struct TailContext<'a> {
     expected_ty: &'a Type,
 }
 
-pub(crate) fn run(typed_ast: &[Expression], module_id: &str, store: &Store, facts: &mut Facts) {
+pub(crate) fn run(
+    typed_ast: &[Expression],
+    module_id: &str,
+    store: &Store,
+    facts: &mut LocalFacts,
+) {
     for item in typed_ast {
         visit_expression(item, None, module_id, store, facts);
     }
@@ -22,7 +27,7 @@ fn visit_expression(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     match expression {
         Expression::Block { items, ty, .. }
@@ -108,7 +113,7 @@ fn visit_block_items(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     let len = items.len();
     for (i, item) in items.iter().enumerate() {
@@ -139,7 +144,7 @@ fn descend_discarded(
     mode: &DiscardMode<'_>,
     module_id: &str,
     store: &Store,
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     match expression.unwrap_parens() {
         Expression::Block { items, .. }
@@ -210,7 +215,7 @@ fn descend_loop_break_values(
     mode: &DiscardMode<'_>,
     module_id: &str,
     store: &Store,
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     match expression {
         Expression::Break {
@@ -234,7 +239,7 @@ fn descend_loop_break_values(
     }
 }
 
-fn emit_unused_at_leaf(leaf: &Expression, module_id: &str, store: &Store, facts: &mut Facts) {
+fn emit_unused_at_leaf(leaf: &Expression, module_id: &str, store: &Store, facts: &mut LocalFacts) {
     let span = leaf.get_span();
     let is_literal = is_literal_or_negated_literal(leaf);
     let ty = leaf.get_type();
@@ -250,7 +255,7 @@ fn check_discarded_tail(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     let unwrapped = item.unwrap_parens();
     let reported_ty = get_call_return_type(unwrapped).unwrap_or_else(|| unwrapped.get_type());
@@ -295,7 +300,7 @@ fn emit_unused_expression(
     ty: &Type,
     is_literal: bool,
     allowed_lints: &[String],
-    facts: &mut Facts,
+    facts: &mut LocalFacts,
 ) {
     let kind = if is_literal {
         Some(UnusedExpressionKind::Literal)

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -7,25 +7,50 @@ use std::cell::RefCell;
 
 use super::from_facts::LintContext;
 use crate::context::AnalysisContext;
+use crate::passes::PARALLEL_THRESHOLD;
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
+use rayon::prelude::*;
+use syntax::program::Module;
 
 pub(crate) fn run(analysis: &AnalysisContext, sink: &LocalSink) {
     let store = analysis.store;
-    for module in store.modules.values() {
-        if module.is_internal() {
-            continue;
+
+    let mut modules: Vec<&Module> = store
+        .modules
+        .values()
+        .filter(|m| !m.is_internal())
+        .collect();
+    modules.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+
+    if modules.len() < PARALLEL_THRESHOLD {
+        for module in &modules {
+            run_module(module, sink);
         }
-        for file in module.files.values() {
-            let ctx = LintContext {
-                ast: &file.items,
-                is_d_lis: file.is_d_lis(),
-                files: &module.files,
-            };
-            let mut diagnostics = AstLintGroup.check(&ctx);
-            diagnostics.sort_by(LisetteDiagnostic::sort_key);
-            sink.extend(diagnostics);
-        }
+        return;
+    }
+
+    let worker_sinks: Vec<LocalSink> = modules
+        .par_iter()
+        .map(|module| {
+            let local_sink = LocalSink::new();
+            run_module(module, &local_sink);
+            local_sink
+        })
+        .collect();
+    sink.extend(LocalSink::merge(worker_sinks));
+}
+
+fn run_module(module: &Module, sink: &LocalSink) {
+    for file in module.files.values() {
+        let ctx = LintContext {
+            ast: &file.items,
+            is_d_lis: file.is_d_lis(),
+            files: &module.files,
+        };
+        let mut diagnostics = AstLintGroup.check(&ctx);
+        diagnostics.sort_by(LisetteDiagnostic::sort_key);
+        sink.extend(diagnostics);
     }
 }
 

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -2,10 +2,12 @@ mod extract;
 mod reference_graph;
 mod visibility_constraints;
 
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::context::AnalysisContext;
 use crate::facts::Facts;
+use crate::passes::PARALLEL_THRESHOLD;
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
@@ -39,28 +41,71 @@ pub(crate) fn run(
     let go_package_names = &store.go_package_names;
     let config = LintConfig::default();
 
-    for module in store.modules.values() {
-        if module.is_internal() {
-            continue;
+    let mut modules: Vec<&Module> = store
+        .modules
+        .values()
+        .filter(|m| !m.is_internal())
+        .collect();
+    modules.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+
+    if modules.len() < PARALLEL_THRESHOLD {
+        for module in &modules {
+            apply_ref_lints(module, go_package_names, &config, facts, unused, sink);
         }
-        let result = run_ref_lints(module, &module.files, go_package_names, &config, facts);
-        if !result.unused_import_aliases.is_empty() {
-            unused.imports_by_module.insert(
-                module.id.clone().into(),
-                result
-                    .unused_import_aliases
-                    .into_iter()
-                    .map(|s| s.into())
-                    .collect(),
-            );
-        }
-        for span in result.unused_definition_spans {
-            unused.mark_definition_unused(span);
-        }
-        let mut diagnostics = result.diagnostics;
-        diagnostics.sort_by(LisetteDiagnostic::sort_key);
-        sink.extend(diagnostics);
+        return;
     }
+
+    type WorkerOutput = (LocalSink, UnusedInfo);
+    let outputs: Vec<WorkerOutput> = modules
+        .par_iter()
+        .map(|module| {
+            let local_sink = LocalSink::new();
+            let mut local_unused = UnusedInfo::default();
+            apply_ref_lints(
+                module,
+                go_package_names,
+                &config,
+                facts,
+                &mut local_unused,
+                &local_sink,
+            );
+            (local_sink, local_unused)
+        })
+        .collect();
+
+    let mut worker_sinks = Vec::with_capacity(outputs.len());
+    for (worker_sink, worker_unused) in outputs {
+        worker_sinks.push(worker_sink);
+        unused.merge(worker_unused);
+    }
+    sink.extend(LocalSink::merge(worker_sinks));
+}
+
+fn apply_ref_lints(
+    module: &Module,
+    go_package_names: &HashMap<String, String>,
+    config: &LintConfig,
+    facts: &Facts,
+    unused: &mut UnusedInfo,
+    sink: &LocalSink,
+) {
+    let result = run_ref_lints(module, &module.files, go_package_names, config, facts);
+    if !result.unused_import_aliases.is_empty() {
+        unused.imports_by_module.insert(
+            module.id.clone().into(),
+            result
+                .unused_import_aliases
+                .into_iter()
+                .map(|s| s.into())
+                .collect(),
+        );
+    }
+    for span in result.unused_definition_spans {
+        unused.mark_definition_unused(span);
+    }
+    let mut diagnostics = result.diagnostics;
+    diagnostics.sort_by(LisetteDiagnostic::sort_key);
+    sink.extend(diagnostics);
 }
 
 fn run_ref_lints(

--- a/crates/semantics/src/passes/lints/replaceable_with_zero_fill.rs
+++ b/crates/semantics/src/passes/lints/replaceable_with_zero_fill.rs
@@ -1,25 +1,49 @@
 use diagnostics::LocalSink;
+use rayon::prelude::*;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Literal, Span, StructFieldAssignment, StructSpread};
-use syntax::program::DefinitionBody;
+use syntax::program::{DefinitionBody, File, Module};
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
 use crate::checker::infer::expressions::struct_call::has_zero;
 use crate::context::AnalysisContext;
+use crate::passes::PARALLEL_THRESHOLD;
 use crate::store::Store;
 
 const ZERO_FIELD_THRESHOLD: usize = 3;
 
 pub(crate) fn run(analysis: &AnalysisContext, sink: &LocalSink) {
     let store = analysis.store;
-    for module in store.modules.values() {
-        if module.is_internal() {
-            continue;
-        }
-        for file in module.files.values() {
+
+    let mut work: Vec<(&Module, &File)> = store
+        .modules
+        .values()
+        .filter(|m| !m.is_internal())
+        .flat_map(|m| m.files.values().map(move |f| (m, f)))
+        .collect();
+    work.sort_unstable_by(|a, b| {
+        a.0.id
+            .cmp(&b.0.id)
+            .then_with(|| a.1.name.cmp(&b.1.name))
+            .then_with(|| a.1.id.cmp(&b.1.id))
+    });
+
+    if work.len() < PARALLEL_THRESHOLD {
+        for (module, file) in &work {
             run_per_file(&file.items, &file.source, &module.id, store, sink);
         }
+        return;
     }
+
+    let worker_sinks: Vec<LocalSink> = work
+        .par_iter()
+        .map(|(module, file)| {
+            let local_sink = LocalSink::new();
+            run_per_file(&file.items, &file.source, &module.id, store, &local_sink);
+            local_sink
+        })
+        .collect();
+    sink.extend(LocalSink::merge(worker_sinks));
 }
 
 fn run_per_file(

--- a/crates/semantics/src/passes/mod.rs
+++ b/crates/semantics/src/passes/mod.rs
@@ -11,6 +11,8 @@ mod lints;
 
 pub use lints::Lint;
 
+pub(crate) const PARALLEL_THRESHOLD: usize = 4;
+
 pub fn run(
     analysis: &AnalysisContext,
     facts: &mut Facts,

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -48,6 +48,22 @@ impl UnusedInfo {
     pub fn is_unused_definition(&self, span: &Span) -> bool {
         self.definitions.contains(span)
     }
+
+    pub fn merge(&mut self, other: UnusedInfo) {
+        let UnusedInfo {
+            bindings,
+            definitions,
+            imports_by_module,
+        } = other;
+        self.bindings.extend(bindings);
+        self.definitions.extend(definitions);
+        for (module, imports) in imports_by_module {
+            self.imports_by_module
+                .entry(module)
+                .or_default()
+                .extend(imports);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -75,4 +91,37 @@ pub struct EmitInput {
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
     pub go_package_names: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(offset: u32) -> Span {
+        Span::new(0, offset, 1)
+    }
+
+    #[test]
+    fn merge_extends_bindings_definitions_and_imports() {
+        let mut a = UnusedInfo::default();
+        a.mark_binding_unused(span(0));
+        a.mark_definition_unused(span(1));
+        a.imports_by_module
+            .insert("m1".into(), HashSet::from_iter(["x".into()]));
+
+        let mut b = UnusedInfo::default();
+        b.mark_binding_unused(span(2));
+        b.mark_definition_unused(span(3));
+        b.imports_by_module
+            .insert("m1".into(), HashSet::from_iter(["y".into()]));
+        b.imports_by_module
+            .insert("m2".into(), HashSet::from_iter(["z".into()]));
+
+        a.merge(b);
+
+        assert_eq!(a.bindings.len(), 2);
+        assert_eq!(a.definitions.len(), 2);
+        assert_eq!(a.imports_by_module["m1"].len(), 2);
+        assert_eq!(a.imports_by_module["m2"].len(), 1);
+    }
 }


### PR DESCRIPTION
Post-inference passes now run in parallel across modules and files. Projects below the 4-item per-phase threshold stay serial.

Cold-cache `lis check` on synthetic multi-module projects:

Modules | Before | After | Delta
-- | -- | -- | --
10 | 40 ms | 37 ms | -7.5%
30 | 112 ms | 93 ms | -17%
100 | ~360 ms | 306 ms | -15%


> `n` modules ~660 LOC each, `LISETTE_NO_CACHE=1`, hyperfine with `--warmup 5 --runs 25`, M1 MBP

Follow-up to #365