### PR TITLE
refactor: centralize alias-aware emit shape queries

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -384,7 +384,10 @@ impl Emitter<'_> {
         collection_ty: &Type,
         elem_option_ty: &Type,
     ) -> CollectionUnwrapShape {
-        let is_map = collection_ty.has_name("Map");
+        let shape = self
+            .nullable_collection_shape(collection_ty)
+            .expect("nullable collection unwrap requires alias-aware shape");
+        let is_map = matches!(shape.kind, crate::types::shape::CollectionKind::Map);
         let is_pointer_bridged = self.is_non_nilable_option(elem_option_ty);
         let inner_ty = elem_option_ty.ok_type();
         let inner_ty_str = self.go_type_as_string(&inner_ty);
@@ -393,12 +396,9 @@ impl Emitter<'_> {
         } else {
             inner_ty_str
         };
-        let raw_collection_ty = if is_map {
-            let params = collection_ty
-                .get_type_params()
-                .expect("Map should have type params");
-            let key_ty = self.go_type_as_string(&params[0]);
-            format!("map[{}]{}", key_ty, raw_elem_ty)
+        let raw_collection_ty = if let Some(key_ty) = shape.key_ty.as_ref() {
+            let key_ty_str = self.go_type_as_string(key_ty);
+            format!("map[{}]{}", key_ty_str, raw_elem_ty)
         } else {
             format!("[]{}", raw_elem_ty)
         };

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -2,6 +2,8 @@ use crate::Emitter;
 use crate::expressions::context::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::patterns::sites::PatternSubject;
+use crate::types::native::NativeGoType;
+use crate::types::shape::RangeShape;
 use crate::utils::DiscardGuard;
 use crate::write_line;
 use syntax::ast::{Binding, Expression, Pattern};
@@ -49,9 +51,9 @@ impl Emitter<'_> {
             iter_expression
         };
 
-        let is_channel = iterable_ty
-            .get_name()
-            .is_some_and(|n| n == "Channel" || n == "Receiver");
+        let is_channel = self
+            .native_shape(&iterable_ty)
+            .is_some_and(|s| matches!(s.kind, NativeGoType::Channel | NativeGoType::Receiver));
 
         self.enter_scope();
         if let Some(label) = self.current_loop_label() {
@@ -90,10 +92,13 @@ impl Emitter<'_> {
         }
 
         let iterable_ty = iterable.get_type();
-        if let Some(ty_name) = iterable_ty.get_name()
-            && matches!(ty_name, "Range" | "RangeInclusive" | "RangeFrom")
+        if let Some(range_shape) = self.range_shape(&iterable_ty)
+            && matches!(
+                range_shape,
+                RangeShape::Range | RangeShape::RangeInclusive | RangeShape::RangeFrom
+            )
         {
-            self.emit_stored_range_for_loop(output, binding, iterable, ty_name, body);
+            self.emit_stored_range_for_loop(output, binding, iterable, range_shape, body);
             return None;
         }
 
@@ -106,6 +111,11 @@ impl Emitter<'_> {
         }
 
         Some(iterable_ty)
+    }
+
+    fn is_map_tuple_iterable(&self, iterable_ty: &Type) -> bool {
+        self.native_shape(iterable_ty)
+            .is_some_and(|s| matches!(s.kind, NativeGoType::Map | NativeGoType::EnumeratedSlice))
     }
 
     fn emit_for_loop_pattern(
@@ -133,10 +143,7 @@ impl Emitter<'_> {
                 output.push_str("}\n");
             }
             Pattern::Tuple { elements, .. }
-                if elements.len() == 2
-                    && iterable_ty.get_name().is_some_and(|n| {
-                        n == "Map" || n == "OrderedMap" || n == "EnumeratedSlice"
-                    }) =>
+                if elements.len() == 2 && self.is_map_tuple_iterable(iterable_ty) =>
             {
                 self.emit_map_tuple_for_loop(output, elements, &binding.ty, iter_expression, body);
             }
@@ -366,7 +373,7 @@ impl Emitter<'_> {
         output: &mut String,
         binding: &Binding,
         iterable: &Expression,
-        ty_name: &str,
+        range_shape: RangeShape,
         body: &Expression,
     ) {
         self.enter_scope();
@@ -382,8 +389,8 @@ impl Emitter<'_> {
             write_line!(output, "{}:", label);
         }
 
-        match ty_name {
-            "Range" => {
+        match range_shape {
+            RangeShape::Range => {
                 write_line!(
                     output,
                     "for {} := {}.Start; {} < {}.End; {}++ {{",
@@ -394,7 +401,7 @@ impl Emitter<'_> {
                     loop_var
                 );
             }
-            "RangeInclusive" => {
+            RangeShape::RangeInclusive => {
                 write_line!(
                     output,
                     "for {} := {}.Start; {} <= {}.End; {}++ {{",
@@ -405,7 +412,7 @@ impl Emitter<'_> {
                     loop_var
                 );
             }
-            "RangeFrom" => {
+            RangeShape::RangeFrom => {
                 write_line!(
                     output,
                     "for {} := {}.Start; ; {}++ {{",
@@ -414,7 +421,9 @@ impl Emitter<'_> {
                     loop_var
                 );
             }
-            _ => unreachable!("unexpected range kind: {}", ty_name),
+            RangeShape::RangeTo | RangeShape::RangeToInclusive => {
+                unreachable!("RangeTo/RangeToInclusive are not iterable")
+            }
         }
 
         self.emit_block(output, body);

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -180,7 +180,7 @@ impl Emitter<'_> {
         expression_ty: &Type,
         result_ty: &Type,
     ) -> Option<String> {
-        if !Self::is_go_imported_type(expression_ty) || !self.is_go_nullable(result_ty) {
+        if self.go_imported_shape(expression_ty).is_none() || !self.is_go_nullable(result_ty) {
             return None;
         }
         let raw_access = format!("{}.{}", expression_string, field);

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -4,6 +4,7 @@ use syntax::types::peel_to_range_type;
 use crate::Emitter;
 use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
+use crate::types::native::NativeGoType;
 
 impl Emitter<'_> {
     pub(crate) fn emit_index_access(
@@ -34,7 +35,7 @@ impl Emitter<'_> {
         // or `r: Prefix` where `type Prefix = RangeTo<int>`).
         let index_ty = index.get_type();
         if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
-            let needs_cap = expression.get_type().has_name("Slice");
+            let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
             let index_staged = self.stage_or_capture(index, "range");
             let values = self.sequence(output, vec![base_staged, index_staged], "_base");
             return self.emit_range_var_slice(&values[0], &values[1], range_kind, needs_cap);
@@ -68,7 +69,7 @@ impl Emitter<'_> {
         end: Option<&Expression>,
         inclusive: bool,
     ) -> String {
-        let needs_cap = expression.get_type().has_name("Slice");
+        let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
         let base_staged = self.stage_base_with_deref(expression);
 
         let mut all_stages = vec![base_staged];

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -57,7 +57,7 @@ impl Emitter<'_> {
             )
         });
 
-        let is_go_struct = Self::is_go_imported_type(ty);
+        let is_go_struct = self.go_imported_shape(ty).is_some();
         let kept = self.kept_struct_call_fields(field_assignments, spread, ty, is_go_struct);
 
         let stages: Vec<EmittedExpression> = kept

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -509,7 +509,7 @@ impl Emitter<'_> {
             ty,
             ..
         } = target
-            && Self::is_go_imported_type(&receiver.get_type())
+            && self.go_imported_shape(&receiver.get_type()).is_some()
             && self.is_go_nullable(ty)
         {
             let coercion =

--- a/crates/emit/src/placement.rs
+++ b/crates/emit/src/placement.rs
@@ -9,6 +9,7 @@ use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
 use crate::statements::assignments::is_lvalue_chain;
 use crate::types::coercion::{Coercion, CoercionDirection};
+use crate::types::native::NativeGoType;
 use crate::write_line;
 use syntax::ast::{Expression, Literal, UnaryOperator};
 use syntax::types::{Type, peel_to_range_type};
@@ -263,14 +264,14 @@ fn maybe_clone_subslice(
     mutable: bool,
     expression: String,
 ) -> String {
-    if !is_mutable_subslice(value, mutable) {
+    if !is_mutable_subslice(emitter, value, mutable) {
         return expression;
     }
     emitter.requirements.require_slices();
     format!("slices.Clone({})", expression)
 }
 
-fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
+fn is_mutable_subslice(emitter: &Emitter, value: &Expression, mutable: bool) -> bool {
     if !mutable {
         return false;
     }
@@ -292,7 +293,7 @@ fn is_mutable_subslice(value: &Expression, mutable: bool) -> bool {
     } else {
         expression.get_type()
     };
-    collection_ty.has_name("Slice")
+    emitter.is_native_shape(&collection_ty, NativeGoType::Slice)
 }
 
 /// Pick the Go type for a `let` binding's `var X T` temp. Diverging values
@@ -718,7 +719,7 @@ impl Emitter<'_> {
         } = func
             && (member == "append" || member == "extend")
         {
-            return expression.get_type().has_name("Slice");
+            return self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
         }
         false
     }

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -190,13 +190,6 @@ impl Emitter<'_> {
         }
     }
 
-    pub(crate) fn is_go_imported_type(ty: &Type) -> bool {
-        let Type::Nominal { id, .. } = ty.strip_refs() else {
-            return false;
-        };
-        go_name::is_go_import(&id)
-    }
-
     /// True for `Option<T>` where T is a concrete non-nilable Go value type
     /// (string, int32, named scalar, named struct). This is the bindgen's
     /// pointer-bridged shape: the corresponding Go layout is `*T`. Excludes
@@ -225,25 +218,7 @@ impl Emitter<'_> {
     pub(crate) fn is_go_nullable(&self, ty: &Type) -> bool {
         self.facts.is_nullable_option(ty)
             || self.is_non_nilable_option(ty)
-            || self.nullable_collection_element_ty(ty).is_some()
-    }
-
-    pub(crate) fn nullable_collection_element_ty(&self, ty: &Type) -> Option<Type> {
-        let is_pointer_bridged_option =
-            |t: &Type| self.facts.is_nullable_option(t) || self.is_non_nilable_option(t);
-        if ty.has_name("Slice") {
-            let elem_ty = ty.inner()?;
-            if is_pointer_bridged_option(&elem_ty) {
-                return Some(elem_ty);
-            }
-        } else if ty.has_name("Map") {
-            let params = ty.get_type_params()?;
-            let val_ty = params.get(1)?.clone();
-            if is_pointer_bridged_option(&val_ty) {
-                return Some(val_ty);
-            }
-        }
-        None
+            || self.nullable_collection_shape(ty).is_some()
     }
 }
 

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -246,7 +246,8 @@ impl Emitter<'_> {
 
         let go_field_ty: Option<Type> = match target {
             Expression::DotAccess { expression, ty, .. }
-                if Self::is_go_imported_type(&expression.get_type()) && self.is_go_nullable(ty) =>
+                if self.go_imported_shape(&expression.get_type()).is_some()
+                    && self.is_go_nullable(ty) =>
             {
                 Some(ty.clone())
             }

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -129,9 +129,9 @@ pub(crate) fn classify_option_shape(emitter: &Emitter, ty: &Type) -> OptionShape
         OptionShape::Nullable
     } else if emitter.is_non_nilable_option(ty) {
         OptionShape::PointerBridged
-    } else if let Some(elem) = emitter.nullable_collection_element_ty(ty) {
+    } else if let Some(shape) = emitter.nullable_collection_shape(ty) {
         OptionShape::NullableCollection {
-            elem_option_ty: elem,
+            elem_option_ty: shape.elem_option_ty,
         }
     } else {
         OptionShape::Plain

--- a/crates/emit/src/types/mod.rs
+++ b/crates/emit/src/types/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod emitter;
 pub(crate) mod go_type;
 pub(crate) mod native;
 pub(crate) mod prelude;
+pub(crate) mod shape;

--- a/crates/emit/src/types/shape.rs
+++ b/crates/emit/src/types/shape.rs
@@ -1,0 +1,172 @@
+use syntax::types::{CompoundKind, Symbol, Type};
+
+use crate::Emitter;
+use crate::names::go_name;
+use crate::types::native::NativeGoType;
+
+#[derive(Debug, Clone)]
+pub(crate) struct NativeShape {
+    pub(crate) kind: NativeGoType,
+    pub(crate) params: Vec<Type>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RangeShape {
+    Range,
+    RangeInclusive,
+    RangeFrom,
+    RangeTo,
+    RangeToInclusive,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GoImportedShape {
+    #[allow(dead_code)]
+    pub(crate) id: Symbol,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CollectionKind {
+    Slice,
+    Map,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NullableCollectionShape {
+    pub(crate) kind: CollectionKind,
+    pub(crate) key_ty: Option<Type>,
+    pub(crate) elem_option_ty: Type,
+}
+
+impl Emitter<'_> {
+    /// Normalize a type for emit decisions by walking aliases and reference
+    /// wrappers to a fixed point. Only peels real type aliases (not newtypes).
+    pub(crate) fn emit_shape_ty(&self, ty: &Type) -> Type {
+        let mut current = ty.clone();
+        loop {
+            let without_refs = current.strip_refs();
+            let peeled = self.facts.peel_alias(&without_refs);
+            if peeled == current {
+                return peeled;
+            }
+            current = peeled;
+        }
+    }
+
+    /// Classify a type as a real native/prelude collection or string after
+    /// alias peeling. Stricter than `NativeTypeKind::from_type` because it
+    /// only accepts `Type::Compound` shapes (not nominals whose leaf name
+    /// happens to be `Slice`/`Map`/etc.) plus `SimpleKind::String`.
+    pub(crate) fn native_shape(&self, ty: &Type) -> Option<NativeShape> {
+        let resolved = self.emit_shape_ty(ty);
+        match resolved {
+            Type::Compound { kind, args } => {
+                let native = match kind {
+                    CompoundKind::Slice => NativeGoType::Slice,
+                    CompoundKind::EnumeratedSlice => NativeGoType::EnumeratedSlice,
+                    CompoundKind::Map => NativeGoType::Map,
+                    CompoundKind::Channel => NativeGoType::Channel,
+                    CompoundKind::Sender => NativeGoType::Sender,
+                    CompoundKind::Receiver => NativeGoType::Receiver,
+                    CompoundKind::Ref | CompoundKind::VarArgs => return None,
+                };
+                Some(NativeShape {
+                    kind: native,
+                    params: args,
+                })
+            }
+            Type::Simple(syntax::types::SimpleKind::String) => Some(NativeShape {
+                kind: NativeGoType::String,
+                params: Vec::new(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// True when `ty` resolves to the given native kind after alias peeling.
+    pub(crate) fn is_native_shape(&self, ty: &Type, kind: NativeGoType) -> bool {
+        self.native_shape(ty).is_some_and(|s| s.kind == kind)
+    }
+
+    /// Classify a type as one of the prelude range structs after alias
+    /// peeling. Unrelated types named `Range` (Go imports, local types) do
+    /// not match.
+    pub(crate) fn range_shape(&self, ty: &Type) -> Option<RangeShape> {
+        let resolved = self.emit_shape_ty(ty);
+        let Type::Nominal { id, .. } = resolved else {
+            return None;
+        };
+        match id.as_str() {
+            "prelude.Range" => Some(RangeShape::Range),
+            "prelude.RangeInclusive" => Some(RangeShape::RangeInclusive),
+            "prelude.RangeFrom" => Some(RangeShape::RangeFrom),
+            "prelude.RangeTo" => Some(RangeShape::RangeTo),
+            "prelude.RangeToInclusive" => Some(RangeShape::RangeToInclusive),
+            _ => None,
+        }
+    }
+
+    /// Classify a type as a Go-imported nominal after alias peeling.
+    /// `type MyFlag = flag.Flag` and `Ref<MyFlag>` both match.
+    pub(crate) fn go_imported_shape(&self, ty: &Type) -> Option<GoImportedShape> {
+        let resolved = self.emit_shape_ty(ty);
+        let Type::Nominal { id, .. } = resolved else {
+            return None;
+        };
+        if go_name::is_go_import(id.as_str()) {
+            Some(GoImportedShape { id })
+        } else {
+            None
+        }
+    }
+
+    /// Classify a type as a nullable collection (`Slice<Option<...>>` or
+    /// `Map<K, Option<...>>`) after alias peeling. Element option types are
+    /// also alias-aware via the inner option classifier.
+    pub(crate) fn nullable_collection_shape(&self, ty: &Type) -> Option<NullableCollectionShape> {
+        let shape = self.native_shape(ty)?;
+        match shape.kind {
+            NativeGoType::Slice => {
+                let elem_ty = shape.params.into_iter().next()?;
+                let resolved_option = self.pointer_bridged_option_ty(&elem_ty)?;
+                Some(NullableCollectionShape {
+                    kind: CollectionKind::Slice,
+                    key_ty: None,
+                    elem_option_ty: resolved_option,
+                })
+            }
+            NativeGoType::Map => {
+                let mut iter = shape.params.into_iter();
+                let key_ty = iter.next()?;
+                let val_ty = iter.next()?;
+                let resolved_option = self.pointer_bridged_option_ty(&val_ty)?;
+                Some(NullableCollectionShape {
+                    kind: CollectionKind::Map,
+                    key_ty: Some(key_ty),
+                    elem_option_ty: resolved_option,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Alias-aware option classifier used by `nullable_collection_shape`.
+    /// Matches `is_nullable_option`/`is_non_nilable_option` semantics but
+    /// peels aliases over the option type itself first. Returns the peeled
+    /// option type when matched so downstream consumers that call
+    /// `is_option()` / `ok_type()` / `Fallible::from_type` work correctly.
+    fn pointer_bridged_option_ty(&self, ty: &Type) -> Option<Type> {
+        let resolved = self.emit_shape_ty(ty);
+        if !resolved.is_option() {
+            return None;
+        }
+        let inner = resolved.ok_type();
+        if self.facts.is_nilable_go_type(&inner) {
+            return Some(resolved);
+        }
+        if inner.contains_unknown() || inner.has_name("any") {
+            return None;
+        }
+        Some(resolved)
+    }
+}

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -3357,3 +3357,51 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn for_loop_map_alias_tuple_destructuring() {
+    let input = r#"
+type Table = Map<string, int>
+
+fn sum(t: Table) -> int {
+  let mut total = 0
+  for (k, v) in t {
+    total = total + k.length() + v
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_range_alias_uses_stored_range_form() {
+    let input = r#"
+type Span = Range<int>
+
+fn sum(r: Span) -> int {
+  let mut total = 0
+  for i in r {
+    total = total + i
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_channel_alias_uses_single_var_range() {
+    let input = r#"
+type Inbox = Channel<int>
+
+fn drain(ch: Inbox) -> int {
+  let mut total = 0
+  for value in ch {
+    total = total + value
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1424,3 +1424,142 @@ pub struct ListInput {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
 }
+
+#[test]
+fn interop_nullable_field_read_through_go_struct_alias_wraps() {
+    let input = r#"
+import "go:flag"
+
+type MyFlag = flag.Flag
+
+fn main() {
+  let f: MyFlag = flag.Flag { .. }
+  let v = f.Value
+  match v {
+    Some(x) => { let _ = x },
+    None => { let _ = 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_nullable_field_assign_through_go_struct_alias_unwraps() {
+    let input = r#"
+import "go:flag"
+
+type MyFlag = flag.Flag
+
+fn main() {
+  let mut f: MyFlag = flag.Flag { .. }
+  f.Value = None
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_nullable_collection_field_read_through_go_struct_alias_wraps() {
+    let input = r#"
+import "go:crypto/x509"
+import "go:net/url"
+
+type Cert = x509.Certificate
+
+fn main() {
+  let u = url.URL {
+    Scheme: "https",
+    Host: "example.com",
+    ..,
+  }
+  let cert: Cert = x509.Certificate {
+    URIs: [Some(&u)],
+    ..,
+  }
+  let urls = cert.URIs
+  let first = urls[0]
+  match first {
+    Some(value) => { let _ = value },
+    None => { let _ = 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_nullable_collection_field_assign_through_go_struct_alias_unwraps() {
+    let input = r#"
+import "go:crypto/x509"
+import "go:net/url"
+
+type Cert = x509.Certificate
+
+fn main() {
+  let u = url.URL {
+    Scheme: "https",
+    Host: "example.com",
+    ..,
+  }
+  let mut cert: Cert = x509.Certificate { .. }
+  let urls: Slice<Option<Ref<url.URL>>> = [Some(&u)]
+  cert.URIs = urls
+  let _ = cert
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_map_alias_value_unwrapped_at_go_struct_literal() {
+    let input = r#"
+import "go:go/ast"
+
+type Objects = Map<string, Option<Ref<ast.Object>>>
+
+fn main() {
+  let obj = ast.Object {
+    Kind: ast.Bad,
+    Name: "x",
+    Decl: None,
+    Data: None,
+    Type: None,
+  }
+  let mut objects: Objects = Map.new<string, Option<Ref<ast.Object>>>()
+  objects["present"] = Some(&obj)
+  objects["absent"] = None
+  let scope = ast.Scope {
+    Outer: None,
+    Objects: objects,
+  }
+  let _ = scope
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_slice_alias_value_unwrapped_at_go_struct_literal() {
+    let input = r#"
+import "go:crypto/x509"
+import "go:net/url"
+
+type URLs = Slice<Option<Ref<url.URL>>>
+
+fn main() {
+  let u = url.URL {
+    Scheme: "https",
+    Host: "example.com",
+    ..,
+  }
+  let urls: URLs = [Some(&u), None]
+  let cert = x509.Certificate {
+    URIs: urls,
+    ..,
+  }
+  let _ = cert
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/for_loop_channel_alias_uses_single_var_range.snap
+++ b/tests/spec/emit/snapshots/for_loop_channel_alias_uses_single_var_range.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: "input: \ntype Inbox = Channel<int>\n\nfn drain(ch: Inbox) -> int {\n  let mut total = 0\n  for value in ch {\n    total = total + value\n  }\n  total\n}\n"
+---
+package main
+
+type Inbox = chan int
+
+func drain(ch Inbox) int {
+	total := 0
+	for value := range ch {
+		total += value
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/for_loop_map_alias_tuple_destructuring.snap
+++ b/tests/spec/emit/snapshots/for_loop_map_alias_tuple_destructuring.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: "input: \ntype Table = Map<string, int>\n\nfn sum(t: Table) -> int {\n  let mut total = 0\n  for (k, v) in t {\n    total = total + k.length() + v\n  }\n  total\n}\n"
+---
+package main
+
+type Table = map[string]int
+
+func sum(t Table) int {
+	total := 0
+	for k, v := range t {
+		total = total + len(k) + v
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/for_loop_range_alias_uses_stored_range_form.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_alias_uses_stored_range_form.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: "input: \ntype Span = Range<int>\n\nfn sum(r: Span) -> int {\n  let mut total = 0\n  for i in r {\n    total = total + i\n  }\n  total\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Span = lisette.Range[int]
+
+func sum(r Span) int {
+	total := 0
+	for i := r.Start; i < r.End; i++ {
+		total += i
+	}
+	return total
+}

--- a/tests/spec/emit/snapshots/immutable_subslice_through_alias_capacity_capped.snap
+++ b/tests/spec/emit/snapshots/immutable_subslice_through_alias_capacity_capped.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Numbers = Slice<int>\n\nfn test() {\n  let xs: Numbers = [1, 2, 3]\n  let view = xs[0..2]\n  let grown = view.append(9)\n  let _ = grown\n  let _ = xs\n}\n"
+---
+package main
+
+type Numbers = []int
+
+func test() {
+	xs := []int{1, 2, 3}
+	view := xs[0:2:2]
+	grown := append(view, 9)
+	_ = grown
+	_ = xs
+}

--- a/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:go/ast\"\n\ntype Objects = Map<string, Option<Ref<ast.Object>>>\n\nfn main() {\n  let obj = ast.Object {\n    Kind: ast.Bad,\n    Name: \"x\",\n    Decl: None,\n    Data: None,\n    Type: None,\n  }\n  let mut objects: Objects = Map.new<string, Option<Ref<ast.Object>>>()\n  objects[\"present\"] = Some(&obj)\n  objects[\"absent\"] = None\n  let scope = ast.Scope {\n    Outer: None,\n    Objects: objects,\n  }\n  let _ = scope\n}\n"
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"go/ast"
+)
+
+type Objects = map[string]lisette.Option[*ast.Object]
+
+func main() {
+	obj := ast.Object{
+		Kind: ast.Bad,
+		Name: "x",
+		Decl: lisette.MakeOptionNone[any](),
+		Data: lisette.MakeOptionNone[any](),
+		Type: lisette.MakeOptionNone[any](),
+	}
+	objects := make(map[string]lisette.Option[*ast.Object])
+	objects["present"] = lisette.MakeOptionSome(&obj)
+	objects["absent"] = lisette.MakeOptionNone[*ast.Object]()
+	opt_1 := lisette.MakeOptionNone[*ast.Scope]()
+	var unwrap_2 *ast.Scope
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	src_3 := objects
+	unwrapped_4 := make(map[string]*ast.Object, len(src_3))
+	for i_5, v_6 := range src_3 {
+		if v_6.Tag == lisette.OptionSome {
+			unwrapped_4[i_5] = v_6.SomeVal
+		} else {
+			unwrapped_4[i_5] = nil
+		}
+	}
+	scope := ast.Scope{
+		Outer:   unwrap_2,
+		Objects: unwrapped_4,
+	}
+	_ = scope
+}

--- a/tests/spec/emit/snapshots/interop_nullable_collection_field_assign_through_go_struct_alias_unwraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_collection_field_assign_through_go_struct_alias_unwraps.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:crypto/x509\"\nimport \"go:net/url\"\n\ntype Cert = x509.Certificate\n\nfn main() {\n  let u = url.URL {\n    Scheme: \"https\",\n    Host: \"example.com\",\n    ..,\n  }\n  let mut cert: Cert = x509.Certificate { .. }\n  let urls: Slice<Option<Ref<url.URL>>> = [Some(&u)]\n  cert.URIs = urls\n  let _ = cert\n}\n"
+---
+package main
+
+import (
+	"crypto/x509"
+	lisette "github.com/ivov/lisette/prelude"
+	"net/url"
+)
+
+type Cert = x509.Certificate
+
+func main() {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+	}
+	cert := x509.Certificate{}
+	urls := []lisette.Option[*url.URL]{lisette.MakeOptionSome(&u)}
+	src_1 := urls
+	unwrapped_2 := make([]*url.URL, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = v_4.SomeVal
+		}
+	}
+	cert.URIs = unwrapped_2
+	_ = cert
+}

--- a/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:crypto/x509\"\nimport \"go:net/url\"\n\ntype Cert = x509.Certificate\n\nfn main() {\n  let u = url.URL {\n    Scheme: \"https\",\n    Host: \"example.com\",\n    ..,\n  }\n  let cert: Cert = x509.Certificate {\n    URIs: [Some(&u)],\n    ..,\n  }\n  let urls = cert.URIs\n  let first = urls[0]\n  match first {\n    Some(value) => { let _ = value },\n    None => { let _ = 0 },\n  }\n}\n"
+---
+package main
+
+import (
+	"crypto/x509"
+	lisette "github.com/ivov/lisette/prelude"
+	"net/url"
+)
+
+type Cert = x509.Certificate
+
+func main() {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+	}
+	src_1 := []lisette.Option[*url.URL]{lisette.MakeOptionSome(&u)}
+	unwrapped_2 := make([]*url.URL, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = v_4.SomeVal
+		}
+	}
+	cert := x509.Certificate{URIs: unwrapped_2}
+	raw_5 := cert.URIs
+	src_6 := raw_5
+	wrapped_7 := make([]lisette.Option[*url.URL], len(src_6))
+	for i_8, v_9 := range src_6 {
+		if v_9 != nil {
+			wrapped_7[i_8] = lisette.MakeOptionSome[*url.URL](v_9)
+		} else {
+			wrapped_7[i_8] = lisette.MakeOptionNone[*url.URL]()
+		}
+	}
+	urls := wrapped_7
+	first := urls[0]
+	if first.Tag == lisette.OptionSome {
+		_ = first.SomeVal
+	} else {
+	}
+}

--- a/tests/spec/emit/snapshots/interop_nullable_field_assign_through_go_struct_alias_unwraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_field_assign_through_go_struct_alias_unwraps.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:flag\"\n\ntype MyFlag = flag.Flag\n\nfn main() {\n  let mut f: MyFlag = flag.Flag { .. }\n  f.Value = None\n}\n"
+---
+package main
+
+import (
+	"flag"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type MyFlag = flag.Flag
+
+func main() {
+	f := flag.Flag{}
+	opt_1 := lisette.MakeOptionNone[flag.Value]()
+	var unwrap_2 flag.Value
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	f.Value = unwrap_2
+}

--- a/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:flag\"\n\ntype MyFlag = flag.Flag\n\nfn main() {\n  let f: MyFlag = flag.Flag { .. }\n  let v = f.Value\n  match v {\n    Some(x) => { let _ = x },\n    None => { let _ = 0 },\n  }\n}\n"
+---
+package main
+
+import (
+	"flag"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type MyFlag = flag.Flag
+
+func main() {
+	f := flag.Flag{}
+	raw_1 := f.Value
+	option_2 := lisette.OptionFromNilable[flag.Value](raw_1, lisette.IsNilInterface(raw_1))
+	v := option_2
+	if v.Tag == lisette.OptionSome {
+		_ = v.SomeVal
+	} else {
+	}
+}

--- a/tests/spec/emit/snapshots/interop_slice_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_slice_alias_value_unwrapped_at_go_struct_literal.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:crypto/x509\"\nimport \"go:net/url\"\n\ntype URLs = Slice<Option<Ref<url.URL>>>\n\nfn main() {\n  let u = url.URL {\n    Scheme: \"https\",\n    Host: \"example.com\",\n    ..,\n  }\n  let urls: URLs = [Some(&u), None]\n  let cert = x509.Certificate {\n    URIs: urls,\n    ..,\n  }\n  let _ = cert\n}\n"
+---
+package main
+
+import (
+	"crypto/x509"
+	lisette "github.com/ivov/lisette/prelude"
+	"net/url"
+)
+
+type URLs = []lisette.Option[*url.URL]
+
+func main() {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+	}
+	urls := []lisette.Option[*url.URL]{
+		lisette.MakeOptionSome(&u),
+		lisette.MakeOptionNone[*url.URL](),
+	}
+	src_1 := urls
+	unwrapped_2 := make([]*url.URL, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = v_4.SomeVal
+		}
+	}
+	cert := x509.Certificate{URIs: unwrapped_2}
+	_ = cert
+}

--- a/tests/spec/emit/snapshots/mutable_subslice_through_alias_cloned.snap
+++ b/tests/spec/emit/snapshots/mutable_subslice_through_alias_cloned.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Numbers = Slice<int>\n\nfn test() {\n  let xs: Numbers = [1, 2, 3]\n  let mut part = xs[0..2]\n  part[0] = 99\n  let _ = xs\n}\n"
+---
+package main
+
+import "slices"
+
+type Numbers = []int
+
+func test() {
+	xs := []int{1, 2, 3}
+	part := slices.Clone(xs[0:2:2])
+	part[0] = 99
+	_ = xs
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -681,6 +681,37 @@ fn test(arr: Slice<int>) {
 }
 
 #[test]
+fn mutable_subslice_through_alias_cloned() {
+    let input = r#"
+type Numbers = Slice<int>
+
+fn test() {
+  let xs: Numbers = [1, 2, 3]
+  let mut part = xs[0..2]
+  part[0] = 99
+  let _ = xs
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn immutable_subslice_through_alias_capacity_capped() {
+    let input = r#"
+type Numbers = Slice<int>
+
+fn test() {
+  let xs: Numbers = [1, 2, 3]
+  let view = xs[0..2]
+  let grown = view.append(9)
+  let _ = grown
+  let _ = xs
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn range_field_access() {
     let input = r#"
 fn test() -> int {


### PR DESCRIPTION
This PR routes emit shape decisions (i.e. native collection kind, prelude range, Go-imported nominal, nullable collection) through a single alias-aware query layer. This allows loop lowering, subslice isolation, and Go-boundary nullable wrapping to see through type aliases instead of matching on surface names.