### PR TITLE
fix: honor allow attributes on interface methods

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -156,6 +156,8 @@ func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goV
 		results = append(results, converter.Convert(exp))
 	}
 
+	converter.FinalizeInterfaceBuilders(results)
+
 	valueEnums, constantTypes, valueEnumTypeNames := convert.DetectValueEnums(results, exports)
 
 	enumConstants := make(map[string][]convert.ConvertResult)

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -440,6 +440,69 @@ func returnIsReceiverShaped(sig *types.Signature) bool {
 	return false
 }
 
+// FinalizeInterfaceBuilders carries the BuilderMethod flag from concrete methods to matching interface methods, when a concrete implementer is itself marked.
+func (c *Converter) FinalizeInterfaceBuilders(results []ConvertResult) {
+	if c.pkg == nil || c.pkg.Types == nil {
+		return
+	}
+
+	concreteBuilders := make(map[string]map[string]bool)
+	for _, r := range results {
+		if r.Kind != extract.ExportMethod || r.Receiver == nil || !r.BuilderMethod {
+			continue
+		}
+		methods, ok := concreteBuilders[r.Receiver.BaseTypeName]
+		if !ok {
+			methods = make(map[string]bool)
+			concreteBuilders[r.Receiver.BaseTypeName] = methods
+		}
+		methods[r.Name] = true
+	}
+	if len(concreteBuilders) == 0 {
+		return
+	}
+
+	scope := c.pkg.Types.Scope()
+	for i := range results {
+		result := &results[i]
+		if result.Kind != extract.ExportType || !result.IsInterface || len(result.InterfaceMethods) == 0 {
+			continue
+		}
+		ifaceObj := scope.Lookup(result.Name)
+		if ifaceObj == nil {
+			continue
+		}
+		ifaceNamed, ok := ifaceObj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		iface, ok := ifaceNamed.Underlying().(*types.Interface)
+		if !ok {
+			continue
+		}
+		for mi := range result.InterfaceMethods {
+			methodName := result.InterfaceMethods[mi].Name
+			for concreteName, builderMethods := range concreteBuilders {
+				if !builderMethods[methodName] {
+					continue
+				}
+				concreteObj := scope.Lookup(concreteName)
+				if concreteObj == nil {
+					continue
+				}
+				concreteNamed, ok := concreteObj.Type().(*types.Named)
+				if !ok {
+					continue
+				}
+				if types.Implements(types.NewPointer(concreteNamed), iface) {
+					result.InterfaceMethods[mi].BuilderMethod = true
+					break
+				}
+			}
+		}
+	}
+}
+
 // isFluentMethod excludes trivial `return self` getters — real fluent setters either do work before returning or delegate via a method call on the receiver.
 func isFluentMethod(fn *ast.FuncDecl, recvName string) bool {
 	if fn == nil || fn.Body == nil || recvName == "" {

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -68,11 +68,12 @@ type StructField struct {
 }
 
 type InterfaceMethod struct {
-	Name        string
-	Params      []FunctionParameter
-	ReturnType  string
-	CommaOk     bool
-	ArrayReturn bool
+	Name          string
+	Params        []FunctionParameter
+	ReturnType    string
+	CommaOk       bool
+	ArrayReturn   bool
+	BuilderMethod bool
 }
 
 // HasReturn reports whether this interface method has a non-unit return type.

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -465,6 +465,9 @@ func (e *Emitter) emitType(result convert.ConvertResult) {
 				if m.ArrayReturn {
 					signature.WriteString("  #[go(array_return)]\n")
 				}
+				if m.BuilderMethod {
+					signature.WriteString("  #[allow(unused_value)]\n")
+				}
 				signature.WriteString("  fn ")
 				signature.WriteString(m.Name)
 				signature.WriteString("(")

--- a/bindgen/tests/testdata/snapshots/builder_methods.d.lis
+++ b/bindgen/tests/testdata/snapshots/builder_methods.d.lis
@@ -38,7 +38,9 @@ pub type Logger
 
 /// Interface self-return on a real fluent setter (mutates state, returns self).
 pub interface Router {
+  #[allow(unused_value)]
   fn Get(path: string) -> Router
+  #[allow(unused_value)]
   fn Post(path: string) -> Router
 }
 

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -308,7 +308,7 @@ impl TaskState<'_> {
             .map(|s| self.convert_to_type(&*store, &s.annotation, &s.span))
             .collect();
 
-        let mut method_defs: Vec<(EcoString, Type, Vec<String>)> = Vec::new();
+        let mut method_defs: Vec<(EcoString, Type, Vec<String>, Vec<String>)> = Vec::new();
         let methods = fn_expressions
             .iter()
             .map(|fe| {
@@ -358,6 +358,7 @@ impl TaskState<'_> {
                     method_sig.name.clone(),
                     fn_ty.clone(),
                     extract_attribute_flags(fn_attrs, "go"),
+                    extract_attribute_flags(fn_attrs, "allow"),
                 ));
                 (method_sig.name, fn_ty)
             })
@@ -405,7 +406,7 @@ impl TaskState<'_> {
         // can look up their go_hints (e.g., comma_ok) by qualified name.
         // Methods inherit the interface's visibility — a `pub interface`'s methods are implicitly public.
         let module_id = self.cursor.module_id.clone();
-        for (method_name, method_ty, go_hints) in method_defs {
+        for (method_name, method_ty, go_hints, allowed_lints) in method_defs {
             let method_qualified_name = format!("{}.{}.{}", module_id, interface_name, method_name);
             module.definitions.insert(
                 method_qualified_name.into(),
@@ -416,7 +417,7 @@ impl TaskState<'_> {
                     name_span: None, // Interface method signatures; span tracked in Interface definition
                     doc: None,
                     body: DefinitionBody::Value {
-                        allowed_lints: vec![],
+                        allowed_lints,
                         go_hints,
                         go_name: None,
                     },

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3869,3 +3869,42 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn interface_method_allow_unused_value_suppresses_lint() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Router {
+  #[allow(unused_value)]
+  fn Get(self, path: string) -> Router
+}
+
+pub fn register(r: Router) {
+  r.Get("/ping")
+}
+
+fn main() {
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn interface_method_without_allow_warns_on_discard() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Router {
+  fn Get(self, path: string) -> Router
+}
+
+pub fn register(r: Router) {
+  r.Get("/ping")
+}
+
+fn main() {
+  ()
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/interface_method_without_allow_warns_on_discard.snap
+++ b/tests/ui/lint/snapshots/interface_method_without_allow_warns_on_discard.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Mismatch between return type and return value
+   ╭─[test.lis:7:3]
+ 5 │ 
+ 6 │ pub fn register(r: Router) {
+   ·                            ┬
+   ·                            ╰── has `()` as implicit return type
+ 7 │   r.Get("/ping")
+   ·   ───────┬──────
+   ·          ╰── returns `Router`
+ 8 │ }
+   ╰────
+  help: If the `()` return type is intended, discard the return value with `let _ = ...`. If the `Router` return value is intended, add `-> Router` to the function signature · code: [infer.mismatched_return_value]


### PR DESCRIPTION
Honor `#[allow(unused_value)]` on interface method declarations so that fluent-chain interfaces stop tripping `lint.unused_value` at every call site.

```rs
let api = app.Group("/api/v1")
api.Get("/ping", |c| c.SendString("pong"))
api.Post("/echo", |c| c.SendString("echo"))
```

Previously, every line warned and had to be wrapped with `let _ = ...`