### PR TITLE
perf: skip per-file gofmt during build

### DIFF
--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -163,7 +163,7 @@ pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> 
 pub fn write_go_outputs(dir: &Path, files: &[OutputFile], heading: &str) -> Result<(), i32> {
     for file in files {
         let go_file_path = dir.join(&file.name);
-        let go_code = file.to_go();
+        let go_code = file.to_go_unformatted();
 
         if let Some(parent) = go_file_path.parent()
             && let Err(e) = fs::create_dir_all(parent)

--- a/crates/emit/src/output.rs
+++ b/crates/emit/src/output.rs
@@ -21,6 +21,10 @@ impl OutputFile {
         self.gofmt(&unformatted).unwrap_or(unformatted)
     }
 
+    pub fn to_go_unformatted(&self) -> String {
+        self.render_unformatted()
+    }
+
     fn render_unformatted(&self) -> String {
         let mut output = OutputCollector::new();
 


### PR DESCRIPTION
Skips the `gofmt` pass that was running once per output file in `write_go_outputs`, duplicated with the final whole target dir pass in `finalize_go_dir`.

`lis build` cold, `--warmup 5 --runs 25`, MBP M1

| Modules | Before  | After  | Delta |
| ------- | ------: | -----: | ----: |
| 1       | 59 ms   | 54 ms  |   -9% |
| 10      | 158 ms  | 102 ms |  -35% |
| 30      | 358 ms  | 191 ms |  -47% |
| 100     | 1119 ms | 567 ms |  -49% |
