### PR TITLE
fix: derive bindgen param names from types

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -160,14 +160,14 @@
         },
         "encoding/binary": {
           "Append": ["buf"],
-          "AppendByteOrder.AppendUint16": ["arg0"],
-          "AppendByteOrder.AppendUint32": ["arg0"],
-          "AppendByteOrder.AppendUint64": ["arg0"],
+          "AppendByteOrder.AppendUint16": ["b"],
+          "AppendByteOrder.AppendUint32": ["b"],
+          "AppendByteOrder.AppendUint64": ["b"],
           "AppendUvarint": ["buf"],
           "AppendVarint": ["buf"],
-          "ByteOrder.PutUint16": ["arg0"],
-          "ByteOrder.PutUint32": ["arg0"],
-          "ByteOrder.PutUint64": ["arg0"],
+          "ByteOrder.PutUint16": ["b"],
+          "ByteOrder.PutUint32": ["b"],
+          "ByteOrder.PutUint64": ["b"],
           "Encode": ["buf"],
           "PutUvarint": ["buf"],
           "PutVarint": ["buf"]
@@ -215,8 +215,8 @@
           "SectionReader.ReadAt": ["p"]
         },
         "io/fs": {
-          "File.Read": ["arg0"],
-          "ReadDirFile.Read": ["arg0"]
+          "File.Read": ["b"],
+          "ReadDirFile.Read": ["b"]
         },
         "log/slog": {
           "Level.AppendText": ["b"],

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -121,13 +121,16 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 	nilableParams := c.cfg.NilableParams(c.currentPkgPath, result.Name)
 
 	params := signature.Params()
+	usedNames := collectNamedParams(params)
 	for i := 0; i < params.Len(); i++ {
 		param := params.At(i)
 		name := param.Name()
 		if name == "" {
-			name = fmt.Sprintf("arg%d", i)
+			isVariadic := signature.Variadic() && i == params.Len()-1
+			name = deriveParamName(param.Type(), i, isVariadic, usedNames)
+		} else {
+			name = sanitizeParamName(name)
 		}
-		name = sanitizeParamName(name)
 
 		paramType := convertParamType(param.Type(), name, nilableParams, c)
 		if paramType.SkipReason != nil {
@@ -278,13 +281,16 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	nilableParams := c.cfg.NilableParams(c.currentPkgPath, qualifiedName)
 
 	params := signature.Params()
+	usedNames := collectNamedParams(params)
 	for i := 0; i < params.Len(); i++ {
 		param := params.At(i)
 		name := param.Name()
 		if name == "" {
-			name = fmt.Sprintf("arg%d", i)
+			isVariadic := signature.Variadic() && i == params.Len()-1
+			name = deriveParamName(param.Type(), i, isVariadic, usedNames)
+		} else {
+			name = sanitizeParamName(name)
 		}
-		name = sanitizeParamName(name)
 
 		paramType := convertParamType(param.Type(), name, nilableParams, c)
 		if paramType.SkipReason != nil {
@@ -1354,13 +1360,17 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 		nilableParams := c.cfg.NilableParams(c.currentPkgPath, qualifiedName)
 
 		var params []FunctionParameter
-		for j := 0; j < signature.Params().Len(); j++ {
-			param := signature.Params().At(j)
+		sigParams := signature.Params()
+		usedNames := collectNamedParams(sigParams)
+		for j := 0; j < sigParams.Len(); j++ {
+			param := sigParams.At(j)
 			name := param.Name()
 			if name == "" {
-				name = fmt.Sprintf("arg%d", j)
+				isVariadic := signature.Variadic() && j == sigParams.Len()-1
+				name = deriveParamName(param.Type(), j, isVariadic, usedNames)
+			} else {
+				name = sanitizeParamName(name)
 			}
-			name = sanitizeParamName(name)
 
 			paramType := convertParamType(param.Type(), name, nilableParams, c)
 			if paramType.SkipReason != nil {
@@ -1368,7 +1378,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 			}
 
 			typeStr := paramType.LisetteType
-			if signature.Variadic() && j == signature.Params().Len()-1 {
+			if signature.Variadic() && j == sigParams.Len()-1 {
 				typeStr = sliceToVarArgs(typeStr)
 			}
 

--- a/bindgen/internal/convert/param_names.go
+++ b/bindgen/internal/convert/param_names.go
@@ -1,0 +1,190 @@
+package convert
+
+import (
+	"fmt"
+	"go/types"
+	"strings"
+	"unicode"
+)
+
+func collectNamedParams(params *types.Tuple) map[string]int {
+	used := make(map[string]int, params.Len())
+	for v := range params.Variables() {
+		if n := v.Name(); n != "" {
+			used[sanitizeParamName(n)]++
+		}
+	}
+	return used
+}
+
+// deriveParamName synthesizes a parameter name from the Go type when the
+// original signature has none.
+func deriveParamName(t types.Type, index int, variadic bool, used map[string]int) string {
+	base := derivedBaseName(t, variadic)
+	if base == "" {
+		base = fmt.Sprintf("arg%d", index)
+	}
+	base = sanitizeParamName(base)
+	used[base]++
+	if used[base] == 1 {
+		return base
+	}
+	return fmt.Sprintf("%s%d", base, used[base])
+}
+
+func derivedBaseName(t types.Type, variadic bool) string {
+	if variadic {
+		if slice, ok := t.(*types.Slice); ok {
+			return pluralizeName(elementLongName(slice.Elem()))
+		}
+	}
+	return scalarName(t)
+}
+
+// elementLongName is like scalarName but uses the full type name for
+// primitives ("string" rather than "s") so pluralization reads naturally.
+// `VarArgs<string>` becomes "strings", `Slice<int>` becomes "ints".
+func elementLongName(t types.Type) string {
+	switch x := t.(type) {
+	case *types.Basic:
+		return x.Name()
+	case *types.Named:
+		if special := specialNamedShortName(x.Obj()); special != "" {
+			return special
+		}
+		return lowerFirst(x.Obj().Name())
+	case *types.TypeParam:
+		return lowerFirst(x.Obj().Name())
+	case *types.Pointer:
+		return elementLongName(x.Elem())
+	case *types.Alias:
+		if special := specialNamedShortName(x.Obj()); special != "" {
+			return special
+		}
+		if name := lowerFirst(x.Obj().Name()); name != "" {
+			return name
+		}
+		return elementLongName(types.Unalias(x))
+	}
+	return scalarName(t)
+}
+
+func scalarName(t types.Type) string {
+	switch x := t.(type) {
+	case *types.Pointer:
+		return scalarName(x.Elem())
+	case *types.Alias:
+		if special := specialNamedShortName(x.Obj()); special != "" {
+			return special
+		}
+		if name := lowerFirst(x.Obj().Name()); name != "" {
+			return name
+		}
+		return scalarName(types.Unalias(x))
+	case *types.Named:
+		obj := x.Obj()
+		if special := specialNamedShortName(obj); special != "" {
+			return special
+		}
+		return lowerFirst(obj.Name())
+	case *types.TypeParam:
+		return lowerFirst(x.Obj().Name())
+	case *types.Slice:
+		if isByteLike(x.Elem()) {
+			return "b"
+		}
+		return pluralizeName(elementLongName(x.Elem()))
+	case *types.Array:
+		if isByteLike(x.Elem()) {
+			return "b"
+		}
+		return pluralizeName(elementLongName(x.Elem()))
+	case *types.Map:
+		return "m"
+	case *types.Chan:
+		return "ch"
+	case *types.Signature:
+		return "f"
+	case *types.Basic:
+		return basicScalarName(x)
+	case *types.Interface:
+		if x.Empty() {
+			return "v"
+		}
+	}
+	return ""
+}
+
+func basicScalarName(b *types.Basic) string {
+	switch b.Kind() {
+	case types.Bool, types.UntypedBool:
+		return "b"
+	case types.String, types.UntypedString:
+		return "s"
+	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
+		types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64,
+		types.Uintptr, types.UntypedInt, types.UntypedRune:
+		return "n"
+	case types.Float32, types.Float64, types.UntypedFloat:
+		return "f"
+	case types.Complex64, types.Complex128, types.UntypedComplex:
+		return "c"
+	}
+	return ""
+}
+
+func specialNamedShortName(obj *types.TypeName) string {
+	if obj == nil {
+		return ""
+	}
+	pkg := obj.Pkg()
+	name := obj.Name()
+	if pkg == nil {
+		if name == "error" {
+			return "err"
+		}
+		return ""
+	}
+	switch pkg.Path() + "." + name {
+	case "context.Context":
+		return "ctx"
+	case "time.Time":
+		return "t"
+	case "time.Duration":
+		return "d"
+	case "github.com/google/uuid.UUID":
+		return "id"
+	}
+	return ""
+}
+
+func isByteLike(t types.Type) bool {
+	switch x := t.(type) {
+	case *types.Basic:
+		return x.Kind() == types.Byte || x.Kind() == types.Uint8
+	case *types.Named:
+		return x.Obj().Name() == "byte"
+	case *types.Alias:
+		return isByteLike(types.Unalias(x))
+	}
+	return false
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToLower(runes[0])
+	return string(runes)
+}
+
+func pluralizeName(s string) string {
+	if s == "" {
+		return ""
+	}
+	if strings.HasSuffix(s, "s") {
+		return s
+	}
+	return s + "s"
+}

--- a/bindgen/tests/testdata/snapshots/functions.d.lis
+++ b/bindgen/tests/testdata/snapshots/functions.d.lis
@@ -4,7 +4,7 @@
 // Lisette: 0.0.0
 
 /// Function with unnamed params - tests convertFunc unnamed param path
-pub fn Callback(arg0: int, arg1: string) -> bool
+pub fn Callback(n: int, s: string) -> bool
 
 /// Comma-ok with pointer inner type - produces tuple to avoid
 /// ambiguity with single-pointer returns that also produce Option<Ref<T>>

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -80,7 +80,7 @@ pub type Salutation = Greeter
 
 /// Generic interface - emits as opaque type with type params
 pub interface Transformer<T> {
-  fn Transform(arg0: T) -> T
+  fn Transform(t: T) -> T
 }
 
 impl<K: Comparable, V> ConstrainedPair<K, V> {

--- a/bindgen/tests/testdata/snapshots/interfaces.d.lis
+++ b/bindgen/tests/testdata/snapshots/interfaces.d.lis
@@ -47,8 +47,8 @@ pub interface ReadWriteSeeker {
 }
 
 pub interface ReadWriter {
-  fn Read(mut arg0: Slice<byte>) -> Partial<int, error>
-  fn Write(arg0: Slice<byte>) -> Partial<int, error>
+  fn Read(mut b: Slice<byte>) -> Partial<int, error>
+  fn Write(b: Slice<byte>) -> Partial<int, error>
 }
 
 /// Error-like but with extra method - not an error

--- a/bindgen/tests/testdata/snapshots/methods.d.lis
+++ b/bindgen/tests/testdata/snapshots/methods.d.lis
@@ -36,5 +36,5 @@ impl Counter {
   /// Variadic method - tests convertMethod variadic path
   fn Log(self: Ref<Counter>, format: string, args: VarArgs<Unknown>)
   /// Method with unnamed params - tests convertMethod unnamed param path
-  fn Process(self: Ref<Counter>, arg0: string, arg1: int)
+  fn Process(self: Ref<Counter>, s: string, n: int)
 }

--- a/bindgen/tests/testdata/snapshots/skipped_generic.d.lis
+++ b/bindgen/tests/testdata/snapshots/skipped_generic.d.lis
@@ -25,7 +25,7 @@ pub type StringTarget
 /// by it becomes unrepresentable.
 pub interface Target<E> {
   fn Apply()
-  fn Set(arg0: Slice<E>)
+  fn Set(es: Slice<E>)
 }
 
 impl<T, S, E> SliceFlag<T, S, E> {

--- a/crates/stdlib/typedefs/database/sql/driver.d.lis
+++ b/crates/stdlib/typedefs/database/sql/driver.d.lis
@@ -55,7 +55,7 @@ pub interface ConnPrepareContext {
 /// If a Connector implements [io.Closer], the [database/sql.DB.Close]
 /// method will call the Close method and return error (if any).
 pub interface Connector {
-  fn Connect(arg0: context.Context) -> Result<Conn, error>
+  fn Connect(ctx: context.Context) -> Result<Conn, error>
   fn Driver() -> Driver
 }
 
@@ -135,7 +135,7 @@ pub struct NamedValue {
 /// path is used for the argument. Drivers may wish to return [ErrSkip] after
 /// they have exhausted their own special cases.
 pub interface NamedValueChecker {
-  fn CheckNamedValue(arg0: Ref<NamedValue>) -> Result<(), error>
+  fn CheckNamedValue(namedValue: Ref<NamedValue>) -> Result<(), error>
 }
 
 /// NotNull is a type that implements [ValueConverter] by disallowing nil

--- a/crates/stdlib/typedefs/encoding/binary.d.lis
+++ b/crates/stdlib/typedefs/encoding/binary.d.lis
@@ -105,9 +105,9 @@ pub fn Write(w: io.Writer, order: ByteOrder, data: Unknown) -> Result<(), error>
 /// 
 /// It is implemented by [LittleEndian], [BigEndian], and [NativeEndian].
 pub interface AppendByteOrder {
-  fn AppendUint16(mut arg0: Slice<byte>, arg1: uint16) -> Slice<byte>
-  fn AppendUint32(mut arg0: Slice<byte>, arg1: uint32) -> Slice<byte>
-  fn AppendUint64(mut arg0: Slice<byte>, arg1: uint64) -> Slice<byte>
+  fn AppendUint16(mut b: Slice<byte>, n: uint16) -> Slice<byte>
+  fn AppendUint32(mut b: Slice<byte>, n: uint32) -> Slice<byte>
+  fn AppendUint64(mut b: Slice<byte>, n: uint64) -> Slice<byte>
   fn String() -> string
 }
 
@@ -116,13 +116,13 @@ pub interface AppendByteOrder {
 /// 
 /// It is implemented by [LittleEndian], [BigEndian], and [NativeEndian].
 pub interface ByteOrder {
-  fn PutUint16(mut arg0: Slice<byte>, arg1: uint16)
-  fn PutUint32(mut arg0: Slice<byte>, arg1: uint32)
-  fn PutUint64(mut arg0: Slice<byte>, arg1: uint64)
+  fn PutUint16(mut b: Slice<byte>, n: uint16)
+  fn PutUint32(mut b: Slice<byte>, n: uint32)
+  fn PutUint64(mut b: Slice<byte>, n: uint64)
   fn String() -> string
-  fn Uint16(arg0: Slice<byte>) -> uint16
-  fn Uint32(arg0: Slice<byte>) -> uint32
-  fn Uint64(arg0: Slice<byte>) -> uint64
+  fn Uint16(b: Slice<byte>) -> uint16
+  fn Uint32(b: Slice<byte>) -> uint32
+  fn Uint64(b: Slice<byte>) -> uint64
 }
 
 /// MaxVarintLenN is the maximum length of a varint-encoded N-bit integer.

--- a/crates/stdlib/typedefs/encoding/gob.d.lis
+++ b/crates/stdlib/typedefs/encoding/gob.d.lis
@@ -52,7 +52,7 @@ pub type Encoder
 /// GobDecoder is the interface describing data that provides its own
 /// routine for decoding transmitted values sent by a GobEncoder.
 pub interface GobDecoder {
-  fn GobDecode(arg0: Slice<byte>) -> Result<(), error>
+  fn GobDecode(b: Slice<byte>) -> Result<(), error>
 }
 
 /// GobEncoder is the interface describing data that provides its own

--- a/crates/stdlib/typedefs/encoding/json.d.lis
+++ b/crates/stdlib/typedefs/encoding/json.d.lis
@@ -363,7 +363,7 @@ pub struct UnmarshalTypeError {
 /// a JSON value. UnmarshalJSON must copy the JSON data
 /// if it wishes to retain the data after returning.
 pub interface Unmarshaler {
-  fn UnmarshalJSON(arg0: Slice<byte>) -> Result<(), error>
+  fn UnmarshalJSON(b: Slice<byte>) -> Result<(), error>
 }
 
 /// An UnsupportedTypeError is returned by [Marshal] when attempting

--- a/crates/stdlib/typedefs/flag.d.lis
+++ b/crates/stdlib/typedefs/flag.d.lis
@@ -214,7 +214,7 @@ pub struct FlagSet {
 /// by this package satisfy the [Getter] interface, except the type used by [Func].
 pub interface Getter {
   fn Get() -> Unknown
-  fn Set(arg0: string) -> Result<(), error>
+  fn Set(s: string) -> Result<(), error>
   fn String() -> string
 }
 
@@ -229,7 +229,7 @@ pub interface Getter {
 /// The flag package may call the [String] method with a zero-valued receiver,
 /// such as a nil pointer.
 pub interface Value {
-  fn Set(arg0: string) -> Result<(), error>
+  fn Set(s: string) -> Result<(), error>
   fn String() -> string
 }
 

--- a/crates/stdlib/typedefs/image.d.lis
+++ b/crates/stdlib/typedefs/image.d.lis
@@ -696,7 +696,7 @@ impl Uniform {
 
   fn ColorModel(self: Ref<Uniform>) -> color.Model
 
-  fn Convert(self: Ref<Uniform>, arg0: color.Color) -> color.Color
+  fn Convert(self: Ref<Uniform>, color: color.Color) -> color.Color
 
   /// Opaque scans the entire image and reports whether it is fully opaque.
   fn Opaque(self: Ref<Uniform>) -> bool

--- a/crates/stdlib/typedefs/image/png.d.lis
+++ b/crates/stdlib/typedefs/image/png.d.lis
@@ -47,7 +47,7 @@ pub type EncoderBuffer
 /// when encoding multiple images.
 pub interface EncoderBufferPool {
   fn Get() -> Ref<EncoderBuffer>
-  fn Put(arg0: Ref<EncoderBuffer>)
+  fn Put(encoderBuffer: Ref<EncoderBuffer>)
 }
 
 /// A FormatError reports that the input is not a valid PNG.

--- a/crates/stdlib/typedefs/io/fs.d.lis
+++ b/crates/stdlib/typedefs/io/fs.d.lis
@@ -148,7 +148,7 @@ pub interface FS {
 /// A file may implement [io.ReaderAt] or [io.Seeker] as optimizations.
 pub interface File {
   fn Close() -> Result<(), error>
-  fn Read(mut arg0: Slice<byte>) -> Partial<int, error>
+  fn Read(mut b: Slice<byte>) -> Partial<int, error>
   fn Stat() -> Result<FileInfo, error>
 }
 
@@ -195,7 +195,7 @@ pub interface ReadDirFS {
 /// but if so ReadDir should return an error for non-directories.)
 pub interface ReadDirFile {
   fn Close() -> Result<(), error>
-  fn Read(mut arg0: Slice<byte>) -> Partial<int, error>
+  fn Read(mut b: Slice<byte>) -> Partial<int, error>
   fn ReadDir(n: int) -> Result<Slice<DirEntry>, error>
   fn Stat() -> Result<FileInfo, error>
 }

--- a/crates/stdlib/typedefs/log/slog.d.lis
+++ b/crates/stdlib/typedefs/log/slog.d.lis
@@ -271,8 +271,8 @@ pub struct Attr {
 /// 
 /// Before implementing your own handler, consult https://go.dev/s/slog-handler-guide.
 pub interface Handler {
-  fn Enabled(arg0: context.Context, arg1: Level) -> bool
-  fn Handle(arg0: context.Context, arg1: Record) -> Result<(), error>
+  fn Enabled(ctx: context.Context, level: Level) -> bool
+  fn Handle(ctx: context.Context, record: Record) -> Result<(), error>
   fn WithAttrs(attrs: Slice<Attr>) -> Handler
   fn WithGroup(name: string) -> Handler
 }

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -739,7 +739,7 @@ pub struct HTTP2Config {
 /// the client sees an interrupted response but the server doesn't log
 /// an error, panic with the value [ErrAbortHandler].
 pub interface Handler {
-  fn ServeHTTP(arg0: ResponseWriter, arg1: Ref<Request>)
+  fn ServeHTTP(responseWriter: ResponseWriter, request: Ref<Request>)
 }
 
 /// The HandlerFunc type is an adapter to allow the use of
@@ -868,7 +868,7 @@ pub type ResponseController
 /// A ResponseWriter may not be used after [Handler.ServeHTTP] has returned.
 pub interface ResponseWriter {
   fn Header() -> Header
-  fn Write(arg0: Slice<byte>) -> Partial<int, error>
+  fn Write(b: Slice<byte>) -> Partial<int, error>
   fn WriteHeader(statusCode: int)
 }
 
@@ -878,7 +878,7 @@ pub interface ResponseWriter {
 /// A RoundTripper must be safe for concurrent use by multiple
 /// goroutines.
 pub interface RoundTripper {
-  fn RoundTrip(arg0: Ref<Request>) -> Result<Ref<Response>, error>
+  fn RoundTrip(request: Ref<Request>) -> Result<Ref<Response>, error>
 }
 
 /// SameSite allows a server to define a cookie attribute making it impossible for

--- a/crates/stdlib/typedefs/net/http/httputil.d.lis
+++ b/crates/stdlib/typedefs/net/http/httputil.d.lis
@@ -105,7 +105,7 @@ pub fn NewSingleHostReverseProxy(target: Ref<url.URL>) -> Ref<ReverseProxy>
 /// byte slices for use by [io.CopyBuffer].
 pub interface BufferPool {
   fn Get() -> Slice<byte>
-  fn Put(arg0: Slice<byte>)
+  fn Put(b: Slice<byte>)
 }
 
 /// ClientConn is an artifact of Go's early HTTP implementation.

--- a/crates/stdlib/typedefs/net/rpc.d.lis
+++ b/crates/stdlib/typedefs/net/rpc.d.lis
@@ -95,9 +95,9 @@ pub type Client
 /// See [NewClient]'s comment for information about concurrent access.
 pub interface ClientCodec {
   fn Close() -> Result<(), error>
-  fn ReadResponseBody(arg0: Unknown) -> Result<(), error>
-  fn ReadResponseHeader(arg0: Ref<Response>) -> Result<(), error>
-  fn WriteRequest(arg0: Ref<Request>, arg1: Unknown) -> Result<(), error>
+  fn ReadResponseBody(any: Unknown) -> Result<(), error>
+  fn ReadResponseHeader(response: Ref<Response>) -> Result<(), error>
+  fn WriteRequest(request: Ref<Request>, any: Unknown) -> Result<(), error>
 }
 
 /// Request is a header written before every RPC call. It is used internally
@@ -130,9 +130,9 @@ pub type Server
 /// See [NewClient]'s comment for information about concurrent access.
 pub interface ServerCodec {
   fn Close() -> Result<(), error>
-  fn ReadRequestBody(arg0: Unknown) -> Result<(), error>
-  fn ReadRequestHeader(arg0: Ref<Request>) -> Result<(), error>
-  fn WriteResponse(arg0: Ref<Response>, arg1: Unknown) -> Result<(), error>
+  fn ReadRequestBody(any: Unknown) -> Result<(), error>
+  fn ReadRequestHeader(request: Ref<Request>) -> Result<(), error>
+  fn WriteResponse(response: Ref<Response>, any: Unknown) -> Result<(), error>
 }
 
 /// ServerError represents an error that has been returned from

--- a/crates/stdlib/typedefs/reflect.d.lis
+++ b/crates/stdlib/typedefs/reflect.d.lis
@@ -447,8 +447,8 @@ pub interface Type {
   fn Key() -> Type
   fn Kind() -> Kind
   fn Len() -> int
-  fn Method(arg0: int) -> Method
-  fn MethodByName(arg0: string) -> Option<Method>
+  fn Method(n: int) -> Method
+  fn MethodByName(s: string) -> Option<Method>
   fn Name() -> string
   fn NumField() -> int
   fn NumIn() -> int

--- a/crates/stdlib/typedefs/testing.d.lis
+++ b/crates/stdlib/typedefs/testing.d.lis
@@ -227,7 +227,7 @@ pub type T
 pub interface TB {
   fn Attr(key: string, value: string)
   fn Chdir(dir: string)
-  fn Cleanup(arg0: fn() -> ())
+  fn Cleanup(f: fn() -> ())
   fn Context() -> context.Context
   fn Error(args: VarArgs<Unknown>)
   fn Errorf(format: string, args: VarArgs<Unknown>)


### PR DESCRIPTION
Replaces `arg0`, `arg1`, etc. in generated typedefs with names derived from each parameter's Go type, so signatures recovered from interface declarations read naturally.