### PR TITLE
fix: clearer error for typed binding missing initializer

### DIFF
--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -909,6 +909,28 @@ impl<'source> Parser<'source> {
 
         let binding = self.parse_binding_allowing_or();
 
+        if !self.is(Equal)
+            && let Some(Annotation::Constructor { span, .. }) = binding.annotation.as_ref()
+        {
+            self.error_missing_initializer(*span);
+            let stub_span = self.span_from_tokens(start);
+            return Expression::Let {
+                binding: Box::new(binding),
+                value: Box::new(Expression::Block {
+                    ty: Type::uninferred(),
+                    items: vec![],
+                    span: stub_span,
+                }),
+                mutable,
+                mut_span,
+                else_block: None,
+                else_span: None,
+                typed_pattern: None,
+                ty: Type::uninferred(),
+                span: stub_span,
+            };
+        }
+
         self.ensure(Equal);
 
         let expression = self.parse_expression();

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -616,6 +616,21 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
+    pub(super) fn error_missing_initializer(&mut self, span: ast::Span) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new(
+            "Missing initializer",
+            span,
+            "annotated binding needs a value",
+        )
+        .with_parse_code("missing_initializer")
+        .with_help("Bindings must be initialized");
+
+        self.errors.push(error);
+    }
+
     fn track_ensure_error(&mut self, expected_token: TokenKind) {
         if self.too_many_errors() {
             return;

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -680,6 +680,16 @@ fn test() {
 }
 
 #[test]
+fn parse_typed_binding_missing_initializer() {
+    let input = r#"
+fn test() {
+  let mut x: atomic.Int64
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_struct_instantiation_missing_comma() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/parse_typed_binding_missing_initializer.snap
+++ b/tests/ui/errors/snapshots/parse_typed_binding_missing_initializer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing initializer
+   ╭─[test.lis:3:14]
+ 2 │ fn test() {
+ 3 │   let mut x: atomic.Int64
+   ·              ──────┬─────
+   ·                    ╰── annotated binding needs a value
+ 4 │ }
+   ╰────
+  help: Bindings must be initialized · code: [parse.missing_initializer]


### PR DESCRIPTION
Emits a missing-initializer diagnostic when a typed `let` binding is missing its value, replacing the cascading `expected =` and `expected expression` pair that previously fired.