### PR TITLE
fix: third-party Go imports can emit a wrong package path

### DIFF
--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -118,7 +118,7 @@ impl Emitter<'_> {
         method: &str,
         is_public: bool,
     ) -> String {
-        let module = type_id.split_once('.').map(|(m, _)| m);
+        let module = type_id.contains('.').then(|| module_part(type_id));
         let computed_alias = match module {
             Some(m) if self.facts.is_foreign_module(m) => Some(self.require_module_import(m)),
             _ => None,

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -148,14 +148,26 @@ pub fn unqualified_name(id: &str) -> &str {
     id.rsplit('.').next().unwrap_or(id)
 }
 
-/// Extract the module part of a dot-qualified identifier — the first
-/// segment, before any dot.
+/// Extract the module part of a dot-qualified identifier.
 ///
 /// `"main.Point.sum"` → `"main"`, `"prelude.Option"` → `"prelude"`,
 /// `"foo"` → `"foo"`. For `go:net/http.Handler`-style ids, returns
 /// `"go:net/http"`. When the id has no dot at all, returns the id
 /// itself (the caller is responsible for handling the no-module case).
+///
+/// Handle Go import ids with slashes (e.g. `"go:github.com/jackc/pgx/v5.TxIsoLevel"`),
+/// here the module boundary is the first `.` that appears
+/// after the last `/`, not the first `.` in the entire string (which would
+/// otherwise split `"github.com"` into `"github"` + `".com/..."`).
 pub fn module_part(id: &str) -> &str {
+    if id.starts_with("go:")
+        && let Some(slash_pos) = id.rfind('/')
+    {
+        if let Some(dot_offset) = id[slash_pos..].find('.') {
+            return &id[..slash_pos + dot_offset];
+        }
+        return id;
+    }
     id.split('.').next().unwrap_or(id)
 }
 

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -399,6 +399,31 @@ pub type IntSlice = Slice<int>
 }
 
 #[test]
+fn third_party_typed_constant_domain_import_path() {
+    // Regression: module_part() split on the first '.' in the type ID, turning
+    // "go:github.com/jackc/pgx/v5.TxIsoLevel" into "go:github" and emitting
+    // `import "github"` instead of `import "github.com/jackc/pgx/v5"`.
+    // Accessing a typed constant (Go's `type T string` + const pattern,
+    // represented as a value_enum in Lisette) requires resolving the module
+    // from the type's ID — unlike plain function calls which use the import
+    // alias directly from the file's AST.
+    let input = r#"
+import "go:github.com/jackc/pgx/v5"
+
+fn test() {
+  let _ = pgx.TxIsoLevel.Serializable
+}
+"#;
+    let typedef = r#"// Package: pgx
+
+pub enum TxIsoLevel: string {
+  Serializable = "serializable",
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:github.com/jackc/pgx/v5", typedef)]);
+}
+
+#[test]
 fn import_filter_handles_apostrophe_in_doc_comments() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/third_party_typed_constant_domain_import_path.snap
+++ b/tests/spec/emit/snapshots/third_party_typed_constant_domain_import_path.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:github.com/jackc/pgx/v5\"\n\nfn test() {\n  let _ = pgx.TxIsoLevel.Serializable\n}\n"
+---
+package main
+
+import pgx "github.com/jackc/pgx/v5"
+
+func test() {
+	_ = pgx.Serializable
+}


### PR DESCRIPTION
I found an edge case in when resolving modules that can cause the resolved Go import path to become  invalid. 

This happens when doing an import on Go type, eg a const (in this case the type is actually compiled to a lis enum). The source can be found here: https://github.com/jackc/pgx/blob/3638a2bc30172d867ca6cf26ba014927c949dfac/tx.go#L13

This does not happen when doing a user-written call expression, like ```pgx.Connect(...)``` as the import is already picked up statically.

Consider this code:

```rust
import "go:github.com/jackc/pgx/v5"

fn main() {
  // Both available in the package scope
  let _ = pgx.TxIsoLevel.Serializable
  let _ = pgx.Serializable
}
```

Generates:

```go
package main

import (
	"github"
	pgx "github.com/jackc/pgx/v5"
)

func main() {
	_ = github.Serializable
	_ = pgx.Serializable
}

```

When it should generate:

```go 
package main

import pgx "github.com/jackc/pgx/v5"

func main() {
	_ = pgx.Serializable
	_ = pgx.Serializable
}
```