### PR TITLE
fix: lower direct Err(...)? and None? propagation

### DIFF
--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -533,7 +533,7 @@ impl Emitter<'_> {
         write_line!(output, "return {}", ok_return);
     }
 
-    /// Optimizes `Err(...)?)` and `None?` by emitting a direct return.
+    /// Optimizes `Err(...)?` and `None?` by emitting a direct return.
     /// Returns `Some(String::new())` if handled, `None` otherwise.
     fn try_emit_error_constructor(
         &mut self,
@@ -566,13 +566,23 @@ impl Emitter<'_> {
             _ => return None,
         };
 
-        self.requirements.require_stdlib();
-        let err_return = {
-            let mut fe = FallibleEmitter::new(self, fallible);
-            fe.emit_contextual_failure(err_arg.as_deref(), return_ctx)
-        };
-
-        write_line!(output, "return {}", err_return);
+        if let Some(shape) = return_ctx.lowered_shape() {
+            let return_ty = return_ctx.expect_ty();
+            let line = if fallible.is_result() {
+                let err_expr = err_arg.as_deref().unwrap_or("");
+                abi_transition::format_lowered_err_return(self, &shape, &return_ty, err_expr)
+            } else {
+                abi_transition::format_lowered_none_return(self, &shape, &return_ty)
+            };
+            write_line!(output, "{}", line);
+        } else {
+            self.requirements.require_stdlib();
+            let err_return = {
+                let mut fe = FallibleEmitter::new(self, fallible);
+                fe.emit_contextual_failure(err_arg.as_deref(), return_ctx)
+            };
+            write_line!(output, "return {}", err_return);
+        }
         Some(String::new())
     }
 

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1370,3 +1370,52 @@ fn test(flag: bool) -> Result<int, string> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn propagate_direct_err_lowered_result_tuple() {
+    let input = r#"
+import "go:errors"
+
+fn fail() -> Result<int, error> {
+  Err(errors.New("boom"))?
+  Ok(1)
+}
+
+fn main() {
+  let _ = fail()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_direct_none_lowered_option_comma_ok() {
+    let input = r#"
+fn missing() -> Option<int> {
+  None?
+  Some(1)
+}
+
+fn main() {
+  let _ = missing()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_direct_err_lowered_bare_error() {
+    let input = r#"
+import "go:errors"
+
+fn fail_unit() -> Result<(), error> {
+  Err(errors.New("boom"))?
+  Ok(())
+}
+
+fn main() {
+  let _ = fail_unit()
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn fail_unit() -> Result<(), error> {\n  Err(errors.New(\"boom\"))?\n  Ok(())\n}\n\nfn main() {\n  let _ = fail_unit()\n}\n"
+---
+package main
+
+import "errors"
+
+func fail_unit() error {
+	return errors.New("boom")
+	return nil
+}
+
+func main() {
+	fail_unit()
+}

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn fail() -> Result<int, error> {\n  Err(errors.New(\"boom\"))?\n  Ok(1)\n}\n\nfn main() {\n  let _ = fail()\n}\n"
+---
+package main
+
+import "errors"
+
+func fail() (int, error) {
+	return *new(int), errors.New("boom")
+	return 1, nil
+}
+
+func main() {
+	fail()
+}

--- a/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nfn missing() -> Option<int> {\n  None?\n  Some(1)\n}\n\nfn main() {\n  let _ = missing()\n}\n"
+---
+package main
+
+func missing() (int, bool) {
+	return *new(int), false
+	return 1, true
+}
+
+func main() {
+	missing()
+}


### PR DESCRIPTION
Direct `Err(...)?` and `None?` propagation now respects the enclosing function's lowered Go return shape instead of returning a tagged `lisette.Result`/`lisette.Option`.

```rs
import "go:errors"

fn fail() -> Result<int, error> {
  Err(errors.New("boom"))?
  Ok(1)
}
```