### PR TITLE
perf: emit nil for empty Slice literals

### DIFF
--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -58,16 +58,18 @@ impl Emitter<'_> {
         });
 
         let is_go_struct = Self::is_go_imported_type(ty);
-        let stages: Vec<EmittedExpression> = field_assignments
+        let kept = self.kept_struct_call_fields(field_assignments, spread, ty, is_go_struct);
+
+        let stages: Vec<EmittedExpression> = kept
             .iter()
             .map(|f| self.stage_composite(&f.value, ExpressionContext::value()))
             .collect();
         let emitted_values = self.sequence(output, stages, "_field");
         let mut field_names: Vec<String> = Vec::new();
         let mut field_values: Vec<String> = Vec::new();
-        for (fi, f) in field_assignments.iter().enumerate() {
+        for (slot, f) in kept.iter().enumerate() {
             let field_name = self.resolve_struct_call_field_name(&f.name, ty, &ctx);
-            let mut value = emitted_values[fi].clone();
+            let mut value = emitted_values[slot].clone();
             value = self.wrap_recursive_enum_field(output, value, f, &ctx);
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
@@ -119,6 +121,9 @@ impl Emitter<'_> {
                     self.lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned);
                 if let Some(unspecified) = unspecified {
                     for (field_name, field_ty) in unspecified {
+                        if field_ty.is_slice() {
+                            continue;
+                        }
                         let go_field_name =
                             self.resolve_struct_call_field_name(&field_name, ty, &ctx);
                         let zero = self.lisette_zero(&field_ty);
@@ -131,6 +136,37 @@ impl Emitter<'_> {
                 self.emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
             }
         }
+    }
+
+    /// Drop empty `Slice<T>` field assignments so Go's nil zero-value applies
+    /// instead of an `[]T{}` allocation. Skipped for Go-imported structs (the
+    /// Go API may distinguish nil from empty) and `From` spreads (the override
+    /// must still fire to clear the inherited value).
+    fn kept_struct_call_fields<'a>(
+        &self,
+        field_assignments: &'a [StructFieldAssignment],
+        spread: &StructSpread,
+        ty: &Type,
+        is_go_struct: bool,
+    ) -> Vec<&'a StructFieldAssignment> {
+        let can_omit_slices = !is_go_struct
+            && !matches!(spread, StructSpread::From(_))
+            && field_assignments
+                .iter()
+                .any(|f| f.value.is_empty_collection());
+        if !can_omit_slices {
+            return field_assignments.iter().collect();
+        }
+        field_assignments
+            .iter()
+            .filter(|f| {
+                !(f.value.is_empty_collection()
+                    && self
+                        .lookup_struct_field_ty(ty, &f.name)
+                        .as_ref()
+                        .is_some_and(Type::is_slice))
+            })
+            .collect()
     }
 
     /// Look up unspecified fields of a Lisette-defined struct or enum struct variant,
@@ -220,7 +256,7 @@ impl Emitter<'_> {
                         .first()
                         .map(|a| self.go_type_as_string(a))
                         .unwrap_or_else(|| "any".to_string());
-                    format!("[]{}{{}}", inner)
+                    format!("([]{})(nil)", inner)
                 }
                 CompoundKind::Map => {
                     let key = args
@@ -253,6 +289,7 @@ impl Emitter<'_> {
                     let go_ty = self.go_type_as_string(ty);
                     let pairs: Vec<(String, String)> = fields
                         .into_iter()
+                        .filter(|(_, field_ty)| !field_ty.is_slice())
                         .map(|(name, field_ty)| {
                             let go_name = if self.field_is_public(ty, &name) {
                                 go_name::make_exported(&name)

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -47,12 +47,6 @@ impl Emitter<'_> {
             }
             Literal::FormatString(parts) => self.emit_format_string(output, parts),
             Literal::Slice(elems) => {
-                let stages: Vec<EmittedExpression> = elems
-                    .iter()
-                    .map(|e| self.stage_composite(e, ExpressionContext::value()))
-                    .collect();
-                let elements = self.sequence(output, stages, "_v");
-
                 let elem_lisette_ty = ty
                     .get_type_params()
                     .expect("Slice type must have type args")
@@ -60,6 +54,19 @@ impl Emitter<'_> {
                     .expect("Slice type must have element type")
                     .clone();
                 let elem_ty = self.go_type_as_string(&elem_lisette_ty);
+
+                if elems.is_empty() {
+                    // Parens around the slice type disambiguate the conversion when
+                    // the element type itself ends in `)` (e.g. `func(int)`); Go
+                    // otherwise parses `[]func(int)(nil)` as a call expression.
+                    return format!("([]{})(nil)", elem_ty);
+                }
+
+                let stages: Vec<EmittedExpression> = elems
+                    .iter()
+                    .map(|e| self.stage_composite(e, ExpressionContext::value()))
+                    .collect();
+                let elements = self.sequence(output, stages, "_v");
 
                 let mut wrapped: Vec<String> = Vec::with_capacity(elements.len());
                 for (expr, emitted) in elems.iter().zip(elements) {

--- a/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
@@ -29,5 +29,5 @@ func (b Box[T]) String() string {
 }
 
 func Box_New[T any]() Box[T] {
-	return Box[T]{Items: []T{}}
+	return Box[T]{}
 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -296,7 +296,7 @@ fn test() -> Outer {
 }
 
 #[test]
-fn struct_zero_fill_lisette_slice_and_map_non_nil() {
+fn struct_zero_fill_lisette_slice_omitted_map_non_nil() {
     let input = r#"
 struct Conf { items: Slice<int>, lookup: Map<string, int> }
 

--- a/tests/spec/emit/literals.rs
+++ b/tests/spec/emit/literals.rs
@@ -151,6 +151,16 @@ fn test() {
 }
 
 #[test]
+fn empty_slice_of_function_type() {
+    let input = r#"
+fn test() {
+  let x: Slice<fn(int) -> int> = [];
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn hex_literal() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
@@ -11,7 +11,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	items := []int{}
+	items := ([]int)(nil)
 	_ = append(items, i, bump(&i))
 	_ = items
 }

--- a/tests/spec/emit/snapshots/double_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/double_newtype_slice_append.snap
@@ -19,6 +19,6 @@ func (b B) String() string {
 }
 
 func main() {
-	w := B(A([]int{}))
+	w := B(A(([]int)(nil)))
 	w = B(A(append([]int(A(w)), 1)))
 }

--- a/tests/spec/emit/snapshots/empty_slice.snap
+++ b/tests/spec/emit/snapshots/empty_slice.snap
@@ -5,5 +5,5 @@ description: "input: \nfn test() {\n  let x: Slice<int> = [];\n}\n"
 package main
 
 func test() {
-	_ = []int{}
+	_ = ([]int)(nil)
 }

--- a/tests/spec/emit/snapshots/empty_slice_of_function_type.snap
+++ b/tests/spec/emit/snapshots/empty_slice_of_function_type.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/emit/literals.rs
+description: "input: \nfn test() {\n  let x: Slice<fn(int) -> int> = [];\n}\n"
+---
+package main
+
+func test() {
+	_ = ([]func(int) int)(nil)
+}

--- a/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
@@ -15,7 +15,7 @@ func (s Stack[T]) String() string {
 }
 
 func Stack_new[T any]() Stack[T] {
-	return Stack[T]{items: []T{}}
+	return Stack[T]{}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
@@ -16,10 +16,7 @@ func (c Container[T]) String() string {
 }
 
 func Container_new[T any](name string) Container[T] {
-	return Container[T]{
-		items: []T{},
-		name:  name,
-	}
+	return Container[T]{name: name}
 }
 
 func test() Container[string] {

--- a/tests/spec/emit/snapshots/interop_array_return_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_call_arg.snap
@@ -11,7 +11,7 @@ func apply(f func([]uint8) []uint8, data []uint8) []uint8 {
 }
 
 func main() {
-	data := []uint8{}
+	data := ([]uint8)(nil)
 	out := apply(func(arg0 []byte) []byte {
 		arr_1 := sha256.Sum256(arg0)
 		return arr_1[:]

--- a/tests/spec/emit/snapshots/interop_array_return_explicit_return.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_explicit_return.snap
@@ -15,6 +15,6 @@ func get() func([]uint8) []uint8 {
 
 func main() {
 	f := get()
-	data := []uint8{}
+	data := ([]uint8)(nil)
 	_ = f(data)
 }

--- a/tests/spec/emit/snapshots/interop_array_return_if_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_if_assignment.snap
@@ -19,6 +19,6 @@ func main() {
 			return arr_2[:]
 		}
 	}
-	data := []uint8{}
+	data := ([]uint8)(nil)
 	_ = f(data)
 }

--- a/tests/spec/emit/snapshots/interop_array_return_if_tail.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_if_tail.snap
@@ -22,6 +22,6 @@ func get(cond bool) func([]uint8) []uint8 {
 
 func main() {
 	f := get(true)
-	data := []uint8{}
+	data := ([]uint8)(nil)
 	_ = f(data)
 }

--- a/tests/spec/emit/snapshots/interop_array_return_parenthesized_call.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_parenthesized_call.snap
@@ -7,7 +7,7 @@ package main
 import "crypto/sha256"
 
 func main() {
-	data := []uint8{}
+	data := ([]uint8)(nil)
 	arr_1 := sha256.Sum256(data)
 	out := arr_1[:]
 	_ = append(out, 1)

--- a/tests/spec/emit/snapshots/interop_result_slice_append.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_append.snap
@@ -9,7 +9,7 @@ import "strconv"
 type F func(string) (int, error)
 
 func main() {
-	xs := []F{}
+	xs := ([]F)(nil)
 	xs = append(xs, strconv.Atoi)
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
+++ b/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
@@ -7,5 +7,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
-	_ = []lisette.Option[int]{}
+	_ = ([]lisette.Option[int])(nil)
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	buckets := []aws.Bucket{}
+	buckets := ([]aws.Bucket)(nil)
 	for _, bucket := range buckets {
 		option_3 := lisette.OptionFromPointer[string](bucket.Name)
 		subject_1 := option_3

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -17,7 +17,7 @@ func main() {
 	if opt_1.Tag == lisette.OptionSome {
 		unwrap_2 = opt_1.SomeVal
 	}
-	src_3 := []lisette.Option[ast.Expr]{}
+	src_3 := ([]lisette.Option[ast.Expr])(nil)
 	unwrapped_4 := make([]ast.Expr, len(src_3))
 	for i_5, v_6 := range src_3 {
 		if v_6.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/map_entry_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append.snap
@@ -16,7 +16,7 @@ func (b Box) String() string {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{items: []int{}}
+	m["a"] = Box{}
 	entry := m["a"]
 	entry.items = append(entry.items, 1)
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -16,7 +16,7 @@ func (b Box) String() string {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{items: []int{}}
+	m["a"] = Box{}
 	r := &m
 	entry := (*r)["a"]
 	entry.items = append(entry.items, 1)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
@@ -20,7 +20,7 @@ func get_map(m map[string]Box) map[string]Box {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{items: []int{}}
+	m["a"] = Box{}
 	map_ := get_map(m)
 	entry := map_["a"]
 	entry.items = append(entry.items, 1)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
@@ -14,6 +14,6 @@ func (w Wrap) String() string {
 
 func main() {
 	m := make(map[string]Wrap)
-	m["a"] = Wrap([]int{})
+	m["a"] = Wrap(([]int)(nil))
 	m["a"] = Wrap(append([]int(m["a"]), 1))
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
@@ -22,7 +22,7 @@ func (w Wrap) String() string {
 
 func main() {
 	m := make(map[string]Wrap)
-	m["a"] = Wrap(Inner{items: []int{}})
+	m["a"] = Wrap(Inner{})
 	inner := Inner(m["a"])
 	inner.items = append(inner.items, 1)
 	m["a"] = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
@@ -18,7 +18,7 @@ func (w Wrap) String() string {
 func main() {
 	m := make(map[string]Wrap)
 	m["a"] = Wrap{
-		F0: []int{},
+		F0: ([]int)(nil),
 		F1: 0,
 	}
 	entry := m["a"]

--- a/tests/spec/emit/snapshots/recover_block_with_panic_never_type.snap
+++ b/tests/spec/emit/snapshots/recover_block_with_panic_never_type.snap
@@ -7,7 +7,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func panicky() int {
-	arr := []int{}
+	arr := ([]int)(nil)
 	return arr[0]
 }
 

--- a/tests/spec/emit/snapshots/struct_zero_fill_lisette_slice_omitted_map_non_nil.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_lisette_slice_omitted_map_non_nil.snap
@@ -16,8 +16,5 @@ func (c Conf) String() string {
 }
 
 func test() Conf {
-	return Conf{
-		items:  []int{},
-		lookup: map[string]int{},
-	}
+	return Conf{lookup: map[string]int{}}
 }

--- a/tests/spec/emit/snapshots/struct_zero_fill_nested_user_struct_recurses.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_nested_user_struct_recurses.snap
@@ -27,8 +27,5 @@ func (o Outer) String() string {
 }
 
 func test() Outer {
-	return Outer{inner: Inner{
-		opt:   lisette.MakeOptionNone[int](),
-		items: []int{},
-	}}
+	return Outer{inner: Inner{opt: lisette.MakeOptionNone[int]()}}
 }

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -7,7 +7,7 @@ package main
 func noop() {}
 
 func main() {
-	xs := []struct{}{}
+	xs := ([]struct{})(nil)
 	_arg_1 := xs
 	noop()
 	_ = append(_arg_1, struct{}{})

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -7,7 +7,7 @@ package main
 func noop() {}
 
 func test() {
-	xs := []struct{}{}
+	xs := ([]struct{})(nil)
 	_arg_1 := xs
 	noop()
 	_ = append(_arg_1, struct{}{})


### PR DESCRIPTION
Empty `Slice<T>` literals now emit as typed nil, and empty `Slice<T>` fields in struct literals are dropped so Go's nil zero value applies. One less allocation per call site.