### PR TITLE
fix: track go import usage during emit

### DIFF
--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -177,6 +177,7 @@ impl<'a, 'e> FallibleEmitter<'a, 'e> {
 
     /// Format the full type string (e.g., `lisette.Result[int, error]`).
     pub(crate) fn full_type_string(&mut self) -> String {
+        self.emitter.requirements.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
@@ -199,6 +200,7 @@ impl<'a, 'e> FallibleEmitter<'a, 'e> {
 
     /// Emit a success wrapper (MakeResultOk or MakeOptionSome).
     pub(crate) fn emit_success(&mut self, value: &str) -> String {
+        self.emitter.requirements.require_stdlib();
         let inner_ty = self.ok_type_string();
         let err_ty = self.err_type_string();
         self.fallible
@@ -207,6 +209,7 @@ impl<'a, 'e> FallibleEmitter<'a, 'e> {
 
     /// Emit a failure wrapper (MakeResultErr or MakeOptionNone).
     pub(crate) fn emit_failure(&mut self, error_value: Option<&str>) -> String {
+        self.emitter.requirements.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
@@ -228,6 +231,7 @@ impl<'a, 'e> FallibleEmitter<'a, 'e> {
         error_value: Option<&str>,
         return_ctx: &crate::ReturnContext,
     ) -> String {
+        self.emitter.requirements.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.contextual_ok_type_string(return_ctx);
         if self.fallible.is_result() {

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -196,8 +196,6 @@ impl Emitter<'_> {
             return true;
         }
 
-        self.requirements.require_stdlib();
-
         let lowered = return_ctx.lowered_shape();
 
         if let Expression::Identifier { .. } = expression
@@ -208,6 +206,7 @@ impl Emitter<'_> {
                 let line = abi_transition::format_lowered_none_return(self, shape, &return_ty);
                 write_line!(output, "{}", line);
             } else {
+                self.requirements.require_stdlib();
                 let mut fe = FallibleEmitter::new(self, &fallible);
                 let failure = fe.emit_failure(None);
                 write_line!(output, "return {}", failure);

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -40,6 +40,10 @@ impl Emitter<'_> {
             self.emit_coerced_expression(output, expression, receiver_coercion, ctx);
         let expression_ty = expression.get_type();
 
+        if let Some(module) = expression_ty.as_import_namespace() {
+            self.require_module_import(module);
+        }
+
         if let Some(s) = self.try_emit_tuple_member_dot(
             &expression_string,
             &expression_ty,
@@ -256,9 +260,8 @@ impl Emitter<'_> {
         is_import_namespace_ident
             || self.is_from_prelude(expression_ty)
             || if let Type::Nominal { id, .. } = expression_ty.strip_refs() {
-                id.split_once('.').is_some_and(|(m, _)| {
-                    !self.facts.is_current_module(m) && m != go_name::PRELUDE_MODULE
-                })
+                id.split_once('.')
+                    .is_some_and(|(m, _)| self.facts.is_foreign_module(m))
             } else {
                 false
             }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -336,20 +336,14 @@ impl Emitter<'_> {
         // not as the underlying "internal.Secret".
         if name.contains('.') && !is_prelude {
             let parts: Vec<&str> = name.split('.').collect();
-            let type_args = if let Type::Nominal { params, .. } = ty {
-                self.format_type_args(params)
-            } else {
-                String::new()
-            };
-
-            let pkg = self.go_pkg_qualifier(parts[0]);
-
-            if is_enum && parts.len() == 3 {
-                // Enum variant via type alias: "module.TypeAlias.Variant"
-                // Emit as "module.TypeAlias" (the variant fields are handled separately)
-                return format!("{}.{}{}", pkg, go_name::snake_to_camel(parts[1]), type_args);
-            } else if !is_enum && parts.len() == 2 {
-                // Cross-module struct reference
+            let emits_qualified = (is_enum && parts.len() == 3) || (!is_enum && parts.len() == 2);
+            if emits_qualified && !self.facts.is_current_module(parts[0]) {
+                let type_args = if let Type::Nominal { params, .. } = ty {
+                    self.format_type_args(params)
+                } else {
+                    String::new()
+                };
+                let pkg = self.require_module_import(parts[0]);
                 return format!("{}.{}{}", pkg, go_name::snake_to_camel(parts[1]), type_args);
             }
         }

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -8,7 +8,7 @@ use syntax::types::{Type, module_part, unqualified_name};
 impl Emitter<'_> {
     /// Emit a value enum variant as a Go constant (e.g., `reflect.String`).
     pub(crate) fn emit_value_enum_variant(
-        &self,
+        &mut self,
         expression: &Expression,
         member: &str,
     ) -> Option<String> {
@@ -27,7 +27,7 @@ impl Emitter<'_> {
 
         let module_key = go_name::module_of_type_id(&enum_id);
 
-        let qualifier = self.go_pkg_qualifier(module_key);
+        let qualifier = self.require_module_import(module_key);
 
         Some(format!("{}.{}", qualifier, member))
     }
@@ -124,7 +124,7 @@ impl Emitter<'_> {
                 }
                 format!("{}{}", resolved.name, type_args)
             } else {
-                let pkg = self.go_pkg_qualifier(enum_module);
+                let pkg = self.require_module_import(enum_module);
                 format!("{}.{}{}", pkg, make_fn_name, type_args)
             }
         } else {
@@ -321,7 +321,7 @@ impl Emitter<'_> {
             go_name::escape_keyword(member).into_owned()
         };
 
-        let pkg = self.go_pkg_qualifier(module_name);
+        let pkg = self.require_module_import(module_name);
         let go_type_name = go_name::snake_to_camel(type_name);
 
         // Extract type args from the receiver parameter

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -350,7 +350,7 @@ impl Emitter<'_> {
         Some(self.qualify_method_call(&type_id, method_name, is_public))
     }
 
-    fn try_classify_value_enum_variant(&self, name: &str, ty: &Type) -> Option<String> {
+    fn try_classify_value_enum_variant(&mut self, name: &str, ty: &Type) -> Option<String> {
         if !name.contains('.') {
             return None;
         }
@@ -366,7 +366,7 @@ impl Emitter<'_> {
 
         let variant_name = go_name::unqualified_name(name);
         let module = go_name::module_of_type_id(enum_id.as_str());
-        let qualifier = self.go_pkg_qualifier(module);
+        let qualifier = self.require_module_import(module);
 
         Some(format!("{}.{}", qualifier, variant_name))
     }

--- a/crates/emit/src/facts.rs
+++ b/crates/emit/src/facts.rs
@@ -137,6 +137,10 @@ impl<'a> EmitFacts<'a> {
         module == self.current_module.as_str()
     }
 
+    pub(crate) fn is_foreign_module(&self, module: &str) -> bool {
+        !self.is_current_module(module) && module != crate::names::go_name::PRELUDE_MODULE
+    }
+
     pub(crate) fn is_entry_module(&self, module: &str) -> bool {
         module == self.entry_module.as_str()
     }

--- a/crates/emit/src/imports.rs
+++ b/crates/emit/src/imports.rs
@@ -1,7 +1,6 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::go_name;
-use crate::utils::mask_go_string_literals;
 use diagnostics::{LisetteDiagnostic, emit as emit_diag};
 use ecow::EcoString;
 use syntax::ast::ImportAlias;
@@ -13,6 +12,7 @@ pub struct ImportBuilder<'a> {
     go_package_names: &'a HashMap<String, String>,
     imports: HashMap<String, String>,
     dropped_aliases: HashMap<String, String>,
+    used_modules: HashSet<String>,
 }
 
 impl<'a> ImportBuilder<'a> {
@@ -27,6 +27,7 @@ impl<'a> ImportBuilder<'a> {
             go_package_names,
             imports: HashMap::default(),
             dropped_aliases: HashMap::default(),
+            used_modules: HashSet::default(),
         }
     }
 
@@ -63,51 +64,24 @@ impl<'a> ImportBuilder<'a> {
                 .cloned()
                 .unwrap_or_default();
             self.imports.entry(module_id.clone()).or_insert(alias);
+            self.used_modules.insert(module_id.clone());
         }
     }
 
-    pub fn require_fmt(&mut self) {
-        self.imports.insert("fmt".to_string(), "fmt".to_string());
-    }
-
     pub fn require_stdlib(&mut self) {
-        self.imports.insert(
-            go_name::PRELUDE_IMPORT_PATH.to_string(),
-            "lisette".to_string(),
-        );
+        let path = go_name::PRELUDE_IMPORT_PATH;
+        self.imports.insert(path.to_string(), "lisette".to_string());
+        self.used_modules.insert(path.to_string());
     }
 
-    pub fn require_errors(&mut self) {
+    pub fn require_path(&mut self, path: &str) {
+        self.imports.insert(path.to_string(), path.to_string());
+        self.used_modules.insert(path.to_string());
+    }
+
+    pub fn filter_unused_imports(&mut self) {
         self.imports
-            .insert("errors".to_string(), "errors".to_string());
-    }
-
-    pub fn require_slices(&mut self) {
-        self.imports
-            .insert("slices".to_string(), "slices".to_string());
-    }
-
-    pub fn require_strings(&mut self) {
-        self.imports
-            .insert("strings".to_string(), "strings".to_string());
-    }
-
-    pub fn require_maps(&mut self) {
-        self.imports.insert("maps".to_string(), "maps".to_string());
-    }
-
-    /// This handles cases where a cross-module type alias resolves to a native
-    /// Go type, erasing the reference to the imported module.
-    pub fn filter_unreferenced(&mut self, source: &str) {
-        let masked = mask_go_string_literals(source);
-        self.imports.retain(|path, alias| {
-            if alias == "_" {
-                return true;
-            }
-            let escaped = go_name::escape_reserved(effective_package_name(path, alias));
-            let pattern = format!("{escaped}.");
-            masked.contains(&pattern)
-        });
+            .retain(|path, alias| alias == "_" || self.used_modules.contains(path));
     }
 
     pub fn build(self) -> (HashMap<String, String>, Vec<LisetteDiagnostic>) {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -497,8 +497,9 @@ impl<'a> Emitter<'a> {
 
             self.requirements.drain_into(&mut import_builder);
 
+            import_builder.filter_unused_imports();
+
             let rendered_source = source.render();
-            import_builder.filter_unreferenced(&rendered_source);
 
             let (imports, diagnostics) = import_builder.build();
             output_files.push(OutputFile {

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -87,8 +87,16 @@ impl Emitter<'_> {
 
     pub(crate) fn require_module_import(&mut self, module: &str) -> String {
         self.requirements
-            .require_go_import(self.facts.go_import_path(module));
+            .require_go_import(self.go_import_path_for_module(module));
         self.go_pkg_qualifier(module)
+    }
+
+    pub(crate) fn go_import_path_for_module(&self, module: &str) -> String {
+        let canonical = self.module.module_for_alias(module).unwrap_or(module);
+        match canonical.strip_prefix(go_name::GO_IMPORT_PREFIX) {
+            Some(rest) => rest.to_string(),
+            None => self.facts.go_import_path(canonical),
+        }
     }
 
     pub(crate) fn go_pkg_qualifier(&self, module: &str) -> String {
@@ -112,9 +120,7 @@ impl Emitter<'_> {
     ) -> String {
         let module = type_id.split_once('.').map(|(m, _)| m);
         let computed_alias = match module {
-            Some(m) if !self.facts.is_current_module(m) && m != go_name::PRELUDE_MODULE => {
-                Some(self.go_pkg_qualifier(m))
-            }
+            Some(m) if self.facts.is_foreign_module(m) => Some(self.require_module_import(m)),
             _ => None,
         };
         let resolved = go_name::qualify_method(
@@ -132,10 +138,8 @@ impl Emitter<'_> {
 
     pub(crate) fn resolve_variant(&mut self, identifier: &str, enum_id: &str) -> String {
         let enum_module = module_part(enum_id);
-        let computed_alias = if !self.facts.is_current_module(enum_module)
-            && enum_module != go_name::PRELUDE_MODULE
-        {
-            Some(self.go_pkg_qualifier(enum_module))
+        let computed_alias = if self.facts.is_foreign_module(enum_module) {
+            Some(self.require_module_import(enum_module))
         } else {
             None
         };

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -977,6 +977,9 @@ fn collect_enum_variant_checks(
         let go_literal = if qualifier.is_empty() || qualifier == emitter.facts.current_module() {
             variant_name.to_string()
         } else {
+            collector
+                .effects
+                .require_go_import(emitter.go_import_path_for_module(module));
             format!("{}.{}", qualifier, variant_name)
         };
         collector.checks.push(Check::Literal {
@@ -987,6 +990,13 @@ fn collect_enum_variant_checks(
     }
 
     if emitter.as_enum(ty).is_none() && identifier.contains('.') {
+        if let Some((module, _)) = identifier.split_once('.')
+            && emitter.facts.is_foreign_module(module)
+        {
+            collector
+                .effects
+                .require_go_import(emitter.go_import_path_for_module(module));
+        }
         collector.checks.push(Check::Literal {
             path: path.clone(),
             go_literal: identifier.to_string(),

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -282,7 +282,7 @@ impl Emitter<'_> {
             let mut field_types = FieldTypeMap::default();
             for (vi, variant) in variants.iter().enumerate() {
                 for (fi, field) in variant.fields.iter().enumerate() {
-                    let mut go_type = self.go_type_as_string(&field.ty);
+                    let mut go_type = self.go_type(&field.ty).code;
                     let recursive = Self::is_recursive_type(&field.ty, &enum_id);
 
                     if recursive {

--- a/crates/emit/src/requirements.rs
+++ b/crates/emit/src/requirements.rs
@@ -66,23 +66,19 @@ impl EmitRequirements {
     pub(crate) fn drain_into(&mut self, builder: &mut ImportBuilder) {
         let drained = std::mem::take(self);
         builder.extend_with_modules(&drained.go_imports);
-        if drained.flags.needs_fmt {
-            builder.require_fmt();
-        }
         if drained.flags.needs_stdlib {
             builder.require_stdlib();
         }
-        if drained.flags.needs_errors {
-            builder.require_errors();
-        }
-        if drained.flags.needs_slices {
-            builder.require_slices();
-        }
-        if drained.flags.needs_strings {
-            builder.require_strings();
-        }
-        if drained.flags.needs_maps {
-            builder.require_maps();
+        for (flag, path) in [
+            (drained.flags.needs_fmt, "fmt"),
+            (drained.flags.needs_errors, "errors"),
+            (drained.flags.needs_slices, "slices"),
+            (drained.flags.needs_strings, "strings"),
+            (drained.flags.needs_maps, "maps"),
+        ] {
+            if flag {
+                builder.require_path(path);
+            }
         }
     }
 }
@@ -102,6 +98,10 @@ pub(crate) struct EmitEffects {
 }
 
 impl EmitEffects {
+    pub(crate) fn require_go_import(&mut self, path: impl Into<String>) {
+        self.go_imports.push(path.into());
+    }
+
     pub(crate) fn merge_from_go_type(&mut self, go_type: &crate::types::go_type::GoType) {
         self.needs_stdlib |= go_type.needs_stdlib;
         self.go_imports.extend(go_type.go_imports.iter().cloned());

--- a/crates/emit/src/types/abi_transition.rs
+++ b/crates/emit/src/types/abi_transition.rs
@@ -71,6 +71,7 @@ pub(crate) fn emit_lowered_result_return(
     return_ty: &Type,
     shape: &AbiShape,
 ) {
+    emitter.requirements.require_stdlib();
     let ok_ty_str = match shape {
         AbiShape::ResultTuple | AbiShape::PartialTuple | AbiShape::CommaOk => {
             let ok_ty = emitter.facts.peel_alias(return_ty).ok_type();
@@ -200,12 +201,13 @@ pub(crate) fn emit_return_adapter(
     lisette_return_type: &Type,
 ) -> Option<(String, String)> {
     let return_type = lisette_return_type;
-    emitter.requirements.require_stdlib();
 
     if return_type.is_result() {
+        emitter.requirements.require_stdlib();
         return Some(emit_result_return_adapter(emitter, inner_call, return_type));
     }
     if return_type.is_partial() {
+        emitter.requirements.require_stdlib();
         return Some(emit_partial_return_adapter(
             emitter,
             inner_call,
@@ -213,9 +215,11 @@ pub(crate) fn emit_return_adapter(
         ));
     }
     if return_type.is_option() {
+        emitter.requirements.require_stdlib();
         return Some(emit_option_return_adapter(emitter, inner_call, return_type));
     }
     if return_type.tuple_arity().is_some_and(|n| n >= 2) {
+        emitter.requirements.require_stdlib();
         return emit_tuple_return_adapter(emitter, inner_call, return_type);
     }
     None
@@ -530,7 +534,6 @@ fn emit_lowered_partial_tail(
     } = expression
         && let Some(variant) = callee.as_partial_constructor()
     {
-        emitter.requirements.require_stdlib();
         match variant {
             "Ok" => {
                 let v = emitter.emit_composite_value(output, &args[0], ExpressionContext::value());

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -222,8 +222,7 @@ impl Emitter<'_> {
         }
 
         if let Some((module, _)) = qualified_name.split_once('.')
-            && !self.facts.is_current_module(module)
-            && module != go_name::PRELUDE_MODULE
+            && self.facts.is_foreign_module(module)
             && !go_name::is_go_import(module)
         {
             let go_path = self.facts.go_import_path(module);
@@ -322,11 +321,11 @@ impl Emitter<'_> {
 
         let escaped = go_name::escape_keyword(unqualified);
 
-        if self.facts.is_current_module(module) || module == go_name::PRELUDE_MODULE {
-            escaped.into_owned()
-        } else {
+        if self.facts.is_foreign_module(module) {
             let pkg = self.go_pkg_qualifier(module);
             format!("{}.{}", pkg, escaped)
+        } else {
+            escaped.into_owned()
         }
     }
 
@@ -519,13 +518,33 @@ impl Emitter<'_> {
             return result;
         }
 
+        let go_import = self.annotation_go_import(name);
+
         if params.is_empty() {
-            return GoType::new(base_name);
+            return match go_import {
+                Some(path) => GoType::with_go_import(base_name, path),
+                None => GoType::new(base_name),
+            };
         }
         let (param_types, type_params) = self.lower_annotation_params(params);
-        let mut result = GoType::new(format!("{}[{}]", base_name, type_params.join(", ")));
+        let code = format!("{}[{}]", base_name, type_params.join(", "));
+        let mut result = match go_import {
+            Some(path) => GoType::with_go_import(code, path),
+            None => GoType::new(code),
+        };
         result.merge_all(&param_types);
         result
+    }
+
+    fn annotation_go_import(&self, name: &str) -> Option<String> {
+        if let Some(rest) = name.strip_prefix(go_name::GO_IMPORT_PREFIX) {
+            return rest.rsplit_once('.').map(|(path, _)| path.to_string());
+        }
+        let (module, _) = name.split_once('.')?;
+        if !self.facts.is_foreign_module(module) {
+            return None;
+        }
+        Some(self.go_import_path_for_module(module))
     }
 
     /// Lower each annotation param to a `GoType`, returning both the full

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -397,3 +397,25 @@ pub type IntSlice = Slice<int>
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
 }
+
+#[test]
+fn import_filter_handles_apostrophe_in_doc_comments() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/lib"
+
+/// Doesn't do much.
+pub fn first() {
+  fmt.Println(lib.Value)
+}
+
+/// Doesn't do much either.
+pub fn second() {
+  fmt.Println("done")
+}
+"#;
+    let typedef = r#"
+pub const Value: int = 1
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
+}

--- a/tests/spec/emit/snapshots/import_filter_handles_apostrophe_in_doc_comments.snap
+++ b/tests/spec/emit/snapshots/import_filter_handles_apostrophe_in_doc_comments.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/imports.rs
+assertion_line: 420
+description: "input: \nimport \"go:fmt\"\nimport \"go:example.com/lib\"\n\n/// Doesn't do much.\npub fn first() {\n  fmt.Println(lib.Value)\n}\n\n/// Doesn't do much either.\npub fn second() {\n  fmt.Println(\"done\")\n}\n"
+---
+package main
+
+import (
+	"example.com/lib"
+	"fmt"
+)
+
+// Doesn't do much.
+func First() {
+	fmt.Println(lib.Value)
+}
+
+// Doesn't do much either.
+func Second() {
+	fmt.Println("done")
+}


### PR DESCRIPTION
The old import filter rendered the Go output, masked string literals, then substring-searched for `{alias}.` to decide which imports to keep. This masking treated the apostrophe inside a `// doesn't` doc comments as a rune opener, swallowing everything up to the next apostrophe and erasing `os.X` and `json.X` references.

The emitter now records every qualified `pkg.X` emission at the site that produces it, keeps a used modules set, and drops anything that was not recorded, so no masking is needed for imports anymore.

Fix #408