### PR TITLE
fix: suppress unused-value cascades on errored expressions

### DIFF
--- a/crates/semantics/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/semantics/src/passes/fact_producers/unused_expressions.rs
@@ -270,6 +270,7 @@ fn check_discarded_tail(
         || reported_ty.is_ignored()
         || reported_ty.is_never()
         || reported_ty.is_variable()
+        || reported_ty.is_error()
     {
         return;
     } else {
@@ -310,7 +311,7 @@ fn emit_unused_expression(
         Some(UnusedExpressionKind::Option)
     } else if ty.is_partial() {
         Some(UnusedExpressionKind::Partial)
-    } else if !ty.is_unit() && !ty.is_variable() && !ty.is_never() {
+    } else if !ty.is_unit() && !ty.is_variable() && !ty.is_never() && !ty.is_error() {
         Some(UnusedExpressionKind::Value)
     } else {
         None

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7233,3 +7233,62 @@ fn main() {
 "#;
     assert_parse_error_snapshot!(input);
 }
+
+#[test]
+fn infer_error_type_does_not_cascade_to_unused_value_lint() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Counter { pub n: int }
+
+impl Counter {
+  fn tick(self: Ref<Counter>) { () }
+}
+
+fn make() -> Result<Counter, error> { Ok(Counter { n: 0 }) }
+
+fn main() {
+  let c = make().unwrap()
+  c.tick()
+  ()
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+    let result = compile_check(fs);
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|l| l.code_str() == Some("lint.unused_value")),
+        "Expected no lint.unused_value on c.tick() after .unwrap() poisoned the receiver type, got: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn infer_error_type_does_not_cascade_to_mismatched_return_value() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Counter { pub n: int }
+
+impl Counter {
+  fn tick(self: Ref<Counter>) { () }
+}
+
+fn make() -> Result<Counter, error> { Ok(Counter { n: 0 }) }
+
+fn main() {
+  let c = make().unwrap()
+  c.tick()
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+    let result = compile_check(fs);
+    assert!(
+        !result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.mismatched_return_value")),
+        "Expected no infer.mismatched_return_value on tail c.tick() after .unwrap() poisoned the receiver type, got: {:?}",
+        result.errors
+    );
+}


### PR DESCRIPTION
Suppresses `lint.unused_value` and `infer.mismatched_return_value` when the discarded expression has type `<error>` carried forward from an earlier failed inference.