### PR TITLE
refactor: emit idiomatic fmt verbs in interpolations

### DIFF
--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -5,7 +5,7 @@ use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
 use crate::types::coercion::{Coercion, CoercionDirection};
 use syntax::ast::{FormatStringPart, Literal};
-use syntax::types::Type;
+use syntax::types::{SimpleKind, Type};
 
 impl Emitter<'_> {
     pub(super) fn emit_literal(
@@ -113,8 +113,8 @@ impl Emitter<'_> {
         let emitted = self.sequence(output, stages, "_fmtarg");
 
         let mut format_string = String::new();
-        let mut args = Vec::new();
-        let mut expression_idx = 0;
+        let mut args = Vec::with_capacity(emitted.len());
+        let mut emitted = emitted.into_iter();
 
         for part in parts {
             match part {
@@ -128,14 +128,20 @@ impl Emitter<'_> {
                     }
                 }
                 FormatStringPart::Expression(expression) => {
-                    let format_verb = if expression.get_type().is_rune() {
-                        "%c"
-                    } else {
-                        "%v"
+                    let format_verb = match expression.get_type().as_simple() {
+                        Some(SimpleKind::Rune) => "%c",
+                        Some(SimpleKind::String) => "%s",
+                        Some(SimpleKind::Bool) => "%t",
+                        Some(k) if k.is_signed_int() || k.is_unsigned_int() => "%d",
+                        Some(k) if k.is_float() => "%g",
+                        _ => "%v",
                     };
                     format_string.push_str(format_verb);
-                    args.push(emitted[expression_idx].clone());
-                    expression_idx += 1;
+                    args.push(
+                        emitted
+                            .next()
+                            .expect("emitted count matches expression parts"),
+                    );
                 }
             }
         }
@@ -145,7 +151,13 @@ impl Emitter<'_> {
         }
 
         self.requirements.require_fmt();
-        if format_string == "%v" && args.len() == 1 {
+        // Solo-expression f-strings round-trip through fmt.Sprint, which skips
+        // the format-string parse. Excluded: `%c`, because Sprint on a rune
+        // prints the integer codepoint instead of the character.
+        if args.len() == 1
+            && matches!(parts, [FormatStringPart::Expression(_)])
+            && format_string != "%c"
+        {
             return format!("fmt.Sprint({})", args[0]);
         }
         format!("fmt.Sprintf(\"{}\", {})", format_string, args.join(", "))

--- a/tests/spec/build/snapshots/cross_module_bounded_impl_tracks_imports.snap
+++ b/tests/spec/build/snapshots/cross_module_bounded_impl_tracks_imports.snap
@@ -18,7 +18,7 @@ func (b Box[T]) String() string {
 }
 
 func (b Box[T]) Display() string {
-	return fmt.Sprintf("Box(%v)", b.Value.Show())
+	return fmt.Sprintf("Box(%s)", b.Value.Show())
 }
 
 

--- a/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
+++ b/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
@@ -10,7 +10,7 @@ import (
 )
 
 func Process(item models.Item) string {
-	return fmt.Sprintf("%v: %v", item.Name, item.Value)
+	return fmt.Sprintf("%s: %d", item.Name, item.Value)
 }
 
 func CreateItem(name string, value int) models.Item {
@@ -37,7 +37,7 @@ func main() {
 	}
 	fmt.Println(logic.Process(item))
 	created := logic.CreateItem("created", 100)
-	fmt.Printf("%v: %v\n", created.Name, created.Value)
+	fmt.Printf("%s: %d\n", created.Name, created.Value)
 }
 
 

--- a/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
+++ b/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
@@ -42,5 +42,5 @@ func main() {
 	b := Box[Name]{value: Name{name: "Alice"}}
 	Box_print(b)
 	b2 := Box[int]{value: 42}
-	fmt.Printf("int box: %v\n", b2.get())
+	fmt.Printf("int box: %d\n", b2.get())
 }

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
@@ -24,7 +24,7 @@ func (c Container[T]) String() string {
 }
 
 func Container_display[T Printable](self Container[T]) string {
-	return fmt.Sprintf("[%v] %v", self.label, self.value.PrintVal())
+	return fmt.Sprintf("[%s] %s", self.label, self.value.PrintVal())
 }
 
 func Container_total[T Summable](self Container[T]) int {
@@ -57,5 +57,5 @@ func main() {
 		label: "box",
 	}
 	fmt.Println(Container_display(c))
-	fmt.Printf("total: %v\n", Container_total(c))
+	fmt.Printf("total: %d\n", Container_total(c))
 }

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -47,7 +47,7 @@ import (
 )
 
 func DescribeTaggedPair[A traits.Showable, B traits.Showable](tp types.Tagged[types.Pair[A, B]]) string {
-	return fmt.Sprintf("tagged_pair: %v", tp.Display())
+	return fmt.Sprintf("tagged_pair: %s", tp.Display())
 }
 
 
@@ -77,11 +77,11 @@ func (p Pair[A, B]) String() string {
 }
 
 func (p Pair[A, B]) Show() string {
-	return fmt.Sprintf("(%v, %v)", p.First.Show(), p.Second.Show())
+	return fmt.Sprintf("(%s, %s)", p.First.Show(), p.Second.Show())
 }
 
 func (p Pair[A, B]) Display() string {
-	return fmt.Sprintf("Pair%v", p.Show())
+	return fmt.Sprintf("Pair%s", p.Show())
 }
 
 type Tagged[T traits.Showable] struct {
@@ -94,9 +94,9 @@ func (t Tagged[T]) String() string {
 }
 
 func (t Tagged[T]) Show() string {
-	return fmt.Sprintf("[%v] %v", t.Label, t.Value.Show())
+	return fmt.Sprintf("[%s] %s", t.Label, t.Value.Show())
 }
 
 func (t Tagged[T]) Display() string {
-	return fmt.Sprintf("Tagged%v", t.Show())
+	return fmt.Sprintf("Tagged%s", t.Show())
 }

--- a/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
+++ b/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
@@ -34,5 +34,5 @@ func (p Person) String() string {
 }
 
 func (p Person) Greet() string {
-	return fmt.Sprintf("Hello, I'm %v", p.Name)
+	return fmt.Sprintf("Hello, I'm %s", p.Name)
 }

--- a/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
+++ b/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
@@ -12,7 +12,7 @@ import (
 func main() {
 	nums := []int{1, 2, 3}
 	strs := lisette.SliceMap[int, string](nums, func(x int) string {
-		return fmt.Sprintf("n=%v", x)
+		return fmt.Sprintf("n=%d", x)
 	})
 	for _, s := range strs {
 		fmt.Println(s)

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -657,6 +657,19 @@ fn test() {
 }
 
 #[test]
+fn format_string_solo_rune() {
+    let input = r#"
+import "go:fmt"
+
+fn test() {
+  let c = 'A';
+  fmt.Print(f"{c}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn compound_assignment() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/closure_let_shadow.snap
+++ b/tests/spec/emit/snapshots/closure_let_shadow.snap
@@ -9,7 +9,7 @@ import "fmt"
 func test() string {
 	f := func() string {
 		x := 1
-		x_1 := fmt.Sprintf("was %v", x)
+		x_1 := fmt.Sprintf("was %d", x)
 		return x_1
 	}
 	return f()

--- a/tests/spec/emit/snapshots/closure_param_shadow_outer_access.snap
+++ b/tests/spec/emit/snapshots/closure_param_shadow_outer_access.snap
@@ -10,8 +10,8 @@ func test() string {
 	x := "outer"
 	f := func(x int) string {
 		x_1 := x * 2
-		return fmt.Sprintf("doubled: %v", x_1)
+		return fmt.Sprintf("doubled: %d", x_1)
 	}
 	result := f(5)
-	return fmt.Sprintf("%v and %v", result, x)
+	return fmt.Sprintf("%s and %s", result, x)
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_public_function.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_public_function.snap
@@ -8,5 +8,5 @@ import "fmt"
 
 // A publicly exported function.
 func Greet(name string) string {
-	return fmt.Sprintf("Hello, %v!", name)
+	return fmt.Sprintf("Hello, %s!", name)
 }

--- a/tests/spec/emit/snapshots/emit_fstring_multiline_text.snap
+++ b/tests/spec/emit/snapshots/emit_fstring_multiline_text.snap
@@ -7,5 +7,5 @@ package main
 import "fmt"
 
 func test(name string) string {
-	return fmt.Sprintf("hello\n%v\nworld", name)
+	return fmt.Sprintf("hello\n%s\nworld", name)
 }

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -49,10 +49,10 @@ func visit(node ASTNode) string {
 	switch node.Tag {
 	case ASTNodeNumber:
 		n := node.Number
-		return fmt.Sprintf("number:%v", n)
+		return fmt.Sprintf("number:%d", n)
 	case ASTNodeString:
 		s := node.ASTNodeString_
-		return fmt.Sprintf("string:%v", s)
+		return fmt.Sprintf("string:%s", s)
 	default:
 		return "null"
 	}

--- a/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
+++ b/tests/spec/emit/snapshots/format_string_escaped_quote_before_interp.snap
@@ -8,5 +8,5 @@ import "fmt"
 
 func test() {
 	x := 7
-	fmt.Printf("prefix \", %v\n", x)
+	fmt.Printf("prefix \", %d\n", x)
 }

--- a/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
@@ -13,6 +13,6 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	s := fmt.Sprintf("%v,%v", i, bump(&i))
+	s := fmt.Sprintf("%d,%d", i, bump(&i))
 	_ = s
 }

--- a/tests/spec/emit/snapshots/format_string_multiple.snap
+++ b/tests/spec/emit/snapshots/format_string_multiple.snap
@@ -9,5 +9,5 @@ import "fmt"
 func test() {
 	x := 10
 	y := 20
-	fmt.Printf("x = %v, y = %v", x, y)
+	fmt.Printf("x = %d, y = %d", x, y)
 }

--- a/tests/spec/emit/snapshots/format_string_percent_sign.snap
+++ b/tests/spec/emit/snapshots/format_string_percent_sign.snap
@@ -8,5 +8,5 @@ import "fmt"
 
 func test() {
 	pct := 50
-	fmt.Printf("%v%% complete", pct)
+	fmt.Printf("%d%% complete", pct)
 }

--- a/tests/spec/emit/snapshots/format_string_simple.snap
+++ b/tests/spec/emit/snapshots/format_string_simple.snap
@@ -8,5 +8,5 @@ import "fmt"
 
 func test() {
 	name := "Alice"
-	fmt.Printf("Hello, %v!", name)
+	fmt.Printf("Hello, %s!", name)
 }

--- a/tests/spec/emit/snapshots/format_string_solo_rune.snap
+++ b/tests/spec/emit/snapshots/format_string_solo_rune.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nimport \"go:fmt\"\n\nfn test() {\n  let c = 'A';\n  fmt.Print(f\"{c}\")\n}\n"
+---
+package main
+
+import "fmt"
+
+func test() {
+	c := 'A'
+	fmt.Printf("%c", c)
+}

--- a/tests/spec/emit/snapshots/format_string_variable.snap
+++ b/tests/spec/emit/snapshots/format_string_variable.snap
@@ -8,5 +8,5 @@ import "fmt"
 
 func test() {
 	result := 15
-	fmt.Printf("Result: %v", result)
+	fmt.Printf("Result: %d", result)
 }

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -45,10 +45,10 @@ func (e Either[L, R]) String() string {
 func (e Either[L, R]) display() string {
 	if e.Tag == EitherLeft {
 		s := e.Left.display()
-		return fmt.Sprintf("Left(%v)", s)
+		return fmt.Sprintf("Left(%s)", s)
 	}
 	s := e.Right.display()
-	return fmt.Sprintf("Right(%v)", s)
+	return fmt.Sprintf("Right(%s)", s)
 }
 
 type Name struct {

--- a/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
@@ -20,6 +20,6 @@ func test() {
 	subject_1 := try_parse("42")
 	if subject_1.Tag == lisette.ResultOk {
 		x := subject_1.OkVal
-		fmt.Printf("Parsed: %v\n", x)
+		fmt.Printf("Parsed: %d\n", x)
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_without_else_branch.snap
@@ -21,6 +21,6 @@ func test() {
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
 		x := subject_1.SomeVal
-		fmt.Printf("Result: %v\n", x)
+		fmt.Printf("Result: %d\n", x)
 	}
 }

--- a/tests/spec/emit/snapshots/interface_bound_method_call.snap
+++ b/tests/spec/emit/snapshots/interface_bound_method_call.snap
@@ -12,5 +12,5 @@ type Stringer interface {
 
 func print_it[T Stringer](x T) {
 	s := x.string_value()
-	fmt.Printf("%v\n", s)
+	fmt.Printf("%s\n", s)
 }

--- a/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
@@ -16,7 +16,7 @@ func use_split(f func(string) (string, string), p string) string {
 	tmp_1 := tup_4
 	dir := tmp_1.First
 	file := tmp_1.Second
-	return fmt.Sprintf("%v/%v", dir, file)
+	return fmt.Sprintf("%s/%s", dir, file)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
+++ b/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
@@ -15,7 +15,7 @@ match_2:
 			n := subject_1
 			if n < 10 {
 				result_3 := n * n
-				result = fmt.Sprintf("small(%v)", result_3)
+				result = fmt.Sprintf("small(%d)", result_3)
 				break match_2
 			}
 		}

--- a/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
@@ -13,10 +13,10 @@ func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
 		n := result.OkVal
-		fmt.Printf("success: %v\n", n)
+		fmt.Printf("success: %d\n", n)
 	} else {
 		e := result.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %s\n", e)
 	}
 	fmt.Print("done\n")
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -16,14 +16,14 @@ match_2:
 	for {
 		if subject_1.Tag == lisette.ResultOk {
 			if subject_1.OkVal > 0 {
-				fmt.Printf("positive: %v\n", subject_1.OkVal)
+				fmt.Printf("positive: %d\n", subject_1.OkVal)
 				break match_2
 			}
-			fmt.Printf("non-positive: %v\n", subject_1.OkVal)
+			fmt.Printf("non-positive: %d\n", subject_1.OkVal)
 			break match_2
 		}
 		e := subject_1.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %s\n", e)
 		break match_2
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
@@ -13,9 +13,9 @@ func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
 		n := result.OkVal
-		fmt.Printf("success: %v\n", n)
+		fmt.Printf("success: %d\n", n)
 	} else {
 		e := result.ErrVal
-		fmt.Printf("error: %v\n", e)
+		fmt.Printf("error: %s\n", e)
 	}
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
@@ -17,7 +17,7 @@ func test() string {
 	{
 		n_1 := pair.First
 		s_2 := pair.Second
-		r = fmt.Sprintf("%v-%v", n_1, s_2)
+		r = fmt.Sprintf("%d-%s", n_1, s_2)
 	}
-	return fmt.Sprintf("%v %v %v", n, s, r)
+	return fmt.Sprintf("%d %s %s", n, s, r)
 }

--- a/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
@@ -19,7 +19,7 @@ func (p Person) String() string {
 }
 
 func (p Person) greet() string {
-	return fmt.Sprintf("Hello, %v", p.name)
+	return fmt.Sprintf("Hello, %s", p.name)
 }
 
 func greet_ref[T Greetable](item T) string {

--- a/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
+++ b/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
@@ -16,8 +16,8 @@ func test() {
 	select {
 	case val, ok_1 := <-ch:
 		if ok_1 {
-			fmt.Printf("received: %v\n", val)
-			fmt.Printf("ok is: %v\n", ok)
+			fmt.Printf("received: %d\n", val)
+			fmt.Printf("ok is: %s\n", ok)
 		} else {
 			fmt.Println("closed")
 		}

--- a/tests/spec/emit/snapshots/task_with_block_body.snap
+++ b/tests/spec/emit/snapshots/task_with_block_body.snap
@@ -9,6 +9,6 @@ import "fmt"
 func test() {
 	go func() {
 		x := 42
-		fmt.Printf("Got %v", x)
+		fmt.Printf("Got %d", x)
 	}()
 }

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -23,7 +23,7 @@ func test() {
 		subject_1 := option_2
 		if subject_1.Tag == lisette.OptionSome {
 			x := subject_1.SomeVal
-			fmt.Printf("Got: %v\n", x)
+			fmt.Printf("Got: %d\n", x)
 			i++
 		} else {
 			break

--- a/tests/spec/emit/snapshots/while_let_result_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_result_function_call.snap
@@ -22,7 +22,7 @@ func test() {
 		subject_1 := next_result(i)
 		if subject_1.Tag == lisette.ResultOk {
 			x := subject_1.OkVal
-			fmt.Printf("Got: %v\n", x)
+			fmt.Printf("Got: %d\n", x)
 			i++
 		} else {
 			break


### PR DESCRIPTION
Interpolation arguments used to emit as `%v` through the reflection-based printer in `fmt` regardless of their static type. The emitter now dispatches on the inferred type of each interpolation argument and picks the matching verb: `%d` for integers, `%s` for strings, `%t` for booleans, `%g` for floats, `%c` for runes, `%v` as fallback.

```rs
f"item-{self.id}-{self.name}"
```

```go
fmt.Sprintf("item-%v-%v", i.Id, i.Name) // before
fmt.Sprintf("item-%d-%s", i.Id, i.Name) // after
```
