### PR TITLE
refactor: consolidate fallible lowering and coercion dispatch

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use super::NativeCallContext;
 use crate::Emitter;
 use crate::names::go_name;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::types::native::NativeGoType;
 use crate::utils::Staged;
 use syntax::ast::{Annotation, Expression, StructKind};
@@ -495,7 +495,8 @@ impl Emitter<'_> {
             .enumerate()
             .map(|(i, ((field_ty, arg), value))| {
                 let value_ty = arg.get_type();
-                let coercion = Coercion::resolve(self, &value_ty, field_ty);
+                let coercion =
+                    Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
                 let coerced = coercion.apply(self, output, value);
                 (format!("F{}", i), coerced)
             })

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet as HashSet;
 use crate::Emitter;
 use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::utils::{Staged, mask_go_string_literals};
 use syntax::ast::{Annotation, Expression, UnaryOperator};
 use syntax::types::Type;
@@ -353,7 +353,8 @@ impl Emitter<'_> {
         self.arg_flows_to_unknown = saved_flows;
         match effective_param_ty {
             Some(target) => {
-                let coercion = Coercion::resolve(self, &arg.get_type(), target);
+                let coercion =
+                    Coercion::resolve(self, &arg.get_type(), target, CoercionDirection::Internal);
                 coercion.apply(self, output, value)
             }
             None => value,
@@ -421,18 +422,17 @@ impl Emitter<'_> {
     ) -> Option<String> {
         let param_ty = effective_param_ty?;
         let arg_ty = arg.get_type();
-        if self.is_nullable_option(param_ty) && self.is_nullable_option(&arg_ty) {
-            return Some(self.emit_unwrap_go_nullable_arg(output, arg, &arg_ty));
+        let shapes_match = (self.is_nullable_option(param_ty) && self.is_nullable_option(&arg_ty))
+            || (self.is_non_nilable_option(param_ty) && self.is_non_nilable_option(&arg_ty));
+        if !shapes_match {
+            return None;
         }
-        if self.is_non_nilable_option(param_ty) && self.is_non_nilable_option(&arg_ty) {
-            if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
-                return Some("nil".to_string());
-            }
-            let value = self.emit_value(output, arg);
-            let coercion = Coercion::resolve_unwrap_go_nullable(self, &arg_ty, Some(param_ty));
-            return Some(coercion.apply(self, output, value));
+        if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
+            return Some("nil".to_string());
         }
-        None
+        let value = self.emit_value(output, arg);
+        let coercion = Coercion::resolve(self, &arg_ty, param_ty, CoercionDirection::ToGoBoundary);
+        Some(coercion.apply(self, output, value))
     }
 
     fn try_emit_nullable_coercion(
@@ -477,7 +477,7 @@ impl Emitter<'_> {
             return "nil".to_string();
         }
         let value = self.emit_value(output, arg);
-        let coercion = Coercion::resolve_unwrap_go_nullable(self, arg_ty, None);
+        let coercion = Coercion::resolve(self, arg_ty, arg_ty, CoercionDirection::ToGoBoundary);
         coercion.apply(self, output, value)
     }
 }

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -464,10 +464,7 @@ impl Emitter<'_> {
                     return;
                 }
                 let expression_string = self.emit_value(output, last);
-                let return_ty = self
-                    .current_return_context
-                    .as_ref()
-                    .map(|ctx| ctx.ty.clone());
+                let return_ty = self.return_lowering.ty().cloned();
                 let expression_string =
                     self.apply_type_coercion(output, return_ty.as_ref(), last, expression_string);
                 write_line!(output, "return {}", expression_string);

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -164,8 +164,8 @@ impl<'a, 'e> FallibleEmitter<'a, 'e> {
 
     /// Get the ok type string from the current return context, falling back to the fallible's ok type.
     pub(crate) fn contextual_ok_type_string(&mut self) -> String {
-        if let Some(ctx) = &self.emitter.current_return_context {
-            let ok_ty = ctx.ty.ok_type();
+        if let Some(ty) = self.emitter.return_lowering.ty() {
+            let ok_ty = ty.ok_type();
             self.emitter.go_type_as_string(&ok_ty)
         } else {
             self.ok_type_string()

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -66,11 +66,7 @@ impl Emitter<'_> {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
 
         if let Some(shape) = self.current_lowered_abi() {
-            let return_ty = self
-                .current_return_context
-                .as_ref()
-                .map(|ctx| ctx.ty.clone())
-                .expect("lowered abi");
+            let return_ty = self.return_lowering.ty().cloned().expect("lowered abi");
             // Option propagation: failure carries no payload, so emit a
             // shape-specific `None` return rather than an err-return.
             let lowered_failure = if fallible.is_result() {
@@ -317,11 +313,10 @@ impl Emitter<'_> {
             && elements.len() == arity
         {
             let return_ty = self
-                .current_return_context
-                .as_ref()
-                .expect("lowered abi requires a return context")
-                .ty
-                .clone();
+                .return_lowering
+                .ty()
+                .cloned()
+                .expect("lowered abi requires a return context");
             let slot_tys = crate::types::abi::tuple_element_types(&self.peel_alias(&return_ty));
             let stages: Vec<Staged> = elements
                 .iter()
@@ -343,11 +338,10 @@ impl Emitter<'_> {
         }
 
         let return_ty = self
-            .current_return_context
-            .as_ref()
-            .expect("lowered abi requires a return context")
-            .ty
-            .clone();
+            .return_lowering
+            .ty()
+            .cloned()
+            .expect("lowered abi requires a return context");
         let value = self.emit_value(output, expression);
         let temp = self.hoist_tmp_value(output, "tup", &value);
         self.emit_lowered_result_return(output, &temp, &return_ty, &AbiShape::Tuple { arity });
@@ -356,11 +350,10 @@ impl Emitter<'_> {
 
     fn emit_lowered_partial_tail(&mut self, output: &mut String, expression: &Expression) -> bool {
         let return_ty = self
-            .current_return_context
-            .as_ref()
-            .expect("lowered abi requires a return context")
-            .ty
-            .clone();
+            .return_lowering
+            .ty()
+            .cloned()
+            .expect("lowered abi requires a return context");
 
         if let Expression::Call {
             expression: callee,
@@ -485,10 +478,7 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn emit_return(&mut self, output: &mut String, expression: &Expression) {
-        let is_unit = self
-            .current_return_context
-            .as_ref()
-            .is_some_and(|ctx| ctx.ty.is_unit());
+        let is_unit = self.return_lowering.ty().is_some_and(Type::is_unit);
 
         if is_unit {
             let is_pure = matches!(
@@ -506,10 +496,7 @@ impl Emitter<'_> {
         {
             let expression_string =
                 self.with_position(Position::Tail, |this| this.emit_value(output, expression));
-            let return_ty = self
-                .current_return_context
-                .as_ref()
-                .map(|ctx| ctx.ty.clone());
+            let return_ty = self.return_lowering.ty().cloned();
             let expression_string =
                 self.apply_type_coercion(output, return_ty.as_ref(), expression, expression_string);
             write_line!(output, "return {}", expression_string);
@@ -530,9 +517,9 @@ impl Emitter<'_> {
         let expression_ty = expression.get_type();
 
         let return_ty = self
-            .current_return_context
-            .as_ref()
-            .map(|ctx| ctx.ty.clone())
+            .return_lowering
+            .ty()
+            .cloned()
             .filter(|ty| Fallible::from_type(ty).is_some())
             .unwrap_or(expression_ty);
 
@@ -548,15 +535,7 @@ impl Emitter<'_> {
 
         self.flags.needs_stdlib = true;
 
-        let force_tagged = self
-            .current_return_context
-            .as_ref()
-            .is_some_and(|ctx| ctx.force_tagged);
-        let lowered = if force_tagged {
-            None
-        } else {
-            self.classify_direct_emission(&return_ty)
-        };
+        let lowered = self.current_lowered_abi();
 
         if let Expression::Identifier { .. } = expression
             && fallible.classify_constructor(expression) == Some(ConstructorKind::Failure)
@@ -820,15 +799,14 @@ impl Emitter<'_> {
         let closure_body_start = output.len();
 
         // The IIFE's signature is the tagged `Result`, so its body must too.
-        let saved_return_context = self
-            .current_return_context
-            .replace(crate::ReturnContext::tagged(effective_ty.clone()));
-
-        self.with_fresh_scope(|emitter| {
-            emitter.emit_try_body(output, items, &fallible);
-        });
-
-        self.current_return_context = saved_return_context;
+        self.with_return_lowering(
+            crate::ReturnLowering::TaggedBlock(effective_ty.clone()),
+            |this| {
+                this.with_fresh_scope(|emitter| {
+                    emitter.emit_try_body(output, items, &fallible);
+                });
+            },
+        );
 
         inline_trivial_bindings(output, closure_body_start);
         output.push_str("}()\n");
@@ -853,9 +831,9 @@ impl Emitter<'_> {
         if !needs_return_context {
             return ty.clone();
         }
-        self.current_return_context
-            .as_ref()
-            .map(|ctx| ctx.ty.clone())
+        self.return_lowering
+            .ty()
+            .cloned()
             .filter(|ty| Fallible::from_type(ty).is_some())
             .unwrap_or_else(|| ty.clone())
     }
@@ -986,15 +964,12 @@ impl Emitter<'_> {
             inner_ty_str
         );
 
-        let saved_return_context = self
-            .current_return_context
-            .replace(crate::ReturnContext::new(fallible.ok_ty().clone()));
-
-        self.with_fresh_scope(|emitter| {
-            emitter.emit_recover_body(output, items, &fallible);
+        let plan = crate::FnLoweringPlan::for_fn(self, fallible.ok_ty().clone());
+        self.with_return_lowering(crate::ReturnLowering::Function(plan), |this| {
+            this.with_fresh_scope(|emitter| {
+                emitter.emit_recover_body(output, items, &fallible);
+            });
         });
-
-        self.current_return_context = saved_return_context;
 
         output.push_str("})\n");
         result_var

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -94,12 +94,9 @@ impl Emitter<'_> {
             && last.get_type().is_unit();
         if should_return
             && (is_statement_only || last_is_unit_expr)
-            && self
-                .current_return_context
-                .as_ref()
-                .is_some_and(|ctx| !ctx.ty.is_unit())
+            && self.return_lowering.ty().is_some_and(|ty| !ty.is_unit())
         {
-            let return_ty = self.current_return_context.as_ref().unwrap().ty.clone();
+            let return_ty = self.return_lowering.ty().cloned().unwrap();
             let zero = self.zero_value(&return_ty);
             write_line!(output, "return {}", zero);
         }
@@ -112,10 +109,7 @@ impl Emitter<'_> {
         self.with_position(Position::Tail, |this| {
             if !requires_temp_var(last) {
                 let expression = this.emit_value(output, last);
-                let return_ty = this
-                    .current_return_context
-                    .as_ref()
-                    .map(|ctx| ctx.ty.clone());
+                let return_ty = this.return_lowering.ty().cloned();
                 let expression =
                     this.apply_type_coercion(output, return_ty.as_ref(), last, expression);
                 output.push_str(&this.wrap_value(&expression));
@@ -210,14 +204,18 @@ impl Emitter<'_> {
 
         let should_return = has_return;
 
-        let saved_return_context = self.current_return_context.clone();
-        if let Type::Function { return_type, .. } = ty {
-            self.current_return_context = Some(if suppress_lowering {
-                crate::ReturnContext::tagged(return_type.as_ref().clone())
+        let new_lowering = if let Type::Function { return_type, .. } = ty {
+            let return_ty = return_type.as_ref().clone();
+            let plan = if suppress_lowering {
+                crate::FnLoweringPlan::for_tagged_lambda(return_ty)
             } else {
-                crate::ReturnContext::new(return_type.as_ref().clone())
-            });
-        }
+                crate::FnLoweringPlan::for_fn(self, return_ty)
+            };
+            crate::ReturnLowering::Function(plan)
+        } else {
+            self.return_lowering.clone()
+        };
+        let saved_return_lowering = std::mem::replace(&mut self.return_lowering, new_lowering);
         let saved_suppress = std::mem::replace(&mut self.suppress_go_fn_short_circuit, false);
         let saved_flows = std::mem::replace(&mut self.arg_flows_to_unknown, false);
 
@@ -234,7 +232,7 @@ impl Emitter<'_> {
         self.scope.scope_depth = saved_scope_depth;
         self.scope.bindings.restore();
 
-        self.current_return_context = saved_return_context;
+        self.return_lowering = saved_return_lowering;
         self.suppress_go_fn_short_circuit = saved_suppress;
         self.arg_flows_to_unknown = saved_flows;
 
@@ -282,10 +280,11 @@ impl Emitter<'_> {
 
         let directive = self.maybe_line_directive(&function_definition.name_span);
 
-        let saved_return_context = self.current_return_context.clone();
-        self.current_return_context = Some(crate::ReturnContext::new(
-            function_definition.return_type.clone(),
-        ));
+        let plan = crate::FnLoweringPlan::for_fn(self, function_definition.return_type.clone());
+        let saved_return_lowering = std::mem::replace(
+            &mut self.return_lowering,
+            crate::ReturnLowering::Function(plan),
+        );
 
         let (function_definition, receiver) =
             self.change_go_builtin_methods(function_definition, receiver);
@@ -374,7 +373,7 @@ impl Emitter<'_> {
         );
         optimize_function_body(&mut body);
 
-        self.current_return_context = saved_return_context;
+        self.return_lowering = saved_return_lowering;
         self.module.absorbed_ref_generics = saved_absorbed;
 
         let trimmed_body = body.trim_end();

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -411,8 +411,8 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn resolve_tuple_slot_types(&mut self, inferred: Vec<Type>) -> Vec<Type> {
-        let return_slots = self.current_return_context.as_ref().and_then(|ctx| {
-            let Type::Tuple(slots) = &ctx.ty else {
+        let return_slots = self.return_lowering.ty().and_then(|ty| {
+            let Type::Tuple(slots) = ty else {
                 return None;
             };
             (slots.len() == inferred.len()).then(|| slots.clone())

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -6,7 +6,7 @@ use syntax::types::Type;
 
 use crate::Emitter;
 use crate::go_name;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 
 impl Emitter<'_> {
     pub(crate) fn emit_dot_access(
@@ -167,7 +167,12 @@ impl Emitter<'_> {
         }
         let raw_access = format!("{}.{}", expression_string, field);
         let raw_var = self.hoist_tmp_value(output, "raw", &raw_access);
-        let coercion = Coercion::resolve_wrap_go_nullable(self, result_ty);
+        let coercion = Coercion::resolve(
+            self,
+            result_ty,
+            result_ty,
+            CoercionDirection::FromGoBoundary,
+        );
         Some(coercion.apply(self, output, raw_var))
     }
 

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -7,7 +7,7 @@ use syntax::types::{CompoundKind, SimpleKind, Type, unqualified_name};
 use crate::Emitter;
 use crate::definitions::enum_layout;
 use crate::go_name;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::utils::{Staged, observable_after_mutation};
 use crate::write_line;
 
@@ -69,12 +69,14 @@ impl Emitter<'_> {
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
             if is_go_struct {
+                let target_ty = field_ty.as_ref().unwrap_or(&value_ty);
                 let coercion =
-                    Coercion::resolve_unwrap_go_nullable(self, &value_ty, field_ty.as_ref());
+                    Coercion::resolve(self, &value_ty, target_ty, CoercionDirection::ToGoBoundary);
                 value = coercion.apply(self, output, value);
             }
             if let Some(field_ty) = field_ty.as_ref() {
-                let coercion = Coercion::resolve(self, &value_ty, field_ty);
+                let coercion =
+                    Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
                 value = coercion.apply(self, output, value);
             }
             field_names.push(field_name);

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::Emitter;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::utils::Staged;
 use syntax::ast::{FormatStringPart, Literal};
 use syntax::types::Type;
@@ -59,7 +59,12 @@ impl Emitter<'_> {
 
                 let mut wrapped: Vec<String> = Vec::with_capacity(elements.len());
                 for (expr, emitted) in elems.iter().zip(elements) {
-                    let coercion = Coercion::resolve(self, &expr.get_type(), &elem_lisette_ty);
+                    let coercion = Coercion::resolve(
+                        self,
+                        &expr.get_type(),
+                        &elem_lisette_ty,
+                        CoercionDirection::Internal,
+                    );
                     wrapped.push(coercion.apply(self, output, emitted));
                 }
                 let elements = wrapped;

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -4,7 +4,7 @@ use syntax::program::DefinitionBody;
 
 use crate::Emitter;
 use crate::is_order_sensitive;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::types::emitter::Position;
 use crate::utils::Staged;
 use crate::write_line;
@@ -397,7 +397,12 @@ impl Emitter<'_> {
         for (i, (expr, emitted)) in elements.iter().zip(elem_expressions).enumerate() {
             let value = match slot_types.get(i) {
                 Some(slot) => {
-                    let coercion = Coercion::resolve(self, &expr.get_type(), slot);
+                    let coercion = Coercion::resolve(
+                        self,
+                        &expr.get_type(),
+                        slot,
+                        CoercionDirection::Internal,
+                    );
                     coercion.apply(self, output, emitted)
                 }
                 None => emitted,
@@ -462,7 +467,7 @@ impl Emitter<'_> {
             )
         {
             let source_ty = expression.get_type();
-            let coercion = Coercion::resolve(self, &source_ty, ty);
+            let coercion = Coercion::resolve(self, &source_ty, ty, CoercionDirection::Internal);
             return coercion.apply(self, output, inner);
         }
 
@@ -535,7 +540,8 @@ impl Emitter<'_> {
             && Self::is_go_imported_type(&receiver.get_type())
             && self.is_go_nullable(ty)
         {
-            let coercion = Coercion::resolve_unwrap_go_nullable(self, &value.get_type(), Some(ty));
+            let coercion =
+                Coercion::resolve(self, &value.get_type(), ty, CoercionDirection::ToGoBoundary);
             let unwrapped = coercion.apply(self, output, rhs_staged.value);
             write_line!(output, "{} = {}", target_str, unwrapped);
         } else {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -314,7 +314,7 @@ pub struct Emitter<'a> {
     // These are implicit arguments — ideally parameters, but
     // plumbing through deep call chains is impractical.
     position: Position,
-    current_return_context: Option<ReturnContext>,
+    return_lowering: ReturnLowering,
     /// Target type for Option/Result assignment (interface coercion).
     assign_target_ty: Option<Type>,
     /// Generic function identifiers should NOT add type args when used as callees
@@ -340,27 +340,49 @@ pub struct Emitter<'a> {
     arg_flows_to_unknown: bool,
 }
 
-/// `force_tagged` is set inside try-block IIFEs whose outer signature is
-/// the unwrapped `Result`; their body must return the tagged form even
-/// when `ty` would normally lower.
 #[derive(Clone)]
-pub(crate) struct ReturnContext {
-    pub(crate) ty: Type,
-    pub(crate) force_tagged: bool,
+pub(crate) struct FnLoweringPlan {
+    return_ty: Type,
+    shape: Option<types::abi::AbiShape>,
 }
 
-impl ReturnContext {
-    pub(crate) fn new(ty: Type) -> Self {
+impl FnLoweringPlan {
+    pub(crate) fn for_fn(emitter: &Emitter<'_>, return_ty: Type) -> Self {
+        let shape = emitter.classify_direct_emission(&return_ty);
+        Self { return_ty, shape }
+    }
+
+    pub(crate) fn for_tagged_lambda(return_ty: Type) -> Self {
         Self {
-            ty,
-            force_tagged: false,
+            return_ty,
+            shape: None,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) enum ReturnLowering {
+    #[default]
+    None,
+    Function(FnLoweringPlan),
+    /// `try { ... }` IIFE: body must return the tagged Result/Option even
+    /// when the outer function's return type would normally lower.
+    TaggedBlock(Type),
+}
+
+impl ReturnLowering {
+    pub(crate) fn ty(&self) -> Option<&Type> {
+        match self {
+            Self::None => None,
+            Self::Function(plan) => Some(&plan.return_ty),
+            Self::TaggedBlock(ty) => Some(ty),
         }
     }
 
-    pub(crate) fn tagged(ty: Type) -> Self {
-        Self {
-            ty,
-            force_tagged: true,
+    pub(crate) fn shape(&self) -> Option<types::abi::AbiShape> {
+        match self {
+            Self::Function(plan) => plan.shape.clone(),
+            _ => None,
         }
     }
 }
@@ -474,7 +496,7 @@ impl<'a> Emitter<'a> {
             flags: EmitFlags::default(),
             ensure_imported: HashSet::default(),
             position: Position::Expression,
-            current_return_context: None,
+            return_lowering: ReturnLowering::default(),
             assign_target_ty: None,
             emitting_call_callee: false,
             in_condition: false,
@@ -529,6 +551,16 @@ impl<'a> Emitter<'a> {
         let saved = std::mem::replace(&mut self.position, position);
         let result = f(self);
         self.position = saved;
+        result
+    }
+
+    pub(crate) fn with_return_lowering<F, R>(&mut self, lowering: ReturnLowering, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let saved = std::mem::replace(&mut self.return_lowering, lowering);
+        let result = f(self);
+        self.return_lowering = saved;
         result
     }
 

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -2,7 +2,7 @@ use crate::Emitter;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::is_order_sensitive;
 use crate::names::go_name;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::types::emitter::Position;
 use crate::write_line;
 use syntax::ast::{BinaryOperator, Expression, Literal, UnaryOperator};
@@ -280,12 +280,21 @@ impl Emitter<'_> {
         output.push_str(&rhs_staged.setup);
 
         if let Some(target_ty) = go_field_ty {
-            let coercion =
-                Coercion::resolve_unwrap_go_nullable(self, &value.get_type(), Some(&target_ty));
+            let coercion = Coercion::resolve(
+                self,
+                &value.get_type(),
+                &target_ty,
+                CoercionDirection::ToGoBoundary,
+            );
             let unwrapped = coercion.apply(self, output, rhs_staged.value);
             write_line!(output, "{} = {}", target_str, unwrapped);
         } else {
-            let coercion = Coercion::resolve(self, &value.get_type(), &target.get_type());
+            let coercion = Coercion::resolve(
+                self,
+                &value.get_type(),
+                &target.get_type(),
+                CoercionDirection::Internal,
+            );
             let adapted = coercion.apply(self, output, rhs_staged.value);
             write_line!(output, "{} = {}", target_str, adapted);
         }

--- a/crates/emit/src/statements/let_bindings.rs
+++ b/crates/emit/src/statements/let_bindings.rs
@@ -2,12 +2,12 @@ use crate::Emitter;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::control_flow::fallible::Fallible;
 use crate::patterns::decision_tree;
-use crate::types::coercion::Coercion;
+use crate::types::coercion::{Coercion, CoercionDirection};
 use crate::types::emitter::Position;
 use crate::utils::{DiscardGuard, requires_temp_var, try_flip_comparison};
 use crate::write_line;
-use syntax::ast::{Binding, Expression, Literal, Pattern};
-use syntax::types::Type;
+use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
+use syntax::types::{Type, peel_to_range_type};
 
 enum LetKind {
     /// Simple identifier binding: `let x = expression`
@@ -207,10 +207,15 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
         raw_go_name: &str,
     ) {
         let value_expression = self.emitter.emit_value(output, self.value);
-        let coercion = Coercion::resolve(self.emitter, &self.value.get_type(), &self.binding.ty);
+        let coercion = Coercion::resolve(
+            self.emitter,
+            &self.value.get_type(),
+            &self.binding.ty,
+            CoercionDirection::Internal,
+        );
         let value_expression = coercion.apply(self.emitter, output, value_expression);
-        let clone = Coercion::resolve_subslice_clone(self.value, self.mutable);
-        let value_expression = clone.apply(self.emitter, output, value_expression);
+        let value_expression =
+            maybe_clone_subslice(self.emitter, self.value, self.mutable, value_expression);
 
         let go_identifier = self.emitter.scope.bindings.add(identifier, raw_go_name);
         let is_new = self.emitter.try_declare(&go_identifier);
@@ -349,12 +354,7 @@ impl<'a, 'e> LetEmitter<'a, 'e> {
             let binding_ty = &self.binding.ty;
             if !binding_ty.is_variable() && !binding_ty.ok_type().is_variable() {
                 self.emitter.go_type_as_string(binding_ty)
-            } else if let Some(ctx_ty) = self
-                .emitter
-                .current_return_context
-                .as_ref()
-                .map(|c| c.ty.clone())
-            {
+            } else if let Some(ctx_ty) = self.emitter.return_lowering.ty().cloned() {
                 if Fallible::from_type(&ctx_ty).is_some() {
                     self.emitter.go_type_as_string(&ctx_ty)
                 } else {
@@ -909,4 +909,51 @@ impl Emitter<'_> {
         let value_expression = self.emit_operand(output, value);
         write_line!(output, "_ = {}", value_expression);
     }
+}
+
+/// `let mut x = arr[range]` would otherwise alias the backing array.
+fn maybe_clone_subslice(
+    emitter: &mut Emitter<'_>,
+    value: &Expression,
+    mutable: bool,
+    expression: String,
+) -> String {
+    if !is_mutable_subslice(value, mutable) {
+        return expression;
+    }
+    emitter.flags.needs_slices = true;
+    format!("slices.Clone({})", expression)
+}
+
+fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
+    if !mutable {
+        return false;
+    }
+    let value = value.unwrap_parens();
+    let Expression::IndexedAccess {
+        expression, index, ..
+    } = value
+    else {
+        return false;
+    };
+
+    let is_range_index = matches!(**index, Expression::Range { .. })
+        || peel_to_range_type(&index.get_type()).is_some();
+
+    if !is_range_index {
+        return false;
+    }
+
+    let collection_ty = match expression.as_ref() {
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            expression: inner,
+            ..
+        } => {
+            let inner_ty = inner.get_type();
+            inner_ty.inner().unwrap_or(inner_ty)
+        }
+        other => other.get_type(),
+    };
+    collection_ty.has_name("Slice")
 }

--- a/crates/emit/src/types/abi.rs
+++ b/crates/emit/src/types/abi.rs
@@ -254,11 +254,7 @@ impl Emitter<'_> {
 
     /// Lowered shape of the enclosing function's return type, if any.
     pub(crate) fn current_lowered_abi(&self) -> Option<AbiShape> {
-        let ctx = self.current_return_context.as_ref()?;
-        if ctx.force_tagged {
-            return None;
-        }
-        self.classify_direct_emission(&ctx.ty)
+        self.return_lowering.shape()
     }
 
     /// Annotation-side mirror of `is_nullable_option`'s inner check.

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -1,136 +1,47 @@
-use syntax::ast::{Expression, UnaryOperator};
-use syntax::types::{Type, peel_to_range_type};
+use syntax::ast::Expression;
+use syntax::types::Type;
 
 use crate::Emitter;
 use crate::definitions::interface_adapter::AdapterPlan;
 
 pub(crate) struct Coercion {
-    #[allow(dead_code)]
-    from: Type,
-    #[allow(dead_code)]
-    to: Type,
     kind: CoercionKind,
 }
 
 pub(crate) enum CoercionKind {
     Identity,
     WrapAsInterface(AdapterPlan),
-    WrapNewtype {
-        ty: Type,
-    },
-    UnwrapNullableOption {
-        ty: Type,
-    },
-    UnwrapPointerOption {
-        ty: Type,
-    },
-    UnwrapNullableCollection {
-        ty: Type,
-        elem_option_ty: Type,
-    },
-    WrapNullableOption {
-        ty: Type,
-    },
-    WrapPointerOption {
-        ty: Type,
-    },
-    WrapNullableCollection {
-        ty: Type,
-        elem_option_ty: Type,
-    },
-    /// Severs the backing-array alias on `let mut x = arr[range]` so writes
-    /// through `x` do not mutate `arr`.
-    CloneSubslice,
+    WrapNewtype { ty: Type },
+    UnwrapNullableOption { ty: Type },
+    UnwrapPointerOption { ty: Type },
+    UnwrapNullableCollection { ty: Type, elem_option_ty: Type },
+    WrapNullableOption { ty: Type },
+    WrapPointerOption { ty: Type },
+    WrapNullableCollection { ty: Type, elem_option_ty: Type },
+}
+
+/// Outbound and inbound Option-bridge cases look identical by type alone,
+/// so direction is picked at the call site rather than inferred.
+#[derive(Clone, Copy)]
+pub(crate) enum CoercionDirection {
+    Internal,
+    ToGoBoundary,
+    FromGoBoundary,
 }
 
 impl Coercion {
-    pub(crate) fn resolve(emitter: &Emitter, from: &Type, to: &Type) -> Self {
-        let kind = if let Some(plan) = emitter.needs_adapter(from, to) {
-            CoercionKind::WrapAsInterface(plan)
-        } else if needs_newtype_wrap(emitter, from, to) {
-            CoercionKind::WrapNewtype { ty: to.clone() }
-        } else {
-            CoercionKind::Identity
-        };
-        Self {
-            from: from.clone(),
-            to: to.clone(),
-            kind,
-        }
-    }
-
-    pub(crate) fn resolve_unwrap_go_nullable(
+    pub(crate) fn resolve(
         emitter: &Emitter,
-        value_ty: &Type,
-        target_ty: Option<&Type>,
+        from: &Type,
+        to: &Type,
+        direction: CoercionDirection,
     ) -> Self {
-        if let Some(target_ty) = target_ty
-            && emitter.is_non_nilable_option(value_ty)
-            && emitter.is_non_nilable_option(target_ty)
-        {
-            return Self {
-                from: value_ty.clone(),
-                to: target_ty.clone(),
-                kind: CoercionKind::UnwrapPointerOption {
-                    ty: value_ty.clone(),
-                },
-            };
-        }
-        let kind = if emitter.is_nullable_option(value_ty) {
-            CoercionKind::UnwrapNullableOption {
-                ty: value_ty.clone(),
-            }
-        } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
-            CoercionKind::UnwrapNullableCollection {
-                ty: value_ty.clone(),
-                elem_option_ty,
-            }
-        } else {
-            CoercionKind::Identity
+        let kind = match direction {
+            CoercionDirection::Internal => resolve_internal(emitter, from, to),
+            CoercionDirection::ToGoBoundary => resolve_to_go(emitter, from, to),
+            CoercionDirection::FromGoBoundary => resolve_from_go(emitter, from),
         };
-        Self {
-            from: value_ty.clone(),
-            to: value_ty.clone(),
-            kind,
-        }
-    }
-
-    pub(crate) fn resolve_subslice_clone(value: &Expression, mutable: bool) -> Self {
-        let kind = if is_mutable_subslice(value, mutable) {
-            CoercionKind::CloneSubslice
-        } else {
-            CoercionKind::Identity
-        };
-        let ty = value.get_type();
-        Self {
-            from: ty.clone(),
-            to: ty,
-            kind,
-        }
-    }
-
-    pub(crate) fn resolve_wrap_go_nullable(emitter: &Emitter, value_ty: &Type) -> Self {
-        let kind = if emitter.is_nullable_option(value_ty) {
-            CoercionKind::WrapNullableOption {
-                ty: value_ty.clone(),
-            }
-        } else if emitter.is_non_nilable_option(value_ty) {
-            CoercionKind::WrapPointerOption {
-                ty: value_ty.clone(),
-            }
-        } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
-            CoercionKind::WrapNullableCollection {
-                ty: value_ty.clone(),
-                elem_option_ty,
-            }
-        } else {
-            CoercionKind::Identity
-        };
-        Self {
-            from: value_ty.clone(),
-            to: value_ty.clone(),
-            kind,
-        }
+        Self { kind }
     }
 
     pub(crate) fn apply(self, emitter: &mut Emitter, output: &mut String, value: String) -> String {
@@ -162,16 +73,7 @@ impl Coercion {
             CoercionKind::WrapNullableCollection { ty, elem_option_ty } => {
                 emitter.emit_collection_nullable_wrap(output, &value, &ty, &elem_option_ty)
             }
-            CoercionKind::CloneSubslice => {
-                emitter.flags.needs_slices = true;
-                format!("slices.Clone({})", value)
-            }
         }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn is_identity(&self) -> bool {
-        matches!(self.kind, CoercionKind::Identity)
     }
 }
 
@@ -186,8 +88,62 @@ impl Emitter<'_> {
         let Some(target) = target_ty else {
             return emitted;
         };
-        let coercion = Coercion::resolve(self, &expression.get_type(), target);
+        let coercion = Coercion::resolve(
+            self,
+            &expression.get_type(),
+            target,
+            CoercionDirection::Internal,
+        );
         coercion.apply(self, output, emitted)
+    }
+}
+
+fn resolve_internal(emitter: &Emitter, from: &Type, to: &Type) -> CoercionKind {
+    if let Some(plan) = emitter.needs_adapter(from, to) {
+        CoercionKind::WrapAsInterface(plan)
+    } else if needs_newtype_wrap(emitter, from, to) {
+        CoercionKind::WrapNewtype { ty: to.clone() }
+    } else {
+        CoercionKind::Identity
+    }
+}
+
+fn resolve_to_go(emitter: &Emitter, value_ty: &Type, target_ty: &Type) -> CoercionKind {
+    if emitter.is_non_nilable_option(value_ty) && emitter.is_non_nilable_option(target_ty) {
+        return CoercionKind::UnwrapPointerOption {
+            ty: value_ty.clone(),
+        };
+    }
+    if emitter.is_nullable_option(value_ty) {
+        CoercionKind::UnwrapNullableOption {
+            ty: value_ty.clone(),
+        }
+    } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
+        CoercionKind::UnwrapNullableCollection {
+            ty: value_ty.clone(),
+            elem_option_ty,
+        }
+    } else {
+        CoercionKind::Identity
+    }
+}
+
+fn resolve_from_go(emitter: &Emitter, value_ty: &Type) -> CoercionKind {
+    if emitter.is_nullable_option(value_ty) {
+        CoercionKind::WrapNullableOption {
+            ty: value_ty.clone(),
+        }
+    } else if emitter.is_non_nilable_option(value_ty) {
+        CoercionKind::WrapPointerOption {
+            ty: value_ty.clone(),
+        }
+    } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
+        CoercionKind::WrapNullableCollection {
+            ty: value_ty.clone(),
+            elem_option_ty,
+        }
+    } else {
+        CoercionKind::Identity
     }
 }
 
@@ -199,37 +155,4 @@ fn needs_newtype_wrap(emitter: &Emitter, from: &Type, to: &Type) -> bool {
         return false;
     };
     underlying == *from
-}
-
-fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
-    if !mutable {
-        return false;
-    }
-    let value = value.unwrap_parens();
-    let Expression::IndexedAccess {
-        expression, index, ..
-    } = value
-    else {
-        return false;
-    };
-
-    let is_range_index = matches!(**index, Expression::Range { .. })
-        || peel_to_range_type(&index.get_type()).is_some();
-
-    if !is_range_index {
-        return false;
-    }
-
-    let collection_ty = match expression.as_ref() {
-        Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } => {
-            let inner_ty = inner.get_type();
-            inner_ty.inner().unwrap_or(inner_ty)
-        }
-        other => other.get_type(),
-    };
-    collection_ty.has_name("Slice")
 }


### PR DESCRIPTION
Makes fallible return shape and coercion direction explicit at every site, replacing the implicit `force_tagged` flag with a `ReturnLowering` enum carrying a precomputed `FnLoweringPlan`, and collapsing three sibling `Coercion::resolve_*` methods into one resolver parameterised by `CoercionDirection`.