### PR TITLE
refactor: restore emit cosmetics

### DIFF
--- a/crates/emit/src/bindings.rs
+++ b/crates/emit/src/bindings.rs
@@ -2,10 +2,38 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::escape_reserved;
 
+#[derive(Clone, Debug)]
+pub(crate) struct InlineExpr(String);
+
+impl InlineExpr {
+    pub(crate) fn new(text: impl Into<String>) -> Self {
+        Self(text.into())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum BindingValue {
+    GoName(String),
+    InlineExpr(InlineExpr),
+}
+
+impl BindingValue {
+    pub(crate) fn as_go_name(&self) -> Option<&str> {
+        match self {
+            BindingValue::GoName(name) => Some(name.as_str()),
+            BindingValue::InlineExpr(_) => None,
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct Bindings {
-    map: HashMap<String, String>,
-    stack: Vec<HashMap<String, String>>,
+    map: HashMap<String, BindingValue>,
+    stack: Vec<HashMap<String, BindingValue>>,
 }
 
 impl Bindings {
@@ -18,18 +46,35 @@ impl Bindings {
         self.stack.clear();
     }
 
-    pub(crate) fn add(&mut self, key: impl Into<String>, value: impl Into<String>) -> String {
+    pub(crate) fn bind_go_name(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> String {
         let go_value = escape_reserved(&value.into()).into_owned();
-        self.map.insert(key.into(), go_value.clone());
+        self.map
+            .insert(key.into(), BindingValue::GoName(go_value.clone()));
         go_value
     }
 
-    pub(crate) fn get(&self, name: &str) -> Option<&str> {
-        self.map.get(name).map(|s| s.as_str())
+    pub(crate) fn bind_inline_expr(&mut self, key: impl Into<String>, expression_text: InlineExpr) {
+        self.map
+            .insert(key.into(), BindingValue::InlineExpr(expression_text));
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&BindingValue> {
+        self.map.get(name)
+    }
+
+    pub(crate) fn get_go_name(&self, name: &str) -> Option<&str> {
+        self.map.get(name).and_then(BindingValue::as_go_name)
     }
 
     pub(crate) fn has_go_name(&self, go_name: &str) -> bool {
-        self.map.values().any(|v| v == go_name)
+        self.map
+            .values()
+            .filter_map(BindingValue::as_go_name)
+            .any(|v| v == go_name)
     }
 
     pub(crate) fn save(&mut self) {
@@ -42,11 +87,15 @@ impl Bindings {
         }
     }
 
-    pub(crate) fn snapshot(&self) -> HashMap<String, String> {
+    pub(crate) fn snapshot(&self) -> HashMap<String, BindingValue> {
         self.map.clone()
     }
 
-    pub(crate) fn restore_snapshot(&mut self, snapshot: HashMap<String, String>) {
+    pub(crate) fn restore_snapshot(&mut self, snapshot: HashMap<String, BindingValue>) {
         self.map = snapshot;
+    }
+
+    pub(crate) fn remove(&mut self, key: &str) {
+        self.map.remove(key);
     }
 }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -608,7 +608,7 @@ impl Emitter<'_> {
 
     fn is_local_binding(&self, function: &Expression) -> bool {
         if let Expression::Identifier { value, .. } = function {
-            self.scope.resolve_binding(value).is_some()
+            self.scope.resolve_identifier_binding(value).is_some()
         } else {
             false
         }

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -1,6 +1,8 @@
 mod nullable;
 mod wrappers;
 
+pub(crate) use wrappers::WrapperTarget;
+
 use crate::Emitter;
 use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
@@ -98,6 +100,45 @@ impl Emitter<'_> {
             }
             GoCallStrategy::Sentinel { value } => {
                 self.emit_go_sentinel_call_wrapped(output, expression, result_ty, *value)
+            }
+        }
+    }
+
+    /// Like `emit_go_wrapped_call` but writes into `target`. `None` for the
+    /// `Tuple` strategy (does not use the slot pattern).
+    pub(crate) fn emit_go_wrapped_call_to(
+        &mut self,
+        output: &mut String,
+        expression: &Expression,
+        strategy: &GoCallStrategy,
+        result_ty: &Type,
+        target: WrapperTarget<'_>,
+    ) -> Option<crate::calls::go_interop::wrappers::WrapperOutcome> {
+        use crate::expressions::context::ExpressionContext;
+        match strategy {
+            GoCallStrategy::Tuple { .. } => None,
+            GoCallStrategy::Result => {
+                let call_str = self.emit_call(output, expression, None, ExpressionContext::value());
+                self.requirements.require_stdlib();
+                Some(self.emit_result_wrapping(output, &call_str, result_ty, target))
+            }
+            GoCallStrategy::CommaOk => {
+                let call_str = self.emit_call(output, expression, None, ExpressionContext::value());
+                Some(self.emit_comma_ok_wrapping(output, &call_str, result_ty, true, target))
+            }
+            GoCallStrategy::NullableReturn => {
+                let call_str = self.emit_call(output, expression, None, ExpressionContext::value());
+                let raw_var = self.hoist_tmp_value(output, "raw", &call_str);
+                Some(self.emit_nil_check_option_wrap(output, &raw_var, result_ty, target))
+            }
+            GoCallStrategy::Partial => {
+                self.requirements.require_stdlib();
+                let call_str = self.emit_call(output, expression, None, ExpressionContext::value());
+                Some(self.emit_partial_wrapping(output, &call_str, result_ty, target))
+            }
+            GoCallStrategy::Sentinel { value } => {
+                let call_str = self.emit_call(output, expression, None, ExpressionContext::value());
+                Some(self.emit_sentinel_wrapping(output, &call_str, result_ty, *value, target))
             }
         }
     }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, write_leaf};
 use crate::control_flow::fallible::{Fallible, FallibleEmitter, OPTION_SOME_TAG};
 use crate::expressions::context::ExpressionContext;
 use crate::write_line;
@@ -13,7 +14,8 @@ impl Emitter<'_> {
         option_ty: &Type,
     ) -> String {
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
-        self.emit_comma_ok_wrapping(output, &call_str, option_ty, true)
+        self.emit_comma_ok_wrapping(output, &call_str, option_ty, true, WrapperTarget::FreshSlot)
+            .expect_slot()
     }
 
     pub(super) fn emit_go_sentinel_call_wrapped(
@@ -24,7 +26,14 @@ impl Emitter<'_> {
         sentinel: i64,
     ) -> String {
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
-        self.emit_sentinel_wrapping(output, &call_str, option_ty, sentinel)
+        self.emit_sentinel_wrapping(
+            output,
+            &call_str,
+            option_ty,
+            sentinel,
+            WrapperTarget::FreshSlot,
+        )
+        .expect_slot()
     }
 
     /// Capture the call's raw return into a temp, then reuse
@@ -35,22 +44,16 @@ impl Emitter<'_> {
         call_str: &str,
         option_ty: &Type,
         sentinel: i64,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         self.requirements.require_stdlib();
         let raw = self.hoist_tmp_value(output, "ret", call_str);
         let inner_ty_str = self.go_type_as_string(&option_ty.ok_type());
-        let option_var = self.fresh_var(Some("option"));
-        self.declare(&option_var);
-        write_line!(
-            output,
-            "{} := lisette.OptionFromCommaOk[{}]({}, {} != {})",
-            option_var,
-            inner_ty_str,
-            raw,
-            raw,
-            sentinel
+        let value_expr = format!(
+            "lisette.OptionFromCommaOk[{}]({}, {} != {})",
+            inner_ty_str, raw, raw, sentinel
         );
-        option_var
+        self.emit_simple_wrapper_value(output, target, "option", &value_expr)
     }
 
     /// Wrap a comma-ok-returning call into a tagged `Option`. `tuple_flattened`
@@ -62,7 +65,8 @@ impl Emitter<'_> {
         call_str: &str,
         option_ty: &Type,
         tuple_flattened: bool,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         self.requirements.require_stdlib();
 
         let inner_ty = option_ty.ok_type();
@@ -74,16 +78,8 @@ impl Emitter<'_> {
 
         if !needs_complex {
             let inner_ty_str = self.go_type_as_string(&inner_ty);
-            let option_var = self.fresh_var(Some("option"));
-            self.declare(&option_var);
-            write_line!(
-                output,
-                "{} := lisette.OptionFromCommaOk[{}]({})",
-                option_var,
-                inner_ty_str,
-                call_str
-            );
-            return option_var;
+            let value_expr = format!("lisette.OptionFromCommaOk[{}]({})", inner_ty_str, call_str);
+            return self.emit_simple_wrapper_value(output, target, "option", &value_expr);
         }
 
         let fallible = Fallible::from_type(option_ty).expect("Option type expected");
@@ -109,10 +105,10 @@ impl Emitter<'_> {
             val_vars[0].clone()
         };
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let option_ty_str = fe.full_type_string();
-        let option_var = fe.emitter.fresh_var(Some("option"));
-        fe.emitter.declare(&option_var);
+        let option_ty_str = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.full_type_string()
+        };
 
         let condition = if self.is_interface_option(option_ty) {
             format!("{} && !lisette.IsNilInterface({})", ok_var, val_vars[0])
@@ -121,22 +117,27 @@ impl Emitter<'_> {
         } else {
             ok_var.clone()
         };
-        write_line!(output, "var {} {}", option_var, option_ty_str);
+
+        let (sink, outcome) = self.open_wrapper_slot(output, target, &option_ty_str, "option");
         write_line!(output, "if {} {{", condition);
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let some_wrapper = fe.emit_success(&val_expression);
-        write_line!(output, "{} = {}", option_var, some_wrapper);
+        let some_wrapper = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.emit_success(&val_expression)
+        };
+        write_leaf(output, &sink, &some_wrapper);
 
         output.push_str("} else {\n");
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let none_wrapper = fe.emit_failure(None);
-        write_line!(output, "{} = {}", option_var, none_wrapper);
+        let none_wrapper = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.emit_failure(None)
+        };
+        write_leaf(output, &sink, &none_wrapper);
 
         output.push_str("}\n");
 
-        option_var
+        outcome
     }
 
     pub(crate) fn emit_nil_check_option_wrap(
@@ -144,7 +145,8 @@ impl Emitter<'_> {
         output: &mut String,
         raw_value: &str,
         option_ty: &Type,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         self.requirements.require_stdlib();
 
         let inner_ty = option_ty.ok_type();
@@ -154,17 +156,11 @@ impl Emitter<'_> {
         } else {
             format!("{} == nil", raw_value)
         };
-        let option_var = self.fresh_var(Some("option"));
-        self.declare(&option_var);
-        write_line!(
-            output,
-            "{} := lisette.OptionFromNilable[{}]({}, {})",
-            option_var,
-            inner_ty_str,
-            raw_value,
-            is_nil_check
+        let value_expr = format!(
+            "lisette.OptionFromNilable[{}]({}, {})",
+            inner_ty_str, raw_value, is_nil_check
         );
-        option_var
+        self.emit_simple_wrapper_value(output, target, "option", &value_expr)
     }
 
     pub(crate) fn emit_option_unwrap_to_nullable(
@@ -390,9 +386,8 @@ impl Emitter<'_> {
         option_ty: &Type,
     ) -> String {
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
-
         let raw_var = self.hoist_tmp_value(output, "raw", &call_str);
-
-        self.emit_nil_check_option_wrap(output, &raw_var, option_ty)
+        self.emit_nil_check_option_wrap(output, &raw_var, option_ty, WrapperTarget::FreshSlot)
+            .expect_slot()
     }
 }

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -11,6 +11,105 @@ use syntax::types::Type;
 
 use super::GoCallStrategy;
 
+#[derive(Clone, Copy)]
+pub(crate) enum WrapperTarget<'a> {
+    /// Allocate a fresh `var slot T` and write `slot = X` per branch.
+    FreshSlot,
+    /// Write `slot = X` per branch into the caller-provided slot name.
+    Slot(&'a str),
+    /// Emit `return X` per branch; caller skips its trailing return.
+    Return,
+}
+
+pub(crate) enum WrapperOutcome {
+    Slot(String),
+    Returned,
+}
+
+impl WrapperOutcome {
+    pub(crate) fn into_slot(self) -> Option<String> {
+        match self {
+            WrapperOutcome::Slot(s) => Some(s),
+            WrapperOutcome::Returned => None,
+        }
+    }
+
+    pub(crate) fn expect_slot(self) -> String {
+        match self {
+            WrapperOutcome::Slot(s) => s,
+            WrapperOutcome::Returned => unreachable!("expected slot, got Returned"),
+        }
+    }
+}
+
+pub(super) enum ResolvedSink {
+    Slot(String),
+    Return,
+}
+
+pub(super) fn write_leaf(output: &mut String, sink: &ResolvedSink, value: &str) {
+    match sink {
+        ResolvedSink::Slot(name) => write_line!(output, "{} = {}", name, value),
+        ResolvedSink::Return => write_line!(output, "return {}", value),
+    }
+}
+
+impl Emitter<'_> {
+    /// Prepare a wrapper sink: declare `var slot T` for slot targets, or
+    /// route writes to `return` for `Return`. Caller emits branches via
+    /// `write_leaf`.
+    pub(super) fn open_wrapper_slot(
+        &mut self,
+        output: &mut String,
+        target: WrapperTarget<'_>,
+        type_str: &str,
+        name_hint: &'static str,
+    ) -> (ResolvedSink, WrapperOutcome) {
+        match target {
+            WrapperTarget::FreshSlot => {
+                let var = self.fresh_var(Some(name_hint));
+                self.declare(&var);
+                write_line!(output, "var {} {}", var, type_str);
+                (ResolvedSink::Slot(var.clone()), WrapperOutcome::Slot(var))
+            }
+            WrapperTarget::Slot(name) => {
+                write_line!(output, "var {} {}", name, type_str);
+                self.declare(name);
+                let owned = name.to_string();
+                (
+                    ResolvedSink::Slot(owned.clone()),
+                    WrapperOutcome::Slot(owned),
+                )
+            }
+            WrapperTarget::Return => (ResolvedSink::Return, WrapperOutcome::Returned),
+        }
+    }
+
+    /// Emit `slot := <expr>` for slot targets or `return <expr>` for `Return`.
+    pub(super) fn emit_simple_wrapper_value(
+        &mut self,
+        output: &mut String,
+        target: WrapperTarget<'_>,
+        name_hint: &'static str,
+        value_expr: &str,
+    ) -> WrapperOutcome {
+        match target {
+            WrapperTarget::FreshSlot => {
+                WrapperOutcome::Slot(self.hoist_tmp_value(output, name_hint, value_expr))
+            }
+            WrapperTarget::Slot(name) => {
+                self.declare(name);
+                write_line!(output, "{} := {}", name, value_expr);
+                WrapperOutcome::Slot(name.to_string())
+            }
+            WrapperTarget::Return => {
+                write_line!(output, "return {}", value_expr);
+                WrapperOutcome::Returned
+            }
+        }
+    }
+}
+
 impl Emitter<'_> {
     pub(super) fn emit_go_tuple_call_wrapped(
         &mut self,
@@ -38,9 +137,9 @@ impl Emitter<'_> {
         partial_ty: &Type,
     ) -> String {
         self.requirements.require_stdlib();
-
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
-        self.emit_partial_wrapping(output, &call_str, partial_ty)
+        self.emit_partial_wrapping(output, &call_str, partial_ty, WrapperTarget::FreshSlot)
+            .expect_slot()
     }
 
     pub(crate) fn emit_partial_wrapping(
@@ -48,7 +147,8 @@ impl Emitter<'_> {
         output: &mut String,
         call_str: &str,
         partial_ty: &Type,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         let ok_ty = partial_ty.ok_type();
         let err_ty = partial_ty.err_type();
         let ok_ty_str = self.go_type_as_string(&ok_ty);
@@ -59,28 +159,26 @@ impl Emitter<'_> {
 
         let type_params = format!("{}, {}", ok_ty_str, err_ty_str);
         let result_ty_str = format!("{pkg}.Partial[{type_params}]");
-        let result_var = self.fresh_var(Some("result"));
-        self.declare(&result_var);
+        let (sink, outcome) = self.open_wrapper_slot(output, target, &result_ty_str, "result");
 
-        write_line!(output, "var {} {}", result_var, result_ty_str);
         write_line!(output, "if {} != nil {{", err_var);
-        write_line!(
+        write_leaf(
             output,
-            "{} = {PARTIAL_BOTH_CTOR}[{type_params}]({}, {})",
-            result_var,
-            val_var,
-            err_var
+            &sink,
+            &format!(
+                "{PARTIAL_BOTH_CTOR}[{type_params}]({}, {})",
+                val_var, err_var
+            ),
         );
         output.push_str("} else {\n");
-        write_line!(
+        write_leaf(
             output,
-            "{} = {PARTIAL_OK_CTOR}[{type_params}]({})",
-            result_var,
-            val_var
+            &sink,
+            &format!("{PARTIAL_OK_CTOR}[{type_params}]({})", val_var),
         );
         output.push_str("}\n");
 
-        result_var
+        outcome
     }
 
     pub(super) fn emit_go_result_call_wrapped(
@@ -90,9 +188,9 @@ impl Emitter<'_> {
         result_ty: &Type,
     ) -> String {
         self.requirements.require_stdlib();
-
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
-        self.emit_result_wrapping(output, &call_str, result_ty)
+        self.emit_result_wrapping(output, &call_str, result_ty, WrapperTarget::FreshSlot)
+            .expect_slot()
     }
 
     pub(crate) fn emit_result_wrapping(
@@ -100,20 +198,21 @@ impl Emitter<'_> {
         output: &mut String,
         call_str: &str,
         result_ty: &Type,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
 
         if fallible.ok_ty().is_unit() {
-            return self.emit_unit_result_wrapping(output, call_str, &fallible);
+            return self.emit_unit_result_wrapping(output, call_str, &fallible, target);
         }
 
         let ok_ty = fallible.ok_ty();
         let (err_var, ok_val) = self.extract_go_returns(output, call_str, ok_ty);
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let result_ty_str = fe.full_type_string();
-        let result_var = fe.emitter.fresh_var(Some("result"));
-        fe.emitter.declare(&result_var);
+        let result_ty_str = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.full_type_string()
+        };
 
         let interface_id = self.facts.as_interface(ok_ty);
         let needs_nil_guard = ok_ty.is_ref()
@@ -121,26 +220,31 @@ impl Emitter<'_> {
                 .as_deref()
                 .is_some_and(|id| id != go_name::PRELUDE_ERROR_ID);
 
-        write_line!(output, "var {} {}", result_var, result_ty_str);
+        let (sink, outcome) = self.open_wrapper_slot(output, target, &result_ty_str, "result");
+
         write_line!(output, "if {} != nil {{", err_var);
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let err_wrapper = fe.emit_failure(Some(&err_var));
-        write_line!(output, "{} = {}", result_var, err_wrapper);
+        let err_wrapper = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.emit_failure(Some(&err_var))
+        };
+        write_leaf(output, &sink, &err_wrapper);
 
         if needs_nil_guard {
-            self.emit_nil_guard(output, &ok_val, ok_ty, &result_var, &fallible);
+            self.emit_nil_guard(output, &ok_val, ok_ty, &sink, &fallible);
         }
 
         output.push_str("} else {\n");
 
-        let mut fe = FallibleEmitter::new(self, &fallible);
-        let ok_wrapper = fe.emit_success(&ok_val);
-        write_line!(output, "{} = {}", result_var, ok_wrapper);
+        let ok_wrapper = {
+            let mut fe = FallibleEmitter::new(self, &fallible);
+            fe.emit_success(&ok_val)
+        };
+        write_leaf(output, &sink, &ok_wrapper);
 
         output.push_str("}\n");
 
-        result_var
+        outcome
     }
 
     fn emit_unit_result_wrapping(
@@ -148,30 +252,36 @@ impl Emitter<'_> {
         output: &mut String,
         call_str: &str,
         fallible: &Fallible,
-    ) -> String {
+        target: WrapperTarget<'_>,
+    ) -> WrapperOutcome {
         let err_var = self.hoist_tmp_value(output, "ret", call_str);
 
-        let mut fe = FallibleEmitter::new(self, fallible);
-        let result_ty_str = fe.full_type_string();
-        let result_var = fe.emitter.fresh_var(Some("result"));
-        fe.emitter.declare(&result_var);
+        let result_ty_str = {
+            let mut fe = FallibleEmitter::new(self, fallible);
+            fe.full_type_string()
+        };
 
-        write_line!(output, "var {} {}", result_var, result_ty_str);
+        let (sink, outcome) = self.open_wrapper_slot(output, target, &result_ty_str, "result");
+
         write_line!(output, "if {} != nil {{", err_var);
 
-        let mut fe = FallibleEmitter::new(self, fallible);
-        let err_wrapper = fe.emit_failure(Some(&err_var));
-        write_line!(output, "{} = {}", result_var, err_wrapper);
+        let err_wrapper = {
+            let mut fe = FallibleEmitter::new(self, fallible);
+            fe.emit_failure(Some(&err_var))
+        };
+        write_leaf(output, &sink, &err_wrapper);
 
         output.push_str("} else {\n");
 
-        let mut fe = FallibleEmitter::new(self, fallible);
-        let ok_wrapper = fe.emit_success("struct{}{}");
-        write_line!(output, "{} = {}", result_var, ok_wrapper);
+        let ok_wrapper = {
+            let mut fe = FallibleEmitter::new(self, fallible);
+            fe.emit_success("struct{}{}")
+        };
+        write_leaf(output, &sink, &ok_wrapper);
 
         output.push_str("}\n");
 
-        result_var
+        outcome
     }
 
     /// Destructure a Go multi-return call into error and value variables.
@@ -205,7 +315,7 @@ impl Emitter<'_> {
         output: &mut String,
         ok_val: &str,
         ok_ty: &Type,
-        result_var: &str,
+        sink: &ResolvedSink,
         fallible: &Fallible,
     ) {
         let nil_check = if ok_ty.is_tuple() {
@@ -228,7 +338,7 @@ impl Emitter<'_> {
         self.requirements.require_errors();
         let mut fe = FallibleEmitter::new(self, fallible);
         let nil_err = fe.emit_failure(Some("errors.New(\"unexpected nil\")"));
-        write_line!(output, "{} = {}", result_var, nil_err);
+        write_leaf(output, sink, &nil_err);
     }
 
     pub(crate) fn classify_go_fn_value(&self, expression: &Expression) -> Option<GoCallStrategy> {
@@ -375,29 +485,50 @@ impl Emitter<'_> {
         let call_str = format!("{}({})", go_fn_str, arg_names.join(", "));
 
         let mut body = String::new();
-        let result_var = match strategy {
-            GoCallStrategy::Result => self.emit_result_wrapping(&mut body, &call_str, &return_type),
-            GoCallStrategy::CommaOk => {
-                self.emit_comma_ok_wrapping(&mut body, &call_str, &return_type, true)
+        let outcome = match strategy {
+            GoCallStrategy::Result => {
+                self.emit_result_wrapping(&mut body, &call_str, &return_type, WrapperTarget::Return)
             }
+            GoCallStrategy::CommaOk => self.emit_comma_ok_wrapping(
+                &mut body,
+                &call_str,
+                &return_type,
+                true,
+                WrapperTarget::Return,
+            ),
             GoCallStrategy::NullableReturn => {
                 let raw_var = self.hoist_tmp_value(&mut body, "raw", &call_str);
-                self.emit_nil_check_option_wrap(&mut body, &raw_var, &return_type)
+                self.emit_nil_check_option_wrap(
+                    &mut body,
+                    &raw_var,
+                    &return_type,
+                    WrapperTarget::Return,
+                )
             }
             GoCallStrategy::Tuple { arity } => {
                 let temp_vars = self.create_temp_vars("ret", *arity);
                 write_line!(body, "{} := {}", temp_vars.join(", "), call_str);
-                self.emit_tuple_from_vars(&mut body, &temp_vars, &return_type)
+                let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars, &return_type);
+                WrapperOutcome::Slot(tuple_str)
             }
-            GoCallStrategy::Partial => {
-                self.emit_partial_wrapping(&mut body, &call_str, &return_type)
-            }
-            GoCallStrategy::Sentinel { value } => {
-                self.emit_sentinel_wrapping(&mut body, &call_str, &return_type, *value)
-            }
+            GoCallStrategy::Partial => self.emit_partial_wrapping(
+                &mut body,
+                &call_str,
+                &return_type,
+                WrapperTarget::Return,
+            ),
+            GoCallStrategy::Sentinel { value } => self.emit_sentinel_wrapping(
+                &mut body,
+                &call_str,
+                &return_type,
+                *value,
+                WrapperTarget::Return,
+            ),
         };
 
-        write_line!(body, "return {}", result_var);
+        if let Some(result_var) = outcome.into_slot() {
+            write_line!(body, "return {}", result_var);
+        }
 
         format!(
             "func({}) {} {{\n{}}}",

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -14,7 +14,6 @@ struct WrappedReturnInfo<'a> {
     fallible: &'a Fallible,
     return_ty: &'a Type,
     lowered: Option<&'a AbiShape>,
-    return_ctx: &'a ReturnContext,
 }
 
 impl Emitter<'_> {
@@ -210,7 +209,6 @@ impl Emitter<'_> {
             fallible: &fallible,
             return_ty: &return_ty,
             lowered: lowered.as_ref(),
-            return_ctx,
         };
 
         if matches!(expression, Expression::Call { .. }) {
@@ -219,7 +217,7 @@ impl Emitter<'_> {
         }
 
         if matches!(expression, Expression::If { .. } | Expression::Match { .. }) {
-            self.emit_wrapped_branching_return(output, expression, info);
+            self.emit_branching_directly(output, expression, &BodyPlace::Return(return_ctx));
             return true;
         }
 
@@ -248,7 +246,6 @@ impl Emitter<'_> {
             fallible,
             return_ty,
             lowered,
-            return_ctx: _,
         } = info;
         let Expression::Call {
             expression: call_expression,
@@ -393,46 +390,6 @@ impl Emitter<'_> {
             return callee_shape == *enclosing_shape;
         }
         false
-    }
-
-    /// Lowered ABI pushes the return into each branch leaf; tagged ABI
-    /// builds a temp and returns it.
-    fn emit_wrapped_branching_return(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        info: WrappedReturnInfo<'_>,
-    ) {
-        let WrappedReturnInfo {
-            fallible,
-            return_ty,
-            lowered,
-            return_ctx,
-        } = info;
-        if lowered.is_some() {
-            self.emit_branching_directly(output, expression, &BodyPlace::Return(return_ctx));
-            return;
-        }
-
-        let temp_var = self.fresh_var(None);
-        self.declare(&temp_var);
-        let full_ty = {
-            let mut fe = FallibleEmitter::new(self, fallible);
-            fe.full_type_string()
-        };
-
-        write_line!(output, "var {} {}", temp_var, full_ty);
-
-        self.emit_branching_directly(
-            output,
-            expression,
-            &BodyPlace::Assign {
-                var: temp_var.clone(),
-                target_ty: Some(return_ty.clone()),
-            },
-        );
-
-        write_line!(output, "return {}", temp_var);
     }
 
     pub(crate) fn emit_try_block(

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -65,15 +65,6 @@ impl Emitter<'_> {
             self.hoist_tmp_value(output, "check", &expression_string)
         };
 
-        let (result_var, result_var_pre_declared) = match result_var_name {
-            Some(name) => (name.to_string(), self.is_declared(name)),
-            None => {
-                let v = self.fresh_var(Some("result"));
-                self.declare(&v);
-                (v, false)
-            }
-        };
-
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
 
         if let Some(shape) = return_ctx.lowered_shape() {
@@ -107,19 +98,21 @@ impl Emitter<'_> {
             );
         }
 
-        if result_var != "_" {
-            let op = if result_var_pre_declared { "=" } else { ":=" };
-            write_line!(
-                output,
-                "{} {} {}.{}",
-                result_var,
-                op,
-                check_var,
-                fallible.ok_field()
-            );
-        }
+        let ok_access = format!("{}.{}", check_var, fallible.ok_field());
 
-        result_var
+        match result_var_name {
+            None => ok_access,
+            Some("_") => "_".to_string(),
+            Some(name) => {
+                let pre_declared = self.is_declared(name);
+                let op = if pre_declared { "=" } else { ":=" };
+                write_line!(output, "{} {} {}", name, op, ok_access);
+                if !pre_declared {
+                    self.declare(name);
+                }
+                name.to_string()
+            }
+        }
     }
     pub(crate) fn emit_propagate_to_let(
         &mut self,

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
 use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
@@ -115,11 +116,11 @@ impl Emitter<'_> {
                     | Literal::Char(_)
             ),
             Expression::Identifier { value, .. } => {
-                let resolved = self
-                    .scope
-                    .resolve_binding(value.as_str())
-                    .unwrap_or(value.as_str());
-                self.is_go_const_binding(resolved)
+                match self.scope.resolve_identifier_binding(value.as_str()) {
+                    Some(BindingValue::GoName(name)) => self.is_go_const_binding(name),
+                    Some(BindingValue::InlineExpr(_)) => false,
+                    None => self.is_go_const_binding(value.as_str()),
+                }
             }
             Expression::Binary { left, right, .. } => {
                 self.is_go_const_eligible(left) && self.is_go_const_eligible(right)

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -1,6 +1,7 @@
 use syntax::program::DefinitionBody;
 
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::expressions::context::ExpressionContext;
 use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
@@ -28,6 +29,9 @@ impl Emitter<'_> {
         ty: &Type,
         ctx: ExpressionContext<'_>,
     ) -> String {
+        if let Some(BindingValue::InlineExpr(expr)) = self.scope.resolve_identifier_binding(value) {
+            return expr.as_str().to_string();
+        }
         match self.classify_identifier(value, ty, ctx) {
             IdentifierKind::UnitValue => "struct{}{}".to_string(),
             IdentifierKind::ValueEnumVariant { go_constant } => go_constant,
@@ -66,7 +70,7 @@ impl Emitter<'_> {
 
         let name = self
             .scope
-            .resolve_binding(value)
+            .resolve_binding_go_name(value)
             .unwrap_or(value)
             .to_string();
 
@@ -380,7 +384,7 @@ impl Emitter<'_> {
             return None;
         }
 
-        if self.scope.resolve_binding(name).is_some() {
+        if self.scope.resolve_identifier_binding(name).is_some() {
             return None;
         }
 

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -1,6 +1,7 @@
 use syntax::program::DefinitionBody;
 
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
 use crate::is_order_sensitive;
@@ -606,16 +607,19 @@ impl Emitter<'_> {
             Expression::Identifier { value, ty, .. }
                 if !matches!(ty.unwrap_forall(), Type::Function { .. }) =>
             {
-                if self.scope.resolve_binding(value).is_some() {
-                    return false;
-                }
-                if let Type::Nominal { id, .. } = ty {
-                    matches!(
-                        self.facts.definition(id.as_str()).map(|d| &d.body),
-                        Some(DefinitionBody::Enum { .. })
-                    )
-                } else {
-                    false
+                match self.scope.resolve_identifier_binding(value) {
+                    Some(BindingValue::GoName(_)) => false,
+                    Some(BindingValue::InlineExpr(_)) => true,
+                    None => {
+                        if let Type::Nominal { id, .. } = ty {
+                            matches!(
+                                self.facts.definition(id.as_str()).map(|d| &d.body),
+                                Some(DefinitionBody::Enum { .. })
+                            )
+                        } else {
+                            false
+                        }
+                    }
                 }
             }
 

--- a/crates/emit/src/inline_uses.rs
+++ b/crates/emit/src/inline_uses.rs
@@ -20,7 +20,10 @@ pub(crate) fn analyze_inline_candidate(
     walker.decide()
 }
 
-pub(crate) fn region_blocks_inline(trees: &[&Expression], lisette_name: &str) -> bool {
+pub(crate) fn region_blocks_inline<'a, I>(trees: I, lisette_name: &str) -> bool
+where
+    I: IntoIterator<Item = &'a Expression>,
+{
     let mut walker = Walker::new(lisette_name);
     for tree in trees {
         walker.walk(tree);

--- a/crates/emit/src/inline_uses.rs
+++ b/crates/emit/src/inline_uses.rs
@@ -1,0 +1,438 @@
+use syntax::ast::{Expression, SelectArmPattern};
+
+use crate::patterns::bindings::pattern_binds_name;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InlineDecision {
+    Inline,
+    Unused,
+    Keep,
+}
+
+pub(crate) fn analyze_inline_candidate(
+    lisette_name: &str,
+    consumers: &[&Expression],
+) -> InlineDecision {
+    let mut walker = Walker::new(lisette_name);
+    for consumer in consumers {
+        walker.walk(consumer);
+    }
+    walker.decide()
+}
+
+pub(crate) fn region_blocks_inline(trees: &[&Expression], lisette_name: &str) -> bool {
+    let mut walker = Walker::new(lisette_name);
+    for tree in trees {
+        walker.walk(tree);
+    }
+    walker.any_use_or_opacity()
+}
+
+struct Walker<'a> {
+    name: &'a str,
+    barriers_seen: u32,
+    inside_reference_operand: u32,
+    inside_assignment_target: u32,
+    enclosure_depth: u32,
+    shadow_depth: u32,
+    uses: Vec<UseRecord>,
+    opaque_raw_go_in_region: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UseRecord {
+    inside_reference_operand: bool,
+    inside_assignment_target: bool,
+    inside_enclosure: bool,
+    preceding_barriers: u32,
+}
+
+impl<'a> Walker<'a> {
+    fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            barriers_seen: 0,
+            inside_reference_operand: 0,
+            inside_assignment_target: 0,
+            enclosure_depth: 0,
+            shadow_depth: 0,
+            uses: Vec::new(),
+            opaque_raw_go_in_region: false,
+        }
+    }
+
+    fn any_use_or_opacity(&self) -> bool {
+        !self.uses.is_empty() || self.opaque_raw_go_in_region
+    }
+
+    fn decide(self) -> InlineDecision {
+        if self.uses.is_empty() {
+            if self.opaque_raw_go_in_region {
+                return InlineDecision::Keep;
+            }
+            return InlineDecision::Unused;
+        }
+        if self.opaque_raw_go_in_region {
+            return InlineDecision::Keep;
+        }
+        if self.uses.len() > 1 {
+            return InlineDecision::Keep;
+        }
+        let occ = self.uses[0];
+        if occ.inside_reference_operand
+            || occ.inside_assignment_target
+            || occ.inside_enclosure
+            || occ.preceding_barriers > 0
+        {
+            return InlineDecision::Keep;
+        }
+        InlineDecision::Inline
+    }
+
+    fn record_use(&mut self) {
+        self.uses.push(UseRecord {
+            inside_reference_operand: self.inside_reference_operand > 0,
+            inside_assignment_target: self.inside_assignment_target > 0,
+            inside_enclosure: self.enclosure_depth > 0,
+            preceding_barriers: self.barriers_seen,
+        });
+    }
+
+    fn walk(&mut self, expression: &Expression) {
+        if self.shadow_depth > 0 {
+            return;
+        }
+        match expression {
+            Expression::Identifier { value, .. } => {
+                if value.as_str() == self.name {
+                    self.record_use();
+                }
+            }
+            Expression::Literal { .. }
+            | Expression::Unit { .. }
+            | Expression::NoOp
+            | Expression::Break { value: None, .. }
+            | Expression::Continue { .. } => {}
+
+            Expression::Call {
+                expression: callee,
+                args,
+                spread,
+                ..
+            } => {
+                self.walk(callee);
+                for arg in args {
+                    self.walk(arg);
+                }
+                if let Some(spread_arg) = spread.as_ref() {
+                    self.walk(spread_arg);
+                }
+                self.barriers_seen += 1;
+            }
+            Expression::Propagate { expression, .. } => {
+                self.walk(expression);
+                self.barriers_seen += 1;
+            }
+            Expression::Assignment { target, value, .. } => {
+                self.inside_assignment_target += 1;
+                self.walk(target);
+                self.inside_assignment_target -= 1;
+                self.walk(value);
+                self.barriers_seen += 1;
+            }
+            Expression::Reference { expression, .. } => {
+                self.inside_reference_operand += 1;
+                self.walk(expression);
+                self.inside_reference_operand -= 1;
+            }
+
+            Expression::Block { items, .. } => {
+                self.walk_block(items);
+            }
+            Expression::Let {
+                binding,
+                value,
+                else_block,
+                ..
+            } => {
+                self.walk(value);
+                if let Some(else_b) = else_block {
+                    self.walk(else_b);
+                }
+                if pattern_binds_name(&binding.pattern, self.name) {
+                    self.shadow_depth += 1;
+                }
+            }
+
+            Expression::If {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
+                self.walk(condition);
+                self.walk(consequence);
+                self.walk(alternative);
+            }
+            Expression::IfLet {
+                pattern,
+                scrutinee,
+                consequence,
+                alternative,
+                ..
+            } => {
+                self.walk(scrutinee);
+                let shadow = pattern_binds_name(pattern, self.name);
+                if shadow {
+                    self.shadow_depth += 1;
+                }
+                self.walk(consequence);
+                if shadow {
+                    self.shadow_depth -= 1;
+                }
+                self.walk(alternative);
+            }
+            Expression::Match { subject, arms, .. } => {
+                self.walk(subject);
+                for arm in arms {
+                    let shadow = pattern_binds_name(&arm.pattern, self.name);
+                    if shadow {
+                        self.shadow_depth += 1;
+                    }
+                    if let Some(guard) = arm.guard.as_ref() {
+                        self.walk(guard);
+                    }
+                    self.walk(&arm.expression);
+                    if shadow {
+                        self.shadow_depth -= 1;
+                    }
+                }
+            }
+
+            Expression::Tuple { elements, .. } => {
+                for el in elements {
+                    self.walk(el);
+                }
+            }
+            Expression::StructCall {
+                field_assignments, ..
+            } => {
+                for fa in field_assignments {
+                    self.walk(&fa.value);
+                }
+            }
+            Expression::DotAccess { expression, .. } => self.walk(expression),
+            Expression::IndexedAccess {
+                expression, index, ..
+            } => {
+                self.walk(expression);
+                self.walk(index);
+            }
+            Expression::Binary { left, right, .. } => {
+                self.walk(left);
+                self.walk(right);
+            }
+            Expression::Unary { expression, .. } => self.walk(expression),
+            Expression::Paren { expression, .. } => self.walk(expression),
+            Expression::Cast { expression, .. } => self.walk(expression),
+            Expression::Range { start, end, .. } => {
+                if let Some(s) = start.as_ref() {
+                    self.walk(s);
+                }
+                if let Some(e) = end.as_ref() {
+                    self.walk(e);
+                }
+            }
+            Expression::Return { expression, .. } => self.walk(expression),
+            Expression::Break {
+                value: Some(value), ..
+            } => self.walk(value),
+
+            Expression::Loop { body, .. } => self.walk_in_enclosure(body),
+            Expression::While {
+                condition, body, ..
+            } => {
+                self.enclosure_depth += 1;
+                self.walk(condition);
+                self.walk(body);
+                self.enclosure_depth -= 1;
+            }
+            Expression::WhileLet {
+                pattern,
+                scrutinee,
+                body,
+                ..
+            } => {
+                self.enclosure_depth += 1;
+                self.walk(scrutinee);
+                let shadow = pattern_binds_name(pattern, self.name);
+                if shadow {
+                    self.shadow_depth += 1;
+                }
+                self.walk(body);
+                if shadow {
+                    self.shadow_depth -= 1;
+                }
+                self.enclosure_depth -= 1;
+            }
+            Expression::For {
+                binding,
+                iterable,
+                body,
+                ..
+            } => {
+                self.walk(iterable);
+                self.enclosure_depth += 1;
+                let shadow = pattern_binds_name(&binding.pattern, self.name);
+                if shadow {
+                    self.shadow_depth += 1;
+                }
+                self.walk(body);
+                if shadow {
+                    self.shadow_depth -= 1;
+                }
+                self.enclosure_depth -= 1;
+            }
+
+            Expression::Lambda { params, body, .. } | Expression::Function { params, body, .. } => {
+                self.enclosure_depth += 1;
+                let shadow = params
+                    .iter()
+                    .any(|p| pattern_binds_name(&p.pattern, self.name));
+                if shadow {
+                    self.shadow_depth += 1;
+                }
+                self.walk(body);
+                if shadow {
+                    self.shadow_depth -= 1;
+                }
+                self.enclosure_depth -= 1;
+            }
+            Expression::Task { expression, .. } => {
+                self.walk_in_enclosure(expression);
+                self.barriers_seen += 1;
+            }
+            Expression::Defer { expression, .. } => {
+                self.walk_in_enclosure(expression);
+                self.barriers_seen += 1;
+            }
+
+            Expression::Select { arms, .. } => {
+                // Select waits before dispatching to an arm body; mark the
+                // barrier before walking arms so any use inside any arm sees
+                // it as preceding. `walk_select_arm` additionally encloses
+                // each body to reject substitutions across the wait.
+                self.barriers_seen += 1;
+                for arm in arms {
+                    self.walk_select_arm(&arm.pattern);
+                }
+            }
+            Expression::TryBlock { items, .. } => {
+                self.walk_block(items);
+                self.barriers_seen += 1;
+            }
+            Expression::RecoverBlock { items, .. } => {
+                self.walk_block(items);
+                self.barriers_seen += 1;
+            }
+            Expression::RawGo { .. } => {
+                self.opaque_raw_go_in_region = true;
+                self.barriers_seen += 1;
+            }
+
+            // Block-local `Const`/`Function` shadowing is applied in `walk_block`.
+            Expression::Const { expression, .. } => self.walk(expression),
+            Expression::VariableDeclaration { .. } => {}
+
+            Expression::ImplBlock { methods, .. } => {
+                for m in methods {
+                    self.walk(m);
+                }
+            }
+
+            Expression::Enum { .. }
+            | Expression::ValueEnum { .. }
+            | Expression::Struct { .. }
+            | Expression::TypeAlias { .. }
+            | Expression::ModuleImport { .. }
+            | Expression::Interface { .. } => {}
+        }
+    }
+
+    fn walk_in_enclosure(&mut self, expression: &Expression) {
+        self.enclosure_depth += 1;
+        self.walk(expression);
+        self.enclosure_depth -= 1;
+    }
+
+    fn walk_block(&mut self, items: &[Expression]) {
+        let pre_shadow = self.shadow_depth;
+        let block_shadows: u32 = items
+            .iter()
+            .filter(|item| match item {
+                Expression::Const { identifier, .. } => identifier.as_str() == self.name,
+                Expression::Function { name, .. } => name.as_str() == self.name,
+                _ => false,
+            })
+            .count() as u32;
+        self.shadow_depth += block_shadows;
+        for item in items {
+            self.walk(item);
+        }
+        self.shadow_depth = pre_shadow;
+    }
+
+    // Select arm bodies run after the select has waited — treat them as
+    // enclosures so a substitution does not skip the wait.
+    fn walk_select_arm(&mut self, pattern: &SelectArmPattern) {
+        match pattern {
+            SelectArmPattern::Receive {
+                binding,
+                receive_expression,
+                body,
+                ..
+            } => {
+                self.walk(receive_expression);
+                let shadow = pattern_binds_name(binding, self.name);
+                if shadow {
+                    self.shadow_depth += 1;
+                }
+                self.walk_in_enclosure(body);
+                if shadow {
+                    self.shadow_depth -= 1;
+                }
+            }
+            SelectArmPattern::Send {
+                send_expression,
+                body,
+            } => {
+                self.walk(send_expression);
+                self.walk_in_enclosure(body);
+            }
+            SelectArmPattern::MatchReceive {
+                receive_expression,
+                arms,
+            } => {
+                self.walk(receive_expression);
+                self.enclosure_depth += 1;
+                for arm in arms {
+                    let shadow = pattern_binds_name(&arm.pattern, self.name);
+                    if shadow {
+                        self.shadow_depth += 1;
+                    }
+                    if let Some(guard) = arm.guard.as_ref() {
+                        self.walk(guard);
+                    }
+                    self.walk(&arm.expression);
+                    if shadow {
+                        self.shadow_depth -= 1;
+                    }
+                }
+                self.enclosure_depth -= 1;
+            }
+            SelectArmPattern::WildCard { body } => {
+                self.walk_in_enclosure(body);
+            }
+        }
+    }
+}

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -1,4 +1,4 @@
-mod bindings;
+pub(crate) mod bindings;
 pub(crate) mod calls;
 mod collectors;
 pub(crate) mod control_flow;
@@ -6,6 +6,7 @@ pub(crate) mod definitions;
 pub(crate) mod expressions;
 mod facts;
 pub mod imports;
+mod inline_uses;
 mod module_state;
 pub(crate) mod names;
 mod output;

--- a/crates/emit/src/patterns/bindings.rs
+++ b/crates/emit/src/patterns/bindings.rs
@@ -93,6 +93,26 @@ pub(crate) fn is_unconditional_catchall(pattern: &Pattern) -> bool {
     }
 }
 
+pub(crate) fn pattern_binds_name(pattern: &Pattern, name: &str) -> bool {
+    match pattern {
+        Pattern::Identifier { identifier, .. } => identifier == name,
+        Pattern::Tuple { elements, .. } => elements.iter().any(|e| pattern_binds_name(e, name)),
+        Pattern::EnumVariant { fields, .. } => fields.iter().any(|f| pattern_binds_name(f, name)),
+        Pattern::Struct { fields, .. } => fields.iter().any(|f| pattern_binds_name(&f.value, name)),
+        Pattern::Slice { prefix, rest, .. } => {
+            prefix.iter().any(|e| pattern_binds_name(e, name))
+                || matches!(rest, RestPattern::Bind { name: n, .. } if n == name)
+        }
+        Pattern::Or { patterns, .. } => patterns.iter().any(|p| pattern_binds_name(p, name)),
+        Pattern::AsBinding {
+            pattern,
+            name: as_name,
+            ..
+        } => as_name == name || pattern_binds_name(pattern, name),
+        Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => false,
+    }
+}
+
 impl Emitter<'_> {
     pub(crate) fn pattern_has_bindings(pattern: &Pattern) -> bool {
         match pattern {
@@ -108,34 +128,6 @@ impl Emitter<'_> {
             }
             Pattern::Or { patterns, .. } => patterns.iter().any(Self::pattern_has_bindings),
             Pattern::AsBinding { .. } => true,
-            Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => false,
-        }
-    }
-
-    pub(crate) fn pattern_binds_name(pattern: &Pattern, name: &str) -> bool {
-        match pattern {
-            Pattern::Identifier { identifier, .. } => identifier == name,
-            Pattern::Tuple { elements, .. } => {
-                elements.iter().any(|e| Self::pattern_binds_name(e, name))
-            }
-            Pattern::EnumVariant { fields, .. } => {
-                fields.iter().any(|f| Self::pattern_binds_name(f, name))
-            }
-            Pattern::Struct { fields, .. } => fields
-                .iter()
-                .any(|f| Self::pattern_binds_name(&f.value, name)),
-            Pattern::Slice { prefix, rest, .. } => {
-                prefix.iter().any(|e| Self::pattern_binds_name(e, name))
-                    || matches!(rest, RestPattern::Bind { name: n, .. } if n == name)
-            }
-            Pattern::Or { patterns, .. } => {
-                patterns.iter().any(|p| Self::pattern_binds_name(p, name))
-            }
-            Pattern::AsBinding {
-                pattern,
-                name: as_name,
-                ..
-            } => as_name == name || Self::pattern_binds_name(pattern, name),
             Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => false,
         }
     }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -82,6 +82,17 @@ impl AccessPath {
         }
         result
     }
+
+    /// Like `render`, but a tail-`Deref` is parenthesized so the result is
+    /// safe to embed as a selector receiver, index target, or call callee.
+    pub(crate) fn render_composable(&self, subject: &str) -> String {
+        let rendered = self.render(subject);
+        if matches!(self.segments.last(), Some(PathSegment::Deref)) {
+            format!("({})", rendered)
+        } else {
+            rendered
+        }
+    }
 }
 
 /// A single runtime check that must be true for a pattern to match.
@@ -1612,13 +1623,23 @@ pub(super) fn render_condition(checks: &[Check], subject_var: &str) -> String {
     conditions.join(" && ")
 }
 
-/// Emit bindings as Go `:=` declarations.
 pub(crate) fn emit_tree_bindings(
     emitter: &mut Emitter,
     output: &mut String,
     bindings: &[PatternBinding],
     subject_var: &str,
 ) {
+    emit_tree_bindings_with_consumers(emitter, output, bindings, subject_var, &[]);
+}
+
+pub(crate) fn emit_tree_bindings_with_consumers(
+    emitter: &mut Emitter,
+    output: &mut String,
+    bindings: &[PatternBinding],
+    subject_var: &str,
+    consumers: &[&syntax::ast::Expression],
+) -> Vec<(String, Option<crate::bindings::BindingValue>)> {
+    let mut installed_inlines = Vec::new();
     for binding in bindings {
         let Some(ref go_name) = binding.go_name else {
             emitter.scope.bind(&binding.lisette_name, "");
@@ -1626,6 +1647,23 @@ pub(crate) fn emit_tree_bindings(
         };
 
         let access_expression = binding.path.render(subject_var);
+
+        if !consumers.is_empty()
+            && crate::inline_uses::analyze_inline_candidate(&binding.lisette_name, consumers)
+                == crate::inline_uses::InlineDecision::Inline
+        {
+            let previous = emitter
+                .scope
+                .resolve_identifier_binding(&binding.lisette_name)
+                .cloned();
+            let safe_text = binding.path.render_composable(subject_var);
+            emitter.scope.bind_inline_expr(
+                &binding.lisette_name,
+                crate::bindings::InlineExpr::new(safe_text),
+            );
+            installed_inlines.push((binding.lisette_name.clone(), previous));
+            continue;
+        }
 
         if emitter.scope.has_binding_for_go_name(go_name) {
             let fresh = emitter.fresh_var(Some(&binding.lisette_name));
@@ -1641,6 +1679,26 @@ pub(crate) fn emit_tree_bindings(
                 emitter.scope.bind(&binding.lisette_name, &fresh);
                 emitter.try_declare(&fresh);
                 write_line!(output, "{} := {}", fresh, access_expression);
+            }
+        }
+    }
+    installed_inlines
+}
+
+pub(crate) fn drop_inline_overlays(
+    emitter: &mut Emitter,
+    installed: &[(String, Option<crate::bindings::BindingValue>)],
+) {
+    for (name, previous) in installed {
+        match previous {
+            Some(crate::bindings::BindingValue::GoName(go)) => {
+                emitter.scope.bind(name.as_str(), go.as_str());
+            }
+            Some(crate::bindings::BindingValue::InlineExpr(expr)) => {
+                emitter.scope.bind_inline_expr(name.as_str(), expr.clone());
+            }
+            None => {
+                emitter.scope.remove_binding(name);
             }
         }
     }
@@ -1660,8 +1718,9 @@ pub(super) fn emit_tree_assignments(
             continue;
         }
 
-        // Only assign to variables that were pre-declared
-        let Some(registered_name) = emitter.scope.resolve_binding(&binding.lisette_name) else {
+        // Only assign to variables that were pre-declared as Go names
+        let Some(registered_name) = emitter.scope.resolve_binding_go_name(&binding.lisette_name)
+        else {
             continue;
         };
         let name = registered_name.to_string();

--- a/crates/emit/src/patterns/emit_plan.rs
+++ b/crates/emit/src/patterns/emit_plan.rs
@@ -12,6 +12,7 @@ pub(crate) struct EmitBinding {
     pub lisette_name: String,
     pub go_name: Option<String>,
     pub rendered_access: String,
+    pub composable_access: String,
 }
 
 #[derive(Debug)]
@@ -284,6 +285,7 @@ fn lower_bindings(ctx: &mut LoweringCtx, bindings: &[PatternBinding]) -> Vec<Emi
             lisette_name: b.lisette_name.clone(),
             go_name: b.go_name.clone(),
             rendered_access: b.path.render(&ctx.current_subject),
+            composable_access: b.path.render_composable(&ctx.current_subject),
         })
         .collect()
 }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,9 +1,11 @@
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::expressions::context::ExpressionContext;
+use crate::patterns::bindings::pattern_binds_name;
 use crate::patterns::tree_emitter::TreeEmitter;
 use crate::placement::BodyPlace;
 use crate::types::abi::AbiShape;
-use crate::utils::DiscardGuard;
+use crate::utils::{DiscardGuard, ValueTempDiscard};
 use crate::write_line;
 use syntax::ast::{Expression, MatchArm, Pattern};
 
@@ -23,16 +25,20 @@ impl Emitter<'_> {
             return;
         }
         let subject_ty = subject.get_type();
-        let subject_var = self.emit_match_subject_var(output, subject, arms);
-        let guard = if matches!(subject, Expression::Literal { .. }) {
+        let (subject_var, value_guard) = self.emit_match_subject_var(output, subject, arms);
+        let plain_guard = if value_guard.is_some() || matches!(subject, Expression::Literal { .. })
+        {
             None
         } else {
             Some(DiscardGuard::new(output, &subject_var))
         };
         let tree_emitter = TreeEmitter::new(self, arms, subject_var, subject_ty);
         tree_emitter.emit(output, place);
-        if let Some(guard) = guard {
-            guard.finish(output);
+        if let Some(g) = value_guard {
+            g.finish(output);
+        }
+        if let Some(g) = plain_guard {
+            g.finish(output);
         }
     }
 
@@ -126,7 +132,7 @@ impl Emitter<'_> {
         output: &mut String,
         subject: &Expression,
         arms: &[MatchArm],
-    ) -> String {
+    ) -> (String, Option<ValueTempDiscard>) {
         let any_guard = arms.iter().any(|arm| arm.has_guard());
         if let Expression::Identifier { value, .. } = subject
             && !any_guard
@@ -134,20 +140,29 @@ impl Emitter<'_> {
             let name = value.to_string();
             let has_collision = arms
                 .iter()
-                .any(|arm| Emitter::pattern_binds_name(&arm.pattern, &name));
-            if !has_collision && !name.contains('.') {
-                return self.scope.resolve_or_escape(&name);
+                .any(|arm| pattern_binds_name(&arm.pattern, &name));
+            let bound_to_inline = matches!(
+                self.scope.resolve_identifier_binding(&name),
+                Some(BindingValue::InlineExpr(_))
+            );
+            if !has_collision && !name.contains('.') && !bound_to_inline {
+                return (self.scope.resolve_or_escape_go_name(&name), None);
             }
         }
         if matches!(subject, Expression::Literal { .. }) {
-            return self.emit_operand(output, subject, ExpressionContext::value());
+            return (
+                self.emit_operand(output, subject, ExpressionContext::value()),
+                None,
+            );
         }
         let var = self.fresh_var(Some("subject"));
         self.declare(&var);
         let subject_expression =
             self.emit_composite_value(output, subject, ExpressionContext::value());
+        let decl_start = output.len();
         write_line!(output, "{} := {}", var, subject_expression);
-        var
+        let guard = ValueTempDiscard::new(output, decl_start, &var, &subject_expression);
+        (var, Some(guard))
     }
 }
 

--- a/crates/emit/src/patterns/mod.rs
+++ b/crates/emit/src/patterns/mod.rs
@@ -1,4 +1,4 @@
-mod bindings;
+pub(crate) mod bindings;
 pub(crate) mod decision_tree;
 pub(crate) mod emit_plan;
 mod matching;

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -12,15 +12,18 @@ use syntax::ast::{Binding, Expression, MatchArm, Pattern, TypedPattern};
 use syntax::types::Type;
 
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
+use crate::patterns::bindings::pattern_binds_name;
 use crate::patterns::decision_tree::{
     self, apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
-    emit_tree_assignments, emit_tree_bindings, render_condition,
+    drop_inline_overlays, emit_tree_assignments, emit_tree_bindings,
+    emit_tree_bindings_with_consumers, render_condition,
 };
 use crate::placement::BodyPlace;
-use crate::utils::DiscardGuard;
+use crate::utils::{DiscardGuard, ValueTempDiscard};
 use crate::write_line;
 
 /// How a pattern's subject value reaches the site.
@@ -56,7 +59,7 @@ impl<'a> PatternSubject<'a> {
 
 struct ResolvedSubject {
     var: String,
-    guard: Option<DiscardGuard>,
+    guard: Option<ValueTempDiscard>,
 }
 
 impl Emitter<'_> {
@@ -74,16 +77,21 @@ impl Emitter<'_> {
             } => {
                 if let Expression::Identifier { value, .. } = scrutinee
                     && !value.contains('.')
-                    && !Self::pattern_binds_name(pattern, value)
+                    && !pattern_binds_name(pattern, value)
+                    && !matches!(
+                        self.scope.resolve_identifier_binding(value),
+                        Some(BindingValue::InlineExpr(_))
+                    )
                 {
-                    let var = self.scope.resolve_or_escape(value);
+                    let var = self.scope.resolve_or_escape_go_name(value);
                     return ResolvedSubject { var, guard: None };
                 }
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
                 let expression = self.emit_value(output, scrutinee, ExpressionContext::value());
+                let decl_start = output.len();
                 write_line!(output, "{} := {}", var, expression);
-                let guard = DiscardGuard::new(output, &var);
+                let guard = ValueTempDiscard::new(output, decl_start, &var, &expression);
                 ResolvedSubject {
                     var,
                     guard: Some(guard),
@@ -168,9 +176,13 @@ impl Emitter<'_> {
         output.push_str("for {\n");
 
         let inline_var = if let Expression::Identifier { value, .. } = scrutinee {
-            let has_collision = Self::pattern_binds_name(pattern, value);
-            if !has_collision && !value.contains('.') {
-                Some(self.scope.resolve_or_escape(value))
+            let has_collision = pattern_binds_name(pattern, value);
+            let bound_to_inline = matches!(
+                self.scope.resolve_identifier_binding(value),
+                Some(BindingValue::InlineExpr(_))
+            );
+            if !has_collision && !value.contains('.') && !bound_to_inline {
+                Some(self.scope.resolve_or_escape_go_name(value))
             } else {
                 None
             }
@@ -200,7 +212,7 @@ impl Emitter<'_> {
         self.enter_scope();
 
         if !matches!(pattern, Pattern::Or { .. }) {
-            emit_tree_bindings(self, output, &info.bindings, &effective);
+            emit_tree_bindings_with_consumers(self, output, &info.bindings, &effective, &[body]);
         }
 
         self.emit_block(output, body);
@@ -358,8 +370,10 @@ impl Emitter<'_> {
 
             self.emit_branch_header(output, &condition, false, i == 0);
 
-            emit_tree_bindings(self, output, &info.bindings, effective);
+            let overlays =
+                emit_tree_bindings_with_consumers(self, output, &info.bindings, effective, &[body]);
             self.emit_block(output, body);
+            drop_inline_overlays(self, &overlays);
         }
 
         self.emit_while_let_break_else(output);
@@ -440,14 +454,16 @@ impl Emitter<'_> {
         self.requirements.apply_effects(&info.effects);
         let (effective, ok_var) = apply_refutable_root_assertion(self, output, &info, subject_var);
         if info.checks.is_empty() && ok_var.is_none() {
-            emit_tree_bindings(self, output, &info.bindings, &effective);
+            emit_tree_bindings_with_consumers(self, output, &info.bindings, &effective, &[body]);
             self.emit_body_to_place(output, body, place);
             return;
         }
         let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
         write_line!(output, "if {} {{", condition);
-        emit_tree_bindings(self, output, &info.bindings, &effective);
+        let overlays =
+            emit_tree_bindings_with_consumers(self, output, &info.bindings, &effective, &[body]);
         self.emit_body_to_place(output, body, place);
+        drop_inline_overlays(self, &overlays);
         failure(self, output);
         output.push_str("}\n");
     }
@@ -532,7 +548,7 @@ impl Emitter<'_> {
                 let Some(go_name) = self.go_name_for_binding(pattern) else {
                     return ("_".to_string(), false);
                 };
-                if self.scope.resolve_binding(identifier).is_some() {
+                if self.scope.resolve_identifier_binding(identifier).is_some() {
                     return (self.fresh_var(Some("recv")), true);
                 }
                 (self.scope.bind(identifier, go_name), false)

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -150,16 +150,15 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
     ) {
         let emits_any_binding = plan.bindings.iter().any(|b| b.go_name.is_some());
         let needs_block = emits_any_binding || plan.pattern_has_collisions;
+        let arm_body = &*self.arms[plan.arm_index].expression;
 
         if needs_block {
             output.push_str("{\n");
             self.emitter.enter_scope();
         }
-
-        let arm_body = &*self.arms[plan.arm_index].expression;
-        self.emit_bindings(output, &plan.bindings, &[arm_body], None);
+        let inlines = self.emit_bindings(output, &plan.bindings, &[arm_body], None);
         self.emit_arm_body(output, plan.arm_index, place);
-
+        self.drop_inline_bindings(&inlines);
         if needs_block {
             self.emitter.exit_scope();
             output.push_str("}\n");
@@ -288,11 +287,11 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 ..
             } => {
                 let wrap = ctx.leaf_scope_explicit();
+                let arm_body = &*self.arms[*arm_index].expression;
                 if wrap {
                     output.push_str("{\n");
                     self.emitter.enter_scope();
                 }
-                let arm_body = &*self.arms[*arm_index].expression;
                 let inlines = self.emit_bindings(output, bindings, &[arm_body], None);
                 self.emit_arm_body(output, *arm_index, ctx.arm_place);
                 self.apply_leaf_terminator(output, ctx);
@@ -739,7 +738,9 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
         if analyze_inline_candidate(lisette_name, consumers) != InlineDecision::Inline {
             return false;
         }
-        if !failure_trees.is_empty() && region_blocks_inline(failure_trees, lisette_name) {
+        if !failure_trees.is_empty()
+            && region_blocks_inline(failure_trees.iter().copied(), lisette_name)
+        {
             return false;
         }
         self.emitter

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1,10 +1,14 @@
-use syntax::ast::MatchArm;
+use syntax::ast::{Expression, MatchArm};
 use syntax::types::Type;
 
 use crate::Emitter;
+use crate::bindings::{BindingValue, InlineExpr};
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::expressions::context::ExpressionContext;
-use crate::patterns::decision_tree::{Decision, compile_expanded_arms, expand_or_patterns};
+use crate::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
+use crate::patterns::decision_tree::{
+    Decision, compile_expanded_arms, drop_inline_overlays, expand_or_patterns,
+};
 use crate::patterns::emit_plan::{
     ChainPlan, EmitBinding, EmitCase, EmitChainTest, EmitDecision, MatchEmitPlan, RetryLoopPlan,
     SingleCatchallPlan, is_empty_emit_decision, lower_match,
@@ -152,7 +156,8 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
             self.emitter.enter_scope();
         }
 
-        self.emit_bindings(output, &plan.bindings);
+        let arm_body = &*self.arms[plan.arm_index].expression;
+        self.emit_bindings(output, &plan.bindings, &[arm_body], None);
         self.emit_arm_body(output, plan.arm_index, place);
 
         if needs_block {
@@ -178,8 +183,10 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 bindings,
                 ..
             } => {
-                self.emit_bindings(output, bindings);
+                let arm_body = &*self.arms[*arm_index].expression;
+                let inlines = self.emit_bindings(output, bindings, &[arm_body], None);
                 self.emit_arm_body(output, *arm_index, place);
+                self.drop_inline_bindings(&inlines);
             }
             EmitDecision::Chain {
                 tests,
@@ -285,9 +292,11 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                     output.push_str("{\n");
                     self.emitter.enter_scope();
                 }
-                self.emit_bindings(output, bindings);
+                let arm_body = &*self.arms[*arm_index].expression;
+                let inlines = self.emit_bindings(output, bindings, &[arm_body], None);
                 self.emit_arm_body(output, *arm_index, ctx.arm_place);
                 self.apply_leaf_terminator(output, ctx);
+                self.drop_inline_bindings(&inlines);
                 if wrap {
                     self.emitter.exit_scope();
                     output.push_str("}\n");
@@ -304,15 +313,26 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                     output.push_str("{\n");
                     self.emitter.enter_scope();
                 }
-                self.emit_bindings(output, bindings);
+                let arm = &self.arms[*arm_index];
+                let arm_guard = arm.guard.as_deref();
+                let arm_body = &*arm.expression;
+                let mut guard_consumers: Vec<&Expression> = Vec::with_capacity(2);
+                if let Some(g) = arm_guard {
+                    guard_consumers.push(g);
+                }
+                guard_consumers.push(arm_body);
+                let inlines = self.emit_bindings(output, bindings, &guard_consumers, Some(failure));
                 if self.emit_guard_header(output, *arm_index) {
                     self.walk(output, success, &ctx.nested());
                     self.emitter.exit_scope();
+                    self.drop_inline_bindings(&inlines);
                     if ctx.role == WalkRole::SwitchCase {
                         self.walk_else_or_flat(output, failure, ctx);
                     } else {
                         output.push_str("}\n");
                     }
+                } else {
+                    self.drop_inline_bindings(&inlines);
                 }
                 if needs_pre_scope {
                     self.emitter.exit_scope();
@@ -557,11 +577,33 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
         tests: &[EmitChainTest],
         ctx: &WalkCtx,
     ) {
+        let mut inlines: Vec<(String, Option<BindingValue>)> = Vec::new();
         if let Some(&ref_idx) = indices
             .iter()
             .find(|&&idx| !decision_top_bindings(&tests[idx].decision).is_empty())
         {
-            self.emit_bindings(output, decision_top_bindings(&tests[ref_idx].decision));
+            let mut consumers: Vec<&Expression> = Vec::new();
+            for &idx in indices {
+                let decision = &*tests[idx].decision;
+                let arm_index = match decision {
+                    EmitDecision::Success { arm_index, .. }
+                    | EmitDecision::Guard { arm_index, .. } => Some(*arm_index),
+                    _ => None,
+                };
+                if let Some(arm_index) = arm_index {
+                    let arm = &self.arms[arm_index];
+                    if let Some(g) = arm.guard.as_deref() {
+                        consumers.push(g);
+                    }
+                    consumers.push(&arm.expression);
+                }
+            }
+            inlines = self.emit_bindings(
+                output,
+                decision_top_bindings(&tests[ref_idx].decision),
+                &consumers,
+                None,
+            );
         }
         for &test_idx in indices {
             match &*tests[test_idx].decision {
@@ -580,6 +622,7 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 _ => self.walk(output, &tests[test_idx].decision, ctx),
             }
         }
+        self.drop_inline_bindings(&inlines);
     }
 
     fn emit_chain_group_per_test(
@@ -605,13 +648,57 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
         }
     }
 
-    fn emit_bindings(&mut self, output: &mut String, bindings: &[EmitBinding]) {
+    /// Returns the per-name (Lisette name, previous binding) pairs that were
+    /// replaced by an inline substitution. Pass to `drop_inline_bindings` to
+    /// roll back exactly the inline overlays without affecting Go-name
+    /// bindings emitted in the same call.
+    fn emit_bindings(
+        &mut self,
+        output: &mut String,
+        bindings: &[EmitBinding],
+        consumers: &[&Expression],
+        failure_blocker: Option<&EmitDecision>,
+    ) -> Vec<(String, Option<BindingValue>)> {
+        let failure_trees: Vec<&Expression> = match failure_blocker {
+            Some(failure) => {
+                let mut reached: Vec<usize> = Vec::new();
+                collect_reachable_arms(failure, &mut reached);
+                let mut trees: Vec<&Expression> = Vec::with_capacity(reached.len() * 2);
+                for idx in reached {
+                    let arm = &self.arms[idx];
+                    if let Some(guard) = arm.guard.as_ref() {
+                        trees.push(guard);
+                    }
+                    trees.push(&arm.expression);
+                }
+                trees
+            }
+            None => Vec::new(),
+        };
+
+        let mut installed_inlines: Vec<(String, Option<BindingValue>)> = Vec::new();
         for binding in bindings {
             let Some(ref go_name) = binding.go_name else {
                 self.emitter.scope.bind(&binding.lisette_name, "");
                 continue;
             };
             let access_expression = &binding.rendered_access;
+
+            let previous = self
+                .emitter
+                .scope
+                .resolve_identifier_binding(&binding.lisette_name)
+                .cloned();
+            if self.try_inline_binding(
+                &binding.lisette_name,
+                &binding.composable_access,
+                consumers,
+                &failure_trees,
+            ) {
+                installed_inlines.push((binding.lisette_name.clone(), previous));
+                continue;
+            }
+
             if self.emitter.scope.has_binding_for_go_name(go_name) {
                 let fresh = self.emitter.fresh_var(Some(&binding.lisette_name));
                 self.emitter.scope.bind(&binding.lisette_name, &fresh);
@@ -632,6 +719,33 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 }
             }
         }
+        installed_inlines
+    }
+
+    fn drop_inline_bindings(&mut self, installed: &[(String, Option<BindingValue>)]) {
+        drop_inline_overlays(self.emitter, installed);
+    }
+
+    fn try_inline_binding(
+        &mut self,
+        lisette_name: &str,
+        composable_access: &str,
+        consumers: &[&Expression],
+        failure_trees: &[&Expression],
+    ) -> bool {
+        if consumers.is_empty() {
+            return false;
+        }
+        if analyze_inline_candidate(lisette_name, consumers) != InlineDecision::Inline {
+            return false;
+        }
+        if !failure_trees.is_empty() && region_blocks_inline(failure_trees, lisette_name) {
+            return false;
+        }
+        self.emitter
+            .scope
+            .bind_inline_expr(lisette_name, InlineExpr::new(composable_access));
+        true
     }
 
     fn emit_arm_body(&mut self, output: &mut String, arm_index: usize, place: &BodyPlace) {
@@ -662,6 +776,57 @@ fn decision_top_bindings(decision: &EmitDecision) -> &[EmitBinding] {
     match decision {
         EmitDecision::Guard { bindings, .. } | EmitDecision::Success { bindings, .. } => bindings,
         _ => &[],
+    }
+}
+
+fn collect_reachable_arms(decision: &EmitDecision, out: &mut Vec<usize>) {
+    match decision {
+        EmitDecision::Success { arm_index, .. } => {
+            if !out.contains(arm_index) {
+                out.push(*arm_index);
+            }
+        }
+        EmitDecision::Guard {
+            arm_index,
+            success,
+            failure,
+            ..
+        } => {
+            if !out.contains(arm_index) {
+                out.push(*arm_index);
+            }
+            collect_reachable_arms(success, out);
+            collect_reachable_arms(failure, out);
+        }
+        EmitDecision::IfElse {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_reachable_arms(then_branch, out);
+            if let Some(else_b) = else_branch.as_deref() {
+                collect_reachable_arms(else_b, out);
+            }
+        }
+        EmitDecision::InlineBranch { branch } => collect_reachable_arms(branch, out),
+        EmitDecision::Switch { cases, default, .. }
+        | EmitDecision::TypeSwitch { cases, default, .. } => {
+            for c in cases {
+                collect_reachable_arms(&c.decision, out);
+            }
+            if let Some(d) = default.as_deref() {
+                collect_reachable_arms(d, out);
+            }
+        }
+        EmitDecision::Chain {
+            tests, fallback, ..
+        } => {
+            for t in tests {
+                collect_reachable_arms(&t.decision, out);
+            }
+            collect_reachable_arms(fallback, out);
+        }
+        EmitDecision::Unreachable => {}
     }
 }
 

--- a/crates/emit/src/placement.rs
+++ b/crates/emit/src/placement.rs
@@ -102,6 +102,55 @@ fn requires_temp_var(expression: &Expression) -> bool {
     )
 }
 
+/// Match `…; let X = <CF>; X` so the caller can emit `<CF>` directly into
+/// the surrounding place, skipping the `X` materialization.
+fn try_elide_tail_let(items: &[Expression]) -> Option<(&Expression, &[Expression])> {
+    if items.len() < 2 {
+        return None;
+    }
+    let last = items.last()?;
+    let Expression::Identifier {
+        value: tail_name, ..
+    } = last
+    else {
+        return None;
+    };
+    let penultimate = &items[items.len() - 2];
+    let Expression::Let {
+        binding,
+        value,
+        else_block,
+        mutable,
+        ..
+    } = penultimate
+    else {
+        return None;
+    };
+    if else_block.is_some() || *mutable {
+        return None;
+    }
+    let syntax::ast::Pattern::Identifier { identifier, .. } = &binding.pattern else {
+        return None;
+    };
+    if identifier != tail_name {
+        return None;
+    }
+    // Only `If` and `Match` can be re-emitted at the surrounding place via
+    // `emit_branching_directly`; other shapes still stage through temps so
+    // eliding the let would not save anything.
+    if !matches!(
+        value.as_ref(),
+        Expression::If { .. } | Expression::Match { .. }
+    ) {
+        return None;
+    }
+    let rest = &items[..items.len() - 2];
+    if crate::inline_uses::region_blocks_inline(rest.iter(), tail_name.as_str()) {
+        return None;
+    }
+    Some((value.as_ref(), rest))
+}
+
 fn needs_explicit_type_declaration(
     emitter: &Emitter,
     value: &Expression,
@@ -711,7 +760,7 @@ impl Emitter<'_> {
             std::slice::from_ref(expression)
         };
 
-        let Some((last, rest)) = items.split_last() else {
+        let Some((last, rest)) = try_elide_tail_let(items).or_else(|| items.split_last()) else {
             return;
         };
 
@@ -1003,6 +1052,18 @@ impl Emitter<'_> {
         binding_ty: &Type,
         mutable: bool,
     ) {
+        if !mutable
+            && self.try_emit_let_into_wrapper_slot(
+                output,
+                identifier,
+                raw_go_name,
+                value,
+                binding_ty,
+            )
+        {
+            return;
+        }
+
         let value_expression = self.emit_value(output, value, ExpressionContext::value());
         let coercion = Coercion::resolve(
             self,
@@ -1033,6 +1094,48 @@ impl Emitter<'_> {
         } else {
             write_line!(output, "{} := {}", go_identifier, value_expression);
         }
+    }
+
+    /// Route a slot-style Go-interop wrapper to write into the let's chosen
+    /// Go name, eliminating the `name := result_N` alias. Returns true on hit.
+    fn try_emit_let_into_wrapper_slot(
+        &mut self,
+        output: &mut String,
+        identifier: &str,
+        raw_go_name: &str,
+        value: &Expression,
+        binding_ty: &Type,
+    ) -> bool {
+        let go_identifier = crate::escape_reserved(raw_go_name);
+        if self.is_declared(&go_identifier)
+            || self.scope.is_active_assign_target(&go_identifier)
+            || self.scope.has_binding_for_go_name(&go_identifier)
+        {
+            return false;
+        }
+        if value.get_type() != *binding_ty {
+            return false;
+        }
+        let Some(strategy) = self.resolve_go_call_strategy(value) else {
+            return false;
+        };
+        if matches!(
+            strategy,
+            crate::calls::go_interop::GoCallStrategy::Tuple { .. }
+        ) {
+            return false;
+        }
+        let target = crate::calls::go_interop::WrapperTarget::Slot(&go_identifier);
+        if self
+            .emit_go_wrapped_call_to(output, value, &strategy, binding_ty, target)
+            .is_none()
+        {
+            return false;
+        }
+        // `open_wrapper_slot` / `emit_simple_wrapper_value` already declared
+        // `go_identifier`; only the binding from the user-name still needs setup.
+        self.scope.bind(identifier, go_identifier.as_ref());
+        true
     }
 
     fn emit_let_temp(

--- a/crates/emit/src/scope.rs
+++ b/crates/emit/src/scope.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::Bindings;
+use crate::bindings::{BindingValue, InlineExpr};
 use crate::types::emitter::LoopContext;
 
 pub(crate) struct ScopeState {
@@ -15,7 +16,7 @@ pub(crate) struct ScopeState {
 }
 
 pub(crate) struct BindingSnapshot {
-    inner: HashMap<String, String>,
+    inner: HashMap<String, BindingValue>,
 }
 
 pub(crate) struct IsolatedFunctionFrame {
@@ -49,18 +50,31 @@ impl ScopeState {
         lisette_name: impl Into<String>,
         go_name: impl Into<String>,
     ) -> String {
-        self.bindings.add(lisette_name, go_name)
+        self.bindings.bind_go_name(lisette_name, go_name)
     }
 
-    pub(crate) fn resolve_binding(&self, lisette_name: &str) -> Option<&str> {
+    pub(crate) fn bind_inline_expr(&mut self, lisette_name: impl Into<String>, expr: InlineExpr) {
+        self.bindings.bind_inline_expr(lisette_name, expr);
+    }
+
+    pub(crate) fn remove_binding(&mut self, lisette_name: &str) {
+        self.bindings.remove(lisette_name);
+    }
+
+    pub(crate) fn resolve_identifier_binding(&self, lisette_name: &str) -> Option<&BindingValue> {
         self.bindings.get(lisette_name)
     }
 
-    /// Resolved Go name for `lisette_name`, falling back to the
-    /// keyword-escaped form when unbound.
-    pub(crate) fn resolve_or_escape(&self, lisette_name: &str) -> String {
+    pub(crate) fn resolve_binding_go_name(&self, lisette_name: &str) -> Option<&str> {
+        self.bindings.get_go_name(lisette_name)
+    }
+
+    /// Falls back to the keyword-escaped form when the name is unbound or
+    /// bound to an inline expression — callers needing a usable local Go
+    /// identifier must materialize a fresh temp in that case.
+    pub(crate) fn resolve_or_escape_go_name(&self, lisette_name: &str) -> String {
         self.bindings
-            .get(lisette_name)
+            .get_go_name(lisette_name)
             .map(String::from)
             .unwrap_or_else(|| crate::escape_reserved(lisette_name).into_owned())
     }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,4 +1,5 @@
 use crate::Emitter;
+use crate::bindings::BindingValue;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::expressions::context::ExpressionContext;
 use crate::is_order_sensitive;
@@ -223,8 +224,9 @@ impl Emitter<'_> {
         let Expression::Identifier { value, .. } = target.unwrap_parens() else {
             return false;
         };
-        match self.scope.resolve_binding(value) {
-            Some(go_name) => go_name == "_",
+        match self.scope.resolve_identifier_binding(value) {
+            Some(BindingValue::GoName(go_name)) => go_name == "_",
+            Some(BindingValue::InlineExpr(_)) => false,
             None => value == "_",
         }
     }
@@ -334,7 +336,7 @@ impl Emitter<'_> {
         match expression {
             Expression::Identifier { value, .. } => self
                 .scope
-                .resolve_binding(value)
+                .resolve_binding_go_name(value)
                 .unwrap_or(value)
                 .to_string(),
             Expression::DotAccess {

--- a/crates/emit/src/types/abi_transition.rs
+++ b/crates/emit/src/types/abi_transition.rs
@@ -1,6 +1,7 @@
 use syntax::types::Type;
 
 use crate::Emitter;
+use crate::calls::go_interop::WrapperTarget;
 use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
 };
@@ -163,15 +164,21 @@ pub(crate) fn emit_callee_abi_wrapping(
     result_ty: &Type,
 ) -> String {
     match shape {
-        AbiShape::PartialTuple => emitter.emit_partial_wrapping(output, call_str, result_ty),
-        AbiShape::CommaOk => emitter.emit_comma_ok_wrapping(output, call_str, result_ty, false),
+        AbiShape::PartialTuple => emitter
+            .emit_partial_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot)
+            .expect_slot(),
+        AbiShape::CommaOk => emitter
+            .emit_comma_ok_wrapping(output, call_str, result_ty, false, WrapperTarget::FreshSlot)
+            .expect_slot(),
         AbiShape::NullableReturn => {
             let raw_var = emitter.hoist_tmp_value(output, "raw", call_str);
-            emitter.emit_nil_check_option_wrap(output, &raw_var, result_ty)
+            emitter
+                .emit_nil_check_option_wrap(output, &raw_var, result_ty, WrapperTarget::FreshSlot)
+                .expect_slot()
         }
-        AbiShape::ResultTuple | AbiShape::BareError => {
-            emitter.emit_result_wrapping(output, call_str, result_ty)
-        }
+        AbiShape::ResultTuple | AbiShape::BareError => emitter
+            .emit_result_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot)
+            .expect_slot(),
         AbiShape::Tuple { arity } => {
             let temps = emitter.create_temp_vars("ret", *arity);
             write_line!(output, "{} := {}", temps.join(", "), call_str);
@@ -183,7 +190,16 @@ pub(crate) fn emit_callee_abi_wrapping(
                     slot_tys
                         .get(i)
                         .filter(|slot_ty| emitter.facts.is_nullable_option(slot_ty))
-                        .map(|slot_ty| emitter.emit_nil_check_option_wrap(output, v, slot_ty))
+                        .map(|slot_ty| {
+                            emitter
+                                .emit_nil_check_option_wrap(
+                                    output,
+                                    v,
+                                    slot_ty,
+                                    WrapperTarget::FreshSlot,
+                                )
+                                .expect_slot()
+                        })
                         .unwrap_or_else(|| v.clone())
                 })
                 .collect();

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -2,6 +2,7 @@ use syntax::ast::Expression;
 use syntax::types::Type;
 
 use crate::Emitter;
+use crate::calls::go_interop::WrapperTarget;
 use crate::definitions::interface_adapter::AdapterPlan;
 
 pub(crate) struct Coercion {
@@ -64,9 +65,9 @@ impl Coercion {
             CoercionKind::UnwrapNullableCollection { ty, elem_option_ty } => {
                 emitter.emit_collection_nullable_unwrap(output, &value, &ty, &elem_option_ty)
             }
-            CoercionKind::WrapNullableOption { ty } => {
-                emitter.emit_nil_check_option_wrap(output, &value, &ty)
-            }
+            CoercionKind::WrapNullableOption { ty } => emitter
+                .emit_nil_check_option_wrap(output, &value, &ty, WrapperTarget::FreshSlot)
+                .expect_slot(),
             CoercionKind::WrapPointerOption { ty } => {
                 emitter.emit_pointer_to_option_wrap(output, &value, &ty)
             }

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -211,7 +211,7 @@ impl ValueTempDiscard {
     }
 }
 
-/// Check if the output ends with a diverging statement (break/continue/return/panic).
+/// True when the last emitted Go line is `break`, `continue`, `return`, or `panic`.
 pub(crate) fn output_ends_with_diverge(output: &str) -> bool {
     output
         .trim_end()

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -183,6 +183,34 @@ fn discard_if_unused(output: &mut String, pre_len: usize, var: &str) {
     }
 }
 
+/// If `var` is never referenced after the captured `tmp := <expr>\n` line,
+/// `finish` rewrites it to `_ = <expr>\n`. Otherwise the declaration stays.
+pub(crate) struct ValueTempDiscard {
+    decl_start: usize,
+    decl_end: usize,
+    var: String,
+    original_expr: String,
+}
+
+impl ValueTempDiscard {
+    pub(crate) fn new(output: &str, decl_start: usize, var: &str, original_expr: &str) -> Self {
+        Self {
+            decl_start,
+            decl_end: output.len(),
+            var: var.to_string(),
+            original_expr: original_expr.to_string(),
+        }
+    }
+
+    pub(crate) fn finish(self, output: &mut String) {
+        if output_references_var(&output[self.decl_end..], &self.var) {
+            return;
+        }
+        let replacement = format!("_ = {}\n", self.original_expr);
+        output.replace_range(self.decl_start..self.decl_end, &replacement);
+    }
+}
+
 /// Check if the output ends with a diverging statement (break/continue/return/panic).
 pub(crate) fn output_ends_with_diverge(output: &str) -> bool {
     output

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -14,8 +14,7 @@ func main() {
 	raw := store.GetValue("count")
 	subject_1 := lisette.AssertType[int](raw)
 	if subject_1.Tag == lisette.OptionSome {
-		n := subject_1.SomeVal
-		fmt.Print(n)
+		fmt.Print(subject_1.SomeVal)
 	} else {
 		fmt.Print("not an int")
 	}

--- a/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
@@ -54,10 +54,8 @@ import (
 func main() {
 	r := lib.Ok2[int, string](42)
 	if r.Tag == lib.Result2Ok2 {
-		v := r.Ok2
-		fmt.Println(v)
+		fmt.Println(r.Ok2)
 	} else {
-		e := r.Err2
-		fmt.Println(e)
+		fmt.Println(r.Err2)
 	}
 }

--- a/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
+++ b/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
@@ -14,15 +14,14 @@ import (
 
 func main() {
 	ret_1, ret_2 := os.Stat("/tmp")
-	var result_3 lisette.Result[fs.FileInfo, error]
+	var result lisette.Result[fs.FileInfo, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[fs.FileInfo, error](ret_2)
+		result = lisette.MakeResultErr[fs.FileInfo, error](ret_2)
 	} else if lisette.IsNilInterface(ret_1) {
-		result_3 = lisette.MakeResultErr[fs.FileInfo, error](errors.New("unexpected nil"))
+		result = lisette.MakeResultErr[fs.FileInfo, error](errors.New("unexpected nil"))
 	} else {
-		result_3 = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
+		result = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
 	}
-	result := result_3
 	if result.Tag == lisette.ResultOk {
 		size := result.OkVal.Size()
 		fmt.Printf("size: %d\n", size)

--- a/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
+++ b/tests/spec/build/snapshots/go_cross_package_type_alias_imports.snap
@@ -24,12 +24,10 @@ func main() {
 	}
 	result := result_3
 	if result.Tag == lisette.ResultOk {
-		info := result.OkVal
-		size := info.Size()
+		size := result.OkVal.Size()
 		fmt.Printf("size: %d\n", size)
 	} else {
-		e := result.ErrVal
-		msg := e.Error()
+		msg := result.ErrVal.Error()
 		fmt.Printf("error: %s\n", msg)
 	}
 }

--- a/tests/spec/build/snapshots/go_method_option_comma_ok_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_option_comma_ok_wrapped.snap
@@ -13,7 +13,6 @@ import (
 
 func main() {
 	ctx := context.Background()
-	option_1 := lisette.OptionFromCommaOk[time.Time](ctx.Deadline())
-	deadline := option_1
+	deadline := lisette.OptionFromCommaOk[time.Time](ctx.Deadline())
 	fmt.Print(deadline.IsSome())
 }

--- a/tests/spec/build/snapshots/go_method_result_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_result_wrapped.snap
@@ -22,8 +22,7 @@ func main() {
 	}
 	line := result_3
 	if line.Tag == lisette.ResultOk {
-		s := line.OkVal
-		fmt.Print(s)
+		fmt.Print(line.OkVal)
 	} else {
 		fmt.Print("error")
 	}

--- a/tests/spec/build/snapshots/go_method_result_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_result_wrapped.snap
@@ -14,13 +14,12 @@ import (
 func main() {
 	reader := bufio.NewReader(strings.NewReader("hello\nworld"))
 	ret_1, ret_2 := reader.ReadString(10)
-	var result_3 lisette.Result[string, error]
+	var line lisette.Result[string, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[string, error](ret_2)
+		line = lisette.MakeResultErr[string, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[string, error](ret_1)
+		line = lisette.MakeResultOk[string, error](ret_1)
 	}
-	line := result_3
 	if line.Tag == lisette.ResultOk {
 		fmt.Print(line.OkVal)
 	} else {

--- a/tests/spec/build/snapshots/go_method_single_pointer_option_wrapped.snap
+++ b/tests/spec/build/snapshots/go_method_single_pointer_option_wrapped.snap
@@ -14,7 +14,6 @@ func main() {
 	l := list.New()
 	_ = l.PushBack(42)
 	raw_1 := l.Front()
-	option_2 := lisette.OptionFromNilable[*list.Element](raw_1, raw_1 == nil)
-	front := option_2
+	front := lisette.OptionFromNilable[*list.Element](raw_1, raw_1 == nil)
 	fmt.Print(front.IsSome())
 }

--- a/tests/spec/build/snapshots/go_nullable_comma_ok_nil_check.snap
+++ b/tests/spec/build/snapshots/go_nullable_comma_ok_nil_check.snap
@@ -12,12 +12,11 @@ import (
 
 func main() {
 	ret_1, ret_2 := debug.ReadBuildInfo()
-	var option_3 lisette.Option[*debug.BuildInfo]
+	var info lisette.Option[*debug.BuildInfo]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[*debug.BuildInfo](ret_1)
+		info = lisette.MakeOptionSome[*debug.BuildInfo](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[*debug.BuildInfo]()
+		info = lisette.MakeOptionNone[*debug.BuildInfo]()
 	}
-	info := option_3
 	fmt.Print(info.IsSome())
 }

--- a/tests/spec/build/snapshots/go_option_call_wrapped.snap
+++ b/tests/spec/build/snapshots/go_option_call_wrapped.snap
@@ -11,7 +11,6 @@ import (
 )
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[string](comment.DefaultLookupPackage("math"))
-	result := option_1
+	result := lisette.OptionFromCommaOk[string](comment.DefaultLookupPackage("math"))
 	fmt.Print(result.IsSome())
 }

--- a/tests/spec/build/snapshots/go_option_unwrap_temp_var_no_collision.snap
+++ b/tests/spec/build/snapshots/go_option_unwrap_temp_var_no_collision.snap
@@ -21,16 +21,15 @@ func main() {
 		unwrap_2 = opt_1.SomeVal
 	}
 	ret_3, ret_4 := http.NewRequest("POST", "https://example.com", unwrap_2)
-	var result_5 lisette.Result[*http.Request, error]
+	var req lisette.Result[*http.Request, error]
 	if ret_4 != nil {
-		result_5 = lisette.MakeResultErr[*http.Request, error](ret_4)
+		req = lisette.MakeResultErr[*http.Request, error](ret_4)
 	} else if ret_3 == nil {
-		result_5 = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
+		req = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
 	} else {
-		result_5 = lisette.MakeResultOk[*http.Request, error](ret_3)
+		req = lisette.MakeResultOk[*http.Request, error](ret_3)
 	}
-	req := result_5
-	unwrap_2_6 := 7
-	_ = unwrap_2_6
+	unwrap_2_5 := 7
+	_ = unwrap_2_5
 	fmt.Println(req)
 }

--- a/tests/spec/build/snapshots/go_result_ref_nil_guard.snap
+++ b/tests/spec/build/snapshots/go_result_ref_nil_guard.snap
@@ -13,14 +13,13 @@ import (
 
 func main() {
 	ret_1, ret_2 := os.Open("/tmp/test.txt")
-	var result_3 lisette.Result[*os.File, error]
+	var result lisette.Result[*os.File, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[*os.File, error](ret_2)
+		result = lisette.MakeResultErr[*os.File, error](ret_2)
 	} else if ret_1 == nil {
-		result_3 = lisette.MakeResultErr[*os.File, error](errors.New("unexpected nil"))
+		result = lisette.MakeResultErr[*os.File, error](errors.New("unexpected nil"))
 	} else {
-		result_3 = lisette.MakeResultOk[*os.File, error](ret_1)
+		result = lisette.MakeResultOk[*os.File, error](ret_1)
 	}
-	result := result_3
 	fmt.Print(result.IsOk())
 }

--- a/tests/spec/build/snapshots/go_single_pointer_option_wrapped.snap
+++ b/tests/spec/build/snapshots/go_single_pointer_option_wrapped.snap
@@ -12,7 +12,6 @@ import (
 
 func main() {
 	raw_1 := flag.Lookup("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	result := option_2
+	result := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	fmt.Print(result.IsSome())
 }

--- a/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
+++ b/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
@@ -8,12 +8,9 @@ import "github.com/user/myproject/shapes"
 
 func describe(s shapes.ShapeKind) float64 {
 	if s.Tag == shapes.ShapeKindCircleKind {
-		c := s.CircleKind
-		return c.Radius
+		return s.CircleKind.Radius
 	}
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }
 
 func main() {

--- a/tests/spec/build/snapshots/multimodule_if_let_in_dependency.snap
+++ b/tests/spec/build/snapshots/multimodule_if_let_in_dependency.snap
@@ -21,8 +21,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func UnwrapOrDefault(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		return x
+		return opt.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
@@ -71,11 +71,8 @@ func main() {
 	}
 	switch e.Tag {
 	case events.EventClick:
-		x := e.X
-		y := e.Y
-		_ = x + y
+		_ = e.X + e.Y
 	case events.EventKeyPress:
-		k := e.KeyPress
-		_ = k
+		_ = e.KeyPress
 	}
 }

--- a/tests/spec/build/snapshots/non_error_err_slot_stays_tagged.snap
+++ b/tests/spec/build/snapshots/non_error_err_slot_stays_tagged.snap
@@ -18,13 +18,10 @@ func (m MyError) String() string {
 }
 
 func parse(s string) lisette.Result[int, MyError] {
-	var tmp_1 lisette.Result[int, MyError]
 	if s == "ok" {
-		tmp_1 = lisette.MakeResultOk[int, MyError](1)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, MyError](MyError{msg: "bad"})
+		return lisette.MakeResultOk[int, MyError](1)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, MyError](MyError{msg: "bad"})
 }
 
 func main() {

--- a/tests/spec/build/snapshots/non_go_err_result_keeps_tagged_form.snap
+++ b/tests/spec/build/snapshots/non_go_err_result_keeps_tagged_form.snap
@@ -30,8 +30,7 @@ func (l Loader) Load(_ string) lisette.Result[int, LoadError] {
 func run(l Loader) int {
 	subject_1 := l.Load("k")
 	if subject_1.Tag == lisette.ResultOk {
-		n := subject_1.OkVal
-		return n
+		return subject_1.OkVal
 	}
 	return -1
 }

--- a/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
+++ b/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
@@ -14,8 +14,7 @@ func find(haystack, needle string) int {
 	option_3 := lisette.OptionFromCommaOk[int](ret_2, ret_2 != -1)
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		i := subject_1.SomeVal
-		return i
+		return subject_1.SomeVal
 	}
 	return -2
 }

--- a/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
+++ b/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
@@ -22,8 +22,7 @@ func consume() int {
 	n := tmp_1.First
 	c := tmp_1.Second
 	if c.Tag == lisette.OptionSome {
-		f := c.SomeVal
-		return n + f()
+		return n + c.SomeVal()
 	}
 	return n
 }

--- a/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
+++ b/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
@@ -19,8 +19,7 @@ func maybe_get() Callback {
 
 func run(cb lisette.Option[Callback]) int {
 	if cb.Tag == lisette.OptionSome {
-		f := cb.SomeVal
-		return f()
+		return cb.SomeVal()
 	}
 	return -1
 }

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -33,10 +33,8 @@ func main() {
 	}
 	subject_1 := result_4
 	if subject_1.Tag == lisette.ResultOk {
-		b := subject_1.OkVal
-		fmt.Println(string(b))
+		fmt.Println(string(subject_1.OkVal))
 	} else {
-		e := subject_1.ErrVal
-		fmt.Println(e)
+		fmt.Println(subject_1.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
@@ -17,8 +17,6 @@ func (p Point) String() string {
 
 func test(p Point) int {
 	{
-		x := p.x
-		pt := p
-		return x + pt.y
+		return p.x + p.y
 	}
 }

--- a/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
@@ -40,8 +40,7 @@ func (s Status) String() string {
 
 func test(s Status) int {
 	if s.Tag == StatusGood {
-		n := s.Good
-		return n
+		return s.Good
 	}
 	return -1
 }

--- a/tests/spec/emit/snapshots/as_binding_on_go_interface_type_switch.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_go_interface_type_switch.snap
@@ -12,8 +12,7 @@ func handle(e events.Event) int {
 		c := e
 		return c.X + c.Y
 	case events.KeyPress:
-		k := e
-		return len(k.Key)
+		return len(e.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/as_binding_on_slice_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_slice_element.snap
@@ -17,8 +17,7 @@ func (p Point) String() string {
 
 func test(pts []Point) int {
 	if len(pts) >= 1 {
-		p := pts[0]
-		return p.x
+		return pts[0].x
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
@@ -20,8 +20,6 @@ func (p Point) String() string {
 
 func test(pair lisette.Tuple2[Point, int]) int {
 	{
-		p := pair.First
-		z := pair.Second
-		return p.x + z
+		return pair.First.x + pair.Second
 	}
 }

--- a/tests/spec/emit/snapshots/as_binding_unused_elided.snap
+++ b/tests/spec/emit/snapshots/as_binding_unused_elided.snap
@@ -17,7 +17,6 @@ func (p Point) String() string {
 
 func test(p Point) int {
 	{
-		x := p.x
-		return x
+		return p.x
 	}
 }

--- a/tests/spec/emit/snapshots/blocking_receive_match.snap
+++ b/tests/spec/emit/snapshots/blocking_receive_match.snap
@@ -10,8 +10,7 @@ func test() int {
 	ch := make(chan int)
 	subject_1 := lisette.ChannelReceive(ch)
 	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
-		return v
+		return subject_1.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/break_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_match_in_loop.snap
@@ -11,8 +11,7 @@ loop_1:
 		if item == 0 {
 			break loop_1
 		}
-		n := item
-		sum += n
+		sum += item
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -29,8 +29,7 @@ func run(s svc.Alias) int {
 	}
 	subject_1 := result_4
 	if subject_1.Tag == lisette.ResultOk {
-		n := subject_1.OkVal
-		return n
+		return subject_1.OkVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
@@ -11,8 +11,7 @@ loop_1:
 		if item == 0 {
 			continue loop_1
 		}
-		n := item
-		sum += n
+		sum += item
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
@@ -30,6 +30,5 @@ func run() (int, error) {
 	if check_4.Tag != lisette.ResultOk {
 		return *new(int), check_4.ErrVal
 	}
-	result_5 := check_4.OkVal
-	return add(result_5, side()), nil
+	return add(check_4.OkVal, side()), nil
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -19,7 +19,7 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	_arg_6 := side()
+	_arg_5 := side()
 	ret_1, ret_2 := get_y()
 	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
@@ -31,6 +31,5 @@ func run() (int, error) {
 	if check_4.Tag != lisette.ResultOk {
 		return *new(int), check_4.ErrVal
 	}
-	result_5 := check_4.OkVal
-	return add(_arg_6, result_5), nil
+	return add(_arg_5, check_4.OkVal), nil
 }

--- a/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
+++ b/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
@@ -44,6 +44,5 @@ func test() int {
 	if t.Tag == TransformIdentity {
 		return 0
 	}
-	f := t.Apply
-	return f(41)
+	return t.Apply(41)
 }

--- a/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
+++ b/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
@@ -40,8 +40,7 @@ func (p Pair[A, B]) String() string {
 
 func test(p Pair[int, string]) int {
 	if p.Tag == PairBoth {
-		n := p.Both0
-		return n
+		return p.Both0
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
+++ b/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
@@ -42,6 +42,5 @@ func list_len[T any](list List[T]) int {
 	if list.Tag == ListNil {
 		return 0
 	}
-	rest := list.Cons1
-	return 1 + list_len(*rest)
+	return 1 + list_len(*list.Cons1)
 }

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -44,12 +44,10 @@ func (e Either[L, R]) String() string {
 
 func (e Either[L, R]) display() string {
 	if e.Tag == EitherLeft {
-		l := e.Left
-		s := l.display()
+		s := e.Left.display()
 		return fmt.Sprintf("Left(%v)", s)
 	}
-	r := e.Right
-	s := r.display()
+	s := e.Right.display()
 	return fmt.Sprintf("Right(%v)", s)
 }
 

--- a/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
@@ -16,7 +16,6 @@ func (b Box[T]) String() string {
 
 func test(b Box[int]) int {
 	{
-		x := b.F0
-		return x
+		return b.F0
 	}
 }

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
@@ -20,8 +20,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_call.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_call.snap
@@ -12,12 +12,11 @@ import (
 
 func main() {
 	ret_1, ret_2 := strconv.Atoi("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	fmt.Println(r)
 }

--- a/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
+++ b/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
@@ -15,7 +15,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	fl := option_2
 	if fl.Tag == lisette.OptionSome {
-		v := fl.SomeVal
-		f(v)
+		f(fl.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
+++ b/tests/spec/emit/snapshots/go_function_ref_first_param_not_pointer_receiver.snap
@@ -12,8 +12,7 @@ import (
 func main() {
 	f := flag.UnquoteUsage
 	raw_1 := flag.Lookup("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	fl := option_2
+	fl := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	if fl.Tag == lisette.OptionSome {
 		f(fl.SomeVal)
 	}

--- a/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
+++ b/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
@@ -20,12 +20,9 @@ func main() {
 	}
 	subject_1 := result_6
 	if subject_1.Tag == lisette.ResultOk {
-		host := subject_1.OkVal.First
-		port := subject_1.OkVal.Second
-		_ = host
-		_ = port
+		_ = subject_1.OkVal.First
+		_ = subject_1.OkVal.Second
 	} else {
-		e := subject_1.ErrVal
-		_ = e
+		_ = subject_1.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/go_interface_method_err_result_type.snap
+++ b/tests/spec/emit/snapshots/go_interface_method_err_result_type.snap
@@ -13,7 +13,6 @@ import (
 func main() {
 	ctx := context.Background()
 	raw_1 := ctx.Err()
-	option_2 := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
-	err := option_2
+	err := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
 	fmt.Printf("err=%v\n", err)
 }

--- a/tests/spec/emit/snapshots/go_keyword_match_binding.snap
+++ b/tests/spec/emit/snapshots/go_keyword_match_binding.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() int {
 	x := lisette.MakeOptionSome(42)
 	if x.Tag == lisette.OptionSome {
-		map_ := x.SomeVal
-		return map_
+		return x.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/go_multi_return_ret_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/go_multi_return_ret_temp_var_no_collision.snap
@@ -12,14 +12,13 @@ import (
 
 func main() {
 	ret_1, ret_2 := strconv.Atoi("42")
-	var result_3 lisette.Result[int, error]
+	var n lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		n = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		n = lisette.MakeResultOk[int, error](ret_1)
 	}
-	n := result_3
-	ret_1_4 := 7
+	ret_1_3 := 7
 	fmt.Println(n)
-	fmt.Println(ret_1_4)
+	fmt.Println(ret_1_3)
 }

--- a/tests/spec/emit/snapshots/go_none_for_interface_parameter.snap
+++ b/tests/spec/emit/snapshots/go_none_for_interface_parameter.snap
@@ -13,14 +13,13 @@ import (
 
 func main() {
 	ret_1, ret_2 := http.NewRequest("GET", "https://example.com", nil)
-	var result_3 lisette.Result[*http.Request, error]
+	var req lisette.Result[*http.Request, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[*http.Request, error](ret_2)
+		req = lisette.MakeResultErr[*http.Request, error](ret_2)
 	} else if ret_1 == nil {
-		result_3 = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
+		req = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
 	} else {
-		result_3 = lisette.MakeResultOk[*http.Request, error](ret_1)
+		req = lisette.MakeResultOk[*http.Request, error](ret_1)
 	}
-	req := result_3
 	fmt.Println(req)
 }

--- a/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
+++ b/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
@@ -21,14 +21,13 @@ func main() {
 		unwrap_2 = opt_1.SomeVal
 	}
 	ret_3, ret_4 := http.NewRequest("POST", "https://example.com", unwrap_2)
-	var result_5 lisette.Result[*http.Request, error]
+	var req lisette.Result[*http.Request, error]
 	if ret_4 != nil {
-		result_5 = lisette.MakeResultErr[*http.Request, error](ret_4)
+		req = lisette.MakeResultErr[*http.Request, error](ret_4)
 	} else if ret_3 == nil {
-		result_5 = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
+		req = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
 	} else {
-		result_5 = lisette.MakeResultOk[*http.Request, error](ret_3)
+		req = lisette.MakeResultOk[*http.Request, error](ret_3)
 	}
-	req := result_5
 	fmt.Println(req)
 }

--- a/tests/spec/emit/snapshots/if_else_branch_with_statements_before_result_return.snap
+++ b/tests/spec/emit/snapshots/if_else_branch_with_statements_before_result_return.snap
@@ -7,15 +7,12 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func checked_sqrt(n int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if n < 0 {
-		tmp_1 = lisette.MakeResultErr[int, string]("negative input")
-	} else {
-		x := n
-		for x*x > n {
-			x--
-		}
-		tmp_1 = lisette.MakeResultOk[int, string](x)
+		return lisette.MakeResultErr[int, string]("negative input")
 	}
-	return tmp_1
+	x := n
+	for x*x > n {
+		x--
+	}
+	return lisette.MakeResultOk[int, string](x)
 }

--- a/tests/spec/emit/snapshots/if_let_else_if_let.snap
+++ b/tests/spec/emit/snapshots/if_let_else_if_let.snap
@@ -8,12 +8,10 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(a, b lisette.Option[int]) int {
 	if a.Tag == lisette.OptionSome {
-		x := a.SomeVal
-		return x
+		return a.SomeVal
 	}
 	if b.Tag == lisette.OptionSome {
-		y := b.SomeVal
-		return y
+		return b.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/if_let_in_let_binding.snap
+++ b/tests/spec/emit/snapshots/if_let_in_let_binding.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test(opt lisette.Option[int]) int {
 	var result int
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		result = x
+		result = opt.SomeVal
 	} else {
 		result = 0
 	}

--- a/tests/spec/emit/snapshots/if_let_irrefutable_unused_subject.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_unused_subject.snap
@@ -19,6 +19,5 @@ func mk() P {
 }
 
 func test() {
-	subject_1 := mk()
-	_ = subject_1
+	_ = mk()
 }

--- a/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
@@ -6,7 +6,6 @@ package main
 
 func test(x int) int {
 	{
-		y := x
-		return y * 2
+		return x * 2
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
@@ -10,13 +10,10 @@ import (
 )
 
 func try_parse(s string) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if s == "42" {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("not 42")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("not 42")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/if_let_statement.snap
+++ b/tests/spec/emit/snapshots/if_let_statement.snap
@@ -8,7 +8,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		_ = x + 1
+		_ = opt.SomeVal + 1
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_with_else.snap
+++ b/tests/spec/emit/snapshots/if_let_with_else.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		return x * 2
+		return opt.SomeVal * 2
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
@@ -44,11 +44,9 @@ func (e Either[L, R]) String() string {
 
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
-		n := self.Left
-		return fmt.Sprintf("int(%d)", n)
+		return fmt.Sprintf("int(%d)", self.Left)
 	}
-	s := self.Right
-	return fmt.Sprintf("str(%s)", s)
+	return fmt.Sprintf("str(%s)", self.Right)
 }
 
 func test() MyString {

--- a/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
@@ -44,9 +44,7 @@ func (e Either[L, R]) String() string {
 
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
-		n := self.Left
-		return fmt.Sprintf("int(%d)", n)
+		return fmt.Sprintf("int(%d)", self.Left)
 	}
-	s := self.Right
-	return fmt.Sprintf("str(%s)", s)
+	return fmt.Sprintf("str(%s)", self.Right)
 }

--- a/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
+++ b/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
@@ -21,8 +21,7 @@ func (n Node) String() string {
 func (n Node) sum() int {
 	subject_1 := n.Next
 	if subject_1.Tag == lisette.OptionSome {
-		n_2 := subject_1.SomeVal
-		return n.Value + n_2
+		return n.Value + subject_1.SomeVal
 	}
 	return n.Value
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
@@ -13,8 +13,7 @@ func apply(f func(string) (string, bool), key string) string {
 	option_2 := lisette.OptionFromCommaOk[string](f(key))
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
-		return v
+		return subject_1.SomeVal
 	}
 	return "unset"
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
@@ -10,8 +10,7 @@ import (
 )
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
-	r := option_1
+	r := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {

--- a/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
@@ -13,8 +13,7 @@ func main() {
 	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
@@ -14,8 +14,7 @@ func main() {
 	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
@@ -18,8 +18,7 @@ func main() {
 	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
+++ b/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
@@ -27,8 +27,7 @@ loop_1:
 		}
 		subject_3 := result_8
 		if subject_3.Tag == lisette.ResultOk {
-			r := subject_3.OkVal.First
-			r_2 = r
+			r_2 = subject_3.OkVal.First
 		} else {
 			if subject_3.ErrVal == io.EOF {
 				break loop_1

--- a/tests/spec/emit/snapshots/interop_nullable_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_direct_call.snap
@@ -11,8 +11,7 @@ import (
 
 func main() {
 	raw_1 := flag.Lookup("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	r := option_2
+	r := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_nullable_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_direct_call.snap
@@ -14,7 +14,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2
 	if r.Tag == lisette.OptionSome {
-		f := r.SomeVal
-		_ = f
+		_ = r.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_function_alias_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_function_alias_direct_call.snap
@@ -11,8 +11,7 @@ import (
 
 func main() {
 	raw_1 := scheduler.MakeCmd()
-	option_2 := lisette.OptionFromNilable[scheduler.Cmd](raw_1, raw_1 == nil)
-	cmd := option_2
+	cmd := lisette.OptionFromNilable[scheduler.Cmd](raw_1, raw_1 == nil)
 	if cmd.Tag == lisette.OptionSome {
 		_ = cmd.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_nullable_function_alias_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_function_alias_direct_call.snap
@@ -14,7 +14,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[scheduler.Cmd](raw_1, raw_1 == nil)
 	cmd := option_2
 	if cmd.Tag == lisette.OptionSome {
-		c := cmd.SomeVal
-		_ = c
+		_ = cmd.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_let_call.snap
@@ -15,7 +15,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
@@ -19,7 +19,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_slice_element.snap
@@ -15,7 +15,6 @@ func main() {
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2
 	if r.Tag == lisette.OptionSome {
-		v := r.SomeVal
-		_ = v
+		_ = r.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -15,8 +15,7 @@ func main() {
 	option_3 := lisette.OptionFromNilable[evts.Msg](raw_2, lisette.IsNilInterface(raw_2))
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		e := subject_1.SomeVal
-		fmt.Println(e)
+		fmt.Println(subject_1.SomeVal)
 	} else {
 		fmt.Println("none")
 	}

--- a/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
+++ b/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
@@ -13,11 +13,9 @@ import (
 func main() {
 	src, db := migrate.Close()
 	if src.Tag == lisette.OptionSome {
-		e := src.SomeVal
-		fmt.Println("source:", e)
+		fmt.Println("source:", src.SomeVal)
 	}
 	if db.Tag == lisette.OptionSome {
-		e := db.SomeVal
-		fmt.Println("db:", e)
+		fmt.Println("db:", db.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_alias_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_alias_call.snap
@@ -21,8 +21,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_assignment.snap
@@ -25,8 +25,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_break_value.snap
+++ b/tests/spec/emit/snapshots/interop_result_break_value.snap
@@ -29,8 +29,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_call_arg.snap
@@ -23,8 +23,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_direct_call.snap
@@ -19,8 +19,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_direct_call.snap
@@ -11,13 +11,12 @@ import (
 
 func main() {
 	ret_1, ret_2 := strconv.Atoi("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -19,8 +19,7 @@ func main() {
 	}
 	subject_1 := result_4
 	if subject_1.Tag == lisette.ResultOk {
-		stored := subject_1.OkVal
-		_ = stored
+		_ = subject_1.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_if_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_if_assignment.snap
@@ -25,8 +25,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_let_call.snap
@@ -20,8 +20,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -33,8 +33,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
@@ -23,8 +23,7 @@ func main() {
 	})
 	subject_4 := ys[0]
 	if subject_4.Tag == lisette.ResultOk {
-		v := subject_4.OkVal
-		_ = v
+		_ = subject_4.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
@@ -13,17 +13,15 @@ func main() {
 	xs := []string{"1"}
 	ys := lisette.SliceMap(xs, func(arg0 string) lisette.Result[int, error] {
 		ret_1, ret_2 := strconv.Atoi(arg0)
-		var result_3 lisette.Result[int, error]
 		if ret_2 != nil {
-			result_3 = lisette.MakeResultErr[int, error](ret_2)
+			return lisette.MakeResultErr[int, error](ret_2)
 		} else {
-			result_3 = lisette.MakeResultOk[int, error](ret_1)
+			return lisette.MakeResultOk[int, error](ret_1)
 		}
-		return result_3
 	})
-	subject_4 := ys[0]
-	if subject_4.Tag == lisette.ResultOk {
-		_ = subject_4.OkVal
+	subject_3 := ys[0]
+	if subject_3.Tag == lisette.ResultOk {
+		_ = subject_3.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
@@ -23,8 +23,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		f := r.OkVal
-		ret_4, ret_5 := f("1")
+		ret_4, ret_5 := r.OkVal("1")
 		var result_6 lisette.Result[int, error]
 		if ret_5 != nil {
 			result_6 = lisette.MakeResultErr[int, error](ret_5)
@@ -33,8 +32,7 @@ func main() {
 		}
 		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
-			v := r2.OkVal
-			_ = v
+			_ = r2.OkVal
 		} else {
 		}
 	} else {

--- a/tests/spec/emit/snapshots/interop_result_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_result_return_pos.snap
@@ -24,8 +24,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_element.snap
@@ -20,8 +20,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_struct_field.snap
+++ b/tests/spec/emit/snapshots/interop_result_struct_field.snap
@@ -29,8 +29,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_try_block.snap
@@ -34,8 +34,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		f := r.OkVal
-		ret_4, ret_5 := f("1")
+		ret_4, ret_5 := r.OkVal("1")
 		var result_6 lisette.Result[int, error]
 		if ret_5 != nil {
 			result_6 = lisette.MakeResultErr[int, error](ret_5)
@@ -44,8 +43,7 @@ func main() {
 		}
 		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
-			v := r2.OkVal
-			_ = v
+			_ = r2.OkVal
 		} else {
 		}
 	} else {

--- a/tests/spec/emit/snapshots/interop_result_tuple_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_element.snap
@@ -20,8 +20,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -35,8 +35,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
@@ -30,8 +30,7 @@ func main() {
 	}
 	r := result_3
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		_ = v
+		_ = r.OkVal
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
@@ -23,7 +23,6 @@ func main() {
 	}
 	subject_1 := wrapped_4["k"]
 	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
-		_ = v
+		_ = subject_1.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -17,8 +17,7 @@ func main() {
 		option_3 := lisette.OptionFromPointer[string](raw_2)
 		subject_1 := option_3
 		if subject_1.Tag == lisette.OptionSome {
-			name := subject_1.SomeVal
-			fmt.Println(name)
+			fmt.Println(subject_1.SomeVal)
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
@@ -15,7 +15,6 @@ func main() {
 	option_3 := lisette.OptionFromPointer[string](raw_2)
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		name := subject_1.SomeVal
-		_ = name
+		_ = subject_1.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
@@ -23,8 +23,7 @@ func main() {
 	}
 	for _, tag := range wrapped_3 {
 		if tag.Tag == lisette.OptionSome {
-			v := tag.SomeVal
-			_ = v
+			_ = tag.SomeVal
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -44,8 +44,7 @@ func main() {
 	elts := wrapped_9
 	for _, elt := range elts {
 		if elt.Tag == lisette.OptionSome {
-			e := elt.SomeVal
-			fmt.Println(e.Pos())
+			fmt.Println(elt.SomeVal.Pos())
 		} else {
 			fmt.Println("nil")
 		}

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
@@ -14,15 +14,14 @@ import (
 
 func main() {
 	ret_1, ret_2 := os.Stat("/tmp")
-	var result_3 lisette.Result[fs.FileInfo, error]
+	var info lisette.Result[fs.FileInfo, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[fs.FileInfo, error](ret_2)
+		info = lisette.MakeResultErr[fs.FileInfo, error](ret_2)
 	} else if lisette.IsNilInterface(ret_1) {
-		result_3 = lisette.MakeResultErr[fs.FileInfo, error](errors.New("unexpected nil"))
+		info = lisette.MakeResultErr[fs.FileInfo, error](errors.New("unexpected nil"))
 	} else {
-		result_3 = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
+		info = lisette.MakeResultOk[fs.FileInfo, error](ret_1)
 	}
-	info := result_3
 	if info.Tag == lisette.ResultOk {
 		fmt.Println(info.OkVal.Size())
 	} else {

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_result_return.snap
@@ -24,10 +24,8 @@ func main() {
 	}
 	info := result_3
 	if info.Tag == lisette.ResultOk {
-		i := info.OkVal
-		fmt.Println(i.Size())
+		fmt.Println(info.OkVal.Size())
 	} else {
-		e := info.ErrVal
-		fmt.Println(e)
+		fmt.Println(info.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
@@ -16,8 +16,7 @@ func main() {
 	option_3 := lisette.OptionFromNilable[error](raw_2, lisette.IsNilInterface(raw_2))
 	subject_1 := option_3
 	if subject_1.Tag == lisette.OptionSome {
-		e := subject_1.SomeVal
-		fmt.Println(e.Error())
+		fmt.Println(subject_1.SomeVal.Error())
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
+++ b/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
@@ -19,9 +19,7 @@ func parse(s string) (int, error) {
 	}
 	result := result_3
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		return n, nil
+		return result.OkVal, nil
 	}
-	e := result.ErrVal
-	return *new(int), e
+	return *new(int), result.ErrVal
 }

--- a/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
+++ b/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
@@ -11,13 +11,12 @@ import (
 
 func parse(s string) (int, error) {
 	ret_1, ret_2 := strconv.Atoi(s)
-	var result_3 lisette.Result[int, error]
+	var result lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		result = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		result = lisette.MakeResultOk[int, error](ret_1)
 	}
-	result := result_3
 	if result.Tag == lisette.ResultOk {
 		return result.OkVal, nil
 	}

--- a/tests/spec/emit/snapshots/let_complex_pattern_unused_temp.snap
+++ b/tests/spec/emit/snapshots/let_complex_pattern_unused_temp.snap
@@ -19,6 +19,5 @@ func mk() P {
 }
 
 func test() {
-	tmp_1 := mk()
-	_ = tmp_1
+	_ = mk()
 }

--- a/tests/spec/emit/snapshots/let_else_irrefutable_unused_subject.snap
+++ b/tests/spec/emit/snapshots/let_else_irrefutable_unused_subject.snap
@@ -19,6 +19,5 @@ func mk() P {
 }
 
 func test() {
-	subject_1 := mk()
-	_ = subject_1
+	_ = mk()
 }

--- a/tests/spec/emit/snapshots/let_else_or_pattern_catchall_unused_subject.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_catchall_unused_subject.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test() {\n  let _ | _ = 1 else {\n    panic(\"x\")\n  
 package main
 
 func test() {
-	subject_1 := 1
-	_ = subject_1
+	_ = 1
 }

--- a/tests/spec/emit/snapshots/let_else_result_direct_call.snap
+++ b/tests/spec/emit/snapshots/let_else_result_direct_call.snap
@@ -7,13 +7,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func parse(s string) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if s == "42" {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("bad")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("bad")
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/let_else_wildcard_unused_subject.snap
+++ b/tests/spec/emit/snapshots/let_else_wildcard_unused_subject.snap
@@ -5,6 +5,5 @@ description: "input: \nfn test() {\n  let _ = 1 else { panic(\"x\") }\n  ()\n}\n
 package main
 
 func test() {
-	subject_1 := 1
-	_ = subject_1
+	_ = 1
 }

--- a/tests/spec/emit/snapshots/let_shadowing_with_match_expression.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_with_match_expression.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test(opt lisette.Option[int]) int {
 	var x int
 	if opt.Tag == lisette.OptionSome {
-		v := opt.SomeVal
-		x = v
+		x = opt.SomeVal
 	} else {
 		x = 0
 	}

--- a/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
+++ b/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
@@ -18,9 +18,7 @@ func (p Point) String() string {
 func test(p Point) int {
 	var result int
 	{
-		x := p.x
-		fmt := p
-		result = fmt.x + x
+		result = p.x + p.x
 	}
 	fmt.Println(result)
 	return result

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -21,8 +21,7 @@ func parse_and_divide(a, b float64) lisette.Result[string, string] {
 	option_2 := lisette.OptionFromCommaOk[float64](safe_divide(a, b))
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
-		result = v
+		result = subject_1.SomeVal
 	} else {
 		return lisette.MakeResultErr[string, string]("division by zero")
 	}

--- a/tests/spec/emit/snapshots/match_call_subject_catchall.snap
+++ b/tests/spec/emit/snapshots/match_call_subject_catchall.snap
@@ -23,7 +23,6 @@ func make_point() Point {
 }
 
 func test() int {
-	subject_1 := make_point()
-	_ = subject_1
+	_ = make_point()
 	return 1
 }

--- a/tests/spec/emit/snapshots/match_expr_same_name_as_let_binding.snap
+++ b/tests/spec/emit/snapshots/match_expr_same_name_as_let_binding.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func extract(opt lisette.Option[int]) int {
 	var x_1 int
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		x_1 = x
+		x_1 = opt.SomeVal
 	} else {
 		x_1 = 0
 	}

--- a/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
@@ -14,8 +14,7 @@ func categorize(items []int) string {
 	if n == 1 {
 		return "single"
 	}
-	n_2 := subject_1
-	if n_2 <= 3 {
+	if subject_1 <= 3 {
 		return "few"
 	}
 	return "many"

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
@@ -18,8 +18,7 @@ func test() int {
 	w := W[int]{F0: 1}
 	subject_1 := w
 	{
-		x := subject_1
-		if x == (W[int]{F0: 2}) {
+		if subject_1 == (W[int]{F0: 2}) {
 			return 0
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_mixed.snap
+++ b/tests/spec/emit/snapshots/match_guard_mixed.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test(opt lisette.Option[int]) string {
 	subject_1 := opt
 	if subject_1.Tag == lisette.OptionSome {
-		x := subject_1.SomeVal
-		if x > 0 {
+		if subject_1.SomeVal > 0 {
 			return "positive"
 		}
 		return "non-positive"

--- a/tests/spec/emit/snapshots/match_guard_on_struct.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_struct.snap
@@ -25,9 +25,7 @@ func test(p Point) string {
 		}
 	}
 	{
-		x := subject_1.x
-		y := subject_1.y
-		if x > y {
+		if subject_1.x > subject_1.y {
 			return "above"
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -20,8 +20,7 @@ func main() {
 		x: 1,
 		y: 2,
 	}
-	subject_1 := p
-	_ = subject_1
+	_ = p
 match_2:
 	for {
 		if (p == Point{

--- a/tests/spec/emit/snapshots/match_guard_tuple.snap
+++ b/tests/spec/emit/snapshots/match_guard_tuple.snap
@@ -16,9 +16,7 @@ func test(pair lisette.Tuple2[int, int]) string {
 		}
 	}
 	{
-		x := subject_1.First
-		y := subject_1.Second
-		if x > y {
+		if subject_1.First > subject_1.Second {
 			return "greater"
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -12,8 +12,7 @@ func main() {
 	match_2:
 		for {
 			{
-				d := subject_1
-				if d < 5 {
+				if subject_1 < 5 {
 					fmt.Println("low")
 					break match_2
 				}

--- a/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
@@ -55,13 +55,10 @@ func test(e E) int {
 		}
 	}
 	if subject_1.Tag == EA {
-		x := subject_1.A
-		return x
+		return subject_1.A
 	}
 	if subject_1.Tag == EB {
-		x := subject_1.B
-		return x
+		return subject_1.B
 	}
-	x := subject_1.C
-	return x
+	return subject_1.C
 }

--- a/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
@@ -19,8 +19,7 @@ func mk() P {
 }
 
 func test() {
-	subject_1 := mk()
-	_ = subject_1
+	_ = mk()
 match_2:
 	for {
 		if false {

--- a/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
@@ -16,8 +16,7 @@ func (p P) String() string {
 
 func test() {
 	p := P{v: 1}
-	subject_1 := p
-	_ = subject_1
+	_ = p
 match_2:
 	for {
 		{

--- a/tests/spec/emit/snapshots/match_in_lambda_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_lambda_unused_subject.snap
@@ -25,8 +25,7 @@ func test() int {
 		return 1
 	})
 	if result.Tag == lisette.OptionSome {
-		x := result.SomeVal
-		return x
+		return result.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -15,12 +15,11 @@ func test() {
 match_2:
 	for {
 		if subject_1.Tag == lisette.ResultOk {
-			n := subject_1.OkVal
-			if n > 0 {
-				fmt.Printf("positive: %v\n", n)
+			if subject_1.OkVal > 0 {
+				fmt.Printf("positive: %v\n", subject_1.OkVal)
 				break match_2
 			}
-			fmt.Printf("non-positive: %v\n", n)
+			fmt.Printf("non-positive: %v\n", subject_1.OkVal)
 			break match_2
 		}
 		e := subject_1.ErrVal

--- a/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
+++ b/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
@@ -10,18 +10,12 @@ func test() int {
 	pair := lisette.MakeTuple2(10, 20)
 	var first int
 	{
-		a := pair.First
-		b := pair.Second
-		first = a + b
+		first = pair.First + pair.Second
 	}
 	nested := lisette.MakeTuple2(lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4))
 	var second int
 	{
-		a := nested.First.First
-		b := nested.First.Second
-		c := nested.Second.First
-		d := nested.Second.Second
-		second = a + b + c + d
+		second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
 	}
 	return first + second
 }

--- a/tests/spec/emit/snapshots/match_on_aliased_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_aliased_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(m events.Msg) int {
 	switch m := m.(type) {
 	case events.Click:
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	case events.KeyPress:
-		key := m.Key
-		return len(key)
+		return len(m.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_chained_alias_of_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_chained_alias_of_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(m events.Outer) int {
 	switch m := m.(type) {
 	case events.Click:
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	case events.KeyPress:
-		key := m.Key
-		return len(key)
+		return len(m.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_emits_type_switch.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x + y
+		return e.X + e.Y
 	case events.KeyPress:
-		key := e.Key
-		return len(key)
+		return len(e.Key)
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
@@ -10,9 +10,7 @@ func handle(e events.Event, active bool) int {
 	subject_1 := e
 	switch subject_1 := subject_1.(type) {
 	case events.Click:
-		x := subject_1.X
-		y := subject_1.Y
-		return x + y
+		return subject_1.X + subject_1.Y
 	case events.KeyPress:
 		if active {
 			return -1

--- a/tests/spec/emit/snapshots/match_on_go_interface_wildcard_only_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_wildcard_only_arm.snap
@@ -9,9 +9,7 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x + y
+		return e.X + e.Y
 	case events.KeyPress:
 		return -1
 	case events.Resize:

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
@@ -24,9 +24,7 @@ func test() int {
 	}
 	var sum int
 	{
-		a_1 := p.F0
-		b_2 := p.F1
-		sum = a_1 + b_2
+		sum = p.F0 + p.F1
 	}
 	return a + b + sum
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
@@ -27,15 +27,12 @@ func test() string {
 		F1: 2,
 	}
 	{
-		x := p.F0
-		y := p.F1
-		_ = x + y
+		_ = p.F0 + p.F1
 	}
 	n := Name("hello")
 	var b string
 	{
-		x := string(n)
-		b = x
+		b = string(n)
 	}
 	return b
 }

--- a/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
@@ -51,11 +51,9 @@ func (e E) String() string {
 func eval(e E) int {
 	switch e.Tag {
 	case EA:
-		x := e.A.First
-		return x
+		return e.A.First
 	case EB:
-		x := e.B.First
-		return x
+		return e.B.First
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/match_returning_result.snap
+++ b/tests/spec/emit/snapshots/match_returning_result.snap
@@ -7,11 +7,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(flag bool) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if flag {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("failed")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("failed")
 }

--- a/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
@@ -43,18 +43,14 @@ func test() int {
 	e1 := MakeEventClick(10, 20)
 	var sum1 int
 	if e1.Tag == EventClick {
-		x := e1.Click0
-		y := e1.Click1
-		sum1 = x + y
+		sum1 = e1.Click0 + e1.Click1
 	} else {
 		sum1 = 0
 	}
 	e2 := MakeEventClick(30, 40)
 	var sum2 int
 	if e2.Tag == EventClick {
-		x := e2.Click0
-		y := e2.Click1
-		sum2 = x + y
+		sum2 = e2.Click0 + e2.Click1
 	} else {
 		sum2 = 0
 	}

--- a/tests/spec/emit/snapshots/match_same_variable_in_multiple_matches_option.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_multiple_matches_option.snap
@@ -10,16 +10,14 @@ func test() int {
 	opt1 := lisette.MakeOptionSome(5)
 	var x1 int
 	if opt1.Tag == lisette.OptionSome {
-		v := opt1.SomeVal
-		x1 = v
+		x1 = opt1.SomeVal
 	} else {
 		x1 = 0
 	}
 	opt2 := lisette.MakeOptionSome(10)
 	var x2 int
 	if opt2.Tag == lisette.OptionSome {
-		v := opt2.SomeVal
-		x2 = v
+		x2 = opt2.SomeVal
 	} else {
 		x2 = 0
 	}

--- a/tests/spec/emit/snapshots/match_same_variable_in_multiple_matches_result.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_multiple_matches_result.snap
@@ -10,16 +10,14 @@ func test() int {
 	res1 := lisette.MakeResultOk[int, string](5)
 	var x1 int
 	if res1.Tag == lisette.ResultOk {
-		v := res1.OkVal
-		x1 = v
+		x1 = res1.OkVal
 	} else {
 		x1 = 0
 	}
 	res2 := lisette.MakeResultOk[int, string](10)
 	var x2 int
 	if res2.Tag == lisette.ResultOk {
-		v := res2.OkVal
-		x2 = v
+		x2 = res2.OkVal
 	} else {
 		x2 = 0
 	}

--- a/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
+++ b/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
@@ -44,7 +44,5 @@ func (s Shape) area() int {
 		r := s.Circle
 		return r * r * 3
 	}
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }

--- a/tests/spec/emit/snapshots/match_single_arm_struct_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_single_arm_struct_unused_subject.snap
@@ -19,6 +19,5 @@ func mk() P {
 }
 
 func test() {
-	subject_1 := mk()
-	_ = subject_1
+	_ = mk()
 }

--- a/tests/spec/emit/snapshots/match_slice_pattern_discard_rest.snap
+++ b/tests/spec/emit/snapshots/match_slice_pattern_discard_rest.snap
@@ -8,6 +8,5 @@ func test(items []int) int {
 	if len(items) == 0 {
 		return 0
 	}
-	first := items[0]
-	return first
+	return items[0]
 }

--- a/tests/spec/emit/snapshots/match_slice_pattern_fixed_length.snap
+++ b/tests/spec/emit/snapshots/match_slice_pattern_fixed_length.snap
@@ -6,10 +6,7 @@ package main
 
 func test(items []int) int {
 	if len(items) == 3 {
-		a := items[0]
-		b := items[1]
-		c := items[2]
-		return a + b + c
+		return items[0] + items[1] + items[2]
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/match_slice_pattern_rest_binding.snap
+++ b/tests/spec/emit/snapshots/match_slice_pattern_rest_binding.snap
@@ -8,6 +8,5 @@ func len_(items []int) int {
 	if len(items) == 0 {
 		return 0
 	}
-	rest := items[1:]
-	return 1 + len_(rest)
+	return 1 + len_(items[1:])
 }

--- a/tests/spec/emit/snapshots/match_slice_pattern_with_rest.snap
+++ b/tests/spec/emit/snapshots/match_slice_pattern_with_rest.snap
@@ -8,6 +8,5 @@ func test(items []int) int {
 	if len(items) == 0 {
 		return 0
 	}
-	first := items[0]
-	return first
+	return items[0]
 }

--- a/tests/spec/emit/snapshots/match_statement_result_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_statement_result_unit_arms.snap
@@ -9,13 +9,10 @@ import lisette "github.com/ivov/lisette/prelude"
 func noop() {}
 
 func divide(a, b int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if b == 0 {
-		tmp_1 = lisette.MakeResultErr[int, string]("err")
-	} else {
-		tmp_1 = lisette.MakeResultOk[int, string](a / b)
+		return lisette.MakeResultErr[int, string]("err")
 	}
-	return tmp_1
+	return lisette.MakeResultOk[int, string](a / b)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
@@ -9,13 +9,10 @@ import lisette "github.com/ivov/lisette/prelude"
 func use_value(_ int) {}
 
 func divide(a, b int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if b == 0 {
-		tmp_1 = lisette.MakeResultErr[int, string]("err")
-	} else {
-		tmp_1 = lisette.MakeResultOk[int, string](a / b)
+		return lisette.MakeResultErr[int, string]("err")
 	}
-	return tmp_1
+	return lisette.MakeResultOk[int, string](a / b)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
@@ -21,8 +21,7 @@ func divide(a, b int) lisette.Result[int, string] {
 func test() {
 	subject_1 := divide(10, 2)
 	if subject_1.Tag == lisette.ResultOk {
-		v := subject_1.OkVal
-		use_value(v)
+		use_value(subject_1.OkVal)
 	} else {
 		use_value(0)
 	}

--- a/tests/spec/emit/snapshots/match_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern.snap
@@ -19,7 +19,5 @@ func test(p Point) int {
 	if p.x == 0 && p.y == 0 {
 		return 0
 	}
-	x := p.x
-	y := p.y
-	return x + y
+	return p.x + p.y
 }

--- a/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
@@ -17,8 +17,6 @@ func (p Point) String() string {
 
 func test(p Point) int {
 	{
-		a := p.x
-		b := p.y
-		return a * b
+		return p.x * p.y
 	}
 }

--- a/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
@@ -9,8 +9,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func main() {
 	opt := lisette.MakeOptionSome(1)
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		_ = x
+		_ = opt.SomeVal
 	} else {
 	}
 	subject_1 := 7

--- a/tests/spec/emit/snapshots/match_subject_unit_returning_call.snap
+++ b/tests/spec/emit/snapshots/match_subject_unit_returning_call.snap
@@ -9,8 +9,7 @@ func noop() {}
 func main() {
 	var x int
 	noop()
-	subject_1 := struct{}{}
-	_ = subject_1
+	_ = struct{}{}
 	x = 1
 	_ = x
 }

--- a/tests/spec/emit/snapshots/match_subject_var_discard_ignores_string_literal_lookalike.snap
+++ b/tests/spec/emit/snapshots/match_subject_var_discard_ignores_string_literal_lookalike.snap
@@ -19,7 +19,6 @@ func make_() Point {
 }
 
 func test() string {
-	subject_1 := make_()
-	_ = subject_1
+	_ = make_()
 	return "subject_1"
 }

--- a/tests/spec/emit/snapshots/match_tuple_nested.snap
+++ b/tests/spec/emit/snapshots/match_tuple_nested.snap
@@ -11,8 +11,5 @@ func test() int {
 	if nested.First.First == 1 && nested.First.Second == 2 && nested.Second == 3 {
 		return 6
 	}
-	x := nested.First.First
-	y := nested.First.Second
-	z := nested.Second
-	return x + y + z
+	return nested.First.First + nested.First.Second + nested.Second
 }

--- a/tests/spec/emit/snapshots/match_tuple_simple.snap
+++ b/tests/spec/emit/snapshots/match_tuple_simple.snap
@@ -13,7 +13,5 @@ func test() int {
 	} else if pair.First == 1 && pair.Second == 2 {
 		return 3
 	}
-	x := pair.First
-	y := pair.Second
-	return x + y
+	return pair.First + pair.Second
 }

--- a/tests/spec/emit/snapshots/match_with_enum_data.snap
+++ b/tests/spec/emit/snapshots/match_with_enum_data.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		return x
+		return opt.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/multiple_result_constructions.snap
+++ b/tests/spec/emit/snapshots/multiple_result_constructions.snap
@@ -7,11 +7,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(flag bool) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if flag {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("error")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("error")
 }

--- a/tests/spec/emit/snapshots/nested_try_in_if_arm_with_never_tail.snap
+++ b/tests/spec/emit/snapshots/nested_try_in_if_arm_with_never_tail.snap
@@ -11,19 +11,16 @@ func die() struct{} {
 }
 
 func test(flag bool) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if flag {
-		tryResult_2 := func() lisette.Result[int, string] {
-			check_3 := lisette.MakeResultOk[int, string](1)
-			if check_3.Tag != lisette.ResultOk {
-				return lisette.MakeResultErr[int, string](check_3.ErrVal)
+		tryResult_1 := func() lisette.Result[int, string] {
+			check_2 := lisette.MakeResultOk[int, string](1)
+			if check_2.Tag != lisette.ResultOk {
+				return lisette.MakeResultErr[int, string](check_2.ErrVal)
 			}
 			die()
 			panic("unreachable")
 		}()
-		tmp_1 = tryResult_2
-	} else {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
+		return tryResult_1
 	}
-	return tmp_1
+	return lisette.MakeResultOk[int, string](42)
 }

--- a/tests/spec/emit/snapshots/newtype_pattern_on_go_interface_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/newtype_pattern_on_go_interface_emits_type_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/patterns.rs
-assertion_line: 1184
 description: "input: \nimport \"go:example.com/events\"\n\nfn describe(e: events.Event) -> int {\n  match e {\n    events.Token(s) => s.length(),\n    _ => 0,\n  }\n}\n"
 ---
 package main
@@ -10,8 +9,7 @@ import "example.com/events"
 func describe(e events.Event) int {
 	switch e := e.(type) {
 	case events.Token:
-		s := string(e)
-		return len(s)
+		return len(string(e))
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
@@ -8,7 +8,6 @@ type Wrap *int
 
 func test(w Wrap) int {
 	{
-		r := (*int)(w)
-		return *r
+		return *(*int)(w)
 	}
 }

--- a/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
@@ -14,7 +14,6 @@ func (u UserId) String() string {
 
 func test(uid UserId) int {
 	{
-		id := int(uid)
-		return id
+		return int(uid)
 	}
 }

--- a/tests/spec/emit/snapshots/option_constructor_as_argument_no_binding.snap
+++ b/tests/spec/emit/snapshots/option_constructor_as_argument_no_binding.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func unwrap_or(o lisette.Option[int], fallback int) int {
 	if o.Tag == lisette.OptionSome {
-		v := o.SomeVal
-		return v
+		return o.SomeVal
 	}
 	return fallback
 }

--- a/tests/spec/emit/snapshots/option_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/option_direct_as_argument.snap
@@ -15,8 +15,7 @@ func maybe_int(b bool) (int, bool) {
 
 func unwrap_or(o lisette.Option[int], fallback int) int {
 	if o.Tag == lisette.OptionSome {
-		v := o.SomeVal
-		return v
+		return o.SomeVal
 	}
 	return fallback
 }

--- a/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
@@ -49,13 +49,10 @@ func (s Shape) String() string {
 func shape_size(s Shape) int {
 	switch s.Tag {
 	case ShapeCircle:
-		r := s.Circle
-		return r
+		return s.Circle
 	case ShapeSquare:
-		r := s.Square
-		return r
+		return s.Square
 	default:
-		r := s.Triangle
-		return r
+		return s.Triangle
 	}
 }

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -47,8 +47,7 @@ func test(r Res, threshold int) int {
 		}
 	}
 	if subject_1.Tag == ResErr {
-		x := subject_1.Err
-		if x > threshold {
+		if subject_1.Err > threshold {
 			return 100
 		}
 	}

--- a/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
@@ -46,12 +46,10 @@ func test() int {
 	sum := 0
 	for {
 		if current.Tag == lisette.OptionSome && current.SomeVal.Tag == EA {
-			x := current.SomeVal.A
-			sum += x
+			sum += current.SomeVal.A
 			current = lisette.MakeOptionNone[E]()
 		} else if current.Tag == lisette.OptionSome && current.SomeVal.Tag == EB {
-			x := current.SomeVal.B
-			sum += x
+			sum += current.SomeVal.B
 			current = lisette.MakeOptionNone[E]()
 		} else {
 			break

--- a/tests/spec/emit/snapshots/or_pattern_on_interface_with_bindings_expands_to_separate_arms.snap
+++ b/tests/spec/emit/snapshots/or_pattern_on_interface_with_bindings_expands_to_separate_arms.snap
@@ -9,11 +9,9 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		return x + 1
+		return e.X + 1
 	case events.Scroll:
-		x := e.X
-		return x + 1
+		return e.X + 1
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
@@ -40,9 +40,7 @@ func (e E) String() string {
 
 func test(e E) int {
 	if e.Tag == EA {
-		x := e.A
-		return x
+		return e.A
 	}
-	x := e.B
-	return x
+	return e.B
 }

--- a/tests/spec/emit/snapshots/partial_match_all_variants.snap
+++ b/tests/spec/emit/snapshots/partial_match_all_variants.snap
@@ -9,12 +9,10 @@ import lisette "github.com/ivov/lisette/prelude"
 func test(p lisette.Partial[int, string]) int {
 	switch p.Tag {
 	case lisette.PartialOk:
-		n := p.OkVal
-		return n
+		return p.OkVal
 	case lisette.PartialErr:
 		return 0
 	default:
-		n := p.OkVal
-		return n
+		return p.OkVal
 	}
 }

--- a/tests/spec/emit/snapshots/partial_match_both_field_access.snap
+++ b/tests/spec/emit/snapshots/partial_match_both_field_access.snap
@@ -11,10 +11,8 @@ func test(p lisette.Partial[int, string]) string {
 	case lisette.PartialOk:
 		return "ok"
 	case lisette.PartialErr:
-		e := p.ErrVal
-		return e
+		return p.ErrVal
 	default:
-		e := p.ErrVal
-		return e
+		return p.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/propagate_direct_err_tail_position.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_tail_position.snap
@@ -11,8 +11,7 @@ func f() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	return result_2
+	return check_1.OkVal
 }
 
 func test() lisette.Result[int, string] {

--- a/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
@@ -11,10 +11,9 @@ func f() (int, bool) {
 	if check_1.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	result_2 := check_1.SomeVal
-	v_3 := result_2
-	if v_3.Tag == lisette.OptionSome {
-		return v_3.SomeVal, true
+	v_2 := check_1.SomeVal
+	if v_2.Tag == lisette.OptionSome {
+		return v_2.SomeVal, true
 	}
 	return *new(int), false
 }

--- a/tests/spec/emit/snapshots/propagate_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_in_expression.snap
@@ -15,6 +15,5 @@ func test() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	return lisette.MakeResultOk[int, string](result_2 + 10)
+	return lisette.MakeResultOk[int, string](check_1.OkVal + 10)
 }

--- a/tests/spec/emit/snapshots/propagate_in_lambda.snap
+++ b/tests/spec/emit/snapshots/propagate_in_lambda.snap
@@ -21,8 +21,7 @@ func test() int {
 	}
 	subject_2 := f(5)
 	if subject_2.Tag == lisette.ResultOk {
-		n := subject_2.OkVal
-		return n
+		return subject_2.OkVal
 	}
 	return -1
 }

--- a/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
@@ -11,6 +11,5 @@ func test() (int, bool) {
 	if x.Tag != lisette.OptionSome {
 		return *new(int), false
 	}
-	result_1 := x.SomeVal
-	return result_1 + 1, true
+	return x.SomeVal + 1, true
 }

--- a/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
@@ -11,10 +11,9 @@ func foo() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	y := result_2 + 1
-	result_2_3 := 7
-	_ = result_2_3
+	y := check_1.OkVal + 1
+	result_2 := 7
+	_ = result_2
 	return lisette.MakeResultOk[int, string](y)
 }
 

--- a/tests/spec/emit/snapshots/recover_block_with_match.snap
+++ b/tests/spec/emit/snapshots/recover_block_with_match.snap
@@ -16,8 +16,7 @@ func test() int {
 	})
 	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {
-		x := result.OkVal
-		return x
+		return result.OkVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -40,9 +40,7 @@ func (l List) String() string {
 
 func list_sum(l List) int {
 	if l.Tag == ListCons {
-		head := l.Cons0
-		tail := *l.Cons1
-		return head + list_sum(tail)
+		return l.Cons0 + list_sum((*l.Cons1))
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -43,7 +43,6 @@ func count_leaves[T any](tree Tree[T]) int {
 	if tree.Tag == TreeLeaf {
 		return 1
 	}
-	left := *tree.Left
 	right := *tree.Right
-	return count_leaves(left) + count_leaves(right)
+	return count_leaves((*tree.Left)) + count_leaves(right)
 }

--- a/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
+++ b/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
@@ -14,8 +14,7 @@ func describe(r lisette.Result[int, string]) string {
 		v := r.OkVal
 		return fmt.Sprint(v)
 	}
-	e := r.ErrVal
-	return e
+	return r.ErrVal
 }
 
 func test() string {

--- a/tests/spec/emit/snapshots/result_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/result_direct_as_argument.snap
@@ -24,8 +24,7 @@ func describe(r lisette.Result[int, string]) string {
 		v := r.OkVal
 		return fmt.Sprint(v)
 	}
-	e := r.ErrVal
-	return e
+	return r.ErrVal
 }
 
 func test() string {

--- a/tests/spec/emit/snapshots/result_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/result_direct_as_argument.snap
@@ -10,13 +10,10 @@ import (
 )
 
 func divide(a, b int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if b == 0 {
-		tmp_1 = lisette.MakeResultErr[int, string]("division by zero")
-	} else {
-		tmp_1 = lisette.MakeResultOk[int, string](a / b)
+		return lisette.MakeResultErr[int, string]("division by zero")
 	}
-	return tmp_1
+	return lisette.MakeResultOk[int, string](a / b)
 }
 
 func describe(r lisette.Result[int, string]) string {

--- a/tests/spec/emit/snapshots/result_in_array_literal.snap
+++ b/tests/spec/emit/snapshots/result_in_array_literal.snap
@@ -7,13 +7,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func try_value(x int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if x > 0 {
-		tmp_1 = lisette.MakeResultOk[int, string](x)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("negative")
+		return lisette.MakeResultOk[int, string](x)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("negative")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/result_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/result_in_tuple_literal.snap
@@ -7,13 +7,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func try_int(x int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if x > 0 {
-		tmp_1 = lisette.MakeResultOk[int, string](x)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("negative")
+		return lisette.MakeResultOk[int, string](x)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("negative")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/select_match_receive_binding_no_leak.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_binding_no_leak.snap
@@ -20,8 +20,7 @@ func main() {
 	select {
 	case recv_2, ok := <-ch:
 		if ok {
-			x := recv_2
-			fmt.Println(x)
+			fmt.Println(recv_2)
 		}
 	default:
 		fmt.Println(x_1)

--- a/tests/spec/emit/snapshots/select_match_receive_none_branch_shadow.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_none_branch_shadow.snap
@@ -14,8 +14,7 @@ func test() int {
 	select {
 	case recv_1, ok := <-ch:
 		if ok {
-			x_2 := recv_1
-			out = x_2
+			out = recv_1
 		} else {
 			out = x
 		}

--- a/tests/spec/emit/snapshots/select_match_receive_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_on_go_interface_uses_comma_ok.snap
@@ -12,9 +12,7 @@ func drain(ch <-chan shapes.Shape) int {
 		if ok {
 			asserted_2, ok_3 := recv_1.(shapes.Rect)
 			if ok_3 {
-				w := asserted_2.W
-				h := asserted_2.H
-				return w * h
+				return asserted_2.W * asserted_2.H
 			} else {
 				return -1
 			}

--- a/tests/spec/emit/snapshots/select_match_receive_propagate_channel_call.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_propagate_channel_call.snap
@@ -18,9 +18,8 @@ func f() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
 	select {
-	case v, ok := <-result_2:
+	case v, ok := <-check_1.OkVal:
 		if ok {
 			x = v
 		} else {

--- a/tests/spec/emit/snapshots/select_pattern_bindings_do_not_leak.snap
+++ b/tests/spec/emit/snapshots/select_pattern_bindings_do_not_leak.snap
@@ -23,8 +23,7 @@ func main() {
 		select {
 		case recv_2, ok := <-ch_1:
 			if ok {
-				x_3 := recv_2.x
-				result = x_3
+				result = recv_2.x
 			} else {
 				ch_1 = nil
 				continue

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_call.snap
@@ -18,15 +18,14 @@ func f() lisette.Result[int, string] {
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	ch_3 := result_2
+	ch_2 := check_1.OkVal
 	for {
 		select {
-		case v, ok := <-ch_3:
+		case v, ok := <-ch_2:
 			if ok {
 				x = v
 			} else {
-				ch_3 = nil
+				ch_2 = nil
 				continue
 			}
 		default:

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
@@ -14,20 +14,19 @@ func f() lisette.Result[int, string] {
 	chans := []chan int{make(chan int, 1)}
 	_ = lisette.ChannelSend(chans[0], 7)
 	var x int
-	_base_3 := chans
+	_base_2 := chans
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	result_2 := check_1.OkVal
-	ch_4 := _base_3[result_2]
+	ch_3 := _base_2[check_1.OkVal]
 	for {
 		select {
-		case v, ok := <-ch_4:
+		case v, ok := <-ch_3:
 			if ok {
 				x = v
 			} else {
-				ch_4 = nil
+				ch_3 = nil
 				continue
 			}
 		default:

--- a/tests/spec/emit/snapshots/select_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern.snap
@@ -21,9 +21,7 @@ func test(ch <-chan Message) int {
 		select {
 		case recv_2, ok := <-ch_1:
 			if ok {
-				id := recv_2.id
-				data := recv_2.data
-				return id + data
+				return recv_2.id + recv_2.data
 			} else {
 				ch_1 = nil
 				continue

--- a/tests/spec/emit/snapshots/select_struct_pattern_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern_on_go_interface_uses_comma_ok.snap
@@ -14,9 +14,7 @@ func drain(ch <-chan shapes.Shape) int {
 			if ok {
 				asserted_3, ok_4 := recv_2.(shapes.Rect)
 				if ok_4 {
-					w := asserted_3.W
-					h := asserted_3.H
-					return w * h
+					return asserted_3.W * asserted_3.H
 				} else {
 					return 0
 				}

--- a/tests/spec/emit/snapshots/sentinel_int_hint_wraps_to_option_at_call_site.snap
+++ b/tests/spec/emit/snapshots/sentinel_int_hint_wraps_to_option_at_call_site.snap
@@ -15,8 +15,7 @@ func main() {
 	pos := option_2
 	var tmp_3 int
 	if pos.Tag == lisette.OptionSome {
-		i := pos.SomeVal
-		tmp_3 = i
+		tmp_3 = pos.SomeVal
 	} else {
 		tmp_3 = -2
 	}

--- a/tests/spec/emit/snapshots/sentinel_int_hint_wraps_to_option_at_call_site.snap
+++ b/tests/spec/emit/snapshots/sentinel_int_hint_wraps_to_option_at_call_site.snap
@@ -11,13 +11,12 @@ import (
 
 func main() {
 	ret_1 := idx.Find("hello", "lo")
-	option_2 := lisette.OptionFromCommaOk[int](ret_1, ret_1 != -1)
-	pos := option_2
-	var tmp_3 int
+	pos := lisette.OptionFromCommaOk[int](ret_1, ret_1 != -1)
+	var tmp_2 int
 	if pos.Tag == lisette.OptionSome {
-		tmp_3 = pos.SomeVal
+		tmp_2 = pos.SomeVal
 	} else {
-		tmp_3 = -2
+		tmp_2 = -2
 	}
-	_ = tmp_3
+	_ = tmp_2
 }

--- a/tests/spec/emit/snapshots/slice_pattern_in_function.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_in_function.snap
@@ -6,9 +6,7 @@ package main
 
 func sum_pair(pair []int) int {
 	if len(pair) == 2 {
-		a := pair[0]
-		b := pair[1]
-		return a + b
+		return pair[0] + pair[1]
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/slice_pattern_match.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_match.snap
@@ -7,10 +7,7 @@ package main
 func test() int {
 	arr := []int{1, 2, 3}
 	if len(arr) == 3 {
-		a := arr[0]
-		b := arr[1]
-		c := arr[2]
-		return a + b + c
+		return arr[0] + arr[1] + arr[2]
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/slice_pattern_match_with_rest.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_match_with_rest.snap
@@ -7,9 +7,7 @@ package main
 func test() int {
 	arr := []int{1, 2, 3, 4, 5}
 	if len(arr) >= 1 {
-		first := arr[0]
-		rest := arr[1:]
-		return first + rest[0]
+		return arr[0] + arr[1:][0]
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/slice_pattern_unused_rest.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_unused_rest.snap
@@ -6,8 +6,7 @@ package main
 
 func test(nums []int) int {
 	if len(nums) >= 1 {
-		first := nums[0]
-		return first
+		return nums[0]
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -19,7 +19,7 @@ func variadic(_ int, _ ...int) int {
 }
 
 func run() (int, error) {
-	_arg_6 := side_a()
+	_arg_5 := side_a()
 	ret_1, ret_2 := get_xs()
 	var result_3 lisette.Result[[]int, error]
 	if ret_2 != nil {
@@ -31,6 +31,5 @@ func run() (int, error) {
 	if check_4.Tag != lisette.ResultOk {
 		return *new(int), check_4.ErrVal
 	}
-	result_5 := check_4.OkVal
-	return variadic(_arg_6, result_5...), nil
+	return variadic(_arg_5, check_4.OkVal...), nil
 }

--- a/tests/spec/emit/snapshots/struct_field_go_interface_pattern_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/struct_field_go_interface_pattern_emits_type_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/patterns.rs
-assertion_line: 1226
 description: "input: \nimport \"go:example.com/events\"\n\nstruct Box {\n  e: events.Event,\n}\n\nfn describe(b: Box) -> int {\n  match b {\n    Box { e: events.Token(s) } => s.length(),\n    _ => 0,\n  }\n}\n"
 ---
 package main
@@ -20,8 +19,7 @@ func (b Box) String() string {
 
 func describe(b Box) int {
 	if func() bool { _, ok := b.e.(events.Token); return ok }() {
-		s := string(b.e.(events.Token))
-		return len(s)
+		return len(string(b.e.(events.Token)))
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/struct_field_init_result_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_result_function.snap
@@ -18,13 +18,10 @@ func (c Container) String() string {
 }
 
 func get_res(b bool) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if b {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("failed")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("failed")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
@@ -26,8 +26,6 @@ func test() int {
 	}
 	subject_1 := b
 	{
-		a := subject_1.a
-		b_2 := subject_1.b
-		return a + b_2
+		return subject_1.a + subject_1.b
 	}
 }

--- a/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
@@ -40,9 +40,7 @@ func (m Message) String() string {
 
 func handle(m Message) int {
 	if m.Tag == MessageMove {
-		x := m.X
-		y := m.Y
-		return x + y
+		return m.X + m.Y
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
@@ -34,7 +34,5 @@ func (s Shape) String() string {
 }
 
 func area(s Shape) int {
-	width := s.Width
-	height := s.Height
-	return width * height
+	return s.Width * s.Height
 }

--- a/tests/spec/emit/snapshots/try_block_basic_result.snap
+++ b/tests/spec/emit/snapshots/try_block_basic_result.snap
@@ -17,13 +17,11 @@ func test() int {
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, string](result_3)
+		return lisette.MakeResultOk[int, string](check_2.OkVal)
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {
-		x := result.OkVal
-		return x
+		return result.OkVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
+++ b/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
@@ -34,11 +34,9 @@ func main() {
 	}()
 	result = tryResult_2
 	if result.Tag == lisette.ResultOk {
-		v := result.OkVal
-		fmt.Println(v)
+		fmt.Println(result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Println(e)
+		fmt.Println(result.ErrVal)
 	}
 	fmt.Println(x_1)
 }

--- a/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
+++ b/tests/spec/emit/snapshots/try_block_bindings_do_not_leak.snap
@@ -10,13 +10,10 @@ import (
 )
 
 func parse(s string) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if s == "42" {
-		tmp_1 = lisette.MakeResultOk[int, string](42)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("bad")
+		return lisette.MakeResultOk[int, string](42)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("bad")
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/try_block_early_exit_with_err.snap
+++ b/tests/spec/emit/snapshots/try_block_early_exit_with_err.snap
@@ -16,8 +16,7 @@ func test(bad bool) int {
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {
-		x := result.OkVal
-		return x
+		return result.OkVal
 	}
 	return -1
 }

--- a/tests/spec/emit/snapshots/try_block_loop_inside.snap
+++ b/tests/spec/emit/snapshots/try_block_loop_inside.snap
@@ -29,8 +29,7 @@ func test() int {
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {
-		s := result.OkVal
-		return s
+		return result.OkVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
+++ b/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
@@ -31,8 +31,7 @@ func test() int {
 	}()
 	result = tryResult_1
 	if result.Tag == lisette.ResultOk {
-		sum := result.OkVal
-		return sum
+		return result.OkVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/try_block_nested.snap
+++ b/tests/spec/emit/snapshots/try_block_nested.snap
@@ -23,29 +23,25 @@ func test() int {
 			if check_3.Tag != lisette.ResultOk {
 				return lisette.MakeResultErr[int, string](check_3.ErrVal)
 			}
-			result_4 := check_3.OkVal
-			return lisette.MakeResultOk[int, string](result_4)
+			return lisette.MakeResultOk[int, string](check_3.OkVal)
 		}()
 		inner = tryResult_2
 		var inner_val int
 		if inner.Tag == lisette.ResultOk {
-			x := inner.OkVal
-			inner_val = x
+			inner_val = inner.OkVal
 		} else {
 			inner_val = 0
 		}
-		_left_7 := inner_val
-		check_5 := risky_b()
-		if check_5.Tag != lisette.ResultOk {
-			return lisette.MakeResultErr[int, string](check_5.ErrVal)
+		_left_5 := inner_val
+		check_4 := risky_b()
+		if check_4.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, string](check_4.ErrVal)
 		}
-		result_6 := check_5.OkVal
-		return lisette.MakeResultOk[int, string](_left_7 + result_6)
+		return lisette.MakeResultOk[int, string](_left_5 + check_4.OkVal)
 	}()
 	outer = tryResult_1
 	if outer.Tag == lisette.ResultOk {
-		x := outer.OkVal
-		return x
+		return outer.OkVal
 	}
 	return -1
 }

--- a/tests/spec/emit/snapshots/try_block_option.snap
+++ b/tests/spec/emit/snapshots/try_block_option.snap
@@ -23,8 +23,7 @@ func test() int {
 	}()
 	opt = tryResult_1
 	if opt.Tag == lisette.OptionSome {
-		v := opt.SomeVal
-		return v
+		return opt.SomeVal
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
@@ -12,12 +12,11 @@ func foo() lisette.Result[int, string] {
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, any](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, any](result_3)
+		return lisette.MakeResultOk[int, any](check_2.OkVal)
 	}()
 	_ = tryResult_1
-	tryResult_1_4 := 7
-	_ = tryResult_1_4
+	tryResult_1_3 := 7
+	_ = tryResult_1_3
 	return lisette.MakeResultOk[int, string](0)
 }
 

--- a/tests/spec/emit/snapshots/try_block_with_semicolon.snap
+++ b/tests/spec/emit/snapshots/try_block_with_semicolon.snap
@@ -17,8 +17,7 @@ func test() {
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}
-		result_3 := check_2.OkVal
-		return lisette.MakeResultOk[int, string](result_3)
+		return lisette.MakeResultOk[int, string](check_2.OkVal)
 	}()
 	result = tryResult_1
 	_ = result

--- a/tests/spec/emit/snapshots/tuple_element_go_interface_pattern_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/tuple_element_go_interface_pattern_emits_type_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/emit/patterns.rs
-assertion_line: 1203
 description: "input: \nimport \"go:example.com/events\"\n\nfn describe(pair: (events.Event, int)) -> int {\n  match pair {\n    (events.Token(s), _) => s.length(),\n    _ => 0,\n  }\n}\n"
 ---
 package main
@@ -12,8 +11,7 @@ import (
 
 func describe(pair lisette.Tuple2[events.Event, int]) int {
 	if func() bool { _, ok := pair.First.(events.Token); return ok }() {
-		s := string(pair.First.(events.Token))
-		return len(s)
+		return len(string(pair.First.(events.Token)))
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/tuple_struct_if_let.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_if_let.snap
@@ -20,9 +20,7 @@ func (p Point) String() string {
 
 func test(p lisette.Option[Point]) int {
 	if p.Tag == lisette.OptionSome {
-		x := p.SomeVal.F0
-		y := p.SomeVal.F1
-		return x + y
+		return p.SomeVal.F0 + p.SomeVal.F1
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
@@ -25,7 +25,6 @@ func test(p Point) int {
 		}
 	}
 	{
-		y := subject_1.F1
-		return y
+		return subject_1.F1
 	}
 }

--- a/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
@@ -17,8 +17,6 @@ func (p Pair) String() string {
 
 func test(p Pair) int {
 	{
-		a := p.F0
-		b := p.F1
-		return a + b
+		return p.F0 + p.F1
 	}
 }

--- a/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
+++ b/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
@@ -14,8 +14,7 @@ func handle(e events.Event, threshold int) int {
 		if x > threshold {
 			return x
 		}
-		x_2 := subject_1.X
-		return x_2 + 1
+		return subject_1.X + 1
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/type_switch_binding_used_in_arm.snap
+++ b/tests/spec/emit/snapshots/type_switch_binding_used_in_arm.snap
@@ -9,12 +9,9 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		y := e.Y
-		return x * y
+		return e.X * e.Y
 	case events.Scroll:
-		delta := e.Delta
-		return delta
+		return e.Delta
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
@@ -22,8 +22,7 @@ func handle(e events.Event) int {
 		if x_3 > 50 {
 			return 2
 		}
-		x_4 := subject_1.X
-		if x_4 > 0 {
+		if subject_1.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
+++ b/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
@@ -18,8 +18,7 @@ func handle(e events.Event) (int, bool) {
 		if x_2 > 0 {
 			return x_2, true
 		}
-		x_3 := subject_1.X
-		return -x_3, true
+		return -subject_1.X, true
 	default:
 		return *new(int), false
 	}

--- a/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
@@ -18,8 +18,7 @@ func handle(e events.Event) int {
 		if x_2 > 50 {
 			return 2
 		}
-		x_3 := subject_1.X
-		if x_3 > 0 {
+		if subject_1.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/type_switch_with_field_literal_check.snap
+++ b/tests/spec/emit/snapshots/type_switch_with_field_literal_check.snap
@@ -12,8 +12,7 @@ func handle(e events.Event) int {
 		if e.X == 5 {
 			return 100
 		}
-		x := e.X
-		return x
+		return e.X
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/underscore_prefixed_match_arm_binding_used.snap
+++ b/tests/spec/emit/snapshots/underscore_prefixed_match_arm_binding_used.snap
@@ -8,8 +8,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		_val := opt.SomeVal
-		return _val + 1
+		return opt.SomeVal + 1
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/user_var_named_subject_no_collision.snap
+++ b/tests/spec/emit/snapshots/user_var_named_subject_no_collision.snap
@@ -10,8 +10,7 @@ func test(opt lisette.Option[int]) int {
 	subject_1 := 42
 	var val int
 	if opt.Tag == lisette.OptionSome {
-		v := opt.SomeVal
-		val = v
+		val = opt.SomeVal
 	} else {
 		val = 0
 	}

--- a/tests/spec/emit/snapshots/variable_shadow_in_match_assigned_to_let.snap
+++ b/tests/spec/emit/snapshots/variable_shadow_in_match_assigned_to_let.snap
@@ -10,9 +10,8 @@ func test() int {
 	val := lisette.MakeOptionSome(42)
 	var result int
 	if val.Tag == lisette.OptionSome {
-		x := val.SomeVal
-		x_1 := x * 2
-		result = x_1
+		x := val.SomeVal * 2
+		result = x
 	} else {
 		result = 0
 	}

--- a/tests/spec/emit/snapshots/variable_shadow_inside_match_arm.snap
+++ b/tests/spec/emit/snapshots/variable_shadow_inside_match_arm.snap
@@ -8,9 +8,8 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
 	if opt.Tag == lisette.OptionSome {
-		x := opt.SomeVal
-		x_1 := x * 2
-		return x_1
+		x := opt.SomeVal * 2
+		return x
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/while_let_result_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_result_function_call.snap
@@ -10,13 +10,10 @@ import (
 )
 
 func next_result(counter int) lisette.Result[int, string] {
-	var tmp_1 lisette.Result[int, string]
 	if counter < 5 {
-		tmp_1 = lisette.MakeResultOk[int, string](counter)
-	} else {
-		tmp_1 = lisette.MakeResultErr[int, string]("done")
+		return lisette.MakeResultOk[int, string](counter)
 	}
-	return tmp_1
+	return lisette.MakeResultErr[int, string]("done")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/while_let_with_break.snap
+++ b/tests/spec/emit/snapshots/while_let_with_break.snap
@@ -10,8 +10,7 @@ func test(opt lisette.Option[int]) {
 	current := opt
 	for {
 		if current.Tag == lisette.OptionSome {
-			x := current.SomeVal
-			if x > 100 {
+			if current.SomeVal > 100 {
 				break
 			}
 			current = lisette.MakeOptionNone[int]()


### PR DESCRIPTION
Reintroduce emit cosmetics from #413 and #414 by threading placement and slot targets through emission.