### PR TITLE
fix: shrink bindgen skip surface

### DIFF
--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -159,6 +159,9 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 	} else if returnType.SkipReason != nil {
 		result.ReturnType = "Unknown"
 	}
+	if returnType.SkipReason != nil {
+		result.SkipNote = returnType.SkipReason
+	}
 	result.CommaOk = returnType.CommaOk
 	result.ArrayReturn = returnType.ArrayReturn
 	c.applySentinelInt(result, result.Name)
@@ -318,6 +321,9 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 		result.ReturnType = returnType.LisetteType
 	} else if returnType.SkipReason != nil {
 		result.ReturnType = "Unknown"
+	}
+	if returnType.SkipReason != nil {
+		result.SkipNote = returnType.SkipReason
 	}
 	result.CommaOk = returnType.CommaOk
 	result.ArrayReturn = returnType.ArrayReturn
@@ -502,6 +508,15 @@ func (c *Converter) convertType(result *ConvertResult, exp extract.SymbolExport)
 		return
 	}
 
+	if basic, ok := exp.GoType.(*types.Basic); ok && basic.Kind() == types.UnsafePointer {
+		result.SkipReason = &SkipReason{
+			Code:           "unrepresentable-builtin",
+			Message:        "Lisette has no untyped pointer type",
+			EmitOpaqueType: true,
+		}
+		return
+	}
+
 	named, ok := exp.GoType.(*types.Named)
 	if !ok {
 		result.SkipReason = &SkipReason{Code: "not-named-type", Message: "expected named type"}
@@ -597,6 +612,7 @@ func (c *Converter) convertConstant(result *ConvertResult, exp extract.SymbolExp
 		if t.SkipReason.Code == "internal-package-ref" {
 			result.LisetteType = "Unknown"
 			result.ConstValue = ""
+			result.SkipNote = t.SkipReason
 			return
 		}
 		result.SkipReason = t.SkipReason
@@ -618,6 +634,7 @@ func (c *Converter) convertVariable(result *ConvertResult, exp extract.SymbolExp
 	}
 	if t.SkipReason != nil {
 		result.LisetteType = "Unknown"
+		result.SkipNote = t.SkipReason
 	} else {
 		result.LisetteType = t.LisetteType
 	}

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -24,10 +24,14 @@ type ConvertResult struct {
 	Variants         []EnumVariant     // for enums (via iota)
 	ConstValue       string            // for constants
 	SkipReason       *SkipReason
-	IsInterface      bool // true when this type should be emitted as `pub interface`
-	IsTypeAlias      bool // true for Go type aliases (type X = Y)
-	CommaOk          bool // true when return is from (T, bool) comma-ok with nilable T
-	ArrayReturn      bool // true when Go type is [N]T but Lisette type is Slice<T>
+	// SkipNote attaches a leading "SKIPPED returns-with"/"SKIPPED type-with"
+	// comment to a binding that still emits its signature. Used when the
+	// return type or declared type silently downgraded to Unknown.
+	SkipNote    *SkipReason
+	IsInterface bool // true when this type should be emitted as `pub interface`
+	IsTypeAlias bool // true for Go type aliases (type X = Y)
+	CommaOk     bool // true when return is from (T, bool) comma-ok with nilable T
+	ArrayReturn bool // true when Go type is [N]T but Lisette type is Slice<T>
 	// SentinelInt is set when this function returns int but the bindgen
 	// config declares a magic value (e.g. -1) for "not found". Bindgen
 	// rewrites the return type to Option<int> and emits the matching

--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -91,6 +91,16 @@ func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, o
 		return "Comparable", true
 	}
 
+	// Comparable type-set unions with no methods (e.g. math/rand/v2.intType =
+	// `~int | ~int8 | ...`). Loses term precision; Go enforces the original
+	// constraint on the generated call.
+	if iface.NumMethods() == 0 && iface.NumEmbeddeds() > 0 && iface.IsComparable() {
+		if allOrderedBasicTerms(iface) {
+			return "Ordered", true
+		}
+		return "Comparable", true
+	}
+
 	// Excludes inline interface literals (bare *types.Interface, never Named
 	// or Alias) and type-set unions (NumEmbeddeds > 0 from embedded *types.Union).
 	if iface.NumMethods() > 0 && iface.NumEmbeddeds() == 0 {
@@ -103,6 +113,36 @@ func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, o
 	}
 
 	return "", false
+}
+
+func allOrderedBasicTerms(iface *types.Interface) bool {
+	for etyp := range iface.EmbeddedTypes() {
+		union, ok := etyp.(*types.Union)
+		if !ok {
+			return false
+		}
+		for term := range union.Terms() {
+			basic, ok := term.Type().Underlying().(*types.Basic)
+			if !ok {
+				return false
+			}
+			if !isOrderedBasicKind(basic.Kind()) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isOrderedBasicKind(kind types.BasicKind) bool {
+	switch kind {
+	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
+		types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64, types.Uintptr,
+		types.Float32, types.Float64,
+		types.String:
+		return true
+	}
+	return false
 }
 
 // Renders a Named or Alias bound by its TypeName, qualifying with the package

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -215,6 +215,8 @@ func basicToLisette(t *types.Basic) string {
 		return "complex128"
 	case types.String:
 		return "string"
+	case types.UnsafePointer:
+		return "Unknown"
 	default:
 		return "Unknown"
 	}
@@ -253,13 +255,6 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 	obj := t.Obj()
 	pkg := obj.Pkg()
 
-	if pkg != nil && pkg.Path() == "unsafe" && obj.Name() == "Pointer" {
-		return TypeResult{SkipReason: &SkipReason{
-			Code:    "unsafe.Pointer",
-			Message: "unsafe.Pointer cannot be represented",
-		}}
-	}
-
 	if obj.Name() == "error" && pkg == nil {
 		return TypeResult{LisetteType: "error"}
 	}
@@ -285,6 +280,12 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 		}
 		if namedImplementsError(t) {
 			return TypeResult{LisetteType: "error"}
+		}
+		if s, ok := t.Underlying().(*types.Struct); ok && s.NumFields() > 0 {
+			return TypeResult{SkipReason: &SkipReason{
+				Code:    "opaque-unexported-struct",
+				Message: fmt.Sprintf("underlying type %q is unexported", obj.Name()),
+			}}
 		}
 		return toLisetteRecursive(t.Underlying(), seen, conv)
 	}

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -14,6 +14,11 @@ func writeSkippedFieldComment(w *strings.Builder, indent string, f convert.Struc
 	fmt.Fprintf(w, "%s// SKIPPED field %q: %s — %s\n", indent, f.Name, f.SkipReason.Code, f.SkipReason.Message)
 }
 
+func writeSkipNote(w *strings.Builder, indent, label string, reason *convert.SkipReason) {
+	fmt.Fprintf(w, "%s// SKIPPED %s: %s\n", indent, label, reason.Code)
+	fmt.Fprintf(w, "%s// %s\n", indent, reason.Message)
+}
+
 type stats struct {
 	functions int
 	methods   int
@@ -305,6 +310,9 @@ func (e *Emitter) String() string {
 }
 
 func (e *Emitter) emitFunction(result convert.ConvertResult) {
+	if result.SkipNote != nil {
+		writeSkipNote(&e.buf, "", "returns-with", result.SkipNote)
+	}
 	e.emitDocWithIndent(result.Doc, "")
 
 	if result.CommaOk {
@@ -383,6 +391,9 @@ func (e *Emitter) emitMethodInImpl(result convert.ConvertResult) {
 		return
 	}
 
+	if result.SkipNote != nil {
+		writeSkipNote(&e.buf, "  ", "returns-with", result.SkipNote)
+	}
 	e.emitDocWithIndent(result.Doc, "  ")
 
 	if result.CommaOk {
@@ -585,6 +596,9 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 }
 
 func (e *Emitter) emitConst(result convert.ConvertResult) {
+	if result.SkipNote != nil {
+		writeSkipNote(&e.buf, "", "type-with", result.SkipNote)
+	}
 	e.emitDocWithIndent(result.Doc, "")
 
 	if result.ConstValue != "" {
@@ -627,6 +641,9 @@ func (e *Emitter) isInferredNamedType(typeStr string) bool {
 }
 
 func (e *Emitter) emitVariable(result convert.ConvertResult) {
+	if result.SkipNote != nil {
+		writeSkipNote(&e.buf, "", "type-with", result.SkipNote)
+	}
 	e.emitDocWithIndent(result.Doc, "")
 	fmt.Fprintf(&e.buf, "pub var %s: %s\n\n", result.Name, result.LisetteType)
 }

--- a/bindgen/tests/testdata/snapshots/decorator_aliases.d.lis
+++ b/bindgen/tests/testdata/snapshots/decorator_aliases.d.lis
@@ -16,9 +16,13 @@ pub struct Offset(uint)
 
 pub struct SpecPriority(int)
 
+// SKIPPED type-with: internal-package-ref
+// references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/decorator_aliases/internal/inner"
 /// Re-exported consts whose declared type lives entirely in an internal
 /// package — should fall back to `Unknown` so the symbol stays usable
 /// as an opaque value passed into VarArgs<Unknown> parameters.
 pub const Focus: Unknown
 
+// SKIPPED type-with: internal-package-ref
+// references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/decorator_aliases/internal/inner"
 pub const Pending: Unknown

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -32,8 +32,8 @@ pub fn MapEqualFunc<K: Comparable, V1, V2>(m1: Map<K, V1>, m2: Map<K, V2>, eq: f
 /// Comparable constraint
 pub fn Max<T: Comparable>(a: T, b: T) -> T
 
-// SKIPPED: Min - constraint:comparable
-// type constraint T cannot be represented
+/// Function with ordered constraint
+pub fn Min<T: Ordered>(a: T, b: T) -> T
 
 /// cmp.Ordered constraint (named-identity recognizer)
 pub fn MinOrdered<T: cmp.Ordered>(a: T, b: T) -> T

--- a/bindgen/tests/testdata/snapshots/internalref.d.lis
+++ b/bindgen/tests/testdata/snapshots/internalref.d.lis
@@ -6,6 +6,8 @@
 // SKIPPED: ConsumeInner - internal-package-ref
 // references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/internalref/internal/inner"
 
+// SKIPPED returns-with: internal-package-ref
+// references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/internalref/internal/inner"
 /// Should be skipped: function returning a type from an internal package.
 pub fn GetInner() -> Option<Unknown>
 
@@ -21,6 +23,8 @@ pub struct Local {
   pub Value: int,
 }
 
+// SKIPPED type-with: internal-package-ref
+// references type from internal package "github.com/ivov/lisette/bindgen/tests/testdata/fixtures/internalref/internal/inner"
 /// Package-level variable typed by an internal package — type collapses to
 /// Unknown so the symbol stays referenceable as an opaque value.
 pub var GlobalInner: Unknown

--- a/bindgen/tests/testdata/snapshots/skipped.d.lis
+++ b/bindgen/tests/testdata/snapshots/skipped.d.lis
@@ -3,12 +3,16 @@
 // Go: 0.0.0
 // Lisette: 0.0.0
 
+// SKIPPED returns-with: anonymous-struct
+// anonymous struct types are not supported
 /// Skip in Option return - tests analyzeReturns Option skip path
 pub fn BadOptionReturn() -> Option<Unknown>
 
 // SKIPPED: BadParam - anonymous-struct
 // anonymous struct types are not supported
 
+// SKIPPED returns-with: anonymous-struct
+// anonymous struct types are not supported
 /// Skip in Result return - tests analyzeReturns Result skip path
 pub fn BadResultReturn() -> Result<Unknown, error>
 
@@ -16,8 +20,7 @@ pub fn BadUnsafeFunc(p: Unknown)
 
 pub fn MakeOpaqueFunc() -> OpaqueFunc
 
-// SKIPPED: SkippedMin - constraint:comparable
-// type constraint T cannot be represented
+pub fn SkippedMin<T: Ordered>(a: T, b: T) -> T
 
 // SKIPPED: TakesAliasArray - array-currently-not-representable
 // fixed-size array cannot currently be represented in Lisette
@@ -79,14 +82,14 @@ pub struct HasUnsafe {
 // SKIPPED field "ChanAnon": anonymous-struct — anonymous struct types are not supported
 pub type NestedAnon
 
-// SKIPPED: OpaqueFunc - anonymous-struct
-// anonymous struct types are not supported
+// SKIPPED: OpaqueFunc - opaque-unexported-struct
+// underlying type "hasPrivate" is unexported
 pub type OpaqueFunc
 
 /// Should be skipped: constrained generic (non-any)
 pub type Ordered
 
-// SKIPPED field "Field": anonymous-struct — anonymous struct types are not supported
+// SKIPPED field "Field": opaque-unexported-struct — underlying type "hasPrivate" is unexported
 pub type Public
 
 /// Should NOT skip: normal struct

--- a/bindgen/tests/testdata/snapshots/structs.d.lis
+++ b/bindgen/tests/testdata/snapshots/structs.d.lis
@@ -8,6 +8,8 @@ import "go:io"
 /// Function that returns a function
 pub fn MakeAdder(x: int) -> Option<fn(int) -> int>
 
+// SKIPPED returns-with: anonymous-struct
+// anonymous struct types are not supported
 pub fn ReturnsAnon() -> Unknown
 
 /// Function that takes a callback

--- a/bindgen/tests/testdata/snapshots/tuple_too_large.d.lis
+++ b/bindgen/tests/testdata/snapshots/tuple_too_large.d.lis
@@ -10,13 +10,19 @@ pub fn Keeper() -> (int, int, int, int, int)
 /// Result<(int, int, int, int, int), error>.
 pub fn KeeperWithError() -> Result<(int, int, int, int, int), error>
 
+// SKIPPED returns-with: tuple-too-large
+// 6-element return tuple exceeds Lisette's 5-element limit
 /// Unpack6 mirrors samber/lo's shape: 6-element return, exceeds limit, skipped.
 pub fn Unpack6() -> Unknown
 
+// SKIPPED returns-with: tuple-too-large
+// 6-element return tuple exceeds Lisette's 5-element limit
 /// Unpack6Err: 6-element inner + trailing error. Inner wrap is too large, so
 /// the function should be skipped entirely (the SkipReason propagates out of
 /// the Result<..., error> wrap via `returns.go`).
 pub fn Unpack6Err() -> Result<Unknown, error>
 
+// SKIPPED returns-with: tuple-too-large
+// 9-element return tuple exceeds Lisette's 5-element limit
 /// Unpack9 is the concrete samber/lo case from bugs.md #8.
 pub fn Unpack9() -> Unknown

--- a/crates/stdlib/typedefs/debug/dwarf.d.lis
+++ b/crates/stdlib/typedefs/debug/dwarf.d.lis
@@ -1083,6 +1083,8 @@ impl Data {
   /// If this compilation unit has no line table, it returns nil, nil.
   fn LineReader(self: Ref<Data>, cu: Ref<Entry>) -> Result<Ref<LineReader>, error>
 
+  // SKIPPED returns-with: array-currently-not-representable
+  // fixed-size array cannot currently be represented in Lisette
   /// Ranges returns the PC ranges covered by e, a slice of [low,high) pairs.
   /// Only some entry types, such as [TagCompileUnit] or [TagSubprogram], have PC
   /// ranges; for others, this will return nil with no error.

--- a/crates/stdlib/typedefs/encoding/binary.d.lis
+++ b/crates/stdlib/typedefs/encoding/binary.d.lis
@@ -138,5 +138,5 @@ pub var BigEndian: ()
 
 pub var LittleEndian: ()
 
-// SKIPPED: NativeEndian - anonymous-struct
-// anonymous struct types are not supported
+// SKIPPED: NativeEndian - opaque-unexported-struct
+// underlying type "nativeEndian" is unexported

--- a/crates/stdlib/typedefs/math/rand/v2.d.lis
+++ b/crates/stdlib/typedefs/math/rand/v2.d.lis
@@ -47,8 +47,10 @@ pub fn Int64N(n: int64) -> int64
 /// It panics if n <= 0.
 pub fn IntN(n: int) -> int
 
-// SKIPPED: N - constraint:comparable
-// type constraint Int cannot be represented
+/// N returns a pseudo-random number in the half-open interval [0,n) from the default Source.
+/// The type parameter Int can be any integer type.
+/// It panics if n <= 0.
+pub fn N<Int: Ordered>(n: Int) -> Int
 
 /// New returns a new Rand that uses random values from src
 /// to generate other random values.

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -1517,8 +1517,8 @@ pub var ErrUseLastResponse: error
 /// Errors used by the HTTP server.
 pub var ErrWriteAfterFlush: error
 
-// SKIPPED: LocalAddrContextKey - anonymous-struct
-// anonymous struct types are not supported
+// SKIPPED: LocalAddrContextKey - opaque-unexported-struct
+// underlying type "contextKey" is unexported
 
 /// NoBody is an [io.ReadCloser] with no bytes. Read always returns EOF
 /// and Close always returns nil. It can be used in an outgoing client
@@ -1526,8 +1526,8 @@ pub var ErrWriteAfterFlush: error
 /// An alternative, however, is to simply set [Request.Body] to nil.
 pub var NoBody: ()
 
-// SKIPPED: ServerContextKey - anonymous-struct
-// anonymous struct types are not supported
+// SKIPPED: ServerContextKey - opaque-unexported-struct
+// underlying type "contextKey" is unexported
 
 impl Client {
   /// CloseIdleConnections closes any connections on its [Transport] which

--- a/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
@@ -615,6 +615,8 @@ pub fn CloseOnExec(fd: Handle)
 
 pub fn Closesocket(s: Handle) -> Result<(), error>
 
+// SKIPPED returns-with: array-currently-not-representable
+// fixed-size array cannot currently be represented in Lisette
 pub fn CommandLineToArgv(cmd: Ref<uint16>, argc: Ref<int32>) -> Result<Unknown, error>
 
 pub fn ComputerName() -> Result<string, error>

--- a/crates/stdlib/typedefs/unsafe.d.lis
+++ b/crates/stdlib/typedefs/unsafe.d.lis
@@ -3,5 +3,6 @@
 // Go: 1.25.10
 // Lisette: 0.2.1
 
-// SKIPPED: Pointer - not-named-type
-// expected named type
+// SKIPPED: Pointer - unrepresentable-builtin
+// Lisette has no untyped pointer type
+pub type Pointer


### PR DESCRIPTION
Four bindgen changes that tighten how skip reasons are reported and unblock previously-skipped symbols.

- `unsafe.Pointer` was leaking a sanity-check code.
- `anonymous-struct` was overloaded, firing for anonymous structs and for unexported named structs reached through an exported declaration.
- Return-position skips were silently dropped.
- Comparable type-set unions are now recognised as bounds.