### PR TITLE
fix: monomorphize generic interface adapters per instantiation

### DIFF
--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -4,7 +4,7 @@ use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::write_line;
 use ecow::EcoString;
 use syntax::program::{Definition, DefinitionBody, Interface};
-use syntax::types::{Type, unqualified_name};
+use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
 pub(crate) struct AdapterPlan {
     pub(crate) concrete_id: EcoString,
     pub(crate) interface_id: EcoString,
@@ -107,7 +107,12 @@ impl Emitter<'_> {
         };
 
         let source_stripped = source_ty.strip_refs();
-        let Type::Nominal { id: source_id, .. } = &source_stripped else {
+        let Type::Nominal {
+            id: source_id,
+            params: source_params,
+            ..
+        } = &source_stripped
+        else {
             return None;
         };
         if source_id.starts_with(GO_IMPORT_PREFIX) {
@@ -116,6 +121,7 @@ impl Emitter<'_> {
         let Some(Definition {
             body:
                 DefinitionBody::Struct {
+                    generics: struct_generics,
                     methods: struct_methods,
                     ..
                 },
@@ -124,6 +130,8 @@ impl Emitter<'_> {
         else {
             return None;
         };
+
+        let subst_map = build_substitution_map(struct_generics, source_params);
 
         let all_interface_methods = self.collect_all_interface_methods(target_id, definition);
         let mut methods = Vec::with_capacity(all_interface_methods.len());
@@ -142,9 +150,12 @@ impl Emitter<'_> {
             let method_params: Vec<Type> = if params.is_empty() {
                 Vec::new()
             } else {
-                params[1..].to_vec()
+                params[1..]
+                    .iter()
+                    .map(|p| substitute(p, &subst_map))
+                    .collect()
             };
-            let return_ty = (**return_type).clone();
+            let return_ty = substitute(return_type, &subst_map);
 
             // Compute the natural shape once and shift it for the interface
             // side if a `#[go(...)]` hint applies, instead of re-walking
@@ -249,11 +260,27 @@ impl Emitter<'_> {
             depth += 1;
             t = t.inner().expect("Ref<T> must have inner").clone();
         }
-        if depth == 0 {
-            concrete_id.clone()
-        } else {
-            EcoString::from("*".repeat(depth) + concrete_id.as_str())
-        }
+        let params = match &t {
+            Type::Nominal { params, .. } if !params.is_empty() => Some(params),
+            _ => None,
+        };
+        let params_suffix = params
+            .map(|ps| {
+                let joined = ps
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("<{joined}>")
+            })
+            .unwrap_or_default();
+
+        EcoString::from(format!(
+            "{}{}{}",
+            "*".repeat(depth),
+            concrete_id.as_str(),
+            params_suffix
+        ))
     }
 
     pub(crate) fn ensure_adapter_type(&mut self, plan: AdapterPlan) -> String {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4837,6 +4837,48 @@ fn main() {
 }
 
 #[test]
+fn generic_struct_adapter_substitutes_and_deduplicates_per_instantiation() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub struct Entry<T> {
+  value: T,
+}
+
+pub interface Cache<T> {
+  #[go(comma_ok)]
+  fn get(key: string) -> Option<Ref<Entry<T>>>
+}
+
+struct MyCache<T> {
+  entry: Entry<T>,
+}
+
+impl<T> MyCache<T> {
+  fn get(self, _key: string) -> Option<Ref<Entry<T>>> {
+    None
+  }
+}
+
+fn use_int(_c: Cache<int>) {}
+fn use_string(_c: Cache<string>) {}
+
+fn main() {
+  let ci = MyCache { entry: Entry { value: 1 } }
+  let cs = MyCache { entry: Entry { value: "x" } }
+  use_int(ci as Cache<int>)
+  use_string(cs as Cache<string>)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn result_with_pointer_error_lowers_to_native_tuple() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
+++ b/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
@@ -1,0 +1,60 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+type Entry[T any] struct {
+	value T
+}
+
+func (e Entry[T]) String() string {
+	return fmt.Sprintf("Entry { value: %v }", e.value)
+}
+
+type Cache[T any] interface {
+	Get(string) (*Entry[T], bool)
+}
+
+type MyCache[T any] struct {
+	entry Entry[T]
+}
+
+func (m MyCache[T]) String() string {
+	return fmt.Sprintf("MyCache { entry: %v }", m.entry)
+}
+
+func (m MyCache[T]) Get(_ string) *Entry[T] {
+	return nil
+}
+
+func use_int(_ Cache[int]) {}
+
+func use_string(_ Cache[string]) {}
+
+func main() {
+	ci := MyCache[int]{entry: Entry[int]{value: 1}}
+	cs := MyCache[string]{entry: Entry[string]{value: "x"}}
+	use_int(_lisAdapter_MyCache_Cache_0{inner: ci})
+	use_string(_lisAdapter_MyCache_Cache_1{inner: cs})
+}
+
+type _lisAdapter_MyCache_Cache_0 struct {
+	inner MyCache[int]
+}
+
+func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry[int], bool) {
+	val_1 := a.inner.Get(arg0)
+	return val_1, val_1 != nil
+}
+
+type _lisAdapter_MyCache_Cache_1 struct {
+	inner MyCache[string]
+}
+
+func (a _lisAdapter_MyCache_Cache_1) Get(arg0 string) (*Entry[string], bool) {
+	val_2 := a.inner.Get(arg0)
+	return val_2, val_2 != nil
+}


### PR DESCRIPTION
Fixes casts of generic structs to interfaces that require an adapter. The adapter pass now substitutes the struct's type parametrs into each method's emitted signature, and adapters are deduplicated per instantiation rather than per bare struct ID.