### PR TITLE
feat: third-party Go dependencies

### DIFF
--- a/crates/cli/agents_template.md
+++ b/crates/cli/agents_template.md
@@ -192,6 +192,8 @@ Full reference: https://github.com/ivov/lisette/tree/main/docs/reference
 - `lis build` — compile to `target/`
 - `lis check` — type check only
 - `lis format` — format code
+- `lis add google/uuid` - add a third-party Go dependency
+- `lis sync` - reconcile `lisette.toml` with imports
 - `lis doc Slice` — show a prelude type and its methods
 - `lis doc Option.map` — show a single method
 - `lis doc go:os` — browse a Go stdlib package

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -77,7 +77,7 @@ pub fn add(dep_string: &str) -> i32 {
             cli_error!(
                 "Invalid dependency",
                 msg,
-                "Example: `lis add github.com/gorilla/mux@v1.8.0`"
+                "Example: `lis add google/uuid@v1.6.0`"
             );
             return 1;
         }
@@ -451,7 +451,7 @@ fn setup_project(
         return Err(1);
     }
 
-    print_preview_notice("lis add");
+    print_preview_notice();
 
     let project_target_dir = project_root.join("target");
     if project_target_dir.is_file() {

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -36,7 +36,7 @@ fn bash_completions() -> &'static str {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="new build run format check learn doc help complete version"
+    commands="new build run format check add sync learn doc help complete version"
 
     case "$prev" in
         lis)
@@ -89,6 +89,8 @@ _lis() {
         'run:Compile and run a project'
         'format:Format a file or project'
         'check:Validate a file or project'
+        'add:Add a third-party Go dependency'
+        'sync:Reconcile project manifest with imports'
         'learn:Generate a sample project'
         'doc:Explore prelude and Go stdlib'
         'help:Print help message'
@@ -147,6 +149,8 @@ complete -c lis -n __fish_use_subcommand -a build -d 'Compile a project'
 complete -c lis -n __fish_use_subcommand -a run -d 'Compile and run a project'
 complete -c lis -n __fish_use_subcommand -a format -d 'Format a file or project'
 complete -c lis -n __fish_use_subcommand -a check -d 'Validate a file or project'
+complete -c lis -n __fish_use_subcommand -a add -d 'Add a third-party Go dependency'
+complete -c lis -n __fish_use_subcommand -a sync -d 'Reconcile project manifest with imports'
 complete -c lis -n __fish_use_subcommand -a learn -d 'Generate a sample project'
 complete -c lis -n __fish_use_subcommand -a doc -d 'Explore prelude and Go stdlib'
 complete -c lis -n __fish_use_subcommand -a help -d 'Print help message'
@@ -160,6 +164,6 @@ complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show o
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'
 complete -c lis -n '__fish_seen_subcommand_from complete' -a 'bash zsh fish' -d 'Shell type'
-complete -c lis -n '__fish_seen_subcommand_from help' -a 'new build run format check learn doc help complete version' -d 'Command'
+complete -c lis -n '__fish_seen_subcommand_from help' -a 'new build run format check add sync learn doc help complete version' -d 'Command'
 "#
 }

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -17,11 +17,13 @@ Commands:
     `run`, `r`     Compile and run a project
     `format`, `f`  Format a project
     `check`, `c`   Validate a project
-    `doc`        Browse symbols and packages
+    `add`        Add a third-party Go dependency
+    `sync`       Reconcile project manifest
 
 Extras:
     `version`    Print compiler version
     `help`       Show help for a command
+    `doc`        Browse symbols and packages
     `learn`      Create a new sample project
     `complete`   Shell completion scripts
     `lsp`        Start the language server",
@@ -38,7 +40,7 @@ Usage:
     `lis help` <command>
 
 Commands:
-    `new`, `build`, `run`, `format`, `check`, `doc`
+    `new`, `build`, `run`, `format`, `check`, `add`, `sync`, `doc`
 
 Extras:
     `version`, `help`, `learn`, `complete`, `lsp`",
@@ -130,6 +132,32 @@ Examples:
     `lis check`                          Check project in current dir
     `lis check` {path/to/project/dir:g}      Check project in specific dir
     `lis check` {script.lis:g}               Check single file",
+        ),
+
+        "add" => print_help(
+            "`lis add` <dependency>
+
+Add a third-party Go dependency to your Lisette project. Will download the
+Go module, record the module and its transitives in `lisette.toml`, and
+generate typedefs for the target module and any imported packages.
+
+Arguments:
+    <dependency>    Go module path with optional `@version` (default: latest)
+
+Examples:
+    `lis add` {google/uuid:g}                   Latest version
+    `lis add` {google/uuid@v1.6.0:g}            Exact version
+    `lis add` {google/uuid@2d3c2a9:g}           Exact commit hash or branch
+    `lis add` {go.uber.org/zap:g}               Full path for non-GitHub host",
+        ),
+
+        "sync" => print_help(
+            "`lis sync`
+
+Tidy `lisette.toml` against the `go:` imports in `src/`, similar to
+`go mod tidy`. Will drop dependency entries no longer reached by any import, and
+generate typedefs for every imported package. Run this after removing imports,
+deleting source files, or pulling new code.",
         ),
 
         "lsp" => print_help(

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -10,7 +10,7 @@ use lisette::fs::collect_lis_filepaths_recursive;
 use crate::go_cli;
 use crate::handlers::add::find_project_root;
 use crate::lock::{acquire_mutation_lock, acquire_target_lock};
-use crate::output::{print_preview_notice, print_sync_summary};
+use crate::output::print_sync_summary;
 use crate::typedef_regen::prewarm_typedef_cache;
 use crate::workspace::WorkspaceBindgen;
 use crate::{cli_error, error};
@@ -62,8 +62,6 @@ pub fn sync() -> i32 {
         );
         return 1;
     }
-
-    print_preview_notice("lis sync");
 
     let target_dir = project_root.join("target");
     if target_dir.is_file() {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -176,20 +176,15 @@ pub fn capitalize_first(s: &str) -> String {
     }
 }
 
-pub fn print_preview_notice(command: &str) {
+pub fn print_preview_notice() {
     eprintln!();
     if use_color() {
         eprintln!(
-            "  ! You are running an unfinished feature: {}",
-            command.bright_magenta()
-        );
-        eprintln!(
-            "  ! Support for third-party Go dependencies is {}",
-            "not yet stable".yellow().underline()
+            "  ! Support for third-party Go dependencies is in {}",
+            "early preview".yellow().underline()
         );
     } else {
-        eprintln!("  ! You are running an unfinished feature: {}", command);
-        eprintln!("  ! Support for third-party Go dependencies is experimental");
+        eprintln!("  ! Support for third-party Go dependencies is in early preview");
     }
     eprintln!("  ! Bug reports are welcome: https://github.com/ivov/lisette/issues");
     eprintln!();

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -153,11 +153,13 @@ Commands:
     run, r     Compile and run a project
     format, f  Format a project
     check, c   Validate a project
-    doc        Browse symbols and packages
+    add        Add a third-party Go dependency
+    sync       Reconcile project manifest
 
 Extras:
     version    Print compiler version
     help       Show help for a command
+    doc        Browse symbols and packages
     learn      Create a new sample project
     complete   Shell completion scripts
     lsp        Start the language server

--- a/docs/intro/roadmap.md
+++ b/docs/intro/roadmap.md
@@ -8,7 +8,6 @@ Status:
 
 Planned work:
 
-- Support third-party packages
 - Implement a test runner
 - Introduce bitwise operators
 - Make diagnostics configurable

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -1,6 +1,6 @@
 # Go Interop
 
-Lisette can import from the Go standard library. Third-party packages will be supported in future.
+Lisette can import from the Go stdlib and from [third-party modules](#third-party-go-dependencies).
 
 ## Importing Go packages
 
@@ -19,11 +19,11 @@ fn main() {
 }
 ```
 
-The `go:` prefix distinguishes Go packages from project modules.
+The `go:` prefix distinguishes Go packages from your own project's modules.
 
 ```rust
 import "go:fmt"       // Go stdlib
-import "handlers"     // project module
+import "handlers"     // project module (dir)
 ```
 
 To import a Go package for its side effects only, use a blank import:
@@ -58,7 +58,7 @@ Compound types are different:
 | `VarArgs<T>`    | `...T` (call-site only)      |
 | `Unknown`       | `any` or `interface{}`       |
 
-Fixed-size arrays `[N]T` are not yet representable in Lisette. In return position they lower to `Slice<T>`. In any other position (e.g. parameters, struct fields, map keys, slice or map elements), bindgen currently skips the declaration. This may change in future.
+Fixed-size arrays `[N]T` are not yet representable in Lisette. In return position they lower to `Slice<T>`. In any other position (e.g. parameters, struct fields, map keys, slice or map elements), the declaration is currently skipped.
 
 ### Named numeric types
 
@@ -132,9 +132,9 @@ claims["iat"] = 1714665600
 let token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
 ```
 
-## Declaration files
+## Type definition files
 
-Declaration files `.d.lis` describe Go packages in Lisette syntax.
+Type definition files `.d.lis` describe Go packages in Lisette syntax.
 
 For example, `Open` in the `os` package in the Go standard library:
 
@@ -272,6 +272,67 @@ task {
 ```
 
 Run `lis doc PanicValue` for available methods.
+
+## Third-party Go dependencies
+
+> [!IMPORTANT]
+> Dependency management is in early preview. 
+> Bug reports and feedback are welcome.
+
+A Lisette project can depend on a third-party Go module.
+
+To add a third-party dependency:
+
+```sh
+lis add google/uuid              # latest version
+lis add google/uuid@v1.6.0       # exact version
+lis add google/uuid@2d3c2a9      # exact commit hash or branch
+lis add go.uber.org/zap          # full path for non-GitHub host
+```
+
+Example output:
+
+```
+✓ Added go.uber.org/zap v1.28.0
+  └─ go.uber.org/multierr v1.10.0
+```
+
+`lis add` will:
+
+1. download the Go module to `~/go/pkg/mod`,
+2. generate [typedefs](#type-definition-files) at `target/.lisette/typedefs`, and
+3. declare the module and its transitives in the `lisette.toml` manifest.
+
+```toml
+[dependencies.go]
+"go.uber.org/zap" = "v1.28.0"
+"go.uber.org/multierr" = { version = "v1.10.0", via = ["go.uber.org/zap"] }
+```
+
+To import a third-party dependency:
+
+```rs
+import "go:github.com/google/uuid"
+
+fn main() {
+  let id = uuid.New()
+}
+```
+
+`lis add` generates typedefs for the target package, plus every package reached by following its imports across modules. For efficiency, typedefs are skipped for sibling subpackages and packages from transitive modules that no import reaches - these are generated on demand as you write imports in your project.
+
+To tidy the manifest:
+
+```sh
+lis sync
+```
+
+This will reconcile your project's manifest against state on disk, removing orphaned transitives from the manifest, and generating typedefs for every import.
+
+To remove a dependency:
+
+- Delete the entry from `lisette.toml`
+- Run `lis sync`
 
 <br>
 


### PR DESCRIPTION
Adds `lis add` and `lis sync` to manage third-party Go dependencies, in early preview.

```sh
lis add go.uber.org/zap

✓ Added go.uber.org/zap v1.28.0
  └─ go.uber.org/multierr v1.10.0
```

```rs
import "go:go.uber.org/zap"

fn main() {
  let logger = zap.NewExample()
  logger.Info("server started", zap.String("port", "8080"))
}
```