### PR TITLE
refactor: improve diagnostics for keyword-named bindings

### DIFF
--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -64,9 +64,36 @@ impl<'source> Parser<'source> {
         if self.current_token().kind.is_keyword() {
             let keyword = self.current_token().text.to_string();
             let span = self.span_from_token(start);
+            let help = match keyword.as_str() {
+                "task" => {
+                    "Rename this binding. `task` is a keyword reserved for spawning concurrent work"
+                        .to_string()
+                }
+                "type" => {
+                    "Rename this binding. `type` is a keyword reserved for declaring named types"
+                        .to_string()
+                }
+                "select" => {
+                    "Rename this binding. `select` is a keyword reserved for waiting on multiple channel operations"
+                        .to_string()
+                }
+                "match" => {
+                    "Rename this binding. `match` is a keyword reserved for pattern matching"
+                        .to_string()
+                }
+                "recover" => {
+                    "Rename this binding. `recover` is a keyword reserved for catching panics"
+                        .to_string()
+                }
+                "defer" => {
+                    "Rename this binding. `defer` is a keyword reserved for scheduling cleanup"
+                        .to_string()
+                }
+                _ => format!("Rename binding `{}`", keyword),
+            };
             let error = ParseError::new("Reserved keyword", span, "reserved keyword")
                 .with_parse_code("keyword_as_binding")
-                .with_help(format!("Rename binding `{}`", keyword));
+                .with_help(help);
             self.errors.push(error);
             self.next();
             return Pattern::Identifier {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4042,6 +4042,56 @@ fn walk_dir(root: string, fn: string) {}
 }
 
 #[test]
+fn parse_keyword_as_binding_task() {
+    let input = r#"
+fn main() {
+  let task = || {}
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_keyword_as_binding_select() {
+    let input = r#"
+fn main() {
+  let select = "SELECT * FROM users"
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_keyword_as_binding_match_kw() {
+    let input = r#"
+fn main() {
+  let match = 1
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_keyword_as_binding_recover() {
+    let input = r#"
+fn main() {
+  let recover = 1
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_keyword_as_binding_defer() {
+    let input = r#"
+fn main() {
+  let defer = 1
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_keyword_as_binding_in_for_loop() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_defer.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_defer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Reserved keyword
+   ╭─[test.lis:3:7]
+ 2 │ fn main() {
+ 3 │   let defer = 1
+   ·       ──┬──
+   ·         ╰── reserved keyword
+ 4 │ }
+   ╰────
+  help: Rename this binding. `defer` is a keyword reserved for scheduling cleanup · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_in_for_loop.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_in_for_loop.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·         ╰── reserved keyword
  5 │     items
    ╰────
-  help: Rename binding `type` · code: [parse.keyword_as_binding]
+  help: Rename this binding. `type` is a keyword reserved for declaring named types · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_in_match.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_in_match.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·            ╰── reserved keyword
  6 │     None => 0,
    ╰────
-  help: Rename binding `type` · code: [parse.keyword_as_binding]
+  help: Rename this binding. `type` is a keyword reserved for declaring named types · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_match_kw.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_match_kw.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Reserved keyword
+   ╭─[test.lis:3:7]
+ 2 │ fn main() {
+ 3 │   let match = 1
+   ·       ──┬──
+   ·         ╰── reserved keyword
+ 4 │ }
+   ╰────
+  help: Rename this binding. `match` is a keyword reserved for pattern matching · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_recover.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_recover.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Reserved keyword
+   ╭─[test.lis:3:7]
+ 2 │ fn main() {
+ 3 │   let recover = 1
+   ·       ───┬───
+   ·          ╰── reserved keyword
+ 4 │ }
+   ╰────
+  help: Rename this binding. `recover` is a keyword reserved for catching panics · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_select.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_select.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Reserved keyword
+   ╭─[test.lis:3:7]
+ 2 │ fn main() {
+ 3 │   let select = "SELECT * FROM users"
+   ·       ───┬──
+   ·          ╰── reserved keyword
+ 4 │ }
+   ╰────
+  help: Rename this binding. `select` is a keyword reserved for waiting on multiple channel operations · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_task.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_task.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Reserved keyword
+   ╭─[test.lis:3:7]
+ 2 │ fn main() {
+ 3 │   let task = || {}
+   ·       ──┬─
+   ·         ╰── reserved keyword
+ 4 │ }
+   ╰────
+  help: Rename this binding. `task` is a keyword reserved for spawning concurrent work · code: [parse.keyword_as_binding]


### PR DESCRIPTION
When a reserved keyword is used as a binding name, the diagnostic now explains what the keyword is for. Covers `task`, `type`, `select`, `match`, `recover`, `defer`.