### PR TITLE
fix: detect map literal attempts at parse time

### DIFF
--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -643,6 +643,17 @@ impl<'source> Parser<'source> {
 
         self.ensure(LeftCurlyBrace);
 
+        if self.looks_like_map_literal() {
+            let key_span = self.span_from_token(self.current_token());
+            self.consume_to_matching_close_brace();
+            self.error_map_literal_not_supported(key_span);
+            return Expression::Block {
+                ty: Type::uninferred(),
+                items: vec![],
+                span: self.span_from_tokens(start),
+            };
+        }
+
         if !self.enter_recursion() {
             let span = self.span_from_token(self.current_token());
             let mut brace_depth = 1u32;
@@ -1540,6 +1551,27 @@ impl<'source> Parser<'source> {
             binding_id: None,
             qualified: None,
         }
+    }
+
+    fn looks_like_map_literal(&self) -> bool {
+        let first = self.current_token().kind;
+        let second = self.stream.peek_ahead(1).kind;
+        matches!(first, String | RawString | Integer | Float) && second == Colon
+    }
+
+    fn consume_to_matching_close_brace(&mut self) {
+        let mut brace_depth = 1u32;
+        while brace_depth > 0 && !self.at_eof() {
+            match self.current_token().kind {
+                LeftCurlyBrace => brace_depth += 1,
+                RightCurlyBrace => brace_depth -= 1,
+                _ => {}
+            }
+            if brace_depth > 0 {
+                self.next();
+            }
+        }
+        self.advance_if(RightCurlyBrace);
     }
 
     fn recover_unexpected_backtick(&mut self) -> Expression {

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -605,6 +605,17 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
+    pub(super) fn error_map_literal_not_supported(&mut self, span: ast::Span) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new("Invalid `Map` initialization", span, "invalid syntax")
+            .with_parse_code("invalid_map_initialization")
+            .with_help("To initialize a `Map`, use `Map.new<K, V>()` then `m[key] = value`");
+
+        self.errors.push(error);
+    }
+
     fn track_ensure_error(&mut self, expected_token: TokenKind) {
         if self.too_many_errors() {
             return;

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -660,6 +660,26 @@ fn test() {
 }
 
 #[test]
+fn parse_map_literal_string_keys() {
+    let input = r#"
+fn test() {
+  let m: Map<string, int> = { "a": 1, "b": 2 }
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_map_literal_int_keys() {
+    let input = r#"
+fn test() {
+  let m: Map<int, string> = { 1: "a", 2: "b" }
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_struct_instantiation_missing_comma() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/parse_map_literal_int_keys.snap
+++ b/tests/ui/errors/snapshots/parse_map_literal_int_keys.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid `Map` initialization
+   ╭─[test.lis:3:31]
+ 2 │ fn test() {
+ 3 │   let m: Map<int, string> = { 1: "a", 2: "b" }
+   ·                               ┬
+   ·                               ╰── invalid syntax
+ 4 │ }
+   ╰────
+  help: To initialize a `Map`, use `Map.new<K, V>()` then `m[key] = value` · code: [parse.invalid_map_initialization]

--- a/tests/ui/errors/snapshots/parse_map_literal_string_keys.snap
+++ b/tests/ui/errors/snapshots/parse_map_literal_string_keys.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid `Map` initialization
+   ╭─[test.lis:3:31]
+ 2 │ fn test() {
+ 3 │   let m: Map<string, int> = { "a": 1, "b": 2 }
+   ·                               ─┬─
+   ·                                ╰── invalid syntax
+ 4 │ }
+   ╰────
+  help: To initialize a `Map`, use `Map.new<K, V>()` then `m[key] = value` · code: [parse.invalid_map_initialization]


### PR DESCRIPTION
Recognizes map literal instantiation attempts at parse time and emits a single `parse.invalid_map_initialization` diagnostic pointing to `Map.new<K, V>()`. The previous behavior was a cascade of `parse.expected_expression` errors, one per `:` and `,` in the literal.