### PR TITLE
fix: cache no longer hides internal_type_leak warnings

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -139,3 +139,88 @@ pub fn compile(
         user_file_count,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::LocalFileSystem;
+    use std::fs as stdfs;
+    use tempfile::tempdir;
+
+    fn check_diagnostics(project_dir: &std::path::Path) -> Vec<(bool, Option<String>)> {
+        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let src_main = project_dir.join("src").join("main.lis");
+        let source = stdfs::read_to_string(&src_main).unwrap();
+        let config = CompileConfig {
+            target_phase: CompilePhase::Check,
+            go_module: "test".to_string(),
+            standalone_mode: false,
+            load_siblings: true,
+            debug: false,
+            project_root: Some(project_dir.to_path_buf()),
+            locator,
+        };
+        let working_dir = src_main
+            .parent()
+            .and_then(|p| p.to_str())
+            .expect("temp project path is valid utf-8");
+        let fs_loader = LocalFileSystem::new(working_dir);
+        let result = compile(&source, "main.lis", &config, &fs_loader);
+
+        let mut diags: Vec<(bool, Option<String>)> = result
+            .errors
+            .iter()
+            .chain(result.lints.iter())
+            .map(|d| (d.is_error(), d.code_str().map(|s| s.to_string())))
+            .collect();
+        diags.sort();
+        diags
+    }
+
+    #[test]
+    fn warm_diagnostics_match_cold_for_param_position_leak() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        stdfs::create_dir_all(root.join("src").join("leaky")).unwrap();
+        stdfs::write(
+            root.join("lisette.toml"),
+            "[project]\nname = \"github.com/test/cache\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("main.lis"),
+            "import \"leaky\"\n\nfn main() {\n  let _ = leaky.make_item(42)\n}\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("leaky").join("leaky.lis"),
+            "struct Item {\n  pub id: int,\n}\n\n\
+             pub fn extract_id(it: Item) -> int {\n  it.id\n}\n\n\
+             pub fn make_item(id: int) -> int {\n  let it = Item { id: id }\n  it.id\n}\n",
+        )
+        .unwrap();
+
+        let cold = check_diagnostics(root);
+        let warm = check_diagnostics(root);
+        let warm_again = check_diagnostics(root);
+
+        assert!(
+            cold.iter()
+                .any(|(_, code)| code.as_deref() == Some("lint.internal_type_leak")),
+            "cold run must produce internal_type_leak; otherwise the test is not exercising the bug. got: {:?}",
+            cold
+        );
+        assert_eq!(
+            cold, warm,
+            "diagnostics diverge between cold and first warm build"
+        );
+        assert_eq!(
+            cold, warm_again,
+            "diagnostics diverge between cold and second warm build"
+        );
+        assert!(
+            !root.join("target/cache/leaky.cache").exists(),
+            "leaky has warnings; cache must not write it"
+        );
+    }
+}

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -335,7 +335,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                 let has_module_warnings = lints.iter().any(|lint| {
                     lint.file_id()
                         .map(|fid| file_ids.contains(&fid))
-                        .unwrap_or(false)
+                        .unwrap_or(true)
                 });
                 if !has_module_warnings
                     && let Err(e) =

--- a/crates/semantics/src/passes/lints/ref_graph/visibility_constraints.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/visibility_constraints.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use diagnostics::LisetteDiagnostic;
-use syntax::ast::{Annotation, Expression};
+use syntax::ast::{Annotation, Expression, Span};
 use syntax::program::File;
 use syntax::program::{Module, Visibility};
 use syntax::types::{Type, unqualified_name};
@@ -24,13 +24,13 @@ pub fn check_visibility_constraints(
         let annotation = find_function_annotation(files, item_name)
             .or_else(|| find_function_annotation(&module.typedefs, item_name));
 
-        check_type_for_private_leak(
+        let mut ctx = LeakCtx {
             module,
-            definition.ty(),
-            annotation.as_ref(),
-            item_name,
+            public_definition: item_name,
+            fallback_span: definition.name_span(),
             diagnostics,
-        );
+        };
+        ctx.check(definition.ty(), annotation.as_ref());
     }
 }
 
@@ -51,134 +51,83 @@ fn find_function_annotation(files: &HashMap<u32, File>, name: &str) -> Option<An
     None
 }
 
-fn check_type_for_private_leak(
-    module: &Module,
-    ty: &Type,
-    annotation: Option<&Annotation>,
-    public_definition: &str,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
-    match ty {
-        Type::Nominal { id, params, .. } => {
-            if let Some(definition) = module.definitions.get(id.as_str())
-                && definition.visibility() == &Visibility::Private
-            {
-                let span = annotation.map(|ann| ann.get_span());
-                let type_name = unqualified_name(id);
-                diagnostics.push(diagnostics::lint::private_type_in_public_api(
-                    span.as_ref(),
-                    type_name,
-                    public_definition,
-                ));
+struct LeakCtx<'a> {
+    module: &'a Module,
+    public_definition: &'a str,
+    /// Used for positions without a user-provided annotation (function parameters,
+    /// tuple elements). Without it, those diagnostics are spanless and the cache
+    /// cannot attribute them to a module.
+    fallback_span: Option<Span>,
+    diagnostics: &'a mut Vec<LisetteDiagnostic>,
+}
+
+impl LeakCtx<'_> {
+    fn check(&mut self, ty: &Type, annotation: Option<&Annotation>) {
+        match ty {
+            Type::Nominal { id, params, .. } => {
+                if let Some(definition) = self.module.definitions.get(id.as_str())
+                    && definition.visibility() == &Visibility::Private
+                {
+                    let span = annotation.map(|ann| ann.get_span()).or(self.fallback_span);
+                    let type_name = unqualified_name(id);
+                    self.diagnostics
+                        .push(diagnostics::lint::private_type_in_public_api(
+                            span.as_ref(),
+                            type_name,
+                            self.public_definition,
+                        ));
+                }
+                for (i, param) in params.iter().enumerate() {
+                    let param_ann = annotation.and_then(|a| match a {
+                        Annotation::Constructor { params, .. } => params.get(i),
+                        _ => None,
+                    });
+                    self.check(param, param_ann);
+                }
             }
-            for (i, param) in params.iter().enumerate() {
-                let param_ann = annotation.and_then(|a| match a {
-                    Annotation::Constructor { params, .. } => params.get(i),
+            Type::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                let return_ann = match annotation {
+                    Some(Annotation::Function { return_type, .. }) => Some(return_type.as_ref()),
+                    Some(ann @ (Annotation::Constructor { .. } | Annotation::Tuple { .. })) => {
+                        Some(ann)
+                    }
+                    _ => None,
+                };
+                for param in params {
+                    self.check(param, None);
+                }
+                self.check(return_type, return_ann);
+            }
+            Type::Forall { body, .. } => {
+                self.check(body, annotation);
+            }
+            Type::Tuple(elements) => {
+                let element_annotations = annotation.and_then(|a| match a {
+                    Annotation::Tuple { elements, .. } => Some(elements),
                     _ => None,
                 });
-                check_type_for_private_leak(
-                    module,
-                    param,
-                    param_ann,
-                    public_definition,
-                    diagnostics,
-                );
-            }
-        }
-        Type::Function {
-            params,
-            return_type,
-            ..
-        } => match annotation {
-            Some(Annotation::Function {
-                return_type: ret_ann,
-                ..
-            }) => {
-                for param in params {
-                    check_type_for_private_leak(
-                        module,
-                        param,
-                        None,
-                        public_definition,
-                        diagnostics,
-                    );
+                for (i, element) in elements.iter().enumerate() {
+                    let element_annotation =
+                        element_annotations.and_then(|annotations| annotations.get(i));
+                    self.check(element, element_annotation);
                 }
-                check_type_for_private_leak(
-                    module,
-                    return_type,
-                    Some(ret_ann.as_ref()),
-                    public_definition,
-                    diagnostics,
-                );
             }
-            Some(ann @ (Annotation::Constructor { .. } | Annotation::Tuple { .. })) => {
-                for param in params {
-                    check_type_for_private_leak(
-                        module,
-                        param,
-                        None,
-                        public_definition,
-                        diagnostics,
-                    );
+            Type::Compound { args, .. } => {
+                for a in args {
+                    self.check(a, None);
                 }
-                check_type_for_private_leak(
-                    module,
-                    return_type,
-                    Some(ann),
-                    public_definition,
-                    diagnostics,
-                );
             }
-            _ => {
-                for param in params {
-                    check_type_for_private_leak(
-                        module,
-                        param,
-                        None,
-                        public_definition,
-                        diagnostics,
-                    );
-                }
-                check_type_for_private_leak(
-                    module,
-                    return_type,
-                    None,
-                    public_definition,
-                    diagnostics,
-                );
-            }
-        },
-        Type::Forall { body, .. } => {
-            check_type_for_private_leak(module, body, annotation, public_definition, diagnostics);
+            Type::Simple(_)
+            | Type::Var { .. }
+            | Type::Parameter(_)
+            | Type::Never
+            | Type::Error
+            | Type::ImportNamespace(_)
+            | Type::ReceiverPlaceholder => {}
         }
-        Type::Tuple(elements) => {
-            let element_annotations = annotation.and_then(|a| match a {
-                Annotation::Tuple { elements, .. } => Some(elements),
-                _ => None,
-            });
-            for (i, element) in elements.iter().enumerate() {
-                let element_annotation =
-                    element_annotations.and_then(|annotations| annotations.get(i));
-                check_type_for_private_leak(
-                    module,
-                    element,
-                    element_annotation,
-                    public_definition,
-                    diagnostics,
-                );
-            }
-        }
-        Type::Compound { args, .. } => {
-            for a in args {
-                check_type_for_private_leak(module, a, None, public_definition, diagnostics);
-            }
-        }
-        Type::Simple(_)
-        | Type::Var { .. }
-        | Type::Parameter(_)
-        | Type::Never
-        | Type::Error
-        | Type::ImportNamespace(_)
-        | Type::ReceiverPlaceholder => {}
     }
 }


### PR DESCRIPTION
`internal_type_leak` warnings emitted from function params or tuple elements had no source span, so the cache could not attribute them to a module and silently cached the module anyway. This fix gives the lint a fallback span, to correct caching behavior.