### PR TITLE
fix: unwrap option at go any and honor tail-return hints

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -180,29 +180,29 @@ impl Emitter<'_> {
         self.emit_simple_wrapper_value(output, target, "option", &value_expr)
     }
 
-    pub(crate) fn emit_option_unwrap_to_nullable(
+    pub(crate) fn emit_option_projection(
         &mut self,
         output: &mut String,
         option_value: &str,
-        option_ty: &Type,
+        slot_hint: &str,
+        slot_ty: &str,
+        address: bool,
     ) -> String {
-        let inner_ty = option_ty.ok_type();
-        let go_inner_ty = self.go_type_as_string(&inner_ty);
-
         let opt_var = self.fresh_var(Some("opt"));
         self.declare(&opt_var);
-        let unwrapped_var = self.fresh_var(Some("unwrap"));
-        self.declare(&unwrapped_var);
+        let slot_var = self.fresh_var(Some(slot_hint));
+        self.declare(&slot_var);
 
         self.requirements.require_stdlib();
 
+        let amp = if address { "&" } else { "" };
         write_line!(output, "{} := {}", opt_var, option_value);
-        write_line!(output, "var {} {}", unwrapped_var, go_inner_ty);
+        write_line!(output, "var {} {}", slot_var, slot_ty);
         write_line!(output, "if {}.Tag == {} {{", opt_var, OPTION_SOME_TAG);
-        write_line!(output, "{} = {}.SomeVal", unwrapped_var, opt_var);
+        write_line!(output, "{} = {}{}.SomeVal", slot_var, amp, opt_var);
         output.push_str("}\n");
 
-        unwrapped_var
+        slot_var
     }
 
     /// Wrap a Go `*T` (T value-typed) into Lisette `Option<T>`.
@@ -224,32 +224,6 @@ impl Emitter<'_> {
             ptr_value
         );
         option_var
-    }
-
-    /// Bridge `Option<T>` to Go `*T` when T is not naturally nilable.
-    pub(crate) fn emit_option_unwrap_to_go_pointer(
-        &mut self,
-        output: &mut String,
-        option_value: &str,
-        option_ty: &Type,
-    ) -> String {
-        let inner_ty = option_ty.ok_type();
-        let go_inner_ty = self.go_type_as_string(&inner_ty);
-
-        let opt_var = self.fresh_var(Some("opt"));
-        self.declare(&opt_var);
-        let ptr_var = self.fresh_var(Some("ptr"));
-        self.declare(&ptr_var);
-
-        self.requirements.require_stdlib();
-
-        write_line!(output, "{} := {}", opt_var, option_value);
-        write_line!(output, "var {} *{}", ptr_var, go_inner_ty);
-        write_line!(output, "if {}.Tag == {} {{", opt_var, OPTION_SOME_TAG);
-        write_line!(output, "{} = &{}.SomeVal", ptr_var, opt_var);
-        output.push_str("}\n");
-
-        ptr_var
     }
 
     pub(crate) fn emit_collection_nullable_wrap(

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -464,7 +464,7 @@ impl Emitter<'_> {
             | (OptionShape::PointerBridged, OptionShape::PointerBridged) => {}
             _ => return None,
         }
-        if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
+        if arg.is_none_literal() {
             return Some("nil".to_string());
         }
         let value = self.emit_value(output, arg, ExpressionContext::value());
@@ -480,24 +480,29 @@ impl Emitter<'_> {
     ) -> Option<String> {
         let param_ty = effective_param_ty?;
         let arg_ty = arg.get_type();
-        if !matches!(classify_option_shape(self, &arg_ty), OptionShape::Nullable) {
-            return None;
-        }
         let check_ty = if param_ty.get_name() == Some("VarArgs") {
             param_ty.inner().unwrap_or_else(|| param_ty.clone())
         } else {
             param_ty.clone()
         };
+
+        if arg_ty.is_option() && check_ty.resolves_to_unknown() {
+            if arg.is_none_literal() {
+                return Some("nil".to_string());
+            }
+            let value = self.emit_value(output, arg, ExpressionContext::value());
+            let coercion =
+                Coercion::resolve(self, &arg_ty, &check_ty, CoercionDirection::ToGoBoundary);
+            return Some(coercion.apply(self, output, value));
+        }
+
+        if !matches!(classify_option_shape(self, &arg_ty), OptionShape::Nullable) {
+            return None;
+        }
         let needs_coercion = self
             .facts
             .as_interface(&check_ty)
-            .is_some_and(|id| go_name::is_go_import(&id))
-            || (check_ty.has_name("Unknown") && {
-                let inner = arg_ty.ok_type();
-                self.facts
-                    .as_interface(&inner)
-                    .is_some_and(|id| go_name::is_go_import(&id))
-            });
+            .is_some_and(|id| go_name::is_go_import(&id));
 
         if !needs_coercion {
             return None;
@@ -512,7 +517,7 @@ impl Emitter<'_> {
         arg: &Expression,
         arg_ty: &Type,
     ) -> String {
-        if matches!(arg, Expression::Identifier { value, .. } if value == "None") {
+        if arg.is_none_literal() {
             return "nil".to_string();
         }
         let value = self.emit_value(output, arg, ExpressionContext::value());

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -385,7 +385,7 @@ impl Emitter<'_> {
         lowered: Option<&AbiShape>,
     ) {
         if let Some(shape) = lowered
-            && self.callee_matches_lowered_shape(call_expression, shape)
+            && self.callee_matches_lowered_shape(expression, call_expression, shape)
         {
             let call = self.emit_call(output, expression, None, ExpressionContext::value());
             write_line!(output, "return {}", call);
@@ -416,26 +416,16 @@ impl Emitter<'_> {
         write_line!(output, "return {}", call);
     }
 
-    /// True when the callee's natural multi-return matches the enclosing
-    /// shape, so a tail return can forward without rewrapping.
+    /// True when the callee already has the enclosing shape, so a tail
+    /// return can forward without rewrapping.
     fn callee_matches_lowered_shape(
         &self,
+        call_expression: &Expression,
         callee: &Expression,
         enclosing_shape: &AbiShape,
     ) -> bool {
-        let inner = callee.unwrap_parens();
-        if let Expression::DotAccess {
-            expression: receiver,
-            ..
-        } = inner
-            && Self::is_go_receiver(receiver)
-        {
-            let callee_ty = callee.get_type();
-            if let Type::Function { return_type, .. } = callee_ty.unwrap_forall()
-                && let Some(strategy) = self.facts.classify_go_return_type(return_type, &[])
-            {
-                return enclosing_shape.matches_go_strategy(&strategy);
-            }
+        if let Some(strategy) = self.resolve_go_call_strategy(call_expression) {
+            return enclosing_shape.matches_go_strategy(&strategy);
         }
         if let Some(callee_shape) = self.classify_callee_abi(callee) {
             return callee_shape == *enclosing_shape;

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -73,8 +73,14 @@ impl Emitter<'_> {
             value = self.wrap_recursive_enum_field(output, value, f, &ctx);
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
-            value =
-                self.coerce_struct_field(output, value, &value_ty, field_ty.as_ref(), is_go_struct);
+            value = self.coerce_struct_field(
+                output,
+                value,
+                &f.value,
+                &value_ty,
+                field_ty.as_ref(),
+                is_go_struct,
+            );
             field_names.push(field_name);
             field_values.push(value);
         }
@@ -122,12 +128,16 @@ impl Emitter<'_> {
         &mut self,
         output: &mut String,
         mut value: String,
+        value_expr: &Expression,
         value_ty: &Type,
         field_ty: Option<&Type>,
         is_go_struct: bool,
     ) -> String {
         if is_go_struct {
             let target_ty = field_ty.unwrap_or(value_ty);
+            if value_expr.is_none_literal() && target_ty.resolves_to_unknown() {
+                return "nil".to_string();
+            }
             let coercion =
                 Coercion::resolve(self, value_ty, target_ty, CoercionDirection::ToGoBoundary);
             value = coercion.apply(self, output, value);

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -247,12 +247,25 @@ impl Emitter<'_> {
         let go_field_ty: Option<Type> = match target {
             Expression::DotAccess { expression, ty, .. }
                 if self.go_imported_shape(&expression.get_type()).is_some()
-                    && self.is_go_nullable(ty) =>
+                    && (self.is_go_nullable(ty) || ty.resolves_to_unknown()) =>
             {
                 Some(ty.clone())
             }
             _ => None,
         };
+
+        if let Some(ref target_ty) = go_field_ty
+            && target_ty.resolves_to_unknown()
+            && value.is_none_literal()
+        {
+            let target_str = if is_order_sensitive(target) {
+                self.emit_left_value_capturing(output, target, false)
+            } else {
+                self.emit_left_value(output, target)
+            };
+            write_line!(output, "{} = nil", target_str);
+            return;
+        }
 
         let rhs_staged = self.stage_composite(value, ExpressionContext::value());
         let rhs_has_setup = !rhs_staged.setup.is_empty();

--- a/crates/emit/src/types/abi_transition.rs
+++ b/crates/emit/src/types/abi_transition.rs
@@ -134,9 +134,8 @@ pub(crate) fn emit_lowered_result_return(
     }
 }
 
-/// `Tuple` shape return: when no slot is nullable, project each tuple field
-/// directly; otherwise unwrap each nullable-Option slot through
-/// `emit_option_unwrap_to_nullable` while passing the rest through raw.
+/// `Tuple` shape return: project each tuple field, unwrapping any
+/// nullable-Option slot to its bare Go nilable.
 fn emit_lowered_tuple_return(
     emitter: &mut Emitter,
     output: &mut String,
@@ -160,7 +159,10 @@ fn emit_lowered_tuple_return(
             slot_tys
                 .get(i)
                 .filter(|t| emitter.facts.is_nullable_option(t))
-                .map(|t| emitter.emit_option_unwrap_to_nullable(output, &raw, t))
+                .map(|t| {
+                    let inner = emitter.go_type_as_string(&t.ok_type());
+                    emitter.emit_option_projection(output, &raw, "unwrap", &inner, false)
+                })
                 .unwrap_or(raw)
         })
         .collect();
@@ -589,8 +591,8 @@ fn emit_lowered_partial_tail(
     true
 }
 
-/// `Some(x)`/`None` collapse to `x`/`nil`; other Option expressions go
-/// through `emit_option_unwrap_to_nullable`.
+/// `Some(x)`/`None` collapse to `x`/`nil`; other Option expressions
+/// project at runtime.
 fn emit_nullable_slot_value(
     emitter: &mut Emitter,
     output: &mut String,
@@ -613,11 +615,10 @@ fn emit_nullable_slot_value(
             Err(()) => "nil".to_string(),
         };
     }
-    if let Expression::Identifier { .. } = expression
-        && expression.as_option_constructor() == Some(Err(()))
-    {
+    if expression.is_none_literal() {
         return "nil".to_string();
     }
     let value = emitter.emit_value(output, expression, ExpressionContext::value());
-    emitter.emit_option_unwrap_to_nullable(output, &value, slot_ty)
+    let inner = emitter.go_type_as_string(&slot_ty.ok_type());
+    emitter.emit_option_projection(output, &value, "unwrap", &inner, false)
 }

--- a/crates/emit/src/types/coercion.rs
+++ b/crates/emit/src/types/coercion.rs
@@ -16,6 +16,7 @@ pub(crate) enum CoercionKind {
     UnwrapNullableOption { ty: Type },
     UnwrapPointerOption { ty: Type },
     UnwrapNullableCollection { ty: Type, elem_option_ty: Type },
+    UnwrapOptionToAny,
     WrapNullableOption { ty: Type },
     WrapPointerOption { ty: Type },
     WrapNullableCollection { ty: Type, elem_option_ty: Type },
@@ -57,13 +58,18 @@ impl Coercion {
                 format!("{}({})", type_name, value)
             }
             CoercionKind::UnwrapNullableOption { ty } => {
-                emitter.emit_option_unwrap_to_nullable(output, &value, &ty)
+                let inner = emitter.go_type_as_string(&ty.ok_type());
+                emitter.emit_option_projection(output, &value, "unwrap", &inner, false)
             }
             CoercionKind::UnwrapPointerOption { ty } => {
-                emitter.emit_option_unwrap_to_go_pointer(output, &value, &ty)
+                let ptr = format!("*{}", emitter.go_type_as_string(&ty.ok_type()));
+                emitter.emit_option_projection(output, &value, "ptr", &ptr, true)
             }
             CoercionKind::UnwrapNullableCollection { ty, elem_option_ty } => {
                 emitter.emit_collection_nullable_unwrap(output, &value, &ty, &elem_option_ty)
+            }
+            CoercionKind::UnwrapOptionToAny => {
+                emitter.emit_option_projection(output, &value, "unwrap", "any", false)
             }
             CoercionKind::WrapNullableOption { ty } => emitter
                 .emit_nil_check_option_wrap(output, &value, &ty, WrapperTarget::FreshSlot)
@@ -140,6 +146,9 @@ pub(crate) fn classify_option_shape(emitter: &Emitter, ty: &Type) -> OptionShape
 
 fn resolve_to_go(emitter: &Emitter, from: &Type, to: &Type) -> CoercionKind {
     use OptionShape::*;
+    if to.resolves_to_unknown() && from.is_option() {
+        return CoercionKind::UnwrapOptionToAny;
+    }
     match classify_option_shape(emitter, from) {
         Plain => CoercionKind::Identity,
         Nullable => CoercionKind::UnwrapNullableOption { ty: from.clone() },

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -985,6 +985,10 @@ impl Expression {
         }
     }
 
+    pub fn is_none_literal(&self) -> bool {
+        matches!(self.as_option_constructor(), Some(Err(())))
+    }
+
     pub fn as_result_constructor(&self) -> Option<std::result::Result<(), ()>> {
         let variant = match self {
             Expression::Identifier { value, .. } => Some(value.as_str()),

--- a/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
+++ b/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
@@ -14,9 +14,9 @@ func main() {
 	obj := ast.Object{
 		Kind: ast.Bad,
 		Name: "x",
-		Decl: lisette.MakeOptionNone[any](),
-		Data: lisette.MakeOptionNone[any](),
-		Type: lisette.MakeOptionNone[any](),
+		Decl: nil,
+		Data: nil,
+		Type: nil,
 	}
 	objects := make(map[string]lisette.Option[*ast.Object])
 	objects["present"] = lisette.MakeOptionSome(&obj)

--- a/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
+++ b/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
@@ -26,6 +26,11 @@ func main() {
 	option_4 := lisette.OptionFromNilable[*debug.Module](raw_3, raw_3 == nil)
 	r := option_4
 	raw_1 := 3
-	fmt.Println(r)
+	opt_5 := r
+	var unwrap_6 any
+	if opt_5.Tag == lisette.OptionSome {
+		unwrap_6 = opt_5.SomeVal
+	}
+	fmt.Println(unwrap_6)
 	fmt.Println(raw_1)
 }

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -684,6 +684,48 @@ pub fn Find(s: string, substr: string) -> Option<int>
 }
 
 #[test]
+fn sentinel_hinted_tail_call_wraps_in_wrapper_fn() {
+    let input = r#"
+import "go:example.com/idx"
+
+fn find(haystack: string, needle: string) -> Option<int> {
+  idx.Find(haystack, needle)
+}
+
+fn main() {
+  let _ = find("hello", "z")
+}
+"#;
+    let typedef = r#"
+#[go(sentinel_minus_one)]
+pub fn Find(s: string, substr: string) -> Option<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
+}
+
+#[test]
+fn comma_ok_hinted_nullable_tail_call_wraps_in_wrapper_fn() {
+    let input = r#"
+import "go:example.com/info"
+
+fn build_info() -> Option<Ref<info.BuildInfo>> {
+  info.Read()
+}
+
+fn main() {
+  let _ = build_info()
+}
+"#;
+    let typedef = r#"
+#[go(comma_ok)]
+pub fn Read() -> Option<Ref<BuildInfo>>
+
+pub struct BuildInfo {}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/info", typedef)]);
+}
+
+#[test]
 fn generic_named_field_struct_constructor_inserts_adapter() {
     let input = r#"
 struct Entry { name: string }

--- a/tests/spec/emit/snapshots/comma_ok_hinted_nullable_tail_call_wraps_in_wrapper_fn.snap
+++ b/tests/spec/emit/snapshots/comma_ok_hinted_nullable_tail_call_wraps_in_wrapper_fn.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/info\"\n\nfn build_info() -> Option<Ref<info.BuildInfo>> {\n  info.Read()\n}\n\nfn main() {\n  let _ = build_info()\n}\n"
+---
+package main
+
+import (
+	"example.com/info"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func build_info() *info.BuildInfo {
+	ret_1, ret_2 := info.Read()
+	var option_3 lisette.Option[*info.BuildInfo]
+	if ret_2 && ret_1 != nil {
+		option_3 = lisette.MakeOptionSome[*info.BuildInfo](ret_1)
+	} else {
+		option_3 = lisette.MakeOptionNone[*info.BuildInfo]()
+	}
+	if option_3.Tag == lisette.OptionSome {
+		return option_3.SomeVal
+	}
+	return nil
+}
+
+func main() {
+	build_info()
+}

--- a/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
@@ -15,9 +15,9 @@ func main() {
 	obj := ast.Object{
 		Kind: ast.Bad,
 		Name: "x",
-		Decl: lisette.MakeOptionNone[any](),
-		Data: lisette.MakeOptionNone[any](),
-		Type: lisette.MakeOptionNone[any](),
+		Decl: nil,
+		Data: nil,
+		Type: nil,
 	}
 	objects := make(map[string]lisette.Option[*ast.Object])
 	objects["present"] = lisette.MakeOptionSome(&obj)

--- a/tests/spec/emit/snapshots/option_assigned_to_go_unknown_field_unwraps_to_any.snap
+++ b/tests/spec/emit/snapshots/option_assigned_to_go_unknown_field_unwraps_to_any.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nimport \"go:example.com/dyn\"\n\nfn main() {\n  let mut obj = dyn.Bag { Decl: \"\", Data: None }\n  obj.Decl = None\n  let _ = obj\n}\n"
+---
+package main
+
+import (
+	"example.com/dyn"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	obj := dyn.Bag{
+		Decl: "",
+		Data: nil,
+	}
+	obj.Decl = nil
+	_ = obj
+}

--- a/tests/spec/emit/snapshots/option_in_go_unknown_call_arg_unwraps_to_any.snap
+++ b/tests/spec/emit/snapshots/option_in_go_unknown_call_arg_unwraps_to_any.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nimport \"go:example.com/dyn\"\n\nfn main() {\n  let _ = dyn.Store(\"k\", None)\n  let _ = dyn.Store(\"k\", Some(1))\n}\n"
+---
+package main
+
+import (
+	"example.com/dyn"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	_ = dyn.Store("k", nil)
+	opt_1 := lisette.MakeOptionSome(1)
+	var unwrap_2 any
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	_ = dyn.Store("k", unwrap_2)
+}

--- a/tests/spec/emit/snapshots/option_in_go_unknown_struct_field_unwraps_to_any.snap
+++ b/tests/spec/emit/snapshots/option_in_go_unknown_struct_field_unwraps_to_any.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nimport \"go:example.com/dyn\"\n\nfn main() {\n  let _ = dyn.Bag {\n    Decl: Some(\"decl\"),\n    Data: None,\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/dyn"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	opt_1 := lisette.MakeOptionSome("decl")
+	var unwrap_2 any
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	_ = dyn.Bag{
+		Decl: unwrap_2,
+		Data: nil,
+	}
+}

--- a/tests/spec/emit/snapshots/sentinel_hinted_tail_call_wraps_in_wrapper_fn.snap
+++ b/tests/spec/emit/snapshots/sentinel_hinted_tail_call_wraps_in_wrapper_fn.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: "input: \nimport \"go:example.com/idx\"\n\nfn find(haystack: string, needle: string) -> Option<int> {\n  idx.Find(haystack, needle)\n}\n\nfn main() {\n  let _ = find(\"hello\", \"z\")\n}\n"
+---
+package main
+
+import (
+	"example.com/idx"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func find(haystack, needle string) (int, bool) {
+	ret_1 := idx.Find(haystack, needle)
+	option_2 := lisette.OptionFromCommaOk[int](ret_1, ret_1 != -1)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return *new(int), false
+}
+
+func main() {
+	find("hello", "z")
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1,4 +1,5 @@
 use crate::assert_emit_snapshot;
+use crate::assert_emit_snapshot_with_go_typedefs;
 
 #[test]
 fn simple_struct_definition() {
@@ -2828,6 +2829,63 @@ fn unknown_return_in_alias_emits_any() {
 type Cb = fn() -> Unknown;
 "#;
     assert_emit_snapshot!(input);
+}
+
+#[test]
+fn option_in_go_unknown_struct_field_unwraps_to_any() {
+    let input = r#"
+import "go:example.com/dyn"
+
+fn main() {
+  let _ = dyn.Bag {
+    Decl: Some("decl"),
+    Data: None,
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Bag {
+  pub Decl: Unknown,
+  pub Data: Unknown,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/dyn", typedef)]);
+}
+
+#[test]
+fn option_assigned_to_go_unknown_field_unwraps_to_any() {
+    let input = r#"
+import "go:example.com/dyn"
+
+fn main() {
+  let mut obj = dyn.Bag { Decl: "", Data: None }
+  obj.Decl = None
+  let _ = obj
+}
+"#;
+    let typedef = r#"
+pub struct Bag {
+  pub Decl: Unknown,
+  pub Data: Unknown,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/dyn", typedef)]);
+}
+
+#[test]
+fn option_in_go_unknown_call_arg_unwraps_to_any() {
+    let input = r#"
+import "go:example.com/dyn"
+
+fn main() {
+  let _ = dyn.Store("k", None)
+  let _ = dyn.Store("k", Some(1))
+}
+"#;
+    let typedef = r#"
+pub fn Store(key: string, value: Unknown) -> int
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/dyn", typedef)]);
 }
 
 #[test]


### PR DESCRIPTION
`Some(x)` and `None` flowing into a Go `any` slot now lower to the raw payload or `nil`, not Lisette's tagged `Option` wrapper. Also, thin wrappers around hinted Go stdlib calls like `strings.Index` (sentinel return) and `debug.ReadBuildInfo` (nilable comma-ok return) now compile. The tail call is re-wrapped instead of forwarded as the bare Go return, which previously produced a return-shape mismatch.