### PR TITLE
fix: support Option<T> when T is a fn type alias

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -11,10 +11,13 @@ use syntax::program::{CallKind, Definition, DefinitionBody};
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute, unqualified_name};
 
 impl Emitter<'_> {
-    /// True when Go's untyped-literal default (`int`/`float64`/`complex128`)
-    /// would mismatch this type, requiring explicit type args at the call site.
-    /// Walks alias chains via the definition map so multi-hop aliases resolve.
+    /// True when Go's inference would lose this alias: function aliases (infer
+    /// as `func(...)`) and non-default numeric aliases (untyped literals default
+    /// to `int`/`float64`/`complex128`).
     pub(crate) fn needs_explicit_args_for_go_inference(&self, ty: &Type) -> bool {
+        if self.is_function_alias(ty) {
+            return true;
+        }
         let mut current = ty.clone();
         let mut seen: HashSet<Symbol> = HashSet::default();
         while let Type::Nominal { id, params, .. } = &current {
@@ -545,7 +548,7 @@ impl Emitter<'_> {
         }
         params
             .iter()
-            .any(|p| self.as_interface(p).is_some() || self.is_go_function_alias(p))
+            .any(|p| self.as_interface(p).is_some() || self.is_function_alias(p))
             .then(|| self.format_type_args(params))
     }
 

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -42,13 +42,10 @@ impl Emitter<'_> {
             .map(|f| f.ty.clone())
     }
 
-    pub(crate) fn is_go_function_alias(&self, ty: &Type) -> bool {
-        let Type::Nominal { id, .. } = ty else {
+    pub(crate) fn is_function_alias(&self, ty: &Type) -> bool {
+        let Type::Nominal { .. } = ty else {
             return false;
         };
-        if !id.starts_with(GO_IMPORT_PREFIX) {
-            return false;
-        }
         self.resolve_to_function_type(ty).is_some()
     }
 

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -471,6 +471,21 @@ impl TaskState<'_> {
 
     pub fn register_type_definitions(&mut self, store: &mut Store, items: &[Expression]) {
         for item in items {
+            if let Expression::TypeAlias {
+                name,
+                name_span,
+                generics,
+                annotation,
+                span,
+                doc,
+                ..
+            } = item
+            {
+                self.populate_type_alias(store, name, name_span, generics, annotation, span, doc);
+            }
+        }
+
+        for item in items {
             match item {
                 Expression::Enum {
                     name,
@@ -527,16 +542,6 @@ impl TaskState<'_> {
                     span,
                     doc,
                 ),
-                Expression::TypeAlias {
-                    name,
-                    name_span,
-                    generics,
-                    annotation,
-                    span,
-                    doc,
-                    ..
-                } => self
-                    .populate_type_alias(store, name, name_span, generics, annotation, span, doc),
                 _ => (),
             }
         }

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -129,6 +129,56 @@ fn test() -> Option<Slice<int>> {
 }
 
 #[test]
+fn some_with_named_function_alias_arg() {
+    let input = r#"
+type Handler = fn(int) -> int
+
+fn double(x: int) -> int {
+  x * 2
+}
+
+struct Wrapper {
+  pub f: Option<Handler>,
+}
+
+fn main() {
+  let _w = Wrapper { f: Some(double) }
+  let _ = _w.f
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_call_with_named_function_alias_arg() {
+    let input = r#"
+type Handler = fn(int) -> int
+
+fn double(x: int) -> int {
+  x * 2
+}
+
+struct Box<T> {
+  pub v: T,
+}
+
+struct Wrap {
+  pub b: Box<Handler>,
+}
+
+fn make_box<T>(x: T) -> Box<T> {
+  Box { v: x }
+}
+
+fn main() {
+  let _w = Wrap { b: make_box(double) }
+  let _ = _w.b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn result_with_struct() {
     let input = r#"
 struct Point { x: int, y: int }

--- a/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+assertion_line: 178
+description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int {\n  x * 2\n}\n\nstruct Box<T> {\n  pub v: T,\n}\n\nstruct Wrap {\n  pub b: Box<Handler>,\n}\n\nfn make_box<T>(x: T) -> Box<T> {\n  Box { v: x }\n}\n\nfn main() {\n  let _w = Wrap { b: make_box(double) }\n  let _ = _w.b\n}\n"
+---
+package main
+
+import "fmt"
+
+type Handler func(int) int
+
+func double(x int) int {
+	return x * 2
+}
+
+type Box[T any] struct {
+	V T
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { v: %v }", b.V)
+}
+
+type Wrap struct {
+	B Box[Handler]
+}
+
+func (w Wrap) String() string {
+	return fmt.Sprintf("Wrap { b: %v }", w.B)
+}
+
+func make_box[T any](x T) Box[T] {
+	return Box[T]{V: x}
+}
+
+func main() {
+	_w := Wrap{B: make_box[Handler](double)}
+	_ = _w.B
+}

--- a/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+assertion_line: 149
+description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int {\n  x * 2\n}\n\nstruct Wrapper {\n  pub f: Option<Handler>,\n}\n\nfn main() {\n  let _w = Wrapper { f: Some(double) }\n  let _ = _w.f\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Handler func(int) int
+
+func double(x int) int {
+	return x * 2
+}
+
+type Wrapper struct {
+	F lisette.Option[Handler]
+}
+
+func (w Wrapper) String() string {
+	return fmt.Sprintf("Wrapper { f: %v }", w.F)
+}
+
+func main() {
+	_w := Wrapper{F: lisette.MakeOptionSome[Handler](double)}
+	_ = _w.F
+}

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4318,3 +4318,81 @@ fn main() {
     );
     infer_module("main", fs).assert_no_errors();
 }
+
+#[test]
+fn struct_field_forward_references_fn_alias() {
+    infer(
+        r#"
+struct Cmd {
+  pub v: Option<Validator>,
+}
+
+type Validator = fn(int) -> Result<(), error>
+
+fn check(_x: int) -> Result<(), error> {
+  Ok(())
+}
+
+fn main() {
+  let _c = Cmd { v: Some(check) }
+  let _ = _c.v
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn imported_struct_field_forward_references_fn_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "cli",
+        "lib.d.lis",
+        r#"
+pub struct Command {
+  pub Args: Option<PositionalArgs>,
+}
+
+pub type PositionalArgs = fn(Ref<Command>, Slice<string>) -> Result<(), error>
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "cli"
+
+fn validate(_cmd: Ref<cli.Command>, _args: Slice<string>) -> Result<(), error> {
+  Ok(())
+}
+
+fn main() {
+  let _c = cli.Command { Args: Some(validate) }
+  let _ = _c.Args
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn struct_field_via_two_alias_hops_to_fn() {
+    infer(
+        r#"
+type Inner = fn(int) -> int
+type Outer = Inner
+
+struct Wrap {
+  pub f: Option<Outer>,
+}
+
+fn dbl(x: int) -> int { x * 2 }
+
+fn main() {
+  let _w = Wrap { f: Some(dbl) }
+  let _ = _w.f
+}
+"#,
+    )
+    .assert_no_errors();
+}


### PR DESCRIPTION
Ensures `Option<T>` accepts `Some(f)` when `T` is a function type alias.

```rs
pub type MyFunc = fn(int) -> int

fn double(x: int) -> int { x * 2 }

struct Wrapper {
  pub f: Option<MyFunc>,
}

fn main() {
  let _w = Wrapper { f: Some(double) }
}
```

Fix #378