### PR TITLE
perf: parallelize codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "ecow",
  "lisette-diagnostics",
  "lisette-syntax",
+ "rayon",
  "rustc-hash",
 ]
 

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -16,4 +16,5 @@ test = false
 syntax = { package = "lisette-syntax", version = "0.2.1", path = "../syntax" }
 diagnostics = { package = "lisette-diagnostics", version = "0.2.1", path = "../diagnostics" }
 ecow.workspace = true
+rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -373,11 +373,11 @@ impl Emitter<'_> {
                 let variant = unqualified_name(value);
                 let enum_name = unqualified_name(&enum_id);
                 let qualified = format!("{}.{}", enum_name, variant);
-                if self.module.make_functions.contains_key(&qualified) {
+                if self.globals.make_function_names.contains_key(&qualified) {
                     return Some((enum_id, variant.to_string()));
                 }
                 if let Type::Function { params, .. } = ty.unwrap_forall() {
-                    for key in self.module.make_functions.keys() {
+                    for key in self.globals.make_function_names.keys() {
                         if let Some((e_name, v_name)) = key.split_once('.')
                             && e_name == enum_name
                             && let Some(layout) = self.module.enum_layouts.get(&enum_id)
@@ -401,7 +401,7 @@ impl Emitter<'_> {
                 } = expression.as_ref()
                 {
                     let qualified = format!("{}.{}", enum_name, member);
-                    if self.module.make_functions.contains_key(&qualified) {
+                    if self.globals.make_function_names.contains_key(&qualified) {
                         let enum_id = enum_id_from_type(ty)?;
                         return Some((enum_id, member.to_string()));
                     }
@@ -411,7 +411,7 @@ impl Emitter<'_> {
                 } = expression.as_ref()
                 {
                     let qualified = format!("{}.{}", type_name, member);
-                    if self.module.make_functions.contains_key(&qualified) {
+                    if self.globals.make_function_names.contains_key(&qualified) {
                         let enum_id = enum_id_from_type(ty)?;
                         return Some((enum_id, member.to_string()));
                     }

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -40,34 +40,7 @@ impl Emitter<'_> {
         return_ty: &Type,
         go_hints: &[String],
     ) -> Option<GoCallStrategy> {
-        if return_ty.is_partial() {
-            return Some(GoCallStrategy::Partial);
-        }
-
-        if return_ty.is_result() {
-            return Some(GoCallStrategy::Result);
-        }
-
-        if return_ty.is_option() {
-            if let Some(sentinel) = sentinel_hint(go_hints) {
-                return Some(GoCallStrategy::Sentinel { value: sentinel });
-            }
-            if !self.is_nullable_option(return_ty) {
-                return Some(GoCallStrategy::CommaOk);
-            }
-            if go_hints.iter().any(|s| s == "comma_ok") {
-                return Some(GoCallStrategy::CommaOk);
-            }
-            return Some(GoCallStrategy::NullableReturn);
-        }
-
-        if let Some(arity) = return_ty.tuple_arity()
-            && arity >= 2
-        {
-            return Some(GoCallStrategy::Tuple { arity });
-        }
-
-        None
+        crate::classify_go_return_type(self.ctx.definitions, return_ty, go_hints)
     }
 
     pub(crate) fn resolve_go_call_strategy(
@@ -93,7 +66,7 @@ impl Emitter<'_> {
             && Self::is_go_receiver(receiver_expression)
         {
             if let Some(qualified_name) = self.go_qualified_name(receiver_expression, member)
-                && let Some(strategy) = self.module.go_call_strategies.get(&qualified_name)
+                && let Some(strategy) = self.globals.go_call_strategies.get(&qualified_name)
             {
                 return Some(strategy.clone());
             }
@@ -257,11 +230,4 @@ impl Emitter<'_> {
         write_line!(output, "{} := {}", tuple_var, constructor);
         tuple_var
     }
-}
-
-fn sentinel_hint(hints: &[String]) -> Option<i64> {
-    hints
-        .iter()
-        .any(|h| h == "sentinel_minus_one")
-        .then_some(-1)
 }

--- a/crates/emit/src/collectors.rs
+++ b/crates/emit/src/collectors.rs
@@ -1,13 +1,12 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::names::go_name;
-use crate::Emitter;
+use crate::{Emitter, PreludeType};
 use syntax::ast::{Expression, Visibility};
 use syntax::program::{DefinitionBody, File};
-use syntax::types::Type;
 
 impl Emitter<'_> {
-    pub(crate) fn collect_exported_method_names(&mut self, files: &[&File]) {
+    pub(crate) fn collect_local_exported_method_names(&mut self, files: &[&File]) {
         for file in files {
             for item in &file.items {
                 if let syntax::ast::Expression::Interface {
@@ -36,32 +35,6 @@ impl Emitter<'_> {
                         }
                     }
                 }
-            }
-        }
-
-        for (key, definition) in self.ctx.definitions.iter() {
-            match &definition.body {
-                DefinitionBody::Interface {
-                    definition: iface, ..
-                } if definition.visibility.is_public() => {
-                    for method_name in iface.methods.keys() {
-                        self.module
-                            .exported_method_names
-                            .insert(method_name.to_string());
-                    }
-                }
-                DefinitionBody::Value { .. }
-                    if definition.visibility.is_public()
-                        && !go_name::is_go_import(key)
-                        && !key.starts_with(go_name::PRELUDE_PREFIX)
-                        && key.chars().filter(|c| *c == '.').count() >= 2 =>
-                {
-                    let method_name = go_name::unqualified_name(key);
-                    self.module
-                        .exported_method_names
-                        .insert(method_name.to_string());
-                }
-                _ => {}
             }
         }
     }
@@ -199,83 +172,42 @@ impl Emitter<'_> {
         }
     }
 
-    pub(crate) fn collect_go_call_strategies(&mut self) {
-        let candidates: Vec<(String, Type, Vec<String>)> = self
-            .ctx
-            .definitions
-            .iter()
-            .filter(|(key, _)| go_name::is_go_import(key))
-            .filter_map(|(key, definition)| {
-                let ty = match definition.ty() {
-                    Type::Forall { body, .. } => body.as_ref().clone(),
-                    other => other.clone(),
-                };
-                let return_ty = match &ty {
-                    Type::Function { return_type, .. } => (**return_type).clone(),
-                    _ => return None,
-                };
-                let go_hints = definition.go_hints().to_vec();
-                Some((key.to_string(), return_ty, go_hints))
-            })
-            .collect();
-
-        for (key, return_ty, go_hints) in candidates {
-            if let Some(strategy) = self.classify_go_return_type(&return_ty, &go_hints) {
-                self.module.go_call_strategies.insert(key, strategy);
-            }
-        }
-    }
-
-    /// Register make function names for all enums; return bodies keyed by declaring file_id.
-    pub(crate) fn collect_make_functions(&mut self) -> HashMap<u32, Vec<String>> {
-        self.register_prelude_make_functions();
-
+    pub(crate) fn collect_local_make_function_code(&mut self) -> HashMap<u32, Vec<String>> {
         let module_prefix = format!("{}.", self.current_module);
         let mut code: HashMap<u32, Vec<String>> = HashMap::default();
 
-        // Collect enum info first to avoid borrow conflicts
-        let enums: Vec<_> = self
+        let local_enums: Vec<_> = self
             .ctx
             .definitions
             .iter()
             .filter_map(|(key, definition)| {
-                if let syntax::program::Definition {
+                let syntax::program::Definition {
                     name: Some(name),
                     name_span: Some(name_span),
                     body: DefinitionBody::Enum { variants, .. },
                     ..
                 } = definition
-                {
-                    if name == "Option" || name == "Result" || name == "Partial" {
-                        return None;
-                    }
-                    Some((
-                        key.to_string(),
-                        name.clone(),
-                        variants.clone(),
-                        name_span.file_id,
-                    ))
-                } else {
-                    None
+                else {
+                    return None;
+                };
+                if PreludeType::from_name(name).is_some() {
+                    return None;
                 }
+                if !key.starts_with(&module_prefix) {
+                    return None;
+                }
+                let rest = &key[module_prefix.len()..];
+                if rest.contains('.') {
+                    return None;
+                }
+                Some((key.to_string(), variants.clone(), name_span.file_id))
             })
             .collect();
 
-        for (_, name, variants, _) in &enums {
-            self.register_make_functions(name, variants);
-        }
-
-        for (key, _name, variants, file_id) in &enums {
-            if !key.starts_with(&module_prefix) {
-                continue;
-            }
-            let rest = &key[module_prefix.len()..];
-            if rest.contains('.') {
-                continue;
-            }
-            for variant in variants {
-                let fn_code = self.create_make_function_code(key, &variant.name);
-                code.entry(*file_id).or_default().push(fn_code);
+        for (key, variants, file_id) in local_enums {
+            for variant in &variants {
+                let fn_code = self.create_make_function_code(&key, &variant.name);
+                code.entry(file_id).or_default().push(fn_code);
             }
         }
 

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -1,7 +1,7 @@
 use crate::Emitter;
 use crate::names::generics::receiver_generics_string;
 use crate::names::go_name;
-use syntax::ast::{Attribute, EnumVariant, Generic};
+use syntax::ast::{Attribute, Generic};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
 
@@ -61,23 +61,6 @@ impl Emitter<'_> {
         }
 
         Some(result)
-    }
-
-    pub(crate) fn register_prelude_make_functions(&mut self) {
-        for prelude_type in crate::PreludeType::enum_types() {
-            for (constructor, make_fn) in prelude_type.make_function_entries() {
-                self.module.make_functions.insert(constructor, make_fn);
-            }
-        }
-    }
-
-    pub(crate) fn register_make_functions(&mut self, name: &str, variants: &[EnumVariant]) {
-        let go_type_name = go_name::escape_keyword(name);
-        for variant in variants {
-            let constructor = format!("{}.{}", name, variant.name);
-            let fn_name = format!("Make{}{}", go_type_name, variant.name);
-            self.module.make_functions.insert(constructor, fn_name);
-        }
     }
 
     pub(crate) fn create_make_function_code(

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -53,15 +53,7 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn resolve_to_function_type(&self, ty: &Type) -> Option<Type> {
-        fn as_function(ty: &Type) -> Option<Type> {
-            if matches!(ty, Type::Function { .. }) {
-                return Some(ty.clone());
-            }
-            ty.get_underlying()
-                .filter(|u| matches!(u, Type::Function { .. }))
-                .cloned()
-        }
-        as_function(ty).or_else(|| as_function(&self.peel_alias(ty)))
+        crate::resolve_to_function_type(self.ctx.definitions, ty)
     }
 
     /// Collect own + transitively inherited methods, tagged with the id

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -102,7 +102,11 @@ impl Emitter<'_> {
         let enum_name = unqualified_name(enum_id);
         let constructor_key = format!("{}.{}", enum_name, variant_name);
 
-        let make_fn_name = self.module.make_functions.get(&constructor_key)?.clone();
+        let make_fn_name = self
+            .globals
+            .make_function_names
+            .get(&constructor_key)?
+            .clone();
 
         let enum_module = go_name::module_of_type_id(enum_id);
         let needs_qualifier = enum_module != self.current_module;
@@ -166,7 +170,7 @@ impl Emitter<'_> {
 
         let enum_name = unqualified_name(enum_id);
         let key = format!("{}.{}", enum_name, variant_name);
-        let make_fn = self.module.make_functions.get(&key)?.clone();
+        let make_fn = self.globals.make_function_names.get(&key)?.clone();
         let type_args = self.format_type_args(params);
 
         if is_prelude {

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -68,7 +68,7 @@ impl Emitter<'_> {
             return IdentifierKind::PublicFunction { capitalized };
         }
 
-        let mut make_fn = self.module.make_functions.get(&name);
+        let mut make_fn = self.globals.make_function_names.get(&name);
 
         if make_fn.is_none() {
             let enum_id = match ty {
@@ -86,7 +86,7 @@ impl Emitter<'_> {
             if let Some(id) = enum_id {
                 let enum_name = unqualified_name(id);
                 let qualified = format!("{}.{}", enum_name, value);
-                make_fn = self.module.make_functions.get(&qualified);
+                make_fn = self.globals.make_function_names.get(&qualified);
             }
         }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -33,12 +33,180 @@ use std::sync::Arc;
 use ecow::EcoString;
 use imports::ImportBuilder;
 use syntax::ast::{Generic, Span};
-use syntax::program::{Definition, EmitInput, File, ModuleId, MutationInfo, UnusedInfo};
+use syntax::program::{
+    Definition, DefinitionBody, EmitInput, File, ModuleId, MutationInfo, UnusedInfo,
+};
 use syntax::types::{Symbol, Type};
 
 #[derive(Clone, Debug, Default)]
 pub struct EmitOptions {
     pub debug: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct GlobalEmitData {
+    pub(crate) go_call_strategies: HashMap<String, GoCallStrategy>,
+    pub(crate) exported_method_names: HashSet<String>,
+    pub(crate) make_function_names: HashMap<String, String>,
+}
+
+impl GlobalEmitData {
+    fn compute(definitions: &HashMap<Symbol, Definition>) -> Self {
+        let mut globals = GlobalEmitData::default();
+
+        for prelude_type in PreludeType::enum_types() {
+            for (constructor, make_fn) in prelude_type.make_function_entries() {
+                globals.make_function_names.insert(constructor, make_fn);
+            }
+        }
+
+        for (key, definition) in definitions.iter() {
+            let is_go = go_name::is_go_import(key);
+
+            if is_go
+                && let Type::Function { return_type, .. } = match definition.ty() {
+                    Type::Forall { body, .. } => body.as_ref(),
+                    other => other,
+                }
+                && let Some(strategy) =
+                    classify_go_return_type(definitions, return_type, definition.go_hints())
+            {
+                globals.go_call_strategies.insert(key.to_string(), strategy);
+            }
+
+            match &definition.body {
+                DefinitionBody::Interface {
+                    definition: iface, ..
+                } if definition.visibility.is_public() => {
+                    for method_name in iface.methods.keys() {
+                        globals
+                            .exported_method_names
+                            .insert(method_name.to_string());
+                    }
+                }
+                DefinitionBody::Value { .. }
+                    if definition.visibility.is_public()
+                        && !is_go
+                        && !key.starts_with(go_name::PRELUDE_PREFIX)
+                        && key.chars().filter(|c| *c == '.').count() >= 2 =>
+                {
+                    let method_name = go_name::unqualified_name(key);
+                    globals
+                        .exported_method_names
+                        .insert(method_name.to_string());
+                }
+                _ => {}
+            }
+
+            if let Definition {
+                name: Some(name),
+                body: DefinitionBody::Enum { variants, .. },
+                ..
+            } = definition
+                && PreludeType::from_name(name).is_none()
+            {
+                for (constructor, make_fn) in user_enum_make_function_entries(name, variants) {
+                    globals.make_function_names.insert(constructor, make_fn);
+                }
+            }
+        }
+
+        globals
+    }
+}
+
+/// Make-function name registry entries for a user-declared enum, paralleling
+/// [`PreludeType::make_function_entries`].
+pub(crate) fn user_enum_make_function_entries<'a>(
+    name: &'a str,
+    variants: &'a [syntax::ast::EnumVariant],
+) -> impl Iterator<Item = (String, String)> + 'a {
+    let go_type_name = go_name::escape_keyword(name).into_owned();
+    variants.iter().map(move |variant| {
+        let constructor = format!("{}.{}", name, variant.name);
+        let make_fn = format!("Make{}{}", go_type_name, variant.name);
+        (constructor, make_fn)
+    })
+}
+
+pub(crate) fn classify_go_return_type(
+    definitions: &HashMap<Symbol, Definition>,
+    return_ty: &Type,
+    go_hints: &[String],
+) -> Option<GoCallStrategy> {
+    if return_ty.is_partial() {
+        return Some(GoCallStrategy::Partial);
+    }
+    if return_ty.is_result() {
+        return Some(GoCallStrategy::Result);
+    }
+    if return_ty.is_option() {
+        if let Some(value) = sentinel_hint(go_hints) {
+            return Some(GoCallStrategy::Sentinel { value });
+        }
+        if !is_nullable_option(definitions, return_ty) {
+            return Some(GoCallStrategy::CommaOk);
+        }
+        if go_hints.iter().any(|s| s == "comma_ok") {
+            return Some(GoCallStrategy::CommaOk);
+        }
+        return Some(GoCallStrategy::NullableReturn);
+    }
+    if let Some(arity) = return_ty.tuple_arity()
+        && arity >= 2
+    {
+        return Some(GoCallStrategy::Tuple { arity });
+    }
+    None
+}
+
+pub(crate) fn sentinel_hint(hints: &[String]) -> Option<i64> {
+    hints
+        .iter()
+        .any(|h| h == "sentinel_minus_one")
+        .then_some(-1)
+}
+
+pub(crate) fn is_nullable_option(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> bool {
+    ty.is_option() && is_nilable_go_type(definitions, &ty.ok_type())
+}
+
+pub(crate) fn is_nilable_go_type(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> bool {
+    ty.is_ref()
+        || as_interface(definitions, ty).is_some()
+        || resolve_to_function_type(definitions, ty).is_some()
+}
+
+pub(crate) fn as_interface(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Option<String> {
+    let Type::Nominal { id, .. } = peel_alias(definitions, ty) else {
+        return None;
+    };
+    matches!(
+        definitions.get(id.as_str()).map(|d| &d.body),
+        Some(DefinitionBody::Interface { .. })
+    )
+    .then(|| id.to_string())
+}
+
+pub(crate) fn resolve_to_function_type(
+    definitions: &HashMap<Symbol, Definition>,
+    ty: &Type,
+) -> Option<Type> {
+    fn as_function(ty: &Type) -> Option<Type> {
+        if matches!(ty, Type::Function { .. }) {
+            return Some(ty.clone());
+        }
+        ty.get_underlying()
+            .filter(|u| matches!(u, Type::Function { .. }))
+            .cloned()
+    }
+    as_function(ty).or_else(|| as_function(&peel_alias(definitions, ty)))
+}
+
+pub(crate) fn peel_alias(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Type {
+    syntax::types::peel_alias(ty, |id| {
+        definitions.get(id).is_some_and(Definition::is_type_alias)
+    })
 }
 
 pub struct TestEmitConfig<'a> {
@@ -65,15 +233,12 @@ struct EmitContext<'a> {
 }
 
 struct ModuleData {
-    make_functions: HashMap<String, String>,
     enum_layouts: HashMap<String, EnumLayout>,
     /// Fields that were exported due to serialization tags (e.g. `#[json]`).
     /// Key is "TypeId.field_name". Checked during field access to match
     /// the capitalization used in the struct definition.
     tag_exported_fields: HashSet<String>,
-    /// Method names that appear in any pub interface.
-    /// These must be capitalized in Go to satisfy the interface,
-    /// regardless of the concrete method's own visibility.
+    /// Local complement to `GlobalEmitData::exported_method_names`.
     exported_method_names: HashSet<String>,
     /// Bounds from constrained impl blocks, keyed by receiver name.
     /// Go requires type parameter constraints on the type definition itself,
@@ -93,8 +258,6 @@ struct ModuleData {
     /// T itself (not *T) to satisfy the interface. So we emit `item T` and let Go
     /// infer T = *ConcreteType. Ref<T> for these params should emit as just T.
     absorbed_ref_generics: HashSet<String>,
-    /// Pre-computed wrapping strategy per Go function.
-    go_call_strategies: HashMap<String, GoCallStrategy>,
     /// Lisette name → freshened Go name when `escape_reserved` would collide
     /// with a sibling top-level definition (e.g. `fn len` and `fn len_` both
     /// targeting `len_`). Consulted at definition and call sites.
@@ -127,6 +290,7 @@ impl ScopeState {
 
 pub struct Emitter<'a> {
     ctx: EmitContext<'a>,
+    globals: Arc<GlobalEmitData>,
     module: ModuleData,
     scope: ScopeState,
 
@@ -215,6 +379,8 @@ impl<'a> Emitter<'a> {
             HashMap::default()
         });
 
+        let globals = Arc::new(GlobalEmitData::compute(&analysis.definitions));
+
         for (module_id, module_info) in &analysis.modules {
             if analysis.cached_modules.contains(module_id) {
                 continue;
@@ -231,7 +397,7 @@ impl<'a> Emitter<'a> {
                 options: options.clone(),
                 line_indexes: line_indexes.clone(),
             };
-            let mut emitter = Self::new(ctx, module_id);
+            let mut emitter = Self::new(ctx, globals.clone(), module_id);
 
             let files: Vec<_> = module_info
                 .file_ids
@@ -275,14 +441,15 @@ impl<'a> Emitter<'a> {
             options: EmitOptions { debug },
             line_indexes,
         };
-        Self::new(ctx, config.module_id)
+        let globals = Arc::new(GlobalEmitData::compute(config.definitions));
+        Self::new(ctx, globals, config.module_id)
     }
 
-    fn new(ctx: EmitContext<'a>, current_module: &str) -> Self {
+    fn new(ctx: EmitContext<'a>, globals: Arc<GlobalEmitData>, current_module: &str) -> Self {
         Self {
             ctx,
+            globals,
             module: ModuleData {
-                make_functions: HashMap::default(),
                 enum_layouts: HashMap::default(),
                 tag_exported_fields: HashSet::default(),
                 exported_method_names: HashSet::default(),
@@ -291,7 +458,6 @@ impl<'a> Emitter<'a> {
                 module_aliases: HashMap::default(),
                 reverse_module_aliases: HashMap::default(),
                 absorbed_ref_generics: HashSet::default(),
-                go_call_strategies: HashMap::default(),
                 escape_remap: HashMap::default(),
             },
             scope: ScopeState {
@@ -505,12 +671,11 @@ impl<'a> Emitter<'a> {
     pub fn emit_files(&mut self, files: &[&File], module_id: &str) -> Vec<OutputFile> {
         self.current_module = module_id.to_string();
         self.collect_module_aliases(files);
-        self.collect_go_call_strategies();
-        self.collect_exported_method_names(files);
+        self.collect_local_exported_method_names(files);
         self.collect_impl_bounds(files);
         self.collect_enum_layouts();
         self.collect_escape_remap(files);
-        let mut make_functions_by_file = self.collect_make_functions();
+        let mut make_functions_by_file = self.collect_local_make_function_code();
 
         let mut output_files = Vec::new();
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -360,8 +360,6 @@ impl ReturnContext {
 
 impl<'a> Emitter<'a> {
     pub fn emit(analysis: &'a EmitInput, go_module: &str, options: EmitOptions) -> Vec<OutputFile> {
-        let mut output = vec![];
-
         let line_indexes: Arc<HashMap<u32, LineIndex>> = Arc::new(if options.debug {
             analysis
                 .files
@@ -381,41 +379,35 @@ impl<'a> Emitter<'a> {
 
         let globals = Arc::new(GlobalEmitData::compute(&analysis.definitions));
 
-        for (module_id, module_info) in &analysis.modules {
-            if analysis.cached_modules.contains(module_id) {
-                continue;
-            }
+        let mut work: Vec<(&ModuleId, &syntax::program::ModuleInfo)> = analysis
+            .modules
+            .iter()
+            .filter(|(id, _)| !analysis.cached_modules.contains(*id))
+            .collect();
+        work.sort_unstable_by(|a, b| a.0.cmp(b.0));
 
-            let ctx = EmitContext {
-                definitions: &analysis.definitions,
-                unused: &analysis.unused,
-                mutations: &analysis.mutations,
-                ufcs_methods: &analysis.ufcs_methods,
-                go_package_names: &analysis.go_package_names,
-                entry_module: analysis.entry_module_id.to_string(),
-                go_module: go_module.to_string(),
-                options: options.clone(),
-                line_indexes: line_indexes.clone(),
-            };
-            let mut emitter = Self::new(ctx, globals.clone(), module_id);
+        const PARALLEL_THRESHOLD: usize = 4;
 
-            let files: Vec<_> = module_info
-                .file_ids
-                .iter()
-                .filter_map(|fid| analysis.files.get(fid))
-                .collect();
+        let emit_one = |&(module_id, module_info): &(&ModuleId, &syntax::program::ModuleInfo)| {
+            emit_module(
+                analysis,
+                go_module,
+                &options,
+                &line_indexes,
+                &globals,
+                module_id,
+                module_info,
+            )
+        };
 
-            let mut module_output = emitter.emit_files(&files, module_id);
+        let mut output: Vec<OutputFile> = if work.len() < PARALLEL_THRESHOLD {
+            work.iter().flat_map(emit_one).collect()
+        } else {
+            use rayon::prelude::*;
+            work.par_iter().flat_map_iter(emit_one).collect()
+        };
 
-            if module_id != &analysis.entry_module_id {
-                for file in &mut module_output {
-                    file.name = format!("{}/{}", module_info.path, file.name);
-                }
-            }
-
-            output.extend(module_output);
-        }
-
+        output.sort_by(|a, b| a.name.cmp(&b.name));
         output
     }
 
@@ -756,4 +748,43 @@ impl<'a> Emitter<'a> {
 
         output_files
     }
+}
+
+fn emit_module(
+    analysis: &EmitInput,
+    go_module: &str,
+    options: &EmitOptions,
+    line_indexes: &Arc<HashMap<u32, LineIndex>>,
+    globals: &Arc<GlobalEmitData>,
+    module_id: &str,
+    module_info: &syntax::program::ModuleInfo,
+) -> Vec<OutputFile> {
+    let ctx = EmitContext {
+        definitions: &analysis.definitions,
+        unused: &analysis.unused,
+        mutations: &analysis.mutations,
+        ufcs_methods: &analysis.ufcs_methods,
+        go_package_names: &analysis.go_package_names,
+        entry_module: analysis.entry_module_id.to_string(),
+        go_module: go_module.to_string(),
+        options: options.clone(),
+        line_indexes: line_indexes.clone(),
+    };
+    let mut emitter = Emitter::new(ctx, globals.clone(), module_id);
+
+    let files: Vec<_> = module_info
+        .file_ids
+        .iter()
+        .filter_map(|fid| analysis.files.get(fid))
+        .collect();
+
+    let mut module_output = emitter.emit_files(&files, module_id);
+
+    if module_id != analysis.entry_module_id.as_str() {
+        for file in &mut module_output {
+            file.name = format!("{}/{}", module_info.path, file.name);
+        }
+    }
+
+    module_output
 }

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -88,7 +88,8 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn method_needs_export(&self, method_name: &str) -> bool {
-        self.module.exported_method_names.contains(method_name)
+        self.globals.exported_method_names.contains(method_name)
+            || self.module.exported_method_names.contains(method_name)
             || matches!(method_name, "string" | "goString" | "error")
     }
 
@@ -165,12 +166,7 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn peel_alias(&self, ty: &Type) -> Type {
-        syntax::types::peel_alias(ty, |id| {
-            self.ctx
-                .definitions
-                .get(id)
-                .is_some_and(Definition::is_type_alias)
-        })
+        crate::peel_alias(self.ctx.definitions, ty)
     }
 
     pub(crate) fn peel_alias_id(&self, id: &str) -> String {
@@ -202,18 +198,7 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn as_interface(&self, ty: &Type) -> Option<String> {
-        let Type::Nominal { id, .. } = self.peel_alias(ty) else {
-            return None;
-        };
-
-        if matches!(
-            self.ctx.definitions.get(id.as_str()).map(|d| &d.body),
-            Some(DefinitionBody::Interface { .. })
-        ) {
-            Some(id.to_string())
-        } else {
-            None
-        }
+        crate::as_interface(self.ctx.definitions, ty)
     }
 
     pub(crate) fn is_go_imported_type(ty: &Type) -> bool {
@@ -227,13 +212,11 @@ impl Emitter<'_> {
     /// `*T`, Lisette/Go interfaces, and function aliases (Go's
     /// function types are themselves nilable).
     pub(crate) fn is_nilable_go_type(&self, ty: &Type) -> bool {
-        ty.is_ref()
-            || self.as_interface(ty).is_some()
-            || self.resolve_to_function_type(ty).is_some()
+        crate::is_nilable_go_type(self.ctx.definitions, ty)
     }
 
     pub(crate) fn is_nullable_option(&self, ty: &Type) -> bool {
-        ty.is_option() && self.is_nilable_go_type(&ty.ok_type())
+        crate::is_nullable_option(self.ctx.definitions, ty)
     }
 
     /// True for `Option<T>` where T is a concrete non-nilable Go value type

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -88,7 +88,7 @@ pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLoc
     deps::TypedefLocator::new(go_deps, None, stdlib::Target::host())
 }
 
-pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {
+pub fn compile_project_files(fs: MockFileSystem, go_module: &str) -> Vec<emit::OutputFile> {
     let main_source = fs
         .scan_folder(ENTRY_MODULE_ID)
         .get("main.lis")
@@ -123,8 +123,15 @@ pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {
         analysis.errors
     );
 
-    let options = EmitOptions { debug: false };
-    let mut files = Emitter::emit(&analysis.into_emit_input(), go_module, options);
+    Emitter::emit(
+        &analysis.into_emit_input(),
+        go_module,
+        EmitOptions { debug: false },
+    )
+}
+
+pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {
+    let mut files = compile_project_files(fs, go_module);
     files.sort_by(|a, b| a.name.cmp(&b.name));
 
     use std::fmt::Write;

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -5000,3 +5000,45 @@ fn main() {
 
     assert_build_snapshot!(fs, "github.com/user/myproject");
 }
+
+#[test]
+fn emit_returns_files_alphabetically_sorted_through_rayon_path() {
+    use crate::_harness::build::compile_project_files;
+
+    let mut fs = MockFileSystem::new();
+    fs.add_file("alpha", "alpha.lis", "pub fn entry() -> int { 1 }\n");
+    fs.add_file("bravo", "bravo.lis", "pub fn entry() -> int { 2 }\n");
+    fs.add_file("charlie", "charlie.lis", "pub fn entry() -> int { 3 }\n");
+    fs.add_file("delta", "delta.lis", "pub fn entry() -> int { 4 }\n");
+    fs.add_file("echo", "echo.lis", "pub fn entry() -> int { 5 }\n");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "alpha"
+import "bravo"
+import "charlie"
+import "delta"
+import "echo"
+
+fn main() {
+  let _ = alpha.entry() + bravo.entry() + charlie.entry() + delta.entry() + echo.entry()
+}
+"#,
+    );
+
+    let files = compile_project_files(fs, "github.com/user/myproject");
+    let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "alpha/alpha.go",
+            "bravo/bravo.go",
+            "charlie/charlie.go",
+            "delta/delta.go",
+            "echo/echo.go",
+            "main.go",
+        ],
+        "Emitter::emit must return files alphabetically sorted by name",
+    );
+}


### PR DESCRIPTION
Codegen now runs in parallel across modules. Projects with <4 modules stay on the serial path.

Cold-cache `lis build` on synthetic projects:

| Modules | Before  | After  |  Delta |
| ------- | ------: | -----: | -----: |
|       1 |   64 ms |  57 ms |   -12% |
|      10 |  160 ms | 143 ms |   -11% |
|      30 |  352 ms | 289 ms |   -18% |
|     100 | 1121 ms | 906 ms |   -19% |

> `n` modules ~715 LOC each, `LISETTE_NO_CACHE=1`, hyperfine with `--warmup 5 --runs 25`, M1 MBP

The 1-module saving is partly noise and partly comes from removing redundant per-module scans of the global definitions table.