### PR TITLE
refactor: reduce emit complexity

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -14,6 +14,11 @@ use syntax::types::{
     SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute, unqualified_name,
 };
 
+struct TupleStructTarget {
+    go_ty: String,
+    field_tys: Vec<Type>,
+}
+
 impl Emitter<'_> {
     /// True when Go's inference would lose this alias: function aliases (infer
     /// as `func(...)`) and non-default numeric aliases (untyped literals default
@@ -494,14 +499,49 @@ impl Emitter<'_> {
         call_ty: Option<&Type>,
         ctx: ExpressionContext<'_>,
     ) -> Option<String> {
-        let ty = function.get_type();
+        let target = self.resolve_tuple_struct_target(function, call_ty)?;
 
+        let stages: Vec<EmittedExpression> = args
+            .iter()
+            .map(|a| self.stage_composite(a, ExpressionContext::value()))
+            .collect();
+        let values = self.sequence(output, stages, "_arg");
+
+        let field_pairs: Vec<(String, String)> = target
+            .field_tys
+            .iter()
+            .zip(args.iter())
+            .zip(values)
+            .enumerate()
+            .map(|(i, ((field_ty, arg), value))| {
+                let value_ty = arg.get_type();
+                let coercion =
+                    Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
+                let coerced = coercion.apply(self, output, value);
+                (format!("F{}", i), coerced)
+            })
+            .collect();
+
+        Some(self.emit_struct_literal(&target.go_ty, &field_pairs, ctx))
+    }
+
+    /// Drill `function`'s return type into a tuple-struct definition, then
+    /// substitute generics to produce the per-field types and the Go target
+    /// type string. Returns `None` for anything that should fall through to
+    /// regular call handling (non-Function, non-Nominal, non-tuple kind, or
+    /// single-field non-generic struct that needs the newtype-cast path).
+    fn resolve_tuple_struct_target(
+        &mut self,
+        function: &Expression,
+        call_ty: Option<&Type>,
+    ) -> Option<TupleStructTarget> {
+        let ty = function.get_type();
         let Type::Function { return_type, .. } = ty.unwrap_forall() else {
             return None;
         };
-        let return_ty = return_type.as_ref().clone();
-
-        let return_ty = call_ty.cloned().unwrap_or(return_ty);
+        let return_ty = call_ty
+            .cloned()
+            .unwrap_or_else(|| return_type.as_ref().clone());
 
         let Type::Nominal { id, params, .. } = &return_ty else {
             return None;
@@ -524,7 +564,6 @@ impl Emitter<'_> {
         if *kind != StructKind::Tuple {
             return None;
         }
-
         if fields.len() == 1 && generics.is_empty() {
             return None;
         }
@@ -540,27 +579,7 @@ impl Emitter<'_> {
         };
 
         let go_ty = self.go_type_as_string(&return_ty);
-        let stages: Vec<EmittedExpression> = args
-            .iter()
-            .map(|a| self.stage_composite(a, ExpressionContext::value()))
-            .collect();
-        let values = self.sequence(output, stages, "_arg");
-
-        let field_pairs: Vec<(String, String)> = field_tys
-            .iter()
-            .zip(args.iter())
-            .zip(values)
-            .enumerate()
-            .map(|(i, ((field_ty, arg), value))| {
-                let value_ty = arg.get_type();
-                let coercion =
-                    Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
-                let coerced = coercion.apply(self, output, value);
-                (format!("F{}", i), coerced)
-            })
-            .collect();
-
-        Some(self.emit_struct_literal(&go_ty, &field_pairs, ctx))
+        Some(TupleStructTarget { go_ty, field_tys })
     }
 
     fn emit_assert_type(

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,10 +1,16 @@
 use crate::Emitter;
-use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, write_leaf};
+use crate::calls::go_interop::wrappers::{ResolvedSink, WrapperOutcome, WrapperTarget, write_leaf};
 use crate::control_flow::fallible::{Fallible, FallibleEmitter, OPTION_SOME_TAG};
 use crate::expressions::context::ExpressionContext;
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
+
+struct CollectionUnwrapShape {
+    raw_collection_ty: String,
+    is_pointer_bridged: bool,
+    emit_nil_else: bool,
+}
 
 impl Emitter<'_> {
     pub(super) fn emit_go_option_call_wrapped(
@@ -15,7 +21,7 @@ impl Emitter<'_> {
     ) -> String {
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
         self.emit_comma_ok_wrapping(output, &call_str, option_ty, true, WrapperTarget::FreshSlot)
-            .expect_slot()
+            .expect("wrapper produced no slot")
     }
 
     pub(super) fn emit_go_sentinel_call_wrapped(
@@ -33,7 +39,7 @@ impl Emitter<'_> {
             sentinel,
             WrapperTarget::FreshSlot,
         )
-        .expect_slot()
+        .expect("wrapper produced no slot")
     }
 
     /// Capture the call's raw return into a temp, then reuse
@@ -112,7 +118,7 @@ impl Emitter<'_> {
 
         let condition = if self.is_interface_option(option_ty) {
             format!("{} && !lisette.IsNilInterface({})", ok_var, val_vars[0])
-        } else if self.facts.is_nullable_option(option_ty) {
+        } else if needs_nilable_validation {
             format!("{} && {} != nil", ok_var, val_vars[0])
         } else {
             ok_var.clone()
@@ -120,24 +126,35 @@ impl Emitter<'_> {
 
         let (sink, outcome) = self.open_wrapper_slot(output, target, &option_ty_str, "option");
         write_line!(output, "if {} {{", condition);
+        self.write_some_none_leaves(output, &sink, &fallible, &val_expression);
+        output.push_str("}\n");
 
+        outcome
+    }
+
+    /// Inside an `if cond { ... } else { ... }` block, write the success leaf
+    /// (`Some(val_expression)`) and failure leaf (`None`) for an option-shaped
+    /// wrapper. The caller is responsible for the surrounding `if`/`}`.
+    fn write_some_none_leaves(
+        &mut self,
+        output: &mut String,
+        sink: &ResolvedSink,
+        fallible: &Fallible,
+        val_expression: &str,
+    ) {
         let some_wrapper = {
-            let mut fe = FallibleEmitter::new(self, &fallible);
-            fe.emit_success(&val_expression)
+            let mut fe = FallibleEmitter::new(self, fallible);
+            fe.emit_success(val_expression)
         };
-        write_leaf(output, &sink, &some_wrapper);
+        write_leaf(output, sink, &some_wrapper);
 
         output.push_str("} else {\n");
 
         let none_wrapper = {
-            let mut fe = FallibleEmitter::new(self, &fallible);
+            let mut fe = FallibleEmitter::new(self, fallible);
             fe.emit_failure(None)
         };
-        write_leaf(output, &sink, &none_wrapper);
-
-        output.push_str("}\n");
-
-        outcome
+        write_leaf(output, sink, &none_wrapper);
     }
 
     pub(crate) fn emit_nil_check_option_wrap(
@@ -307,10 +324,68 @@ impl Emitter<'_> {
         elem_option_ty: &Type,
     ) -> String {
         self.requirements.require_stdlib();
+        let shape = self.classify_collection_unwrap_shape(collection_ty, elem_option_ty);
 
+        let src_var = self.fresh_var(Some("src"));
+        self.declare(&src_var);
+        let unwrapped_var = self.fresh_var(Some("unwrapped"));
+        self.declare(&unwrapped_var);
+        let idx_var = self.fresh_var(Some("i"));
+        self.declare(&idx_var);
+        let val_var = self.fresh_var(Some("v"));
+        self.declare(&val_var);
+
+        write_line!(output, "{} := {}", src_var, lisette_value);
+        write_line!(
+            output,
+            "{} := make({}, len({}))",
+            unwrapped_var,
+            shape.raw_collection_ty,
+            src_var
+        );
+
+        write_line!(
+            output,
+            "for {}, {} := range {} {{",
+            idx_var,
+            val_var,
+            src_var
+        );
+
+        let some_assignment = if shape.is_pointer_bridged {
+            format!("&{}.SomeVal", val_var)
+        } else {
+            format!("{}.SomeVal", val_var)
+        };
+        write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
+        write_line!(
+            output,
+            "{}[{}] = {}",
+            unwrapped_var,
+            idx_var,
+            some_assignment
+        );
+        if shape.emit_nil_else {
+            output.push_str("} else {\n");
+            write_line!(output, "{}[{}] = nil", unwrapped_var, idx_var);
+        }
+        output.push_str("}\n");
+        output.push_str("}\n");
+
+        unwrapped_var
+    }
+
+    /// Per-emission shape of a collection unwrap: the Go collection type, the
+    /// prefix that promotes the `SomeVal` to a pointer when needed, and
+    /// whether the `Some` branch needs an explicit `else nil` for the
+    /// `Option<T>` => `nil`-on-`None` projection.
+    fn classify_collection_unwrap_shape(
+        &mut self,
+        collection_ty: &Type,
+        elem_option_ty: &Type,
+    ) -> CollectionUnwrapShape {
         let is_map = collection_ty.has_name("Map");
         let is_pointer_bridged = self.is_non_nilable_option(elem_option_ty);
-
         let inner_ty = elem_option_ty.ok_type();
         let inner_ty_str = self.go_type_as_string(&inner_ty);
         let raw_elem_ty = if is_pointer_bridged {
@@ -327,56 +402,11 @@ impl Emitter<'_> {
         } else {
             format!("[]{}", raw_elem_ty)
         };
-
-        let src_var = self.fresh_var(Some("src"));
-        self.declare(&src_var);
-        let unwrapped_var = self.fresh_var(Some("unwrapped"));
-        self.declare(&unwrapped_var);
-        let idx_var = self.fresh_var(Some("i"));
-        self.declare(&idx_var);
-        let val_var = self.fresh_var(Some("v"));
-        self.declare(&val_var);
-
-        write_line!(output, "{} := {}", src_var, lisette_value);
-        write_line!(
-            output,
-            "{} := make({}, len({}))",
-            unwrapped_var,
+        CollectionUnwrapShape {
             raw_collection_ty,
-            src_var
-        );
-
-        write_line!(
-            output,
-            "for {}, {} := range {} {{",
-            idx_var,
-            val_var,
-            src_var
-        );
-
-        let some_assignment = if is_pointer_bridged {
-            format!("&{}.SomeVal", val_var)
-        } else {
-            format!("{}.SomeVal", val_var)
-        };
-
-        write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
-        write_line!(
-            output,
-            "{}[{}] = {}",
-            unwrapped_var,
-            idx_var,
-            some_assignment
-        );
-        if is_map || is_pointer_bridged {
-            output.push_str("} else {\n");
-            write_line!(output, "{}[{}] = nil", unwrapped_var, idx_var);
+            is_pointer_bridged,
+            emit_nil_else: is_map || is_pointer_bridged,
         }
-        output.push_str("}\n");
-
-        output.push_str("}\n");
-
-        unwrapped_var
     }
 
     pub(super) fn emit_go_single_return_option_wrapped(
@@ -388,6 +418,6 @@ impl Emitter<'_> {
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
         let raw_var = self.hoist_tmp_value(output, "raw", &call_str);
         self.emit_nil_check_option_wrap(output, &raw_var, option_ty, WrapperTarget::FreshSlot)
-            .expect_slot()
+            .expect("wrapper produced no slot")
     }
 }

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -21,26 +21,9 @@ pub(crate) enum WrapperTarget<'a> {
     Return,
 }
 
-pub(crate) enum WrapperOutcome {
-    Slot(String),
-    Returned,
-}
-
-impl WrapperOutcome {
-    pub(crate) fn into_slot(self) -> Option<String> {
-        match self {
-            WrapperOutcome::Slot(s) => Some(s),
-            WrapperOutcome::Returned => None,
-        }
-    }
-
-    pub(crate) fn expect_slot(self) -> String {
-        match self {
-            WrapperOutcome::Slot(s) => s,
-            WrapperOutcome::Returned => unreachable!("expected slot, got Returned"),
-        }
-    }
-}
+/// `Some(slot_name)` when the wrapper wrote into a fresh or named slot; `None`
+/// when it wrote a `return` statement and the caller should not emit its own.
+pub(crate) type WrapperOutcome = Option<String>;
 
 pub(super) enum ResolvedSink {
     Slot(String),
@@ -70,18 +53,15 @@ impl Emitter<'_> {
                 let var = self.fresh_var(Some(name_hint));
                 self.declare(&var);
                 write_line!(output, "var {} {}", var, type_str);
-                (ResolvedSink::Slot(var.clone()), WrapperOutcome::Slot(var))
+                (ResolvedSink::Slot(var.clone()), Some(var))
             }
             WrapperTarget::Slot(name) => {
                 write_line!(output, "var {} {}", name, type_str);
                 self.declare(name);
                 let owned = name.to_string();
-                (
-                    ResolvedSink::Slot(owned.clone()),
-                    WrapperOutcome::Slot(owned),
-                )
+                (ResolvedSink::Slot(owned.clone()), Some(owned))
             }
-            WrapperTarget::Return => (ResolvedSink::Return, WrapperOutcome::Returned),
+            WrapperTarget::Return => (ResolvedSink::Return, None),
         }
     }
 
@@ -94,17 +74,15 @@ impl Emitter<'_> {
         value_expr: &str,
     ) -> WrapperOutcome {
         match target {
-            WrapperTarget::FreshSlot => {
-                WrapperOutcome::Slot(self.hoist_tmp_value(output, name_hint, value_expr))
-            }
+            WrapperTarget::FreshSlot => Some(self.hoist_tmp_value(output, name_hint, value_expr)),
             WrapperTarget::Slot(name) => {
                 self.declare(name);
                 write_line!(output, "{} := {}", name, value_expr);
-                WrapperOutcome::Slot(name.to_string())
+                Some(name.to_string())
             }
             WrapperTarget::Return => {
                 write_line!(output, "return {}", value_expr);
-                WrapperOutcome::Returned
+                None
             }
         }
     }
@@ -139,7 +117,7 @@ impl Emitter<'_> {
         self.requirements.require_stdlib();
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
         self.emit_partial_wrapping(output, &call_str, partial_ty, WrapperTarget::FreshSlot)
-            .expect_slot()
+            .expect("wrapper produced no slot")
     }
 
     pub(crate) fn emit_partial_wrapping(
@@ -190,7 +168,7 @@ impl Emitter<'_> {
         self.requirements.require_stdlib();
         let call_str = self.emit_call(output, call_expression, None, ExpressionContext::value());
         self.emit_result_wrapping(output, &call_str, result_ty, WrapperTarget::FreshSlot)
-            .expect_slot()
+            .expect("wrapper produced no slot")
     }
 
     pub(crate) fn emit_result_wrapping(
@@ -509,7 +487,7 @@ impl Emitter<'_> {
                 let temp_vars = self.create_temp_vars("ret", *arity);
                 write_line!(body, "{} := {}", temp_vars.join(", "), call_str);
                 let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars, &return_type);
-                WrapperOutcome::Slot(tuple_str)
+                Some(tuple_str)
             }
             GoCallStrategy::Partial => self.emit_partial_wrapping(
                 &mut body,
@@ -526,7 +504,7 @@ impl Emitter<'_> {
             ),
         };
 
-        if let Some(result_var) = outcome.into_slot() {
+        if let Some(result_var) = outcome {
             write_line!(body, "return {}", result_var);
         }
 

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -5,9 +5,16 @@ use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
 use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
-use crate::types::coercion::{Coercion, CoercionDirection};
-use syntax::ast::{Annotation, Expression, UnaryOperator};
+use crate::types::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
+use syntax::ast::{Annotation, Expression};
 use syntax::types::Type;
+
+struct CalleeAnalysis {
+    fn_param_types: Vec<Type>,
+    pointer_indices: HashSet<usize>,
+    is_go_call: bool,
+    is_prelude_dispatch: bool,
+}
 
 struct CallArgsContext<'a> {
     fn_param_types: &'a [Type],
@@ -130,13 +137,7 @@ impl Emitter<'_> {
 
         let mut function_string = self.emit_operand(output, function, expression_ctx.callee());
 
-        if matches!(
-            function,
-            Expression::Unary {
-                operator: UnaryOperator::Deref,
-                ..
-            }
-        ) {
+        if function.deref_inner().is_some() {
             function_string = format!("({})", function_string);
         }
 
@@ -148,32 +149,12 @@ impl Emitter<'_> {
             expression_ctx,
         );
 
-        let pointer_indices = self.get_recursive_enum_pointer_indices(function);
-
-        let fn_param_types: Vec<Type> = match function.get_type().unwrap_forall() {
-            Type::Function { params, .. } => params.clone(),
-            _ => vec![],
-        };
-
-        let (is_go_call, is_prelude_dispatch) = match function.unwrap_parens() {
-            Expression::DotAccess { expression, .. } => {
-                let is_prelude = matches!(
-                    expression.get_type().strip_refs().unwrap_forall(),
-                    Type::Nominal { id, .. } if id.starts_with("prelude.")
-                );
-                (Self::is_go_receiver(expression), is_prelude)
-            }
-            Expression::Identifier {
-                qualified: Some(q), ..
-            } if q.starts_with("prelude.") => (false, true),
-            _ => (false, false),
-        };
-
+        let analysis = self.analyze_callee(function);
         let args_ctx = CallArgsContext {
-            fn_param_types: &fn_param_types,
-            pointer_indices: &pointer_indices,
-            is_go_call,
-            is_prelude_dispatch,
+            fn_param_types: &analysis.fn_param_types,
+            pointer_indices: &analysis.pointer_indices,
+            is_go_call: analysis.is_go_call,
+            is_prelude_dispatch: analysis.is_prelude_dispatch,
             spread,
             wrap_spread_to_any: Self::spread_needs_any_wrap(function, spread),
             combine_variadic: Self::variadic_combine_for(function, spread, 0),
@@ -194,6 +175,33 @@ impl Emitter<'_> {
             return wrapped;
         }
         call_str
+    }
+
+    fn analyze_callee(&mut self, function: &Expression) -> CalleeAnalysis {
+        let pointer_indices = self.get_recursive_enum_pointer_indices(function);
+        let fn_param_types: Vec<Type> = match function.get_type().unwrap_forall() {
+            Type::Function { params, .. } => params.clone(),
+            _ => vec![],
+        };
+        let (is_go_call, is_prelude_dispatch) = match function.unwrap_parens() {
+            Expression::DotAccess { expression, .. } => {
+                let is_prelude = matches!(
+                    expression.get_type().strip_refs().unwrap_forall(),
+                    Type::Nominal { id, .. } if id.starts_with("prelude.")
+                );
+                (Self::is_go_receiver(expression), is_prelude)
+            }
+            Expression::Identifier {
+                qualified: Some(q), ..
+            } if q.starts_with("prelude.") => (false, true),
+            _ => (false, false),
+        };
+        CalleeAnalysis {
+            fn_param_types,
+            pointer_indices,
+            is_go_call,
+            is_prelude_dispatch,
+        }
     }
 
     /// Materialize a Go array-returning call into a variable and reslice it,
@@ -436,10 +444,10 @@ impl Emitter<'_> {
         ))
     }
 
-    /// Bridge a Lisette `Option<T>` argument to Go's nil-accepting form: `*T`
-    /// when the param is `Option<Ref<T>>` (`is_nullable_option`), and also `*T`
-    /// when the param is `Option<scalar>` (`is_non_nilable_option`, the
-    /// pointer-bridged shape produced by bindgen's `nilable_param` config).
+    /// Bridge a Lisette `Option<T>` argument to Go's nil-accepting form when
+    /// the param and arg agree on an Option shape that Go expresses as `*T`:
+    /// either both `Nullable` (`Option<Ref<T>>`) or both `PointerBridged`
+    /// (`Option<scalar>` produced by bindgen's `nilable_param` config).
     fn try_emit_go_pointer_param_unwrap(
         &mut self,
         output: &mut String,
@@ -448,11 +456,13 @@ impl Emitter<'_> {
     ) -> Option<String> {
         let param_ty = effective_param_ty?;
         let arg_ty = arg.get_type();
-        let shapes_match = (self.facts.is_nullable_option(param_ty)
-            && self.facts.is_nullable_option(&arg_ty))
-            || (self.is_non_nilable_option(param_ty) && self.is_non_nilable_option(&arg_ty));
-        if !shapes_match {
-            return None;
+        match (
+            classify_option_shape(self, param_ty),
+            classify_option_shape(self, &arg_ty),
+        ) {
+            (OptionShape::Nullable, OptionShape::Nullable)
+            | (OptionShape::PointerBridged, OptionShape::PointerBridged) => {}
+            _ => return None,
         }
         if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
             return Some("nil".to_string());
@@ -470,7 +480,7 @@ impl Emitter<'_> {
     ) -> Option<String> {
         let param_ty = effective_param_ty?;
         let arg_ty = arg.get_type();
-        if !self.facts.is_nullable_option(&arg_ty) {
+        if !matches!(classify_option_shape(self, &arg_ty), OptionShape::Nullable) {
             return None;
         }
         let check_ty = if param_ty.get_name() == Some("VarArgs") {

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -96,12 +96,41 @@ impl Emitter<'_> {
             unreachable!("UFCS receiver must be a constructor type");
         };
 
-        let coercion = *coercion;
+        let (receiver_arg, emitted_args) =
+            self.stage_ufcs_call_args(output, function, receiver, args, spread);
+        let receiver_arg = self.apply_receiver_coercion(output, receiver, receiver_arg, *coercion);
 
-        // The DotAccess function type curries `self` out, so its params
-        // line up 1:1 with the user args. Pair each so a function-typed
-        // param suppresses the Go-fn-value identity short-circuit before
-        // dispatch into prelude helpers like `lisette.OptionAndThen`.
+        if let Some(inlined) =
+            self.try_inline_native_ufcs(receiver, member, &receiver_arg, &emitted_args)
+        {
+            return inlined;
+        }
+
+        let mut new_args = vec![receiver_arg];
+        new_args.extend(emitted_args);
+
+        let fn_name = self.build_ufcs_qualified_call(
+            function,
+            type_args,
+            &receiver_ty,
+            qualified_name,
+            member,
+        );
+        format!("{}({})", fn_name, new_args.join(", "))
+    }
+
+    fn stage_ufcs_call_args(
+        &mut self,
+        output: &mut String,
+        function: &Expression,
+        receiver: &Expression,
+        args: &[Expression],
+        spread: Option<&Expression>,
+    ) -> (String, Vec<String>) {
+        // The DotAccess function type curries `self` out, so its params line
+        // up 1:1 with the user args. Pair each so a function-typed param
+        // suppresses the Go-fn-value identity short-circuit before dispatch
+        // into prelude helpers like `lisette.OptionAndThen`.
         let formal_params: Vec<Type> = match function.get_type().unwrap_forall() {
             Type::Function { params, .. } => params.clone(),
             _ => Vec::new(),
@@ -117,40 +146,21 @@ impl Emitter<'_> {
             self.sequence_with_spread(output, all_stages, spread, false, "_arg", combine);
         let receiver_arg = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
+        (receiver_arg, emitted_args)
+    }
 
-        let receiver_arg = match coercion {
-            Some(ReceiverCoercion::AutoAddress) => {
-                if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
-                    let tmp = self.hoist_tmp_value(output, "ref", &receiver_arg);
-                    format!("&{}", tmp)
-                } else {
-                    format!("&{}", receiver_arg)
-                }
-            }
-            Some(ReceiverCoercion::AutoDeref) => format!("*{}", receiver_arg),
-            None => receiver_arg,
-        };
-
-        if let Some(native_type) = NativeGoType::from_type(&receiver.get_type())
-            && let Some((inlined, extra_import)) = super::native::try_inline_native_method(
-                &native_type,
-                member,
-                &receiver_arg,
-                &emitted_args,
-                false,
-            )
-        {
-            self.apply_inline_import(extra_import);
-            return inlined;
-        }
-
-        let mut new_args = vec![receiver_arg];
-        new_args.extend(emitted_args);
-
+    fn build_ufcs_qualified_call(
+        &mut self,
+        function: &Expression,
+        type_args: &[Annotation],
+        receiver_ty: &Type,
+        qualified_name: &str,
+        member: &str,
+    ) -> String {
         let type_args_string = if !type_args.is_empty() {
-            self.format_type_args_with_receiver(&receiver_ty, type_args)
+            self.format_type_args_with_receiver(receiver_ty, type_args)
         } else {
-            self.infer_ufcs_return_only_type_args(function, qualified_name, member, &receiver_ty)
+            self.infer_ufcs_return_only_type_args(function, qualified_name, member, receiver_ty)
                 .unwrap_or_default()
         };
 
@@ -163,9 +173,47 @@ impl Emitter<'_> {
             || self.method_needs_export(member);
 
         let qualified_method_name = self.qualify_method_call(qualified_name, member, is_public);
-        let fn_name = format!("{}{}", qualified_method_name, type_args_string);
+        format!("{}{}", qualified_method_name, type_args_string)
+    }
 
-        format!("{}({})", fn_name, new_args.join(", "))
+    fn apply_receiver_coercion(
+        &mut self,
+        output: &mut String,
+        receiver: &Expression,
+        receiver_arg: String,
+        coercion: Option<ReceiverCoercion>,
+    ) -> String {
+        match coercion {
+            Some(ReceiverCoercion::AutoAddress) => {
+                if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
+                    let tmp = self.hoist_tmp_value(output, "ref", &receiver_arg);
+                    format!("&{}", tmp)
+                } else {
+                    format!("&{}", receiver_arg)
+                }
+            }
+            Some(ReceiverCoercion::AutoDeref) => format!("*{}", receiver_arg),
+            None => receiver_arg,
+        }
+    }
+
+    fn try_inline_native_ufcs(
+        &mut self,
+        receiver: &Expression,
+        member: &str,
+        receiver_arg: &str,
+        emitted_args: &[String],
+    ) -> Option<String> {
+        let native_type = NativeGoType::from_type(&receiver.get_type())?;
+        let (inlined, extra_import) = super::native::try_inline_native_method(
+            &native_type,
+            member,
+            receiver_arg,
+            emitted_args,
+            false,
+        )?;
+        self.apply_inline_import(extra_import);
+        Some(inlined)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -37,35 +37,13 @@ impl Emitter<'_> {
     ) {
         self.set_current_loop_label_if_needed(needs_label);
 
-        if let Expression::Range {
-            start,
-            end,
-            inclusive,
-            ..
-        } = iterable
-        {
-            self.emit_range_for_loop(output, binding, start, end, *inclusive, body);
+        let Some(iterable_ty) = self.try_emit_specialized_for_loop(output, binding, iterable, body)
+        else {
             return;
-        }
-
-        let iterable_ty = iterable.get_type();
-        if let Some(ty_name) = iterable_ty.get_name()
-            && matches!(ty_name, "Range" | "RangeInclusive" | "RangeFrom")
-        {
-            self.emit_stored_range_for_loop(output, binding, iterable, ty_name, body);
-            return;
-        }
-
-        if let Some((kind, receiver)) = recognize_string_view_loop(binding, iterable) {
-            match kind {
-                StringViewKind::Runes => self.emit_runes_for_loop(output, binding, receiver, body),
-                StringViewKind::Bytes => self.emit_bytes_for_loop(output, binding, receiver, body),
-            }
-            return;
-        }
+        };
 
         let iter_expression = self.emit_operand(output, iterable, ExpressionContext::value());
-        let iter_expression = if iterable.get_type().is_ref() {
+        let iter_expression = if iterable_ty.is_ref() {
             format!("*{}", iter_expression)
         } else {
             iter_expression
@@ -76,17 +54,75 @@ impl Emitter<'_> {
             .is_some_and(|n| n == "Channel" || n == "Receiver");
 
         self.enter_scope();
-
         if let Some(label) = self.current_loop_label() {
             write_line!(output, "{}:", label);
         }
+        self.emit_for_loop_pattern(
+            output,
+            binding,
+            &iter_expression,
+            is_channel,
+            &iterable_ty,
+            body,
+        );
+        self.exit_scope();
+    }
 
+    /// Try the specialized for-loop emitters. Returns the computed iterable
+    /// type when the caller still needs to fall through to the generic
+    /// `range` path; returns `None` when a specialized emitter handled it.
+    fn try_emit_specialized_for_loop(
+        &mut self,
+        output: &mut String,
+        binding: &Binding,
+        iterable: &Expression,
+        body: &Expression,
+    ) -> Option<Type> {
+        if let Expression::Range {
+            start,
+            end,
+            inclusive,
+            ..
+        } = iterable
+        {
+            self.emit_range_for_loop(output, binding, start, end, *inclusive, body);
+            return None;
+        }
+
+        let iterable_ty = iterable.get_type();
+        if let Some(ty_name) = iterable_ty.get_name()
+            && matches!(ty_name, "Range" | "RangeInclusive" | "RangeFrom")
+        {
+            self.emit_stored_range_for_loop(output, binding, iterable, ty_name, body);
+            return None;
+        }
+
+        if let Some((kind, receiver)) = recognize_string_view_loop(binding, iterable) {
+            match kind {
+                StringViewKind::Runes => self.emit_runes_for_loop(output, binding, receiver, body),
+                StringViewKind::Bytes => self.emit_bytes_for_loop(output, binding, receiver, body),
+            }
+            return None;
+        }
+
+        Some(iterable_ty)
+    }
+
+    fn emit_for_loop_pattern(
+        &mut self,
+        output: &mut String,
+        binding: &Binding,
+        iter_expression: &str,
+        is_channel: bool,
+        iterable_ty: &Type,
+        body: &Expression,
+    ) {
         match &binding.pattern {
             Pattern::Identifier { .. } => {
                 self.emit_identifier_for_loop(
                     output,
                     &binding.pattern,
-                    &iter_expression,
+                    iter_expression,
                     is_channel,
                     body,
                 );
@@ -102,20 +138,12 @@ impl Emitter<'_> {
                         n == "Map" || n == "OrderedMap" || n == "EnumeratedSlice"
                     }) =>
             {
-                self.emit_map_tuple_for_loop(output, elements, &binding.ty, &iter_expression, body);
+                self.emit_map_tuple_for_loop(output, elements, &binding.ty, iter_expression, body);
             }
             _ => {
-                self.emit_for_loop_pattern_site(
-                    output,
-                    binding,
-                    &iter_expression,
-                    is_channel,
-                    body,
-                );
+                self.emit_for_loop_pattern_site(output, binding, iter_expression, is_channel, body);
             }
         }
-
-        self.exit_scope();
     }
 
     /// For loops over an identifier-bound iterable: `for x := range xs` (or
@@ -175,38 +203,72 @@ impl Emitter<'_> {
         );
 
         if !first_is_simple || !second_is_simple {
-            let key_var = self.fresh_var(Some("key"));
-            let value_var = self.fresh_var(Some("value"));
-            write_line!(
+            self.emit_map_tuple_compound_for_loop(
                 output,
-                "for {}, {} := range {} {{",
-                key_var,
-                value_var,
-                iter_expression
-            );
-            let key_guard = DiscardGuard::new(output, &key_var);
-            let value_guard = DiscardGuard::new(output, &value_var);
-            self.emit_irrefutable_pattern_site(
-                output,
-                PatternSubject::for_value(key_var),
                 first,
-                None,
-                first_ty,
-            );
-            self.emit_irrefutable_pattern_site(
-                output,
-                PatternSubject::for_value(value_var),
                 second,
-                None,
+                first_ty,
                 second_ty,
+                iter_expression,
+                body,
             );
-            self.emit_block(output, body);
-            key_guard.finish(output);
-            value_guard.finish(output);
-            output.push_str("}\n");
-            return;
+        } else {
+            self.emit_map_tuple_simple_for_loop(output, first, second, iter_expression, body);
         }
+    }
 
+    /// Compound element pattern: capture key and value into fresh vars, then
+    /// emit pattern-site destructuring before the body.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_map_tuple_compound_for_loop(
+        &mut self,
+        output: &mut String,
+        first: &Pattern,
+        second: &Pattern,
+        first_ty: &Type,
+        second_ty: &Type,
+        iter_expression: &str,
+        body: &Expression,
+    ) {
+        let key_var = self.fresh_var(Some("key"));
+        let value_var = self.fresh_var(Some("value"));
+        write_line!(
+            output,
+            "for {}, {} := range {} {{",
+            key_var,
+            value_var,
+            iter_expression
+        );
+        let key_guard = DiscardGuard::new(output, &key_var);
+        let value_guard = DiscardGuard::new(output, &value_var);
+        self.emit_irrefutable_pattern_site(
+            output,
+            PatternSubject::for_value(key_var),
+            first,
+            None,
+            first_ty,
+        );
+        self.emit_irrefutable_pattern_site(
+            output,
+            PatternSubject::for_value(value_var),
+            second,
+            None,
+            second_ty,
+        );
+        self.emit_block(output, body);
+        key_guard.finish(output);
+        value_guard.finish(output);
+        output.push_str("}\n");
+    }
+
+    fn emit_map_tuple_simple_for_loop(
+        &mut self,
+        output: &mut String,
+        first: &Pattern,
+        second: &Pattern,
+        iter_expression: &str,
+        body: &Expression,
+    ) {
         let first_is_discard =
             matches!(first, Pattern::WildCard { .. }) || self.go_name_for_binding(first).is_none();
         let second_is_discard = matches!(second, Pattern::WildCard { .. })

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -32,26 +32,52 @@ impl Emitter<'_> {
             && let Some(result) =
                 self.try_emit_error_constructor(output, expression, &fallible, return_ctx)
         {
-            // Direct failure constructor (e.g. Err(...)? or None?) already emitted
-            // `return ...`. Declare the binding variable so any dead code after
-            // this point that references it doesn't produce "undefined" in Go.
-            if var_name != "_" {
-                let inner_ty = fallible.ok_ty();
-                let (zero, effects) = self.zero_value(inner_ty);
-                self.requirements.apply_effects(&effects);
-                if self.is_declared(var_name) {
-                    write_line!(output, "{} = {}", var_name, zero);
-                } else {
-                    let go_ty = self.go_type_as_string(inner_ty);
-                    write_line!(output, "var {} {} = {}", var_name, go_ty, zero);
-                    self.declare(var_name);
-                }
-            }
+            self.declare_zero_for_dead_path(output, var_name, &fallible);
             return result;
         }
 
         self.requirements.require_stdlib();
-        let check_var = if let Expression::Identifier { value, ty, .. } = expression {
+        let check_var = self.hoist_propagate_check_var(output, expression);
+        self.emit_propagate_failure_check(output, &check_var, &fallible, return_ctx);
+
+        let ok_access = format!("{}.{}", check_var, fallible.ok_field());
+        match result_var_name {
+            None => ok_access,
+            Some("_") => "_".to_string(),
+            Some(name) => self.bind_propagate_ok(output, name, &ok_access),
+        }
+    }
+
+    /// `Err(...)?` and `None?` already emitted `return ...`. Declare the
+    /// binding with a zero value so any dead code below that references it
+    /// stays well-typed in Go.
+    fn declare_zero_for_dead_path(
+        &mut self,
+        output: &mut String,
+        var_name: &str,
+        fallible: &Fallible,
+    ) {
+        if var_name == "_" {
+            return;
+        }
+        let inner_ty = fallible.ok_ty();
+        let (zero, effects) = self.zero_value(inner_ty);
+        self.requirements.apply_effects(&effects);
+        if self.is_declared(var_name) {
+            write_line!(output, "{} = {}", var_name, zero);
+        } else {
+            let go_ty = self.go_type_as_string(inner_ty);
+            write_line!(output, "var {} {} = {}", var_name, go_ty, zero);
+            self.declare(var_name);
+        }
+    }
+
+    fn hoist_propagate_check_var(
+        &mut self,
+        output: &mut String,
+        expression: &Expression,
+    ) -> String {
+        if let Expression::Identifier { value, ty, .. } = expression {
             let go_name = self.emit_identifier(value, ty, ExpressionContext::value());
             if go_name.contains('(') {
                 self.hoist_tmp_value(output, "check", &go_name)
@@ -62,9 +88,18 @@ impl Emitter<'_> {
             let expression_string =
                 self.emit_operand(output, expression, ExpressionContext::value());
             self.hoist_tmp_value(output, "check", &expression_string)
-        };
+        }
+    }
 
+    fn emit_propagate_failure_check(
+        &mut self,
+        output: &mut String,
+        check_var: &str,
+        fallible: &Fallible,
+        return_ctx: &ReturnContext,
+    ) {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
+        let success_tag = fallible.success_tag();
 
         if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
@@ -80,38 +115,32 @@ impl Emitter<'_> {
                 output,
                 "if {}.Tag != {} {{\n{}\n}}",
                 check_var,
-                fallible.success_tag(),
+                success_tag,
                 lowered_failure
             );
         } else {
             let err_return = {
-                let mut fe = FallibleEmitter::new(self, &fallible);
+                let mut fe = FallibleEmitter::new(self, fallible);
                 fe.emit_contextual_failure(Some(&format!("{}{}", check_var, err_field)), return_ctx)
             };
             write_line!(
                 output,
                 "if {}.Tag != {} {{\nreturn {}\n}}",
                 check_var,
-                fallible.success_tag(),
+                success_tag,
                 err_return
             );
         }
+    }
 
-        let ok_access = format!("{}.{}", check_var, fallible.ok_field());
-
-        match result_var_name {
-            None => ok_access,
-            Some("_") => "_".to_string(),
-            Some(name) => {
-                let pre_declared = self.is_declared(name);
-                let op = if pre_declared { "=" } else { ":=" };
-                write_line!(output, "{} {} {}", name, op, ok_access);
-                if !pre_declared {
-                    self.declare(name);
-                }
-                name.to_string()
-            }
+    fn bind_propagate_ok(&mut self, output: &mut String, name: &str, ok_access: &str) -> String {
+        let pre_declared = self.is_declared(name);
+        let op = if pre_declared { "=" } else { ":=" };
+        write_line!(output, "{} {} {}", name, op, ok_access);
+        if !pre_declared {
+            self.declare(name);
         }
+        name.to_string()
     }
     pub(crate) fn emit_propagate_to_let(
         &mut self,
@@ -192,16 +221,15 @@ impl Emitter<'_> {
         if let Expression::Identifier { .. } = expression
             && fallible.classify_constructor(expression) == Some(ConstructorKind::Failure)
         {
-            // Only `None` reaches here — `Err` always has a payload.
-            if let Some(shape) = lowered.as_ref() {
-                let line = abi_transition::format_lowered_none_return(self, shape, &return_ty);
-                write_line!(output, "{}", line);
-            } else {
-                self.requirements.require_stdlib();
-                let mut fe = FallibleEmitter::new(self, &fallible);
-                let failure = fe.emit_failure(None);
-                write_line!(output, "return {}", failure);
-            }
+            // Only `None` reaches here — `Err` always has a payload, so an
+            // identifier failure constructor must be a payload-less Option.
+            self.emit_failure_constructor_return(
+                output,
+                &[],
+                &fallible,
+                &return_ty,
+                lowered.as_ref(),
+            );
             return true;
         }
 
@@ -222,15 +250,25 @@ impl Emitter<'_> {
         }
 
         let value = self.emit_value(output, expression, ExpressionContext::value());
+        self.emit_value_wrapped_return(output, value, &return_ty, lowered.as_ref());
+        true
+    }
+
+    fn emit_value_wrapped_return(
+        &mut self,
+        output: &mut String,
+        value: String,
+        return_ty: &Type,
+        lowered: Option<&AbiShape>,
+    ) {
         if let Some(shape) = lowered {
             // The destructure references the value multiple times (`.Tag`,
             // `.OkVal`, `.ErrVal` etc.); hoist to avoid re-evaluating.
             let temp = self.hoist_tmp_value(output, "v", &value);
-            abi_transition::emit_lowered_result_return(self, output, &temp, &return_ty, &shape);
+            abi_transition::emit_lowered_result_return(self, output, &temp, return_ty, shape);
         } else {
             write_line!(output, "return {}", value);
         }
-        true
     }
 
     /// Emit a return for a call whose result is wrapped in the function's
@@ -257,62 +295,10 @@ impl Emitter<'_> {
         };
         match fallible.classify_constructor(call_expression) {
             Some(ConstructorKind::Success) => {
-                if let Some(shape) = lowered {
-                    let ok_arg = if matches!(shape, AbiShape::BareError) {
-                        // Unit Ok — emit args[0] for side effects, then drop.
-                        if !args.is_empty() {
-                            let _ = self.emit_composite_value(
-                                output,
-                                &args[0],
-                                ExpressionContext::value(),
-                            );
-                        }
-                        String::new()
-                    } else if args.is_empty() {
-                        // `Some` with no payload wouldn't typecheck; only
-                        // possible when Ok type is unit and we still need a
-                        // value for the tuple (`Some(())` under CommaOk).
-                        "struct{}{}".to_string()
-                    } else {
-                        self.emit_composite_value(output, &args[0], ExpressionContext::value())
-                    };
-                    let line = abi_transition::format_lowered_ok_return(shape, &ok_arg);
-                    write_line!(output, "{}", line);
-                } else {
-                    let arg =
-                        self.emit_composite_value(output, &args[0], ExpressionContext::value());
-                    let mut fe = FallibleEmitter::new(self, fallible);
-                    let success = fe.emit_success(&arg);
-                    write_line!(output, "return {}", success);
-                }
+                self.emit_success_constructor_return(output, args, fallible, lowered);
             }
             Some(ConstructorKind::Failure) => {
-                if let Some(shape) = lowered {
-                    if args.is_empty() {
-                        // `None` under lowered Option (CommaOk/NullableReturn).
-                        let line =
-                            abi_transition::format_lowered_none_return(self, shape, return_ty);
-                        write_line!(output, "{}", line);
-                    } else {
-                        let err_expr =
-                            self.emit_composite_value(output, &args[0], ExpressionContext::value());
-                        let line = abi_transition::format_lowered_err_return(
-                            self, shape, return_ty, &err_expr,
-                        );
-                        write_line!(output, "{}", line);
-                    }
-                } else {
-                    let failure = if fallible.is_result() {
-                        let arg =
-                            self.emit_composite_value(output, &args[0], ExpressionContext::value());
-                        let mut fe = FallibleEmitter::new(self, fallible);
-                        fe.emit_failure(Some(&arg))
-                    } else {
-                        let mut fe = FallibleEmitter::new(self, fallible);
-                        fe.emit_failure(None)
-                    };
-                    write_line!(output, "return {}", failure);
-                }
+                self.emit_failure_constructor_return(output, args, fallible, return_ty, lowered);
             }
             None => self.emit_wrapped_passthrough_return(
                 output,
@@ -321,6 +307,71 @@ impl Emitter<'_> {
                 return_ty,
                 lowered,
             ),
+        }
+    }
+
+    fn emit_success_constructor_return(
+        &mut self,
+        output: &mut String,
+        args: &[Expression],
+        fallible: &Fallible,
+        lowered: Option<&AbiShape>,
+    ) {
+        if let Some(shape) = lowered {
+            let ok_arg = if matches!(shape, AbiShape::BareError) {
+                // Unit Ok — emit args[0] for side effects, then drop.
+                if !args.is_empty() {
+                    let _ = self.emit_composite_value(output, &args[0], ExpressionContext::value());
+                }
+                String::new()
+            } else if args.is_empty() {
+                // `Some` with no payload would not typecheck; only possible
+                // when Ok type is unit and we still need a value for the
+                // tuple (`Some(())` under CommaOk).
+                "struct{}{}".to_string()
+            } else {
+                self.emit_composite_value(output, &args[0], ExpressionContext::value())
+            };
+            let line = abi_transition::format_lowered_ok_return(shape, &ok_arg);
+            write_line!(output, "{}", line);
+        } else {
+            let arg = self.emit_composite_value(output, &args[0], ExpressionContext::value());
+            let mut fe = FallibleEmitter::new(self, fallible);
+            let success = fe.emit_success(&arg);
+            write_line!(output, "return {}", success);
+        }
+    }
+
+    fn emit_failure_constructor_return(
+        &mut self,
+        output: &mut String,
+        args: &[Expression],
+        fallible: &Fallible,
+        return_ty: &Type,
+        lowered: Option<&AbiShape>,
+    ) {
+        if let Some(shape) = lowered {
+            if args.is_empty() {
+                // `None` under lowered Option (CommaOk/NullableReturn).
+                let line = abi_transition::format_lowered_none_return(self, shape, return_ty);
+                write_line!(output, "{}", line);
+            } else {
+                let err_expr =
+                    self.emit_composite_value(output, &args[0], ExpressionContext::value());
+                let line =
+                    abi_transition::format_lowered_err_return(self, shape, return_ty, &err_expr);
+                write_line!(output, "{}", line);
+            }
+        } else {
+            let failure = if fallible.is_result() {
+                let arg = self.emit_composite_value(output, &args[0], ExpressionContext::value());
+                let mut fe = FallibleEmitter::new(self, fallible);
+                fe.emit_failure(Some(&arg))
+            } else {
+                let mut fe = FallibleEmitter::new(self, fallible);
+                fe.emit_failure(None)
+            };
+            write_line!(output, "return {}", failure);
         }
     }
 

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -47,10 +47,34 @@ impl Emitter<'_> {
         if needs_retry_loop {
             output.push_str("for {\n");
         }
-
         self.enter_scope();
         output.push_str("select {\n");
 
+        self.emit_select_arms(output, arms, &prep, place);
+
+        output.push_str("}\n");
+        self.exit_scope();
+
+        if needs_retry_loop {
+            output.push_str("break\n}\n");
+            // Go can't see that `break` is unreachable (all select paths either
+            // return or continue), so emit panic to satisfy the compiler.
+            emit_unreachable_panic_if_needed(output, place, false);
+        } else {
+            let has_default = arms
+                .iter()
+                .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
+            emit_unreachable_panic_if_needed(output, place, has_default);
+        }
+    }
+
+    fn emit_select_arms(
+        &mut self,
+        output: &mut String,
+        arms: &[SelectArm],
+        prep: &SelectPrep,
+        place: &BodyPlace,
+    ) {
         let default_body = arms.iter().find_map(|arm| {
             if let SelectArmPattern::WildCard { body } = &arm.pattern {
                 Some(body.as_ref())
@@ -101,21 +125,6 @@ impl Emitter<'_> {
                     self.emit_body_to_place(output, body, place);
                 }
             }
-        }
-
-        output.push_str("}\n");
-        self.exit_scope();
-
-        if needs_retry_loop {
-            output.push_str("break\n}\n");
-            // Go can't see that `break` is unreachable (all select paths either
-            // return or continue), so emit panic to satisfy the compiler.
-            emit_unreachable_panic_if_needed(output, place, false);
-        } else {
-            let has_default = arms
-                .iter()
-                .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
-            emit_unreachable_panic_if_needed(output, place, has_default);
         }
     }
 
@@ -313,62 +322,81 @@ impl Emitter<'_> {
         ctx: &SelectReceiveContext,
     ) {
         let effective_pattern = unwrap_some_pattern(binding);
-        let needs_ok_check = is_some_pattern(binding);
         let inner_typed = unwrap_some_typed_pattern(typed_pattern);
 
         self.scope.push_binding_frame();
+        if is_some_pattern(binding) {
+            self.emit_receive_arm_with_ok_check(output, effective_pattern, inner_typed, ctx);
+        } else {
+            self.emit_receive_arm_simple(output, effective_pattern, inner_typed, ctx);
+        }
+    }
 
-        match effective_pattern {
-            Pattern::Identifier { identifier, .. } => {
-                if let Some(go_name) = self.go_name_for_binding(effective_pattern) {
-                    let var = self.scope.bind(identifier, go_name);
-                    if needs_ok_check {
-                        self.emit_ok_guard(output, &var, None, ctx);
-                        return;
-                    } else {
-                        write_line!(output, "case {} := <-{}:", var, ctx.channel);
-                    }
-                } else if needs_ok_check {
-                    let ok_var = self.fresh_ok_var();
-                    write_line!(output, "case _, {} := <-{}:", ok_var, ctx.channel);
-                    self.emit_ok_check(output, &ok_var, ctx);
-                    self.scope.pop_binding_frame();
-                    return;
-                } else {
-                    write_line!(output, "case <-{}:", ctx.channel);
-                }
-            }
-            Pattern::WildCard { .. } => {
-                if needs_ok_check {
-                    let ok_var = self.fresh_ok_var();
-                    write_line!(output, "case _, {} := <-{}:", ok_var, ctx.channel);
-                    self.emit_ok_check(output, &ok_var, ctx);
-                    self.scope.pop_binding_frame();
-                    return;
-                }
-                write_line!(output, "case <-{}:", ctx.channel);
-            }
-            _ => {
-                let receiver_var = self.fresh_var(Some("recv"));
-                if needs_ok_check {
-                    self.emit_ok_guard(
-                        output,
-                        &receiver_var,
-                        Some((effective_pattern, inner_typed)),
-                        ctx,
-                    );
-                    return;
-                } else {
-                    write_line!(output, "case {} := <-{}:", receiver_var, ctx.channel);
-                    self.emit_irrefutable_pattern_site(
-                        output,
-                        PatternSubject::for_value(receiver_var.clone()),
-                        effective_pattern,
-                        inner_typed,
-                        &ctx.element_ty,
-                    );
-                }
-            }
+    /// Option-binding receive: emits a `case x, ok := <-ch:` header and
+    /// either an `if ok { ... } else { ... }` guard around the body, or a
+    /// discard `if !ok { break }`. Always pops the binding frame.
+    fn emit_receive_arm_with_ok_check(
+        &mut self,
+        output: &mut String,
+        effective_pattern: &Pattern,
+        inner_typed: Option<&TypedPattern>,
+        ctx: &SelectReceiveContext,
+    ) {
+        if let Pattern::Identifier { identifier, .. } = effective_pattern
+            && let Some(go_name) = self.go_name_for_binding(effective_pattern)
+        {
+            let var = self.scope.bind(identifier, go_name);
+            self.emit_ok_guard(output, &var, None, ctx);
+            return;
+        }
+        if matches!(
+            effective_pattern,
+            Pattern::Identifier { .. } | Pattern::WildCard { .. }
+        ) {
+            let ok_var = self.fresh_ok_var();
+            write_line!(output, "case _, {} := <-{}:", ok_var, ctx.channel);
+            self.emit_ok_check(output, &ok_var, ctx);
+            self.scope.pop_binding_frame();
+            return;
+        }
+        let receiver_var = self.fresh_var(Some("recv"));
+        self.emit_ok_guard(
+            output,
+            &receiver_var,
+            Some((effective_pattern, inner_typed)),
+            ctx,
+        );
+    }
+
+    /// Plain receive (no Option semantics): emits the `case ... := <-ch:`
+    /// header, then the arm body. Always pops the binding frame.
+    fn emit_receive_arm_simple(
+        &mut self,
+        output: &mut String,
+        effective_pattern: &Pattern,
+        inner_typed: Option<&TypedPattern>,
+        ctx: &SelectReceiveContext,
+    ) {
+        if let Pattern::Identifier { identifier, .. } = effective_pattern
+            && let Some(go_name) = self.go_name_for_binding(effective_pattern)
+        {
+            let var = self.scope.bind(identifier, go_name);
+            write_line!(output, "case {} := <-{}:", var, ctx.channel);
+        } else if matches!(
+            effective_pattern,
+            Pattern::Identifier { .. } | Pattern::WildCard { .. }
+        ) {
+            write_line!(output, "case <-{}:", ctx.channel);
+        } else {
+            let receiver_var = self.fresh_var(Some("recv"));
+            write_line!(output, "case {} := <-{}:", receiver_var, ctx.channel);
+            self.emit_irrefutable_pattern_site(
+                output,
+                PatternSubject::for_value(receiver_var.clone()),
+                effective_pattern,
+                inner_typed,
+                &ctx.element_ty,
+            );
         }
         self.emit_body_to_place(output, ctx.body, ctx.place);
         self.scope.pop_binding_frame();

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -251,55 +251,7 @@ impl EnumLayout {
 
         for variant in &self.variants {
             lines.push(format!("case {}:", variant.tag_constant));
-
-            if variant.fields.is_empty() {
-                lines.push(format!("return \"{}.{}\"", self.enum_name, variant.name));
-            } else if variant.is_struct_variant {
-                let format_parts: Vec<String> = variant
-                    .fields
-                    .iter()
-                    .map(|f| format!("{}: {}", f.source_name, stringer_verb(f.is_function)))
-                    .collect();
-                let args: Vec<String> = variant
-                    .fields
-                    .iter()
-                    .map(|f| format!("{receiver}.{}", f.go_name))
-                    .collect();
-                lines.push(format!(
-                    "return fmt.Sprintf(\"{}.{} {{ {} }}\", {})",
-                    self.enum_name,
-                    variant.name,
-                    format_parts.join(", "),
-                    args.join(", ")
-                ));
-            } else if variant.fields.len() == 1 {
-                let f = &variant.fields[0];
-                lines.push(format!(
-                    "return fmt.Sprintf(\"{}.{}({})\", {receiver}.{})",
-                    self.enum_name,
-                    variant.name,
-                    stringer_verb(f.is_function),
-                    f.go_name
-                ));
-            } else {
-                let placeholders: Vec<&str> = variant
-                    .fields
-                    .iter()
-                    .map(|f| stringer_verb(f.is_function))
-                    .collect();
-                let args: Vec<String> = variant
-                    .fields
-                    .iter()
-                    .map(|f| format!("{receiver}.{}", f.go_name))
-                    .collect();
-                lines.push(format!(
-                    "return fmt.Sprintf(\"{}.{}({})\", {})",
-                    self.enum_name,
-                    variant.name,
-                    placeholders.join(", "),
-                    args.join(", ")
-                ));
-            }
+            lines.push(self.build_variant_stringer_line(variant, &receiver));
         }
 
         lines.push("default:".to_string());
@@ -311,6 +263,45 @@ impl EnumLayout {
         lines.push("}".to_string());
 
         lines.join("\n")
+    }
+
+    /// Build the per-variant `return ...` line for the Stringer method. Three
+    /// shapes: no fields (string literal), struct-variant (`{ k: v, ... }`),
+    /// or positional (`(v, ...)`). Positional collapses single and multi-field
+    /// since `Sprintf("Name(%v)", x)` is the degenerate multi case.
+    fn build_variant_stringer_line(&self, variant: &VariantLayout, receiver: &str) -> String {
+        if variant.fields.is_empty() {
+            return format!("return \"{}.{}\"", self.enum_name, variant.name);
+        }
+        let args: Vec<String> = variant
+            .fields
+            .iter()
+            .map(|f| format!("{receiver}.{}", f.go_name))
+            .collect();
+        let (open, close, placeholders) = if variant.is_struct_variant {
+            let parts: Vec<String> = variant
+                .fields
+                .iter()
+                .map(|f| format!("{}: {}", f.source_name, stringer_verb(f.is_function)))
+                .collect();
+            (" { ", " }", parts.join(", "))
+        } else {
+            let parts: Vec<&str> = variant
+                .fields
+                .iter()
+                .map(|f| stringer_verb(f.is_function))
+                .collect();
+            ("(", ")", parts.join(", "))
+        };
+        format!(
+            "return fmt.Sprintf(\"{}.{}{}{}{}\", {})",
+            self.enum_name,
+            variant.name,
+            open,
+            placeholders,
+            close,
+            args.join(", ")
+        )
     }
 
     pub(crate) fn emit_json_methods(&self, receiver_generics: &str) -> String {

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::Emitter;
+use crate::ReturnContext;
 use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
 use crate::placement::ValuePlace;
@@ -13,6 +14,16 @@ use syntax::types::Type;
 
 /// Owned param-destructure record: temp var, pattern, typed pattern, param type.
 type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
+
+/// Borrowed lambda param-destructure record. Lambdas keep references to the
+/// caller's `params` slice since they cannot outlive emission scope.
+type LambdaParamDestructure<'a> = (String, &'a Pattern, Option<&'a TypedPattern>, &'a Type);
+
+struct LambdaReturnInfo {
+    ty_string: String,
+    ctx: ReturnContext,
+    has_return: bool,
+}
 
 impl Emitter<'_> {
     pub(crate) fn emit_function_body(
@@ -64,9 +75,30 @@ impl Emitter<'_> {
     ) -> String {
         let frame = self.scope.enter_isolated_function();
 
-        let mut destructure_bindings: Vec<(String, &Pattern, Option<&TypedPattern>, &Type)> =
-            vec![];
+        let (param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params);
+        let return_info = self.lambda_return_info(ty, ctx);
+        let body_string = self.emit_lambda_body_with_deferred(
+            body,
+            &destructure_bindings,
+            &return_info.ctx,
+            return_info.has_return,
+        );
 
+        self.scope.exit_isolated_function(frame);
+
+        format!(
+            "func({}){} {{\n{}}}",
+            group_params(&param_pairs),
+            return_info.ty_string,
+            body_string
+        )
+    }
+
+    fn build_lambda_param_pairs<'a>(
+        &mut self,
+        params: &'a [Binding],
+    ) -> (Vec<(String, String)>, Vec<LambdaParamDestructure<'a>>) {
+        let mut destructure_bindings: Vec<LambdaParamDestructure<'a>> = vec![];
         let param_pairs: Vec<(String, String)> = params
             .iter()
             .map(|p| {
@@ -93,19 +125,23 @@ impl Emitter<'_> {
                 (name, self.go_type_as_string(&p.ty))
             })
             .collect();
+        (param_pairs, destructure_bindings)
+    }
 
-        let argument_flows_to_unknown = ctx.argument_flows_to_unknown();
+    /// Compute the lambda's Go return-type string and `ReturnContext`. When
+    /// the lambda flows into a Go-prelude generic callback that expects the
+    /// unlowered single-return form, suppress the lambda's own return-type
+    /// lowering so signature and body match.
+    fn lambda_return_info(&mut self, ty: &Type, ctx: ExpressionContext<'_>) -> LambdaReturnInfo {
         let suppress_lowering = ctx.forces_tagged_go_function();
+        let argument_flows_to_unknown = ctx.argument_flows_to_unknown();
 
         let has_return = matches!(ty, Type::Function { return_type, .. }
             if !(return_type.is_unit()
                 || return_type.is_variable()
                 || (argument_flows_to_unknown && return_type.is_never())));
 
-        // When the lambda flows into a Go-prelude generic callback that
-        // expects the unlowered single-return form, suppress the lambda's
-        // own return-type lowering so signature and body match.
-        let return_ty_string = if has_return {
+        let ty_string = if has_return {
             match ty {
                 Type::Function { return_type, .. } => {
                     if !suppress_lowering
@@ -122,23 +158,35 @@ impl Emitter<'_> {
             String::new()
         };
 
-        let should_return = has_return;
-
-        let return_ctx = match ty {
+        let ctx = match ty {
             Type::Function { return_type, .. } => {
                 let return_ty = return_type.as_ref().clone();
                 if suppress_lowering {
-                    crate::ReturnContext::Tagged(return_ty)
+                    ReturnContext::Tagged(return_ty)
                 } else {
                     self.return_context_for_type(return_ty)
                 }
             }
-            _ => crate::ReturnContext::None,
+            _ => ReturnContext::None,
         };
 
+        LambdaReturnInfo {
+            ty_string,
+            ctx,
+            has_return,
+        }
+    }
+
+    fn emit_lambda_body_with_deferred(
+        &mut self,
+        body: &Expression,
+        destructure_bindings: &[LambdaParamDestructure<'_>],
+        return_ctx: &ReturnContext,
+        should_return: bool,
+    ) -> String {
         let mut body_string = String::new();
         self.with_scope_return_context_fallback(return_ctx.clone(), |this| {
-            for (temp_name, pattern, typed, param_ty) in &destructure_bindings {
+            for (temp_name, pattern, typed, param_ty) in destructure_bindings {
                 this.emit_irrefutable_pattern_site(
                     &mut body_string,
                     crate::patterns::sites::PatternSubject::for_value(temp_name.clone()),
@@ -147,17 +195,9 @@ impl Emitter<'_> {
                     param_ty,
                 );
             }
-            this.emit_function_body(&mut body_string, body, should_return, &return_ctx);
+            this.emit_function_body(&mut body_string, body, should_return, return_ctx);
         });
-
-        self.scope.exit_isolated_function(frame);
-
-        format!(
-            "func({}){} {{\n{}}}",
-            group_params(&param_pairs),
-            return_ty_string,
-            body_string
-        )
+        body_string
     }
 
     /// Bind and declare a parameter. If the natural post-escape Go name is
@@ -195,12 +235,10 @@ impl Emitter<'_> {
         }
 
         let directive = self.maybe_line_directive(&function_definition.name_span);
-
         let return_ctx = self.return_context_for_type(function_definition.return_type.clone());
 
         let (function_definition, receiver) =
             self.change_go_builtin_methods(function_definition, receiver);
-
         let (params_to_process, receiver_override) =
             self.extract_receiver(&function_definition, receiver.is_some());
 
@@ -212,17 +250,65 @@ impl Emitter<'_> {
             parts.push(part);
         }
 
-        let function_name = if is_public {
+        parts.push(self.pick_go_function_name(&function_definition, receiver.is_some(), is_public));
+
+        let generics_str = self.build_generics_string(&function_definition, params_to_process);
+        if !generics_str.is_empty() {
+            parts.push(generics_str);
+        }
+
+        let mut body = String::new();
+        let signature = self.with_absorbed_ref_generics(
+            params_to_process,
+            &function_definition.generics,
+            |this| {
+                let (params_string, return_ty, deferred_patterns) =
+                    this.build_signature_tail(&function_definition, params_to_process);
+                parts.push(params_string);
+                if !return_ty.is_empty() {
+                    parts.push(return_ty);
+                }
+                let signature = parts.join(" ");
+                this.emit_function_body_with_deferred_patterns(
+                    &mut body,
+                    &function_definition,
+                    deferred_patterns,
+                    &return_ctx,
+                );
+                signature
+            },
+        );
+
+        let trimmed_body = body.trim_end();
+        if trimmed_body.is_empty() {
+            format!("{}{} {{}}", directive, signature)
+        } else {
+            format!("{}{} {{\n{}\n}}", directive, signature, trimmed_body)
+        }
+    }
+
+    fn pick_go_function_name(
+        &self,
+        function_definition: &FunctionDefinition,
+        has_receiver: bool,
+        is_public: bool,
+    ) -> String {
+        if is_public {
             go_name::snake_to_camel(&function_definition.name)
-        } else if receiver.is_some() {
+        } else if has_receiver {
             go_name::escape_keyword(&function_definition.name).into_owned()
         } else if let Some(remapped) = self.module.escape_remap(function_definition.name.as_str()) {
             remapped.to_string()
         } else {
             go_name::escape_reserved(&function_definition.name).into_owned()
-        };
-        parts.push(function_name);
+        }
+    }
 
+    fn build_generics_string(
+        &mut self,
+        function_definition: &FunctionDefinition,
+        params_to_process: &[Binding],
+    ) -> String {
         let generic_names: Vec<&str> = function_definition
             .generics
             .iter()
@@ -240,67 +326,48 @@ impl Emitter<'_> {
                 map_key_generics.insert(name.to_string());
             }
         }
+        self.generics_to_string_with_map_keys(&function_definition.generics, &map_key_generics)
+    }
 
-        let generics_str =
-            self.generics_to_string_with_map_keys(&function_definition.generics, &map_key_generics);
-        if !generics_str.is_empty() {
-            parts.push(generics_str);
-        }
+    fn build_signature_tail(
+        &mut self,
+        function_definition: &FunctionDefinition,
+        params_to_process: &[Binding],
+    ) -> (String, String, Vec<DeferredParamDestructure>) {
+        let (params_string, deferred_patterns) = self.emit_function_params(params_to_process);
 
-        let mut body = String::new();
-        let signature = self.with_absorbed_ref_generics(
-            params_to_process,
-            &function_definition.generics,
-            |this| {
-                let (params_string, deferred_patterns) =
-                    this.emit_function_params(params_to_process);
-                parts.push(params_string);
-
-                let return_ty = if function_definition.return_type.is_unit() {
-                    String::new()
-                } else if let Some(shape) =
-                    this.classify_direct_emission(&function_definition.return_type)
-                {
-                    this.render_lowered_return_ty(&shape, &function_definition.return_type)
-                } else {
-                    this.go_type_as_string(&function_definition.return_type)
-                };
-
-                if !return_ty.is_empty() {
-                    parts.push(return_ty);
-                }
-
-                let signature = parts.join(" ");
-                let should_return = !function_definition.return_type.is_unit();
-
-                this.with_scope_return_context_fallback(return_ctx.clone(), |this| {
-                    for (var_name, pattern, typed, param_ty) in deferred_patterns {
-                        this.emit_irrefutable_pattern_site(
-                            &mut body,
-                            crate::patterns::sites::PatternSubject::for_value(var_name),
-                            &pattern,
-                            typed.as_ref(),
-                            &param_ty,
-                        );
-                    }
-
-                    this.emit_function_body(
-                        &mut body,
-                        &function_definition.body,
-                        should_return,
-                        &return_ctx,
-                    );
-                });
-                signature
-            },
-        );
-
-        let trimmed_body = body.trim_end();
-        if trimmed_body.is_empty() {
-            format!("{}{} {{}}", directive, signature)
+        let return_ty = if function_definition.return_type.is_unit() {
+            String::new()
+        } else if let Some(shape) = self.classify_direct_emission(&function_definition.return_type)
+        {
+            self.render_lowered_return_ty(&shape, &function_definition.return_type)
         } else {
-            format!("{}{} {{\n{}\n}}", directive, signature, trimmed_body)
-        }
+            self.go_type_as_string(&function_definition.return_type)
+        };
+
+        (params_string, return_ty, deferred_patterns)
+    }
+
+    fn emit_function_body_with_deferred_patterns(
+        &mut self,
+        body: &mut String,
+        function_definition: &FunctionDefinition,
+        deferred_patterns: Vec<DeferredParamDestructure>,
+        return_ctx: &ReturnContext,
+    ) {
+        let should_return = !function_definition.return_type.is_unit();
+        self.with_scope_return_context_fallback(return_ctx.clone(), |this| {
+            for (var_name, pattern, typed, param_ty) in deferred_patterns {
+                this.emit_irrefutable_pattern_site(
+                    body,
+                    crate::patterns::sites::PatternSubject::for_value(var_name),
+                    &pattern,
+                    typed.as_ref(),
+                    &param_ty,
+                );
+            }
+            this.emit_function_body(body, &function_definition.body, should_return, return_ctx);
+        });
     }
 
     fn change_go_builtin_methods(

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -4,7 +4,7 @@ use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::write_line;
 use ecow::EcoString;
 use syntax::program::{Definition, DefinitionBody, Interface};
-use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
+use syntax::types::{SubstitutionMap, Type, build_substitution_map, substitute, unqualified_name};
 pub(crate) struct AdapterPlan {
     pub(crate) concrete_id: EcoString,
     pub(crate) interface_id: EcoString,
@@ -140,48 +140,12 @@ impl Emitter<'_> {
 
         for (method_name, _interface_method_ty, declaring_id) in &all_interface_methods {
             let impl_ty = struct_methods.get(method_name)?;
-            let Type::Function {
-                params,
-                return_type,
-                ..
-            } = impl_ty.unwrap_forall()
-            else {
-                return None;
-            };
-            let method_params: Vec<Type> = if params.is_empty() {
-                Vec::new()
-            } else {
-                params[1..]
-                    .iter()
-                    .map(|p| substitute(p, &subst_map))
-                    .collect()
-            };
-            let return_ty = substitute(return_type, &subst_map);
-
-            // Compute the natural shape once and shift it for the interface
-            // side if a `#[go(...)]` hint applies, instead of re-walking
-            // `peel_alias` twice via two `classify_direct_emission` calls.
-            let user_shape = self.classify_direct_emission(&return_ty);
-            let interface_hints = self.go_interface_method_hints(declaring_id, method_name);
-            let interface_shape = match user_shape.as_ref() {
-                Some(crate::types::abi::AbiShape::NullableReturn)
-                    if interface_hints.iter().any(|h| h == "comma_ok") =>
-                {
-                    Some(crate::types::abi::AbiShape::CommaOk)
-                }
-                other => other.cloned(),
-            };
-            if user_shape != interface_shape {
+            let (method, adapted) =
+                self.build_adapter_method(method_name, declaring_id, impl_ty, &subst_map)?;
+            if adapted {
                 any_adapted = true;
             }
-
-            methods.push(AdapterMethod {
-                name: method_name.clone(),
-                param_types: method_params,
-                return_type: return_ty,
-                user_shape,
-                interface_shape,
-            });
+            methods.push(method);
         }
 
         if !any_adapted {
@@ -194,6 +158,61 @@ impl Emitter<'_> {
             concrete_ty: source_ty.clone(),
             methods,
         })
+    }
+
+    /// Build one `AdapterMethod`, plus a flag set when the user-side natural
+    /// shape disagrees with the interface-side hint-shifted shape (in which
+    /// case the adapter is meaningful, not just structural).
+    fn build_adapter_method(
+        &self,
+        method_name: &EcoString,
+        declaring_id: &EcoString,
+        impl_ty: &Type,
+        subst_map: &SubstitutionMap,
+    ) -> Option<(AdapterMethod, bool)> {
+        let Type::Function {
+            params,
+            return_type,
+            ..
+        } = impl_ty.unwrap_forall()
+        else {
+            return None;
+        };
+        let param_types: Vec<Type> = if params.is_empty() {
+            Vec::new()
+        } else {
+            params[1..]
+                .iter()
+                .map(|p| substitute(p, subst_map))
+                .collect()
+        };
+        let return_type = substitute(return_type, subst_map);
+
+        // Compute the natural shape once and shift it for the interface side
+        // if a `#[go(...)]` hint applies, instead of re-walking `peel_alias`
+        // twice via two `classify_direct_emission` calls.
+        let user_shape = self.classify_direct_emission(&return_type);
+        let interface_hints = self.go_interface_method_hints(declaring_id, method_name);
+        let interface_shape = match user_shape.as_ref() {
+            Some(crate::types::abi::AbiShape::NullableReturn)
+                if interface_hints.iter().any(|h| h == "comma_ok") =>
+            {
+                Some(crate::types::abi::AbiShape::CommaOk)
+            }
+            other => other.cloned(),
+        };
+        let adapted = user_shape != interface_shape;
+
+        Some((
+            AdapterMethod {
+                name: method_name.clone(),
+                param_types,
+                return_type,
+                user_shape,
+                interface_shape,
+            },
+            adapted,
+        ))
     }
 
     /// `NullableReturn` → `CommaOk` bridge for `#[go(comma_ok)]` methods.
@@ -329,16 +348,12 @@ impl Emitter<'_> {
             self.declare(name);
         }
 
-        let param_type_strs: Vec<String> = method
-            .param_types
+        let params_str = param_names
             .iter()
-            .map(|t| self.go_type_as_string(t))
-            .collect();
-        let params_decl: Vec<String> = param_names
-            .iter()
-            .zip(param_type_strs.iter())
-            .map(|(n, t)| format!("{} {}", n, t))
-            .collect();
+            .zip(method.param_types.iter())
+            .map(|(n, t)| format!("{} {}", n, self.go_type_as_string(t)))
+            .collect::<Vec<_>>()
+            .join(", ");
 
         let go_method_name = if self.method_needs_export(&method.name) {
             go_name::snake_to_camel(&method.name)
@@ -347,65 +362,62 @@ impl Emitter<'_> {
         };
         let inner_call = format!("a.inner.{}({})", go_method_name, param_names.join(", "));
 
-        let user_shape = method.user_shape.clone();
-        let interface_shape = method.interface_shape.clone();
-        let params_str = params_decl.join(", ");
+        let (go_ret, body) = self.build_adapter_body(method, &inner_call);
+        self.finish_adapter_method(
+            decl,
+            adapter_name,
+            &go_method_name,
+            &params_str,
+            &go_ret,
+            &body,
+        );
+    }
+
+    fn build_adapter_body(&mut self, method: &AdapterMethod, inner_call: &str) -> (String, String) {
+        let user_shape = &method.user_shape;
+        let interface_shape = &method.interface_shape;
 
         if user_shape == interface_shape
             && let Some(shape) = user_shape
         {
-            let go_ret = self.render_lowered_return_ty(&shape, &method.return_type);
-            write_method_header(decl, adapter_name, &go_method_name, &params_str, &go_ret);
-            decl.push_str(&format!("return {}\n", inner_call));
-            write_line!(decl, "}}");
-            self.exit_scope();
-            return;
+            let go_ret = self.render_lowered_return_ty(shape, &method.return_type);
+            return (go_ret, format!("return {}\n", inner_call));
         }
 
         if let (Some(user), Some(interface)) = (user_shape, interface_shape)
             && user != interface
-            && let Some((go_ret, body)) =
-                self.emit_hint_shift_bridge(&inner_call, &method.return_type, &user, &interface)
+            && let Some(bridge) =
+                self.emit_hint_shift_bridge(inner_call, &method.return_type, user, interface)
         {
-            write_method_header(decl, adapter_name, &go_method_name, &params_str, &go_ret);
-            decl.push_str(&body);
-            write_line!(decl, "}}");
-            self.exit_scope();
-            return;
+            return bridge;
         }
 
-        let (go_ret, body) = match crate::types::abi_transition::emit_return_adapter(
-            self,
-            &inner_call,
-            &method.return_type,
-        ) {
-            Some((ret, body)) => (ret, body),
-            None => {
-                if method.return_type.is_unit() {
-                    (String::new(), format!("{}\n", inner_call))
-                } else {
-                    let ret = self.go_type_as_string(&method.return_type);
-                    (ret, format!("return {}\n", inner_call))
-                }
-            }
-        };
+        if let Some(adapter) =
+            crate::types::abi_transition::emit_return_adapter(self, inner_call, &method.return_type)
+        {
+            return adapter;
+        }
 
-        let ret_suffix = if go_ret.is_empty() {
-            String::new()
+        if method.return_type.is_unit() {
+            (String::new(), format!("{}\n", inner_call))
         } else {
-            format!(" {}", go_ret)
-        };
-        write_line!(
-            decl,
-            "func (a {}) {}({}){} {{",
-            adapter_name,
-            go_method_name,
-            params_decl.join(", "),
-            ret_suffix
-        );
-        decl.push_str(&body);
-        write_line!(decl, "}}");
+            let ret = self.go_type_as_string(&method.return_type);
+            (ret, format!("return {}\n", inner_call))
+        }
+    }
 
+    fn finish_adapter_method(
+        &mut self,
+        decl: &mut String,
+        adapter_name: &str,
+        method_name: &str,
+        params: &str,
+        go_ret: &str,
+        body: &str,
+    ) {
+        write_method_header(decl, adapter_name, method_name, params, go_ret);
+        decl.push_str(body);
+        write_line!(decl, "}}");
         self.exit_scope();
     }
 
@@ -468,12 +480,17 @@ fn write_method_header(
     params: &str,
     go_ret: &str,
 ) {
+    let ret_suffix = if go_ret.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", go_ret)
+    };
     write_line!(
         decl,
-        "func (a {}) {}({}) {} {{",
+        "func (a {}) {}({}){} {{",
         adapter_name,
         method_name,
         params,
-        go_ret
+        ret_suffix
     );
 }

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, StructKind, UnaryOperator};
+use syntax::ast::{Expression, StructKind};
 use syntax::program::{
     Definition, DefinitionBody, DotAccessKind as SemanticDotKind, ReceiverCoercion,
 };
@@ -279,11 +279,7 @@ impl Emitter<'_> {
         coercion: Option<ReceiverCoercion>,
         ctx: ExpressionContext<'_>,
     ) -> String {
-        let (expression_string, had_explicit_deref) = if let Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } = expression
+        let (expression_string, had_explicit_deref) = if let Some(inner) = expression.deref_inner()
         {
             (self.emit_operand(output, inner, ctx), true)
         } else {
@@ -309,16 +305,7 @@ impl Emitter<'_> {
     /// Check if expression has an absorbed `Ref<T>` generic (T already emitted as `*Concrete`).
     /// When true, suppress auto-deref coercion — the pointer is already the right type.
     fn is_absorbed_ref_generic(&self, expression: &Expression) -> bool {
-        let check_expression = if let Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } = expression
-        {
-            inner.as_ref()
-        } else {
-            expression
-        };
+        let check_expression = expression.deref_inner().unwrap_or(expression);
         let expression_ty = check_expression.get_type();
         expression_ty.is_ref()
             && expression_ty.inner().is_some_and(|inner| {

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, UnaryOperator};
+use syntax::ast::Expression;
 use syntax::types::peel_to_range_type;
 
 use crate::Emitter;
@@ -45,15 +45,8 @@ impl Emitter<'_> {
         format!("{}[{}]", values[0], values[1])
     }
 
-    /// Stage an indexable base expression, unwrapping an explicit deref into
-    /// a parenthesized `(*x)` form while preserving evaluation-order setup.
     fn stage_base_with_deref(&mut self, expression: &Expression) -> EmittedExpression {
-        let Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } = expression
-        else {
+        let Some(inner) = expression.deref_inner() else {
             return self.stage_operand(expression, ExpressionContext::value());
         };
         let s = self.stage_operand(inner, ExpressionContext::value());

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -73,17 +73,8 @@ impl Emitter<'_> {
             value = self.wrap_recursive_enum_field(output, value, f, &ctx);
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
-            if is_go_struct {
-                let target_ty = field_ty.as_ref().unwrap_or(&value_ty);
-                let coercion =
-                    Coercion::resolve(self, &value_ty, target_ty, CoercionDirection::ToGoBoundary);
-                value = coercion.apply(self, output, value);
-            }
-            if let Some(field_ty) = field_ty.as_ref() {
-                let coercion =
-                    Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
-                value = coercion.apply(self, output, value);
-            }
+            value =
+                self.coerce_struct_field(output, value, &value_ty, field_ty.as_ref(), is_go_struct);
             field_names.push(field_name);
             field_values.push(value);
         }
@@ -115,26 +106,62 @@ impl Emitter<'_> {
                 self.emit_struct_update(output, base, &field_pairs, &field_side_effects)
             }
             StructSpread::ZeroFill { .. } if !is_go_struct => {
-                let assigned: HashSet<&str> =
-                    field_assignments.iter().map(|f| f.name.as_str()).collect();
-                let unspecified =
-                    self.lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned);
-                if let Some(unspecified) = unspecified {
-                    for (field_name, field_ty) in unspecified {
-                        if field_ty.is_slice() {
-                            continue;
-                        }
-                        let go_field_name =
-                            self.resolve_struct_call_field_name(&field_name, ty, &ctx);
-                        let zero = self.lisette_zero(&field_ty);
-                        field_pairs.push((go_field_name, zero));
-                    }
-                }
+                self.append_zero_fills(&mut field_pairs, field_assignments, ty, name, &ctx);
                 self.emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
             }
             StructSpread::ZeroFill { .. } | StructSpread::None => {
                 self.emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
             }
+        }
+    }
+
+    /// Apply Go-boundary coercion followed by internal coercion. The Go-boundary
+    /// step targets `field_ty` (falling back to `value_ty` when no declared
+    /// field exists); the internal step targets `field_ty` only.
+    fn coerce_struct_field(
+        &mut self,
+        output: &mut String,
+        mut value: String,
+        value_ty: &Type,
+        field_ty: Option<&Type>,
+        is_go_struct: bool,
+    ) -> String {
+        if is_go_struct {
+            let target_ty = field_ty.unwrap_or(value_ty);
+            let coercion =
+                Coercion::resolve(self, value_ty, target_ty, CoercionDirection::ToGoBoundary);
+            value = coercion.apply(self, output, value);
+        }
+        if let Some(field_ty) = field_ty {
+            let coercion = Coercion::resolve(self, value_ty, field_ty, CoercionDirection::Internal);
+            value = coercion.apply(self, output, value);
+        }
+        value
+    }
+
+    /// Append zero-value pairs for fields the user did not assign. Slice fields
+    /// are skipped so Go's nil zero-value applies instead of `[]T{}`.
+    fn append_zero_fills(
+        &mut self,
+        field_pairs: &mut Vec<(String, String)>,
+        field_assignments: &[StructFieldAssignment],
+        ty: &Type,
+        name: &str,
+        ctx: &StructCallContext,
+    ) {
+        let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
+        let Some(unspecified) =
+            self.lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned)
+        else {
+            return;
+        };
+        for (field_name, field_ty) in unspecified {
+            if field_ty.is_slice() {
+                continue;
+            }
+            let go_field_name = self.resolve_struct_call_field_name(&field_name, ty, ctx);
+            let zero = self.lisette_zero(&field_ty);
+            field_pairs.push((go_field_name, zero));
         }
     }
 

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -193,50 +193,21 @@ impl Emitter<'_> {
         left: &BinaryOperand<'_>,
         right: &BinaryOperand<'_>,
     ) -> Option<NumericBinaryEmitInfo> {
-        use BinaryOperator::*;
-
-        if !matches!(
-            operator,
-            Addition
-                | Subtraction
-                | Multiplication
-                | Division
-                | Remainder
-                | LessThan
-                | LessThanOrEqual
-                | GreaterThan
-                | GreaterThanOrEqual
-                | Equal
-                | NotEqual
-        ) {
+        if !is_numeric_binary_op(operator) {
             return None;
         }
 
-        let left_underlying_ty = left.ty.underlying_numeric_type();
-        let right_underlying_ty = right.ty.underlying_numeric_type();
-
-        let (left_underlying_ty, right_underlying_ty) =
-            match (&left_underlying_ty, &right_underlying_ty) {
-                (Some(l), Some(r)) => (l, r),
-                _ => return None,
-            };
-
-        let left_family = left_underlying_ty.numeric_family()?;
-        let right_family = right_underlying_ty.numeric_family()?;
-
-        if left_family != right_family {
-            return None;
-        }
+        let left_underlying_ty = matching_underlying_numeric(&left.ty, &right.ty)?;
 
         let left_is_aliased = left.ty.is_aliased_numeric_type();
         let right_is_aliased = right.ty.is_aliased_numeric_type();
 
         if left.ty == right.ty {
-            if left_is_aliased && matches!(operator, Division) {
+            if left_is_aliased && matches!(operator, BinaryOperator::Division) {
                 return Some(NumericBinaryEmitInfo {
                     cast_left_to: None,
                     cast_right_to: None,
-                    cast_result_to: Some(left_underlying_ty.clone()),
+                    cast_result_to: Some(left_underlying_ty),
                 });
             }
             return None;
@@ -248,24 +219,14 @@ impl Emitter<'_> {
         match (left_is_aliased, right_is_aliased) {
             (true, false) => Some(NumericBinaryEmitInfo {
                 cast_left_to: None,
-                cast_right_to: if right_is_literal {
-                    None
-                } else {
-                    Some(left.ty.clone())
-                },
+                cast_right_to: cast_unless_literal(right_is_literal, &left.ty),
                 cast_result_to: None,
             }),
-
             (false, true) => Some(NumericBinaryEmitInfo {
-                cast_left_to: if left_is_literal {
-                    None
-                } else {
-                    Some(right.ty.clone())
-                },
+                cast_left_to: cast_unless_literal(left_is_literal, &right.ty),
                 cast_right_to: None,
                 cast_result_to: None,
             }),
-
             _ => None,
         }
     }
@@ -328,5 +289,43 @@ fn is_literal_expression(expression: &Expression) -> bool {
             ..
         } => is_literal_expression(expression),
         _ => false,
+    }
+}
+
+fn is_numeric_binary_op(operator: &BinaryOperator) -> bool {
+    use BinaryOperator::*;
+    matches!(
+        operator,
+        Addition
+            | Subtraction
+            | Multiplication
+            | Division
+            | Remainder
+            | LessThan
+            | LessThanOrEqual
+            | GreaterThan
+            | GreaterThanOrEqual
+            | Equal
+            | NotEqual
+    )
+}
+
+/// Common underlying numeric type when both operands lower to the same
+/// numeric family; `None` if either operand is non-numeric or the two
+/// numeric families differ.
+fn matching_underlying_numeric(left: &Type, right: &Type) -> Option<Type> {
+    let left_underlying = left.underlying_numeric_type()?;
+    let right_underlying = right.underlying_numeric_type()?;
+    if left_underlying.numeric_family()? != right_underlying.numeric_family()? {
+        return None;
+    }
+    Some(left_underlying)
+}
+
+fn cast_unless_literal(is_literal: bool, target: &Type) -> Option<Type> {
+    if is_literal {
+        None
+    } else {
+        Some(target.clone())
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1,6 +1,8 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use syntax::ast::{MatchArm, Pattern, RestPattern, StructFieldPattern, TypedPattern};
+use syntax::ast::{
+    EnumFieldDefinition, MatchArm, Pattern, RestPattern, StructFieldPattern, TypedPattern,
+};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::{Type, unqualified_name};
 
@@ -515,20 +517,49 @@ fn build_tree(arms: Vec<ArmInfo>) -> Decision {
 /// first check (EnumTag/Value), with guards permitted only for TypeSwitch.
 fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
     let first_relevant = arms.iter().find(|a| !a.is_catchall())?;
+    let (kind, switch_path) = pick_switch_kind(first_relevant)?;
 
-    let (kind, switch_path) = if let Some(assertion) = &first_relevant.root_assertion {
-        (SwitchKind::TypeSwitch, assertion.path.clone())
+    validate_switch_arms(arms, &kind, &switch_path)?;
+
+    let grouped = group_switch_branches(arms, &kind);
+    let branches = build_switch_branches(&kind, grouped.order, grouped.by_label, &grouped.fallback);
+
+    let fallback = if grouped.fallback.is_empty() {
+        None
     } else {
-        let first_check = first_relevant.checks.first()?;
-        if first_check.as_enum_tag().is_some() {
-            (SwitchKind::EnumTag, first_check.path()?.clone())
-        } else if first_check.as_literal().is_some() {
-            (SwitchKind::Value, first_check.path()?.clone())
-        } else {
-            return None;
-        }
+        Some(Box::new(build_tree(grouped.fallback)))
     };
 
+    let shape = classify_switch_shape(&kind, &branches, &fallback);
+    Some(Decision::Switch {
+        path: switch_path,
+        kind,
+        shape,
+        branches,
+        fallback,
+    })
+}
+
+fn pick_switch_kind(arm: &ArmInfo) -> Option<(SwitchKind, AccessPath)> {
+    if let Some(assertion) = &arm.root_assertion {
+        return Some((SwitchKind::TypeSwitch, assertion.path.clone()));
+    }
+    let first_check = arm.checks.first()?;
+    let path = first_check.path()?.clone();
+    if first_check.as_enum_tag().is_some() {
+        Some((SwitchKind::EnumTag, path))
+    } else if first_check.as_literal().is_some() {
+        Some((SwitchKind::Value, path))
+    } else {
+        None
+    }
+}
+
+fn validate_switch_arms(
+    arms: &[ArmInfo],
+    kind: &SwitchKind,
+    switch_path: &AccessPath,
+) -> Option<()> {
     for arm in arms {
         if arm.is_catchall() {
             continue;
@@ -537,7 +568,7 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
             return None;
         }
 
-        let arm_path = match &kind {
+        let arm_path = match kind {
             SwitchKind::EnumTag => {
                 if arm.root_assertion.is_some() {
                     return None;
@@ -559,22 +590,36 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
             }
             SwitchKind::TypeSwitch => &arm.root_assertion.as_ref()?.path,
         };
-        if arm_path != &switch_path {
+        if arm_path != switch_path {
             return None;
         }
     }
+    Some(())
+}
 
-    let mut branch_map: HashMap<String, (bool, Vec<ArmInfo>)> = HashMap::default();
-    let mut branch_order: Vec<String> = Vec::new();
-    let mut fallback_arms = Vec::new();
+struct BranchGroup {
+    needs_stdlib: bool,
+    arms: Vec<ArmInfo>,
+}
+
+struct GroupedBranches {
+    order: Vec<String>,
+    by_label: HashMap<String, BranchGroup>,
+    fallback: Vec<ArmInfo>,
+}
+
+fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches {
+    let mut by_label: HashMap<String, BranchGroup> = HashMap::default();
+    let mut order: Vec<String> = Vec::new();
+    let mut fallback = Vec::new();
 
     for arm in arms {
         if arm.is_catchall() {
-            fallback_arms.push(arm.clone());
+            fallback.push(arm.clone());
             continue;
         }
 
-        let (case_label, needs_stdlib, inner_checks) = match &kind {
+        let (case_label, needs_stdlib, inner_checks) = match kind {
             SwitchKind::EnumTag => {
                 let (tag, needs) = arm.checks[0].as_enum_tag().unwrap();
                 (tag.to_string(), needs, arm.checks[1..].to_vec())
@@ -596,22 +641,41 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
             has_guard: arm.has_guard,
         };
 
-        branch_map
+        by_label
             .entry(case_label.clone())
-            .and_modify(|(_, arms)| arms.push(inner_arm.clone()))
+            .and_modify(|group| group.arms.push(inner_arm.clone()))
             .or_insert_with(|| {
-                branch_order.push(case_label);
-                (needs_stdlib, vec![inner_arm])
+                order.push(case_label);
+                BranchGroup {
+                    needs_stdlib,
+                    arms: vec![inner_arm],
+                }
             });
     }
 
-    let branches: Vec<SwitchBranch> = branch_order
+    GroupedBranches {
+        order,
+        by_label,
+        fallback,
+    }
+}
+
+/// Splice the catchall into any type-switch case whose inner tree can still
+/// fail. Go type-switch cases do not fall through, so the fallback arms must
+/// be inlined into each fail-prone case body.
+fn build_switch_branches(
+    kind: &SwitchKind,
+    order: Vec<String>,
+    mut by_label: HashMap<String, BranchGroup>,
+    fallback_arms: &[ArmInfo],
+) -> Vec<SwitchBranch> {
+    order
         .into_iter()
         .map(|label| {
-            let (needs_stdlib, inner_arms) = branch_map.remove(&label).unwrap();
-            // For type switches: if any inner arm can fail (via guard or remaining
-            // checks), the catchall arms must be appended so the case body stays
-            // exhaustive — Go type-switch cases don't fall through automatically.
+            let BranchGroup {
+                needs_stdlib,
+                arms: inner_arms,
+            } = by_label.remove(&label).unwrap();
             let any_inner_can_fail = inner_arms
                 .iter()
                 .any(|a| a.has_guard || !a.checks.is_empty());
@@ -628,22 +692,7 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
                 decision,
             }
         })
-        .collect();
-
-    let fallback = if fallback_arms.is_empty() {
-        None
-    } else {
-        Some(Box::new(build_tree(fallback_arms)))
-    };
-
-    let shape = classify_switch_shape(&kind, &branches, &fallback);
-    Some(Decision::Switch {
-        path: switch_path,
-        kind,
-        shape,
-        branches,
-        fallback,
-    })
+        .collect()
 }
 
 /// Build a Chain (if/else if/else) from the arms.
@@ -762,75 +811,11 @@ fn collect_checks_and_bindings(
         }
 
         Pattern::Tuple { elements, .. } => {
-            let typed_elements: Vec<Option<&TypedPattern>> = match typed {
-                Some(TypedPattern::Tuple { elements: te, .. }) => te.iter().map(Some).collect(),
-                _ => vec![None; elements.len()],
-            };
-
-            let stripped_path_ty = path_ty.map(Type::strip_refs);
-            let element_tys: Option<&[Type]> = match &stripped_path_ty {
-                Some(Type::Tuple(tys)) => Some(tys.as_slice()),
-                _ => None,
-            };
-
-            for (i, element) in elements.iter().enumerate() {
-                let field_name = TUPLE_FIELDS.get(i).expect("oversize tuple arity");
-                let field_path = path.push(PathSegment::Field(field_name.to_string()));
-                collect_checks_and_bindings(
-                    emitter,
-                    &field_path,
-                    element,
-                    typed_elements.get(i).copied().flatten(),
-                    element_tys.and_then(|tys| tys.get(i)),
-                    collector,
-                );
-            }
+            collect_tuple_checks(emitter, path, elements, typed, path_ty, collector);
         }
 
         Pattern::Slice { prefix, rest, .. } => {
-            let has_rest = rest.is_present();
-            if has_rest {
-                if !prefix.is_empty() {
-                    collector.checks.push(Check::SliceLenGe {
-                        path: path.clone(),
-                        min_length: prefix.len(),
-                    });
-                }
-            } else {
-                collector.checks.push(Check::SliceLenEq {
-                    path: path.clone(),
-                    length: prefix.len(),
-                });
-            }
-
-            let typed_prefix: Vec<Option<&TypedPattern>> = match typed {
-                Some(TypedPattern::Slice {
-                    prefix: tp_prefix, ..
-                }) => tp_prefix.iter().map(Some).collect(),
-                _ => vec![None; prefix.len()],
-            };
-
-            for (i, elem) in prefix.iter().enumerate() {
-                let elem_path = path.push(PathSegment::Index(i));
-                collect_checks_and_bindings(
-                    emitter,
-                    &elem_path,
-                    elem,
-                    typed_prefix.get(i).copied().flatten(),
-                    None,
-                    collector,
-                );
-            }
-
-            // Rest binding
-            if let RestPattern::Bind { name, .. } = rest {
-                let go_name = emitter.go_name_for_rest_binding(rest);
-                collector.bindings.push(PatternBinding {
-                    lisette_name: name.to_string(),
-                    go_name,
-                    path: path.push(PathSegment::SliceFrom(prefix.len())),
-                });
-            }
+            collect_slice_checks(emitter, path, prefix, rest, typed, collector);
         }
 
         Pattern::Or { patterns, .. } => {
@@ -850,6 +835,90 @@ fn collect_checks_and_bindings(
                 path: path.clone(),
             });
         }
+    }
+}
+
+fn collect_tuple_checks(
+    emitter: &Emitter,
+    path: &AccessPath,
+    elements: &[Pattern],
+    typed: Option<&TypedPattern>,
+    path_ty: Option<&Type>,
+    collector: &mut PatternCollector,
+) {
+    let typed_elements: Vec<Option<&TypedPattern>> = match typed {
+        Some(TypedPattern::Tuple { elements: te, .. }) => te.iter().map(Some).collect(),
+        _ => vec![None; elements.len()],
+    };
+
+    let stripped_path_ty = path_ty.map(Type::strip_refs);
+    let element_tys: Option<&[Type]> = match &stripped_path_ty {
+        Some(Type::Tuple(tys)) => Some(tys.as_slice()),
+        _ => None,
+    };
+
+    for (i, element) in elements.iter().enumerate() {
+        let field_name = TUPLE_FIELDS.get(i).expect("oversize tuple arity");
+        let field_path = path.push(PathSegment::Field(field_name.to_string()));
+        collect_checks_and_bindings(
+            emitter,
+            &field_path,
+            element,
+            typed_elements.get(i).copied().flatten(),
+            element_tys.and_then(|tys| tys.get(i)),
+            collector,
+        );
+    }
+}
+
+fn collect_slice_checks(
+    emitter: &Emitter,
+    path: &AccessPath,
+    prefix: &[Pattern],
+    rest: &RestPattern,
+    typed: Option<&TypedPattern>,
+    collector: &mut PatternCollector,
+) {
+    if rest.is_present() {
+        if !prefix.is_empty() {
+            collector.checks.push(Check::SliceLenGe {
+                path: path.clone(),
+                min_length: prefix.len(),
+            });
+        }
+    } else {
+        collector.checks.push(Check::SliceLenEq {
+            path: path.clone(),
+            length: prefix.len(),
+        });
+    }
+
+    let typed_prefix: Vec<Option<&TypedPattern>> = match typed {
+        Some(TypedPattern::Slice {
+            prefix: tp_prefix, ..
+        }) => tp_prefix.iter().map(Some).collect(),
+        _ => vec![None; prefix.len()],
+    };
+
+    for (i, elem) in prefix.iter().enumerate() {
+        let elem_path = path.push(PathSegment::Index(i));
+        collect_checks_and_bindings(
+            emitter,
+            &elem_path,
+            elem,
+            typed_prefix.get(i).copied().flatten(),
+            None,
+            collector,
+        );
+    }
+
+    if let RestPattern::Bind { name, .. } = rest {
+        let go_name = emitter.go_name_for_rest_binding(rest);
+        collector.bindings.push(PatternBinding {
+            lisette_name: name.to_string(),
+            go_name,
+            path: path.push(PathSegment::SliceFrom(prefix.len())),
+        });
     }
 }
 
@@ -1013,46 +1082,78 @@ fn collect_enum_variant_checks(
         return;
     }
 
-    if emitter.is_go_value_enum(ty) {
-        let Type::Nominal { id, .. } = ty.strip_refs() else {
-            return;
-        };
-        let variant_name = go_name::unqualified_name(identifier);
-        let Some(module) = emitter.facts.module_for_qualified_name(id.as_str()) else {
-            return;
-        };
-        let qualifier = emitter.go_pkg_qualifier(module);
-        let go_literal = if qualifier.is_empty() || qualifier == emitter.facts.current_module() {
-            variant_name.to_string()
-        } else {
-            collector
-                .effects
-                .require_go_import(emitter.go_import_path_for_module(module));
-            format!("{}.{}", qualifier, variant_name)
-        };
-        collector.checks.push(Check::Literal {
-            path: path.clone(),
-            go_literal,
-        });
+    if handle_go_value_enum_variant(emitter, path, ty, identifier, collector) {
         return;
     }
 
-    if emitter.as_enum(ty).is_none() && identifier.contains('.') {
-        if let Some((module, _)) = identifier.split_once('.')
-            && emitter.facts.is_foreign_module(module)
-        {
-            collector
-                .effects
-                .require_go_import(emitter.go_import_path_for_module(module));
-        }
-        collector.checks.push(Check::Literal {
-            path: path.clone(),
-            go_literal: identifier.to_string(),
-        });
+    if handle_foreign_variant_literal(emitter, path, ty, identifier, collector) {
         return;
     }
 
     collect_tagged_enum_checks(emitter, path, &variant_data, collector);
+}
+
+/// Returns `true` when `ty` is a Go value-enum (and the variant has been
+/// emitted as a `Check::Literal`, or silently skipped when its qualified name
+/// is not resolvable). Returns `false` for non-Go-value enums.
+fn handle_go_value_enum_variant(
+    emitter: &Emitter,
+    path: &AccessPath,
+    ty: &Type,
+    identifier: &str,
+    collector: &mut PatternCollector,
+) -> bool {
+    if !emitter.is_go_value_enum(ty) {
+        return false;
+    }
+    let Type::Nominal { id, .. } = ty.strip_refs() else {
+        return true;
+    };
+    let variant_name = go_name::unqualified_name(identifier);
+    let Some(module) = emitter.facts.module_for_qualified_name(id.as_str()) else {
+        return true;
+    };
+    let qualifier = emitter.go_pkg_qualifier(module);
+    let go_literal = if qualifier.is_empty() || qualifier == emitter.facts.current_module() {
+        variant_name.to_string()
+    } else {
+        collector
+            .effects
+            .require_go_import(emitter.go_import_path_for_module(module));
+        format!("{}.{}", qualifier, variant_name)
+    };
+    collector.checks.push(Check::Literal {
+        path: path.clone(),
+        go_literal,
+    });
+    true
+}
+
+/// Returns `true` when the variant is a foreign-module dotted name (e.g.
+/// `httpkg.MethodGet`) emitted as a `Check::Literal` with the original
+/// identifier as the Go literal. Returns `false` for known enums.
+fn handle_foreign_variant_literal(
+    emitter: &Emitter,
+    path: &AccessPath,
+    ty: &Type,
+    identifier: &str,
+    collector: &mut PatternCollector,
+) -> bool {
+    if emitter.as_enum(ty).is_some() || !identifier.contains('.') {
+        return false;
+    }
+    if let Some((module, _)) = identifier.split_once('.')
+        && emitter.facts.is_foreign_module(module)
+    {
+        collector
+            .effects
+            .require_go_import(emitter.go_import_path_for_module(module));
+    }
+    collector.checks.push(Check::Literal {
+        path: path.clone(),
+        go_literal: identifier.to_string(),
+    });
+    true
 }
 
 /// Collect checks and bindings for a newtype struct pattern (single-field wrapper).
@@ -1232,82 +1333,21 @@ fn collect_struct_checks(
         return;
     };
 
-    let (enum_info, child_path) = if let Some(asserted) =
-        interface_assert_child_path(emitter, path, ty, path_ty, collector)
-    {
-        (None, asserted)
-    } else {
-        let enum_info = detect_enum_info(emitter, ty, identifier, typed);
-        if enum_info.is_some() {
-            let alias = emitter.module_alias_for_type(ty);
-            let enum_module = enum_module_of(emitter, ty);
-            let resolved = go_name::variant(
-                identifier,
-                ty,
-                enum_module,
-                emitter.facts.current_module(),
-                alias.as_deref(),
-            );
-            if resolved.needs_stdlib {
-                collector.effects.needs_stdlib = true;
-            }
-            collector.checks.push(Check::EnumTag {
-                path: path.clone(),
-                tag_constant: resolved.name.clone(),
-                needs_stdlib: resolved.needs_stdlib,
-            });
-        }
-        (enum_info, path.clone())
-    };
-
-    let typed_fields_map: Option<Vec<(&str, Option<&TypedPattern>)>> = match typed {
-        Some(TypedPattern::Struct { pattern_fields, .. })
-        | Some(TypedPattern::EnumStructVariant { pattern_fields, .. }) => Some(
-            pattern_fields
-                .iter()
-                .map(|(name, tp)| (name.as_str(), Some(tp)))
-                .collect(),
-        ),
-        _ => None,
-    };
-
-    let typed_variant_fields = match typed {
-        Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => {
-            Some(variant_fields.as_slice())
-        }
-        _ => None,
-    };
-
-    let field_tys: Vec<(&str, &Type)> = match typed {
-        Some(TypedPattern::Struct { struct_fields, .. }) => struct_fields
-            .iter()
-            .map(|f| (f.name.as_str(), &f.ty))
-            .collect(),
-        Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => variant_fields
-            .iter()
-            .map(|f| (f.name.as_str(), &f.ty))
-            .collect(),
-        _ => Vec::new(),
-    };
+    let (enum_info, child_path) =
+        resolve_struct_child_path(emitter, path, ty, identifier, typed, path_ty, collector);
+    let types = StructPatternTypes::build(typed);
 
     for field in fields {
-        let typed_child = typed_fields_map
-            .as_ref()
-            .and_then(|m| m.iter().find(|(name, _)| *name == field.name))
-            .and_then(|(_, tp)| *tp);
-
+        let typed_child = types.lookup_typed_child(&field.name);
         let field_path = compute_struct_field_path(
             emitter,
             &child_path,
             field,
             ty,
             enum_info.as_ref(),
-            typed_variant_fields,
+            types.typed_variant_fields,
         );
-        let field_ty = field_tys
-            .iter()
-            .find(|(name, _)| *name == field.name)
-            .map(|(_, ty)| *ty);
+        let field_ty = types.lookup_field_ty(&field.name);
         collect_checks_and_bindings(
             emitter,
             &field_path,
@@ -1316,6 +1356,106 @@ fn collect_struct_checks(
             field_ty,
             collector,
         );
+    }
+}
+
+/// Resolve the access path for struct-pattern field lookups. Returns the
+/// enum-variant identity (when the pattern is an enum-struct variant) and the
+/// child path used for field projection: either the interface-assertion alias
+/// or the input path. Pushes the variant's tag check into `collector` when
+/// applicable.
+fn resolve_struct_child_path(
+    emitter: &Emitter,
+    path: &AccessPath,
+    ty: &Type,
+    identifier: &str,
+    typed: Option<&TypedPattern>,
+    path_ty: Option<&Type>,
+    collector: &mut PatternCollector,
+) -> (Option<(String, String)>, AccessPath) {
+    if let Some(asserted) = interface_assert_child_path(emitter, path, ty, path_ty, collector) {
+        return (None, asserted);
+    }
+    let enum_info = detect_enum_info(emitter, ty, identifier, typed);
+    if enum_info.is_some() {
+        let alias = emitter.module_alias_for_type(ty);
+        let enum_module = enum_module_of(emitter, ty);
+        let resolved = go_name::variant(
+            identifier,
+            ty,
+            enum_module,
+            emitter.facts.current_module(),
+            alias.as_deref(),
+        );
+        if resolved.needs_stdlib {
+            collector.effects.needs_stdlib = true;
+        }
+        collector.checks.push(Check::EnumTag {
+            path: path.clone(),
+            tag_constant: resolved.name.clone(),
+            needs_stdlib: resolved.needs_stdlib,
+        });
+    }
+    (enum_info, path.clone())
+}
+
+/// Per-call typed-pattern lookups for a struct pattern. Built once so the
+/// per-field loop can do `O(1)` lookups instead of three parallel matches.
+struct StructPatternTypes<'a> {
+    typed_fields_map: Option<Vec<(&'a str, Option<&'a TypedPattern>)>>,
+    typed_variant_fields: Option<&'a [EnumFieldDefinition]>,
+    field_tys: Vec<(&'a str, &'a Type)>,
+}
+
+impl<'a> StructPatternTypes<'a> {
+    fn build(typed: Option<&'a TypedPattern>) -> Self {
+        let typed_fields_map = match typed {
+            Some(TypedPattern::Struct { pattern_fields, .. })
+            | Some(TypedPattern::EnumStructVariant { pattern_fields, .. }) => Some(
+                pattern_fields
+                    .iter()
+                    .map(|(name, tp)| (name.as_str(), Some(tp)))
+                    .collect(),
+            ),
+            _ => None,
+        };
+        let typed_variant_fields = match typed {
+            Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => {
+                Some(variant_fields.as_slice())
+            }
+            _ => None,
+        };
+        let field_tys: Vec<(&str, &Type)> = match typed {
+            Some(TypedPattern::Struct { struct_fields, .. }) => struct_fields
+                .iter()
+                .map(|f| (f.name.as_str(), &f.ty))
+                .collect(),
+            Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => variant_fields
+                .iter()
+                .map(|f| (f.name.as_str(), &f.ty))
+                .collect(),
+            _ => Vec::new(),
+        };
+        Self {
+            typed_fields_map,
+            typed_variant_fields,
+            field_tys,
+        }
+    }
+
+    fn lookup_typed_child(&self, field_name: &str) -> Option<&'a TypedPattern> {
+        self.typed_fields_map
+            .as_ref()?
+            .iter()
+            .find(|(name, _)| *name == field_name)
+            .and_then(|(_, tp)| *tp)
+    }
+
+    fn lookup_field_ty(&self, field_name: &str) -> Option<&'a Type> {
+        self.field_tys
+            .iter()
+            .find(|(name, _)| *name == field_name)
+            .map(|(_, ty)| *ty)
     }
 }
 

--- a/crates/emit/src/patterns/emit_plan.rs
+++ b/crates/emit/src/patterns/emit_plan.rs
@@ -299,87 +299,116 @@ fn lower_switch(
     fallback: &Option<Box<Decision>>,
 ) -> EmitDecision {
     propagate_stdlib(ctx, branches);
-
     let rendered_path = path.render(&ctx.current_subject);
 
     match shape {
-        SwitchShape::TypeSwitch => {
-            let base = rendered_path;
-            ctx.with_subject(base.clone(), |ctx| {
-                let (cases, default) =
-                    lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
-                EmitDecision::TypeSwitch {
-                    base,
-                    cases,
-                    default,
-                }
-            })
-        }
-        SwitchShape::Bool => {
-            // Select branches by label so `then_branch` is always the
-            // semantic-true subtree regardless of source order.
-            let true_branch = branches
-                .iter()
-                .find(|b| b.case_label == "true")
-                .expect("Bool shape requires a true-labeled branch");
-            let false_branch = branches
-                .iter()
-                .find(|b| b.case_label == "false")
-                .expect("Bool shape requires a false-labeled branch");
-            let cond = wrap_if_struct_literal(rendered_path);
-            EmitDecision::IfElse {
-                cond,
-                then_branch: Box::new(lower_decision(ctx, &true_branch.decision)),
-                else_branch: Some(Box::new(lower_decision(ctx, &false_branch.decision))),
-            }
-        }
-        SwitchShape::Binary => {
-            let first = &branches[0];
-            let second = &branches[1];
-            let expr = render_switch_expression(&rendered_path, kind);
-            let cond = format!("{} == {}", expr, first.case_label);
-            EmitDecision::IfElse {
-                cond,
-                then_branch: Box::new(lower_decision(ctx, &first.decision)),
-                else_branch: Some(Box::new(lower_decision(ctx, &second.decision))),
-            }
-        }
+        SwitchShape::TypeSwitch => lower_type_switch(ctx, rendered_path, branches, fallback),
+        SwitchShape::Bool => lower_bool_switch(ctx, rendered_path, branches),
+        SwitchShape::Binary => lower_binary_switch(ctx, &rendered_path, kind, branches),
         SwitchShape::SingleArm => {
-            let branch = &branches[0];
-            let expr = render_switch_expression(&rendered_path, kind);
-            match fallback {
-                None => {
-                    // Exhaustive enum: inline body, no condition wrapper.
-                    EmitDecision::InlineBranch {
-                        branch: Box::new(lower_decision(ctx, &branch.decision)),
-                    }
-                }
-                Some(fb) => {
-                    let lowered_fallback = lower_decision(ctx, fb);
-                    let cond = format!("{} == {}", expr, branch.case_label);
-                    let else_branch = if is_empty_emit_decision(&lowered_fallback) {
-                        None
-                    } else {
-                        Some(Box::new(lowered_fallback))
-                    };
-                    EmitDecision::IfElse {
-                        cond,
-                        then_branch: Box::new(lower_decision(ctx, &branch.decision)),
-                        else_branch,
-                    }
-                }
-            }
+            lower_single_arm_switch(ctx, &rendered_path, kind, branches, fallback)
         }
-        SwitchShape::Multi => {
-            let expr = render_switch_expression(&rendered_path, kind);
-            let (cases, default) =
-                lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
-            EmitDecision::Switch {
-                expr,
-                cases,
-                default,
-            }
+        SwitchShape::Multi => lower_multi_switch(ctx, &rendered_path, kind, branches, fallback),
+    }
+}
+
+fn lower_type_switch(
+    ctx: &mut LoweringCtx,
+    base: String,
+    branches: &[crate::patterns::decision_tree::SwitchBranch],
+    fallback: &Option<Box<Decision>>,
+) -> EmitDecision {
+    ctx.with_subject(base.clone(), |ctx| {
+        let (cases, default) =
+            lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
+        EmitDecision::TypeSwitch {
+            base,
+            cases,
+            default,
         }
+    })
+}
+
+fn lower_bool_switch(
+    ctx: &mut LoweringCtx,
+    rendered_path: String,
+    branches: &[crate::patterns::decision_tree::SwitchBranch],
+) -> EmitDecision {
+    // Select branches by label so `then_branch` is always the semantic-true
+    // subtree regardless of source order.
+    let true_branch = branches
+        .iter()
+        .find(|b| b.case_label == "true")
+        .expect("Bool shape requires a true-labeled branch");
+    let false_branch = branches
+        .iter()
+        .find(|b| b.case_label == "false")
+        .expect("Bool shape requires a false-labeled branch");
+    EmitDecision::IfElse {
+        cond: wrap_if_struct_literal(rendered_path),
+        then_branch: Box::new(lower_decision(ctx, &true_branch.decision)),
+        else_branch: Some(Box::new(lower_decision(ctx, &false_branch.decision))),
+    }
+}
+
+fn lower_binary_switch(
+    ctx: &mut LoweringCtx,
+    rendered_path: &str,
+    kind: &SwitchKind,
+    branches: &[crate::patterns::decision_tree::SwitchBranch],
+) -> EmitDecision {
+    let first = &branches[0];
+    let second = &branches[1];
+    let expr = render_switch_expression(rendered_path, kind);
+    EmitDecision::IfElse {
+        cond: format!("{} == {}", expr, first.case_label),
+        then_branch: Box::new(lower_decision(ctx, &first.decision)),
+        else_branch: Some(Box::new(lower_decision(ctx, &second.decision))),
+    }
+}
+
+fn lower_single_arm_switch(
+    ctx: &mut LoweringCtx,
+    rendered_path: &str,
+    kind: &SwitchKind,
+    branches: &[crate::patterns::decision_tree::SwitchBranch],
+    fallback: &Option<Box<Decision>>,
+) -> EmitDecision {
+    let branch = &branches[0];
+    let Some(fb) = fallback else {
+        // Exhaustive enum: inline body, no condition wrapper.
+        return EmitDecision::InlineBranch {
+            branch: Box::new(lower_decision(ctx, &branch.decision)),
+        };
+    };
+    let expr = render_switch_expression(rendered_path, kind);
+    let lowered_fallback = lower_decision(ctx, fb);
+    let else_branch = if is_empty_emit_decision(&lowered_fallback) {
+        None
+    } else {
+        Some(Box::new(lowered_fallback))
+    };
+    EmitDecision::IfElse {
+        cond: format!("{} == {}", expr, branch.case_label),
+        then_branch: Box::new(lower_decision(ctx, &branch.decision)),
+        else_branch,
+    }
+}
+
+fn lower_multi_switch(
+    ctx: &mut LoweringCtx,
+    rendered_path: &str,
+    kind: &SwitchKind,
+    branches: &[crate::patterns::decision_tree::SwitchBranch],
+    fallback: &Option<Box<Decision>>,
+) -> EmitDecision {
+    let expr = render_switch_expression(rendered_path, kind);
+    let (cases, default) =
+        lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
+    EmitDecision::Switch {
+        expr,
+        cases,
+        default,
     }
 }
 

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -8,6 +8,8 @@
 //! subject materialization, root assertions, refutable condition assembly,
 //! binding emission, and or-pattern scope policy.
 
+use std::borrow::Cow;
+
 use syntax::ast::{Binding, Expression, MatchArm, Pattern, TypedPattern};
 use syntax::types::Type;
 
@@ -18,8 +20,8 @@ use crate::expressions::context::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::bindings::pattern_binds_name;
 use crate::patterns::decision_tree::{
-    self, apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
-    drop_inline_overlays, emit_tree_assignments, emit_tree_bindings,
+    self, PatternInfo, apply_refutable_root_assertion, apply_root_assertion,
+    compose_refutable_condition, drop_inline_overlays, emit_tree_assignments, emit_tree_bindings,
     emit_tree_bindings_with_consumers, render_condition,
 };
 use crate::placement::BodyPlace;
@@ -60,6 +62,12 @@ impl<'a> PatternSubject<'a> {
 struct ResolvedSubject {
     var: String,
     guard: Option<ValueTempDiscard>,
+}
+
+struct LetElseAlternatives<'s> {
+    collected: Vec<PatternInfo>,
+    hoisted: Vec<(Cow<'s, str>, Option<String>)>,
+    irrefutable_idx: Option<usize>,
 }
 
 impl Emitter<'_> {
@@ -271,62 +279,84 @@ impl Emitter<'_> {
         subject_ty: &Type,
         else_block: &Expression,
     ) {
-        let outer_snapshot = self.scope.binding_snapshot();
-
+        let pre_let_snapshot = self.scope.binding_snapshot();
         self.emit_binding_declarations_with_type(output, pattern, binding_ty, typed);
+        let post_decl_snapshot = self.scope.binding_snapshot();
 
-        let pattern_snapshot = self.scope.binding_snapshot();
+        let alts = self.collect_let_else_alternatives(output, patterns, subject_ty, subject_var);
+        self.emit_let_else_chain(output, &alts);
 
-        let collected: Vec<_> = patterns
+        if let Some(idx) = alts.irrefutable_idx {
+            self.emit_let_else_irrefutable_tail(output, &alts, idx);
+            return;
+        }
+
+        self.scope.restore_binding_snapshot(pre_let_snapshot);
+        output.push_str("} else {\n");
+        self.emit_block(output, else_block);
+        output.push_str("}\n");
+
+        self.scope.restore_binding_snapshot(post_decl_snapshot);
+    }
+
+    fn collect_let_else_alternatives<'s>(
+        &mut self,
+        output: &mut String,
+        patterns: &[Pattern],
+        subject_ty: &Type,
+        subject_var: &'s str,
+    ) -> LetElseAlternatives<'s> {
+        let collected: Vec<PatternInfo> = patterns
             .iter()
             .map(|alt| decision_tree::collect_pattern_info(self, alt, None, subject_ty))
             .collect();
         for info in &collected {
             self.requirements.apply_effects(&info.effects);
         }
-
-        let hoisted: Vec<_> = collected
+        let hoisted: Vec<(Cow<'s, str>, Option<String>)> = collected
             .iter()
             .map(|info| apply_refutable_root_assertion(self, output, info, subject_var))
             .collect();
-
         let irrefutable_idx = collected
             .iter()
             .zip(hoisted.iter())
             .position(|(info, (_, ok_var))| info.checks.is_empty() && ok_var.is_none());
-        let chain_len = irrefutable_idx.unwrap_or(collected.len());
+        LetElseAlternatives {
+            collected,
+            hoisted,
+            irrefutable_idx,
+        }
+    }
 
-        for (i, info) in collected.iter().take(chain_len).enumerate() {
-            let (effective, ok_var) = &hoisted[i];
+    fn emit_let_else_chain(&mut self, output: &mut String, alts: &LetElseAlternatives<'_>) {
+        let chain_len = alts.irrefutable_idx.unwrap_or(alts.collected.len());
+        for (i, info) in alts.collected.iter().take(chain_len).enumerate() {
+            let (effective, ok_var) = &alts.hoisted[i];
             let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
             if i == 0 {
                 write_line!(output, "if {} {{", condition);
             } else {
                 write_line!(output, "}} else if {} {{", condition);
             }
-
             emit_tree_assignments(self, output, &info.bindings, effective);
         }
+    }
 
-        if let Some(idx) = irrefutable_idx {
-            let info = &collected[idx];
-            let (effective, _) = &hoisted[idx];
-            if idx == 0 {
-                emit_tree_assignments(self, output, &info.bindings, effective);
-            } else {
-                output.push_str("} else {\n");
-                emit_tree_assignments(self, output, &info.bindings, effective);
-                output.push_str("}\n");
-            }
-            return;
+    fn emit_let_else_irrefutable_tail(
+        &mut self,
+        output: &mut String,
+        alts: &LetElseAlternatives<'_>,
+        idx: usize,
+    ) {
+        let info = &alts.collected[idx];
+        let (effective, _) = &alts.hoisted[idx];
+        if idx == 0 {
+            emit_tree_assignments(self, output, &info.bindings, effective);
+        } else {
+            output.push_str("} else {\n");
+            emit_tree_assignments(self, output, &info.bindings, effective);
+            output.push_str("}\n");
         }
-
-        self.scope.restore_binding_snapshot(outer_snapshot);
-        output.push_str("} else {\n");
-        self.emit_block(output, else_block);
-        output.push_str("}\n");
-
-        self.scope.restore_binding_snapshot(pattern_snapshot);
     }
 
     fn emit_while_let_or_pattern(

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -306,41 +306,7 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 bindings,
                 success,
                 failure,
-            } => {
-                let needs_pre_scope = ctx.leaf_scope_explicit() && !bindings.is_empty();
-                if needs_pre_scope {
-                    output.push_str("{\n");
-                    self.emitter.enter_scope();
-                }
-                let arm = &self.arms[*arm_index];
-                let arm_guard = arm.guard.as_deref();
-                let arm_body = &*arm.expression;
-                let mut guard_consumers: Vec<&Expression> = Vec::with_capacity(2);
-                if let Some(g) = arm_guard {
-                    guard_consumers.push(g);
-                }
-                guard_consumers.push(arm_body);
-                let inlines = self.emit_bindings(output, bindings, &guard_consumers, Some(failure));
-                if self.emit_guard_header(output, *arm_index) {
-                    self.walk(output, success, &ctx.nested());
-                    self.emitter.exit_scope();
-                    self.drop_inline_bindings(&inlines);
-                    if ctx.role == WalkRole::SwitchCase {
-                        self.walk_else_or_flat(output, failure, ctx);
-                    } else {
-                        output.push_str("}\n");
-                    }
-                } else {
-                    self.drop_inline_bindings(&inlines);
-                }
-                if needs_pre_scope {
-                    self.emitter.exit_scope();
-                    output.push_str("}\n");
-                }
-                if ctx.role == WalkRole::RetryLoopTop {
-                    self.walk(output, failure, ctx);
-                }
-            }
+            } => self.walk_guard(output, *arm_index, bindings, success, failure, ctx),
             EmitDecision::IfElse {
                 cond,
                 then_branch,
@@ -389,6 +355,49 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
                 }
             }
             EmitDecision::Unreachable => {}
+        }
+    }
+
+    fn walk_guard(
+        &mut self,
+        output: &mut String,
+        arm_index: usize,
+        bindings: &[EmitBinding],
+        success: &EmitDecision,
+        failure: &EmitDecision,
+        ctx: &WalkCtx,
+    ) {
+        let needs_pre_scope = ctx.leaf_scope_explicit() && !bindings.is_empty();
+        if needs_pre_scope {
+            output.push_str("{\n");
+            self.emitter.enter_scope();
+        }
+        let arm = &self.arms[arm_index];
+        let arm_body = &*arm.expression;
+        let mut guard_consumers: Vec<&Expression> = Vec::with_capacity(2);
+        if let Some(g) = arm.guard.as_deref() {
+            guard_consumers.push(g);
+        }
+        guard_consumers.push(arm_body);
+        let inlines = self.emit_bindings(output, bindings, &guard_consumers, Some(failure));
+        if self.emit_guard_header(output, arm_index) {
+            self.walk(output, success, &ctx.nested());
+            self.emitter.exit_scope();
+            self.drop_inline_bindings(&inlines);
+            if ctx.role == WalkRole::SwitchCase {
+                self.walk_else_or_flat(output, failure, ctx);
+            } else {
+                output.push_str("}\n");
+            }
+        } else {
+            self.drop_inline_bindings(&inlines);
+        }
+        if needs_pre_scope {
+            self.emitter.exit_scope();
+            output.push_str("}\n");
+        }
+        if ctx.role == WalkRole::RetryLoopTop {
+            self.walk(output, failure, ctx);
         }
     }
 

--- a/crates/emit/src/placement.rs
+++ b/crates/emit/src/placement.rs
@@ -286,16 +286,11 @@ fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
     if !is_range_index {
         return false;
     }
-    let collection_ty = match expression.as_ref() {
-        Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } => {
-            let inner_ty = inner.get_type();
-            inner_ty.inner().unwrap_or(inner_ty)
-        }
-        other => other.get_type(),
+    let collection_ty = if let Some(inner) = expression.deref_inner() {
+        let inner_ty = inner.get_type();
+        inner_ty.inner().unwrap_or(inner_ty)
+    } else {
+        expression.get_type()
     };
     collection_ty.has_name("Slice")
 }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -342,12 +342,7 @@ impl Emitter<'_> {
             Expression::DotAccess {
                 expression, member, ..
             } => {
-                let base_str = if let Expression::Unary {
-                    operator: UnaryOperator::Deref,
-                    expression: inner,
-                    ..
-                } = expression.as_ref()
-                {
+                let base_str = if let Some(inner) = expression.deref_inner() {
                     self.emit_operand(output, inner, ExpressionContext::value())
                 } else {
                     self.emit_operand(output, expression, ExpressionContext::value())
@@ -358,12 +353,7 @@ impl Emitter<'_> {
             Expression::IndexedAccess {
                 expression, index, ..
             } => {
-                let expression_string = if let Expression::Unary {
-                    operator: UnaryOperator::Deref,
-                    expression: inner,
-                    ..
-                } = expression.as_ref()
-                {
+                let expression_string = if let Some(inner) = expression.deref_inner() {
                     let inner_str = self.emit_operand(output, inner, ExpressionContext::value());
                     format!("(*{})", inner_str)
                 } else {
@@ -438,42 +428,8 @@ impl Emitter<'_> {
                 index,
                 ..
             } => {
-                let base_str = if is_order_sensitive(base) {
-                    if let Expression::Unary {
-                        operator: UnaryOperator::Deref,
-                        expression: inner,
-                        ..
-                    } = base.as_ref()
-                    {
-                        let inner_str = self.emit_force_capture(output, inner, "base");
-                        format!("(*{})", inner_str)
-                    } else {
-                        self.emit_force_capture(output, base, "base")
-                    }
-                } else if let Expression::Unary {
-                    operator: UnaryOperator::Deref,
-                    expression: inner,
-                    ..
-                } = base.as_ref()
-                {
-                    let inner_str = self.emit_operand(output, inner, ExpressionContext::value());
-                    format!("(*{})", inner_str)
-                } else {
-                    self.emit_operand(output, base, ExpressionContext::value())
-                };
-                // When the RHS produces temp statements (if/match/block used as value),
-                // the index must be captured even for simple identifiers — the RHS
-                // setup (emitted later) could mutate the index variable.
-                let index_needs_capture = if rhs_has_setup {
-                    !matches!(index.unwrap_parens(), Expression::Literal { .. })
-                } else {
-                    is_order_sensitive(index)
-                };
-                let index_str = if index_needs_capture {
-                    self.emit_force_capture(output, index, "idx")
-                } else {
-                    self.emit_operand(output, index, ExpressionContext::value())
-                };
+                let base_str = self.emit_indexed_base_lvalue(output, base);
+                let index_str = self.emit_index_lvalue(output, index, rhs_has_setup);
                 format!("{}[{}]", base_str, index_str)
             }
             Expression::DotAccess {
@@ -481,12 +437,7 @@ impl Emitter<'_> {
                 member,
                 ..
             } => {
-                let base_str = if let Expression::Unary {
-                    operator: UnaryOperator::Deref,
-                    expression: inner,
-                    ..
-                } = base.as_ref()
-                {
+                let base_str = if let Some(inner) = base.deref_inner() {
                     self.emit_operand(output, inner, ExpressionContext::value())
                 } else if is_order_sensitive(base) {
                     self.emit_left_value_capturing(output, base, rhs_has_setup)
@@ -502,6 +453,53 @@ impl Emitter<'_> {
                 ..
             } => self.emit_deref_lvalue(output, inner),
             _ => self.emit_left_value(output, expression),
+        }
+    }
+
+    /// Emit the base of an `IndexedAccess` lvalue, peeling an explicit deref
+    /// so `(*ptr)[i]` evaluates the pointer separately from the index, and
+    /// capturing the base to a temp when ordering matters.
+    fn emit_indexed_base_lvalue(&mut self, output: &mut String, base: &Expression) -> String {
+        let force = is_order_sensitive(base);
+        if let Some(inner) = base.deref_inner() {
+            let inner_str = self.emit_base_operand(output, inner, force);
+            format!("(*{})", inner_str)
+        } else {
+            self.emit_base_operand(output, base, force)
+        }
+    }
+
+    fn emit_base_operand(
+        &mut self,
+        output: &mut String,
+        expression: &Expression,
+        force_capture: bool,
+    ) -> String {
+        if force_capture {
+            self.emit_force_capture(output, expression, "base")
+        } else {
+            self.emit_operand(output, expression, ExpressionContext::value())
+        }
+    }
+
+    /// Emit the index of an `IndexedAccess` lvalue, capturing to a temp when
+    /// the RHS will emit setup statements that could mutate the index variable,
+    /// or when the index expression itself is order-sensitive.
+    fn emit_index_lvalue(
+        &mut self,
+        output: &mut String,
+        index: &Expression,
+        rhs_has_setup: bool,
+    ) -> String {
+        let needs_capture = if rhs_has_setup {
+            !matches!(index.unwrap_parens(), Expression::Literal { .. })
+        } else {
+            is_order_sensitive(index)
+        };
+        if needs_capture {
+            self.emit_force_capture(output, index, "idx")
+        } else {
+            self.emit_operand(output, index, ExpressionContext::value())
         }
     }
 

--- a/crates/emit/src/types/abi_transition.rs
+++ b/crates/emit/src/types/abi_transition.rs
@@ -129,29 +129,42 @@ pub(crate) fn emit_lowered_result_return(
             );
         }
         AbiShape::Tuple { arity } => {
-            let peeled = emitter.facts.peel_alias(return_ty);
-            let slot_tys = tuple_element_types(&peeled);
-            let any_nullable = slot_tys.iter().any(|t| emitter.facts.is_nullable_option(t));
-            if !any_nullable {
-                let fields: Vec<String> = (0..*arity)
-                    .map(|i| format!("{}.{}", result_value, syntax::parse::TUPLE_FIELDS[i]))
-                    .collect();
-                write_line!(output, "return {}", fields.join(", "));
-                return;
-            }
-            let fields: Vec<String> = (0..*arity)
-                .map(|i| {
-                    let raw = format!("{}.{}", result_value, syntax::parse::TUPLE_FIELDS[i]);
-                    slot_tys
-                        .get(i)
-                        .filter(|t| emitter.facts.is_nullable_option(t))
-                        .map(|t| emitter.emit_option_unwrap_to_nullable(output, &raw, t))
-                        .unwrap_or(raw)
-                })
-                .collect();
-            write_line!(output, "return {}", fields.join(", "));
+            emit_lowered_tuple_return(emitter, output, result_value, return_ty, *arity);
         }
     }
+}
+
+/// `Tuple` shape return: when no slot is nullable, project each tuple field
+/// directly; otherwise unwrap each nullable-Option slot through
+/// `emit_option_unwrap_to_nullable` while passing the rest through raw.
+fn emit_lowered_tuple_return(
+    emitter: &mut Emitter,
+    output: &mut String,
+    result_value: &str,
+    return_ty: &Type,
+    arity: usize,
+) {
+    let peeled = emitter.facts.peel_alias(return_ty);
+    let slot_tys = tuple_element_types(&peeled);
+    let any_nullable = slot_tys.iter().any(|t| emitter.facts.is_nullable_option(t));
+    if !any_nullable {
+        let fields: Vec<String> = (0..arity)
+            .map(|i| format!("{}.{}", result_value, syntax::parse::TUPLE_FIELDS[i]))
+            .collect();
+        write_line!(output, "return {}", fields.join(", "));
+        return;
+    }
+    let fields: Vec<String> = (0..arity)
+        .map(|i| {
+            let raw = format!("{}.{}", result_value, syntax::parse::TUPLE_FIELDS[i]);
+            slot_tys
+                .get(i)
+                .filter(|t| emitter.facts.is_nullable_option(t))
+                .map(|t| emitter.emit_option_unwrap_to_nullable(output, &raw, t))
+                .unwrap_or(raw)
+        })
+        .collect();
+    write_line!(output, "return {}", fields.join(", "));
 }
 
 /// Wrap a lowered-callee `call_str` (Go-shaped return) into the Lisette
@@ -166,19 +179,19 @@ pub(crate) fn emit_callee_abi_wrapping(
     match shape {
         AbiShape::PartialTuple => emitter
             .emit_partial_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot)
-            .expect_slot(),
+            .expect("wrapper produced no slot"),
         AbiShape::CommaOk => emitter
             .emit_comma_ok_wrapping(output, call_str, result_ty, false, WrapperTarget::FreshSlot)
-            .expect_slot(),
+            .expect("wrapper produced no slot"),
         AbiShape::NullableReturn => {
             let raw_var = emitter.hoist_tmp_value(output, "raw", call_str);
             emitter
                 .emit_nil_check_option_wrap(output, &raw_var, result_ty, WrapperTarget::FreshSlot)
-                .expect_slot()
+                .expect("wrapper produced no slot")
         }
         AbiShape::ResultTuple | AbiShape::BareError => emitter
             .emit_result_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot)
-            .expect_slot(),
+            .expect("wrapper produced no slot"),
         AbiShape::Tuple { arity } => {
             let temps = emitter.create_temp_vars("ret", *arity);
             write_line!(output, "{} := {}", temps.join(", "), call_str);
@@ -198,7 +211,7 @@ pub(crate) fn emit_callee_abi_wrapping(
                                     slot_ty,
                                     WrapperTarget::FreshSlot,
                                 )
-                                .expect_slot()
+                                .expect("wrapper produced no slot")
                         })
                         .unwrap_or_else(|| v.clone())
                 })

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -67,7 +67,7 @@ impl Coercion {
             }
             CoercionKind::WrapNullableOption { ty } => emitter
                 .emit_nil_check_option_wrap(output, &value, &ty, WrapperTarget::FreshSlot)
-                .expect_slot(),
+                .expect("wrapper produced no slot"),
             CoercionKind::WrapPointerOption { ty } => {
                 emitter.emit_pointer_to_option_wrap(output, &value, &ty)
             }
@@ -109,42 +109,63 @@ fn resolve_internal(emitter: &Emitter, from: &Type, to: &Type) -> CoercionKind {
     }
 }
 
-fn resolve_to_go(emitter: &Emitter, value_ty: &Type, target_ty: &Type) -> CoercionKind {
-    if emitter.is_non_nilable_option(value_ty) && emitter.is_non_nilable_option(target_ty) {
-        return CoercionKind::UnwrapPointerOption {
-            ty: value_ty.clone(),
-        };
-    }
-    if emitter.facts.is_nullable_option(value_ty) {
-        CoercionKind::UnwrapNullableOption {
-            ty: value_ty.clone(),
-        }
-    } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
-        CoercionKind::UnwrapNullableCollection {
-            ty: value_ty.clone(),
-            elem_option_ty,
+/// Option-related shape of a type at a Go boundary. Adding a new variant is
+/// a compile-time call to revisit every `match` against it.
+pub(crate) enum OptionShape {
+    Plain,
+    /// Lisette `Option<T>` where `T` is Go-nilable (interface, slice, pointer);
+    /// the Go side uses nil itself as the absence marker.
+    Nullable,
+    /// Lisette `Option<T>` where `T` is a Go non-nilable scalar; the Go side
+    /// uses `*T` and bridges nil ↔ `None`.
+    PointerBridged,
+    NullableCollection {
+        elem_option_ty: Type,
+    },
+}
+
+pub(crate) fn classify_option_shape(emitter: &Emitter, ty: &Type) -> OptionShape {
+    if emitter.facts.is_nullable_option(ty) {
+        OptionShape::Nullable
+    } else if emitter.is_non_nilable_option(ty) {
+        OptionShape::PointerBridged
+    } else if let Some(elem) = emitter.nullable_collection_element_ty(ty) {
+        OptionShape::NullableCollection {
+            elem_option_ty: elem,
         }
     } else {
-        CoercionKind::Identity
+        OptionShape::Plain
     }
 }
 
-fn resolve_from_go(emitter: &Emitter, value_ty: &Type) -> CoercionKind {
-    if emitter.facts.is_nullable_option(value_ty) {
-        CoercionKind::WrapNullableOption {
-            ty: value_ty.clone(),
+fn resolve_to_go(emitter: &Emitter, from: &Type, to: &Type) -> CoercionKind {
+    use OptionShape::*;
+    match classify_option_shape(emitter, from) {
+        Plain => CoercionKind::Identity,
+        Nullable => CoercionKind::UnwrapNullableOption { ty: from.clone() },
+        // Only unwrap to `*T` when the Go side also expects `*T`. A
+        // pointer-bridged source against any other target stays tagged.
+        PointerBridged if matches!(classify_option_shape(emitter, to), PointerBridged) => {
+            CoercionKind::UnwrapPointerOption { ty: from.clone() }
         }
-    } else if emitter.is_non_nilable_option(value_ty) {
-        CoercionKind::WrapPointerOption {
-            ty: value_ty.clone(),
-        }
-    } else if let Some(elem_option_ty) = emitter.nullable_collection_element_ty(value_ty) {
-        CoercionKind::WrapNullableCollection {
-            ty: value_ty.clone(),
+        PointerBridged => CoercionKind::Identity,
+        NullableCollection { elem_option_ty } => CoercionKind::UnwrapNullableCollection {
+            ty: from.clone(),
             elem_option_ty,
-        }
-    } else {
-        CoercionKind::Identity
+        },
+    }
+}
+
+fn resolve_from_go(emitter: &Emitter, from: &Type) -> CoercionKind {
+    use OptionShape::*;
+    match classify_option_shape(emitter, from) {
+        Plain => CoercionKind::Identity,
+        Nullable => CoercionKind::WrapNullableOption { ty: from.clone() },
+        PointerBridged => CoercionKind::WrapPointerOption { ty: from.clone() },
+        NullableCollection { elem_option_ty } => CoercionKind::WrapNullableCollection {
+            ty: from.clone(),
+            elem_option_ty,
+        },
     }
 }
 

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -113,24 +113,15 @@ impl Emitter<'_> {
             .join(", ");
 
         if kind == CompoundKind::EnumeratedSlice {
-            let mut result = GoType::new(format!("[]{}", type_args));
-            result.merge_all(&param_types);
-            return result;
+            return build_param_typed(format!("[]{}", type_args), &param_types);
         }
-
         if kind == CompoundKind::VarArgs {
-            let mut result = GoType::new(format!("...{}", type_args));
-            result.merge_all(&param_types);
-            return result;
+            return build_param_typed(format!("...{}", type_args), &param_types);
         }
-
         if args.is_empty() {
             return GoType::new(kind.leaf_name().to_string());
         }
-
-        let mut result = GoType::new(format!("{}[{}]", kind.leaf_name(), type_args));
-        result.merge_all(&param_types);
-        result
+        build_param_typed(format!("{}[{}]", kind.leaf_name(), type_args), &param_types)
     }
 
     pub(crate) fn go_type_as_string(&mut self, ty: &Type) -> String {
@@ -198,41 +189,19 @@ impl Emitter<'_> {
             .join(", ");
 
         if name == "EnumeratedSlice" {
-            let mut result = GoType::new(format!("[]{}", type_args));
-            result.merge_all(&param_types);
-            return result;
+            return build_param_typed(format!("[]{}", type_args), &param_types);
         }
-
         if name == "VarArgs" {
-            let mut result = GoType::new(format!("...{}", type_args));
-            result.merge_all(&param_types);
-            return result;
+            return build_param_typed(format!("...{}", type_args), &param_types);
         }
 
-        if let Some(rest) = qualified_name.strip_prefix(go_name::GO_IMPORT_PREFIX)
-            && let Some((go_path, _)) = rest.rsplit_once('.')
-        {
-            let mut result = if params.is_empty() {
-                GoType::with_go_import(name, go_path.to_string())
+        if let Some(go_path) = self.resolve_go_import_path(qualified_name) {
+            let code = if params.is_empty() {
+                name.clone()
             } else {
-                GoType::with_go_import(format!("{}[{}]", name, type_args), go_path.to_string())
+                format!("{}[{}]", name, type_args)
             };
-            result.merge_all(&param_types);
-            return result;
-        }
-
-        if let Some((module, _)) = qualified_name.split_once('.')
-            && self.facts.is_foreign_module(module)
-            && !go_name::is_go_import(module)
-        {
-            let go_path = self.facts.go_import_path(module);
-            let mut result = if params.is_empty() {
-                GoType::with_go_import(name.clone(), go_path)
-            } else {
-                GoType::with_go_import(format!("{}[{}]", name, type_args), go_path)
-            };
-            result.merge_all(&param_types);
-            return result;
+            return build_go_import_typed(code, go_path, &param_types);
         }
 
         if let Some(name) = qualified_name.strip_prefix(go_name::PRELUDE_PREFIX)
@@ -247,10 +216,24 @@ impl Emitter<'_> {
         if params.is_empty() {
             return GoType::new(name);
         }
+        build_param_typed(format!("{}[{}]", name, type_args), &param_types)
+    }
 
-        let mut result = GoType::new(format!("{}[{}]", name, type_args));
-        result.merge_all(&param_types);
-        result
+    /// Resolve a Go-import path for a nominal constructor: either an explicit
+    /// `lisette/go/...` prefix on `qualified_name`, or an implicit one via a
+    /// foreign module mapped to a Go import. Returns `None` for prelude,
+    /// stdlib, or local nominal types.
+    fn resolve_go_import_path(&self, qualified_name: &str) -> Option<String> {
+        if let Some(rest) = qualified_name.strip_prefix(go_name::GO_IMPORT_PREFIX)
+            && let Some((go_path, _)) = rest.rsplit_once('.')
+        {
+            return Some(go_path.to_string());
+        }
+        let (module, _) = qualified_name.split_once('.')?;
+        if self.facts.is_foreign_module(module) && !go_name::is_go_import(module) {
+            return Some(self.facts.go_import_path(module));
+        }
+        None
     }
 
     fn emit_native_type(&self, native: NativeGoType, ty: &Type) -> GoType {
@@ -266,9 +249,7 @@ impl Emitter<'_> {
         let arg_types: Vec<GoType> = args.iter().map(|a| self.go_type(a)).collect();
         let type_args: Vec<String> = arg_types.iter().map(|t| t.code.clone()).collect();
 
-        let mut result = GoType::new(native.emit_type_syntax(&type_args));
-        result.merge_all(&arg_types);
-        result
+        build_param_typed(native.emit_type_syntax(&type_args), &arg_types)
     }
 
     fn emit_function_type(&self, params: &[Type], return_ty: &Type) -> GoType {
@@ -558,4 +539,16 @@ impl Emitter<'_> {
         let type_params: Vec<String> = param_types.iter().map(|t| t.code.clone()).collect();
         (param_types, type_params)
     }
+}
+
+fn build_param_typed(code: String, param_types: &[GoType]) -> GoType {
+    let mut result = GoType::new(code);
+    result.merge_all(param_types);
+    result
+}
+
+fn build_go_import_typed(code: String, go_path: String, param_types: &[GoType]) -> GoType {
+    let mut result = GoType::with_go_import(code, go_path);
+    result.merge_all(param_types);
+    result
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1447,6 +1447,19 @@ impl Expression {
         }
     }
 
+    /// Inner expression of an explicit `x.*` deref, or `None` for anything else.
+    #[inline]
+    pub fn deref_inner(&self) -> Option<&Expression> {
+        match self {
+            Expression::Unary {
+                operator: UnaryOperator::Deref,
+                expression,
+                ..
+            } => Some(expression),
+            _ => None,
+        }
+    }
+
     pub fn as_dotted_path(&self) -> Option<String> {
         match self {
             Expression::Identifier { value, .. } => Some(value.to_string()),


### PR DESCRIPTION
Reduces complexity in the `emit` crate: 

- Splits the longest emit functions into smaller helpers that read as named pipelines instead of multi-axis dispatchers. 
- Centralizes the Lisette-Option-to-Go-nil classification into a single enum consumed via exhaustive matches.
