### PR TITLE
fix: solve more emit edge cases

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -4,11 +4,14 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use super::NativeCallContext;
 use crate::Emitter;
 use crate::names::go_name;
+use crate::types::coercion::Coercion;
 use crate::types::native::NativeGoType;
 use crate::utils::Staged;
 use syntax::ast::{Annotation, Expression, StructKind};
 use syntax::program::{CallKind, Definition, DefinitionBody};
-use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute, unqualified_name};
+use syntax::types::{
+    SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute, unqualified_name,
+};
 
 impl Emitter<'_> {
     /// True when Go's inference would lose this alias: function aliases (infer
@@ -445,7 +448,7 @@ impl Emitter<'_> {
 
         let return_ty = call_ty.cloned().unwrap_or(return_ty);
 
-        let Type::Nominal { id, .. } = &return_ty else {
+        let Type::Nominal { id, params, .. } = &return_ty else {
             return None;
         };
 
@@ -471,14 +474,31 @@ impl Emitter<'_> {
             return None;
         }
 
+        let field_tys: Vec<Type> = if generics.is_empty() {
+            fields.iter().map(|f| f.ty.clone()).collect()
+        } else {
+            let subst_map = build_substitution_map(generics, params);
+            fields
+                .iter()
+                .map(|f| substitute(&f.ty, &subst_map))
+                .collect()
+        };
+
         let go_ty = self.go_type_as_string(&return_ty);
         let stages: Vec<Staged> = args.iter().map(|a| self.stage_composite(a)).collect();
         let values = self.sequence(output, stages, "_arg");
 
-        let field_pairs: Vec<(String, String)> = values
-            .into_iter()
+        let field_pairs: Vec<(String, String)> = field_tys
+            .iter()
+            .zip(args.iter())
+            .zip(values)
             .enumerate()
-            .map(|(i, value)| (format!("F{}", i), value))
+            .map(|(i, ((field_ty, arg), value))| {
+                let value_ty = arg.get_type();
+                let coercion = Coercion::resolve(self, &value_ty, field_ty);
+                let coerced = coercion.apply(self, output, value);
+                (format!("F{}", i), coerced)
+            })
             .collect();
 
         Some(self.emit_struct_literal(&go_ty, &field_pairs))

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -137,15 +137,12 @@ impl Emitter<'_> {
                     let channel_has_call = Self::channel_expression_has_call(receive_expression);
                     let ch = self.emit_channel_operand(output, receive_expression);
                     if Self::is_some_pattern(binding) && needs_retry_loop {
-                        let shadow = self.fresh_var(Some("ch"));
-                        write_line!(output, "{} := {}", shadow, ch);
+                        let shadow = self.hoist_temp(output, "ch", &ch);
                         channel_operands.push(Some(ch));
                         channel_shadows.push(Some(shadow));
                     } else {
                         let ch = if needs_retry_loop && channel_has_call {
-                            let tmp = self.fresh_var(Some("ch"));
-                            write_line!(output, "{} := {}", tmp, ch);
-                            tmp
+                            self.hoist_temp(output, "ch", &ch)
                         } else {
                             ch
                         };
@@ -160,9 +157,7 @@ impl Emitter<'_> {
                     let channel_has_call = Self::channel_expression_has_call(receive_expression);
                     let ch = self.emit_channel_operand(output, receive_expression);
                     let ch = if needs_retry_loop && channel_has_call {
-                        let tmp = self.fresh_var(Some("ch"));
-                        write_line!(output, "{} := {}", tmp, ch);
-                        tmp
+                        self.hoist_temp(output, "ch", &ch)
                     } else {
                         ch
                     };
@@ -391,18 +386,14 @@ impl Emitter<'_> {
                 ch = cancel_deref_of_address(ch);
             }
             if ch_has_call {
-                let tmp = self.fresh_var(Some("ch"));
-                write_line!(output, "{} := {}", tmp, ch);
-                ch = tmp;
+                ch = self.hoist_temp(output, "ch", &ch);
             }
             match member {
                 "send" if !args.is_empty() => {
                     let val_has_call = needs_hoist && contains_call(&args[0]);
                     let mut val = self.emit_composite_value(output, &args[0]);
                     if val_has_call {
-                        let tmp = self.fresh_var(Some("send_val"));
-                        write_line!(output, "{} := {}", tmp, val);
-                        val = tmp;
+                        val = self.hoist_temp(output, "send_val", &val);
                     }
                     SendArmParts::Send(ch, val)
                 }
@@ -416,12 +407,20 @@ impl Emitter<'_> {
                 ch = cancel_deref_of_address(ch);
             }
             if expression_has_call {
-                let tmp = self.fresh_var(Some("ch"));
-                write_line!(output, "{} := {}", tmp, ch);
-                ch = tmp;
+                ch = self.hoist_temp(output, "ch", &ch);
             }
             SendArmParts::Receive(ch)
         }
+    }
+
+    /// Hoist a value into a fresh `tmp := value` binding, registering the
+    /// temp as declared so later bindings in the same scope cannot reuse the
+    /// Go name with `:=` (which would error as "no new variables on left").
+    fn hoist_temp(&mut self, output: &mut String, hint: &str, value: &str) -> String {
+        let tmp = self.fresh_var(Some(hint));
+        write_line!(output, "{} := {}", tmp, value);
+        self.declare(&tmp);
+        tmp
     }
 
     /// Emit the `case` line and body for a pre-processed send arm.

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -26,20 +26,25 @@ impl Emitter<'_> {
         struct_ty: &Type,
         field_name: &str,
     ) -> Option<Type> {
-        let Type::Nominal { id, .. } = struct_ty.strip_refs() else {
+        let stripped = struct_ty.strip_refs();
+        let Type::Nominal { id, params, .. } = &stripped else {
             return None;
         };
         let Some(Definition {
-            body: DefinitionBody::Struct { fields, .. },
+            body: DefinitionBody::Struct {
+                fields, generics, ..
+            },
             ..
         }) = self.ctx.definitions.get(id.as_str())
         else {
             return None;
         };
-        fields
-            .iter()
-            .find(|f| f.name == field_name)
-            .map(|f| f.ty.clone())
+        let field_ty = fields.iter().find(|f| f.name == field_name)?.ty.clone();
+        if generics.is_empty() {
+            return Some(field_ty);
+        }
+        let subst_map = build_substitution_map(generics, params);
+        Some(substitute(&field_ty, &subst_map))
     }
 
     pub(crate) fn is_function_alias(&self, ty: &Type) -> bool {

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -9,6 +9,7 @@ use crate::types::emitter::Position;
 use crate::utils::Staged;
 use crate::write_line;
 use syntax::ast::{Expression, Visibility};
+use syntax::program::CallKind;
 use syntax::types::Type;
 
 impl Emitter<'_> {
@@ -210,7 +211,10 @@ impl Emitter<'_> {
         expression: &Expression,
     ) -> String {
         if expression.get_type().is_unit()
-            && matches!(expression.unwrap_parens(), Expression::Call { .. })
+            && matches!(
+                expression.unwrap_parens(),
+                Expression::Call { .. } | Expression::Block { .. }
+            )
         {
             let call_str = self.emit_value(output, expression);
             if !call_str.is_empty() {
@@ -636,13 +640,25 @@ impl Emitter<'_> {
                 emitter.emit_block(output, expression);
                 output.push_str("}()\n");
             });
-            String::new()
-        } else if let Some(call_str) = self.emit_go_call_discarded(output, expression) {
-            format!("{} {}", keyword, call_str)
-        } else {
-            let inner = self.emit_value(output, expression);
-            format!("{} {}", keyword, inner)
+            return String::new();
         }
+        if let Some(call_str) = self.emit_go_call_discarded(output, expression) {
+            return format!("{} {}", keyword, call_str);
+        }
+        let inner = self.emit_value(output, expression);
+        if needs_iife_for_async(expression, &inner) {
+            write_line!(output, "{} func() {{", keyword);
+            if !inner.is_empty() {
+                if expression.get_type().is_unit() {
+                    write_line!(output, "{}", inner);
+                } else {
+                    write_line!(output, "_ = {}", inner);
+                }
+            }
+            output.push_str("}()\n");
+            return String::new();
+        }
+        format!("{} {}", keyword, inner)
     }
 }
 
@@ -700,4 +716,35 @@ impl Emitter<'_> {
             _ => false,
         }
     }
+}
+
+fn needs_iife_for_async(expression: &Expression, emitted: &str) -> bool {
+    let Expression::Call { call_kind, .. } = expression.unwrap_parens() else {
+        return false;
+    };
+    if !matches!(
+        call_kind,
+        Some(CallKind::NativeMethod(_) | CallKind::NativeMethodIdentifier(_))
+    ) {
+        return false;
+    }
+    !is_valid_go_async_target(emitted)
+}
+
+fn is_valid_go_async_target(emitted: &str) -> bool {
+    let trimmed = emitted.trim();
+    if !trimmed.ends_with(')') {
+        return false;
+    }
+    let Some(open) = trimmed.find('(') else {
+        return false;
+    };
+    let callee = trimmed[..open].trim_end();
+    if callee.is_empty() || callee.starts_with('[') {
+        return false;
+    }
+    !matches!(
+        callee,
+        "len" | "cap" | "append" | "copy" | "new" | "make" | "complex" | "real" | "imag"
+    )
 }

--- a/crates/emit/src/imports.rs
+++ b/crates/emit/src/imports.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::go_name;
+use crate::utils::mask_go_string_literals;
 use diagnostics::{LisetteDiagnostic, emit as emit_diag};
 use ecow::EcoString;
 use syntax::ast::ImportAlias;
@@ -98,13 +99,14 @@ impl<'a> ImportBuilder<'a> {
     /// This handles cases where a cross-module type alias resolves to a native
     /// Go type, erasing the reference to the imported module.
     pub fn filter_unreferenced(&mut self, source: &str) {
+        let masked = mask_go_string_literals(source);
         self.imports.retain(|path, alias| {
             if alias == "_" {
                 return true;
             }
             let escaped = go_name::escape_reserved(effective_package_name(path, alias));
             let pattern = format!("{escaped}.");
-            source.contains(&pattern)
+            masked.contains(&pattern)
         });
     }
 

--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -253,10 +253,11 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
             }
         }
 
-        if is_fn_alias_nominal(binding_ty)
-            && matches!(self.value.unwrap_parens(), Expression::Lambda { .. })
-        {
-            return true;
+        if is_fn_alias_nominal(binding_ty) {
+            let value_ty = self.value.get_type();
+            if matches!(value_ty.unwrap_forall(), Type::Function { .. }) {
+                return true;
+            }
         }
 
         let inner_value = unwrap_unary_negation(self.value);
@@ -763,22 +764,14 @@ fn unwrap_unary_negation(expression: &Expression) -> &Expression {
 }
 
 fn is_fn_alias_nominal(ty: &Type) -> bool {
-    let resolved = match ty {
-        Type::Forall { body, .. } => body.as_ref(),
-        other => other,
-    };
     let Type::Nominal {
         underlying_ty: Some(inner),
         ..
-    } = resolved
+    } = ty.unwrap_forall()
     else {
         return false;
     };
-    let inner = match inner.as_ref() {
-        Type::Forall { body, .. } => body.as_ref(),
-        other => other,
-    };
-    matches!(inner, Type::Function { .. })
+    matches!(inner.unwrap_forall(), Type::Function { .. })
 }
 
 /// Check if an expression contains a binding with the given name.

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -1071,3 +1071,94 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn task_native_method_inlined_to_builtin_wraps_in_iife() {
+    let input = r#"
+fn test() {
+  let xs = [1]
+  task xs.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_native_method_inlined_to_builtin_wraps_in_iife() {
+    let input = r#"
+fn test() {
+  let xs = [1]
+  defer xs.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn task_native_method_inlined_to_non_call_wraps_in_iife() {
+    let input = r#"
+fn test() {
+  let xs = [1]
+  task xs.is_empty()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn task_native_method_inlining_to_regular_call_skips_wrap() {
+    let input = r#"
+fn test() {
+  let xs = [1, 2, 3]
+  task xs.contains(2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn select_hoist_channel_temp_declared_before_user_binding() {
+    let input = r#"
+fn get_ch() -> Channel<int> {
+  Channel.buffered<int>(1)
+}
+
+fn test() -> int {
+  let result = select {
+    let Some(v) = get_ch().receive() => v,
+    _ => 0,
+  }
+  let ch_1 = result + 1
+  ch_1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn select_hoist_send_value_temp_declared_before_user_binding() {
+    let input = r#"
+import "go:fmt"
+
+fn mark(log: Channel<int>, tag: int) -> int {
+  log.send(tag)
+  tag
+}
+
+fn test() {
+  let log = Channel.buffered<int>(8)
+  let closed = Channel.new<int>()
+  closed.close()
+  let out_ch = Channel.new<int>()
+
+  let result = select {
+    let Some(v) = closed.receive() => v,
+    out_ch.send(mark(log, 1)) => 0,
+    _ => -1,
+  }
+  let send_val_2 = result + 1
+  fmt.Println(send_val_2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4029,3 +4029,39 @@ fn test(i: int) -> Box {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn unit_block_as_tuple_element_emits_struct_empty() {
+    let input = r#"
+import "go:fmt"
+
+fn side() {
+  fmt.Println("side")
+}
+
+fn test() -> int {
+  let t = ({ side() }, 1)
+  t.1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn typed_function_alias_from_named_function_declares_alias_type() {
+    let input = r#"
+type Handler = fn() -> int
+
+fn make_handler() -> int { 1 }
+
+fn use_ref(r: Ref<Handler>) -> int {
+  r.*()
+}
+
+fn test() -> int {
+  let h: Handler = make_handler
+  use_ref(&h)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -682,3 +682,61 @@ pub fn Find(s: string, substr: string) -> Option<int>
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
 }
+
+#[test]
+fn generic_named_field_struct_constructor_inserts_adapter() {
+    let input = r#"
+struct Entry { name: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Entry>>
+}
+
+struct MyCache {}
+
+impl MyCache {
+  fn Get(self, _key: string) -> Option<Ref<Entry>> {
+    None
+  }
+}
+
+struct Wrapper<T> {
+  cache: T,
+}
+
+fn main() {
+  let c = MyCache {}
+  let _: Wrapper<Cache> = Wrapper { cache: c }
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}
+
+#[test]
+fn generic_tuple_struct_constructor_inserts_adapter() {
+    let input = r#"
+struct Entry { name: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Entry>>
+}
+
+struct MyCache {}
+
+impl MyCache {
+  fn Get(self, _key: string) -> Option<Ref<Entry>> {
+    None
+  }
+}
+
+struct Wrapper<T>(T)
+
+fn main() {
+  let c = MyCache {}
+  let _: Wrapper<Cache> = Wrapper<Cache>(c)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[]);
+}

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -380,3 +380,20 @@ pub fn WithOption() -> Option
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/validator", typedef)]);
 }
+
+#[test]
+fn import_filter_ignores_package_alias_in_string_literal() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/lib"
+
+fn test() {
+  let s: lib.IntSlice = [1]
+  fmt.Println("lib.", s[0])
+}
+"#;
+    let typedef = r#"
+pub type IntSlice = Slice<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
+}

--- a/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn test() {\n  let xs = [1]\n  defer xs.length()\n}\n"
+---
+package main
+
+func test() {
+	xs := []int{1}
+	defer func() {
+		_ = len(xs)
+	}()
+}

--- a/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nstruct Entry { name: string }\n\npub interface Cache {\n  #[go(comma_ok)]\n  fn Get(key: string) -> Option<Ref<Entry>>\n}\n\nstruct MyCache {}\n\nimpl MyCache {\n  fn Get(self, _key: string) -> Option<Ref<Entry>> {\n    None\n  }\n}\n\nstruct Wrapper<T> {\n  cache: T,\n}\n\nfn main() {\n  let c = MyCache {}\n  let _: Wrapper<Cache> = Wrapper { cache: c }\n}\n"
+---
+package main
+
+import "fmt"
+
+type Entry struct {
+	name string
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf("Entry { name: %v }", e.name)
+}
+
+type Cache interface {
+	Get(string) (*Entry, bool)
+}
+
+type MyCache struct{}
+
+func (m MyCache) String() string {
+	return "MyCache"
+}
+
+func (m MyCache) Get(_ string) *Entry {
+	return nil
+}
+
+type Wrapper[T any] struct {
+	cache T
+}
+
+func (w Wrapper[T]) String() string {
+	return fmt.Sprintf("Wrapper { cache: %v }", w.cache)
+}
+
+func main() {
+	c := MyCache{}
+	_ = Wrapper[Cache]{cache: _lisAdapter_MyCache_Cache_0{inner: c}}
+}
+
+type _lisAdapter_MyCache_Cache_0 struct {
+	inner MyCache
+}
+
+func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry, bool) {
+	val_1 := a.inner.Get(arg0)
+	return val_1, val_1 != nil
+}

--- a/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nstruct Entry { name: string }\n\npub interface Cache {\n  #[go(comma_ok)]\n  fn Get(key: string) -> Option<Ref<Entry>>\n}\n\nstruct MyCache {}\n\nimpl MyCache {\n  fn Get(self, _key: string) -> Option<Ref<Entry>> {\n    None\n  }\n}\n\nstruct Wrapper<T>(T)\n\nfn main() {\n  let c = MyCache {}\n  let _: Wrapper<Cache> = Wrapper<Cache>(c)\n}\n"
+---
+package main
+
+import "fmt"
+
+type Entry struct {
+	name string
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf("Entry { name: %v }", e.name)
+}
+
+type Cache interface {
+	Get(string) (*Entry, bool)
+}
+
+type MyCache struct{}
+
+func (m MyCache) String() string {
+	return "MyCache"
+}
+
+func (m MyCache) Get(_ string) *Entry {
+	return nil
+}
+
+type Wrapper[T any] struct {
+	F0 T
+}
+
+func (w Wrapper[T]) String() string {
+	return fmt.Sprintf("Wrapper(%v)", w.F0)
+}
+
+func main() {
+	c := MyCache{}
+	_ = Wrapper[Cache]{F0: _lisAdapter_MyCache_Cache_0{inner: c}}
+}
+
+type _lisAdapter_MyCache_Cache_0 struct {
+	inner MyCache
+}
+
+func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry, bool) {
+	val_1 := a.inner.Get(arg0)
+	return val_1, val_1 != nil
+}

--- a/tests/spec/emit/snapshots/import_filter_ignores_package_alias_in_string_literal.snap
+++ b/tests/spec/emit/snapshots/import_filter_ignores_package_alias_in_string_literal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:fmt\"\nimport \"go:example.com/lib\"\n\nfn test() {\n  let s: lib.IntSlice = [1]\n  fmt.Println(\"lib.\", s[0])\n}\n"
+---
+package main
+
+import "fmt"
+
+func test() {
+	s := []int{1}
+	fmt.Println("lib.", s[0])
+}

--- a/tests/spec/emit/snapshots/select_hoist_channel_temp_declared_before_user_binding.snap
+++ b/tests/spec/emit/snapshots/select_hoist_channel_temp_declared_before_user_binding.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn get_ch() -> Channel<int> {\n  Channel.buffered<int>(1)\n}\n\nfn test() -> int {\n  let result = select {\n    let Some(v) = get_ch().receive() => v,\n    _ => 0,\n  }\n  let ch_1 = result + 1\n  ch_1\n}\n"
+---
+package main
+
+func get_ch() chan int {
+	return make(chan int, 1)
+}
+
+func test() int {
+	var result int
+	ch_1 := get_ch()
+	for {
+		select {
+		case v, ok := <-ch_1:
+			if ok {
+				result = v
+			} else {
+				ch_1 = nil
+				continue
+			}
+		default:
+			result = 0
+		}
+		break
+	}
+	return result + 1
+}

--- a/tests/spec/emit/snapshots/select_hoist_send_value_temp_declared_before_user_binding.snap
+++ b/tests/spec/emit/snapshots/select_hoist_send_value_temp_declared_before_user_binding.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nimport \"go:fmt\"\n\nfn mark(log: Channel<int>, tag: int) -> int {\n  log.send(tag)\n  tag\n}\n\nfn test() {\n  let log = Channel.buffered<int>(8)\n  let closed = Channel.new<int>()\n  closed.close()\n  let out_ch = Channel.new<int>()\n\n  let result = select {\n    let Some(v) = closed.receive() => v,\n    out_ch.send(mark(log, 1)) => 0,\n    _ => -1,\n  }\n  let send_val_2 = result + 1\n  fmt.Println(send_val_2)\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func mark(log chan int, tag int) int {
+	_ = lisette.ChannelSend(log, tag)
+	return tag
+}
+
+func test() {
+	log := make(chan int, 8)
+	closed := make(chan int)
+	lisette.ChannelClose(closed)
+	out_ch := make(chan int)
+	var result int
+	ch_1 := closed
+	send_val_2 := mark(log, 1)
+	for {
+		select {
+		case v, ok := <-ch_1:
+			if ok {
+				result = v
+			} else {
+				ch_1 = nil
+				continue
+			}
+		case out_ch <- send_val_2:
+			result = 0
+		default:
+			result = -1
+		}
+		break
+	}
+	send_val_2_3 := result + 1
+	fmt.Println(send_val_2_3)
+}

--- a/tests/spec/emit/snapshots/task_native_method_inlined_to_builtin_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlined_to_builtin_wraps_in_iife.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn test() {\n  let xs = [1]\n  task xs.length()\n}\n"
+---
+package main
+
+func test() {
+	xs := []int{1}
+	go func() {
+		_ = len(xs)
+	}()
+}

--- a/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn test() {\n  let xs = [1]\n  task xs.is_empty()\n}\n"
+---
+package main
+
+func test() {
+	xs := []int{1}
+	go func() {
+		_ = len(xs) == 0
+	}()
+}

--- a/tests/spec/emit/snapshots/task_native_method_inlining_to_regular_call_skips_wrap.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlining_to_regular_call_skips_wrap.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn test() {\n  let xs = [1, 2, 3]\n  task xs.contains(2)\n}\n"
+---
+package main
+
+import "slices"
+
+func test() {
+	xs := []int{1, 2, 3}
+	go slices.Contains(xs, 2)
+}

--- a/tests/spec/emit/snapshots/typed_function_alias_from_named_function_declares_alias_type.snap
+++ b/tests/spec/emit/snapshots/typed_function_alias_from_named_function_declares_alias_type.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \ntype Handler = fn() -> int\n\nfn make_handler() -> int { 1 }\n\nfn use_ref(r: Ref<Handler>) -> int {\n  r.*()\n}\n\nfn test() -> int {\n  let h: Handler = make_handler\n  use_ref(&h)\n}\n"
+---
+package main
+
+type Handler func() int
+
+func make_handler() int {
+	return 1
+}
+
+func use_ref(r *Handler) int {
+	return (*r)()
+}
+
+func test() int {
+	var h Handler = make_handler
+	return use_ref(&h)
+}

--- a/tests/spec/emit/snapshots/unit_block_as_tuple_element_emits_struct_empty.snap
+++ b/tests/spec/emit/snapshots/unit_block_as_tuple_element_emits_struct_empty.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn side() {\n  fmt.Println(\"side\")\n}\n\nfn test() -> int {\n  let t = ({ side() }, 1)\n  t.1\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func side() {
+	fmt.Println("side")
+}
+
+func test() int {
+	side()
+	t := lisette.MakeTuple2(struct{}{}, 1)
+	return t.Second
+}


### PR DESCRIPTION
- Filter unused Go imports when the only remaining occurrence of an alias is inside a string literal
- Insert the Go-interface adapter when a generic struct constructor stores a concrete into a field whose type widens through the struct's type parameter
- Emit `struct{}{}` for a unit-typed block used as a tuple element
- Wrap `task` and `defer` around native methods that inline to Go builtins
- Declare a typed function-alias let from a named function
- Register select-preprocessing temps as declared to prevent collisions
