### PR TITLE
fix: prevent silent emit miscompilations

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -4,7 +4,7 @@ use crate::Emitter;
 use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
 use crate::types::coercion::Coercion;
-use crate::utils::Staged;
+use crate::utils::{Staged, mask_go_string_literals};
 use crate::write_line;
 use syntax::ast::{Annotation, Expression, UnaryOperator};
 use syntax::types::Type;
@@ -73,11 +73,32 @@ fn collapse_fmt_print(function_string: &str, args_strings: &[String], call_str: 
     if let Some(inner) = arg
         .strip_prefix("fmt.Sprint(")
         .and_then(|s| s.strip_suffix(')'))
+        && is_single_top_level_arg(inner)
     {
         return format!("{}({})", function_string, inner);
     }
 
     call_str
+}
+
+/// True when `args` has no comma at top-level paren depth — i.e. represents a
+/// single argument. Commas inside nested parens/brackets/braces or inside
+/// string literals do not split.
+fn is_single_top_level_arg(args: &str) -> bool {
+    if args.is_empty() {
+        return false;
+    }
+    let masked = mask_go_string_literals(args);
+    let mut depth: i32 = 0;
+    for &b in masked.as_bytes() {
+        match b {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b',' if depth == 0 => return false,
+            _ => {}
+        }
+    }
+    true
 }
 
 impl Emitter<'_> {

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -134,7 +134,7 @@ impl Emitter<'_> {
         {
             let mut alternatives: Vec<_> = patterns
                 .iter()
-                .map(|alt| decision_tree::collect_pattern_info(self, alt, None))
+                .map(|alt| decision_tree::collect_pattern_info(self, alt, None, None))
                 .collect();
 
             let unused_names: rustc_hash::FxHashSet<String> = alternatives
@@ -164,7 +164,8 @@ impl Emitter<'_> {
             return;
         }
 
-        let (checks, bindings) = decision_tree::collect_pattern_info(self, pattern, typed_pattern);
+        let (checks, bindings) =
+            decision_tree::collect_pattern_info(self, pattern, typed_pattern, None);
         let condition = decision_tree::render_condition(&checks, &subject_var);
         write_line!(output, "if {} {{", condition);
         self.enter_scope();

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -171,9 +171,9 @@ impl Emitter<'_> {
             );
             let key_guard = DiscardGuard::new(output, &key_var);
             let value_guard = DiscardGuard::new(output, &value_var);
-            let (_, key_bindings) = decision_tree::collect_pattern_info(self, first, None);
+            let (_, key_bindings) = decision_tree::collect_pattern_info(self, first, None, None);
             decision_tree::emit_tree_bindings(self, output, &key_bindings, &key_var);
-            let (_, value_bindings) = decision_tree::collect_pattern_info(self, second, None);
+            let (_, value_bindings) = decision_tree::collect_pattern_info(self, second, None, None);
             decision_tree::emit_tree_bindings(self, output, &value_bindings, &value_var);
             self.emit_block(output, body);
             key_guard.finish(output);
@@ -214,10 +214,11 @@ impl Emitter<'_> {
         is_channel: bool,
         body: &Expression,
     ) {
-        let (_, bindings) = decision_tree::collect_pattern_info(
+        let (mut checks, bindings) = decision_tree::collect_pattern_info(
             self,
             &binding.pattern,
             binding.typed_pattern.as_ref(),
+            Some(&binding.ty),
         );
         if bindings.is_empty() {
             write_line!(output, "for range {} {{", iter_expression);
@@ -237,7 +238,9 @@ impl Emitter<'_> {
             );
         }
         let guard = DiscardGuard::new(output, &item_var);
-        decision_tree::emit_tree_bindings(self, output, &bindings, &item_var);
+        let effective_item =
+            decision_tree::apply_root_type_assertion(self, output, &mut checks, &item_var);
+        decision_tree::emit_tree_bindings(self, output, &bindings, &effective_item);
         self.emit_block(output, body);
         guard.finish(output);
         output.push_str("}\n");

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -279,7 +279,8 @@ impl Emitter<'_> {
         );
         let guard = DiscardGuard::new(output, receiver_var);
         if let Some((pattern, typed)) = inner_pattern {
-            let (checks, bindings) = decision_tree::collect_pattern_info(self, pattern, typed);
+            let (checks, bindings) =
+                decision_tree::collect_pattern_info(self, pattern, typed, None);
             if checks.is_empty() {
                 decision_tree::emit_tree_bindings(self, output, &bindings, receiver_var);
                 self.emit_in_position(output, ctx.body);
@@ -367,6 +368,7 @@ impl Emitter<'_> {
                         &receiver_var,
                         effective_pattern,
                         inner_typed,
+                        None,
                     );
                 }
             }
@@ -536,7 +538,7 @@ impl Emitter<'_> {
             }
             let inner_typed = Self::unwrap_some_typed_pattern(some_arm.typed_pattern.as_ref());
             let (checks, bindings) =
-                decision_tree::collect_pattern_info(this, receiver_var_pattern, inner_typed);
+                decision_tree::collect_pattern_info(this, receiver_var_pattern, inner_typed, None);
             if checks.is_empty() {
                 decision_tree::emit_tree_bindings(this, output, &bindings, case_var);
                 this.emit_in_position(output, &some_arm.expression);

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -11,6 +11,9 @@ use syntax::ast::{
 };
 use syntax::types::Type;
 
+/// Owned param-destructure record: temp var, pattern, typed pattern, param type.
+type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
+
 impl Emitter<'_> {
     pub(crate) fn emit_function_body(
         &mut self,
@@ -149,7 +152,8 @@ impl Emitter<'_> {
 
         self.scope.bindings.save();
 
-        let mut destructure_bindings: Vec<(String, &Pattern, Option<&TypedPattern>)> = vec![];
+        let mut destructure_bindings: Vec<(String, &Pattern, Option<&TypedPattern>, &Type)> =
+            vec![];
 
         let param_pairs: Vec<(String, String)> = params
             .iter()
@@ -170,6 +174,7 @@ impl Emitter<'_> {
                         temp_name.clone(),
                         &p.pattern,
                         p.typed_pattern.as_ref(),
+                        &p.ty,
                     ));
                     temp_name
                 };
@@ -218,8 +223,14 @@ impl Emitter<'_> {
 
         let mut body_string = String::new();
 
-        for (temp_name, pattern, typed) in &destructure_bindings {
-            self.emit_pattern_bindings(&mut body_string, temp_name, pattern, *typed);
+        for (temp_name, pattern, typed, param_ty) in &destructure_bindings {
+            self.emit_pattern_bindings(
+                &mut body_string,
+                temp_name,
+                pattern,
+                *typed,
+                Some(param_ty),
+            );
         }
 
         self.emit_function_body(&mut body_string, body, should_return);
@@ -358,8 +369,14 @@ impl Emitter<'_> {
 
         let mut body = String::new();
 
-        for (var_name, pattern, typed) in deferred_patterns {
-            self.emit_pattern_bindings(&mut body, &var_name, &pattern, typed.as_ref());
+        for (var_name, pattern, typed, param_ty) in deferred_patterns {
+            self.emit_pattern_bindings(
+                &mut body,
+                &var_name,
+                &pattern,
+                typed.as_ref(),
+                Some(&param_ty),
+            );
         }
 
         self.emit_function_body(
@@ -486,7 +503,7 @@ impl Emitter<'_> {
     fn emit_function_params(
         &mut self,
         params_to_process: &[Binding],
-    ) -> (String, Vec<(String, Pattern, Option<TypedPattern>)>) {
+    ) -> (String, Vec<DeferredParamDestructure>) {
         let mut deferred_patterns = Vec::new();
         let mut params = Vec::new();
         for param in params_to_process {
@@ -506,6 +523,7 @@ impl Emitter<'_> {
                         var.clone(),
                         param.pattern.clone(),
                         param.typed_pattern.clone(),
+                        param.ty.clone(),
                     ));
                     var
                 }

--- a/crates/emit/src/patterns/bindings.rs
+++ b/crates/emit/src/patterns/bindings.rs
@@ -9,7 +9,9 @@ use syntax::types::{Type, unqualified_name};
 use crate::Emitter;
 use crate::expressions::literals::{convert_escape_sequences, emit_raw_string};
 use crate::names::generics;
-use crate::patterns::decision_tree::{collect_pattern_info, emit_tree_bindings};
+use crate::patterns::decision_tree::{
+    apply_root_type_assertion, collect_pattern_info, emit_tree_bindings,
+};
 use crate::write_line;
 
 /// Shared access to a named, typed field — implemented for both
@@ -78,9 +80,11 @@ impl Emitter<'_> {
         subject: &str,
         pattern: &Pattern,
         typed: Option<&TypedPattern>,
+        subject_ty: Option<&Type>,
     ) {
-        let (_, bindings) = collect_pattern_info(self, pattern, typed);
-        emit_tree_bindings(self, output, &bindings, subject);
+        let (mut checks, bindings) = collect_pattern_info(self, pattern, typed, subject_ty);
+        let effective = apply_root_type_assertion(self, output, &mut checks, subject);
+        emit_tree_bindings(self, output, &bindings, &effective);
     }
 
     pub(crate) fn fresh_var(&mut self, hint: Option<&str>) -> String {

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1264,11 +1264,12 @@ pub(super) fn compile_expanded_arms<'a>(
 }
 
 /// Collect checks and bindings from a single pattern for use outside match
-/// emission (let-else, while-let, for-loop, complex let).
+/// emission (let-else, while-let, for-loop, complex let, function param).
 pub(crate) fn collect_pattern_info(
     emitter: &mut Emitter,
     pattern: &Pattern,
     typed: Option<&TypedPattern>,
+    path_ty: Option<&Type>,
 ) -> (Vec<Check>, Vec<PatternBinding>) {
     let mut collector = PatternCollector::new();
     collect_checks_and_bindings(
@@ -1276,10 +1277,45 @@ pub(crate) fn collect_pattern_info(
         &AccessPath::root(),
         pattern,
         typed,
-        None,
+        path_ty,
         &mut collector,
     );
     (collector.checks, collector.bindings)
+}
+
+/// Pop a root-path `Check::TypeAssert` from `checks`. Most non-match callers
+/// want [`apply_root_type_assertion`] which handles the `asserted := s.(T)`
+/// emission; this lower-level form is for let-else, which folds the assertion
+/// into a comma-ok form.
+pub(crate) fn take_root_type_assertion(checks: &mut Vec<Check>) -> Option<String> {
+    let position = checks
+        .iter()
+        .position(|c| matches!(c, Check::TypeAssert { path, .. } if path.is_root()))?;
+    match checks.remove(position) {
+        Check::TypeAssert { go_type, .. } => Some(go_type),
+        _ => unreachable!(),
+    }
+}
+
+/// If `checks` contains a root `Check::TypeAssert` (concrete pattern against a
+/// Go-interface scrutinee), pop it, emit `asserted := subject.(T)`, and return
+/// the new subject. Otherwise borrow `subject` unchanged. Used by every
+/// non-match destructure path; let-else has its own comma-ok lowering.
+pub(crate) fn apply_root_type_assertion<'s>(
+    emitter: &mut Emitter,
+    output: &mut String,
+    checks: &mut Vec<Check>,
+    subject: &'s str,
+) -> std::borrow::Cow<'s, str> {
+    match take_root_type_assertion(checks) {
+        Some(go_type) => {
+            let var = emitter.fresh_var(Some("asserted"));
+            emitter.declare(&var);
+            write_line!(output, "{} := {}.({})", var, subject, go_type);
+            std::borrow::Cow::Owned(var)
+        }
+        None => std::borrow::Cow::Borrowed(subject),
+    }
 }
 
 /// Render checks as a Go condition string.

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -126,7 +126,10 @@ impl Emitter<'_> {
         subject: &Expression,
         arms: &[MatchArm],
     ) -> String {
-        if let Expression::Identifier { value, .. } = subject {
+        let any_guard = arms.iter().any(|arm| arm.has_guard());
+        if let Expression::Identifier { value, .. } = subject
+            && !any_guard
+        {
             let name = value.to_string();
             let has_collision = arms
                 .iter()

--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -490,6 +490,7 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
     ///
     /// This creates a temp variable and destructures from it.
     fn emit_complex_pattern(&mut self, output: &mut String) {
+        let value_ty = self.value.get_type();
         if let Expression::Identifier { value, .. } = self.value
             && !value.contains('.')
         {
@@ -500,12 +501,19 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
                 .get(value)
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| crate::escape_reserved(value).into_owned());
-            let (_checks, bindings) = decision_tree::collect_pattern_info(
+            let (mut checks, bindings) = decision_tree::collect_pattern_info(
                 self.emitter,
                 &self.binding.pattern,
                 self.binding.typed_pattern.as_ref(),
+                Some(&value_ty),
             );
-            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &go_name);
+            let subject = decision_tree::apply_root_type_assertion(
+                self.emitter,
+                output,
+                &mut checks,
+                &go_name,
+            );
+            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &subject);
             return;
         }
 
@@ -515,12 +523,15 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         write_line!(output, "{} := {}", temp_var, value_expression);
 
         let guard = DiscardGuard::new(output, &temp_var);
-        let (_checks, bindings) = decision_tree::collect_pattern_info(
+        let (mut checks, bindings) = decision_tree::collect_pattern_info(
             self.emitter,
             &self.binding.pattern,
             self.binding.typed_pattern.as_ref(),
+            Some(&value_ty),
         );
-        decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &temp_var);
+        let subject =
+            decision_tree::apply_root_type_assertion(self.emitter, output, &mut checks, &temp_var);
+        decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &subject);
         guard.finish(output);
     }
 
@@ -570,27 +581,58 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
             return;
         }
 
-        let (checks, bindings) = decision_tree::collect_pattern_info(
+        let value_ty = self.value.get_type();
+        let (mut checks, bindings) = decision_tree::collect_pattern_info(
             self.emitter,
             &self.binding.pattern,
             self.binding.typed_pattern.as_ref(),
+            Some(&value_ty),
         );
 
-        if checks.is_empty() {
-            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &subject_var);
-        } else {
-            let condition = decision_tree::render_condition(&checks, &subject_var);
-            let guard = if checks.len() == 1 {
-                negate_condition(&condition)
-            } else {
-                format!("!({})", condition)
+        let assert_go_type = decision_tree::take_root_type_assertion(&mut checks);
+        let (effective_subject, assert_ok_var): (std::borrow::Cow<'_, str>, _) =
+            match assert_go_type {
+                Some(go_type) => {
+                    let asserted = self.emitter.fresh_var(Some("asserted"));
+                    self.emitter.declare(&asserted);
+                    let ok = self.emitter.fresh_var(Some("ok"));
+                    self.emitter.declare(&ok);
+                    write_line!(
+                        output,
+                        "{}, {} := {}.({})",
+                        asserted,
+                        ok,
+                        subject_var,
+                        go_type,
+                    );
+                    (std::borrow::Cow::Owned(asserted), Some(ok))
+                }
+                None => (std::borrow::Cow::Borrowed(subject_var.as_str()), None),
             };
-            let guard = wrap_if_struct_literal(guard);
+
+        if checks.is_empty() && assert_ok_var.is_none() {
+            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &effective_subject);
+        } else {
+            let mut guard_parts: Vec<String> = Vec::new();
+            if let Some(ref ok) = assert_ok_var {
+                guard_parts.push(format!("!{}", ok));
+            }
+            if !checks.is_empty() {
+                let condition = decision_tree::render_condition(&checks, &effective_subject);
+                let single = checks.len() == 1;
+                let negated = if single {
+                    negate_condition(&condition)
+                } else {
+                    format!("!({})", condition)
+                };
+                guard_parts.push(wrap_if_struct_literal(negated));
+            }
+            let guard = guard_parts.join(" || ");
             write_line!(output, "if {} {{", guard);
             self.emitter.emit_block(output, else_block);
             output.push_str("}\n");
 
-            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &subject_var);
+            decision_tree::emit_tree_bindings(self.emitter, output, &bindings, &effective_subject);
         }
 
         if let Some(guard) = subject_guard {
@@ -619,7 +661,7 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
 
         let collected: Vec<_> = patterns
             .iter()
-            .map(|alt| decision_tree::collect_pattern_info(self.emitter, alt, None))
+            .map(|alt| decision_tree::collect_pattern_info(self.emitter, alt, None, None))
             .collect();
 
         let irrefutable_idx = collected.iter().position(|(checks, _)| checks.is_empty());

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -48,7 +48,7 @@ fn is_at_token_boundary(bytes: &[u8], pos: usize, token_len: usize) -> bool {
 
 /// Replace Go string/rune/raw-string contents with spaces, preserving byte
 /// positions. Borrows when no quote is present.
-fn mask_go_string_literals(go_text: &str) -> Cow<'_, str> {
+pub(crate) fn mask_go_string_literals(go_text: &str) -> Cow<'_, str> {
     if !go_text.bytes().any(|b| matches!(b, b'"' | b'\'' | b'`')) {
         return Cow::Borrowed(go_text);
     }
@@ -118,27 +118,73 @@ pub(crate) fn group_params(params: &[(String, String)]) -> String {
 
 /// Try to negate a simple comparison by flipping its operator.
 /// Returns `None` for compound expressions (`&&`/`||`) or non-comparisons.
+/// Only considers operators at the outermost paren depth that contains any
+/// token character, so a comparison inside a call argument or other inner
+/// parenthesized context is not mistaken for the expression being negated.
 /// Used by unary-not emission and let-else condition negation.
 pub(crate) fn try_flip_comparison(expression: &str) -> Option<String> {
-    let masked = mask_go_string_literals(expression);
-    if masked.contains(" && ") || masked.contains(" || ") {
-        return None;
-    }
-    for (op, flipped) in [
+    const FLIPS: &[(&str, &str)] = &[
         (" == ", " != "),
         (" != ", " == "),
         (" <= ", " > "),
         (" >= ", " < "),
         (" < ", " >= "),
         (" > ", " <= "),
-    ] {
-        if let Some(position) = masked.find(op) {
-            let lhs = &expression[..position];
-            let rhs = &expression[position + op.len()..];
-            return Some(format!("{}{}{}", lhs, flipped, rhs));
+    ];
+
+    let masked = mask_go_string_literals(expression);
+    let bytes = masked.as_bytes();
+
+    // The main operator may sit inside outer parens (e.g. `("x" == s)`), so
+    // pick the smallest depth where a non-paren, non-whitespace byte appears
+    // and look for operators at exactly that depth.
+    let mut depth: i32 = 0;
+    let mut target: Option<i32> = None;
+    for &b in bytes {
+        match b {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b' ' | b'\t' | b'\n' | b'\r' => {}
+            _ => target = Some(target.map_or(depth, |d| d.min(depth))),
         }
     }
-    None
+    let target = target.unwrap_or(0);
+
+    let mut depth: i32 = 0;
+    let mut found: Option<(usize, usize, &str)> = None;
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                continue;
+            }
+            b')' | b']' | b'}' => {
+                depth -= 1;
+                continue;
+            }
+            _ => {}
+        }
+        if depth != target {
+            continue;
+        }
+        let rest = &bytes[i..];
+        if rest.starts_with(b" && ") || rest.starts_with(b" || ") {
+            return None;
+        }
+        if found.is_none() {
+            for (op, flipped) in FLIPS {
+                if rest.starts_with(op.as_bytes()) {
+                    found = Some((i, op.len(), flipped));
+                    break;
+                }
+            }
+        }
+    }
+
+    let (position, op_len, flipped) = found?;
+    let lhs = &expression[..position];
+    let rhs = &expression[position + op_len..];
+    Some(format!("{}{}{}", lhs, flipped, rhs))
 }
 
 pub(crate) fn requires_temp_var(expression: &Expression) -> bool {

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -2930,6 +2930,26 @@ fn test() {
 }
 
 #[test]
+fn match_guard_cannot_mutate_inlined_identifier_subject() {
+    let input = r#"
+fn bump_false(r: Ref<int>) -> bool {
+  r.* = 1
+  false
+}
+
+fn test() -> int {
+  let mut x = 0
+  match x {
+    0 if bump_false(&x) => -1,
+    1 => 1,
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn match_in_recover_unused_subject() {
     let input = r#"
 struct P { v: int }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -215,6 +215,18 @@ fn test(s: string) -> bool {
 }
 
 #[test]
+fn unary_not_does_not_flip_comparison_inside_call_argument() {
+    let input = r#"
+fn always_false(b: bool) -> bool { false }
+
+fn test(x: int, y: int) -> bool {
+  !always_false(x == y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn parenthesized_expression() {
     let input = r#"
 fn test() -> int {
@@ -3925,6 +3937,30 @@ fn make_int() -> int { 2 }
 
 fn test() -> int {
   takes_two(1, &make_int())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_does_not_collapse_multi_arg_sprint() {
+    let input = r#"
+import "go:fmt"
+
+fn test() {
+  fmt.Println(fmt.Sprint("a", "b"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_still_collapses_single_arg_sprint() {
+    let input = r#"
+import "go:fmt"
+
+fn test(x: int) {
+  fmt.Println(fmt.Sprint(x))
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -1221,3 +1221,73 @@ pub struct Token(string)
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/events", typedef)]);
 }
+
+#[test]
+fn let_struct_pattern_on_go_interface_asserts_type() {
+    let input = r#"
+import "go:example.com/shapes"
+
+fn area(s: shapes.Shape) -> int {
+  let shapes.Rect { W: w, H: h } = s
+  w * h
+}
+"#;
+    let typedef = r#"
+pub interface Shape {}
+pub struct Rect { pub W: int, pub H: int }
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/shapes", typedef)]);
+}
+
+#[test]
+fn let_else_struct_pattern_on_go_interface_uses_comma_ok() {
+    let input = r#"
+import "go:example.com/shapes"
+
+fn try_area(s: shapes.Shape) -> int {
+  let shapes.Rect { W: w, H: h } = s else { return -1 }
+  w * h
+}
+"#;
+    let typedef = r#"
+pub interface Shape {}
+pub struct Rect { pub W: int, pub H: int }
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/shapes", typedef)]);
+}
+
+#[test]
+fn param_struct_pattern_on_go_interface_asserts_type() {
+    let input = r#"
+import "go:example.com/shapes"
+
+fn area(shapes.Rect { W: w, H: h }: shapes.Shape) -> int {
+  w * h
+}
+"#;
+    let typedef = r#"
+pub interface Shape {}
+pub struct Rect { pub W: int, pub H: int }
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/shapes", typedef)]);
+}
+
+#[test]
+fn for_struct_pattern_on_go_interface_asserts_type() {
+    let input = r#"
+import "go:example.com/shapes"
+
+fn sum(items: Slice<shapes.Shape>) -> int {
+  let mut total = 0
+  for shapes.Rect { W: w, H: h } in items {
+    total = total + w * h
+  }
+  total
+}
+"#;
+    let typedef = r#"
+pub interface Shape {}
+pub struct Rect { pub W: int, pub H: int }
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/shapes", typedef)]);
+}

--- a/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
@@ -8,16 +8,17 @@ func find_first_negative(items []int) int {
 	result := 0
 loop_1:
 	for _, item := range items {
-	match_2:
+		subject_2 := item
+	match_3:
 		for {
 			{
-				n := item
+				n := subject_2
 				if n < 0 {
 					result = n
 					break loop_1
 				}
 			}
-			break match_2
+			break match_3
 		}
 	}
 	return result

--- a/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
@@ -8,13 +8,14 @@ func sum_positives(items []int) int {
 	sum := 0
 loop_1:
 	for _, item := range items {
-	match_2:
+		subject_2 := item
+	match_3:
 		for {
 			{
-				n := item
+				n := subject_2
 				if n > 0 {
 					sum += n
-					break match_2
+					break match_3
 				}
 			}
 			continue loop_1

--- a/tests/spec/emit/snapshots/fmt_println_does_not_collapse_multi_arg_sprint.snap
+++ b/tests/spec/emit/snapshots/fmt_println_does_not_collapse_multi_arg_sprint.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn test() {\n  fmt.Println(fmt.Sprint(\"a\", \"b\"))\n}\n"
+---
+package main
+
+import "fmt"
+
+func test() {
+	fmt.Println(fmt.Sprint("a", "b"))
+}

--- a/tests/spec/emit/snapshots/fmt_println_still_collapses_single_arg_sprint.snap
+++ b/tests/spec/emit/snapshots/fmt_println_still_collapses_single_arg_sprint.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn test(x: int) {\n  fmt.Println(fmt.Sprint(x))\n}\n"
+---
+package main
+
+import "fmt"
+
+func test(x int) {
+	fmt.Println(x)
+}

--- a/tests/spec/emit/snapshots/for_struct_pattern_on_go_interface_asserts_type.snap
+++ b/tests/spec/emit/snapshots/for_struct_pattern_on_go_interface_asserts_type.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nimport \"go:example.com/shapes\"\n\nfn sum(items: Slice<shapes.Shape>) -> int {\n  let mut total = 0\n  for shapes.Rect { W: w, H: h } in items {\n    total = total + w * h\n  }\n  total\n}\n"
+---
+package main
+
+import "example.com/shapes"
+
+func sum(items []shapes.Shape) int {
+	total := 0
+	for _, item_1 := range items {
+		asserted_2 := item_1.(shapes.Rect)
+		total += asserted_2.W * asserted_2.H
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/let_else_struct_pattern_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/let_else_struct_pattern_on_go_interface_uses_comma_ok.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nimport \"go:example.com/shapes\"\n\nfn try_area(s: shapes.Shape) -> int {\n  let shapes.Rect { W: w, H: h } = s else { return -1 }\n  w * h\n}\n"
+---
+package main
+
+import "example.com/shapes"
+
+func try_area(s shapes.Shape) int {
+	asserted_1, ok_2 := s.(shapes.Rect)
+	if !ok_2 {
+		return -1
+	}
+	return asserted_1.W * asserted_1.H
+}

--- a/tests/spec/emit/snapshots/let_struct_pattern_on_go_interface_asserts_type.snap
+++ b/tests/spec/emit/snapshots/let_struct_pattern_on_go_interface_asserts_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nimport \"go:example.com/shapes\"\n\nfn area(s: shapes.Shape) -> int {\n  let shapes.Rect { W: w, H: h } = s\n  w * h\n}\n"
+---
+package main
+
+import "example.com/shapes"
+
+func area(s shapes.Shape) int {
+	asserted_1 := s.(shapes.Rect)
+	return asserted_1.W * asserted_1.H
+}

--- a/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
+++ b/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
@@ -7,12 +7,13 @@ package main
 import "fmt"
 
 func test(x int) string {
+	subject_1 := x
 	for {
 		{
-			n := x
+			n := subject_1
 			if n < 10 {
-				result_2 := n * n
-				return fmt.Sprintf("small(%v)", result_2)
+				result_3 := n * n
+				return fmt.Sprintf("small(%v)", result_3)
 			}
 		}
 		return "other"

--- a/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
@@ -6,13 +6,14 @@ package main
 
 func categorize(items []int) string {
 	len_ := len(items)
-	if len_ == 0 {
+	subject_1 := len_
+	if subject_1 == 0 {
 		return "empty"
 	}
-	if len_ == 1 {
+	if subject_1 == 1 {
 		return "single"
 	}
-	if len_ <= 3 {
+	if subject_1 <= 3 {
 		return "few"
 	}
 	return "many"

--- a/tests/spec/emit/snapshots/match_guard_basic.snap
+++ b/tests/spec/emit/snapshots/match_guard_basic.snap
@@ -7,8 +7,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) string {
-	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
+	subject_1 := opt
+	if subject_1.Tag == lisette.OptionSome {
+		x := subject_1.SomeVal
 		if x > 0 {
 			return "positive"
 		}

--- a/tests/spec/emit/snapshots/match_guard_cannot_mutate_inlined_identifier_subject.snap
+++ b/tests/spec/emit/snapshots/match_guard_cannot_mutate_inlined_identifier_subject.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: "input: \nfn bump_false(r: Ref<int>) -> bool {\n  r.* = 1\n  false\n}\n\nfn test() -> int {\n  let mut x = 0\n  match x {\n    0 if bump_false(&x) => -1,\n    1 => 1,\n    _ => 0,\n  }\n}\n"
+---
+package main
+
+func bump_false(r *int) bool {
+	*r = 1
+	return false
+}
+
+func test() int {
+	x := 0
+	subject_1 := x
+	if subject_1 == 0 {
+		if bump_false(&x) {
+			return -1
+		}
+	}
+	if subject_1 == 1 {
+		return 1
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
@@ -16,8 +16,9 @@ func (w W[T]) String() string {
 
 func test() int {
 	w := W[int]{F0: 1}
+	subject_1 := w
 	{
-		if w == (W[int]{F0: 2}) {
+		if subject_1 == (W[int]{F0: 2}) {
 			return 0
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_mixed.snap
+++ b/tests/spec/emit/snapshots/match_guard_mixed.snap
@@ -7,8 +7,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) string {
-	if opt.Tag == lisette.OptionSome {
-		if opt.SomeVal > 0 {
+	subject_1 := opt
+	if subject_1.Tag == lisette.OptionSome {
+		if subject_1.SomeVal > 0 {
 			return "positive"
 		}
 		return "non-positive"

--- a/tests/spec/emit/snapshots/match_guard_on_struct.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_struct.snap
@@ -16,16 +16,17 @@ func (p Point) String() string {
 }
 
 func test(p Point) string {
+	subject_1 := p
 	{
-		x := p.x
-		y := p.y
+		x := subject_1.x
+		y := subject_1.y
 		if x == y {
 			return "diagonal"
 		}
 	}
 	{
-		x := p.x
-		y := p.y
+		x := subject_1.x
+		y := subject_1.y
 		if x > y {
 			return "above"
 		}

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -20,14 +20,15 @@ func main() {
 		x: 1,
 		y: 2,
 	}
-match_1:
+	_ = p
+match_2:
 	for {
 		if (p == Point{
 			x: 1,
 			y: 2,
 		}) {
-			break match_1
+			break match_2
 		}
-		break match_1
+		break match_2
 	}
 }

--- a/tests/spec/emit/snapshots/match_guard_tuple.snap
+++ b/tests/spec/emit/snapshots/match_guard_tuple.snap
@@ -7,16 +7,17 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(pair lisette.Tuple2[int, int]) string {
+	subject_1 := pair
 	{
-		x := pair.First
-		y := pair.Second
+		x := subject_1.First
+		y := subject_1.Second
 		if x == y {
 			return "equal"
 		}
 	}
 	{
-		x := pair.First
-		y := pair.Second
+		x := subject_1.First
+		y := subject_1.Second
 		if x > y {
 			return "greater"
 		}

--- a/tests/spec/emit/snapshots/match_guard_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_binding.snap
@@ -7,8 +7,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
-	if opt.Tag == lisette.OptionSome {
-		n := opt.SomeVal
+	subject_1 := opt
+	if subject_1.Tag == lisette.OptionSome {
+		n := subject_1.SomeVal
 		if n > 100 {
 			return n * 2
 		}

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -8,20 +8,21 @@ import "fmt"
 
 func main() {
 	for i := 0; i < 10; i++ {
-	match_1:
+		subject_1 := i
+	match_2:
 		for {
 			{
-				if i < 5 {
+				if subject_1 < 5 {
 					fmt.Println("low")
-					break match_1
+					break match_2
 				}
 			}
-			if i == 5 {
+			if subject_1 == 5 {
 				fmt.Println("five")
 			} else {
 				fmt.Println("high")
 			}
-			break match_1
+			break match_2
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
@@ -47,20 +47,21 @@ func (e E) String() string {
 }
 
 func test(e E) int {
-	if e.Tag == EC {
-		x := e.C
+	subject_1 := e
+	if subject_1.Tag == EC {
+		x := subject_1.C
 		if x > 0 {
 			return x * 100
 		}
 	}
-	if e.Tag == EA {
-		x := e.A
+	if subject_1.Tag == EA {
+		x := subject_1.A
 		return x
 	}
-	if e.Tag == EB {
-		x := e.B
+	if subject_1.Tag == EB {
+		x := subject_1.B
 		return x
 	}
-	x := e.C
+	x := subject_1.C
 	return x
 }

--- a/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
@@ -16,13 +16,13 @@ func (p P) String() string {
 
 func test() {
 	_ = P{v: 1}
-match_1:
+match_2:
 	for {
 		{
 			if false {
-				break match_1
+				break match_2
 			}
 		}
-		break match_1
+		break match_2
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -11,18 +11,19 @@ import (
 
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
-match_1:
+	subject_1 := result
+match_2:
 	for {
-		if result.Tag == lisette.ResultOk {
-			n := result.OkVal
+		if subject_1.Tag == lisette.ResultOk {
+			n := subject_1.OkVal
 			if n > 0 {
 				fmt.Printf("positive: %v\n", n)
-				break match_1
+				break match_2
 			}
 			fmt.Printf("non-positive: %v\n", n)
-			break match_1
+			break match_2
 		}
-		fmt.Printf("error: %v\n", result.ErrVal)
-		break match_1
+		fmt.Printf("error: %v\n", subject_1.ErrVal)
+		break match_2
 	}
 }

--- a/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
@@ -7,9 +7,10 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, active bool) int {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		return e.X + e.Y
+		return subject_1.X + subject_1.Y
 	case events.KeyPress:
 		if active {
 			return -1

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
@@ -49,14 +49,15 @@ func (e E) String() string {
 }
 
 func eval(e E) int {
-	if e.Tag == EA {
-		x := e.A.First
+	subject_1 := e
+	if subject_1.Tag == EA {
+		x := subject_1.A.First
 		if x > 0 {
 			return x
 		}
 	}
-	if e.Tag == EB {
-		x := e.B.First
+	if subject_1.Tag == EB {
+		x := subject_1.B.First
 		if x > 0 {
 			return x
 		}

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
@@ -47,18 +47,19 @@ func (e E) String() string {
 
 func test() {
 	e := MakeEC()
-match_1:
+	subject_1 := e
+match_2:
 	for {
-		if e.Tag == EA {
+		if subject_1.Tag == EA {
 			if false {
-				break match_1
+				break match_2
 			}
 		}
-		if e.Tag == EB {
+		if subject_1.Tag == EB {
 			if false {
-				break match_1
+				break match_2
 			}
 		}
-		break match_1
+		break match_2
 	}
 }

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -39,14 +39,15 @@ func (r Res) String() string {
 }
 
 func test(r Res, threshold int) int {
-	if r.Tag == ResOk {
-		x := r.Ok
+	subject_1 := r
+	if subject_1.Tag == ResOk {
+		x := subject_1.Ok
 		if x > threshold {
 			return 100
 		}
 	}
-	if r.Tag == ResErr {
-		x := r.Err
+	if subject_1.Tag == ResErr {
+		x := subject_1.Err
 		if x > threshold {
 			return 100
 		}

--- a/tests/spec/emit/snapshots/or_pattern_on_interface_field_check_with_guard.snap
+++ b/tests/spec/emit/snapshots/or_pattern_on_interface_field_check_with_guard.snap
@@ -7,9 +7,10 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, active bool) int {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		if e.X == 5 {
+		if subject_1.X == 5 {
 			if active {
 				return 1
 			}

--- a/tests/spec/emit/snapshots/param_struct_pattern_on_go_interface_asserts_type.snap
+++ b/tests/spec/emit/snapshots/param_struct_pattern_on_go_interface_asserts_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nimport \"go:example.com/shapes\"\n\nfn area(shapes.Rect { W: w, H: h }: shapes.Shape) -> int {\n  w * h\n}\n"
+---
+package main
+
+import "example.com/shapes"
+
+func area(arg_1 shapes.Shape) int {
+	asserted_2 := arg_1.(shapes.Rect)
+	return asserted_2.W * asserted_2.H
+}

--- a/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
@@ -16,15 +16,16 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
+	subject_1 := p
 	{
-		x := p.F0
-		y := p.F1
+		x := subject_1.F0
+		y := subject_1.F1
 		if x > 0 {
 			return x + y
 		}
 	}
 	{
-		y := p.F1
+		y := subject_1.F1
 		return y
 	}
 }

--- a/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
+++ b/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
@@ -7,13 +7,14 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, threshold int) int {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		x := e.X
+		x := subject_1.X
 		if x > threshold {
 			return x
 		}
-		return e.X + 1
+		return subject_1.X + 1
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
@@ -7,18 +7,19 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) int {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		if e.X > 1000 {
+		if subject_1.X > 1000 {
 			return 4
 		}
-		if e.X > 100 {
+		if subject_1.X > 100 {
 			return 3
 		}
-		if e.X > 50 {
+		if subject_1.X > 50 {
 			return 2
 		}
-		if e.X > 0 {
+		if subject_1.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
+++ b/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
@@ -7,17 +7,18 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) (int, bool) {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		x := e.X
+		x := subject_1.X
 		if x > 100 {
 			return x * 10, true
 		}
-		x_1 := e.X
-		if x_1 > 0 {
-			return x_1, true
+		x_2 := subject_1.X
+		if x_2 > 0 {
+			return x_2, true
 		}
-		return -e.X, true
+		return -subject_1.X, true
 	default:
 		return *new(int), false
 	}

--- a/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
@@ -7,15 +7,16 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) int {
-	switch e := e.(type) {
+	subject_1 := e
+	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		if e.X > 100 {
+		if subject_1.X > 100 {
 			return 3
 		}
-		if e.X > 50 {
+		if subject_1.X > 50 {
 			return 2
 		}
-		if e.X > 0 {
+		if subject_1.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/unary_not_does_not_flip_comparison_inside_call_argument.snap
+++ b/tests/spec/emit/snapshots/unary_not_does_not_flip_comparison_inside_call_argument.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn always_false(b: bool) -> bool { false }\n\nfn test(x: int, y: int) -> bool {\n  !always_false(x == y)\n}\n"
+---
+package main
+
+func always_false(_ bool) bool {
+	return false
+}
+
+func test(x, y int) bool {
+	return !always_false(x == y)
+}


### PR DESCRIPTION
- Unary `!` no longer flips a comparison inside a call argument
- `fmt.Println(fmt.Sprint(...))` is collapsed only when the inner `Sprint` has a single argument
- Match arms with a guard now materialize the subject into a temp
- `let`, `let...else`, function parameter, and `for` patterns destructuring a concrete shape from a Go-interface scrutinee now emit a type assertion