### PR TITLE
fix: suppress unused locals in fused Result match emit

### DIFF
--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -78,53 +78,75 @@ impl Emitter<'_> {
         if ok_binding.is_none() && !ok_arm_payload_is_omitted(ok_arm, &shape) {
             return false;
         }
+        let ok_name = ok_binding.filter(|n| *n != "_");
+        let err_name = err_binding.filter(|n| *n != "_");
 
-        let val_var = match shape {
-            AbiShape::ResultTuple => {
-                let v = self.fresh_var(Some("ret"));
-                self.declare(&v);
-                Some(v)
-            }
-            AbiShape::BareError => None,
-            AbiShape::PartialTuple
-            | AbiShape::CommaOk
-            | AbiShape::NullableReturn
-            | AbiShape::Tuple { .. } => unreachable!("rejected above"),
+        let val_var = if matches!(shape, AbiShape::ResultTuple) && ok_name.is_some() {
+            let v = self.fresh_var(Some("ret"));
+            self.declare(&v);
+            Some(v)
+        } else {
+            None
         };
         let err_var = self.fresh_var(Some("ret"));
         self.declare(&err_var);
         let call_str = self.emit_call(output, subject, None, ExpressionContext::value());
         match &val_var {
             Some(v) => write_line!(output, "{}, {} := {}", v, err_var, call_str),
-            None => write_line!(output, "{} := {}", err_var, call_str),
+            None => match shape {
+                AbiShape::ResultTuple => write_line!(output, "_, {} := {}", err_var, call_str),
+                AbiShape::BareError => write_line!(output, "{} := {}", err_var, call_str),
+                AbiShape::PartialTuple
+                | AbiShape::CommaOk
+                | AbiShape::NullableReturn
+                | AbiShape::Tuple { .. } => unreachable!("rejected above"),
+            },
         }
 
         write_line!(output, "if {} == nil {{", err_var);
-        self.scope.push_binding_frame();
-        if let (Some(name), Some(val)) = (ok_binding, &val_var)
-            && name != "_"
-        {
-            self.bind_fused(output, name, val);
-        }
-        self.emit_body_to_place(output, &ok_arm.expression, place);
-        self.scope.pop_binding_frame();
+        self.emit_fused_arm(
+            output,
+            ok_name.zip(val_var.as_deref()),
+            &ok_arm.expression,
+            place,
+        );
         output.push_str("} else {\n");
-        self.scope.push_binding_frame();
-        if let Some(name) = err_binding
-            && name != "_"
-        {
-            self.bind_fused(output, name, &err_var);
-        }
-        self.emit_body_to_place(output, &err_arm.expression, place);
-        self.scope.pop_binding_frame();
+        self.emit_fused_arm(
+            output,
+            err_name.map(|n| (n, err_var.as_str())),
+            &err_arm.expression,
+            place,
+        );
         output.push_str("}\n");
         true
     }
 
-    fn bind_fused(&mut self, output: &mut String, name: &str, value: &str) {
+    fn emit_fused_arm(
+        &mut self,
+        output: &mut String,
+        binding: Option<(&str, &str)>,
+        body: &Expression,
+        place: &BodyPlace,
+    ) {
+        self.scope.push_binding_frame();
+        let guard = binding.map(|(name, value)| self.bind_fused_with_guard(output, name, value));
+        self.emit_body_to_place(output, body, place);
+        if let Some(g) = guard {
+            g.finish(output);
+        }
+        self.scope.pop_binding_frame();
+    }
+
+    fn bind_fused_with_guard(
+        &mut self,
+        output: &mut String,
+        name: &str,
+        value: &str,
+    ) -> DiscardGuard {
         let go_name = self.scope.bind(name, name);
         self.declare(&go_name);
         write_line!(output, "{} := {}", go_name, value);
+        DiscardGuard::new(output, &go_name)
     }
 
     fn emit_match_subject_var(

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -646,6 +646,63 @@ fn test() {
 }
 
 #[test]
+fn fused_result_match_ok_wildcard() {
+    let input = r#"
+import "go:errors"
+
+fn fallible(ok: bool) -> Result<int, error> {
+  if ok { Ok(1) } else { Err(errors.New("nope")) }
+}
+
+fn test() {
+  match fallible(true) {
+    Ok(_) => {},
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_result_match_ok_unused_named_payload() {
+    let input = r#"
+import "go:errors"
+
+fn fallible(ok: bool) -> Result<int, error> {
+  if ok { Ok(1) } else { Err(errors.New("nope")) }
+}
+
+fn test() {
+  match fallible(true) {
+    Ok(x) => {},
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_result_match_err_unused_named_payload() {
+    let input = r#"
+import "go:errors"
+
+fn fallible(ok: bool) -> Result<int, error> {
+  if ok { Ok(1) } else { Err(errors.New("nope")) }
+}
+
+fn test() {
+  match fallible(true) {
+    Ok(x) => { let _ = x },
+    Err(e) => {},
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn while_let_option_function_call() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn fallible(ok: bool) -> Result<int, error> {\n  if ok { Ok(1) } else { Err(errors.New(\"nope\")) }\n}\n\nfn test() {\n  match fallible(true) {\n    Ok(x) => { let _ = x },\n    Err(e) => {},\n  }\n}\n"
+---
+package main
+
+import "errors"
+
+func fallible(ok bool) (int, error) {
+	if ok {
+		return 1, nil
+	}
+	return *new(int), errors.New("nope")
+}
+
+func test() {
+	ret_1, ret_2 := fallible(true)
+	if ret_2 == nil {
+		x := ret_1
+		_ = x
+	} else {
+		e := ret_2
+		_ = e
+	}
+}

--- a/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn fallible(ok: bool) -> Result<int, error> {\n  if ok { Ok(1) } else { Err(errors.New(\"nope\")) }\n}\n\nfn test() {\n  match fallible(true) {\n    Ok(x) => {},\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import "errors"
+
+func fallible(ok bool) (int, error) {
+	if ok {
+		return 1, nil
+	}
+	return *new(int), errors.New("nope")
+}
+
+func test() {
+	ret_1, ret_2 := fallible(true)
+	if ret_2 == nil {
+		x := ret_1
+		_ = x
+	} else {
+		e := ret_2
+		_ = e
+	}
+}

--- a/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn fallible(ok: bool) -> Result<int, error> {\n  if ok { Ok(1) } else { Err(errors.New(\"nope\")) }\n}\n\nfn test() {\n  match fallible(true) {\n    Ok(_) => {},\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import "errors"
+
+func fallible(ok bool) (int, error) {
+	if ok {
+		return 1, nil
+	}
+	return *new(int), errors.New("nope")
+}
+
+func test() {
+	_, ret_1 := fallible(true)
+	if ret_1 == nil {
+	} else {
+		e := ret_1
+		_ = e
+	}
+}


### PR DESCRIPTION
Matching on `Result<T, error>` with a wildcard or unused-named payload no longer emits unused Go locals.

```rs
import "go:errors"

fn fallible(ok: bool) -> Result<int, error> {
  if ok { Ok(1) } else { Err(errors.New("nope")) }
}

fn main() {
  match fallible(true) {
    Ok(_) => {},
    Err(e) => { let _ = e },
  }
}
```

This previously emitted `ret_1, ret_2 := fallible(true)` followed by a branch that never read `ret_1`. The fused emit path now uses `_` in the tuple LHS for `Ok(_)` and wraps named payload bindings with a discard guard, so unused names get `_ = name`.
