### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.6](https://github.com/ivov/lisette/compare/lisette-v0.2.5...lisette-v0.2.6) - 2026-05-16
+
+- fix: resolve dotted go import paths [#419](https://github.com/ivov/lisette/pull/419) [`d22fdfa`](https://github.com/ivov/lisette/commit/d22fdfaa0bc78850c07c0130769379999294042f)
+- fix: tighten bit-flag detection in bindgen [#418](https://github.com/ivov/lisette/pull/418) [`7a3c6fd`](https://github.com/ivov/lisette/commit/7a3c6fd20034195fb28d32175ba43b6cb2a0f306)
+- refactor: restore emit cosmetics [#416](https://github.com/ivov/lisette/pull/416) [`57f60eb`](https://github.com/ivov/lisette/commit/57f60ebda8ad332de8e77434f97620a4f44b0136)
+- fix: dedupe blank-import diagnostic [#415](https://github.com/ivov/lisette/pull/415) [`6aa882b`](https://github.com/ivov/lisette/commit/6aa882b04b58195f209113b23f151eaef1aed3eb)
+- refactor: drop last cosmetic emit cleanup pass [#414](https://github.com/ivov/lisette/pull/414) [`8e41a3a`](https://github.com/ivov/lisette/commit/8e41a3a9195374606918f872b6352e4bca8b2e0d)
+- refactor: drop four cosmetic emit cleanup passes [#413](https://github.com/ivov/lisette/pull/413) [`ed30007`](https://github.com/ivov/lisette/commit/ed300078ea67500655a10e7bfd5bfae205280b63)
+- refactor: ast-level emit negation and fmt collapse [#411](https://github.com/ivov/lisette/pull/411) [`f0b3966`](https://github.com/ivov/lisette/commit/f0b3966580b23a38cd536211f181bbe8286c06a2)
 ## [0.2.5](https://github.com/ivov/lisette/compare/lisette-v0.2.4...lisette-v0.2.5) - 2026-05-14
 
 - fix: track go import usage during emit [#410](https://github.com/ivov/lisette/pull/410) [`00d1b7a`](https://github.com/ivov/lisette/commit/00d1b7ab37daa2e0af24fb55e84622cb6e10a18c)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bincode",
  "ecow",
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.5", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.5", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.5", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.5", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.6", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.6", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.6", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.6", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.5", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.5", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.6", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.6", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.5", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.5", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.5", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.5", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.6 (upcoming)

- fix: resolve dotted go import paths [#419](https://github.com/ivov/lisette/pull/419) [`d22fdfa`](https://github.com/ivov/lisette/commit/d22fdfaa0bc78850c07c0130769379999294042f)
- fix: tighten bit-flag detection in bindgen [#418](https://github.com/ivov/lisette/pull/418) [`7a3c6fd`](https://github.com/ivov/lisette/commit/7a3c6fd20034195fb28d32175ba43b6cb2a0f306)
- refactor: restore emit cosmetics [#416](https://github.com/ivov/lisette/pull/416) [`57f60eb`](https://github.com/ivov/lisette/commit/57f60ebda8ad332de8e77434f97620a4f44b0136)
- fix: dedupe blank-import diagnostic [#415](https://github.com/ivov/lisette/pull/415) [`6aa882b`](https://github.com/ivov/lisette/commit/6aa882b04b58195f209113b23f151eaef1aed3eb)
- refactor: drop last cosmetic emit cleanup pass [#414](https://github.com/ivov/lisette/pull/414) [`8e41a3a`](https://github.com/ivov/lisette/commit/8e41a3a9195374606918f872b6352e4bca8b2e0d)
- refactor: drop four cosmetic emit cleanup passes [#413](https://github.com/ivov/lisette/pull/413) [`ed30007`](https://github.com/ivov/lisette/commit/ed300078ea67500655a10e7bfd5bfae205280b63)
- refactor: ast-level emit negation and fmt collapse [#411](https://github.com/ivov/lisette/pull/411) [`f0b3966`](https://github.com/ivov/lisette/commit/f0b3966580b23a38cd536211f181bbe8286c06a2)
