### PR TITLE
fix: prevent go const eligibility from leaking across scopes

### DIFF
--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -18,6 +18,17 @@ impl Emitter<'_> {
         body: &Expression,
         should_return: bool,
     ) {
+        self.push_const_frame();
+        self.emit_function_body_inner(output, body, should_return);
+        self.pop_const_frame();
+    }
+
+    fn emit_function_body_inner(
+        &mut self,
+        output: &mut String,
+        body: &Expression,
+        should_return: bool,
+    ) {
         let items: &[Expression] = if let Expression::Block { items, .. } = body {
             items
         } else {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -92,7 +92,7 @@ impl Emitter<'_> {
             &expression_string
         };
         let keyword = if self.is_go_const_eligible(expression) {
-            self.scope.go_const_bindings.insert(go_identifier.clone());
+            self.record_go_const(go_identifier.clone());
             "const"
         } else {
             "var"
@@ -112,7 +112,12 @@ impl Emitter<'_> {
                     | Literal::Char(_)
             ),
             Expression::Identifier { value, .. } => {
-                self.scope.go_const_bindings.contains(value.as_str())
+                let resolved = self
+                    .scope
+                    .bindings
+                    .get(value.as_str())
+                    .unwrap_or(value.as_str());
+                self.is_go_const_binding(resolved)
             }
             Expression::Binary { left, right, .. } => {
                 self.is_go_const_eligible(left) && self.is_go_const_eligible(right)

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -275,8 +275,8 @@ struct ScopeState {
     loop_stack: Vec<LoopContext>,
     /// Go variable names currently used as block-to-var assign targets.
     assign_targets: HashSet<String>,
-    /// Go identifiers emitted as `const` (not `var`).
-    go_const_bindings: HashSet<String>,
+    /// Per-scope stack so const eligibility does not leak across siblings.
+    go_const_bindings: Vec<HashSet<String>>,
 }
 
 impl ScopeState {
@@ -285,6 +285,13 @@ impl ScopeState {
         self.bindings.reset();
         self.declared.clear();
         self.declared.push(HashSet::default());
+        self.go_const_bindings.truncate(1);
+    }
+}
+
+fn pop_keep_base<T>(stack: &mut Vec<T>) {
+    if stack.len() > 1 {
+        stack.pop();
     }
 }
 
@@ -459,7 +466,7 @@ impl<'a> Emitter<'a> {
                 scope_depth: 0,
                 loop_stack: Vec::new(),
                 assign_targets: HashSet::default(),
-                go_const_bindings: HashSet::default(),
+                go_const_bindings: vec![HashSet::default()],
             },
             current_module: current_module.to_string(),
             synthesized_adapter_types: HashMap::default(),
@@ -610,18 +617,39 @@ impl<'a> Emitter<'a> {
         self.scope.scope_depth += 1;
         self.scope.bindings.save();
         self.scope.declared.push(HashSet::default());
+        self.scope.go_const_bindings.push(HashSet::default());
     }
 
     pub(crate) fn exit_scope(&mut self) {
         self.scope.scope_depth = self.scope.scope_depth.saturating_sub(1);
         self.scope.bindings.restore();
-        if self.scope.declared.len() > 1 {
-            self.scope.declared.pop();
-        }
+        pop_keep_base(&mut self.scope.declared);
+        pop_keep_base(&mut self.scope.go_const_bindings);
     }
 
     pub(crate) fn current_module(&self) -> &str {
         &self.current_module
+    }
+
+    pub(crate) fn push_const_frame(&mut self) {
+        self.scope.go_const_bindings.push(HashSet::default());
+    }
+
+    pub(crate) fn pop_const_frame(&mut self) {
+        pop_keep_base(&mut self.scope.go_const_bindings);
+    }
+
+    pub(crate) fn record_go_const(&mut self, go_identifier: String) {
+        if let Some(top) = self.scope.go_const_bindings.last_mut() {
+            top.insert(go_identifier);
+        }
+    }
+
+    pub(crate) fn is_go_const_binding(&self, go_identifier: &str) -> bool {
+        self.scope
+            .go_const_bindings
+            .iter()
+            .any(|frame| frame.contains(go_identifier))
     }
 
     pub(crate) fn module_alias_for_type(&self, ty: &Type) -> Option<String> {

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -491,6 +491,71 @@ fn main() {
 }
 
 #[test]
+fn const_eligibility_does_not_leak_across_shadow() {
+    let input = r#"
+import "go:fmt"
+
+fn make() -> int {
+  2
+}
+
+fn main() {
+  const x = 1
+  let x = make()
+  const y = x
+  fmt.Println(y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn const_eligibility_does_not_leak_out_of_block() {
+    let input = r#"
+import "go:fmt"
+
+fn make() -> int {
+  2
+}
+
+fn main() {
+  {
+    const x = 1
+    fmt.Println(x)
+  }
+  let x = make()
+  const y = x
+  fmt.Println(y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn const_eligibility_does_not_leak_across_functions() {
+    let input = r#"
+import "go:fmt"
+
+fn make() -> int {
+  2
+}
+
+fn a() {
+  const x = 1
+  fmt.Println(x)
+}
+
+fn main() {
+  a()
+  let x = make()
+  const y = x
+  fmt.Println(y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn format_string_simple() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/const_eligibility_does_not_leak_across_functions.snap
+++ b/tests/spec/emit/snapshots/const_eligibility_does_not_leak_across_functions.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn make() -> int {\n  2\n}\n\nfn a() {\n  const x = 1\n  fmt.Println(x)\n}\n\nfn main() {\n  a()\n  let x = make()\n  const y = x\n  fmt.Println(y)\n}\n"
+---
+package main
+
+import "fmt"
+
+func make_() int {
+	return 2
+}
+
+func a() {
+	const x int = 1
+	fmt.Println(x)
+}
+
+func main() {
+	a()
+	var y int = make_()
+	fmt.Println(y)
+}

--- a/tests/spec/emit/snapshots/const_eligibility_does_not_leak_across_shadow.snap
+++ b/tests/spec/emit/snapshots/const_eligibility_does_not_leak_across_shadow.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn make() -> int {\n  2\n}\n\nfn main() {\n  const x = 1\n  let x = make()\n  const y = x\n  fmt.Println(y)\n}\n"
+---
+package main
+
+import "fmt"
+
+func make_() int {
+	return 2
+}
+
+func main() {
+	const x int = 1
+	var y int = make_()
+	fmt.Println(y)
+}

--- a/tests/spec/emit/snapshots/const_eligibility_does_not_leak_out_of_block.snap
+++ b/tests/spec/emit/snapshots/const_eligibility_does_not_leak_out_of_block.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn make() -> int {\n  2\n}\n\nfn main() {\n  {\n    const x = 1\n    fmt.Println(x)\n  }\n  let x = make()\n  const y = x\n  fmt.Println(y)\n}\n"
+---
+package main
+
+import "fmt"
+
+func make_() int {
+	return 2
+}
+
+func main() {
+	{
+		const x int = 1
+		fmt.Println(x)
+	}
+	x := make_()
+	var y int = x
+	fmt.Println(y)
+}


### PR DESCRIPTION
Scope Go-const eligibility tracking per function and block, so a local `const` does not make a sibling or later `const` inherit Go-const status when its initializer is a runtime value.