### PR TITLE
fix: detect fluent builders on promoted methods

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -377,7 +377,7 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 
 // isFluentBuilderCandidate gates AST inspection. Clone/Copy return new values despite the fluent shape.
 func isFluentBuilderCandidate(result *ConvertResult, exp extract.SymbolExport, sig *types.Signature) bool {
-	if result.Receiver == nil || !result.Receiver.IsPointer || exp.IsPromoted {
+	if result.Receiver == nil || !result.Receiver.IsPointer {
 		return false
 	}
 	if result.Name == "Clone" || result.Name == "Copy" {

--- a/bindgen/tests/testdata/fixtures/builder_methods/builder_methods.go
+++ b/bindgen/tests/testdata/fixtures/builder_methods/builder_methods.go
@@ -86,3 +86,13 @@ func (v *Var) Origin() *Var {
 	}
 	return v
 }
+
+type Inner struct{ routes []string }
+
+func (i *Inner) Get(path string) Router  { i.routes = append(i.routes, "GET "+path); return i }
+func (i *Inner) Post(path string) Router { i.routes = append(i.routes, "POST "+path); return i }
+func (i *Inner) NewGroup() *Group        { return &Group{} }
+
+type Engine struct{ Inner }
+
+var _ Router = (*Inner)(nil)

--- a/bindgen/tests/testdata/snapshots/builder_methods.d.lis
+++ b/bindgen/tests/testdata/snapshots/builder_methods.d.lis
@@ -23,8 +23,14 @@ pub struct Coord {
   pub Y: int,
 }
 
+pub struct Engine {
+  pub Inner: Inner,
+}
+
 /// Pointer receiver returning a *different* concrete type — must not be marked.
 pub type Group
+
+pub type Inner
 
 /// Copy-and-modify pattern (slog.Logger.With shape) — must not be marked.
 /// Body assigns to a local and returns the local.
@@ -79,6 +85,22 @@ impl Config {
 
 impl Coord {
   fn Translate(self, dx: int, dy: int) -> Coord
+}
+
+impl Engine {
+  #[allow(unused_value)]
+  fn Get(self: Ref<Engine>, path: string) -> Router
+  fn NewGroup(self: Ref<Engine>) -> Ref<Group>
+  #[allow(unused_value)]
+  fn Post(self: Ref<Engine>, path: string) -> Router
+}
+
+impl Inner {
+  #[allow(unused_value)]
+  fn Get(self: Ref<Inner>, path: string) -> Router
+  fn NewGroup(self: Ref<Inner>) -> Ref<Group>
+  #[allow(unused_value)]
+  fn Post(self: Ref<Inner>, path: string) -> Router
 }
 
 impl Logger {


### PR DESCRIPTION
Route registration on `gin.Engine` no longer warns as `lint.unused_value`. The bindgen fluent-builder heuristic now also fires on methods promoted from an embedded type.
