### PR TITLE
refactor: trim dead temps and discards from emitted Go

### DIFF
--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -6,7 +6,7 @@ use crate::types::coercion::Coercion;
 use crate::types::emitter::Position;
 use crate::utils::{DiscardGuard, requires_temp_var, try_flip_comparison};
 use crate::write_line;
-use syntax::ast::{Binding, Expression, Pattern};
+use syntax::ast::{Binding, Expression, Literal, Pattern};
 use syntax::types::Type;
 
 enum LetKind {
@@ -305,40 +305,7 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
 
     fn emit_temp_var_binding(&mut self, output: &mut String, identifier: &str) {
         if !self.emitter.is_declared(identifier) {
-            let resolved_ty = self.resolve_temp_var_decl_ty();
-            let ty = &resolved_ty;
-
-            // When a try/recover block's ok_ty is an unresolved variable, the
-            // var decl would be `Result[any, ...]`. Use the binding type if it
-            // has a resolved ok_ty, or fall back to the return context type.
-            let has_variable_ok_ty = matches!(
-                self.value,
-                Expression::TryBlock { .. } | Expression::RecoverBlock { .. }
-            ) && !ty.is_variable()
-                && ty.ok_type().is_variable();
-
-            let var_ty = if has_variable_ok_ty {
-                let binding_ty = &self.binding.ty;
-                if !binding_ty.is_variable() && !binding_ty.ok_type().is_variable() {
-                    self.emitter.go_type_as_string(binding_ty)
-                } else if let Some(ctx_ty) = self
-                    .emitter
-                    .current_return_context
-                    .as_ref()
-                    .map(|c| c.ty.clone())
-                {
-                    if Fallible::from_type(&ctx_ty).is_some() {
-                        self.emitter.go_type_as_string(&ctx_ty)
-                    } else {
-                        self.emitter.go_type_as_string(ty)
-                    }
-                } else {
-                    self.emitter.go_type_as_string(ty)
-                }
-            } else {
-                self.emitter.go_type_as_string(ty)
-            };
-            write_line!(output, "var {} {}", identifier, var_ty);
+            self.emit_var_decl_if_needed(output, identifier);
             self.emitter.try_declare(identifier);
         }
 
@@ -350,6 +317,46 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         self.emit_value_to_temp(output, identifier);
 
         self.emitter.assign_target_ty = saved_target_ty;
+    }
+
+    fn emit_var_decl_if_needed(&mut self, output: &mut String, identifier: &str) {
+        if identifier == "_" {
+            return;
+        }
+        let resolved_ty = self.resolve_temp_var_decl_ty();
+        let ty = &resolved_ty;
+
+        // When a try/recover block's ok_ty is an unresolved variable, the
+        // var decl would be `Result[any, ...]`. Use the binding type if it
+        // has a resolved ok_ty, or fall back to the return context type.
+        let has_variable_ok_ty = matches!(
+            self.value,
+            Expression::TryBlock { .. } | Expression::RecoverBlock { .. }
+        ) && !ty.is_variable()
+            && ty.ok_type().is_variable();
+
+        let var_ty = if has_variable_ok_ty {
+            let binding_ty = &self.binding.ty;
+            if !binding_ty.is_variable() && !binding_ty.ok_type().is_variable() {
+                self.emitter.go_type_as_string(binding_ty)
+            } else if let Some(ctx_ty) = self
+                .emitter
+                .current_return_context
+                .as_ref()
+                .map(|c| c.ty.clone())
+            {
+                if Fallible::from_type(&ctx_ty).is_some() {
+                    self.emitter.go_type_as_string(&ctx_ty)
+                } else {
+                    self.emitter.go_type_as_string(ty)
+                }
+            } else {
+                self.emitter.go_type_as_string(ty)
+            }
+        } else {
+            self.emitter.go_type_as_string(ty)
+        };
+        write_line!(output, "var {} {}", identifier, var_ty);
     }
 
     /// Emit the value-producing expression into the already-declared temp var
@@ -779,6 +786,25 @@ fn negate_condition(condition: &str) -> String {
     try_flip_comparison(condition).unwrap_or_else(|| format!("!({})", condition))
 }
 
+/// True when discarding `expression` is safe to omit — its value has no
+/// side effects. `FormatString` and `Slice` literals are excluded since they
+/// can hold sub-expressions that do.
+fn is_side_effect_free_discard(expression: &Expression) -> bool {
+    match expression {
+        Expression::Unit { .. } => true,
+        Expression::Literal { literal, .. } => matches!(
+            literal,
+            Literal::Integer { .. }
+                | Literal::Float { .. }
+                | Literal::Imaginary(_)
+                | Literal::Boolean(_)
+                | Literal::String { .. }
+                | Literal::Char(_)
+        ),
+        _ => false,
+    }
+}
+
 impl Emitter<'_> {
     pub(crate) fn emit_let(
         &mut self,
@@ -793,6 +819,10 @@ impl Emitter<'_> {
 
     pub(crate) fn emit_discard(&mut self, output: &mut String, value: &Expression) {
         let unwrapped = value.unwrap_parens();
+
+        if is_side_effect_free_discard(unwrapped) {
+            return;
+        }
 
         if let Expression::Propagate { expression, .. } = unwrapped {
             self.emit_propagate(output, expression, Some("_"));

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -28,18 +28,22 @@ pub(crate) fn receiver_name(type_name: &str) -> String {
 pub(crate) fn output_references_var(output: &str, var: &str) -> bool {
     let masked = mask_go_string_literals(output);
     let bytes = masked.as_bytes();
-    masked.match_indices(var).any(|(abs, _)| {
-        let before_ok = abs == 0 || {
-            let c = bytes[abs - 1];
-            !c.is_ascii_alphanumeric() && c != b'_'
-        };
-        let after = abs + var.len();
-        let after_ok = after >= bytes.len() || {
-            let c = bytes[after];
-            !c.is_ascii_alphanumeric() && c != b'_'
-        };
-        before_ok && after_ok
-    })
+    masked
+        .match_indices(var)
+        .any(|(abs, _)| is_at_token_boundary(bytes, abs, var.len()))
+}
+
+fn is_at_token_boundary(bytes: &[u8], pos: usize, token_len: usize) -> bool {
+    let before_ok = pos == 0 || {
+        let c = bytes[pos - 1];
+        !c.is_ascii_alphanumeric() && c != b'_'
+    };
+    let after = pos + token_len;
+    let after_ok = after >= bytes.len() || {
+        let c = bytes[after];
+        !c.is_ascii_alphanumeric() && c != b'_'
+    };
+    before_ok && after_ok
 }
 
 /// Replace Go string/rune/raw-string contents with spaces, preserving byte
@@ -267,37 +271,43 @@ pub(crate) fn optimize_function_body(output: &mut String) {
 /// Only collapses when VAR appears nowhere else in the region (true single-use).
 /// Pattern bindings are always pure field accesses, so reordering is safe.
 pub(crate) fn inline_trivial_bindings(output: &mut String, pre_len: usize) {
-    let region = &output[pre_len..];
-    let lines: Vec<&str> = region.lines().collect();
+    // Loop to fixpoint: collapsing one binding can expose another (e.g.
+    // `y := pair.Second` collapsing into the return line then makes
+    // `x := pair.First; return x + …` collapsible too).
+    loop {
+        let region = &output[pre_len..];
+        let lines: Vec<&str> = region.lines().collect();
 
-    let mut result = String::with_capacity(region.len());
-    let mut i = 0;
-    let mut changed = false;
+        let mut result = String::with_capacity(region.len());
+        let mut i = 0;
+        let mut changed = false;
 
-    while i < lines.len() {
-        if i + 1 < lines.len()
-            && let Some((var, expression)) = parse_binding(lines[i])
-            && let Some(collapsed) = try_inline_binding(lines[i + 1], var, expression)
-        {
-            let used_elsewhere = lines
-                .iter()
-                .enumerate()
-                .any(|(j, line)| j != i && j != i + 1 && output_references_var(line, var));
+        while i < lines.len() {
+            if i + 1 < lines.len()
+                && let Some((var, expression)) = parse_binding(lines[i])
+                && let Some(collapsed) = try_inline_binding(lines[i + 1], var, expression)
+            {
+                let used_elsewhere = lines
+                    .iter()
+                    .enumerate()
+                    .any(|(j, line)| j != i && j != i + 1 && output_references_var(line, var));
 
-            if !used_elsewhere {
-                result.push_str(&collapsed);
-                result.push('\n');
-                i += 2;
-                changed = true;
-                continue;
+                if !used_elsewhere {
+                    result.push_str(&collapsed);
+                    result.push('\n');
+                    i += 2;
+                    changed = true;
+                    continue;
+                }
             }
+            result.push_str(lines[i]);
+            result.push('\n');
+            i += 1;
         }
-        result.push_str(lines[i]);
-        result.push('\n');
-        i += 1;
-    }
 
-    if changed {
+        if !changed {
+            break;
+        }
         output.truncate(pre_len);
         output.push_str(&result);
     }
@@ -495,7 +505,57 @@ fn try_inline_binding(next_line: &str, var: &str, expression: &str) -> Option<St
             return Some(format!("{} = {}", target, expression));
         }
     }
+    // Skip `for` headers: Lisette emits capture temps (`_bound_N`) precisely
+    // to evaluate the bound once; inlining would re-evaluate per iteration.
+    // Skip `&VAR` use sites: substituting a function reference (`&add1`,
+    // `&pkg.Fn`, `&s.method`) is invalid Go — VAR must be an addressable local.
+    if is_pure_dot_path(expression)
+        && !next_line.trim_start().starts_with("for ")
+        && let Some(pos) = single_token_position(next_line, var)
+        && !(pos > 0 && next_line.as_bytes()[pos - 1] == b'&')
+    {
+        return Some(format!(
+            "{}{}{}",
+            &next_line[..pos],
+            expression,
+            &next_line[pos + var.len()..]
+        ));
+    }
     None
+}
+
+/// True for `IDENT` or `IDENT(.IDENT)*` — no parens, brackets, or operators.
+fn is_pure_dot_path(s: &str) -> bool {
+    let mut want_ident_start = true;
+    for c in s.chars() {
+        if want_ident_start {
+            if !(c.is_ascii_alphabetic() || c == '_') {
+                return false;
+            }
+            want_ident_start = false;
+        } else if c == '.' {
+            want_ident_start = true;
+        } else if !(c.is_ascii_alphanumeric() || c == '_') {
+            return false;
+        }
+    }
+    !want_ident_start
+}
+
+/// Byte offset of `token` if it appears exactly once as a complete identifier
+/// in `line`, ignoring string-literal contents.
+fn single_token_position(line: &str, token: &str) -> Option<usize> {
+    let masked = mask_go_string_literals(line);
+    let bytes = masked.as_bytes();
+    let mut iter = masked
+        .match_indices(token)
+        .filter(|(abs, _)| is_at_token_boundary(bytes, *abs, token.len()))
+        .map(|(abs, _)| abs);
+    let first = iter.next()?;
+    if iter.next().is_some() {
+        return None;
+    }
+    Some(first)
 }
 
 /// Whether the body `lines[start..end]` declares a `var :=` whose name is also

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -14,8 +14,7 @@ func main() {
 	raw := store.GetValue("count")
 	subject_1 := lisette.AssertType[int](raw)
 	if subject_1.Tag == lisette.OptionSome {
-		n := subject_1.SomeVal
-		fmt.Print(n)
+		fmt.Print(subject_1.SomeVal)
 	} else {
 		fmt.Print("not an int")
 	}

--- a/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
@@ -54,10 +54,8 @@ import (
 func main() {
 	r := lib.Ok2[int, string](42)
 	if r.Tag == lib.Result2Ok2 {
-		v := r.Ok2
-		fmt.Println(v)
+		fmt.Println(r.Ok2)
 	} else {
-		e := r.Err2
-		fmt.Println(e)
+		fmt.Println(r.Err2)
 	}
 }

--- a/tests/spec/build/snapshots/cross_module_instance_method_value.snap
+++ b/tests/spec/build/snapshots/cross_module_instance_method_value.snap
@@ -30,6 +30,5 @@ func main() {
 		X: 1,
 		Y: 2,
 	}
-	g := lib.Point.Sum
-	_ = g(p)
+	_ = lib.Point.Sum(p)
 }

--- a/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
+++ b/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
@@ -23,12 +23,10 @@ func main() {
 		result = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
 	}
 	if result.Tag == lisette.ResultOk {
-		info := result.OkVal
-		size := info.Size()
+		size := result.OkVal.Size()
 		fmt.Printf("size: %d\n", size)
 	} else {
-		e := result.ErrVal
-		msg := e.Error()
+		msg := result.ErrVal.Error()
 		fmt.Printf("error: %s\n", msg)
 	}
 }

--- a/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
+++ b/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
@@ -10,14 +10,11 @@ import (
 )
 
 func main() {
-	parse := strconv.Atoi
-	ret_1, ret_2 := parse("42")
+	ret_1, ret_2 := strconv.Atoi("42")
 	if ret_2 == nil {
-		n := ret_1
-		fmt.Printf("parsed: %d\n", n)
+		fmt.Printf("parsed: %d\n", ret_1)
 	} else {
-		e := ret_2
-		msg := e.Error()
+		msg := ret_2.Error()
 		fmt.Println(msg)
 	}
 }

--- a/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
+++ b/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
@@ -39,8 +39,7 @@ func main() {
 		Outer:   unwrap_2,
 		Objects: unwrapped_4,
 	}
-	raw_7 := scope.Objects
-	src_8 := raw_7
+	src_8 := scope.Objects
 	wrapped_9 := make(map[string]lisette.Option[*ast.Object], len(src_8))
 	for i_10, v_11 := range src_8 {
 		if v_11 != nil {

--- a/tests/spec/build/snapshots/go_method_option_comma_ok_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_option_comma_ok_wrapped.snap
@@ -14,6 +14,5 @@ import (
 func main() {
 	ctx := context.Background()
 	option_1 := lisette.OptionFromCommaOk[time.Time](ctx.Deadline())
-	deadline := option_1
-	fmt.Print(deadline.IsSome())
+	fmt.Print(option_1.IsSome())
 }

--- a/tests/spec/build/snapshots/go_method_result_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_result_wrapped.snap
@@ -21,8 +21,7 @@ func main() {
 		line = lisette.MakeResultOk[string, error](ret_1)
 	}
 	if line.Tag == lisette.ResultOk {
-		s := line.OkVal
-		fmt.Print(s)
+		fmt.Print(line.OkVal)
 	} else {
 		fmt.Print("error")
 	}

--- a/tests/spec/build/snapshots/go_method_single_pointer_option_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_single_pointer_option_wrapped.snap
@@ -15,6 +15,5 @@ func main() {
 	_ = l.PushBack(42)
 	raw_1 := l.Front()
 	option_2 := lisette.OptionFromNilable[*list.Element](raw_1, raw_1 == nil)
-	front := option_2
-	fmt.Print(front.IsSome())
+	fmt.Print(option_2.IsSome())
 }

--- a/tests/spec/build/snapshots/go_option_call_wrapped.snap
+++ b/tests/spec/build/snapshots/go_option_call_wrapped.snap
@@ -12,6 +12,5 @@ import (
 
 func main() {
 	option_1 := lisette.OptionFromCommaOk[string](comment.DefaultLookupPackage("math"))
-	result := option_1
-	fmt.Print(result.IsSome())
+	fmt.Print(option_1.IsSome())
 }

--- a/tests/spec/build/snapshots/go_single_pointer_option_wrapped.snap
+++ b/tests/spec/build/snapshots/go_single_pointer_option_wrapped.snap
@@ -13,6 +13,5 @@ import (
 func main() {
 	raw_1 := flag.Lookup("verbose")
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	result := option_2
-	fmt.Print(result.IsSome())
+	fmt.Print(option_2.IsSome())
 }

--- a/tests/spec/build/snapshots/go_three_value_return_tuple.snap
+++ b/tests/spec/build/snapshots/go_three_value_return_tuple.snap
@@ -13,6 +13,5 @@ import (
 func main() {
 	ret_1, ret_2, ret_3 := strings.Cut("hello-world", "-")
 	tup_4 := lisette.MakeTuple3(ret_1, ret_2, ret_3)
-	result := tup_4
-	fmt.Println(result)
+	fmt.Println(tup_4)
 }

--- a/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
+++ b/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
@@ -16,8 +16,7 @@ func main() {
 	option_2 := lisette.OptionFromCommaOk[any](m.Load("key"))
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
-		fmt.Printf("got: %v\n", v)
+		fmt.Printf("got: %v\n", subject_1.SomeVal)
 	} else {
 		fmt.Println("not found")
 	}

--- a/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
+++ b/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
@@ -8,12 +8,9 @@ import "github.com/user/myproject/shapes"
 
 func describe(s shapes.ShapeKind) float64 {
 	if s.Tag == shapes.ShapeKindCircleKind {
-		c := s.CircleKind
-		return c.Radius
+		return s.CircleKind.Radius
 	}
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }
 
 func main() {

--- a/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
@@ -71,9 +71,7 @@ func main() {
 	}
 	switch e.Tag {
 	case events.EventClick:
-		x := e.X
-		y := e.Y
-		_ = x + y
+		_ = e.X + e.Y
 	case events.EventKeyPress:
 		_ = e.KeyPress
 	}

--- a/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
+++ b/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
@@ -22,8 +22,7 @@ func consume() int {
 	n := tmp_1.First
 	c := tmp_1.Second
 	if c.Tag == lisette.OptionSome {
-		f := c.SomeVal
-		return n + f()
+		return n + c.SomeVal()
 	}
 	return n
 }

--- a/tests/spec/build/snapshots/unused_variables_prefixed_in_go_output.snap
+++ b/tests/spec/build/snapshots/unused_variables_prefixed_in_go_output.snap
@@ -5,7 +5,6 @@ source: tests/spec/build/mod.rs
 package main
 
 func process(_, used_param int) int {
-	_ = 42
 	return used_param * 2
 }
 

--- a/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
+++ b/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
@@ -19,8 +19,7 @@ func maybe_get() Callback {
 
 func run(cb lisette.Option[Callback]) int {
 	if cb.Tag == lisette.OptionSome {
-		f := cb.SomeVal
-		return f()
+		return cb.SomeVal()
 	}
 	return -1
 }
@@ -28,6 +27,5 @@ func run(cb lisette.Option[Callback]) int {
 func main() {
 	raw_1 := maybe_get()
 	option_2 := lisette.OptionFromNilable[Callback](raw_1, raw_1 == nil)
-	cb := option_2
-	fmt.Println(run(cb))
+	fmt.Println(run(option_2))
 }

--- a/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
+++ b/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
@@ -16,10 +16,8 @@ func parse_int(s string) (int, error) {
 func main() {
 	ret_1, ret_2 := parse_int("42")
 	if ret_2 == nil {
-		n := ret_1
-		fmt.Println(n)
+		fmt.Println(ret_1)
 	} else {
-		e := ret_2
-		fmt.Println(e)
+		fmt.Println(ret_2)
 	}
 }

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -32,10 +32,8 @@ func main() {
 		subject_1 = lisette.MakeResultOk[[]byte, error](ret_2)
 	}
 	if subject_1.Tag == lisette.ResultOk {
-		b := subject_1.OkVal
-		fmt.Println(string(b))
+		fmt.Println(string(subject_1.OkVal))
 	} else {
-		e := subject_1.ErrVal
-		fmt.Println(e)
+		fmt.Println(subject_1.ErrVal)
 	}
 }

--- a/tests/spec/build/snapshots/write_only_mut_local_emits_blank_identifier_to_avoid_unused_var_error.snap
+++ b/tests/spec/build/snapshots/write_only_mut_local_emits_blank_identifier_to_avoid_unused_var_error.snap
@@ -4,7 +4,4 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-func main() {
-	_ = 0
-	_ = 1
-}
+func main() {}

--- a/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
@@ -16,7 +16,5 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
-	x := p.x
-	pt := p
-	return x + pt.y
+	return p.x + p.y
 }

--- a/tests/spec/emit/snapshots/as_binding_on_go_interface_type_switch.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_go_interface_type_switch.snap
@@ -12,8 +12,7 @@ func handle(e events.Event) int {
 		c := e
 		return c.X + c.Y
 	case events.KeyPress:
-		k := e
-		return len(k.Key)
+		return len(e.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
@@ -19,7 +19,5 @@ func (p Point) String() string {
 }
 
 func test(pair lisette.Tuple2[Point, int]) int {
-	p := pair.First
-	z := pair.Second
-	return p.x + z
+	return pair.First.x + pair.Second
 }

--- a/tests/spec/emit/snapshots/assignment_with_regular_value.snap
+++ b/tests/spec/emit/snapshots/assignment_with_regular_value.snap
@@ -4,7 +4,4 @@ description: "input: \nfn test() {\n  let mut x = 0;\n  x = 42;\n}\n"
 ---
 package main
 
-func test() {
-	_ = 0
-	_ = 42
-}
+func test() {}

--- a/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 162
 description: "input: \nfn track(flag: Ref<bool>) -> Result<int, error> {\n  flag.* = true\n  Ok(1)\n}\n\nfn test() {\n  let mut ran = false\n  if false && track(&ran).is_ok() {\n    panic(\"body should not run\")\n  }\n  if ran {\n    panic(\"rhs evaluated despite short-circuit\")\n  }\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 184
 description: "input: \nfn track(flag: Ref<bool>) -> Result<int, error> {\n  flag.* = true\n  Ok(1)\n}\n\nfn test() {\n  let mut ran = false\n  if true || track(&ran).is_ok() {\n    if ran {\n      panic(\"rhs evaluated despite short-circuit\")\n    }\n    return\n  }\n  panic(\"if-body should run\")\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/block_tail_append_unused_binding.snap
+++ b/tests/spec/emit/snapshots/block_tail_append_unused_binding.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test(s: Slice<int>) {\n  let _x = { s.append(2) }\n}\n
 package main
 
 func test(s []int) {
-	var _ []int
 	_ = append(s, 2)
 }

--- a/tests/spec/emit/snapshots/break_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_match_in_loop.snap
@@ -11,8 +11,7 @@ loop_1:
 		if item == 0 {
 			break loop_1
 		}
-		n := item
-		sum += n
+		sum += item
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -31,8 +31,7 @@ func (c Carrier) String() string {
 }
 
 func bump(c Carrier) int {
-	p := c.P
-	*p = 1
+	*c.P = 1
 	return 9
 }
 

--- a/tests/spec/emit/snapshots/chained_option_construction.snap
+++ b/tests/spec/emit/snapshots/chained_option_construction.snap
@@ -12,8 +12,7 @@ func get_value() (int, bool) {
 
 func test() (int, bool) {
 	option_1 := lisette.OptionFromCommaOk[int](get_value())
-	x := option_1
-	v_2 := x
+	v_2 := option_1
 	if v_2.Tag == lisette.OptionSome {
 		return v_2.SomeVal, true
 	}

--- a/tests/spec/emit/snapshots/chained_propagate_option.snap
+++ b/tests/spec/emit/snapshots/chained_propagate_option.snap
@@ -14,6 +14,5 @@ func get_nested(outer lisette.Option[lisette.Option[int]]) (int, bool) {
 	if inner.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	val := inner.SomeVal
-	return val, true
+	return inner.SomeVal, true
 }

--- a/tests/spec/emit/snapshots/chained_propagate_result.snap
+++ b/tests/spec/emit/snapshots/chained_propagate_result.snap
@@ -14,6 +14,5 @@ func get_nested(outer lisette.Result[lisette.Result[int, string], string]) liset
 	if inner.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](inner.ErrVal)
 	}
-	val := inner.OkVal
-	return lisette.MakeResultOk[int, string](val)
+	return lisette.MakeResultOk[int, string](inner.OkVal)
 }

--- a/tests/spec/emit/snapshots/channel_split_destructure.snap
+++ b/tests/spec/emit/snapshots/channel_split_destructure.snap
@@ -9,6 +9,5 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() {
 	ch := make(chan int)
 	tmp_1 := lisette.ChannelSplit(ch)
-	tx := tmp_1.First
-	_ = lisette.SenderSend(tx, 42)
+	_ = lisette.SenderSend(tmp_1.First, 42)
 }

--- a/tests/spec/emit/snapshots/complex_param_pattern_no_name_collision.snap
+++ b/tests/spec/emit/snapshots/complex_param_pattern_no_name_collision.snap
@@ -7,7 +7,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func f(arg_1 int, arg_2 lisette.Tuple2[int, int]) int {
-	x := arg_2.First
-	y := arg_2.Second
-	return arg_1 + x + y
+	return arg_1 + arg_2.First + arg_2.Second
 }

--- a/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
@@ -11,8 +11,7 @@ loop_1:
 		if item == 0 {
 			continue loop_1
 		}
-		n := item
-		sum += n
+		sum += item
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/deref_map_index_assignment.snap
+++ b/tests/spec/emit/snapshots/deref_map_index_assignment.snap
@@ -5,6 +5,5 @@ description: "input: \nfn update(m: Ref<Map<string, int>>, key: string, val: int
 package main
 
 func update(m *map[string]int, key string, val int) {
-	base_1 := m
-	(*base_1)[key] = val
+	(*m)[key] = val
 }

--- a/tests/spec/emit/snapshots/embedded_interface_comparable_propagation.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_comparable_propagation.snap
@@ -12,6 +12,4 @@ type B[K comparable] interface {
 	A[K]
 }
 
-func main() {
-	_ = 0
-}
+func main() {}

--- a/tests/spec/emit/snapshots/embedded_interface_comparable_transitive.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_comparable_transitive.snap
@@ -16,6 +16,4 @@ type C[K comparable] interface {
 	B[K]
 }
 
-func main() {
-	_ = 0
-}
+func main() {}

--- a/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
+++ b/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
@@ -44,6 +44,5 @@ func test() int {
 	if t.Tag == TransformIdentity {
 		return 0
 	}
-	f := t.Apply
-	return f(41)
+	return t.Apply(41)
 }

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -48,11 +48,9 @@ func (a ASTNode) String() string {
 func visit(node ASTNode) string {
 	switch node.Tag {
 	case ASTNodeNumber:
-		n := node.Number
-		return fmt.Sprintf("number:%v", n)
+		return fmt.Sprintf("number:%v", node.Number)
 	case ASTNodeString:
-		s := node.ASTNodeString_
-		return fmt.Sprintf("string:%v", s)
+		return fmt.Sprintf("string:%v", node.ASTNodeString_)
 	default:
 		return "null"
 	}

--- a/tests/spec/emit/snapshots/enumerated_slice_filter.snap
+++ b/tests/spec/emit/snapshots/enumerated_slice_filter.snap
@@ -8,7 +8,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(s []int) []lisette.Tuple2[int, int] {
 	return lisette.EnumeratedSliceFilter(s, func(arg_1 lisette.Tuple2[int, int]) bool {
-		i := arg_1.First
-		return i%2 == 0
+		return arg_1.First%2 == 0
 	})
 }

--- a/tests/spec/emit/snapshots/enumerated_slice_find.snap
+++ b/tests/spec/emit/snapshots/enumerated_slice_find.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(s []int) (lisette.Tuple2[int, int], bool) {
 	v_2 := lisette.EnumeratedSliceFind(s, func(arg_1 lisette.Tuple2[int, int]) bool {
-		v := arg_1.Second
-		return v > 10
+		return arg_1.Second > 10
 	})
 	if v_2.Tag == lisette.OptionSome {
 		return v_2.SomeVal, true

--- a/tests/spec/emit/snapshots/enumerated_slice_fold.snap
+++ b/tests/spec/emit/snapshots/enumerated_slice_fold.snap
@@ -8,8 +8,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(s []int) int {
 	return lisette.EnumeratedSliceFold(s, 0, func(acc int, arg_1 lisette.Tuple2[int, int]) int {
-		i := arg_1.First
-		v := arg_1.Second
-		return acc + i*v
+		return acc + arg_1.First*arg_1.Second
 	})
 }

--- a/tests/spec/emit/snapshots/enumerated_slice_map.snap
+++ b/tests/spec/emit/snapshots/enumerated_slice_map.snap
@@ -8,8 +8,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(s []int) []int {
 	return lisette.EnumeratedSliceMap(s, func(arg_1 lisette.Tuple2[int, int]) int {
-		i := arg_1.First
-		v := arg_1.Second
-		return i * v
+		return arg_1.First * arg_1.Second
 	})
 }

--- a/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
+++ b/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
@@ -42,6 +42,5 @@ func list_len[T any](list List[T]) int {
 	if list.Tag == ListNil {
 		return 0
 	}
-	rest := list.Cons1
-	return 1 + list_len(*rest)
+	return 1 + list_len(*list.Cons1)
 }

--- a/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
+++ b/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 115
 description: "input: \nfn main() {\n  let mut s = \"ab\"\n  let mut count = 0\n  for b in s.bytes() {\n    count += 1\n    s = \"\"\n    let _ = b\n  }\n  if count != 2 {\n    panic(\"expected count 2 — bytes loop must iterate over the original string\")\n  }\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
+++ b/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 96
 description: "input: \nimport \"go:fmt\"\nfn test(s: string) {\n  for b in s.bytes() {\n    fmt.Println(b)\n  }\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
+++ b/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
@@ -17,6 +17,5 @@ func (f Foo) String() string {
 func main() {
 	items := []Foo{Foo{x: 1}, Foo{x: 2}}
 	for range items {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/for_enumerate_complex_key_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_key_unused.snap
@@ -11,9 +11,7 @@ func test() int {
 	sum := 0
 	for key_1, value_2 := range items {
 		_ = key_1
-		a := value_2.First
-		b := value_2.Second
-		sum = sum + a + b
+		sum = sum + value_2.First + value_2.Second
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
@@ -11,8 +11,7 @@ func test() int {
 	sum := 0
 	for key_1, value_2 := range items {
 		_ = value_2
-		i := key_1
-		sum += i
+		sum += key_1
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/for_loop_enumerate_both_wildcards.snap
+++ b/tests/spec/emit/snapshots/for_loop_enumerate_both_wildcards.snap
@@ -6,6 +6,5 @@ package main
 
 func test(items []int) {
 	for range items {
-		_ = 1
 	}
 }

--- a/tests/spec/emit/snapshots/for_loop_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/for_loop_struct_pattern.snap
@@ -18,9 +18,7 @@ func (p Point) String() string {
 func test(points []Point) int {
 	sum := 0
 	for _, item_1 := range points {
-		x := item_1.x
-		y := item_1.y
-		sum = sum + x + y
+		sum = sum + item_1.x + item_1.y
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/for_loop_tuple_pattern_slice.snap
+++ b/tests/spec/emit/snapshots/for_loop_tuple_pattern_slice.snap
@@ -11,8 +11,6 @@ import (
 
 func test(pairs []lisette.Tuple2[int, string]) {
 	for _, item_1 := range pairs {
-		a := item_1.First
-		b := item_1.Second
-		fmt.Println(a, b)
+		fmt.Println(item_1.First, item_1.Second)
 	}
 }

--- a/tests/spec/emit/snapshots/for_runes_zero_alloc.snap
+++ b/tests/spec/emit/snapshots/for_runes_zero_alloc.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 83
 description: "input: \nimport \"go:fmt\"\nfn test(s: string) {\n  for r in s.runes() {\n    fmt.Println(r)\n  }\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
+++ b/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 477
 description: "input: \nimport \"go:fmt\"\n\nfn test() {\n  let x = 7;\n  fmt.Println(f\"prefix \\\", {x}\")\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/result_option_patterns.rs
-assertion_line: 178
 description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int {\n  x * 2\n}\n\nstruct Box<T> {\n  pub v: T,\n}\n\nstruct Wrap {\n  pub b: Box<Handler>,\n}\n\nfn make_box<T>(x: T) -> Box<T> {\n  Box { v: x }\n}\n\nfn main() {\n  let _w = Wrap { b: make_box(double) }\n  let _ = _w.b\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -44,12 +44,10 @@ func (e Either[L, R]) String() string {
 
 func (e Either[L, R]) display() string {
 	if e.Tag == EitherLeft {
-		l := e.Left
-		s := l.display()
+		s := e.Left.display()
 		return fmt.Sprintf("Left(%v)", s)
 	}
-	r := e.Right
-	s := r.display()
+	s := e.Right.display()
 	return fmt.Sprintf("Right(%v)", s)
 }
 

--- a/tests/spec/emit/snapshots/go_callback_bound_to_aliased_fn_type.snap
+++ b/tests/spec/emit/snapshots/go_callback_bound_to_aliased_fn_type.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/functions.rs
-assertion_line: 1373
 description: "input: \nimport \"go:path/filepath\"\nimport \"go:io/fs\"\n\nfn main() {\n  let walker: filepath.WalkFunc = |_path: string, _info: fs.FileInfo, _err: error| -> Result<(), error> {\n    Ok(())\n  }\n  let _ = filepath.Walk(\"/tmp\", walker)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
@@ -21,6 +21,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/go_fn_value_shadowed_wrapping.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_shadowed_wrapping.snap
@@ -12,8 +12,7 @@ import (
 
 func main() {
 	_ = strconv.Atoi
-	f := strconv.Atoi
-	ret_1, ret_2 := f("42")
+	ret_1, ret_2 := strconv.Atoi("42")
 	var r lisette.Result[int, error]
 	if ret_2 != nil {
 		r = lisette.MakeResultErr[int, error](ret_2)

--- a/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
+++ b/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
@@ -15,7 +15,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	fl := option_2
 	if fl.Tag == lisette.OptionSome {
-		v := fl.SomeVal
-		f(v)
+		f(fl.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/go_interface_method_err_result_type.snap
+++ b/tests/spec/emit/snapshots/go_interface_method_err_result_type.snap
@@ -14,6 +14,5 @@ func main() {
 	ctx := context.Background()
 	raw_1 := ctx.Err()
 	option_2 := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
-	err := option_2
-	fmt.Printf("err=%v\n", err)
+	fmt.Printf("err=%v\n", option_2)
 }

--- a/tests/spec/emit/snapshots/go_variadic_fn_value_wrapper_spreads_args.snap
+++ b/tests/spec/emit/snapshots/go_variadic_fn_value_wrapper_spreads_args.snap
@@ -10,6 +10,5 @@ import (
 )
 
 func main() {
-	f := fmt.Fprintf
-	f(os.Stdout, "hi %d", 3)
+	fmt.Fprintf(os.Stdout, "hi %d", 3)
 }

--- a/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test(x: int) -> int {\n  if let y = x {\n    y * 2\n  
 package main
 
 func test(x int) int {
-	y := x
-	return y * 2
+	return x * 2
 }

--- a/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
@@ -19,7 +19,6 @@ func try_parse(s string) lisette.Result[int, string] {
 func test() {
 	subject_1 := try_parse("42")
 	if subject_1.Tag == lisette.ResultOk {
-		x := subject_1.OkVal
-		fmt.Printf("Parsed: %v\n", x)
+		fmt.Printf("Parsed: %v\n", subject_1.OkVal)
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_statement.snap
+++ b/tests/spec/emit/snapshots/if_let_statement.snap
@@ -8,7 +8,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		_ = x + 1
+		_ = opt.SomeVal + 1
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_with_else.snap
+++ b/tests/spec/emit/snapshots/if_let_with_else.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		return x * 2
+		return opt.SomeVal * 2
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/if_let_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_without_else_branch.snap
@@ -20,7 +20,6 @@ func test() {
 	option_2 := lisette.OptionFromCommaOk[int](divide(100, 10))
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
-		x := subject_1.SomeVal
-		fmt.Printf("Result: %v\n", x)
+		fmt.Printf("Result: %v\n", subject_1.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/if_with_else.snap
+++ b/tests/spec/emit/snapshots/if_with_else.snap
@@ -6,8 +6,6 @@ package main
 
 func test(x int) {
 	if x > 10 {
-		_ = 1
 	} else {
-		_ = 2
 	}
 }

--- a/tests/spec/emit/snapshots/if_without_else.snap
+++ b/tests/spec/emit/snapshots/if_without_else.snap
@@ -6,6 +6,5 @@ package main
 
 func test(x int) {
 	if x > 10 {
-		_ = 1
 	}
 }

--- a/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
@@ -44,11 +44,9 @@ func (e Either[L, R]) String() string {
 
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
-		n := self.Left
-		return fmt.Sprintf("int(%d)", n)
+		return fmt.Sprintf("int(%d)", self.Left)
 	}
-	s := self.Right
-	return fmt.Sprintf("str(%s)", s)
+	return fmt.Sprintf("str(%s)", self.Right)
 }
 
 func test() MyString {

--- a/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
@@ -44,9 +44,7 @@ func (e Either[L, R]) String() string {
 
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
-		n := self.Left
-		return fmt.Sprintf("int(%d)", n)
+		return fmt.Sprintf("int(%d)", self.Left)
 	}
-	s := self.Right
-	return fmt.Sprintf("str(%s)", s)
+	return fmt.Sprintf("str(%s)", self.Right)
 }

--- a/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
+++ b/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
@@ -21,8 +21,7 @@ func (n Node) String() string {
 func (n Node) sum() int {
 	subject_1 := n.Next
 	if subject_1.Tag == lisette.OptionSome {
-		n_2 := subject_1.SomeVal
-		return n.Value + n_2
+		return n.Value + subject_1.SomeVal
 	}
 	return n.Value
 }

--- a/tests/spec/emit/snapshots/interop_array_return_defer.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_defer.snap
@@ -9,5 +9,4 @@ import "crypto/sha256"
 func main() {
 	data := []uint8{1, 2, 3}
 	defer sha256.Sum256(data)
-	_ = 0
 }

--- a/tests/spec/emit/snapshots/interop_array_return_statement_position.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_statement_position.snap
@@ -9,5 +9,4 @@ import "crypto/sha256"
 func main() {
 	data := []uint8{1, 2, 3}
 	sha256.Sum256(data)
-	_ = 0
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
@@ -15,6 +15,5 @@ func main() {
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {
-		_ = ""
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
@@ -10,12 +10,10 @@ import (
 )
 
 func main() {
-	f := os.LookupEnv
-	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
+	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {
-		_ = ""
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
@@ -20,6 +20,5 @@ func main() {
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {
-		_ = ""
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
@@ -12,8 +12,7 @@ import (
 func apply(f func(string) *flag.Flag, name string) bool {
 	raw_2 := f(name)
 	option_3 := lisette.OptionFromNilable[*flag.Flag](raw_2, raw_2 == nil)
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
+	if option_3.Tag == lisette.OptionSome {
 		return true
 	}
 	return false

--- a/tests/spec/emit/snapshots/interop_nullable_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_let_call.snap
@@ -10,8 +10,7 @@ import (
 )
 
 func main() {
-	f := flag.Lookup
-	raw_1 := f("verbose")
+	raw_1 := flag.Lookup("verbose")
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2
 	if r.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -15,8 +15,7 @@ func main() {
 	option_3 := lisette.OptionFromNilable[evts.Msg](raw_2, lisette.IsNilInterface(raw_2))
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		e := subject_1.SomeVal
-		fmt.Println(e)
+		fmt.Println(subject_1.SomeVal)
 	} else {
 		fmt.Println("none")
 	}

--- a/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
+++ b/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
@@ -13,11 +13,9 @@ import (
 func main() {
 	src, db := migrate.Close()
 	if src.Tag == lisette.OptionSome {
-		e := src.SomeVal
-		fmt.Println("source:", e)
+		fmt.Println("source:", src.SomeVal)
 	}
 	if db.Tag == lisette.OptionSome {
-		e := db.SomeVal
-		fmt.Println("db:", e)
+		fmt.Println("db:", db.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_pointer_scalar_param_none.snap
+++ b/tests/spec/emit/snapshots/interop_pointer_scalar_param_none.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1280
 description: "input: \nimport \"go:example.com/cfg\"\n\nfn main() {\n  cfg.Configure(None)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
+++ b/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1265
 description: "input: \nimport \"go:example.com/cfg\"\n\nfn main() {\n  cfg.Configure(Some(\"custom\"))\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/interop_result_alias_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_alias_call.snap
@@ -10,9 +10,7 @@ import (
 )
 
 func main() {
-	f := strconv.Atoi
-	g := f
-	ret_1, ret_2 := g("42")
+	ret_1, ret_2 := strconv.Atoi("42")
 	var r lisette.Result[int, error]
 	if ret_2 != nil {
 		r = lisette.MakeResultErr[int, error](ret_2)
@@ -22,6 +20,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_assignment.snap
@@ -26,6 +26,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_break_value.snap
+++ b/tests/spec/emit/snapshots/interop_result_break_value.snap
@@ -27,6 +27,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_call_arg.snap
@@ -24,6 +24,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_direct_call.snap
@@ -20,6 +20,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -20,6 +20,5 @@ func main() {
 	if subject_1.Tag == lisette.ResultOk {
 		_ = subject_1.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_if_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_if_assignment.snap
@@ -26,6 +26,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_let_call.snap
@@ -10,8 +10,7 @@ import (
 )
 
 func main() {
-	f := strconv.Atoi
-	ret_1, ret_2 := f("42")
+	ret_1, ret_2 := strconv.Atoi("42")
 	var r lisette.Result[int, error]
 	if ret_2 != nil {
 		r = lisette.MakeResultErr[int, error](ret_2)
@@ -21,6 +20,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -34,6 +34,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
@@ -22,6 +22,5 @@ func main() {
 	if subject_4.Tag == lisette.ResultOk {
 		_ = subject_4.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
@@ -22,8 +22,7 @@ func main() {
 		r = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
 	}
 	if r.Tag == lisette.ResultOk {
-		f := r.OkVal
-		ret_4, ret_5 := f("1")
+		ret_4, ret_5 := r.OkVal("1")
 		var result_6 lisette.Result[int, error]
 		if ret_5 != nil {
 			result_6 = lisette.MakeResultErr[int, error](ret_5)
@@ -34,9 +33,7 @@ func main() {
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
 		} else {
-			_ = 0
 		}
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_result_return_pos.snap
@@ -25,6 +25,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_select_send.snap
+++ b/tests/spec/emit/snapshots/interop_result_select_send.snap
@@ -10,8 +10,6 @@ func main() {
 	ch := make(chan func(string) (int, error))
 	select {
 	case ch <- strconv.Atoi:
-		_ = 0
 	default:
-		_ = 1
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_element.snap
@@ -21,6 +21,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_struct_field.snap
+++ b/tests/spec/emit/snapshots/interop_result_struct_field.snap
@@ -30,6 +30,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_try_block.snap
@@ -33,8 +33,7 @@ func main() {
 		r = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
 	}
 	if r.Tag == lisette.ResultOk {
-		f := r.OkVal
-		ret_4, ret_5 := f("1")
+		ret_4, ret_5 := r.OkVal("1")
 		var result_6 lisette.Result[int, error]
 		if ret_5 != nil {
 			result_6 = lisette.MakeResultErr[int, error](ret_5)
@@ -45,9 +44,7 @@ func main() {
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
 		} else {
-			_ = 0
 		}
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_element.snap
@@ -21,6 +21,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -36,6 +36,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
@@ -31,6 +31,5 @@ func main() {
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1376
 description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let mut b = aws.Bucket { .. }\n  b.Name = Some(\"hi\")\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1358
 description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let b = aws.Bucket { .. }\n  match b.Annotations[\"k\"] {\n    Some(v) => { let _ = v },\n    None => {},\n  }\n}\n"
 ---
 package main
@@ -12,8 +11,7 @@ import (
 
 func main() {
 	b := aws.Bucket{}
-	raw_2 := b.Annotations
-	src_3 := raw_2
+	src_3 := b.Annotations
 	wrapped_4 := make(map[string]lisette.Option[string], len(src_3))
 	for i_5, v_6 := range src_3 {
 		if v_6 != nil {

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1290
 description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let input = aws.ListInput { .. }\n  let n = input.MaxItems\n  let _ = n\n}\n"
 ---
 package main
@@ -12,7 +11,5 @@ import (
 
 func main() {
 	input := aws.ListInput{}
-	raw_1 := input.MaxItems
-	option_2 := lisette.OptionFromPointer[int32](raw_1)
-	_ = option_2
+	_ = lisette.OptionFromPointer[int32](input.MaxItems)
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1314
 description: "input: \nimport \"go:example.com/aws\"\nimport \"go:fmt\"\n\nfn main() {\n  let buckets: Slice<aws.Bucket> = []\n  for bucket in buckets {\n    match bucket.Name {\n      Some(name) => fmt.Println(name),\n      None => {},\n    }\n  }\n}\n"
 ---
 package main
@@ -14,12 +13,10 @@ import (
 func main() {
 	buckets := []aws.Bucket{}
 	for _, bucket := range buckets {
-		raw_2 := bucket.Name
-		option_3 := lisette.OptionFromPointer[string](raw_2)
+		option_3 := lisette.OptionFromPointer[string](bucket.Name)
 		subject_1 := option_3
 		if subject_1.Tag == lisette.OptionSome {
-			name := subject_1.SomeVal
-			fmt.Println(name)
+			fmt.Println(subject_1.SomeVal)
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1271
 description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let bucket = aws.Bucket { .. }\n  match bucket.Name {\n    Some(name) => { let _ = name },\n    None => {},\n  }\n}\n"
 ---
 package main
@@ -12,8 +11,7 @@ import (
 
 func main() {
 	bucket := aws.Bucket{}
-	raw_2 := bucket.Name
-	option_3 := lisette.OptionFromPointer[string](raw_2)
+	option_3 := lisette.OptionFromPointer[string](bucket.Name)
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
 		_ = subject_1.SomeVal

--- a/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/interop_matrix.rs
-assertion_line: 1337
 description: "input: \nimport \"go:example.com/aws\"\n\nfn main() {\n  let b = aws.Bucket { .. }\n  for tag in b.Tags {\n    match tag {\n      Some(v) => { let _ = v },\n      None => {},\n    }\n  }\n}\n"
 ---
 package main
@@ -12,8 +11,7 @@ import (
 
 func main() {
 	b := aws.Bucket{}
-	raw_1 := b.Tags
-	src_2 := raw_1
+	src_2 := b.Tags
 	wrapped_3 := make([]lisette.Option[string], len(src_2))
 	for i_4, v_5 := range src_2 {
 		if v_5 != nil {

--- a/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
@@ -14,9 +14,7 @@ func use_split(f func(string) (string, string), p string) string {
 	ret_2, ret_3 := f(p)
 	tup_4 := lisette.MakeTuple2(ret_2, ret_3)
 	tmp_1 := tup_4
-	dir := tmp_1.First
-	file := tmp_1.Second
-	return fmt.Sprintf("%v/%v", dir, file)
+	return fmt.Sprintf("%v/%v", tmp_1.First, tmp_1.Second)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_tuple_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_direct_call.snap
@@ -11,6 +11,5 @@ import (
 
 func main() {
 	ret_1, ret_2 := path.Split("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	_ = tup_3
+	_ = lisette.MakeTuple2(ret_1, ret_2)
 }

--- a/tests/spec/emit/snapshots/interop_tuple_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_let_call.snap
@@ -10,8 +10,6 @@ import (
 )
 
 func main() {
-	f := path.Split
-	ret_1, ret_2 := f("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	_ = tup_3
+	ret_1, ret_2 := path.Split("/foo/bar.txt")
+	_ = lisette.MakeTuple2(ret_1, ret_2)
 }

--- a/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
@@ -16,6 +16,5 @@ func make_splitter() func(string) (string, string) {
 func main() {
 	f := make_splitter()
 	ret_1, ret_2 := f("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	_ = tup_3
+	_ = lisette.MakeTuple2(ret_1, ret_2)
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -31,8 +31,7 @@ func main() {
 		Rbrace:     token.Pos(0),
 		Incomplete: false,
 	}
-	raw_7 := lit.Elts
-	src_8 := raw_7
+	src_8 := lit.Elts
 	wrapped_9 := make([]lisette.Option[ast.Expr], len(src_8))
 	for i_10, v_11 := range src_8 {
 		if !lisette.IsNilInterface(v_11) {
@@ -44,8 +43,7 @@ func main() {
 	elts := wrapped_9
 	for _, elt := range elts {
 		if elt.Tag == lisette.OptionSome {
-			e := elt.SomeVal
-			fmt.Println(e.Pos())
+			fmt.Println(elt.SomeVal.Pos())
 		} else {
 			fmt.Println("nil")
 		}

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
@@ -23,10 +23,8 @@ func main() {
 		info = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
 	}
 	if info.Tag == lisette.ResultOk {
-		i := info.OkVal
-		fmt.Println(i.Size())
+		fmt.Println(info.OkVal.Size())
 	} else {
-		e := info.ErrVal
-		fmt.Println(e)
+		fmt.Println(info.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
@@ -16,8 +16,7 @@ func main() {
 	option_3 := lisette.OptionFromNilable[error](raw_2, lisette.IsNilInterface(raw_2))
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		e := subject_1.SomeVal
-		fmt.Println(e.Error())
+		fmt.Println(subject_1.SomeVal.Error())
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
+++ b/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
@@ -10,7 +10,6 @@ import (
 )
 
 func parse(s string) (int, error) {
-	_ = "context"
 	ret_1, ret_2 := strconv.Atoi(s)
 	var result lisette.Result[int, error]
 	if ret_2 != nil {
@@ -19,9 +18,7 @@ func parse(s string) (int, error) {
 		result = lisette.MakeResultOk[int, error](ret_1)
 	}
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		return n, nil
+		return result.OkVal, nil
 	}
-	e := result.ErrVal
-	return *new(int), e
+	return *new(int), result.ErrVal
 }

--- a/tests/spec/emit/snapshots/let_else_or_pattern_irrefutable_binding.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_irrefutable_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/control_flow.rs
-assertion_line: 3012
 description: "input: \nfn test() -> int {\n  let x | x = 42 else {\n    return 0\n  }\n  x\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/let_else_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_struct_pattern.snap
@@ -22,7 +22,5 @@ func test(opt lisette.Option[Point]) int {
 	if opt.Tag != lisette.OptionSome {
 		return 0
 	}
-	x := opt.SomeVal.x
-	y := opt.SomeVal.y
-	return x + y
+	return opt.SomeVal.x + opt.SomeVal.y
 }

--- a/tests/spec/emit/snapshots/let_else_tuple_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_tuple_pattern.snap
@@ -10,7 +10,5 @@ func test(opt lisette.Option[lisette.Tuple2[int, int]]) int {
 	if opt.Tag != lisette.OptionSome {
 		return 0
 	}
-	a := opt.SomeVal.First
-	b := opt.SomeVal.Second
-	return a + b
+	return opt.SomeVal.First + opt.SomeVal.Second
 }

--- a/tests/spec/emit/snapshots/let_shadowing_multiple_times.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_multiple_times.snap
@@ -5,7 +5,6 @@ description: "input: \nfn test(cond1: bool, cond2: bool) -> int {\n  let x = 1;\
 package main
 
 func test(cond1, cond2 bool) int {
-	_ = 1
 	var x int
 	if cond1 {
 		x = 2

--- a/tests/spec/emit/snapshots/let_shadowing_three_levels_method_call.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_three_levels_method_call.snap
@@ -5,7 +5,6 @@ description: "input: \nfn test() -> int {\n  let x = 10;\n  let x = \"now a stri
 package main
 
 func test() int {
-	_ = 10
 	x := "now a string"
 	return len(x)
 }

--- a/tests/spec/emit/snapshots/let_shadowing_with_if_expression.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_with_if_expression.snap
@@ -5,7 +5,6 @@ description: "input: \nfn test(cond: bool) -> int {\n  let x = 1;\n  let x = if 
 package main
 
 func test(cond bool) int {
-	_ = 1
 	if cond {
 		return 2
 	}

--- a/tests/spec/emit/snapshots/let_shadowing_with_match_expression.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_with_match_expression.snap
@@ -7,7 +7,6 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
-	_ = 1
 	if opt.Tag == lisette.OptionSome {
 		return opt.SomeVal
 	}

--- a/tests/spec/emit/snapshots/let_shadowing_with_type_change.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_with_type_change.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test() -> string {\n  let x = 42;\n  let x = \"hello\"
 package main
 
 func test() string {
-	_ = 42
 	return "hello"
 }

--- a/tests/spec/emit/snapshots/local_binding_imaginary_not_hijacked.snap
+++ b/tests/spec/emit/snapshots/local_binding_imaginary_not_hijacked.snap
@@ -9,6 +9,5 @@ func id(x int) int {
 }
 
 func test() int {
-	imaginary := id
-	return imaginary(1)
+	return id(1)
 }

--- a/tests/spec/emit/snapshots/local_binding_new_not_hijacked.snap
+++ b/tests/spec/emit/snapshots/local_binding_new_not_hijacked.snap
@@ -9,6 +9,5 @@ func mk() int {
 }
 
 func test() int {
-	new_ := mk
-	return new_()
+	return mk()
 }

--- a/tests/spec/emit/snapshots/local_const_shadows_let_binding.snap
+++ b/tests/spec/emit/snapshots/local_const_shadows_let_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 1274
 description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  let x = 1\n  fmt.Println(x)\n  const x = 2\n  fmt.Println(x)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/local_let_shadows_const_binding.snap
+++ b/tests/spec/emit/snapshots/local_let_shadows_const_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 1289
 description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  const x = 1\n  fmt.Println(x)\n  let x = 2\n  fmt.Println(x)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -20,6 +20,5 @@ func main() {
 	r := &m
 	entry := (*r)["a"]
 	entry.items = append(entry.items, 1)
-	base_1 := r
-	(*base_1)["a"] = entry
+	(*r)["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -22,6 +22,5 @@ func main() {
 	r := &m
 	entry := (*r)["k"]
 	entry.x = 1
-	base_1 := r
-	(*base_1)["k"] = entry
+	(*r)["k"] = entry
 }

--- a/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
+++ b/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
@@ -19,8 +19,7 @@ func test(p Point) int {
 	var result int
 	{
 		x := p.x
-		fmt := p
-		result = fmt.x + x
+		result = p.x + x
 	}
 	fmt.Println(result)
 	return result

--- a/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
@@ -9,12 +9,10 @@ func categorize(items []int) string {
 	if len_ == 0 {
 		return "empty"
 	}
-	n := len_
-	if n == 1 {
+	if len_ == 1 {
 		return "single"
 	}
-	n_1 := len_
-	if n_1 <= 3 {
+	if len_ <= 3 {
 		return "few"
 	}
 	return "many"

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
@@ -17,8 +17,7 @@ func (w W[T]) String() string {
 func test() int {
 	w := W[int]{F0: 1}
 	{
-		x := w
-		if x == (W[int]{F0: 2}) {
+		if w == (W[int]{F0: 2}) {
 			return 0
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_mixed.snap
+++ b/tests/spec/emit/snapshots/match_guard_mixed.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) string {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		if x > 0 {
+		if opt.SomeVal > 0 {
 			return "positive"
 		}
 		return "non-positive"

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -26,10 +26,8 @@ match_1:
 			x: 1,
 			y: 2,
 		}) {
-			_ = 1
 			break match_1
 		}
-		_ = 2
 		break match_1
 	}
 }

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -11,8 +11,7 @@ func main() {
 	match_1:
 		for {
 			{
-				d := i
-				if d < 5 {
+				if i < 5 {
 					fmt.Println("low")
 					break match_1
 				}

--- a/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
@@ -12,11 +12,9 @@ import (
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		fmt.Printf("success: %v\n", n)
+		fmt.Printf("success: %v\n", result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %v\n", result.ErrVal)
 	}
 	fmt.Print("done\n")
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -22,8 +22,7 @@ match_1:
 			fmt.Printf("non-positive: %v\n", n)
 			break match_1
 		}
-		e := result.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %v\n", result.ErrVal)
 		break match_1
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
@@ -12,10 +12,8 @@ import (
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		fmt.Printf("success: %v\n", n)
+		fmt.Printf("success: %v\n", result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %v\n", result.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
+++ b/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
@@ -10,18 +10,12 @@ func test() int {
 	pair := lisette.MakeTuple2(10, 20)
 	var first int
 	{
-		a := pair.First
-		b := pair.Second
-		first = a + b
+		first = pair.First + pair.Second
 	}
 	nested := lisette.MakeTuple2(lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4))
 	var second int
 	{
-		a := nested.First.First
-		b := nested.First.Second
-		c := nested.Second.First
-		d := nested.Second.Second
-		second = a + b + c + d
+		second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
 	}
 	return first + second
 }

--- a/tests/spec/emit/snapshots/match_on_aliased_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_aliased_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(m events.Msg) int {
 	switch m := m.(type) {
 	case events.Click:
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	case events.KeyPress:
-		key := m.Key
-		return len(key)
+		return len(m.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_chained_alias_of_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_chained_alias_of_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(m events.Outer) int {
 	switch m := m.(type) {
 	case events.Click:
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	case events.KeyPress:
-		key := m.Key
-		return len(key)
+		return len(m.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x + y
+		return e.X + e.Y
 	case events.KeyPress:
-		key := e.Key
-		return len(key)
+		return len(e.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
@@ -9,9 +9,7 @@ import "example.com/events"
 func handle(e events.Event, active bool) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x + y
+		return e.X + e.Y
 	case events.KeyPress:
 		if active {
 			return -1

--- a/tests/spec/emit/snapshots/match_on_go_interface_wildcard_only_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_wildcard_only_arm.snap
@@ -9,9 +9,7 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x + y
+		return e.X + e.Y
 	case events.KeyPress:
 		return -1
 	case events.Resize:

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
@@ -15,9 +15,7 @@ func test() string {
 	pair := lisette.MakeTuple2(100, "replaced")
 	var r string
 	{
-		n_1 := pair.First
-		s_2 := pair.Second
-		r = fmt.Sprintf("%v-%v", n_1, s_2)
+		r = fmt.Sprintf("%v-%v", pair.First, pair.Second)
 	}
 	return fmt.Sprintf("%v %v %v", n, s, r)
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
@@ -24,9 +24,7 @@ func test() int {
 	}
 	var sum int
 	{
-		a_1 := p.F0
-		b_2 := p.F1
-		sum = a_1 + b_2
+		sum = p.F0 + p.F1
 	}
 	return a + b + sum
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
@@ -26,11 +26,8 @@ func test() string {
 		F0: 1,
 		F1: 2,
 	}
-	var _ int
 	{
-		x := p.F0
-		y := p.F1
-		_ = x + y
+		_ = p.F0 + p.F1
 	}
 	n := Name("hello")
 	return string(n)

--- a/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
@@ -43,18 +43,14 @@ func test() int {
 	e1 := MakeEventClick(10, 20)
 	var sum1 int
 	if e1.Tag == EventClick {
-		x := e1.Click0
-		y := e1.Click1
-		sum1 = x + y
+		sum1 = e1.Click0 + e1.Click1
 	} else {
 		sum1 = 0
 	}
 	e2 := MakeEventClick(30, 40)
 	var sum2 int
 	if e2.Tag == EventClick {
-		x := e2.Click0
-		y := e2.Click1
-		sum2 = x + y
+		sum2 = e2.Click0 + e2.Click1
 	} else {
 		sum2 = 0
 	}

--- a/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
+++ b/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
@@ -44,7 +44,5 @@ func (s Shape) area() int {
 		r := s.Circle
 		return r * r * 3
 	}
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }

--- a/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
@@ -17,8 +17,7 @@ func maybe(b bool) (int, bool) {
 
 func test() {
 	option_2 := lisette.OptionFromCommaOk[int](maybe(true))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
+	if option_2.Tag == lisette.OptionSome {
 		noop()
 	} else {
 		noop()

--- a/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
@@ -18,8 +18,7 @@ func divide(a, b int) lisette.Result[int, string] {
 func test() {
 	subject_1 := divide(10, 2)
 	if subject_1.Tag == lisette.ResultOk {
-		v := subject_1.OkVal
-		use_value(v)
+		use_value(subject_1.OkVal)
 	} else {
 		use_value(0)
 	}

--- a/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
@@ -16,7 +16,5 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
-	a := p.x
-	b := p.y
-	return a * b
+	return p.x * p.y
 }

--- a/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
@@ -11,7 +11,6 @@ func main() {
 	if opt.Tag == lisette.OptionSome {
 		_ = opt.SomeVal
 	} else {
-		_ = 0
 	}
 	_ = 7
 }

--- a/tests/spec/emit/snapshots/match_tuple_nested.snap
+++ b/tests/spec/emit/snapshots/match_tuple_nested.snap
@@ -11,8 +11,5 @@ func test() int {
 	if nested.First.First == 1 && nested.First.Second == 2 && nested.Second == 3 {
 		return 6
 	}
-	x := nested.First.First
-	y := nested.First.Second
-	z := nested.Second
-	return x + y + z
+	return nested.First.First + nested.First.Second + nested.Second
 }

--- a/tests/spec/emit/snapshots/match_tuple_simple.snap
+++ b/tests/spec/emit/snapshots/match_tuple_simple.snap
@@ -13,7 +13,5 @@ func test() int {
 	} else if pair.First == 1 && pair.Second == 2 {
 		return 3
 	}
-	x := pair.First
-	y := pair.Second
-	return x + y
+	return pair.First + pair.Second
 }

--- a/tests/spec/emit/snapshots/method_expression_as_value_public.snap
+++ b/tests/spec/emit/snapshots/method_expression_as_value_public.snap
@@ -19,6 +19,5 @@ func (b Box) Add(y int) int {
 }
 
 func main() {
-	f := Box.Add
-	_ = f(Box{x: 1}, 2)
+	_ = Box.Add(Box{x: 1}, 2)
 }

--- a/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
+++ b/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 917
 description: "input: \ntype Prefix = Range<int>\nfn test(arr: Slice<int>, r: Prefix) -> Slice<int> {\n  let mut owned = arr[r]\n  owned[0] = 99\n  owned\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/or_pattern_let_else_rest_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_rest_shadow.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/patterns.rs
-assertion_line: 596
 description: "input: \nimport \"go:fmt\"\n\nfn main() {\n  let rest = [99]\n  fmt.Println(rest[0])\n  let [x, ..rest] | [x, ..rest] = [1, 2] else {\n    return\n  }\n  fmt.Println(x, rest[0])\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
@@ -46,7 +46,6 @@ func (e E) String() string {
 }
 
 func test(e E) int {
-	_ = 1
 	var x int
 	if e.Tag == EA {
 		x = e.A

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 794
 description: "input: \nfn main() {\n  let g = Some\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(g)\n  let _ = r\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 808
 description: "input: \nfn doubler(x: int) -> Option<int> { Some(x * 2) }\nfn main() {\n  let g = doubler\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(g)\n  let _ = r\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 781
 description: "input: \nfn doubler(x: int) -> Option<int> { Some(x * 2) }\nfn main() {\n  let opt: Option<int> = Some(1)\n  let r = opt.and_then(doubler)\n  let _ = r\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
+++ b/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
@@ -15,6 +15,5 @@ func main() {
 		}
 		return *new(int), false
 	}
-	option_3 := lisette.OptionFromCommaOk[int](f(42))
-	_ = option_3
+	_ = lisette.OptionFromCommaOk[int](f(42))
 }

--- a/tests/spec/emit/snapshots/propagate_chained.snap
+++ b/tests/spec/emit/snapshots/propagate_chained.snap
@@ -24,6 +24,5 @@ func test() lisette.Result[int, string] {
 	if check_2.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_2.ErrVal)
 	}
-	y := check_2.OkVal
-	return lisette.MakeResultOk[int, string](x + y)
+	return lisette.MakeResultOk[int, string](x + check_2.OkVal)
 }

--- a/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
@@ -11,8 +11,7 @@ func f() (int, bool) {
 	if check_1.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	result_2 := check_1.SomeVal
-	v_3 := result_2
+	v_3 := check_1.SomeVal
 	if v_3.Tag == lisette.OptionSome {
 		return v_3.SomeVal, true
 	}

--- a/tests/spec/emit/snapshots/propagate_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_in_expression.snap
@@ -15,6 +15,5 @@ func test() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	return lisette.MakeResultOk[int, string](result_2 + 10)
+	return lisette.MakeResultOk[int, string](check_1.OkVal + 10)
 }

--- a/tests/spec/emit/snapshots/propagate_in_lambda.snap
+++ b/tests/spec/emit/snapshots/propagate_in_lambda.snap
@@ -16,8 +16,7 @@ func test() int {
 		if check_1.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_1.ErrVal)
 		}
-		v := check_1.OkVal
-		return lisette.MakeResultOk[int, string](v + x)
+		return lisette.MakeResultOk[int, string](check_1.OkVal + x)
 	}
 	subject_2 := f(5)
 	if subject_2.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/propagate_on_result_variable.snap
+++ b/tests/spec/emit/snapshots/propagate_on_result_variable.snap
@@ -11,6 +11,5 @@ func test() lisette.Result[int, string] {
 	if r.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](r.ErrVal)
 	}
-	x := r.OkVal
-	return lisette.MakeResultOk[int, string](x + 1)
+	return lisette.MakeResultOk[int, string](r.OkVal + 1)
 }

--- a/tests/spec/emit/snapshots/propagate_on_variable.snap
+++ b/tests/spec/emit/snapshots/propagate_on_variable.snap
@@ -11,6 +11,5 @@ func test() (int, bool) {
 	if x.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	y := x.SomeVal
-	return y + 1, true
+	return x.SomeVal + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
@@ -11,6 +11,5 @@ func test() (int, bool) {
 	if x.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	result_1 := x.SomeVal
-	return result_1 + 1, true
+	return x.SomeVal + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_option_in_function.snap
+++ b/tests/spec/emit/snapshots/propagate_option_in_function.snap
@@ -16,6 +16,5 @@ func process() (int, bool) {
 	if check_2.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	x := check_2.SomeVal
-	return x + 1, true
+	return check_2.SomeVal + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
+++ b/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
@@ -26,6 +26,5 @@ func process() (int, error) {
 	if check_5.Tag != lisette.ResultOk {
 		return *new(int), check_5.ErrVal
 	}
-	x_1 := check_5.OkVal
-	return x_1 + 1, nil
+	return check_5.OkVal + 1, nil
 }

--- a/tests/spec/emit/snapshots/propagate_simple.snap
+++ b/tests/spec/emit/snapshots/propagate_simple.snap
@@ -15,6 +15,5 @@ func get_value() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result := check_1.OkVal
-	return lisette.MakeResultOk[int, string](result)
+	return lisette.MakeResultOk[int, string](check_1.OkVal)
 }

--- a/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
+++ b/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
@@ -12,8 +12,7 @@ func maybe() (int, bool) {
 
 func test() (struct{}, bool) {
 	option_1 := lisette.OptionFromCommaOk[int](maybe())
-	check_2 := option_1
-	if check_2.Tag != lisette.OptionSome {
+	if option_1.Tag != lisette.OptionSome {
 		return *new(struct{}), false
 	}
 	return struct{}{}, true

--- a/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
@@ -11,8 +11,7 @@ func foo() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	y := result_2 + 1
+	y := check_1.OkVal + 1
 	_ = 7
 	return lisette.MakeResultOk[int, string](y)
 }

--- a/tests/spec/emit/snapshots/recover_block_never_returning_user_function.snap
+++ b/tests/spec/emit/snapshots/recover_block_never_returning_user_function.snap
@@ -15,8 +15,7 @@ func test() string {
 		fail("intentional")
 		panic("unreachable")
 	})
-	result := recoverResult_1
-	if result.Tag == lisette.ResultOk {
+	if recoverResult_1.Tag == lisette.ResultOk {
 		return "ok"
 	}
 	return "caught"

--- a/tests/spec/emit/snapshots/recover_block_panic_pattern_match.snap
+++ b/tests/spec/emit/snapshots/recover_block_panic_pattern_match.snap
@@ -10,8 +10,7 @@ func test() string {
 	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
 		panic("oh no!")
 	})
-	result := recoverResult_1
-	if result.Tag == lisette.ResultOk {
+	if recoverResult_1.Tag == lisette.ResultOk {
 		return "ok"
 	}
 	return "caught panic"

--- a/tests/spec/emit/snapshots/recover_block_unit_ok_binding.snap
+++ b/tests/spec/emit/snapshots/recover_block_unit_ok_binding.snap
@@ -10,7 +10,6 @@ func test() {
 	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
 		panic("boom")
 	})
-	result := recoverResult_1
-	if result.Tag == lisette.ResultOk {
+	if recoverResult_1.Tag == lisette.ResultOk {
 	}
 }

--- a/tests/spec/emit/snapshots/ref_of_ref_collapses_in_codegen.snap
+++ b/tests/spec/emit/snapshots/ref_of_ref_collapses_in_codegen.snap
@@ -7,6 +7,5 @@ package main
 func test() {
 	x := 42
 	r1 := &x
-	r2 := r1
-	_ = *r2
+	_ = *r1
 }

--- a/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
+++ b/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
@@ -11,8 +11,7 @@ import (
 
 func describe(r lisette.Result[int, string]) string {
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		return fmt.Sprint(v)
+		return fmt.Sprint(r.OkVal)
 	}
 	return r.ErrVal
 }

--- a/tests/spec/emit/snapshots/result_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/result_direct_as_argument.snap
@@ -18,8 +18,7 @@ func divide(a, b int) lisette.Result[int, string] {
 
 func describe(r lisette.Result[int, string]) string {
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		return fmt.Sprint(v)
+		return fmt.Sprint(r.OkVal)
 	}
 	return r.ErrVal
 }

--- a/tests/spec/emit/snapshots/result_err_with_value_propagation.snap
+++ b/tests/spec/emit/snapshots/result_err_with_value_propagation.snap
@@ -15,6 +15,5 @@ func process() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	x := check_1.OkVal
-	return lisette.MakeResultOk[int, string](x)
+	return lisette.MakeResultOk[int, string](check_1.OkVal)
 }

--- a/tests/spec/emit/snapshots/return_unit_function_preserves_side_effects.snap
+++ b/tests/spec/emit/snapshots/return_unit_function_preserves_side_effects.snap
@@ -4,9 +4,7 @@ description: "input: \nfn foo() {\n  let _ = 1\n}\n\nfn main() {\n  return foo()
 ---
 package main
 
-func foo() {
-	_ = 1
-}
+func foo() {}
 
 func main() {
 	foo()

--- a/tests/spec/emit/snapshots/select_match_receive_unused_binding.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_unused_binding.snap
@@ -8,10 +8,6 @@ func main() {
 	ch := make(chan int)
 	select {
 	case _, ok := <-ch:
-		if ok {
-			_ = 0
-		} else {
-			_ = 1
-		}
+		_ = ok
 	}
 }

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
@@ -18,8 +18,7 @@ func f() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	ch_3 := result_2
+	ch_3 := check_1.OkVal
 	for {
 		select {
 		case v, ok := <-ch_3:

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/control_flow.rs
-assertion_line: 2665
 description: "input: \nfn g() -> Result<int, string> { Ok(0) }\n\nfn f() -> Result<int, string> {\n  let chans = [Channel.buffered<int>(1)]\n  chans[0].send(7)\n  let x = select {\n    let Some(v) = chans[g()?].receive() => v,\n    _ => 0,\n  }\n  Ok(x)\n}\n\nfn main() { let _ = f() }\n"
 ---
 package main
@@ -20,8 +19,7 @@ func f() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	ch_4 := _base_3[result_2]
+	ch_4 := _base_3[check_1.OkVal]
 	for {
 		select {
 		case v, ok := <-ch_4:

--- a/tests/spec/emit/snapshots/select_receive_unused_some_ok_check.snap
+++ b/tests/spec/emit/snapshots/select_receive_unused_some_ok_check.snap
@@ -10,9 +10,7 @@ func test() {
 	for {
 		select {
 		case _, ok := <-ch_1:
-			if ok {
-				_ = 1
-			} else {
+			if !ok {
 				ch_1 = nil
 				continue
 			}

--- a/tests/spec/emit/snapshots/select_send_hoisted_temp_no_redeclare.snap
+++ b/tests/spec/emit/snapshots/select_send_hoisted_temp_no_redeclare.snap
@@ -13,9 +13,7 @@ func main() {
 	ref_1 := get(ch)
 	select {
 	case ref_1 <- 1:
-		_ = 0
 	default:
-		_ = 1
 	}
 	_ = 2
 }

--- a/tests/spec/emit/snapshots/select_send_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/select_send_value_eval_order.snap
@@ -17,6 +17,5 @@ func main() {
 	}
 	select {
 	case make_ch() <- to_send:
-		_ = 0
 	}
 }

--- a/tests/spec/emit/snapshots/select_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern.snap
@@ -21,9 +21,7 @@ func test(ch <-chan Message) int {
 		select {
 		case recv_2, ok := <-ch_1:
 			if ok {
-				id := recv_2.id
-				data := recv_2.data
-				return id + data
+				return recv_2.id + recv_2.data
 			}
 			ch_1 = nil
 			continue

--- a/tests/spec/emit/snapshots/select_ufcs_send.snap
+++ b/tests/spec/emit/snapshots/select_ufcs_send.snap
@@ -8,8 +8,6 @@ func main() {
 	ch := make(chan int)
 	select {
 	case ch <- 1:
-		_ = 0
 	default:
-		_ = 1
 	}
 }

--- a/tests/spec/emit/snapshots/simple_function.snap
+++ b/tests/spec/emit/snapshots/simple_function.snap
@@ -4,6 +4,4 @@ description: "input: \nfn foo() {\n  let x = 42;\n}\n"
 ---
 package main
 
-func foo() {
-	_ = 42
-}
+func foo() {}

--- a/tests/spec/emit/snapshots/slice_index_aliased_range.snap
+++ b/tests/spec/emit/snapshots/slice_index_aliased_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 904
 description: "input: \ntype Prefix = RangeTo<int>\nfn test(xs: Slice<int>, r: Prefix) -> Slice<int> {\n  xs[r]\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 1751
 description: "input: \nimport \"go:fmt\"\n\nfn make_items() -> Slice<int> {\n  fmt.Println(\"receiver\")\n  [10, 20, 30, 40]\n}\n\nfn make_range() -> Range<int> {\n  fmt.Println(\"range\")\n  1..3\n}\n\nfn main() {\n  let xs = make_items()[make_range()]\n  fmt.Println(xs.length())\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/result_option_patterns.rs
-assertion_line: 149
 description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int {\n  x * 2\n}\n\nstruct Wrapper {\n  pub f: Option<Handler>,\n}\n\nfn main() {\n  let _w = Wrapper { f: Some(double) }\n  let _ = _w.f\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/spread_arg_with_leading_args_into_go_variadic.snap
+++ b/tests/spec/emit/snapshots/spread_arg_with_leading_args_into_go_variadic.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/functions.rs
-assertion_line: 1493
 description: "input: \nimport filepath \"go:path/filepath\"\n\nfn test(base: string, rest: Slice<string>) -> string {\n  filepath.Join(base, rest...)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/spread_arg_with_leading_args_into_native_slice_append_assignment.snap
+++ b/tests/spec/emit/snapshots/spread_arg_with_leading_args_into_native_slice_append_assignment.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/functions.rs
-assertion_line: 1557
 description: "input: \nfn test(mut s: Slice<int>, extra: int, more: Slice<int>) -> Slice<int> {\n  s = s.append(extra, more...)\n  s\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/functions.rs
-description: "input: \nfn side_a() -> int { 1 }\n\nfn get_xs() -> Result<Slice<int>, error> { Ok([1, 2, 3]) }\n\nfn variadic(_first: int, _rest: VarArgs<int>) -> int { 0 }\n\nfn run() -> Result<int, error> {\n  Ok(variadic(side_a(), ..get_xs()?))\n}\n"
+description: "input: \nfn side_a() -> int { 1 }\n\nfn get_xs() -> Result<Slice<int>, error> { Ok([1, 2, 3]) }\n\nfn variadic(_first: int, _rest: VarArgs<int>) -> int { 0 }\n\nfn run() -> Result<int, error> {\n  Ok(variadic(side_a(), get_xs()?...))\n}\n"
 ---
 package main
 
@@ -30,6 +30,5 @@ func run() (int, error) {
 	if check_4.Tag != lisette.ResultOk {
 		return *new(int), check_4.ErrVal
 	}
-	result_5 := check_4.OkVal
-	return variadic(_arg_6, result_5...), nil
+	return variadic(_arg_6, check_4.OkVal...), nil
 }

--- a/tests/spec/emit/snapshots/static_method_as_value.snap
+++ b/tests/spec/emit/snapshots/static_method_as_value.snap
@@ -19,6 +19,5 @@ func Box_new(x int) Box {
 }
 
 func main() {
-	f := Box_new
-	_ = f(1)
+	_ = Box_new(1)
 }

--- a/tests/spec/emit/snapshots/string_bytes.snap
+++ b/tests/spec/emit/snapshots/string_bytes.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 60
 description: "input: \nfn test(s: string) -> Slice<byte> {\n  s.bytes()\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_native_method_on_alias.snap
+++ b/tests/spec/emit/snapshots/string_native_method_on_alias.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 882
 description: "input: \ntype MyString = string\n\nfn test(s: MyString) -> bool {\n  s.contains(\"foo\")\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_runes.snap
+++ b/tests/spec/emit/snapshots/string_runes.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 70
 description: "input: \nfn test(s: string) -> Slice<rune> {\n  s.runes()\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_alias_receiver.snap
+++ b/tests/spec/emit/snapshots/string_substring_alias_receiver.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 870
 description: "input: \ntype MyString = string\n\nfn test(s: MyString, r: RangeTo<int>) -> string {\n  s.substring(r)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_aliased_range.snap
+++ b/tests/spec/emit/snapshots/string_substring_aliased_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 893
 description: "input: \ntype Prefix = RangeTo<int>\nfn test(s: string, r: Prefix) -> string {\n  s.substring(r)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range.snap
+++ b/tests/spec/emit/snapshots/string_substring_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 818
 description: "input: \nfn test(s: string) -> string {\n  s.substring(0..5)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range_from.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_from.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 838
 description: "input: \nfn test(s: string) -> string {\n  s.substring(6..)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range_inclusive.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_inclusive.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 828
 description: "input: \nfn test(s: string) -> string {\n  s.substring(0..=4)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range_to.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_to.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 848
 description: "input: \nfn test(s: string) -> string {\n  s.substring(..5)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range_to_inclusive.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_to_inclusive.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 858
 description: "input: \nfn test(s: string) -> string {\n  s.substring(..=4)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 890
 description: "input: \nimport \"go:fmt\"\n\nfn make_s() -> string {\n  fmt.Println(\"receiver\")\n  \"hello\"\n}\n\nfn make_range() -> Range<int> {\n  fmt.Println(\"range\")\n  1..4\n}\n\nfn main() {\n  fmt.Println(make_s().substring(make_range()))\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_ref_receiver_range_literal.snap
+++ b/tests/spec/emit/snapshots/string_substring_ref_receiver_range_literal.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 912
 description: "input: \nfn test(r: Ref<string>) -> string {\n  r.substring(1..4)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_ref_receiver_range_value.snap
+++ b/tests/spec/emit/snapshots/string_substring_ref_receiver_range_value.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 922
 description: "input: \nfn test(r: Ref<string>, range: Range<int>) -> string {\n  r.substring(range)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_stored_range_to.snap
+++ b/tests/spec/emit/snapshots/string_substring_stored_range_to.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 848
 description: "input: \nfn test(s: string, r: RangeTo<int>) -> string {\n  s.substring(r)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/string_substring_ufcs.snap
+++ b/tests/spec/emit/snapshots/string_substring_ufcs.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/prelude.rs
-assertion_line: 858
 description: "input: \nfn test(s: string) -> string {\n  string.substring(s, 0..5)\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
@@ -25,9 +25,5 @@ func test() int {
 		d: 4,
 	}
 	subject_1 := b
-	{
-		a := subject_1.a
-		b_2 := subject_1.b
-		return a + b_2
-	}
+	return subject_1.a + subject_1.b
 }

--- a/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
@@ -40,9 +40,7 @@ func (m Message) String() string {
 
 func handle(m Message) int {
 	if m.Tag == MessageMove {
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
@@ -34,7 +34,5 @@ func (s Shape) String() string {
 }
 
 func area(s Shape) int {
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }

--- a/tests/spec/emit/snapshots/try_block_basic_result.snap
+++ b/tests/spec/emit/snapshots/try_block_basic_result.snap
@@ -17,8 +17,7 @@ func test() int {
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, string](result_3)
+		return lisette.MakeResultOk[int, string](check_2.OkVal)
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
+++ b/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
@@ -26,16 +26,13 @@ func main() {
 		if check_3.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_3.ErrVal)
 		}
-		x := check_3.OkVal
-		return lisette.MakeResultOk[int, string](x + 1)
+		return lisette.MakeResultOk[int, string](check_3.OkVal + 1)
 	}()
 	result = tryResult_2
 	if result.Tag == lisette.ResultOk {
-		v := result.OkVal
-		fmt.Println(v)
+		fmt.Println(result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Println(e)
+		fmt.Println(result.ErrVal)
 	}
 	fmt.Println(x_1)
 }

--- a/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
+++ b/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
@@ -26,8 +26,7 @@ func test() int {
 		if check_3.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_3.ErrVal)
 		}
-		b := check_3.OkVal
-		return lisette.MakeResultOk[int, string](a + b)
+		return lisette.MakeResultOk[int, string](a + check_3.OkVal)
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/try_block_nested.snap
+++ b/tests/spec/emit/snapshots/try_block_nested.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/control_flow.rs
-assertion_line: 1737
 description: "input: \nfn risky_a() -> Result<int, string> { Ok(1) }\nfn risky_b() -> Result<int, string> { Ok(2) }\n\nfn test() -> int {\n  let outer = try {\n    let inner: Result<int, string> = try {\n      risky_a()?\n    };\n    let inner_val = match inner {\n      Ok(x) => x,\n      Err(_) => 0,\n    };\n    inner_val + risky_b()?\n  };\n  match outer {\n    Ok(x) => x,\n    Err(_) => -1,\n  }\n}\n"
 ---
 package main
@@ -24,8 +23,7 @@ func test() int {
 			if check_3.Tag != lisette.ResultOk {
 				return lisette.MakeResultErr[int, string](check_3.ErrVal)
 			}
-			result_4 := check_3.OkVal
-			return lisette.MakeResultOk[int, string](result_4)
+			return lisette.MakeResultOk[int, string](check_3.OkVal)
 		}()
 		inner = tryResult_2
 		var _left_7 int
@@ -38,8 +36,7 @@ func test() int {
 		if check_5.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_5.ErrVal)
 		}
-		result_6 := check_5.OkVal
-		return lisette.MakeResultOk[int, string](_left_7 + result_6)
+		return lisette.MakeResultOk[int, string](_left_7 + check_5.OkVal)
 	}()
 	outer = tryResult_1
 	if outer.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/try_block_option.snap
+++ b/tests/spec/emit/snapshots/try_block_option.snap
@@ -18,8 +18,7 @@ func test() int {
 		if check_3.Tag != lisette.OptionSome {
 			return lisette.MakeOptionNone[int]()
 		}
-		x := check_3.SomeVal
-		return lisette.MakeOptionSome[int](x + 1)
+		return lisette.MakeOptionSome[int](check_3.SomeVal + 1)
 	}()
 	opt = tryResult_1
 	if opt.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
@@ -7,14 +7,12 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func foo() lisette.Result[int, string] {
-	var _ lisette.Result[int, any]
 	tryResult_1 := func() lisette.Result[int, any] {
 		check_2 := lisette.MakeResultOk[int, any](1)
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, any](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, any](result_3)
+		return lisette.MakeResultOk[int, any](check_2.OkVal)
 	}()
 	_ = tryResult_1
 	_ = 7

--- a/tests/spec/emit/snapshots/try_block_with_semicolon.snap
+++ b/tests/spec/emit/snapshots/try_block_with_semicolon.snap
@@ -17,8 +17,7 @@ func test() {
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, string](result_3)
+		return lisette.MakeResultOk[int, string](check_2.OkVal)
 	}()
 	result = tryResult_1
 	_ = result

--- a/tests/spec/emit/snapshots/tuple_destructuring.snap
+++ b/tests/spec/emit/snapshots/tuple_destructuring.snap
@@ -8,7 +8,5 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
 	pair := lisette.MakeTuple2(10, 20)
-	a := pair.First
-	b := pair.Second
-	return a + b
+	return pair.First + pair.Second
 }

--- a/tests/spec/emit/snapshots/tuple_pattern_in_function_param.snap
+++ b/tests/spec/emit/snapshots/tuple_pattern_in_function_param.snap
@@ -7,7 +7,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func sum(arg_1 lisette.Tuple2[int, int]) int {
-	x := arg_1.First
-	y := arg_1.Second
-	return x + y
+	return arg_1.First + arg_1.Second
 }

--- a/tests/spec/emit/snapshots/tuple_struct_if_let.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_if_let.snap
@@ -20,9 +20,7 @@ func (p Point) String() string {
 
 func test(p lisette.Option[Point]) int {
 	if p.Tag == lisette.OptionSome {
-		x := p.SomeVal.F0
-		y := p.SomeVal.F1
-		return x + y
+		return p.SomeVal.F0 + p.SomeVal.F1
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
@@ -16,7 +16,5 @@ func (p Pair) String() string {
 }
 
 func test(p Pair) int {
-	a := p.F0
-	b := p.F1
-	return a + b
+	return p.F0 + p.F1
 }

--- a/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
+++ b/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
@@ -13,8 +13,7 @@ func handle(e events.Event, threshold int) int {
 		if x > threshold {
 			return x
 		}
-		x_1 := e.X
-		return x_1 + 1
+		return e.X + 1
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/type_switch_binding_used_in_arm.snap
+++ b/tests/spec/emit/snapshots/type_switch_binding_used_in_arm.snap
@@ -9,9 +9,7 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x * y
+		return e.X * e.Y
 	case events.Scroll:
 		return e.Delta
 	default:

--- a/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
@@ -9,20 +9,16 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		if x > 1000 {
+		if e.X > 1000 {
 			return 4
 		}
-		x_1 := e.X
-		if x_1 > 100 {
+		if e.X > 100 {
 			return 3
 		}
-		x_2 := e.X
-		if x_2 > 50 {
+		if e.X > 50 {
 			return 2
 		}
-		x_3 := e.X
-		if x_3 > 0 {
+		if e.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
+++ b/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
@@ -17,8 +17,7 @@ func handle(e events.Event) (int, bool) {
 		if x_1 > 0 {
 			return x_1, true
 		}
-		x_2 := e.X
-		return -x_2, true
+		return -e.X, true
 	default:
 		return *new(int), false
 	}

--- a/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
@@ -9,16 +9,13 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		if x > 100 {
+		if e.X > 100 {
 			return 3
 		}
-		x_1 := e.X
-		if x_1 > 50 {
+		if e.X > 50 {
 			return 2
 		}
-		x_2 := e.X
-		if x_2 > 0 {
+		if e.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 2673
 description: "input: \nstruct Counter { x: int }\n\nimpl Counter {\n  fn inc(self: Ref<Counter>) -> int {\n    self.x = self.x + 1\n    self.x\n  }\n}\n\nfn main() {\n  let _ = Counter.inc(&Counter { x: 0 })\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 2328
 description: "input: \npub struct Service {}\n\nimpl Service {\n  pub fn get_session(self) -> int { 42 }\n}\n\nfn main() {\n  let s = Service {};\n  let _ = Service.get_session(s);\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/underscore_prefixed_binding_unused.snap
+++ b/tests/spec/emit/snapshots/underscore_prefixed_binding_unused.snap
@@ -4,6 +4,4 @@ description: "input: \nfn test() {\n  let _x = 42;\n}\n"
 ---
 package main
 
-func test() {
-	_ = 42
-}
+func test() {}

--- a/tests/spec/emit/snapshots/underscore_prefixed_match_arm_binding_used.snap
+++ b/tests/spec/emit/snapshots/underscore_prefixed_match_arm_binding_used.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		_val := opt.SomeVal
-		return _val + 1
+		return opt.SomeVal + 1
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
+++ b/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 3491
 description: "input: \nfn noop() {}\n\nfn main() {\n  let mut m = Map.new<(), int>()\n  m[()] = 7\n  let x = m[noop()]\n  let _ = x\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/concurrency.rs
-assertion_line: 881
 description: "input: \nfn noop() {}\n\nfn test() {\n  let ch = Channel.buffered<()>(1)\n  ch.send(noop())\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 3463
 description: "input: \nfn noop() {}\n\nfn main() {\n  let xs: Slice<()> = []\n  let y = Slice.append(xs, noop())\n  let _ = y\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/expressions.rs
-assertion_line: 3410
 description: "input: \nfn noop() {}\n\nfn test() {\n  let mut xs: Slice<()> = []\n  xs.append(noop())\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/functions.rs
-assertion_line: 1428
 description: "input: \nfn noop() {}\n\nstruct Box {}\n\nimpl Box {\n  fn ping(self, _x: ()) {}\n}\n\nfn test() {\n  let b = Box {}\n  Box.ping(b, noop())\n}\n"
 ---
 package main

--- a/tests/spec/emit/snapshots/unit_return_early.snap
+++ b/tests/spec/emit/snapshots/unit_return_early.snap
@@ -8,5 +8,4 @@ func test(flag bool) {
 	if flag {
 		return
 	}
-	_ = 10
 }

--- a/tests/spec/emit/snapshots/unit_return_explicit.snap
+++ b/tests/spec/emit/snapshots/unit_return_explicit.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test() -> () {\n  let x = 42;\n  return ()\n}\n"
 package main
 
 func test() {
-	_ = 42
 	return
 }

--- a/tests/spec/emit/snapshots/unit_return_implicit.snap
+++ b/tests/spec/emit/snapshots/unit_return_implicit.snap
@@ -4,6 +4,4 @@ description: "input: \nfn test() -> () {\n  let x = 42;\n  ()\n}\n"
 ---
 package main
 
-func test() {
-	_ = 42
-}
+func test() {}

--- a/tests/spec/emit/snapshots/unused_mutable_variable_multiple_reassignments.snap
+++ b/tests/spec/emit/snapshots/unused_mutable_variable_multiple_reassignments.snap
@@ -13,7 +13,6 @@ func g() int {
 }
 
 func test() {
-	_ = 0
 	_ = f()
 	_ = g()
 }

--- a/tests/spec/emit/snapshots/unused_mutable_variable_reassignment.snap
+++ b/tests/spec/emit/snapshots/unused_mutable_variable_reassignment.snap
@@ -4,7 +4,4 @@ description: "input: \nfn test() {\n  let mut x = 0\n  x = 1\n}\n"
 ---
 package main
 
-func test() {
-	_ = 0
-	_ = 1
-}
+func test() {}

--- a/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
+++ b/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
@@ -14,6 +14,5 @@ func maybe_pair(n int) (lisette.Tuple2[int, int], bool) {
 }
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybe_pair(5))
-	_ = option_1
+	_ = lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybe_pair(5))
 }

--- a/tests/spec/emit/snapshots/variable_shadow_in_match_assigned_to_let.snap
+++ b/tests/spec/emit/snapshots/variable_shadow_in_match_assigned_to_let.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() int {
 	val := lisette.MakeOptionSome(42)
 	if val.Tag == lisette.OptionSome {
-		x := val.SomeVal
-		return x * 2
+		return val.SomeVal * 2
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/variable_shadow_inside_match_arm.snap
+++ b/tests/spec/emit/snapshots/variable_shadow_inside_match_arm.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		return x * 2
+		return opt.SomeVal * 2
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -22,8 +22,7 @@ func test() {
 		option_2 := lisette.OptionFromCommaOk[int](next_item(i))
 		subject_1 := option_2
 		if subject_1.Tag == lisette.OptionSome {
-			x := subject_1.SomeVal
-			fmt.Printf("Got: %v\n", x)
+			fmt.Printf("Got: %v\n", subject_1.SomeVal)
 			i++
 		} else {
 			break

--- a/tests/spec/emit/snapshots/while_let_result_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_result_function_call.snap
@@ -21,8 +21,7 @@ func test() {
 	for {
 		subject_1 := next_result(i)
 		if subject_1.Tag == lisette.ResultOk {
-			x := subject_1.OkVal
-			fmt.Printf("Got: %v\n", x)
+			fmt.Printf("Got: %v\n", subject_1.OkVal)
 			i++
 		} else {
 			break

--- a/tests/spec/emit/snapshots/while_let_with_break.snap
+++ b/tests/spec/emit/snapshots/while_let_with_break.snap
@@ -10,8 +10,7 @@ func test(opt lisette.Option[int]) {
 	current := opt
 	for {
 		if current.Tag == lisette.OptionSome {
-			x := current.SomeVal
-			if x > 100 {
+			if current.SomeVal > 100 {
 				break
 			}
 			current = lisette.MakeOptionNone[int]()


### PR DESCRIPTION
Emitted Go now skips three sources of noise: 

- unused `var _ T` declarations
- pure-literal `_ = lit` discards
- single-use field-read temps