### PR TITLE
fix: resolve dotted go import paths

### DIFF
--- a/crates/diagnostics/src/result.rs
+++ b/crates/diagnostics/src/result.rs
@@ -24,6 +24,7 @@ pub struct SemanticResult {
     /// stdlib typedefs.
     pub typedef_paths: HashMap<u32, PathBuf>,
     pub go_package_names: HashMap<String, String>,
+    pub go_module_ids: HashSet<String>,
 }
 
 impl SemanticResult {
@@ -41,6 +42,7 @@ impl SemanticResult {
             ufcs_methods: HashSet::default(),
             typedef_paths: HashMap::default(),
             go_package_names: HashMap::default(),
+            go_module_ids: HashSet::default(),
         }
     }
 
@@ -59,6 +61,7 @@ impl SemanticResult {
             cached_modules: self.cached_modules,
             ufcs_methods: self.ufcs_methods,
             go_package_names: self.go_package_names,
+            go_module_ids: self.go_module_ids,
         }
     }
 }

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -42,12 +42,13 @@ impl Emitter<'_> {
         let ty_string = self.go_type_as_string(underlying);
 
         if let Type::Nominal { id, .. } = underlying
-            && let Some((module, _)) = id.split_once('.')
+            && let Some(module) = self.facts.module_for_qualified_name(id.as_str())
             && !self.facts.is_current_module(module)
             && module != go_name::PRELUDE_MODULE
             && !go_name::is_go_import(module)
         {
-            self.require_module_import(module);
+            let module = module.to_string();
+            self.require_module_import(&module);
         }
 
         let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -260,8 +260,9 @@ impl Emitter<'_> {
         is_import_namespace_ident
             || self.is_from_prelude(expression_ty)
             || if let Type::Nominal { id, .. } = expression_ty.strip_refs() {
-                id.split_once('.')
-                    .is_some_and(|(m, _)| self.facts.is_foreign_module(m))
+                self.facts
+                    .module_for_qualified_name(id.as_str())
+                    .is_some_and(|m| self.facts.is_foreign_module(m))
             } else {
                 false
             }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -419,10 +419,11 @@ impl Emitter<'_> {
     }
 
     fn add_enum_imports_if_needed(&mut self, name: &str, enum_id: &str) {
-        let enum_module = go_name::module_of_type_id(enum_id);
-
-        if !self.facts.is_current_module(enum_module) {
-            self.require_module_import(enum_module);
+        if let Some(enum_module) = self.facts.module_for_qualified_name(enum_id)
+            && !self.facts.is_current_module(enum_module)
+        {
+            let enum_module = enum_module.to_string();
+            self.require_module_import(&enum_module);
         }
 
         let parts: Vec<&str> = name.split('.').collect();

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -3,7 +3,7 @@ use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
 use syntax::ast::Expression;
 use syntax::program::DefinitionBody;
-use syntax::types::{Type, module_part, unqualified_name};
+use syntax::types::{Type, unqualified_name};
 
 impl Emitter<'_> {
     /// Emit a value enum variant as a Go constant (e.g., `reflect.String`).
@@ -25,7 +25,7 @@ impl Emitter<'_> {
             _ => return None,
         };
 
-        let module_key = go_name::module_of_type_id(&enum_id);
+        let module_key = self.facts.module_for_qualified_name(&enum_id)?;
 
         let qualifier = self.require_module_import(module_key);
 
@@ -106,7 +106,7 @@ impl Emitter<'_> {
 
         let make_fn_name = self.facts.make_function_name(&constructor_key)?.to_string();
 
-        let enum_module = go_name::module_of_type_id(enum_id);
+        let enum_module = self.facts.module_for_qualified_name(enum_id)?;
         let needs_qualifier = !self.facts.is_current_module(enum_module);
 
         let needs_type_args = ret_params.len() > fn_params.len();
@@ -148,7 +148,7 @@ impl Emitter<'_> {
             return None;
         };
 
-        let enum_module = module_part(enum_id);
+        let enum_module = self.facts.module_for_qualified_name(enum_id)?;
         let is_prelude = enum_module == go_name::PRELUDE_MODULE;
         let is_cross_module = !self.facts.is_current_module(enum_module) && !is_prelude;
 
@@ -227,9 +227,9 @@ impl Emitter<'_> {
         let alias_module = inner_ty.as_import_namespace()?.to_string();
         let alias_module = alias_module.as_str();
 
-        let enum_module = module_part(enum_id);
+        let enum_module = self.facts.module_for_qualified_name(enum_id)?.to_string();
 
-        self.require_module_import(enum_module);
+        self.require_module_import(&enum_module);
 
         let type_args = self.format_type_args(params);
 

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -369,7 +369,7 @@ impl Emitter<'_> {
         }
 
         let variant_name = go_name::unqualified_name(name);
-        let module = go_name::module_of_type_id(enum_id.as_str());
+        let module = self.facts.module_for_qualified_name(enum_id.as_str())?;
         let qualifier = self.require_module_import(module);
 
         Some(format!("{}.{}", qualifier, variant_name))

--- a/crates/emit/src/facts.rs
+++ b/crates/emit/src/facts.rs
@@ -16,6 +16,7 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) mutations: &'a MutationInfo,
     pub(crate) ufcs_methods: &'a HashSet<(String, String)>,
     pub(crate) go_package_names: &'a HashMap<String, String>,
+    pub(crate) go_module_ids: &'a HashSet<String>,
     pub(crate) entry_module: ModuleId,
     pub(crate) go_module: String,
     pub(crate) options: EmitOptions,
@@ -30,6 +31,7 @@ pub(crate) struct EmitFacts<'a> {
     mutations: &'a MutationInfo,
     ufcs_methods: &'a HashSet<(String, String)>,
     go_package_names: &'a HashMap<String, String>,
+    go_module_ids: &'a HashSet<String>,
     entry_module: ModuleId,
     go_module: String,
     options: EmitOptions,
@@ -46,6 +48,7 @@ impl<'a> EmitFacts<'a> {
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
             go_package_names: config.go_package_names,
+            go_module_ids: config.go_module_ids,
             entry_module: config.entry_module,
             go_module: config.go_module,
             options: config.options,
@@ -53,6 +56,13 @@ impl<'a> EmitFacts<'a> {
             globals: config.globals,
             current_module: config.current_module,
         }
+    }
+
+    pub(crate) fn module_for_qualified_name<'b>(&self, id: &'b str) -> Option<&'b str>
+    where
+        'a: 'b,
+    {
+        syntax::types::module_for_qualified_name(id, self.go_module_ids.iter().map(String::as_str))
     }
 
     pub(crate) fn definition(&self, id: &str) -> Option<&'a Definition> {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -183,6 +183,7 @@ pub struct TestEmitConfig<'a> {
     pub mutations: &'a MutationInfo,
     pub ufcs_methods: &'a HashSet<(String, String)>,
     pub go_package_names: &'a HashMap<String, String>,
+    pub go_module_ids: &'a HashSet<String>,
 }
 
 pub struct Emitter<'a> {
@@ -297,6 +298,7 @@ impl<'a> Emitter<'a> {
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
             go_package_names: config.go_package_names,
+            go_module_ids: config.go_module_ids,
             entry_module: config.module_id.to_string(),
             go_module: config.go_module.to_string(),
             options: EmitOptions { debug },
@@ -426,7 +428,7 @@ impl<'a> Emitter<'a> {
 
     pub(crate) fn module_alias_for_type(&self, ty: &Type) -> Option<String> {
         if let Type::Nominal { id, .. } = ty {
-            let module = names::go_name::module_of_type_id(id);
+            let module = self.facts.module_for_qualified_name(id)?;
             self.module.module_alias(module).map(str::to_string)
         } else {
             None
@@ -531,6 +533,7 @@ fn emit_module<'a>(
         mutations: &analysis.mutations,
         ufcs_methods: &analysis.ufcs_methods,
         go_package_names: &analysis.go_package_names,
+        go_module_ids: &analysis.go_module_ids,
         entry_module: analysis.entry_module_id.to_string(),
         go_module: go_module.to_string(),
         options: options.clone(),

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -44,10 +44,6 @@ pub(crate) fn go_package_name(module: &str) -> &str {
     module.rsplit('/').next().unwrap_or(module)
 }
 
-pub(crate) fn module_of_type_id(id: &str) -> &str {
-    syntax::types::module_part(id)
-}
-
 pub(crate) fn sanitize_package_name(name: &str) -> Cow<'_, str> {
     let has_bad_chars = name.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_');
     let starts_with_digit = name.starts_with(|c: char| c.is_ascii_digit());
@@ -148,6 +144,7 @@ pub(crate) fn resolve(name: &str) -> ResolvedName {
 pub(crate) fn variant(
     identifier: &str,
     ty: &Type,
+    enum_module: &str,
     current_module: &str,
     module_alias: Option<&str>,
 ) -> ResolvedName {
@@ -155,17 +152,17 @@ pub(crate) fn variant(
         return ResolvedName::local(identifier.replace('.', "_"));
     };
 
-    variant_by_id(identifier, id, current_module, module_alias)
+    variant_by_id(identifier, id, enum_module, current_module, module_alias)
 }
 
 pub(crate) fn variant_by_id(
     identifier: &str,
     enum_id: &str,
+    enum_module: &str,
     current_module: &str,
     module_alias: Option<&str>,
 ) -> ResolvedName {
     let is_prelude = enum_id.starts_with(PRELUDE_PREFIX);
-    let enum_module = module_of_type_id(enum_id);
     let enum_name = unqualified_name(enum_id);
     let variant_name = unqualified_name(identifier);
 
@@ -276,19 +273,20 @@ pub(crate) fn escape_reserved(name: &str) -> Cow<'_, str> {
 }
 
 pub(crate) fn qualify_method(
-    type_id: &str,
+    module: Option<&str>,
+    type_name: &str,
     method: &str,
     current_module: &str,
     is_public: bool,
     module_alias: Option<&str>,
 ) -> ResolvedName {
-    let Some((module, type_name)) = type_id.split_once('.') else {
+    let Some(module) = module else {
         let method_name = if is_public {
             snake_to_camel(method)
         } else {
             method.to_string()
         };
-        return ResolvedName::local(format!("{}_{}", type_id, method_name));
+        return ResolvedName::local(format!("{}_{}", type_name, method_name));
     };
 
     if module == PRELUDE_MODULE {

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -1,4 +1,4 @@
-use syntax::types::{module_part, unqualified_name};
+use syntax::types::unqualified_name;
 
 use crate::Emitter;
 use crate::names::go_name;
@@ -50,7 +50,7 @@ impl Emitter<'_> {
         if id == qualified {
             return None;
         }
-        let type_module = module_part(&id);
+        let type_module = self.facts.module_for_qualified_name(&id).unwrap_or(&id);
         if self.facts.is_current_module(type_module) {
             return Some(unqualified_name(&id).to_string());
         }
@@ -118,13 +118,18 @@ impl Emitter<'_> {
         method: &str,
         is_public: bool,
     ) -> String {
-        let module = type_id.split_once('.').map(|(m, _)| m);
-        let computed_alias = match module {
+        let module = self
+            .facts
+            .module_for_qualified_name(type_id)
+            .map(str::to_string);
+        let type_name = unqualified_name(type_id);
+        let computed_alias = match module.as_deref() {
             Some(m) if self.facts.is_foreign_module(m) => Some(self.require_module_import(m)),
             _ => None,
         };
         let resolved = go_name::qualify_method(
-            type_id,
+            module.as_deref(),
+            type_name,
             method,
             self.facts.current_module(),
             is_public,
@@ -137,7 +142,10 @@ impl Emitter<'_> {
     }
 
     pub(crate) fn resolve_variant(&mut self, identifier: &str, enum_id: &str) -> String {
-        let enum_module = module_part(enum_id);
+        let enum_module = self
+            .facts
+            .module_for_qualified_name(enum_id)
+            .unwrap_or(enum_id);
         let computed_alias = if self.facts.is_foreign_module(enum_module) {
             Some(self.require_module_import(enum_module))
         } else {
@@ -146,6 +154,7 @@ impl Emitter<'_> {
         let resolved = go_name::variant_by_id(
             identifier,
             enum_id,
+            enum_module,
             self.facts.current_module(),
             computed_alias.as_deref(),
         );

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1018,7 +1018,9 @@ fn collect_enum_variant_checks(
             return;
         };
         let variant_name = go_name::unqualified_name(identifier);
-        let module = go_name::module_of_type_id(id.as_str());
+        let Some(module) = emitter.facts.module_for_qualified_name(id.as_str()) else {
+            return;
+        };
         let qualifier = emitter.go_pkg_qualifier(module);
         let go_literal = if qualifier.is_empty() || qualifier == emitter.facts.current_module() {
             variant_name.to_string()
@@ -1107,6 +1109,13 @@ struct EnumVariantData<'a> {
     typed_variant_fields: Option<&'a [syntax::ast::EnumFieldDefinition]>,
 }
 
+fn enum_module_of<'a>(emitter: &Emitter<'a>, ty: &'a Type) -> &'a str {
+    match ty {
+        Type::Nominal { id, .. } => emitter.facts.module_for_qualified_name(id).unwrap_or(id),
+        _ => "",
+    }
+}
+
 /// Collect checks and bindings for a tagged enum variant pattern.
 fn collect_tagged_enum_checks(
     emitter: &Emitter,
@@ -1115,9 +1124,11 @@ fn collect_tagged_enum_checks(
     collector: &mut PatternCollector,
 ) {
     let alias = emitter.module_alias_for_type(variant.ty);
+    let enum_module = enum_module_of(emitter, variant.ty);
     let resolved = go_name::variant(
         variant.identifier,
         variant.ty,
+        enum_module,
         emitter.facts.current_module(),
         alias.as_deref(),
     );
@@ -1229,9 +1240,11 @@ fn collect_struct_checks(
         let enum_info = detect_enum_info(emitter, ty, identifier, typed);
         if enum_info.is_some() {
             let alias = emitter.module_alias_for_type(ty);
+            let enum_module = enum_module_of(emitter, ty);
             let resolved = go_name::variant(
                 identifier,
                 ty,
+                enum_module,
                 emitter.facts.current_module(),
                 alias.as_deref(),
             );

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -540,7 +540,7 @@ impl Emitter<'_> {
         if let Some(rest) = name.strip_prefix(go_name::GO_IMPORT_PREFIX) {
             return rest.rsplit_once('.').map(|(path, _)| path.to_string());
         }
-        let (module, _) = name.split_once('.')?;
+        let module = self.facts.module_for_qualified_name(name)?;
         if !self.facts.is_foreign_module(module) {
             return None;
         }

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -354,6 +354,13 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
     let mut definitions = HashMap::default();
     let mut modules = HashMap::default();
 
+    let go_module_ids: HashSet<String> = store
+        .modules
+        .keys()
+        .filter(|id| id.starts_with(syntax::types::GO_IMPORT_PREFIX))
+        .cloned()
+        .collect();
+
     for (mod_id, module) in store.modules {
         let is_internal = module.is_internal();
 
@@ -394,6 +401,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
         ufcs_methods,
         typedef_paths: store.typedef_paths,
         go_package_names: store.go_package_names,
+        go_module_ids,
     };
 
     (result, facts)

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -5,7 +5,7 @@ use syntax::ast::{Expression, Span, StructKind};
 use syntax::program::{
     Definition, DefinitionBody, DotAccessKind, NativeTypeKind, ReceiverCoercion,
 };
-use syntax::types::{Symbol, Type, module_part, substitute, unqualified_name};
+use syntax::types::{Symbol, Type, substitute, unqualified_name};
 
 use super::super::TaskState;
 use super::super::addressability::check_is_non_addressable;
@@ -278,8 +278,8 @@ impl TaskState<'_> {
 
     /// Whether a type's owning module is foreign (not current, prelude, or Go stdlib).
     /// Used to gate cross-module visibility checks on methods.
-    fn is_foreign_type(&self, type_id: &str) -> bool {
-        let type_module = module_part(type_id);
+    fn is_foreign_type(&self, store: &Store, type_id: &str) -> bool {
+        let type_module = store.module_for_qualified_name(type_id).unwrap_or(type_id);
         type_module != self.cursor.module_id
             && type_module != "prelude"
             && !type_module.starts_with("go:")
@@ -437,7 +437,9 @@ impl TaskState<'_> {
 
         self.facts.add_usage(*args.span, field.name_span);
 
-        let struct_module = module_part(&struct_name);
+        let struct_module = store
+            .module_for_qualified_name(&struct_name)
+            .unwrap_or(&struct_name);
         let is_cross_module = struct_module != self.cursor.module_id;
 
         if is_cross_module && !field_is_pub {
@@ -658,7 +660,7 @@ impl TaskState<'_> {
                 self.facts.add_usage(*args.span, definition_span);
             }
 
-            if self.is_foreign_type(&qualified_name)
+            if self.is_foreign_type(store, &qualified_name)
                 && let Some(def) = store.get_definition(&method_key)
                 && matches!(def.body, DefinitionBody::Value { .. })
                 && !def.visibility.is_public()
@@ -918,7 +920,7 @@ impl TaskState<'_> {
             return None;
         };
 
-        let is_foreign = self.is_foreign_type(&id);
+        let is_foreign = self.is_foreign_type(store, &id);
         if is_foreign && !visibility.is_public() {
             return None;
         }
@@ -1019,7 +1021,7 @@ impl TaskState<'_> {
                 ));
         }
 
-        if self.is_foreign_type(&id) && !is_public {
+        if self.is_foreign_type(store, &id) && !is_public {
             self.sink.push(diagnostics::infer::private_method_access(
                 args.member_name,
                 type_simple_name,
@@ -1038,7 +1040,7 @@ impl TaskState<'_> {
 
         self.unify(store, args.expected_ty, &method_ty, args.span);
 
-        let type_module = module_part(&id);
+        let type_module = store.module_for_qualified_name(&id).unwrap_or(&id);
         let is_cross_module = type_module != self.cursor.module_id;
         let is_exported = is_public || is_cross_module;
         let kind = DotAccessKind::StaticMethod { is_exported };
@@ -1052,7 +1054,7 @@ impl TaskState<'_> {
             // fall back to false; the emitter will check method_needs_export.
             return false;
         };
-        let type_module = module_part(&id);
+        let type_module = store.module_for_qualified_name(&id).unwrap_or(&id);
         let is_cross_module = type_module != self.cursor.module_id;
 
         if is_cross_module {

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -7,7 +7,7 @@ use syntax::ast::{
     TypedPattern,
 };
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{Type, module_part, substitute, unqualified_name};
+use syntax::types::{Type, substitute, unqualified_name};
 
 use crate::checker::EnvResolve;
 use crate::store::Store;
@@ -532,7 +532,9 @@ impl TaskState<'_> {
 
         let scrutinee_is_error = expected_ty.shallow_resolve_in(&self.env).is_error();
 
-        let struct_module = module_part(&qualified_name);
+        let struct_module = store
+            .module_for_qualified_name(&qualified_name)
+            .unwrap_or(&qualified_name);
         let is_cross_module = struct_module != self.cursor.module_id;
 
         let available: Vec<String> = struct_fields.iter().map(|f| f.name.to_string()).collect();

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -6,8 +6,7 @@ use ecow::EcoString;
 use syntax::ast::{Expression, Span, StructFieldAssignment, StructSpread};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{
-    CompoundKind, SimpleKind, SubstitutionMap, Symbol, Type, module_part, substitute,
-    unqualified_name,
+    CompoundKind, SimpleKind, SubstitutionMap, Symbol, Type, substitute, unqualified_name,
 };
 
 use super::super::TaskState;
@@ -264,7 +263,9 @@ impl TaskState<'_> {
 
         let new_spread = self.infer_struct_spread(store, spread, &struct_call_ty);
 
-        let struct_module = module_part(&qualified_name);
+        let struct_module = store
+            .module_for_qualified_name(&qualified_name)
+            .unwrap_or(&qualified_name);
         let is_cross_module = struct_module != self.cursor.module_id
             || struct_name
                 .split_once('.')
@@ -313,9 +314,8 @@ impl TaskState<'_> {
             && is_cross_module
             && !is_go_imported
         {
-            let owning_module = qualified_name
-                .split_once('.')
-                .map(|(m, _)| m)
+            let owning_module = store
+                .module_for_qualified_name(&qualified_name)
                 .unwrap_or(&qualified_name);
             for field in &struct_fields {
                 if !matched_fields.contains(&field.name) && !field.visibility.is_public() {
@@ -648,10 +648,8 @@ fn has_zero_nominal(
         DefinitionBody::Struct { fields, .. } => {
             let def_ty = &def.ty;
             let map = build_substitution(def_ty, params);
-            let struct_module = id
-                .as_str()
-                .split_once('.')
-                .map(|(m, _)| m)
+            let struct_module = store
+                .module_for_qualified_name(id.as_str())
                 .unwrap_or(from_module);
             let struct_is_foreign = struct_module != from_module;
             let struct_name: EcoString = id.last_segment().into();

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -233,15 +233,18 @@ impl TaskState<'_> {
                     substituted_method,
                     impl_method_without_receiver.clone(),
                 ));
-            } else if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env) {
-                let parts: Vec<&str> = id.split('.').collect();
-                if parts.len() == 2 {
-                    self.facts.mark_method_used_for_interface(
-                        parts[0].to_string(),
-                        method_name.to_string(),
-                        Span::dummy(),
-                    );
-                }
+            } else if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
+                && let Some(module) = store.module_for_qualified_name(id.as_str())
+                && id
+                    .as_str()
+                    .get(module.len() + 1..)
+                    .is_some_and(|rest| !rest.contains('.'))
+            {
+                self.facts.mark_method_used_for_interface(
+                    module.to_string(),
+                    method_name.to_string(),
+                    Span::dummy(),
+                );
             }
         }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -171,23 +171,10 @@ impl Store {
     }
 
     pub fn module_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
-        if !qualified_name.starts_with("go:") || !qualified_name.contains('/') {
-            let (module_name, _) = qualified_name.split_once('.')?;
-            return Some(module_name);
-        }
-
-        let mut best: Option<&str> = None;
-        for module_id in self.modules.keys() {
-            if qualified_name.starts_with(module_id.as_str())
-                && qualified_name.as_bytes().get(module_id.len()) == Some(&b'.')
-                && best
-                    .as_ref()
-                    .is_none_or(|prev| module_id.len() > prev.len())
-            {
-                best = Some(module_id.as_str());
-            }
-        }
-        best
+        syntax::types::module_for_qualified_name(
+            qualified_name,
+            self.modules.keys().map(String::as_str),
+        )
     }
 
     pub fn variants_of(&self, qualified_name: &str) -> Option<&[EnumVariant]> {

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -91,6 +91,7 @@ pub struct EmitInput {
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
     pub go_package_names: HashMap<String, String>,
+    pub go_module_ids: HashSet<String>,
 }
 
 #[cfg(test)]

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -64,13 +64,6 @@ impl Symbol {
     pub fn without_last_segment(&self) -> Option<&str> {
         self.0.rsplit_once('.').map(|(rest, _)| rest)
     }
-
-    /// Naive first segment (first dot split). Correct for user modules; for
-    /// `go:net/http.Handler`-style symbols, resolve via
-    /// `Store::module_for_qualified_name` instead.
-    pub fn simple_module_part(&self) -> Option<&str> {
-        self.0.split_once('.').map(|(m, _)| m)
-    }
 }
 
 impl Borrow<str> for Symbol {
@@ -148,15 +141,30 @@ pub fn unqualified_name(id: &str) -> &str {
     id.rsplit('.').next().unwrap_or(id)
 }
 
-/// Extract the module part of a dot-qualified identifier — the first
-/// segment, before any dot.
-///
-/// `"main.Point.sum"` → `"main"`, `"prelude.Option"` → `"prelude"`,
-/// `"foo"` → `"foo"`. For `go:net/http.Handler`-style ids, returns
-/// `"go:net/http"`. When the id has no dot at all, returns the id
-/// itself (the caller is responsible for handling the no-module case).
-pub fn module_part(id: &str) -> &str {
-    id.split('.').next().unwrap_or(id)
+pub const GO_IMPORT_PREFIX: &str = "go:";
+
+/// Resolve the module of a qualified ID. For `go:` IDs containing `/`,
+/// does a longest-prefix match against `module_ids` to disambiguate paths
+/// whose module segment contains dots (e.g. `gopkg.in/yaml.v3`). Otherwise
+/// splits on the first dot. Returns `None` when the id has no dot and is
+/// not a registered `go:` module.
+pub fn module_for_qualified_name<'a, I>(id: &'a str, module_ids: I) -> Option<&'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    if !id.starts_with(GO_IMPORT_PREFIX) || !id.contains('/') {
+        return id.split_once('.').map(|(m, _)| m);
+    }
+    let mut best: Option<&str> = None;
+    for module_id in module_ids {
+        if id.starts_with(module_id)
+            && id.as_bytes().get(module_id.len()) == Some(&b'.')
+            && best.is_none_or(|prev| module_id.len() > prev.len())
+        {
+            best = Some(module_id);
+        }
+    }
+    best
 }
 
 pub fn is_range_type_name(name: &str) -> bool {

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -48,6 +48,7 @@ fn emit_inner(
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
         go_package_names: &result.go_package_names,
+        go_module_ids: &result.go_module_ids,
     };
     let mut emitter = Emitter::new_for_tests(&config, source_for_debug);
     let emitted_files = emitter.emit_files(&[&file], &result.module_id);

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -98,7 +98,15 @@ impl CompiledTest {
 
         init_prelude(&mut store);
 
-        let (typed_ast, definitions, unused, mutations, ufcs_methods, go_package_names) = {
+        let (
+            typed_ast,
+            definitions,
+            unused,
+            mutations,
+            ufcs_methods,
+            go_package_names,
+            go_module_ids,
+        ) = {
             let mut checker = TaskState::with_fresh_allocator(&sink);
             checker
                 .ufcs_methods
@@ -256,6 +264,12 @@ impl CompiledTest {
 
             let ufcs_methods = std::mem::take(&mut checker.ufcs_methods);
             let go_package_names = store.go_package_names.clone();
+            let go_module_ids: HashSet<String> = store
+                .modules
+                .keys()
+                .filter(|id| id.starts_with(syntax::types::GO_IMPORT_PREFIX))
+                .cloned()
+                .collect();
 
             (
                 typed_ast,
@@ -264,6 +278,7 @@ impl CompiledTest {
                 mutations,
                 ufcs_methods,
                 go_package_names,
+                go_module_ids,
             )
         };
 
@@ -276,6 +291,7 @@ impl CompiledTest {
             mutations,
             ufcs_methods,
             go_package_names,
+            go_module_ids,
         }
     }
 }
@@ -289,6 +305,7 @@ pub struct InferenceResult {
     pub mutations: MutationInfo,
     pub ufcs_methods: HashSet<(String, String)>,
     pub go_package_names: HashMap<String, String>,
+    pub go_module_ids: HashSet<String>,
 }
 
 fn unwrap_test_wrapper(expression: Expression) -> Expression {

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -61,6 +61,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
         go_package_names: &result.go_package_names,
+        go_module_ids: &result.go_module_ids,
     };
     let mut emitter = Emitter::new_for_tests(&config, None);
     let mut emitted_files = emitter.emit_files(&[&file], &result.module_id);

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -419,3 +419,78 @@ pub const Value: int = 1
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
 }
+
+#[test]
+fn gopkg_in_dotted_version_path_resolves_module() {
+    let input = r#"
+import "go:gopkg.in/yaml.v3"
+
+fn test() {
+  let _ = yaml.Decoder{}
+}
+"#;
+    let typedef = r#"// Package: yaml
+
+pub struct Decoder {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:gopkg.in/yaml.v3", typedef)]);
+}
+
+#[test]
+fn gopkg_in_value_enum_chain_access_emits_correct_qualifier() {
+    let input = r#"
+import "go:gopkg.in/yaml.v3"
+
+fn test() {
+  let _ = yaml.Kind.ScalarNode
+}
+"#;
+    let typedef = r#"// Package: yaml
+
+pub enum Kind: uint32 {
+  ScalarNode = 8,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:gopkg.in/yaml.v3", typedef)]);
+}
+
+#[test]
+fn gopkg_in_instance_method_emits_correct_qualifier() {
+    let input = r#"
+import "go:gopkg.in/yaml.v3"
+
+fn test() {
+  let mut d = yaml.Decoder{}
+  d.KnownFields(true)
+}
+"#;
+    let typedef = r#"// Package: yaml
+
+pub struct Decoder {}
+
+impl Decoder {
+  pub fn KnownFields(self: Ref<Decoder>, enable: bool)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:gopkg.in/yaml.v3", typedef)]);
+}
+
+#[test]
+fn gopkg_in_struct_pattern_match_emits_correct_qualifier() {
+    let input = r#"
+import "go:gopkg.in/yaml.v3"
+
+fn describe(e: yaml.TypeError) -> int {
+  match e {
+    yaml.TypeError { Errors: errs } => errs.length(),
+  }
+}
+"#;
+    let typedef = r#"// Package: yaml
+
+pub struct TypeError {
+  pub Errors: Slice<string>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:gopkg.in/yaml.v3", typedef)]);
+}

--- a/tests/spec/emit/snapshots/gopkg_in_dotted_version_path_resolves_module.snap
+++ b/tests/spec/emit/snapshots/gopkg_in_dotted_version_path_resolves_module.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:gopkg.in/yaml.v3\"\n\nfn test() {\n  let _ = yaml.Decoder{}\n}\n"
+---
+package main
+
+import yaml "gopkg.in/yaml.v3"
+
+func test() {
+	_ = yaml.Decoder{}
+}

--- a/tests/spec/emit/snapshots/gopkg_in_instance_method_emits_correct_qualifier.snap
+++ b/tests/spec/emit/snapshots/gopkg_in_instance_method_emits_correct_qualifier.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:gopkg.in/yaml.v3\"\n\nfn test() {\n  let mut d = yaml.Decoder{}\n  d.KnownFields(true)\n}\n"
+---
+package main
+
+import yaml "gopkg.in/yaml.v3"
+
+func test() {
+	d := yaml.Decoder{}
+	d.KnownFields(true)
+}

--- a/tests/spec/emit/snapshots/gopkg_in_struct_pattern_match_emits_correct_qualifier.snap
+++ b/tests/spec/emit/snapshots/gopkg_in_struct_pattern_match_emits_correct_qualifier.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:gopkg.in/yaml.v3\"\n\nfn describe(e: yaml.TypeError) -> int {\n  match e {\n    yaml.TypeError { Errors: errs } => errs.length(),\n  }\n}\n"
+---
+package main
+
+import yaml "gopkg.in/yaml.v3"
+
+func describe(e yaml.TypeError) int {
+	{
+		return len(e.Errors)
+	}
+}

--- a/tests/spec/emit/snapshots/gopkg_in_value_enum_chain_access_emits_correct_qualifier.snap
+++ b/tests/spec/emit/snapshots/gopkg_in_value_enum_chain_access_emits_correct_qualifier.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:gopkg.in/yaml.v3\"\n\nfn test() {\n  let _ = yaml.Kind.ScalarNode\n}\n"
+---
+package main
+
+import yaml "gopkg.in/yaml.v3"
+
+func test() {
+	_ = yaml.ScalarNode
+}


### PR DESCRIPTION
Resolving the module of a qualified ID by splitting on the first dot works for user modules and Go stdlib, but this breaks any Go import path whose module segment contains a dot:

```rust
import "go:gopkg.in/Knetic/govaluate.v3"

fn main() {
  let _ = govaluate.TokenKind.BOOLEAN
}
```

wrongly produced

```go
import "gopkg"
func main() {
    _ = gopkg.BOOLEAN
}
```

#417 showed one symptom like `github.com/foo/bar/v2` but paths whose last segment is dotted share the same root cause, i.e. there is no way to recover the module boundary syntactically when the module path contains a dot.

This PR replaces the dot-splitting heuristic with a module-aware resolver, which both infer and emit use. All callsites of the old heuristic plus all hand-rolled `split_once('.')` siblings were migrated to the new resolver.

Supersedes #417