### PR TITLE
fix: dedupe blank-import diagnostic

### DIFF
--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -40,13 +40,18 @@ pub fn invalid_module_path(module_name: &str, span: Span) -> LisetteDiagnostic {
         )
 }
 
-pub fn missing_go_prefix(module_name: &str, span: Span) -> LisetteDiagnostic {
+pub fn missing_go_prefix(module_name: &str, span: Span, is_blank: bool) -> LisetteDiagnostic {
+    let suggestion = if is_blank {
+        format!("import _ \"go:{}\"", module_name)
+    } else {
+        format!("import \"go:{}\"", module_name)
+    };
     LisetteDiagnostic::error(format!("Invalid module path `{}`", module_name))
         .with_resolve_code("missing_go_prefix")
         .with_span_label(&span, "Go imports require the `go:` prefix")
         .with_help(format!(
-            "`{0}` is a declared Go dependency. Did you mean `import \"go:{0}\"`?",
-            module_name
+            "`{}` is a declared Go dependency. Did you mean `{}`?",
+            module_name, suggestion
         ))
 }
 

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -653,11 +653,7 @@ impl<'s> TaskState<'s> {
             }
             seen_paths.insert(import.name.to_string());
 
-            if let Some(ImportAlias::Blank(blank_span)) = &import.alias {
-                if !import.name.starts_with("go:") {
-                    self.sink
-                        .push(diagnostics::infer::blank_import_non_go(*blank_span));
-                }
+            if matches!(import.alias, Some(ImportAlias::Blank(_))) {
                 continue;
             }
 

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -313,18 +313,31 @@ fn process_file_imports(
             continue;
         }
 
-        if file_import.name.contains('.') {
-            if locator.is_declared_go_dep(&file_import.name) {
-                sink.push(diagnostics::module_graph::missing_go_prefix(
-                    &file_import.name,
-                    file_import.name_span,
-                ));
-            } else {
-                sink.push(diagnostics::module_graph::invalid_module_path(
-                    &file_import.name,
-                    file_import.name_span,
-                ));
-            }
+        let blank_span = match &file_import.alias {
+            Some(ImportAlias::Blank(span)) => Some(*span),
+            _ => None,
+        };
+        let is_dotted = file_import.name.contains('.');
+
+        if is_dotted && locator.is_declared_go_dep(&file_import.name) {
+            sink.push(diagnostics::module_graph::missing_go_prefix(
+                &file_import.name,
+                file_import.name_span,
+                blank_span.is_some(),
+            ));
+            continue;
+        }
+
+        if is_dotted {
+            sink.push(diagnostics::module_graph::invalid_module_path(
+                &file_import.name,
+                file_import.name_span,
+            ));
+        }
+        if let Some(span) = blank_span {
+            sink.push(diagnostics::infer::blank_import_non_go(span));
+        }
+        if is_dotted || blank_span.is_some() {
             continue;
         }
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -3888,6 +3888,95 @@ fn main() {}
 }
 
 #[test]
+fn declared_go_dep_blank_without_prefix_preserves_blank_in_suggestion() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"import _ "github.com/gin-gonic/gin"
+
+fn main() {}
+"#,
+    );
+
+    let result = compile_check_with_locator(
+        fs,
+        locator_with_go_dep("github.com/gin-gonic/gin", "v1.12.0"),
+    );
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(
+        result.errors[0].code_str(),
+        Some("resolve.missing_go_prefix")
+    );
+    let rendered = result.errors[0].plain_help().unwrap_or_default();
+    assert!(
+        rendered.contains("import _ \"go:github.com/gin-gonic/gin\""),
+        "expected blank-preserving suggestion in help, got: {}",
+        rendered
+    );
+}
+
+#[test]
+fn blank_import_of_project_module_emits_single_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("utils", "lib.lis", "pub fn helper() -> int { 42 }\n");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"import _ "utils"
+
+fn main() {}
+"#,
+    );
+
+    let result = compile_check(fs);
+    let blank_errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.code_str() == Some("resolve.blank_import_non_go"))
+        .collect();
+    assert_eq!(
+        blank_errors.len(),
+        1,
+        "expected single blank_import_non_go diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn undeclared_dotted_blank_import_reports_both_path_and_blank() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"import _ "github.com/some/other"
+
+fn main() {}
+"#,
+    );
+
+    let result = compile_check_with_locator(
+        fs,
+        locator_with_go_dep("github.com/gin-gonic/gin", "v1.12.0"),
+    );
+    let codes: Vec<_> = result.errors.iter().map(|e| e.code_str()).collect();
+    assert!(
+        codes.contains(&Some("resolve.invalid_module_path")),
+        "expected invalid_module_path, got: {:?}",
+        codes
+    );
+    let blank_count = codes
+        .iter()
+        .filter(|c| **c == Some("resolve.blank_import_non_go"))
+        .count();
+    assert_eq!(
+        blank_count, 1,
+        "expected exactly one blank_import_non_go, got codes: {:?}",
+        codes
+    );
+}
+
+#[test]
 fn undeclared_dotted_path_keeps_generic_diagnostic() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/ui/errors/snapshots/infer_duplicate_import_blank_after_named.snap
+++ b/tests/ui/errors/snapshots/infer_duplicate_import_blank_after_named.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/ui/errors/mod.rs
+assertion_line: 3887
 ---
-  [error] Duplicate import
-   ╭─[main.lis:3:10]
+  [error] Invalid import
+   ╭─[main.lis:3:8]
  2 │ import u "utils"
  3 │ import _ "utils"
-   ·          ───┬───
-   ·             ╰── already imported above
+   ·        ┬
+   ·        ╰── only allowed for Go modules
  4 │ 
    ╰────
-  help: Module `utils` is already imported. Remove the duplicate import · code: [resolve.duplicate_import]
+  help: Remove the underscore. Blank imports are allowed only for Go imports, because Lisette modules have no `init()` side effects · code: [resolve.blank_import_non_go]


### PR DESCRIPTION
`resolve.blank_import_non_go` no longer fires multiple times for the same import. Also, this diagnostic now accounts for a blank alias in its suggestion.
