### PR TITLE
fix: mut param correctness

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2542,21 +2542,12 @@ pub fn reference_through_newtype(span: Span) -> LisetteDiagnostic {
 
 pub fn immutable_argument_to_mut_param(
     var_name: &str,
+    callee_label: &str,
     span: Span,
-    is_external: bool,
 ) -> LisetteDiagnostic {
-    let help = if is_external {
-        format!(
-            "Bindings in Lisette are immutable by default. Use `let mut {} = ...` to allow mutation",
-            var_name
-        )
-    } else {
-        format!(
-            "Bindings in Lisette are immutable by default. Use `let mut {} = ...` to allow mutation, \
-             or make the parameter immutable by removing `mut` from the function signature",
-            var_name
-        )
-    };
+    let help = format!(
+        "{callee_label} may mutate `{var_name}`, so declare it mutable using `let mut {var_name} = ...`."
+    );
     LisetteDiagnostic::error("Immutable argument passed to `mut` parameter")
         .with_infer_code("immutable_arg_to_mut_param")
         .with_span_label(&span, "expected mutable, found immutable")

--- a/crates/semantics/src/checker/infer/carry_mut.rs
+++ b/crates/semantics/src/checker/infer/carry_mut.rs
@@ -1,0 +1,108 @@
+use rustc_hash::FxHashSet;
+
+use crate::checker::EnvResolve;
+use crate::checker::type_env::TypeEnv;
+use crate::store::Store;
+use syntax::ast::VariantFields;
+use syntax::program::DefinitionBody;
+use syntax::types::{CompoundKind, Symbol, Type, build_substitution_map, substitute};
+
+/// Whether a value of `ty` can carry mutation across a function call boundary.
+///
+/// True for `Slice<T>`, `Map<K,V>`, `EnumeratedSlice<T>`, and any struct,
+/// tuple, or enum that recursively contains one. `Ref<T>`, `Channel<T>`,
+/// `Sender<T>`, and `Receiver<T>` are excluded by design.
+pub(super) fn can_carry_mutation_across_fn_boundary(
+    ty: &Type,
+    env: &TypeEnv,
+    store: &Store,
+) -> bool {
+    let mut visited: FxHashSet<Symbol> = FxHashSet::default();
+    can_carry_mutation(ty, env, store, &mut visited)
+}
+
+fn can_carry_mutation(
+    ty: &Type,
+    env: &TypeEnv,
+    store: &Store,
+    visited: &mut FxHashSet<Symbol>,
+) -> bool {
+    let resolved = ty.resolve_in(env);
+    match &resolved {
+        Type::Compound { kind, args } => match kind {
+            CompoundKind::Slice | CompoundKind::Map | CompoundKind::EnumeratedSlice => true,
+            CompoundKind::Ref
+            | CompoundKind::Channel
+            | CompoundKind::Sender
+            | CompoundKind::Receiver => false,
+            CompoundKind::VarArgs => args
+                .first()
+                .is_some_and(|inner| can_carry_mutation(inner, env, store, visited)),
+        },
+        Type::Tuple(elems) => elems
+            .iter()
+            .any(|e| can_carry_mutation(e, env, store, visited)),
+        Type::Nominal { id, params, .. } => {
+            let peeled = store.peel_alias(&resolved);
+            if !matches!(&peeled, Type::Nominal { id: pid, .. } if pid == id) {
+                return can_carry_mutation(&peeled, env, store, visited);
+            }
+            if !visited.insert(id.clone()) {
+                return false;
+            }
+            let result = nominal_can_carry_mutation(id, params, env, store, visited);
+            visited.remove(id);
+            result
+        }
+        Type::Forall { body, .. } => can_carry_mutation(body, env, store, visited),
+        Type::Function { .. }
+        | Type::Var { .. }
+        | Type::Parameter(_)
+        | Type::Simple(_)
+        | Type::Never
+        | Type::ImportNamespace(_)
+        | Type::ReceiverPlaceholder
+        | Type::Error => false,
+    }
+}
+
+fn nominal_can_carry_mutation(
+    id: &Symbol,
+    params: &[Type],
+    env: &TypeEnv,
+    store: &Store,
+    visited: &mut FxHashSet<Symbol>,
+) -> bool {
+    let Some(def) = store.get_definition(id.as_str()) else {
+        return false;
+    };
+    match &def.body {
+        DefinitionBody::Struct {
+            generics, fields, ..
+        } => {
+            let map = build_substitution_map(generics, params);
+            fields.iter().any(|f| {
+                let substituted = substitute(&f.ty, &map);
+                can_carry_mutation(&substituted, env, store, visited)
+            })
+        }
+        DefinitionBody::Enum {
+            generics, variants, ..
+        } => {
+            let map = build_substitution_map(generics, params);
+            variants.iter().any(|v| match &v.fields {
+                VariantFields::Unit => false,
+                VariantFields::Tuple(fields) | VariantFields::Struct(fields) => {
+                    fields.iter().any(|f| {
+                        let substituted = substitute(&f.ty, &map);
+                        can_carry_mutation(&substituted, env, store, visited)
+                    })
+                }
+            })
+        }
+        DefinitionBody::TypeAlias { .. }
+        | DefinitionBody::ValueEnum { .. }
+        | DefinitionBody::Interface { .. }
+        | DefinitionBody::Value { .. } => false,
+    }
+}

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -9,6 +9,7 @@ use syntax::types::{
 };
 
 use super::super::TaskState;
+use super::super::carry_mut::can_carry_mutation_across_fn_boundary;
 use super::super::unify::Dispatched;
 use super::primitives::contains_deref;
 use crate::checker::scopes::UseContext;
@@ -382,7 +383,13 @@ impl TaskState<'_> {
 
         let new_args = self.infer_call_arguments(store, args, &effective_param_types);
         self.check_call_arity(&param_types, &new_args, &callee_expression, &span);
-        self.check_mut_param_arguments(&new_args, &param_mutability, &callee_expression);
+        self.check_mut_param_arguments(
+            store,
+            &new_args,
+            &param_types,
+            &param_mutability,
+            &callee_expression,
+        );
         self.check_range_to_for_variadic(&new_args, &variadic_elem_ty);
 
         if let Some(idx) = substring_range_idx
@@ -397,13 +404,13 @@ impl TaskState<'_> {
                     let var = self.new_type_var();
                     self.type_slice(var)
                 } else {
-                    self.type_slice(elem_ty)
+                    self.type_slice(elem_ty.clone())
                 };
                 let inferred =
                     self.with_value_context(|s| s.infer_expression(store, spread_expr, &expected));
                 if param_mutability.last().copied().unwrap_or(false) {
-                    let is_external = self.is_external_callee(&callee_expression);
-                    self.check_arg_against_mut_param(&inferred, is_external);
+                    let callee_label = callee_label(&callee_expression);
+                    self.check_arg_against_mut_param(store, &inferred, &elem_ty, &callee_label);
                 }
                 inferred
             }
@@ -1292,21 +1299,6 @@ impl TaskState<'_> {
         }
     }
 
-    fn is_external_callee(&self, expression: &Expression) -> bool {
-        if let Expression::DotAccess {
-            expression: base, ..
-        } = expression
-            && let Expression::Identifier { value, .. } = base.as_ref()
-        {
-            return self
-                .imports
-                .prefix_to_module
-                .get(value.as_ref())
-                .is_some_and(|module_id| module_id.starts_with("go:"));
-        }
-        false
-    }
-
     /// Check that native mutating methods (append, extend,
     /// delete) are called on mutable receivers. The emitter rewrites these into
     /// mutations, so the checker must enforce `mut` on the binding.
@@ -1390,19 +1382,34 @@ impl TaskState<'_> {
 
     fn check_mut_param_arguments(
         &mut self,
+        store: &Store,
         args: &[Expression],
+        param_types: &[Type],
         param_mutability: &[bool],
         callee: &Expression,
     ) {
-        let is_external = self.is_external_callee(callee);
+        let callee_label = callee_label(callee);
         for (i, arg) in args.iter().enumerate() {
-            if param_mutability.get(i).copied().unwrap_or(false) {
-                self.check_arg_against_mut_param(arg, is_external);
+            if !param_mutability.get(i).copied().unwrap_or(false) {
+                continue;
             }
+            let Some(param_ty) = param_types.get(i) else {
+                continue;
+            };
+            self.check_arg_against_mut_param(store, arg, param_ty, &callee_label);
         }
     }
 
-    fn check_arg_against_mut_param(&mut self, arg: &Expression, is_external: bool) {
+    fn check_arg_against_mut_param(
+        &mut self,
+        store: &Store,
+        arg: &Expression,
+        param_ty: &Type,
+        callee_label: &str,
+    ) {
+        if !can_carry_mutation_across_fn_boundary(param_ty, &self.env, store) {
+            return;
+        }
         let Some(var_name) = arg.get_var_name() else {
             return;
         };
@@ -1410,8 +1417,8 @@ impl TaskState<'_> {
             self.sink
                 .push(diagnostics::infer::immutable_argument_to_mut_param(
                     &var_name,
+                    callee_label,
                     arg.get_span(),
-                    is_external,
                 ));
         }
         if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
@@ -1464,5 +1471,18 @@ impl TaskState<'_> {
                 .get_name()
                 .is_some_and(|n| n == "Range")
         })
+    }
+}
+
+fn callee_label(expr: &Expression) -> String {
+    match expr {
+        Expression::Identifier { value, .. } => format!("`{}()`", value),
+        Expression::DotAccess {
+            expression, member, ..
+        } => match expression.as_ref() {
+            Expression::Identifier { value, .. } => format!("`{}.{}()`", value, member),
+            _ => "the function".to_string(),
+        },
+        _ => "the function".to_string(),
     }
 }

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod addressability;
+mod carry_mut;
 pub(crate) mod expressions;
 mod interface;
 mod unify;

--- a/crates/semantics/src/passes/checks/pattern_analysis/inhabitance.rs
+++ b/crates/semantics/src/passes/checks/pattern_analysis/inhabitance.rs
@@ -5,7 +5,7 @@ use crate::store::Store;
 use syntax::ast::{EnumVariant, Generic, StructFieldDefinition};
 use syntax::program::DefinitionBody;
 use syntax::types::Type;
-use syntax::types::{SubstitutionMap, substitute};
+use syntax::types::{SubstitutionMap, build_substitution_map, substitute};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InhabitanceState {
@@ -193,12 +193,4 @@ pub fn is_struct_inhabited(
         let field_ty = substitute(&f.ty, &map);
         is_inhabited(&field_ty, store, cache)
     })
-}
-
-fn build_substitution_map(generics: &[Generic], type_args: &[Type]) -> SubstitutionMap {
-    generics
-        .iter()
-        .map(|g| g.name.clone())
-        .zip(type_args.iter().cloned())
-        .collect()
 }

--- a/crates/semantics/src/passes/lints/from_facts.rs
+++ b/crates/semantics/src/passes/lints/from_facts.rs
@@ -97,8 +97,9 @@ fn collect_bindings(facts: &Facts, unused: &mut UnusedInfo, out: &mut Vec<Lisett
     for b in facts.bindings.values() {
         let is_anon = b.name.starts_with('_');
         let written_but_not_read = b.kind.is_mutable() && b.mutated && !b.used && !is_anon;
+        let is_write_only_param = written_but_not_read && b.kind.is_param();
 
-        if !b.used {
+        if !b.used && !is_write_only_param {
             if !is_anon && b.kind.is_param() && !b.is_typedef && b.name != "self" {
                 out.push(diagnostics::lint::unused_parameter(&b.span, &b.name));
             } else if !written_but_not_read

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -4,6 +4,8 @@ use std::cell::OnceCell;
 
 use ecow::EcoString;
 
+use crate::ast::Generic;
+
 /// Dot-qualified identifier for a named type, method, value, or variant.
 ///
 /// Wraps the qualified name (`"main.Point.sum"`, `"prelude.Option"`,
@@ -177,6 +179,16 @@ pub fn peel_to_range_type(ty: &Type) -> Option<&Type> {
 
 /// type param name -> type variable
 pub type SubstitutionMap = HashMap<EcoString, Type>;
+
+/// Build a substitution map from a list of generics and their type arguments,
+/// pairing each generic's name with the type at the same position.
+pub fn build_substitution_map(generics: &[Generic], type_args: &[Type]) -> SubstitutionMap {
+    generics
+        .iter()
+        .zip(type_args.iter())
+        .map(|(g, t)| (g.name.clone(), t.clone()))
+        .collect()
+}
 
 pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
     if map.is_empty() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -912,8 +912,8 @@
    ·               <span class="diag-ptr">╰── expected mutable, found immutable</span>
  <span class="diag-dim">6</span> │ }
    ╰────
-  <span class="diag-dim">help: Bindings in Lisette are immutable by default.
-        Use <span class="diag-accent">let mut nums = ...</span> to allow mutation</span></pre>
+  <span class="diag-dim">help: <span class="diag-accent">sort.Ints()</span> may mutate <span class="diag-accent">nums</span>, so declare it mutable
+        using <span class="diag-accent">let mut nums = ...</span></span></pre>
         </div>
 
         <div class="diag-block">

--- a/docs/intro/safety.md
+++ b/docs/intro/safety.md
@@ -266,16 +266,16 @@ In Lisette, value receivers are immutable like any other binding:
   help: Use `self: Ref<Counter>` to mutate the receiver
 ```
 
-### Mutability indicator
+### Mutable parameters
 
-Go functions that mutate their parameters (e.g. `sort.Ints`) do not signal that they do so:
+Go does not signal parameter mutation that affects the caller:
 
 ```go
 nums := []int{3, 1, 2}
 sort.Ints(nums) // silently mutates `nums`
 ```
 
-In Lisette, functions that mutate their parameters must declare so:
+In Lisette, functions that mutate their parameters in a way observable to the caller must declare so with `mut`.
 
 ```
   [error] Immutable argument passed to `mut` parameter
@@ -285,26 +285,10 @@ In Lisette, functions that mutate their parameters must declare so:
    ·             ──┬─
    ·               ╰── expected mutable, found immutable
    ╰────
-  help: Bindings in Lisette are immutable by default. Use `let mut nums = ...` to allow mutation
+  help: `sort.Ints()` may mutate `nums`, so declare it mutable using `let mut nums = ...`
 ```
 
-Lisette warns about excess mutability:
-
-```
-  [warning] Unnecessary `mut`
-   ╭─[example.lis:2:11]
- 1 │ fn main() {
- 2 │   let mut count = items.length()
-   ·           ──┬──
-   ·             ╰── declared as mutable
- 3 │ }
-   ╰────
-  help: Remove `mut` from the declaration if you do not need to mutate the variable
-```
-
-ℹ️ The immutability of `let` protects the binding from reassignment, but it does not protect the value from mutation through a `Ref<T>` pointer.
-
-📚 See [`02-types.md`](../reference/02-types.md)
+📚 See [`05-functions.md`](../reference/05-functions.md#mutable-parameters)
 
 ## Zero values
 

--- a/docs/reference/05-functions.md
+++ b/docs/reference/05-functions.md
@@ -96,19 +96,26 @@ fn sorted<T: Ordered>(xs: Slice<T>) -> Slice<T> { ... }
 
 ## Mutable parameters
 
-Parameters are immutable by default. If a function mutates a parameter (e.g. sorting a slice in place), mark it with `mut`:
+By default, parameters disallow rebinding inside the function body. Mark them `mut` to allow rebinding.
+
+Additionally, if the function writes through the parameter in a way observable to the caller, marking the parameter `mut` requires the call-site binding to be `mut` as well.
 
 ```rust
 fn sort_in_place(mut items: Slice<int>) {
   // ...
 }
 
-let mut mutable_nums = [3, 1, 2]
-sort_in_place(mutable_nums)  // ok
+let mut nums = [3, 1, 2] // arg mutable
+sort_in_place(nums)  // param mutable, ok
 
-let immutable_nums = [3, 1, 2]
-sort_in_place(immutable_nums)  // error
+let nums = [3, 1, 2] // arg immutable
+sort_in_place(nums)  // param immutable, error
 ```
+
+This additional rule applies to `Slice<T>`, `Map<K, V>`, and any struct, tuple, or enum that recursively contains one. This rule does not apply to:
+
+- Values that Go passes by copy, e.g. `int`, `string`, `bool`, `float64`, plain structs, tuples.
+- `Ref<T>` and `Channel<T>`. The purpose of pointers and channels is to share or transmit data, so mutation is implied.
 
 ## Lambdas
 

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -233,26 +233,14 @@ let new_age: Option<int> = Some(30)
 db.Exec("UPDATE users SET age = ? WHERE id = ?", new_age, id)?
 ```
 
-Go functions that mutate a parameter declare it with `mut`
+Go functions that mutate their parameters in a way observable to the caller must declare so with `mut`.
 
 ```rust
 // sort.d.lis
 pub fn Ints(mut x: Slice<int>)
 ```
 
-The compiler enforces that callers pass a mutable binding:
-
-```rust
-import "go:sort"
-
-let mut nums = [3, 1, 2]
-sort.Ints(nums)   // ok
-
-let frozen = [3, 1, 2]
-sort.Ints(frozen)  // error
-```
-
-Run e.g. `lis doc go:os` to view the declaration file for a Go stdlib package or `lis doc go:os.File` to view the declaration file for a Go stdlib type.
+📚 See [`05-functions.md`](../reference/05-functions.md#mutable-parameters)
 
 ## Panic recovery
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4938,3 +4938,65 @@ fn go_import_collision_silent_when_aliases_differ() {
         diagnostics.iter().map(|d| d.code_str()).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn write_only_mut_param_keeps_name_in_codegen_via_reassignment() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn reassign_only(mut items: Slice<int>) {
+  items = [99, 99, 99]
+}
+
+fn main() {
+  let mut data = [1, 2, 3]
+  reassign_only(data)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn write_only_mut_local_emits_blank_identifier_to_avoid_unused_var_error() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let mut x = 0
+  x = 1
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn write_only_mut_param_keeps_name_in_codegen_via_index_write() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn index_write(mut items: Slice<int>) {
+  items[0] = 99
+}
+
+fn main() {
+  let mut data = [1, 2, 3]
+  index_write(data)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}

--- a/tests/spec/build/snapshots/write_only_mut_local_emits_blank_identifier_to_avoid_unused_var_error.snap
+++ b/tests/spec/build/snapshots/write_only_mut_local_emits_blank_identifier_to_avoid_unused_var_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+func main() {
+	_ = 0
+	_ = 1
+}

--- a/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_index_write.snap
+++ b/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_index_write.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+func index_write(items []int) {
+	items[0] = 99
+}
+
+func main() {
+	data := []int{1, 2, 3}
+	index_write(data)
+}

--- a/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_reassignment.snap
+++ b/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_reassignment.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+func reassign_only(items []int) {
+	items = []int{99, 99, 99}
+}
+
+func main() {
+	data := []int{1, 2, 3}
+	reassign_only(data)
+}

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2218,3 +2218,261 @@ fn my_sort(items: Slice<int>) {
     )
     .assert_infer_code("immutable_arg_to_mut_param");
 }
+
+#[test]
+fn mut_int_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn to_char(mut n: int) -> int {
+  n = n - 10
+  return n
+}
+
+fn main() {
+  let rnd = 42
+  let _ = to_char(rnd)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_string_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn append_bang(mut s: string) -> string {
+  s = s + "!"
+  return s
+}
+
+fn main() {
+  let greeting = "hi"
+  let _ = append_bang(greeting)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_bool_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn flip(mut b: bool) -> bool {
+  b = !b
+  return b
+}
+
+fn main() {
+  let flag = true
+  let _ = flip(flag)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_float_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn bump(mut f: float64) -> float64 {
+  f = f + 1.0
+  return f
+}
+
+fn main() {
+  let v = 1.5
+  let _ = bump(v)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_byte_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn inc(mut x: byte) -> byte {
+  x = x + 1
+  return x
+}
+
+fn main() {
+  let b: byte = 65
+  let _ = inc(b)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_value_struct_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+struct Point { x: int, y: int }
+
+fn relocate(mut p: Point) -> Point {
+  p = Point { x: 0, y: 0 }
+  return p
+}
+
+fn main() {
+  let p = Point { x: 1, y: 2 }
+  let _ = relocate(p)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_value_tuple_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn reset(mut t: (int, int)) -> (int, int) {
+  t = (0, 0)
+  return t
+}
+
+fn main() {
+  let t = (1, 2)
+  let _ = reset(t)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_struct_containing_slice_requires_mut_arg() {
+    infer(
+        r#"
+struct Box { items: Slice<int> }
+
+fn write_first(mut b: Box) {
+  b.items[0] = 99
+}
+
+fn main() {
+  let b = Box { items: [1, 2, 3] }
+  write_first(b)
+}
+"#,
+    )
+    .assert_infer_code("immutable_arg_to_mut_param");
+}
+
+#[test]
+fn mut_enum_variant_carrying_slice_requires_mut_arg() {
+    infer(
+        r#"
+enum Payload { Items(Slice<int>), Empty }
+
+fn touch(mut p: Payload) {
+  let _ = p
+}
+
+fn main() {
+  let p = Payload.Items([1, 2, 3])
+  touch(p)
+}
+"#,
+    )
+    .assert_infer_code("immutable_arg_to_mut_param");
+}
+
+#[test]
+fn mut_ref_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn bump(mut r: Ref<int>) {
+  r.* = r.* + 1
+}
+
+fn main() {
+  let x = 10
+  bump(&x)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_channel_param_does_not_require_mut_arg() {
+    infer(
+        r#"
+fn send_one(mut ch: Channel<int>) {
+  ch.send(1)
+}
+
+fn main() {
+  let ch = Channel.new<int>()
+  send_one(ch)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_struct_with_only_ref_field_does_not_require_mut_arg() {
+    infer(
+        r#"
+struct Wrap { r: Ref<int> }
+
+fn touch(mut w: Wrap) {
+  let _ = w
+}
+
+fn main() {
+  let x = 10
+  let w = Wrap { r: &x }
+  touch(w)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_generic_struct_with_slice_requires_mut_arg() {
+    infer(
+        r#"
+struct Box<T> { item: T }
+
+fn write_first(mut b: Box<Slice<int>>) {
+  b.item[0] = 99
+}
+
+fn main() {
+  let b: Box<Slice<int>> = Box { item: [1, 2, 3] }
+  write_first(b)
+}
+"#,
+    )
+    .assert_infer_code("immutable_arg_to_mut_param");
+}
+
+#[test]
+fn mut_generic_struct_with_int_does_not_require_mut_arg() {
+    infer(
+        r#"
+struct Box<T> { item: T }
+
+fn replace(mut b: Box<int>) {
+  b = Box { item: 0 }
+}
+
+fn main() {
+  let b: Box<int> = Box { item: 42 }
+  replace(b)
+}
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7083,12 +7083,14 @@ fn test(parts: Slice<string>) {
 #[test]
 fn infer_immutable_spread_to_mut_variadic_param() {
     let input = r#"
-fn touch(mut items: VarArgs<int>) {
+fn touch(mut items: VarArgs<Slice<int>>) {
   let _ = items
 }
 
 fn main() {
-  let data = [3, 1, 2]
+  let xs = [1, 2]
+  let ys = [3, 4]
+  let data = [xs, ys]
   touch(data...)
 }
 "#;
@@ -7098,15 +7100,15 @@ fn main() {
 #[test]
 fn infer_immutable_args_to_mut_variadic_param() {
     let input = r#"
-fn touch(x: int, mut ys: VarArgs<int>) -> int {
+fn touch(x: int, mut ys: VarArgs<Slice<int>>) -> int {
   let _ = ys
   x
 }
 
 fn main() {
   let a = 1
-  let b = 2
-  let c = 3
+  let b = [1, 2]
+  let c = [3, 4]
   let _ = touch(a, b, c)
 }
 "#;

--- a/tests/ui/errors/snapshots/infer_immutable_arg_to_mut_param.snap
+++ b/tests/ui/errors/snapshots/infer_immutable_arg_to_mut_param.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·          ╰── expected mutable, found immutable
  9 │ }
    ╰────
-  help: Bindings in Lisette are immutable by default. Use `let mut data = ...` to allow mutation, or make the parameter immutable by removing `mut` from the function signature · code: [infer.immutable_arg_to_mut_param]
+  help: `sort()` may mutate `data`, so declare it mutable using `let mut data = ...` · code: [infer.immutable_arg_to_mut_param]

--- a/tests/ui/errors/snapshots/infer_immutable_args_to_mut_variadic_param.snap
+++ b/tests/ui/errors/snapshots/infer_immutable_args_to_mut_variadic_param.snap
@@ -3,10 +3,10 @@ source: tests/ui/errors/mod.rs
 ---
   [error] Immutable argument passed to `mut` parameter
     ╭─[test.lis:11:20]
- 10 │   let c = 3
+ 10 │   let c = [3, 4]
  11 │   let _ = touch(a, b, c)
     ·                    ┬
     ·                    ╰── expected mutable, found immutable
  12 │ }
     ╰────
-  help: Bindings in Lisette are immutable by default. Use `let mut b = ...` to allow mutation, or make the parameter immutable by removing `mut` from the function signature · code: [infer.immutable_arg_to_mut_param]
+  help: `touch()` may mutate `b`, so declare it mutable using `let mut b = ...` · code: [infer.immutable_arg_to_mut_param]

--- a/tests/ui/errors/snapshots/infer_immutable_spread_to_mut_variadic_param.snap
+++ b/tests/ui/errors/snapshots/infer_immutable_spread_to_mut_variadic_param.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   [error] Immutable argument passed to `mut` parameter
-   ╭─[test.lis:8:9]
- 7 │   let data = [3, 1, 2]
- 8 │   touch(data...)
-   ·         ──┬─
-   ·           ╰── expected mutable, found immutable
- 9 │ }
-   ╰────
-  help: Bindings in Lisette are immutable by default. Use `let mut data = ...` to allow mutation, or make the parameter immutable by removing `mut` from the function signature · code: [infer.immutable_arg_to_mut_param]
+    ╭─[test.lis:10:9]
+  9 │   let data = [xs, ys]
+ 10 │   touch(data...)
+    ·         ──┬─
+    ·           ╰── expected mutable, found immutable
+ 11 │ }
+    ╰────
+  help: `touch()` may mutate `data`, so declare it mutable using `let mut data = ...` · code: [infer.immutable_arg_to_mut_param]


### PR DESCRIPTION
`mut`-parameter calls now require `mut` on the caller binding only when the param type can carry mutation back to the caller: `Slice<T>`, `Map<K, V>`, or a struct, tuple, or enum that recursively contains one.

```rs
fn to_char(mut n: int) -> int {
  n = n - 10
  return n
}

fn main() {
  let rnd = 42
  let chr = to_char(rnd)  // ok; previously rejected
}
```

Fixes #369
