### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.5](https://github.com/ivov/lisette/compare/lisette-v0.2.4...lisette-v0.2.5) - 2026-05-14
+
+- fix: track go import usage during emit [#410](https://github.com/ivov/lisette/pull/410) [`00d1b7a`](https://github.com/ivov/lisette/commit/00d1b7ab37daa2e0af24fb55e84622cb6e10a18c)
+- perf: emit nil for empty Slice literals [#409](https://github.com/ivov/lisette/pull/409) [`1155da5`](https://github.com/ivov/lisette/commit/1155da531aa7e536c256c7460e611209f58e8e12)
+- refactor: emit architecture overhaul [#407](https://github.com/ivov/lisette/pull/407) [`01c7c34`](https://github.com/ivov/lisette/commit/01c7c3443a8f7e41ed94fd6fc2dda8b082278d47)
+- fix: cache no longer hides internal_type_leak warnings [#405](https://github.com/ivov/lisette/pull/405) [`d820e1d`](https://github.com/ivov/lisette/commit/d820e1d8472f35cd56a578d40c9c62d9d2b2329d)
+- perf: skip unchanged emit/gofmt/tidy work on rebuilds [#403](https://github.com/ivov/lisette/pull/403) [`3ef0961`](https://github.com/ivov/lisette/commit/3ef096162bba93a595c84c711962607082a29295)
 ## [0.2.4](https://github.com/ivov/lisette/compare/lisette-v0.2.3...lisette-v0.2.4) - 2026-05-12
 
 - fix: honor allow attributes on interface methods [#402](https://github.com/ivov/lisette/pull/402) [`3e2e5c2`](https://github.com/ivov/lisette/commit/3e2e5c2ddba766bd8a81c4451877845c2c1909f2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bincode",
  "ecow",
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.4", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.4", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.4", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.4", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.4", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.4", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.4", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.5", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.5", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.5", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.5", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.4", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.4", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.4", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.4", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.4", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.4", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.5", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.5", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.4", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.4", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.4", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.4", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.5 (upcoming)

- fix: track go import usage during emit [#410](https://github.com/ivov/lisette/pull/410) [`00d1b7a`](https://github.com/ivov/lisette/commit/00d1b7ab37daa2e0af24fb55e84622cb6e10a18c)
- perf: emit nil for empty Slice literals [#409](https://github.com/ivov/lisette/pull/409) [`1155da5`](https://github.com/ivov/lisette/commit/1155da531aa7e536c256c7460e611209f58e8e12)
- refactor: emit architecture overhaul [#407](https://github.com/ivov/lisette/pull/407) [`01c7c34`](https://github.com/ivov/lisette/commit/01c7c3443a8f7e41ed94fd6fc2dda8b082278d47)
- fix: cache no longer hides internal_type_leak warnings [#405](https://github.com/ivov/lisette/pull/405) [`d820e1d`](https://github.com/ivov/lisette/commit/d820e1d8472f35cd56a578d40c9c62d9d2b2329d)
- perf: skip unchanged emit/gofmt/tidy work on rebuilds [#403](https://github.com/ivov/lisette/pull/403) [`3ef0961`](https://github.com/ivov/lisette/commit/3ef096162bba93a595c84c711962607082a29295)
