### PR TITLE
fix: emit tail panic as statement in fallible function

### DIFF
--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -543,6 +543,12 @@ impl Emitter<'_> {
             return false;
         };
 
+        if Self::is_go_never(expression) {
+            let call_str = self.emit_call(output, expression, None);
+            write_line!(output, "{}", call_str);
+            return true;
+        }
+
         self.flags.needs_stdlib = true;
 
         let force_tagged = self

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1343,6 +1343,16 @@ fn test() -> Option<int> {
 }
 
 #[test]
+fn tail_panic_in_result_returning_function() {
+    let input = r#"
+fn forbidden() -> Result<int, error> {
+  panic("boom")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_try_in_if_arm_with_never_tail() {
     let input = r#"
 fn die() -> Never { panic("dead") }

--- a/tests/spec/emit/snapshots/tail_panic_in_result_returning_function.snap
+++ b/tests/spec/emit/snapshots/tail_panic_in_result_returning_function.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nfn forbidden() -> Result<int, error> {\n  panic(\"boom\")\n}\n"
+---
+package main
+
+func forbidden() (int, error) {
+	panic("boom")
+}


### PR DESCRIPTION
A tail `panic(...)` in a function returning `Result<T, error>` (or any fallible type whose generic parameter is an interface) is now emitted as a divergent Go statement.