### PR TITLE
fix: prevent emit corner cases

### DIFF
--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -42,8 +42,19 @@ impl Emitter<'_> {
             ..
         } = alternative
         {
-            let condition_string = self.emit_condition_operand(output, condition);
+            let mut condition_buffer = String::new();
+            let condition_string = self.emit_condition_operand(&mut condition_buffer, condition);
             let condition_string = wrap_if_struct_literal(condition_string);
+            if !condition_buffer.is_empty() {
+                self.emit_else_if_with_setup(
+                    output,
+                    &condition_buffer,
+                    &condition_string,
+                    consequence,
+                    next_alternative,
+                );
+                return;
+            }
             write_line!(output, "}} else if {} {{", condition_string);
             self.enter_scope();
             self.emit_in_position(output, consequence);
@@ -59,6 +70,26 @@ impl Emitter<'_> {
             self.exit_scope();
             output.push_str("}\n");
         }
+    }
+
+    fn emit_else_if_with_setup(
+        &mut self,
+        output: &mut String,
+        condition_setup: &str,
+        condition_string: &str,
+        consequence: &Expression,
+        next_alternative: &Expression,
+    ) {
+        output.push_str("} else {\n");
+        self.enter_scope();
+        output.push_str(condition_setup);
+        write_line!(output, "if {} {{", condition_string);
+        self.enter_scope();
+        self.emit_in_position(output, consequence);
+        self.exit_scope();
+        self.emit_else_chain(output, next_alternative);
+        self.exit_scope();
+        output.push_str("}\n");
     }
 
     /// Emit an if/else-if branch header for pattern matching chains.

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -30,9 +30,13 @@ impl Emitter<'_> {
             if var_name != "_" {
                 let inner_ty = fallible.ok_ty();
                 let zero = self.zero_value(inner_ty);
-                let go_ty = self.go_type_as_string(inner_ty);
-                write_line!(output, "var {} {} = {}", var_name, go_ty, zero);
-                self.declare(var_name);
+                if self.is_declared(var_name) {
+                    write_line!(output, "{} = {}", var_name, zero);
+                } else {
+                    let go_ty = self.go_type_as_string(inner_ty);
+                    write_line!(output, "var {} {} = {}", var_name, go_ty, zero);
+                    self.declare(var_name);
+                }
             }
             return result;
         }
@@ -50,11 +54,14 @@ impl Emitter<'_> {
             self.capture_check_var(output, &expression_string)
         };
 
-        let result_var = result_var_name.map(|s| s.to_string()).unwrap_or_else(|| {
-            let v = self.fresh_var(Some("result"));
-            self.declare(&v);
-            v
-        });
+        let (result_var, result_var_pre_declared) = match result_var_name {
+            Some(name) => (name.to_string(), self.is_declared(name)),
+            None => {
+                let v = self.fresh_var(Some("result"));
+                self.declare(&v);
+                (v, false)
+            }
+        };
 
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
 
@@ -94,10 +101,12 @@ impl Emitter<'_> {
         }
 
         if result_var != "_" {
+            let op = if result_var_pre_declared { "=" } else { ":=" };
             write_line!(
                 output,
-                "{} := {}.{}",
+                "{} {} {}.{}",
                 result_var,
+                op,
                 check_var,
                 fallible.ok_field()
             );

--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -277,15 +277,24 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         }
     }
 
+    fn binding_widens_to_interface(&self) -> bool {
+        let binding_ty = &self.binding.ty;
+        let value_ty = self.value.get_type();
+        self.emitter.as_interface(binding_ty).is_some() && *binding_ty != value_ty
+    }
+
     /// Pick the Go type for a `var X T` temp. Diverging values use the
     /// binding type so dead `return x` paths still typecheck; tuple
     /// branching values widen slots to match the assignment site.
     fn resolve_temp_var_decl_ty(&mut self) -> Type {
         let value_ty = self.value.get_type();
+        let binding_ty = &self.binding.ty;
+        if !value_ty.is_unit() && !value_ty.is_never() && self.binding_widens_to_interface() {
+            return binding_ty.clone();
+        }
         let base = if value_ty.is_unit() || value_ty.is_never() {
-            let binding_ty = &self.binding.ty;
             if !binding_ty.is_unit() && !binding_ty.is_variable() {
-                self.binding.ty.clone()
+                binding_ty.clone()
             } else {
                 value_ty
             }
@@ -429,6 +438,12 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         } else {
             go_identifier
         };
+
+        if self.binding_widens_to_interface() {
+            let var_ty = self.emitter.go_type_as_string(&self.binding.ty);
+            write_line!(output, "var {} {}", go_identifier, var_ty);
+            self.emitter.declare(&go_identifier);
+        }
 
         self.emitter
             .emit_propagate_to_let(output, &go_identifier, self.value);

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -15,6 +15,9 @@ pub(crate) struct Coercion {
 pub(crate) enum CoercionKind {
     Identity,
     WrapAsInterface(AdapterPlan),
+    WrapNewtype {
+        ty: Type,
+    },
     UnwrapNullableOption {
         ty: Type,
     },
@@ -44,6 +47,8 @@ impl Coercion {
     pub(crate) fn resolve(emitter: &Emitter, from: &Type, to: &Type) -> Self {
         let kind = if let Some(plan) = emitter.needs_adapter(from, to) {
             CoercionKind::WrapAsInterface(plan)
+        } else if needs_newtype_wrap(emitter, from, to) {
+            CoercionKind::WrapNewtype { ty: to.clone() }
         } else {
             CoercionKind::Identity
         };
@@ -135,6 +140,10 @@ impl Coercion {
                 let adapter_name = emitter.ensure_adapter_type(plan);
                 format!("{}{{inner: {}}}", adapter_name, value)
             }
+            CoercionKind::WrapNewtype { ty } => {
+                let type_name = emitter.go_type_as_string(&ty);
+                format!("{}({})", type_name, value)
+            }
             CoercionKind::UnwrapNullableOption { ty } => {
                 emitter.emit_option_unwrap_to_nullable(output, &value, &ty)
             }
@@ -180,6 +189,16 @@ impl Emitter<'_> {
         let coercion = Coercion::resolve(self, &expression.get_type(), target);
         coercion.apply(self, output, emitted)
     }
+}
+
+fn needs_newtype_wrap(emitter: &Emitter, from: &Type, to: &Type) -> bool {
+    if from == to {
+        return false;
+    }
+    let Some(underlying) = emitter.get_newtype_underlying(to) else {
+        return false;
+    };
+    underlying == *from
 }
 
 fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -3317,3 +3317,25 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn else_if_condition_setup_emitted_in_else_scope() {
+    let input = r#"
+fn track(flag: Ref<bool>) -> Result<int, error> {
+  flag.* = true
+  Ok(1)
+}
+
+fn test() {
+  let mut ran = false
+  if true {
+    let _ = 1
+  } else if track(&ran).is_ok() {
+    let _ = 2
+  } else {
+    let _ = 3
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -3965,3 +3965,67 @@ fn test(x: int) {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn newtype_return_from_underlying_variable_casts() {
+    let input = r#"
+struct UserId(int)
+
+fn make(i: int) -> UserId {
+  i
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_typed_let_from_underlying_call_casts() {
+    let input = r#"
+struct UserId(int)
+
+fn raw() -> int { 1 }
+
+fn take(u: UserId) {
+  let _ = u
+}
+
+fn test() {
+  let id: UserId = raw()
+  take(id)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_assignment_from_underlying_value_casts() {
+    let input = r#"
+struct UserId(int)
+
+fn raw() -> int { 1 }
+
+fn take(u: UserId) {
+  let _ = u
+}
+
+fn test() {
+  let mut id = UserId(0)
+  id = raw()
+  take(id)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_struct_field_from_underlying_value_casts() {
+    let input = r#"
+struct UserId(int)
+struct Box { v: UserId }
+
+fn test(i: int) -> Box {
+  Box { v: i }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
+++ b/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: "input: \nfn track(flag: Ref<bool>) -> Result<int, error> {\n  flag.* = true\n  Ok(1)\n}\n\nfn test() {\n  let mut ran = false\n  if true {\n    let _ = 1\n  } else if track(&ran).is_ok() {\n    let _ = 2\n  } else {\n    let _ = 3\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func track(flag *bool) (int, error) {
+	*flag = true
+	return 1, nil
+}
+
+func test() {
+	ran := false
+	if true {
+	} else {
+		ret_1, ret_2 := track(&ran)
+		var result_3 lisette.Result[int, error]
+		if ret_2 != nil {
+			result_3 = lisette.MakeResultErr[int, error](ret_2)
+		} else {
+			result_3 = lisette.MakeResultOk[int, error](ret_1)
+		}
+		if result_3.IsOk() {
+		} else {
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let mut id = UserId(0)\n  id = raw()\n  take(id)\n}\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) String() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+func raw() int {
+	return 1
+}
+
+func take(u UserId) {
+	_ = u
+}
+
+func test() {
+	id := UserId(0)
+	id = UserId(raw())
+	take(id)
+}

--- a/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct UserId(int)\n\nfn make(i: int) -> UserId {\n  i\n}\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) String() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+func make_(i int) UserId {
+	return UserId(i)
+}

--- a/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct UserId(int)\nstruct Box { v: UserId }\n\nfn test(i: int) -> Box {\n  Box { v: i }\n}\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) String() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+type Box struct {
+	v UserId
+}
+
+func (b Box) String() string {
+	return fmt.Sprintf("Box { v: %v }", b.v)
+}
+
+func test(i int) Box {
+	return Box{v: UserId(i)}
+}

--- a/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let id: UserId = raw()\n  take(id)\n}\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) String() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+func raw() int {
+	return 1
+}
+
+func take(u UserId) {
+	_ = u
+}
+
+func test() {
+	id := UserId(raw())
+	take(id)
+}

--- a/tests/spec/emit/snapshots/typed_let_loop_interface_declares_annotated_type.snap
+++ b/tests/spec/emit/snapshots/typed_let_loop_interface_declares_annotated_type.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ninterface Printable {\n  fn text(self) -> string\n}\n\nstruct A {}\nstruct B {}\n\nimpl A { fn text(self) -> string { \"a\" } }\nimpl B { fn text(self) -> string { \"b\" } }\n\nfn test() {\n  let mut p: Printable = loop {\n    break A {}\n  }\n  p = B {}\n  let _ = p\n}\n"
+---
+package main
+
+type Printable interface {
+	text() string
+}
+
+type A struct{}
+
+func (a A) String() string {
+	return "A"
+}
+
+type B struct{}
+
+func (b B) String() string {
+	return "B"
+}
+
+func (a A) text() string {
+	return "a"
+}
+
+func (b B) text() string {
+	return "b"
+}
+
+func test() {
+	var p Printable
+	for {
+		p = A{}
+		break
+	}
+	p = B{}
+	_ = p
+}

--- a/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
+++ b/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ninterface Printable {\n  fn text(self) -> string\n}\n\nstruct A {}\nstruct B {}\n\nimpl A { fn text(self) -> string { \"a\" } }\nimpl B { fn text(self) -> string { \"b\" } }\n\nfn make_a() -> Result<A, string> { Ok(A {}) }\n\nfn run() -> Result<(), string> {\n  let mut p: Printable = make_a()?\n  p = B {}\n  let _ = p\n  Ok(())\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Printable interface {
+	text() string
+}
+
+type A struct{}
+
+func (a A) String() string {
+	return "A"
+}
+
+type B struct{}
+
+func (b B) String() string {
+	return "B"
+}
+
+func (a A) text() string {
+	return "a"
+}
+
+func (b B) text() string {
+	return "b"
+}
+
+func make_a() lisette.Result[A, string] {
+	return lisette.MakeResultOk[A, string](A{})
+}
+
+func run() lisette.Result[struct{}, string] {
+	var p Printable
+	check_1 := make_a()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
+	}
+	p = check_1.OkVal
+	p = B{}
+	_ = p
+	return lisette.MakeResultOk[struct{}, string](struct{}{})
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1909,6 +1909,55 @@ fn test() {
 }
 
 #[test]
+fn typed_let_loop_interface_declares_annotated_type() {
+    let input = r#"
+interface Printable {
+  fn text(self) -> string
+}
+
+struct A {}
+struct B {}
+
+impl A { fn text(self) -> string { "a" } }
+impl B { fn text(self) -> string { "b" } }
+
+fn test() {
+  let mut p: Printable = loop {
+    break A {}
+  }
+  p = B {}
+  let _ = p
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn typed_let_propagate_interface_declares_annotated_type() {
+    let input = r#"
+interface Printable {
+  fn text(self) -> string
+}
+
+struct A {}
+struct B {}
+
+impl A { fn text(self) -> string { "a" } }
+impl B { fn text(self) -> string { "b" } }
+
+fn make_a() -> Result<A, string> { Ok(A {}) }
+
+fn run() -> Result<(), string> {
+  let mut p: Printable = make_a()?
+  p = B {}
+  let _ = p
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn json_tagged_struct_field_access() {
     let input = r#"
 #[json]


### PR DESCRIPTION
- `int` flowing to a tuple newtype (e.g. `UserId(int)`) now emits the required Go cast on `return`, typed `let`, assignment, and struct-field positions, replacing `return i` with `return UserId(i)`
- `else if` arms whose condition lowers through setup temps now place that setup in the `else` scope rather than inside the preceding `if` body, fixing `undefined: result_N` Go errors
- `let mut p: Printable = loop { break A {} }` and `let mut p: Printable = make_a()?` now declare `p` at the annotated interface type, so later assignments to another implementation typecheck
