### PR TITLE
refactor: collect generic constraints before emit

### DIFF
--- a/crates/emit/src/collectors.rs
+++ b/crates/emit/src/collectors.rs
@@ -94,33 +94,9 @@ impl Emitter<'_> {
         }
     }
 
-    pub(crate) fn collect_impl_bounds(&mut self, files: &[&File]) {
-        use syntax::ast::Expression;
-
-        for file in files {
-            for item in &file.items {
-                let Expression::ImplBlock {
-                    receiver_name,
-                    generics,
-                    ..
-                } = item
-                else {
-                    continue;
-                };
-                if !generics.iter().any(|g| !g.bounds.is_empty()) {
-                    self.module
-                        .record_unconstrained_impl_receiver(receiver_name.to_string());
-                    continue;
-                }
-                self.record_bound_imports(generics);
-                self.module.record_impl_bounds(receiver_name, generics);
-            }
-        }
-    }
-
     /// Register cross-module imports for any bound types referenced in these generics.
     /// In-module, Go-imported, and prelude modules don't need explicit imports.
-    fn record_bound_imports(&mut self, generics: &[syntax::ast::Generic]) {
+    pub(crate) fn record_bound_imports(&mut self, generics: &[syntax::ast::Generic]) {
         for generic in generics {
             for bound in &generic.bounds {
                 let syntax::ast::Annotation::Constructor { name, .. } = bound else {

--- a/crates/emit/src/constraint_collector.rs
+++ b/crates/emit/src/constraint_collector.rs
@@ -1,0 +1,546 @@
+use rustc_hash::FxHashSet as HashSet;
+
+use crate::Emitter;
+use crate::names::constraints::{GenericConstraintTable, classify_bound_annotation};
+use crate::names::go_name;
+use syntax::EcoString;
+use syntax::ast::{Annotation, Expression, Generic, Pattern, Visibility};
+use syntax::program::{DefinitionBody, File, Interface};
+use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
+
+impl Emitter<'_> {
+    pub(crate) fn collect_generic_constraints(&mut self, files: &[&File]) {
+        let mut table = GenericConstraintTable::default();
+
+        self.seed_global_definitions(&mut table);
+        self.seed_local_functions(files, &mut table);
+        self.seed_local_impl_blocks(files, &mut table);
+
+        self.for_each_definition_type(|key, names, ty| {
+            collect_demands_from_type(ty, key, names, &mut table);
+        });
+        self.collect_demands_from_local_functions(files, &mut table);
+        self.collect_demands_from_local_impl_blocks(files, &mut table);
+
+        self.propagate_constraints(&mut table);
+
+        self.module.set_generic_constraints(table);
+    }
+
+    fn seed_global_definitions(&self, table: &mut GenericConstraintTable) {
+        for (id, def) in self.facts.iter_definitions() {
+            let key = id.as_str();
+            match &def.body {
+                DefinitionBody::Struct { generics, .. }
+                | DefinitionBody::Enum { generics, .. }
+                | DefinitionBody::TypeAlias { generics, .. } => {
+                    table.ensure_seeded(key, generics);
+                }
+                DefinitionBody::Interface {
+                    definition: Interface { name, generics, .. },
+                    ..
+                } => {
+                    // Go has no F-bound syntax; strip `T: Cloner<T>`-style bounds.
+                    let filtered = strip_self_referential_bounds(generics, name);
+                    table.ensure_seeded(key, &filtered);
+                }
+                DefinitionBody::Value { .. } | DefinitionBody::ValueEnum { .. } => {}
+            }
+        }
+    }
+
+    fn seed_local_functions(&self, files: &[&File], table: &mut GenericConstraintTable) {
+        for file in files {
+            for item in &file.items {
+                if let Expression::Function { name, generics, .. } = item {
+                    let key = self.facts.qualified_current(name);
+                    table.ensure_seeded(&key, generics);
+                }
+            }
+        }
+    }
+
+    fn seed_local_impl_blocks(&mut self, files: &[&File], table: &mut GenericConstraintTable) {
+        // Pull out the bound-imports work first so the side-effectful
+        // `record_bound_imports` (&mut self) doesn't conflict with the rest
+        // of the iteration which calls `&self` methods.
+        let impl_generics_lists: Vec<Vec<Generic>> = files
+            .iter()
+            .flat_map(|f| &f.items)
+            .filter_map(|item| match item {
+                Expression::ImplBlock {
+                    generics: impl_generics,
+                    ..
+                } => Some(impl_generics.clone()),
+                _ => None,
+            })
+            .collect();
+        for impl_generics in &impl_generics_lists {
+            self.record_bound_imports(impl_generics);
+        }
+
+        for file in files {
+            for item in &file.items {
+                let Expression::ImplBlock {
+                    receiver_name,
+                    generics: impl_generics,
+                    methods,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                let receiver_key = self.facts.qualified_current(receiver_name);
+                for method in methods {
+                    let Expression::Function {
+                        generics: method_generics,
+                        ..
+                    } = method
+                    else {
+                        continue;
+                    };
+                    let layout = self.impl_method_emission_layout(
+                        &receiver_key,
+                        receiver_name,
+                        impl_generics,
+                        method,
+                    );
+                    match layout {
+                        ImplMethodLayout::Receiver { method_key } => {
+                            for impl_g in impl_generics {
+                                for bound in &impl_g.bounds {
+                                    table.add_explicit(
+                                        &receiver_key,
+                                        impl_g.name.as_str(),
+                                        classify_bound_annotation(bound),
+                                    );
+                                }
+                            }
+                            table.ensure_seeded(&method_key, method_generics);
+                        }
+                        ImplMethodLayout::FreeFunction {
+                            free_fn_key,
+                            combined_generics,
+                        } => {
+                            table.ensure_seeded(&free_fn_key, &combined_generics);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn impl_method_emission_layout(
+        &self,
+        receiver_key: &str,
+        receiver_name: &str,
+        impl_generics: &[Generic],
+        method: &Expression,
+    ) -> ImplMethodLayout {
+        let Expression::Function {
+            name: method_name,
+            generics: method_generics,
+            visibility,
+            ..
+        } = method
+        else {
+            unreachable!("callers filter to Function expressions");
+        };
+
+        let function = method.to_function_definition();
+        let has_self = function.params.first().is_some_and(|p| {
+            matches!(p.pattern, Pattern::Identifier { ref identifier, .. } if identifier == "self")
+        });
+        let is_ufcs = self.facts.is_ufcs_method(receiver_key, method_name);
+        if has_self && !is_ufcs {
+            return ImplMethodLayout::Receiver {
+                method_key: self
+                    .facts
+                    .qualified_current_member(receiver_name, method_name),
+            };
+        }
+
+        let is_public = matches!(visibility, Visibility::Public);
+        let should_export = is_public || self.method_needs_export(method_name);
+        let exported_method_name = if should_export {
+            go_name::snake_to_camel(method_name)
+        } else {
+            method_name.to_string()
+        };
+        let free_fn_name = format!("{}_{}", receiver_name, exported_method_name);
+        let free_fn_key = self.facts.qualified_current(&free_fn_name);
+
+        let mut combined_generics = impl_generics.to_vec();
+        combined_generics.extend(method_generics.iter().cloned());
+
+        ImplMethodLayout::FreeFunction {
+            free_fn_key,
+            combined_generics,
+        }
+    }
+
+    fn for_each_definition_type<F>(&self, mut visit: F)
+    where
+        F: FnMut(&str, &[&str], &Type),
+    {
+        for (id, def) in self.facts.iter_definitions() {
+            let key = id.as_str();
+            match &def.body {
+                DefinitionBody::Struct {
+                    generics, fields, ..
+                } => {
+                    let names = generic_names(generics);
+                    for f in fields {
+                        visit(key, &names, &f.ty);
+                    }
+                }
+                DefinitionBody::Enum {
+                    generics, variants, ..
+                } => {
+                    let names = generic_names(generics);
+                    for v in variants {
+                        for f in v.fields.iter() {
+                            visit(key, &names, &f.ty);
+                        }
+                    }
+                }
+                DefinitionBody::TypeAlias { generics, .. } => {
+                    let names = generic_names(generics);
+                    let body = def.ty.unwrap_forall();
+                    visit(key, &names, body);
+                }
+                DefinitionBody::Interface {
+                    definition: iface, ..
+                } => {
+                    let names = generic_names(&iface.generics);
+                    for method_ty in iface.methods.values() {
+                        visit(key, &names, method_ty);
+                    }
+                    for parent in &iface.parents {
+                        visit(key, &names, parent);
+                    }
+                }
+                DefinitionBody::Value { .. } | DefinitionBody::ValueEnum { .. } => {}
+            }
+        }
+    }
+
+    fn collect_demands_from_local_functions(
+        &self,
+        files: &[&File],
+        table: &mut GenericConstraintTable,
+    ) {
+        for file in files {
+            for item in &file.items {
+                let Expression::Function {
+                    name,
+                    generics,
+                    params,
+                    return_type,
+                    body,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                let key = self.facts.qualified_current(name);
+                let names = generic_names(generics);
+                for p in params {
+                    collect_demands_from_type(&p.ty, &key, &names, table);
+                }
+                collect_demands_from_type(return_type, &key, &names, table);
+                self.collect_demands_from_expression(body, &key, &names, table);
+            }
+        }
+    }
+
+    fn collect_demands_from_local_impl_blocks(
+        &self,
+        files: &[&File],
+        table: &mut GenericConstraintTable,
+    ) {
+        for file in files {
+            for item in &file.items {
+                let Expression::ImplBlock {
+                    receiver_name,
+                    generics: impl_generics,
+                    methods,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                let receiver_key = self.facts.qualified_current(receiver_name);
+                let receiver_names = generic_names(impl_generics);
+
+                for method in methods {
+                    let Expression::Function {
+                        generics: method_generics,
+                        params,
+                        return_type,
+                        body,
+                        ..
+                    } = method
+                    else {
+                        continue;
+                    };
+                    let layout = self.impl_method_emission_layout(
+                        &receiver_key,
+                        receiver_name,
+                        impl_generics,
+                        method,
+                    );
+                    match layout {
+                        ImplMethodLayout::Receiver { method_key } => {
+                            let method_names = generic_names(method_generics);
+                            for p in params {
+                                collect_demands_from_type(
+                                    &p.ty,
+                                    &receiver_key,
+                                    &receiver_names,
+                                    table,
+                                );
+                                collect_demands_from_type(&p.ty, &method_key, &method_names, table);
+                            }
+                            collect_demands_from_type(
+                                return_type,
+                                &receiver_key,
+                                &receiver_names,
+                                table,
+                            );
+                            collect_demands_from_type(
+                                return_type,
+                                &method_key,
+                                &method_names,
+                                table,
+                            );
+                            self.collect_demands_from_expression(
+                                body,
+                                &receiver_key,
+                                &receiver_names,
+                                table,
+                            );
+                            self.collect_demands_from_expression(
+                                body,
+                                &method_key,
+                                &method_names,
+                                table,
+                            );
+                        }
+                        ImplMethodLayout::FreeFunction {
+                            free_fn_key,
+                            combined_generics,
+                        } => {
+                            let combined_names = generic_names(&combined_generics);
+                            for p in params {
+                                collect_demands_from_type(
+                                    &p.ty,
+                                    &free_fn_key,
+                                    &combined_names,
+                                    table,
+                                );
+                            }
+                            collect_demands_from_type(
+                                return_type,
+                                &free_fn_key,
+                                &combined_names,
+                                table,
+                            );
+                            self.collect_demands_from_expression(
+                                body,
+                                &free_fn_key,
+                                &combined_names,
+                                table,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_demands_from_expression(
+        &self,
+        expression: &Expression,
+        symbol: &str,
+        local_generics: &[&str],
+        table: &mut GenericConstraintTable,
+    ) {
+        // `get_type()` catches `Map.new<T, int>()` inside a non-map context
+        // like `.is_empty()` or an if-condition.
+        collect_demands_from_type(&expression.get_type(), symbol, local_generics, table);
+        // Let bindings carry an explicit type that `children()` does not walk.
+        if let Expression::Let { binding, .. } = expression {
+            collect_demands_from_type(&binding.ty, symbol, local_generics, table);
+        }
+        for child in expression.children() {
+            self.collect_demands_from_expression(child, symbol, local_generics, table);
+        }
+    }
+
+    fn propagate_constraints(&self, table: &mut GenericConstraintTable) {
+        loop {
+            let edges = self.collect_propagation_edges(table);
+            let mut changed = false;
+            for edge in edges {
+                if table.mark_inferred_comparable(&edge.from_symbol, &edge.from_param) {
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    fn collect_propagation_edges(&self, table: &GenericConstraintTable) -> Vec<PropagationEdge> {
+        let mut edges = Vec::new();
+        self.for_each_definition_type(|key, names, ty| {
+            scan_propagation(ty, key, names, table, &mut edges);
+        });
+        edges
+    }
+}
+
+struct PropagationEdge {
+    from_symbol: String,
+    from_param: EcoString,
+}
+
+enum ImplMethodLayout {
+    Receiver {
+        method_key: String,
+    },
+    FreeFunction {
+        free_fn_key: String,
+        combined_generics: Vec<Generic>,
+    },
+}
+
+fn collect_demands_from_type(
+    ty: &Type,
+    symbol: &str,
+    local_generics: &[&str],
+    table: &mut GenericConstraintTable,
+) {
+    let mut stack: Vec<&Type> = vec![ty];
+    while let Some(current) = stack.pop() {
+        if let Some(key_ty) = map_key_of(current)
+            && let Type::Parameter(name) = key_ty
+            && local_generics.contains(&name.as_str())
+        {
+            table.mark_inferred_comparable(symbol, name);
+        }
+        for child in current.children() {
+            stack.push(child);
+        }
+        // `Type::children()` excludes function bounds; include them so bound
+        // type expressions can also impose constraints.
+        if let Type::Function { bounds, .. } = current {
+            for b in bounds {
+                stack.push(&b.ty);
+            }
+        }
+    }
+}
+
+fn scan_propagation(
+    ty: &Type,
+    symbol: &str,
+    local_generics: &[&str],
+    table: &GenericConstraintTable,
+    edges: &mut Vec<PropagationEdge>,
+) {
+    let mut stack: Vec<&Type> = vec![ty];
+    let mut visited_nominals: HashSet<Symbol> = HashSet::default();
+
+    while let Some(current) = stack.pop() {
+        if let Type::Nominal { id, params, .. } = current {
+            // Direct `Map<P, _>` is already handled by the initial collection;
+            // here we only chase nominal callees with constrained positions.
+            if !is_map_id(id)
+                && let Some(callee_sets) = table.get(id.as_str())
+            {
+                for (i, set) in callee_sets.iter().enumerate() {
+                    if !set.requires_comparable() {
+                        continue;
+                    }
+                    let Some(arg) = params.get(i) else { continue };
+                    if let Type::Parameter(name) = arg
+                        && local_generics.contains(&name.as_str())
+                    {
+                        edges.push(PropagationEdge {
+                            from_symbol: symbol.to_string(),
+                            from_param: name.clone(),
+                        });
+                    }
+                }
+            }
+            // Skip re-entry into the same nominal in chains like `Alias<Alias<T>>`.
+            if visited_nominals.insert(id.clone()) {
+                for p in params {
+                    stack.push(p);
+                }
+            }
+            continue;
+        }
+        for child in current.children() {
+            stack.push(child);
+        }
+        if let Type::Function { bounds, .. } = current {
+            for b in bounds {
+                stack.push(&b.ty);
+            }
+        }
+    }
+}
+
+fn map_key_of(ty: &Type) -> Option<&Type> {
+    if let Type::Compound {
+        kind: CompoundKind::Map,
+        args,
+    } = ty
+        && !args.is_empty()
+    {
+        return Some(&args[0]);
+    }
+    if let Type::Nominal { id, params, .. } = ty
+        && is_map_id(id)
+        && !params.is_empty()
+    {
+        return Some(&params[0]);
+    }
+    None
+}
+
+fn is_map_id(id: &Symbol) -> bool {
+    let s = id.as_str();
+    s == "Map" || s.ends_with(".Map")
+}
+
+fn generic_names(generics: &[Generic]) -> Vec<&str> {
+    generics.iter().map(|g| g.name.as_str()).collect()
+}
+
+fn strip_self_referential_bounds(generics: &[Generic], interface_name: &str) -> Vec<Generic> {
+    generics
+        .iter()
+        .map(|g| Generic {
+            name: g.name.clone(),
+            bounds: g
+                .bounds
+                .iter()
+                .filter(|ann| !bound_references_interface(ann, interface_name))
+                .cloned()
+                .collect(),
+            span: g.span,
+        })
+        .collect()
+}
+
+fn bound_references_interface(annotation: &Annotation, interface_name: &str) -> bool {
+    let Annotation::Constructor { name, .. } = annotation else {
+        return false;
+    };
+    unqualified_name(name) == interface_name
+}

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -38,11 +38,8 @@ impl Emitter<'_> {
             let _ = self.go_type_as_string(ty);
         }
 
-        let generics = self.merge_impl_bounds(name, generics);
-        let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();
-        let map_key_generics = self.enum_map_key_generics(&enum_id, &generic_names);
-        let generics_string = self.generics_to_string_with_map_keys(&generics, &map_key_generics);
-        let receiver_generics = receiver_generics_string(&generics);
+        let generics_string = self.generics_to_string_for_symbol(&enum_id, generics);
+        let receiver_generics = receiver_generics_string(generics);
         let has_json = attributes.iter().any(|a| a.name == "json");
 
         let stringer_name = self.stringer_method_name(name);
@@ -108,10 +105,7 @@ impl Emitter<'_> {
                 .map(|g| g.name.as_str())
                 .collect::<Vec<_>>()
                 .join(", ");
-            let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();
-            let map_key_generics = self.enum_map_key_generics(enum_id, &generic_names);
-            let generics_string =
-                self.generics_to_string_with_map_keys(&generics, &map_key_generics);
+            let generics_string = self.generics_to_string_for_symbol(enum_id, &generics);
             (generics_string, format!("[{}]", args))
         };
 

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -15,6 +15,14 @@ use syntax::types::Type;
 /// Owned param-destructure record: temp var, pattern, typed pattern, param type.
 type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
 
+fn receiver_type_name(ty: &Type) -> Option<&str> {
+    if let Type::Nominal { id, .. } = ty.unwrap_forall() {
+        Some(syntax::types::unqualified_name(id.as_str()))
+    } else {
+        None
+    }
+}
+
 /// Borrowed lambda param-destructure record. Lambdas keep references to the
 /// caller's `params` slice since they cannot outlive emission scope.
 type LambdaParamDestructure<'a> = (String, &'a Pattern, Option<&'a TypedPattern>, &'a Type);
@@ -252,7 +260,8 @@ impl Emitter<'_> {
 
         parts.push(self.pick_go_function_name(&function_definition, receiver.is_some(), is_public));
 
-        let generics_str = self.build_generics_string(&function_definition, params_to_process);
+        let generics_str =
+            self.build_generics_string(&function_definition, params_to_process, receiver.as_ref());
         if !generics_str.is_empty() {
             parts.push(generics_str);
         }
@@ -307,26 +316,28 @@ impl Emitter<'_> {
     fn build_generics_string(
         &mut self,
         function_definition: &FunctionDefinition,
-        params_to_process: &[Binding],
+        _params_to_process: &[Binding],
+        receiver: Option<&(String, Type)>,
     ) -> String {
-        let generic_names: Vec<&str> = function_definition
-            .generics
-            .iter()
-            .map(|g| g.name.as_ref())
-            .collect();
-        let sig_types = params_to_process
-            .iter()
-            .map(|p| &p.ty)
-            .chain(std::iter::once(&function_definition.return_type));
-        let mut map_key_generics = Self::collect_map_key_generics(sig_types, &generic_names);
-        for name in &generic_names {
-            if !map_key_generics.contains(*name)
-                && Self::body_has_map_key_generic(&function_definition.body, name)
-            {
-                map_key_generics.insert(name.to_string());
-            }
+        let symbol = self.symbol_for_function(&function_definition.name, receiver);
+        self.generics_to_string_for_symbol(&symbol, &function_definition.generics)
+    }
+
+    fn symbol_for_function(
+        &self,
+        function_name: &str,
+        receiver: Option<&(String, Type)>,
+    ) -> String {
+        if let Some((_, receiver_ty)) = receiver
+            && let Some(name) = receiver_type_name(receiver_ty)
+        {
+            return self.facts.qualified_current_member(name, function_name);
         }
-        self.generics_to_string_with_map_keys(&function_definition.generics, &map_key_generics)
+        if let Some((receiver, method)) = function_name.split_once('.') {
+            self.facts.qualified_current_member(receiver, method)
+        } else {
+            self.facts.qualified_current(function_name)
+        }
     }
 
     fn build_signature_tail(

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -1,9 +1,7 @@
-use rustc_hash::FxHashSet as HashSet;
-
 use crate::Emitter;
 use crate::names::go_name;
 use syntax::ast::{Annotation, Expression, Generic, ParentInterface, Pattern};
-use syntax::types::{Type, unqualified_name};
+use syntax::types::unqualified_name;
 
 impl Emitter<'_> {
     pub(crate) fn emit_interface(
@@ -18,26 +16,9 @@ impl Emitter<'_> {
             return format!("type {} struct{{}}", name);
         }
 
-        let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();
-        let method_types: Vec<Type> = items.iter().map(|item| item.get_type()).collect();
-        let mut map_key_generics =
-            Self::collect_map_key_generics(method_types.iter(), &generic_names);
-
-        let mut visited = HashSet::default();
-        for parent in parents {
-            if let Type::Nominal { id, params, .. } = &parent.ty {
-                for position in self.map_key_positions(id, &mut visited) {
-                    if let Some(Type::Parameter(name)) = params.get(position)
-                        && generic_names.contains(&name.as_ref())
-                    {
-                        map_key_generics.insert(name.to_string());
-                    }
-                }
-            }
-        }
-
         let filtered = strip_self_referential_bounds(generics, name);
-        let generics_str = self.generics_to_string_with_map_keys(&filtered, &map_key_generics);
+        let symbol = self.facts.qualified_current(name);
+        let generics_str = self.generics_to_string_for_symbol(&symbol, &filtered);
 
         let mut output = Vec::new();
         output.push(format!(

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -16,14 +16,11 @@ impl Emitter<'_> {
         kind: &StructKind,
         struct_attrs: &[Attribute],
     ) -> String {
-        let generics = self.merge_impl_bounds(name, generics);
-        let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();
-        let map_key_generics =
-            Self::collect_map_key_generics(fields.iter().map(|f| &f.ty), &generic_names);
-        let generics_string = self.generics_to_string_with_map_keys(&generics, &map_key_generics);
+        let symbol = self.facts.qualified_current(name);
+        let generics_string = self.generics_to_string_for_symbol(&symbol, generics);
 
         if *kind == StructKind::Tuple {
-            return self.emit_tuple_struct(name, &generics_string, fields, &generics);
+            return self.emit_tuple_struct(name, &generics_string, fields, generics);
         }
 
         let (field_strings, stringer_fields): (Vec<String>, Vec<StringerField>) = fields
@@ -31,7 +28,7 @@ impl Emitter<'_> {
             .map(|f| self.emit_struct_field(f, name, struct_attrs))
             .unzip();
 
-        let receiver_generics = receiver_generics_string(&generics);
+        let receiver_generics = receiver_generics_string(generics);
         let go_type_name = go_name::escape_keyword(name);
 
         let definition = if field_strings.is_empty() {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -51,10 +51,8 @@ impl Emitter<'_> {
             self.require_module_import(&module);
         }
 
-        let generic_names: Vec<&str> = generics.iter().map(|g| g.name.as_ref()).collect();
-        let map_key_generics =
-            Self::collect_map_key_generics(std::iter::once(underlying), &generic_names);
-        let generics_string = self.generics_to_string_with_map_keys(generics, &map_key_generics);
+        let symbol = self.facts.qualified_current(name);
+        let generics_string = self.generics_to_string_for_symbol(&symbol, generics);
 
         let separator = if is_fn_alias { " " } else { " = " };
         format!(

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -1,6 +1,7 @@
 pub(crate) mod bindings;
 pub(crate) mod calls;
 mod collectors;
+mod constraint_collector;
 pub(crate) mod control_flow;
 pub(crate) mod definitions;
 pub(crate) mod expressions;
@@ -454,7 +455,7 @@ impl<'a> Emitter<'a> {
         self.facts.set_current_module(module_id);
         self.collect_module_aliases(files);
         self.collect_local_exported_method_names(files);
-        self.collect_impl_bounds(files);
+        self.collect_generic_constraints(files);
         self.collect_enum_layouts();
         self.collect_escape_remap(files);
         let mut make_functions_by_file = self.collect_local_make_function_code();

--- a/crates/emit/src/module_state.rs
+++ b/crates/emit/src/module_state.rs
@@ -1,9 +1,8 @@
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
-use syntax::ast::Generic;
-
 use crate::EnumLayout;
+use crate::names::constraints::{GenericConstraintTable, ParamConstraintSet};
 
 #[derive(Default)]
 pub(crate) struct ModuleState {
@@ -12,16 +11,10 @@ pub(crate) struct ModuleState {
     /// definition because Go cares about exported-vs-private field casing.
     tag_exported_fields: HashSet<String>,
     exported_method_names: HashSet<String>,
-    /// Multiple impl blocks with the same receiver must contribute their
-    /// bounds because Go requires generic constraints on the type definition
-    /// itself.
-    impl_bounds: HashMap<String, Vec<Generic>>,
-    /// Receivers with both constrained and unconstrained impl blocks need
-    /// special-cased generic-arg emission.
-    unconstrained_impl_receivers: HashSet<String>,
     module_aliases: HashMap<String, String>,
     reverse_module_aliases: HashMap<String, String>,
     escape_remap: HashMap<String, String>,
+    generic_constraints: GenericConstraintTable,
 }
 
 impl ModuleState {
@@ -51,43 +44,6 @@ impl ModuleState {
 
     pub(crate) fn has_local_exported_method_name(&self, name: &str) -> bool {
         self.exported_method_names.contains(name)
-    }
-
-    /// Merge new bounds into an existing impl_bounds entry, or insert fresh.
-    /// Multiple impl blocks with the same receiver must contribute their bounds
-    /// because Go requires generic constraints on the type definition itself.
-    pub(crate) fn record_impl_bounds(&mut self, receiver_name: &str, generics: &[Generic]) {
-        let Some(existing_generics) = self.impl_bounds.get_mut(receiver_name) else {
-            self.impl_bounds
-                .insert(receiver_name.to_string(), generics.to_vec());
-            return;
-        };
-        for new_gen in generics {
-            let Some(existing_gen) = existing_generics
-                .iter_mut()
-                .find(|g| g.name == new_gen.name)
-            else {
-                continue;
-            };
-            for bound in &new_gen.bounds {
-                if !existing_gen.bounds.contains(bound) {
-                    existing_gen.bounds.push(bound.clone());
-                }
-            }
-        }
-    }
-
-    pub(crate) fn impl_bounds(&self, type_name: &str) -> Option<&[Generic]> {
-        self.impl_bounds.get(type_name).map(Vec::as_slice)
-    }
-
-    pub(crate) fn record_unconstrained_impl_receiver(&mut self, receiver_name: impl Into<String>) {
-        self.unconstrained_impl_receivers
-            .insert(receiver_name.into());
-    }
-
-    pub(crate) fn has_unconstrained_impl_receiver(&self, type_name: &str) -> bool {
-        self.unconstrained_impl_receivers.contains(type_name)
     }
 
     pub(crate) fn record_module_alias(
@@ -120,6 +76,14 @@ impl ModuleState {
 
     pub(crate) fn escape_remap(&self, lisette_name: &str) -> Option<&str> {
         self.escape_remap.get(lisette_name).map(String::as_str)
+    }
+
+    pub(crate) fn set_generic_constraints(&mut self, table: GenericConstraintTable) {
+        self.generic_constraints = table;
+    }
+
+    pub(crate) fn generic_constraints_for(&self, symbol: &str) -> Option<&[ParamConstraintSet]> {
+        self.generic_constraints.get(symbol)
     }
 }
 

--- a/crates/emit/src/names/constraints.rs
+++ b/crates/emit/src/names/constraints.rs
@@ -1,0 +1,185 @@
+use rustc_hash::FxHashMap as HashMap;
+
+use syntax::EcoString;
+use syntax::ast::{Annotation, Generic};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ConstraintAtom {
+    Comparable,
+    /// Implies `Comparable`; renders as `cmp.Ordered`.
+    Ordered,
+    Named(Annotation),
+}
+
+impl ConstraintAtom {
+    pub(crate) fn implies_comparable(&self) -> bool {
+        matches!(self, ConstraintAtom::Comparable | ConstraintAtom::Ordered)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ParamConstraintSet {
+    pub(crate) name: EcoString,
+    pub(crate) explicit: Vec<ConstraintAtom>,
+    pub(crate) inferred_comparable: bool,
+}
+
+impl ParamConstraintSet {
+    pub(crate) fn add_explicit(&mut self, atom: ConstraintAtom) -> bool {
+        if self.explicit.contains(&atom) {
+            return false;
+        }
+        self.explicit.push(atom);
+        true
+    }
+
+    pub(crate) fn mark_inferred_comparable(&mut self) -> bool {
+        if self.inferred_comparable {
+            return false;
+        }
+        self.inferred_comparable = true;
+        true
+    }
+
+    pub(crate) fn requires_comparable(&self) -> bool {
+        self.inferred_comparable || self.explicit.iter().any(ConstraintAtom::implies_comparable)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct GenericConstraintTable {
+    by_symbol: HashMap<String, Vec<ParamConstraintSet>>,
+}
+
+impl GenericConstraintTable {
+    /// Idempotent.
+    pub(crate) fn ensure_seeded(&mut self, symbol: &str, generics: &[Generic]) {
+        if self.by_symbol.contains_key(symbol) {
+            return;
+        }
+        let mut sets = Vec::with_capacity(generics.len());
+        for generic in generics {
+            let mut set = ParamConstraintSet {
+                name: generic.name.clone(),
+                ..Default::default()
+            };
+            for bound in &generic.bounds {
+                set.add_explicit(classify_bound_annotation(bound));
+            }
+            sets.push(set);
+        }
+        self.by_symbol.insert(symbol.to_string(), sets);
+    }
+
+    pub(crate) fn get(&self, symbol: &str) -> Option<&[ParamConstraintSet]> {
+        self.by_symbol.get(symbol).map(Vec::as_slice)
+    }
+
+    pub(crate) fn add_explicit(&mut self, symbol: &str, param: &str, atom: ConstraintAtom) -> bool {
+        let Some(sets) = self.by_symbol.get_mut(symbol) else {
+            return false;
+        };
+        let Some(set) = sets.iter_mut().find(|s| s.name.as_str() == param) else {
+            return false;
+        };
+        set.add_explicit(atom)
+    }
+
+    pub(crate) fn mark_inferred_comparable(&mut self, symbol: &str, param: &str) -> bool {
+        let Some(sets) = self.by_symbol.get_mut(symbol) else {
+            return false;
+        };
+        let Some(set) = sets.iter_mut().find(|s| s.name.as_str() == param) else {
+            return false;
+        };
+        set.mark_inferred_comparable()
+    }
+}
+
+pub(crate) fn classify_bound_annotation(annotation: &Annotation) -> ConstraintAtom {
+    if let Annotation::Constructor { name, .. } = annotation
+        && let Some(builtin) = classify_builtin_name(name)
+    {
+        return builtin;
+    }
+    ConstraintAtom::Named(annotation.clone())
+}
+
+pub(crate) fn classify_builtin_name(name: &str) -> Option<ConstraintAtom> {
+    match name {
+        "Comparable" | "prelude.Comparable" => Some(ConstraintAtom::Comparable),
+        "Ordered" | "prelude.Ordered" | "go:cmp.Ordered" | "cmp.Ordered" => {
+            Some(ConstraintAtom::Ordered)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::ast::Span;
+
+    fn ctor(name: &str) -> Annotation {
+        Annotation::Constructor {
+            name: name.into(),
+            params: vec![],
+            span: Span::dummy(),
+        }
+    }
+
+    fn set(name: &str) -> ParamConstraintSet {
+        ParamConstraintSet {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn classify_recognizes_prelude_comparable() {
+        assert_eq!(
+            classify_bound_annotation(&ctor("Comparable")),
+            ConstraintAtom::Comparable
+        );
+        assert_eq!(
+            classify_bound_annotation(&ctor("prelude.Comparable")),
+            ConstraintAtom::Comparable
+        );
+    }
+
+    #[test]
+    fn classify_recognizes_prelude_ordered() {
+        assert_eq!(
+            classify_bound_annotation(&ctor("Ordered")),
+            ConstraintAtom::Ordered
+        );
+        assert_eq!(
+            classify_bound_annotation(&ctor("prelude.Ordered")),
+            ConstraintAtom::Ordered
+        );
+        assert_eq!(
+            classify_bound_annotation(&ctor("go:cmp.Ordered")),
+            ConstraintAtom::Ordered
+        );
+    }
+
+    #[test]
+    fn classify_passes_named_bounds_through() {
+        let ann = ctor("Named");
+        assert_eq!(classify_bound_annotation(&ann), ConstraintAtom::Named(ann));
+    }
+
+    #[test]
+    fn add_explicit_dedups() {
+        let mut s = set("T");
+        assert!(s.add_explicit(ConstraintAtom::Comparable));
+        assert!(!s.add_explicit(ConstraintAtom::Comparable));
+    }
+
+    #[test]
+    fn ordered_implies_comparable() {
+        let mut s = set("T");
+        s.add_explicit(ConstraintAtom::Ordered);
+        assert!(s.requires_comparable());
+    }
+}

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -1,9 +1,9 @@
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::Emitter;
+use crate::names::constraints::{ConstraintAtom, ParamConstraintSet, classify_builtin_name};
 use syntax::EcoString;
-use syntax::ast::{Expression, Generic};
-use syntax::program::{Definition, DefinitionBody};
+use syntax::ast::{Annotation, Generic};
 use syntax::types::Type;
 
 fn build_type_map(generics: &[Generic], type_args: &[Type]) -> HashMap<EcoString, Type> {
@@ -41,281 +41,92 @@ pub(crate) fn receiver_generics_string(generics: &[Generic]) -> String {
 }
 
 impl Emitter<'_> {
-    pub(crate) fn merge_impl_bounds(&self, type_name: &str, generics: &[Generic]) -> Vec<Generic> {
-        let Some(impl_generics) = self.module.impl_bounds(type_name) else {
-            return generics.to_vec();
-        };
-
-        if self.module.has_unconstrained_impl_receiver(type_name) {
-            return generics.to_vec();
-        }
-
-        generics
-            .iter()
-            .map(|g| {
-                if !g.bounds.is_empty() {
-                    return g.clone();
-                }
-                if let Some(impl_g) = impl_generics.iter().find(|ig| ig.name == g.name) {
-                    Generic {
-                        bounds: impl_g.bounds.clone(),
-                        ..g.clone()
-                    }
-                } else {
-                    g.clone()
-                }
-            })
-            .collect()
-    }
-
-    fn is_map_key_type(ty: &Type, generic_name: &str) -> bool {
-        if let Type::Compound {
-            kind: syntax::types::CompoundKind::Map,
-            args,
-        } = ty
-            && !args.is_empty()
-            && let Type::Parameter(name) = &args[0]
-            && name.as_ref() == generic_name
-        {
-            return true;
-        }
-        match ty {
-            Type::Nominal { id, params, .. } => {
-                if (id.as_ref() == "Map" || id.as_ref().ends_with(".Map"))
-                    && !params.is_empty()
-                    && let Type::Parameter(name) = &params[0]
-                    && name.as_ref() == generic_name
-                {
-                    return true;
-                }
-                params
-                    .iter()
-                    .any(|p| Self::is_map_key_type(p, generic_name))
-            }
-            Type::Compound { args, .. } => {
-                args.iter().any(|a| Self::is_map_key_type(a, generic_name))
-            }
-            Type::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                params
-                    .iter()
-                    .any(|p| Self::is_map_key_type(p, generic_name))
-                    || Self::is_map_key_type(return_type, generic_name)
-            }
-            Type::Tuple(elements) => elements
-                .iter()
-                .any(|e| Self::is_map_key_type(e, generic_name)),
-            _ => false,
-        }
-    }
-
-    pub(crate) fn collect_map_key_generics<'a>(
-        types: impl Iterator<Item = &'a Type>,
-        generic_names: &[&str],
-    ) -> HashSet<String> {
-        let mut result = HashSet::default();
-        for ty in types {
-            for generic_name in generic_names {
-                if !result.contains(*generic_name) && Self::is_map_key_type(ty, generic_name) {
-                    result.insert(generic_name.to_string());
-                }
-            }
-        }
-        result
-    }
-
-    pub(crate) fn map_key_positions(
-        &self,
-        id: &str,
-        visited: &mut HashSet<String>,
-    ) -> HashSet<usize> {
-        if !visited.insert(id.to_string()) {
-            return HashSet::default();
-        }
-        let peeled = self.peel_alias_id(id);
-        let Some(Definition {
-            body: DefinitionBody::Interface { definition },
-            ..
-        }) = self.facts.definition(peeled.as_str())
-        else {
-            return HashSet::default();
-        };
-        let names: Vec<&str> = definition
-            .generics
-            .iter()
-            .map(|g| g.name.as_ref())
-            .collect();
-        let keys = Self::collect_map_key_generics(definition.methods.values(), &names);
-        let mut positions: HashSet<usize> = definition
-            .generics
-            .iter()
-            .enumerate()
-            .filter(|(_, g)| keys.contains(g.name.as_ref()))
-            .map(|(i, _)| i)
-            .collect();
-        for p in &definition.parents {
-            if let Type::Nominal {
-                id: pid, params, ..
-            } = p
-            {
-                for position in self.map_key_positions(pid, visited) {
-                    if let Some(Type::Parameter(name)) = params.get(position)
-                        && let Some(idx) = definition.generics.iter().position(|g| g.name == *name)
-                    {
-                        positions.insert(idx);
-                    }
-                }
-            }
-        }
-        positions
-    }
-
-    pub(crate) fn enum_map_key_generics(
-        &self,
-        enum_id: &str,
-        generic_names: &[&str],
-    ) -> HashSet<String> {
-        if let Some(Definition {
-            body: DefinitionBody::Enum { variants, .. },
-            ..
-        }) = self.facts.definition(enum_id)
-        {
-            let types = variants.iter().flat_map(|v| v.fields.iter().map(|f| &f.ty));
-            Self::collect_map_key_generics(types, generic_names)
-        } else {
-            HashSet::default()
-        }
-    }
-
-    pub(crate) fn body_has_map_key_generic(expression: &Expression, generic_name: &str) -> bool {
-        match expression {
-            Expression::Block { items, .. }
-            | Expression::TryBlock { items, .. }
-            | Expression::RecoverBlock { items, .. } => items
-                .iter()
-                .any(|item| Self::body_has_map_key_generic(item, generic_name)),
-            Expression::Let {
-                binding,
-                else_block,
-                ..
-            } => {
-                Self::is_map_key_type(&binding.ty, generic_name)
-                    || else_block
-                        .as_ref()
-                        .is_some_and(|eb| Self::body_has_map_key_generic(eb, generic_name))
-            }
-            Expression::If {
-                consequence,
-                alternative,
-                ..
-            }
-            | Expression::IfLet {
-                consequence,
-                alternative,
-                ..
-            } => {
-                Self::body_has_map_key_generic(consequence, generic_name)
-                    || Self::body_has_map_key_generic(alternative, generic_name)
-            }
-            Expression::Match { arms, .. } => arms
-                .iter()
-                .any(|arm| Self::body_has_map_key_generic(&arm.expression, generic_name)),
-            Expression::Loop { body, .. }
-            | Expression::While { body, .. }
-            | Expression::WhileLet { body, .. }
-            | Expression::For { body, .. } => Self::body_has_map_key_generic(body, generic_name),
-            Expression::Task { expression, .. } | Expression::Defer { expression, .. } => {
-                Self::body_has_map_key_generic(expression, generic_name)
-            }
-            Expression::Select { arms, .. } => arms.iter().any(|arm| {
-                use syntax::ast::SelectArmPattern;
-                match &arm.pattern {
-                    SelectArmPattern::Receive { body, .. }
-                    | SelectArmPattern::Send { body, .. }
-                    | SelectArmPattern::WildCard { body, .. } => {
-                        Self::body_has_map_key_generic(body, generic_name)
-                    }
-                    SelectArmPattern::MatchReceive { arms, .. } => arms
-                        .iter()
-                        .any(|a| Self::body_has_map_key_generic(&a.expression, generic_name)),
-                }
-            }),
-            Expression::Lambda { body, .. } | Expression::Function { body, .. } => {
-                Self::body_has_map_key_generic(body, generic_name)
-            }
-            _ => {
-                Self::is_map_key_type(&expression.get_type(), generic_name)
-                    || Self::expression_tree_has_map_key(expression, generic_name)
-            }
-        }
-    }
-
-    fn expression_tree_has_map_key(expression: &Expression, generic_name: &str) -> bool {
-        match expression {
-            Expression::Call {
-                expression,
-                args,
-                spread,
-                ..
-            } => {
-                Self::is_map_key_type(&expression.get_type(), generic_name)
-                    || args
-                        .iter()
-                        .any(|a| Self::is_map_key_type(&a.get_type(), generic_name))
-                    || args
-                        .iter()
-                        .any(|a| Self::expression_tree_has_map_key(a, generic_name))
-                    || spread.as_ref().as_ref().is_some_and(|s| {
-                        Self::is_map_key_type(&s.get_type(), generic_name)
-                            || Self::expression_tree_has_map_key(s, generic_name)
-                    })
-            }
-            _ => false,
-        }
-    }
-
-    pub(crate) fn generics_to_string_with_map_keys(
+    pub(crate) fn generics_to_string_for_symbol(
         &mut self,
+        symbol: &str,
         generics: &[Generic],
-        map_key_generics: &HashSet<String>,
     ) -> String {
         if generics.is_empty() {
             return String::new();
         }
+        let constraints = self
+            .module
+            .generic_constraints_for(symbol)
+            .map(<[ParamConstraintSet]>::to_vec);
 
-        let generics_string = generics
+        let rendered = generics
             .iter()
             .map(|g| {
-                let bounds: Vec<_> = g
-                    .bounds
-                    .iter()
-                    .map(|ann| self.annotation_to_go_type(ann))
-                    .collect();
-
-                let constraint = match bounds.as_slice() {
-                    [] => {
-                        if map_key_generics.contains(g.name.as_ref()) {
-                            "comparable".to_string()
-                        } else {
-                            "any".to_string()
-                        }
-                    }
-                    [single] => single.clone(),
-                    multiple => {
-                        let ifaces = multiple.join("; ");
-                        return format!("{} interface {{ {} }}", g.name, ifaces);
-                    }
-                };
-
+                let set = constraints
+                    .as_ref()
+                    .and_then(|sets| sets.iter().find(|s| s.name == g.name));
+                let constraint = self.render_constraint(g, set);
                 format!("{} {}", g.name, constraint)
             })
             .collect::<Vec<_>>()
             .join(", ");
 
-        format!("[{}]", generics_string)
+        format!("[{}]", rendered)
+    }
+
+    fn render_constraint(
+        &mut self,
+        generic: &Generic,
+        constraint_set: Option<&ParamConstraintSet>,
+    ) -> String {
+        let (explicit_atoms, inferred_comparable) = match constraint_set {
+            Some(set) => (set.explicit.clone(), set.inferred_comparable),
+            None => {
+                // Fallback for symbols that bypassed `collect_generic_constraints`.
+                let atoms: Vec<ConstraintAtom> = generic
+                    .bounds
+                    .iter()
+                    .map(|ann| {
+                        if let Annotation::Constructor { name, .. } = ann
+                            && let Some(b) = classify_builtin_name(name)
+                        {
+                            b
+                        } else {
+                            ConstraintAtom::Named(ann.clone())
+                        }
+                    })
+                    .collect();
+                (atoms, false)
+            }
+        };
+
+        // `Ordered` already implies `Comparable`; never double up.
+        let needs_comparable_appendage = inferred_comparable
+            && !explicit_atoms
+                .iter()
+                .any(ConstraintAtom::implies_comparable);
+
+        let mut named_bounds: Vec<String> = Vec::new();
+        let mut comparable_seen = false;
+        for atom in &explicit_atoms {
+            match atom {
+                ConstraintAtom::Comparable => {
+                    comparable_seen = true;
+                }
+                ConstraintAtom::Ordered => {
+                    self.requirements.require_go_import("cmp");
+                    named_bounds.push("cmp.Ordered".to_string());
+                }
+                ConstraintAtom::Named(ann) => {
+                    named_bounds.push(self.annotation_to_go_type(ann));
+                }
+            }
+        }
+
+        if needs_comparable_appendage || comparable_seen {
+            named_bounds.push("comparable".to_string());
+        }
+
+        match named_bounds.as_slice() {
+            [] => "any".to_string(),
+            [single] => single.clone(),
+            multiple => format!("interface {{ {} }}", multiple.join("; ")),
+        }
     }
 }
 

--- a/crates/emit/src/names/mod.rs
+++ b/crates/emit/src/names/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod constraints;
 pub(crate) mod generics;
 pub(crate) mod go_name;
 pub(crate) mod resolution;

--- a/crates/emit/src/queries.rs
+++ b/crates/emit/src/queries.rs
@@ -4,7 +4,6 @@ use crate::Emitter;
 use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
 use crate::definitions::structs::is_raw_function_type;
-use crate::names::go_name;
 use syntax::ast::{Pattern, RestPattern, StructKind};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Type, substitute};
@@ -226,9 +225,9 @@ impl Emitter<'_> {
 
 impl Emitter<'_> {
     /// Pre-compute enum layouts for all known enum definitions.
-    ///
-    /// Must be called after `collect_impl_bounds()` since layouts need merged bounds.
-    /// Replaces the previous lazy `ensure_enum_layout()` pattern.
+    /// Replaces the previous lazy `ensure_enum_layout()` pattern. Generic
+    /// constraints are looked up from the constraint table at render time,
+    /// so layouts only need to store the source-AST generics.
     pub(crate) fn collect_enum_layouts(&mut self) {
         let enum_defs: Vec<_> = self
             .facts
@@ -274,9 +273,6 @@ impl Emitter<'_> {
                     );
                 }
             }
-
-            let enum_name = go_name::unqualified_name(&enum_id);
-            let generics = self.merge_impl_bounds(enum_name, &generics);
 
             let layout = EnumLayout::new(&enum_id, &generics, &variants, &field_types);
             self.module.record_enum_layout(enum_id, layout);

--- a/tests/spec/emit/snapshots/alias_chain_propagates_comparable_through_two_steps.snap
+++ b/tests/spec/emit/snapshots/alias_chain_propagates_comparable_through_two_steps.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype B<T> = Map<T, int>\ntype A<T> = B<T>\n\nstruct Box<T> {\n  table: A<T>,\n}\n\nfn main() {\n  let b = Box { table: Map.new<string, int>() }\n  let _ = b\n}\n"
+---
+package main
+
+import "fmt"
+
+type B[T comparable] = map[T]int
+
+type A[T comparable] = B[T]
+
+type Box[T comparable] struct {
+	table A[T]
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { table: %v }", b.table)
+}
+
+func main() {
+	b := Box[string]{table: make(map[string]int)}
+	_ = b
+}

--- a/tests/spec/emit/snapshots/builtin_comparable_bound_lowers_to_go_comparable.snap
+++ b/tests/spec/emit/snapshots/builtin_comparable_bound_lowers_to_go_comparable.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn id<T: Comparable>(x: T) -> T {\n  x\n}\n\nfn main() {\n  let _ = id(1)\n}\n"
+---
+package main
+
+func id[T comparable](x T) T {
+	return x
+}
+
+func main() {
+	_ = id(1)
+}

--- a/tests/spec/emit/snapshots/builtin_ordered_bound_lowers_to_cmp_ordered_with_import.snap
+++ b/tests/spec/emit/snapshots/builtin_ordered_bound_lowers_to_cmp_ordered_with_import.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn id<T: Ordered>(x: T) -> T {\n  x\n}\n\nfn main() {\n  let _ = id(1)\n}\n"
+---
+package main
+
+import "cmp"
+
+func id[T cmp.Ordered](x T) T {
+	return x
+}
+
+func main() {
+	_ = id(1)
+}

--- a/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_function.snap
+++ b/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_function.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ninterface Named {\n  fn name(self) -> string\n}\n\nstruct Person {\n  value: string,\n}\n\nimpl Person {\n  fn name(self) -> string {\n    self.value\n  }\n}\n\nfn count<T: Named>(x: T) -> int {\n  let mut m: Map<T, int> = Map.new()\n  m[x] = 1\n  m.length()\n}\n\nfn main() {\n  let _ = count(Person { value: \"Ada\" })\n}\n"
+---
+package main
+
+import "fmt"
+
+type Named interface {
+	name() string
+}
+
+type Person struct {
+	value string
+}
+
+func (p Person) String() string {
+	return fmt.Sprintf("Person { value: %v }", p.value)
+}
+
+func (p Person) name() string {
+	return p.value
+}
+
+func count[T interface {
+	Named
+	comparable
+}](x T) int {
+	m := make(map[T]int)
+	m[x] = 1
+	return len(m)
+}
+
+func main() {
+	_ = count(Person{value: "Ada"})
+}

--- a/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_struct.snap
+++ b/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_struct.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ninterface Named {\n  fn name(self) -> string\n}\n\nstruct Person {\n  value: string,\n}\n\nimpl Person {\n  fn name(self) -> string {\n    self.value\n  }\n}\n\nstruct Box<T: Named> {\n  table: Map<T, int>,\n}\n\nfn main() {\n  let p = Person { value: \"Ada\" }\n  let _ = p.name()\n  let b: Box<Person> = Box { table: Map.new() }\n  let _ = b\n}\n"
+---
+package main
+
+import "fmt"
+
+type Named interface {
+	name() string
+}
+
+type Person struct {
+	value string
+}
+
+func (p Person) String() string {
+	return fmt.Sprintf("Person { value: %v }", p.value)
+}
+
+func (p Person) name() string {
+	return p.value
+}
+
+type Box[T interface {
+	Named
+	comparable
+}] struct {
+	table map[T]int
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { table: %v }", b.table)
+}
+
+func main() {
+	p := Person{value: "Ada"}
+	_ = p.name()
+	b := Box[Person]{table: make(map[Person]int)}
+	_ = b
+}

--- a/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_enum_receiver_and_make_function.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_enum_receiver_and_make_function.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nenum Holder<T> {\n  Empty,\n}\n\nimpl<T> Holder<T> {\n  fn count(self) -> int {\n    let m = Map.new<T, int>()\n    m.length()\n  }\n}\n\nfn main() {\n  let h: Holder<string> = Holder.Empty\n  let _ = h.count()\n}\n"
+---
+package main
+
+import "fmt"
+
+func MakeHolderEmpty[T comparable]() Holder[T] {
+	return Holder[T]{Tag: HolderEmpty}
+}
+
+type HolderTag int
+
+const (
+	HolderEmpty HolderTag = iota
+)
+
+type Holder[T comparable] struct {
+	Tag HolderTag
+}
+
+func (h Holder[T]) String() string {
+	switch h.Tag {
+	case HolderEmpty:
+		return "Holder.Empty"
+	default:
+		return fmt.Sprintf("Holder(%d)", h.Tag)
+	}
+}
+
+func (h Holder[T]) count() int {
+	m := make(map[T]int)
+	return len(m)
+}
+
+func main() {
+	h := MakeHolderEmpty[string]()
+	_ = h.count()
+}

--- a/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_struct_receiver.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_struct_receiver.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Box<T> {\n  value: T,\n}\n\nimpl<T> Box<T> {\n  fn count(self) -> int {\n    let m = Map.new<T, int>()\n    m.length()\n  }\n}\n\nfn main() {\n  let b = Box { value: \"a\" }\n  let _ = b.count()\n}\n"
+---
+package main
+
+import "fmt"
+
+type Box[T comparable] struct {
+	value T
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { value: %v }", b.value)
+}
+
+func (b Box[T]) count() int {
+	m := make(map[T]int)
+	return len(m)
+}
+
+func main() {
+	b := Box[string]{value: "a"}
+	_ = b.count()
+}

--- a/tests/spec/emit/snapshots/impl_method_map_key_return_constrains_struct_receiver.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_return_constrains_struct_receiver.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Box<T> {\n  value: T,\n}\n\nimpl<T> Box<T> {\n  fn make_map(self) -> Map<T, int> {\n    Map.new<T, int>()\n  }\n}\n\nfn main() {\n  let b = Box { value: \"a\" }\n  let _ = b.make_map()\n}\n"
+---
+package main
+
+import "fmt"
+
+type Box[T comparable] struct {
+	value T
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { value: %v }", b.value)
+}
+
+func (b Box[T]) make_map() map[T]int {
+	return make(map[T]int)
+}
+
+func main() {
+	b := Box[string]{value: "a"}
+	_ = b.make_map()
+}

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_enum_variant.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_enum_variant.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Table<T> = Map<T, int>\n\nenum Holder<T> {\n  Some(Table<T>),\n}\n\nfn main() {\n  let h = Holder.Some(Map.new<string, int>())\n  let _ = h\n}\n"
+---
+package main
+
+import "fmt"
+
+func MakeHolderSome[T comparable](arg0 Table[T]) Holder[T] {
+	return Holder[T]{Tag: HolderSome, Some: arg0}
+}
+
+type Table[T comparable] = map[T]int
+
+type HolderTag int
+
+const (
+	HolderSome HolderTag = iota
+)
+
+type Holder[T comparable] struct {
+	Tag  HolderTag
+	Some Table[T]
+}
+
+func (h Holder[T]) String() string {
+	switch h.Tag {
+	case HolderSome:
+		return fmt.Sprintf("Holder.Some(%v)", h.Some)
+	default:
+		return fmt.Sprintf("Holder(%d)", h.Tag)
+	}
+}
+
+func main() {
+	h := MakeHolderSome(make(map[string]int))
+	_ = h
+}

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_function_signature.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_function_signature.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Table<T> = Map<T, int>\n\nfn id<T>(table: Table<T>) -> Table<T> {\n  table\n}\n\nfn main() {\n  let t = Map.new<string, int>()\n  let _ = id(t)\n}\n"
+---
+package main
+
+type Table[T comparable] = map[T]int
+
+func id[T comparable](table Table[T]) Table[T] {
+	return table
+}
+
+func main() {
+	t := make(map[string]int)
+	_ = id(t)
+}

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_interface_method.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_interface_method.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Table<T> = Map<T, int>\n\ninterface Uses<T> {\n  fn id(self, table: Table<T>) -> Table<T>\n}\n\nfn main() {\n  let _ = 1\n}\n"
+---
+package main
+
+type Table[T comparable] = map[T]int
+
+type Uses[T comparable] interface {
+	id(Table[T]) Table[T]
+}
+
+func main() {}

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_struct_field_use.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_struct_field_use.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ntype Table<T> = Map<T, int>\n\nstruct Box<T> {\n  table: Table<T>,\n}\n\nfn main() {\n  let b = Box { table: Map.new<string, int>() }\n  let _ = b\n}\n"
+---
+package main
+
+import "fmt"
+
+type Table[T comparable] = map[T]int
+
+type Box[T comparable] struct {
+	table Table[T]
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { table: %v }", b.table)
+}
+
+func main() {
+	b := Box[string]{table: make(map[string]int)}
+	_ = b
+}

--- a/tests/spec/emit/snapshots/map_key_use_in_if_condition_constrains_generic.snap
+++ b/tests/spec/emit/snapshots/map_key_use_in_if_condition_constrains_generic.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn score<T>() -> int {\n  if Map.new<T, int>().is_empty() {\n    1\n  } else {\n    0\n  }\n}\n\nfn main() {\n  let _ = score<int>()\n}\n"
+---
+package main
+
+func score[T comparable]() int {
+	if len(make(map[T]int)) == 0 {
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	_ = score[int]()
+}

--- a/tests/spec/emit/snapshots/map_key_use_in_let_initializer_constrains_generic.snap
+++ b/tests/spec/emit/snapshots/map_key_use_in_let_initializer_constrains_generic.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn is_empty<T>() -> bool {\n  let empty = Map.new<T, int>().is_empty()\n  empty\n}\n\nfn main() {\n  let _ = is_empty<int>()\n}\n"
+---
+package main
+
+func is_empty[T comparable]() bool {
+	empty := len(make(map[T]int)) == 0
+	return empty
+}
+
+func main() {
+	_ = is_empty[int]()
+}

--- a/tests/spec/emit/snapshots/map_key_use_in_tail_expression_constrains_generic.snap
+++ b/tests/spec/emit/snapshots/map_key_use_in_tail_expression_constrains_generic.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn is_empty<T>() -> bool {\n  Map.new<T, int>().is_empty()\n}\n\nfn main() {\n  let _ = is_empty<int>()\n}\n"
+---
+package main
+
+func is_empty[T comparable]() bool {
+	return len(make(map[T]int)) == 0
+}
+
+func main() {
+	_ = is_empty[int]()
+}

--- a/tests/spec/emit/snapshots/ordered_bound_plus_map_key_use_stays_cmp_ordered.snap
+++ b/tests/spec/emit/snapshots/ordered_bound_plus_map_key_use_stays_cmp_ordered.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nfn count<T: Ordered>(x: T) -> int {\n  let mut m: Map<T, int> = Map.new()\n  m[x] = 1\n  m.length()\n}\n\nfn main() {\n  let _ = count(1)\n}\n"
+---
+package main
+
+import "cmp"
+
+func count[T cmp.Ordered](x T) int {
+	m := make(map[T]int)
+	m[x] = 1
+	return len(m)
+}
+
+func main() {
+	_ = count(1)
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2837,3 +2837,305 @@ fn run(callback: fn(int)) {}
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn impl_method_map_key_return_constrains_struct_receiver() {
+    let input = r#"
+struct Box<T> {
+  value: T,
+}
+
+impl<T> Box<T> {
+  fn make_map(self) -> Map<T, int> {
+    Map.new<T, int>()
+  }
+}
+
+fn main() {
+  let b = Box { value: "a" }
+  let _ = b.make_map()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn impl_method_map_key_body_constrains_struct_receiver() {
+    let input = r#"
+struct Box<T> {
+  value: T,
+}
+
+impl<T> Box<T> {
+  fn count(self) -> int {
+    let m = Map.new<T, int>()
+    m.length()
+  }
+}
+
+fn main() {
+  let b = Box { value: "a" }
+  let _ = b.count()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn impl_method_map_key_body_constrains_enum_receiver_and_make_function() {
+    let input = r#"
+enum Holder<T> {
+  Empty,
+}
+
+impl<T> Holder<T> {
+  fn count(self) -> int {
+    let m = Map.new<T, int>()
+    m.length()
+  }
+}
+
+fn main() {
+  let h: Holder<string> = Holder.Empty
+  let _ = h.count()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn builtin_comparable_bound_lowers_to_go_comparable() {
+    let input = r#"
+fn id<T: Comparable>(x: T) -> T {
+  x
+}
+
+fn main() {
+  let _ = id(1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn builtin_ordered_bound_lowers_to_cmp_ordered_with_import() {
+    let input = r#"
+fn id<T: Ordered>(x: T) -> T {
+  x
+}
+
+fn main() {
+  let _ = id(1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_alias_propagates_comparable_to_struct_field_use() {
+    let input = r#"
+type Table<T> = Map<T, int>
+
+struct Box<T> {
+  table: Table<T>,
+}
+
+fn main() {
+  let b = Box { table: Map.new<string, int>() }
+  let _ = b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_alias_propagates_comparable_to_function_signature() {
+    let input = r#"
+type Table<T> = Map<T, int>
+
+fn id<T>(table: Table<T>) -> Table<T> {
+  table
+}
+
+fn main() {
+  let t = Map.new<string, int>()
+  let _ = id(t)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_alias_propagates_comparable_to_enum_variant() {
+    let input = r#"
+type Table<T> = Map<T, int>
+
+enum Holder<T> {
+  Some(Table<T>),
+}
+
+fn main() {
+  let h = Holder.Some(Map.new<string, int>())
+  let _ = h
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_alias_propagates_comparable_to_interface_method() {
+    let input = r#"
+type Table<T> = Map<T, int>
+
+interface Uses<T> {
+  fn id(self, table: Table<T>) -> Table<T>
+}
+
+fn main() {
+  let _ = 1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_key_use_in_let_initializer_constrains_generic() {
+    let input = r#"
+fn is_empty<T>() -> bool {
+  let empty = Map.new<T, int>().is_empty()
+  empty
+}
+
+fn main() {
+  let _ = is_empty<int>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_key_use_in_tail_expression_constrains_generic() {
+    let input = r#"
+fn is_empty<T>() -> bool {
+  Map.new<T, int>().is_empty()
+}
+
+fn main() {
+  let _ = is_empty<int>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_key_use_in_if_condition_constrains_generic() {
+    let input = r#"
+fn score<T>() -> int {
+  if Map.new<T, int>().is_empty() {
+    1
+  } else {
+    0
+  }
+}
+
+fn main() {
+  let _ = score<int>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn explicit_named_bound_merges_with_inferred_comparable_on_function() {
+    let input = r#"
+interface Named {
+  fn name(self) -> string
+}
+
+struct Person {
+  value: string,
+}
+
+impl Person {
+  fn name(self) -> string {
+    self.value
+  }
+}
+
+fn count<T: Named>(x: T) -> int {
+  let mut m: Map<T, int> = Map.new()
+  m[x] = 1
+  m.length()
+}
+
+fn main() {
+  let _ = count(Person { value: "Ada" })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn explicit_named_bound_merges_with_inferred_comparable_on_struct() {
+    let input = r#"
+interface Named {
+  fn name(self) -> string
+}
+
+struct Person {
+  value: string,
+}
+
+impl Person {
+  fn name(self) -> string {
+    self.value
+  }
+}
+
+struct Box<T: Named> {
+  table: Map<T, int>,
+}
+
+fn main() {
+  let p = Person { value: "Ada" }
+  let _ = p.name()
+  let b: Box<Person> = Box { table: Map.new() }
+  let _ = b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn ordered_bound_plus_map_key_use_stays_cmp_ordered() {
+    let input = r#"
+fn count<T: Ordered>(x: T) -> int {
+  let mut m: Map<T, int> = Map.new()
+  m[x] = 1
+  m.length()
+}
+
+fn main() {
+  let _ = count(1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_chain_propagates_comparable_through_two_steps() {
+    let input = r#"
+type B<T> = Map<T, int>
+type A<T> = B<T>
+
+struct Box<T> {
+  table: A<T>,
+}
+
+fn main() {
+  let b = Box { table: Map.new<string, int>() }
+  let _ = b
+}
+"#;
+    assert_emit_snapshot!(input);
+}


### PR DESCRIPTION
Consolidates generic constraint inference in the emitter. Instead of each definition site gathering its parameters' Go constraints from a local scan, a single pre-emit pass computes the final constraint for every generic parameter, and rendering becomes a table lookup.

