### PR TITLE
fix: suppress unused-field lint on pub fields

### DIFF
--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -289,6 +289,7 @@ fn collect_items(
                             field_id,
                             StructFieldInfo {
                                 span: struct_field.name_span,
+                                is_public: struct_field.visibility == Visibility::Public,
                                 parent_is_public: is_public,
                                 parent_has_serialization_attr: has_serialization_attr,
                                 has_tag_attribute,

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -35,6 +35,7 @@ impl StructFieldId {
 #[derive(Debug, Clone)]
 pub struct StructFieldInfo {
     pub span: Span,
+    pub is_public: bool,
     pub parent_is_public: bool,
     pub parent_has_serialization_attr: bool,
     pub has_tag_attribute: bool,
@@ -161,7 +162,8 @@ impl ReferenceGraph {
         self.struct_fields
             .iter()
             .filter(|(id, info)| {
-                !info.parent_is_public
+                !info.is_public
+                    && !info.parent_is_public
                     && !info.parent_has_serialization_attr
                     && !info.has_tag_attribute
                     && !self.used_struct_fields.contains(*id)

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1095,6 +1095,22 @@ fn main() {
 }
 
 #[test]
+fn public_field_on_private_struct_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+struct Person {
+  pub name: string,
+  pub age: int,
+}
+
+fn main() {
+  let _p = Person { name: "", age: 0 }
+}
+"#
+    );
+}
+
+#[test]
 fn serialization_struct_fields_not_unused() {
     assert_no_lint_warnings!(
         r#"


### PR DESCRIPTION
Stops `lint.unused_struct_field` from firing on `pub` struct fields. Field-level `pub` marks a field as exposed beyond the Lisette source, typically to Go reflection libraries e.g. `mapstructure`, so the absence of an in-source read is not evidence of deadness.