### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.7](https://github.com/ivov/lisette/compare/lisette-v0.2.6...lisette-v0.2.7) - 2026-05-17
+
+- fix: unwrap option at go any and honor tail-return hints [#437](https://github.com/ivov/lisette/pull/437) [`afcf72c`](https://github.com/ivov/lisette/commit/afcf72ccfc6258e0c986de233cb299485c161f05)
+- refactor: collect generic constraints before emit [#436](https://github.com/ivov/lisette/pull/436) [`7671020`](https://github.com/ivov/lisette/commit/7671020249d3b4606c31f7caa5ebc84e61b8419d)
+- refactor: centralize alias-aware emit shape queries [#435](https://github.com/ivov/lisette/pull/435) [`7fcdfc3`](https://github.com/ivov/lisette/commit/7fcdfc390b5f367a349cbbf9b66b5b68761e7ade)
+- fix: lower direct Err(...)? and None? propagation [#434](https://github.com/ivov/lisette/pull/434) [`9620f8a`](https://github.com/ivov/lisette/commit/9620f8a51e413ba67442e85c14f3924e0aa9e3f7)
+- fix: suppress unused locals in fused Result match emit [#433](https://github.com/ivov/lisette/pull/433) [`cd93588`](https://github.com/ivov/lisette/commit/cd935888a6c984434625f2bcb7660592a3121ba2)
+- fix: require screaming snake case for constants [#432](https://github.com/ivov/lisette/pull/432) [`ac5cdca`](https://github.com/ivov/lisette/commit/ac5cdca88f8ea3e1add257f9cec0c8b9fc4c663e)
+- docs: mention mise install path [#431](https://github.com/ivov/lisette/pull/431) [`046b3b0`](https://github.com/ivov/lisette/commit/046b3b0c533393207c87a6bc1230198b1c23885b)
+- docs: mention homebrew install path [#430](https://github.com/ivov/lisette/pull/430) [`19d6493`](https://github.com/ivov/lisette/commit/19d6493424cf01f7d28ac6db8786a51dbbf56f9d)
+- fix: clearer error for typed binding missing initializer [#429](https://github.com/ivov/lisette/pull/429) [`ab431c9`](https://github.com/ivov/lisette/commit/ab431c9e0740e85b6a72dd6015d1f4edd5e5b819)
+- fix: correct bindgen overrides for sourcegraph/conc [#428](https://github.com/ivov/lisette/pull/428) [`83297ba`](https://github.com/ivov/lisette/commit/83297ba35ecbcf8791d6692fad50cd8557a4b821)
+- fix: suppress unused-value cascades on errored expressions [#427](https://github.com/ivov/lisette/pull/427) [`04a5822`](https://github.com/ivov/lisette/commit/04a5822d64855f6752b337e4877d13940d1ab5ae)
+- fix: pointer receiver promotion in bindgen [#426](https://github.com/ivov/lisette/pull/426) [`96abad6`](https://github.com/ivov/lisette/commit/96abad60b42a6cbecb168c1adf97774d6ae42e2e)
+- fix: detect map literal attempts at parse time [#425](https://github.com/ivov/lisette/pull/425) [`52508e7`](https://github.com/ivov/lisette/commit/52508e748ea2f671e5993b4bda1086f6cd379221)
+- fix: suppress unused-field lint on pub fields [#424](https://github.com/ivov/lisette/pull/424) [`cc241a7`](https://github.com/ivov/lisette/commit/cc241a7b96eec4250dd77a80223278e558289546)
+- refactor: reduce emit complexity [#423](https://github.com/ivov/lisette/pull/423) [`bcc574b`](https://github.com/ivov/lisette/commit/bcc574b373d4257cb0c4eee7c2295fecdbc2e3fd)
+- docs: add section on typed nil at the boundary [#422](https://github.com/ivov/lisette/pull/422) [`045e502`](https://github.com/ivov/lisette/commit/045e502b90a54591aaffa763c366e39ba5295ea3)
+- refactor: emit idiomatic fmt verbs in interpolations [#420](https://github.com/ivov/lisette/pull/420) [`5121f0d`](https://github.com/ivov/lisette/commit/5121f0de48c9bdd8f6c00bb73f5b6311918b9834)
 ## [0.2.6](https://github.com/ivov/lisette/compare/lisette-v0.2.5...lisette-v0.2.6) - 2026-05-16
 
 - fix: resolve dotted go import paths [#419](https://github.com/ivov/lisette/pull/419) [`d22fdfa`](https://github.com/ivov/lisette/commit/d22fdfaa0bc78850c07c0130769379999294042f)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bincode",
  "ecow",
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.6"
+version = "0.2.7"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.6", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.6", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.6", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.6", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.7", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.7", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.7", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.7", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.6", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.6", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.7", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.7", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.6", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.6", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.6", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.6", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.7 (upcoming)

- fix: unwrap option at go any and honor tail-return hints [#437](https://github.com/ivov/lisette/pull/437) [`afcf72c`](https://github.com/ivov/lisette/commit/afcf72ccfc6258e0c986de233cb299485c161f05)
- refactor: collect generic constraints before emit [#436](https://github.com/ivov/lisette/pull/436) [`7671020`](https://github.com/ivov/lisette/commit/7671020249d3b4606c31f7caa5ebc84e61b8419d)
- refactor: centralize alias-aware emit shape queries [#435](https://github.com/ivov/lisette/pull/435) [`7fcdfc3`](https://github.com/ivov/lisette/commit/7fcdfc390b5f367a349cbbf9b66b5b68761e7ade)
- fix: lower direct Err(...)? and None? propagation [#434](https://github.com/ivov/lisette/pull/434) [`9620f8a`](https://github.com/ivov/lisette/commit/9620f8a51e413ba67442e85c14f3924e0aa9e3f7)
- fix: suppress unused locals in fused Result match emit [#433](https://github.com/ivov/lisette/pull/433) [`cd93588`](https://github.com/ivov/lisette/commit/cd935888a6c984434625f2bcb7660592a3121ba2)
- fix: require screaming snake case for constants [#432](https://github.com/ivov/lisette/pull/432) [`ac5cdca`](https://github.com/ivov/lisette/commit/ac5cdca88f8ea3e1add257f9cec0c8b9fc4c663e)
- docs: mention mise install path [#431](https://github.com/ivov/lisette/pull/431) [`046b3b0`](https://github.com/ivov/lisette/commit/046b3b0c533393207c87a6bc1230198b1c23885b)
- docs: mention homebrew install path [#430](https://github.com/ivov/lisette/pull/430) [`19d6493`](https://github.com/ivov/lisette/commit/19d6493424cf01f7d28ac6db8786a51dbbf56f9d)
- fix: clearer error for typed binding missing initializer [#429](https://github.com/ivov/lisette/pull/429) [`ab431c9`](https://github.com/ivov/lisette/commit/ab431c9e0740e85b6a72dd6015d1f4edd5e5b819)
- fix: correct bindgen overrides for sourcegraph/conc [#428](https://github.com/ivov/lisette/pull/428) [`83297ba`](https://github.com/ivov/lisette/commit/83297ba35ecbcf8791d6692fad50cd8557a4b821)
- fix: suppress unused-value cascades on errored expressions [#427](https://github.com/ivov/lisette/pull/427) [`04a5822`](https://github.com/ivov/lisette/commit/04a5822d64855f6752b337e4877d13940d1ab5ae)
- fix: pointer receiver promotion in bindgen [#426](https://github.com/ivov/lisette/pull/426) [`96abad6`](https://github.com/ivov/lisette/commit/96abad60b42a6cbecb168c1adf97774d6ae42e2e)
- fix: detect map literal attempts at parse time [#425](https://github.com/ivov/lisette/pull/425) [`52508e7`](https://github.com/ivov/lisette/commit/52508e748ea2f671e5993b4bda1086f6cd379221)
- fix: suppress unused-field lint on pub fields [#424](https://github.com/ivov/lisette/pull/424) [`cc241a7`](https://github.com/ivov/lisette/commit/cc241a7b96eec4250dd77a80223278e558289546)
- refactor: reduce emit complexity [#423](https://github.com/ivov/lisette/pull/423) [`bcc574b`](https://github.com/ivov/lisette/commit/bcc574b373d4257cb0c4eee7c2295fecdbc2e3fd)
- docs: add section on typed nil at the boundary [#422](https://github.com/ivov/lisette/pull/422) [`045e502`](https://github.com/ivov/lisette/commit/045e502b90a54591aaffa763c366e39ba5295ea3)
- refactor: emit idiomatic fmt verbs in interpolations [#420](https://github.com/ivov/lisette/pull/420) [`5121f0d`](https://github.com/ivov/lisette/commit/5121f0de48c9bdd8f6c00bb73f5b6311918b9834)
