### PR TITLE
fix: reject member access on uninferred receiver

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -738,6 +738,22 @@ pub fn field_no_zero(
         .with_help(main)
 }
 
+pub fn unresolved_receiver_type(member: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot infer receiver type")
+        .with_infer_code("unresolved_receiver_type")
+        .with_span_label(
+            &span,
+            format!(
+                "cannot resolve `.{}` because the receiver type is unknown",
+                member
+            ),
+        )
+        .with_help(
+            "Annotate the receiver's binding, e.g. `let x: SomeType = ...` or \
+             `|param: SomeType| ...`.",
+        )
+}
+
 pub fn member_not_found(
     ty: &Type,
     field: &str,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -215,7 +215,14 @@ impl TaskState<'_> {
             expected_ty,
         };
 
-        if resolved_expression_ty.is_error() || resolved_expression_ty.is_variable() {
+        if resolved_expression_ty.is_error() {
+            self.unify(store, expected_ty, &Type::Error, &span);
+            return args.build_dot_access(Type::Error, None, None);
+        }
+
+        if resolved_expression_ty.is_variable() {
+            self.sink
+                .push(diagnostics::infer::unresolved_receiver_type(&member, span));
             self.unify(store, expected_ty, &Type::Error, &span);
             return args.build_dot_access(Type::Error, None, None);
         }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1458,6 +1458,30 @@ fn test(p: Partial<int, error>) -> int {
 }
 
 #[test]
+fn infer_unresolved_receiver_in_lambda_to_unknown_varargs() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(|c| c.foo)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_unresolved_receiver_in_lambda_method_call() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(|c| c.Next())
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_struct_missing_fields() {
     let input = r#"
 struct Person {

--- a/tests/ui/errors/snapshots/infer_unresolved_receiver_in_lambda_method_call.snap
+++ b/tests/ui/errors/snapshots/infer_unresolved_receiver_in_lambda_method_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot infer receiver type
+   ╭─[test.lis:5:19]
+ 4 │ fn main() {
+ 5 │   fmt.Println(|c| c.Next())
+   ·                   ───┬──
+   ·                      ╰── cannot resolve `.Next` because the receiver type is unknown
+ 6 │ }
+   ╰────
+  help: Annotate the receiver's binding, e.g. `let x: SomeType = ...` or `|param: SomeType| ...` · code: [infer.unresolved_receiver_type]

--- a/tests/ui/errors/snapshots/infer_unresolved_receiver_in_lambda_to_unknown_varargs.snap
+++ b/tests/ui/errors/snapshots/infer_unresolved_receiver_in_lambda_to_unknown_varargs.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot infer receiver type
+   ╭─[test.lis:5:19]
+ 4 │ fn main() {
+ 5 │   fmt.Println(|c| c.foo)
+   ·                   ──┬──
+   ·                     ╰── cannot resolve `.foo` because the receiver type is unknown
+ 6 │ }
+   ╰────
+  help: Annotate the receiver's binding, e.g. `let x: SomeType = ...` or `|param: SomeType| ...` · code: [infer.unresolved_receiver_type]


### PR DESCRIPTION
Reports a diagnostic when a dot access happens on a value whose type could not be inferred. The most common trigger is a lambda passed to a parameter typed `Unknown` (Go's `interface{}` / `any`), where the parameter type cannot be derived from context and the body then accesses a member on it.