### PR TITLE
proposal: add relative file paths to lisette errors

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -212,6 +212,88 @@ impl Loader for LocalFileSystem {
 mod tests {
     use super::*;
     use std::fs as stdfs;
+    use syntax::program::File;
+
+    fn make_file(name: &str) -> File {
+        File::new(".", name, "", vec![], 0)
+    }
+
+    #[test]
+    fn go_filename_plain() {
+        assert_eq!(make_file("main.lis").go_filename(), "main.go");
+    }
+
+    #[test]
+    fn go_filename_strips_path_prefix() {
+        assert_eq!(make_file("src/main.lis").go_filename(), "main.go");
+    }
+
+    #[test]
+    fn go_filename_nested_path() {
+        assert_eq!(
+            make_file("src/utils/helpers.lis").go_filename(),
+            "helpers.go"
+        );
+    }
+
+    #[test]
+    fn plain_path_inside_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("src/main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn file_at_cwd_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("main.lis"), Some(cwd)),
+            Some("main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_leading_dot_slash() {
+        // Simulates Path::new(".").join("src/main.lis") → "./src/main.lis"
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("./src/main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_mid_path_dot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("src/./main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn path_outside_cwd_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        assert_eq!(
+            relative_to_cwd_with(&other.path().join("main.lis"), Some(tmp.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_cwd_returns_none() {
+        assert_eq!(
+            relative_to_cwd_with(Path::new("/any/path/main.lis"), None),
+            None
+        );
+    }
 
     fn write_file(dir: &Path, name: &str, content: &str) -> PathBuf {
         let path = dir.join(name);

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::OsStr,
     fs::{File, read_dir, read_to_string, remove_file},
     io::{self, BufRead, BufReader},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use semantics::loader::{Files, Loader};
@@ -11,6 +11,7 @@ use semantics::store::ENTRY_MODULE_ID;
 
 pub struct LocalFileSystem {
     search_paths: Vec<PathBuf>,
+    display_cwd: Option<PathBuf>,
 }
 
 impl LocalFileSystem {
@@ -22,6 +23,7 @@ impl LocalFileSystem {
 
         Self {
             search_paths: vec![current_path, stdlib_path],
+            display_cwd: std::env::current_dir().ok(),
         }
     }
 
@@ -36,10 +38,18 @@ impl LocalFileSystem {
             let path = entry.path();
 
             if path.extension().is_some_and(|e| e == "lis")
-                && let Some(filename) = path.file_name().and_then(|s| s.to_str())
                 && let Ok(source) = read_to_string(&path)
             {
-                files.insert(filename.to_string(), source);
+                let key =
+                    relative_to_cwd_with(&path, self.display_cwd.as_deref()).unwrap_or_else(|| {
+                        path.file_name()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or_default()
+                            .to_string()
+                    });
+                if !key.is_empty() {
+                    files.insert(key, source);
+                }
             }
         }
 
@@ -47,10 +57,39 @@ impl LocalFileSystem {
     }
 }
 
-/// Translate module ID to filesystem path (entry module maps to current directory)
+/// Returns path relative to the cwd, with bare "." components stripped.
+/// Returns None if the cwd is unknown or the path lies outside it.
+pub fn relative_to_cwd(path: &Path) -> Option<String> {
+    relative_to_cwd_with(path, std::env::current_dir().ok().as_deref())
+}
+
+fn relative_to_cwd_with(path: &Path, cwd: Option<&Path>) -> Option<String> {
+    let cwd = cwd?;
+    let full = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let rel = full.strip_prefix(cwd).ok()?;
+    // Strip bare "." path components ("./src/main.lis" becomes "src/main.lis").
+    let normalized: PathBuf = rel
+        .components()
+        .filter(|c| *c != Component::CurDir)
+        .collect();
+    let s = normalized.to_str()?;
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Translate module ID to filesystem path.  The entry module maps to the
+/// search-path root itself (empty string) so that search_path.join("")
+/// equals search_path without introducing a trailing ./ component.
 fn to_fs_path(folder_name: &str) -> &str {
     if folder_name == ENTRY_MODULE_ID {
-        "."
+        ""
     } else {
         folder_name
     }
@@ -152,9 +191,14 @@ pub fn collect_lis_filepaths_recursive(dir: &Path) -> Vec<PathBuf> {
 
 impl Loader for LocalFileSystem {
     fn scan_folder(&self, folder_name: &str) -> Files {
-        let folder_name = to_fs_path(folder_name);
+        let fs_name = to_fs_path(folder_name);
         for search_path in &self.search_paths {
-            let folder_path = search_path.join(folder_name);
+            let folder_path = if fs_name.is_empty() {
+                search_path.clone()
+            } else {
+                search_path.join(fs_name)
+            };
+
             let files = self.collect_files(&folder_path);
 
             if !files.is_empty() {

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -47,9 +47,7 @@ impl LocalFileSystem {
                             .unwrap_or_default()
                             .to_string()
                     });
-                if !key.is_empty() {
-                    files.insert(key, source);
-                }
+                files.insert(key, source);
             }
         }
 
@@ -84,9 +82,9 @@ fn relative_to_cwd_with(path: &Path, cwd: Option<&Path>) -> Option<String> {
     }
 }
 
-/// Translate module ID to filesystem path.  The entry module maps to the
-/// search-path root itself (empty string) so that search_path.join("")
-/// equals search_path without introducing a trailing ./ component.
+/// Translate module ID to filesystem path.  The entry module returns an empty
+/// string so that `scan_folder` uses the search path directly rather than
+/// joining with `"."`, which would introduce spurious `./` components.
 fn to_fs_path(folder_name: &str) -> &str {
     if folder_name == ENTRY_MODULE_ID {
         ""

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -8,7 +8,7 @@ use crate::go_cli;
 use crate::lock::acquire_target_lock;
 use crate::workspace::WorkspaceBindgen;
 use diagnostics::render::{self, Filter};
-use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
+use lisette::fs::{LocalFileSystem, prune_orphan_go_files, relative_to_cwd};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 
 pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
@@ -110,12 +110,13 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
         }
     };
 
-    let display_path = std::env::current_dir()
-        .ok()
-        .and_then(|cwd| main_lis.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
-        .unwrap_or_else(|| main_lis.to_path_buf());
-
-    let filename = "main.lis";
+    let filename = relative_to_cwd(&main_lis).unwrap_or_else(|| {
+        main_lis
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("main.lis")
+            .to_string()
+    });
 
     let project_name = go_module_name.rsplit('/').next().unwrap_or(go_module_name);
 
@@ -146,9 +147,8 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
     let source_dir = main_lis.parent().and_then(|p| p.to_str()).unwrap_or(".");
     let local_fs = LocalFileSystem::new(source_dir);
 
-    let result = compile(&main_lis_source, filename, &compile_config, &local_fs);
+    let result = compile(&main_lis_source, &filename, &compile_config, &local_fs);
 
-    let filename = display_path.display().to_string();
     let filter = Filter {
         errors_only: false,
         warnings_only: false,

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use deps::TypedefLocator;
 use diagnostics::render::{self, Filter};
-use lisette::fs::LocalFileSystem;
+use lisette::fs::{LocalFileSystem, relative_to_cwd};
 use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
 use crate::cli_error;
@@ -161,10 +161,13 @@ fn compile_single_file(
         }
     };
 
-    let filename = file_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("main.lis");
+    let filename = relative_to_cwd(file_path).unwrap_or_else(|| {
+        file_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("main.lis")
+            .to_string()
+    });
 
     let config = CompileConfig {
         target_phase: CompilePhase::Check,
@@ -179,10 +182,9 @@ fn compile_single_file(
     let working_dir = file_path.parent().and_then(|p| p.to_str()).unwrap_or(".");
 
     let fs = LocalFileSystem::new(working_dir);
-    let result = compile(&source, filename, &config, &fs);
-    let display_filename = file_path.display().to_string();
+    let result = compile(&source, &filename, &config, &fs);
 
-    Some((result, source, display_filename))
+    Some((result, source, filename))
 }
 
 fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -239,11 +239,6 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         return 1;
     }
 
-    let filename = file_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("main.lis");
-
     let compile_config = CompileConfig {
         target_phase: CompilePhase::Emit,
         go_module: "lis-standalone".to_string(),
@@ -262,7 +257,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
     }
 
     let no_loader = NoLoader;
-    let result = compile(&source, filename, &compile_config, &no_loader);
+    let result = compile(&source, file, &compile_config, &no_loader);
 
     let filter = Filter {
         errors_only: false,

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -236,7 +236,7 @@ impl<'a> Emitter<'a> {
                 .iter()
                 .map(|(file_id, file)| {
                     let path = if file.module_id == analysis.entry_module_id {
-                        format!("src/{}", file.name)
+                        file.name.clone()
                     } else {
                         format!("{}/{}", file.module_id, file.name)
                     };

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -210,7 +210,11 @@ fn all_go_outputs_exist(module_id: &str, cached_files: &[CachedFile], project_ro
 
     for cached_file in cached_files {
         if cached_file.name.ends_with(".lis") && !cached_file.name.ends_with(".d.lis") {
-            let go_name = cached_file.name.replace(".lis", ".go");
+            let go_name = std::path::Path::new(&cached_file.name)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&cached_file.name)
+                .replace(".lis", ".go");
             if !target_dir.join(&go_name).exists() {
                 return false;
             }

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -98,7 +98,11 @@ impl File {
     }
 
     pub fn go_filename(&self) -> String {
-        std::path::Path::new(&self.name)
+        let base = std::path::Path::new(&self.name)
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new(&self.name));
+
+        std::path::Path::new(base)
             .with_extension("go")
             .display()
             .to_string()

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -100,7 +100,7 @@ impl File {
     pub fn go_filename(&self) -> String {
         let base = std::path::Path::new(&self.name)
             .file_name()
-            .unwrap_or_else(|| std::ffi::OsStr::new(&self.name));
+            .unwrap_or_default();
 
         std::path::Path::new(base)
             .with_extension("go")


### PR DESCRIPTION
This change adds relative file paths to Lisette compiler errors.

Currently, the compiler only shows the file name in compile errors, which causes a few problems:

1) If there are multiple files with the same name, for example `foo/utils.lis` and `bar/utils.lis`, the error output only shows `utils.lis`. This makes it unclear which file the error actually comes from.

2) This also improves support for external tooling, such as Vim quickfix list[1] and likely other editors as well. Since the current error output does not include a relative path, editor integrations often require additional setup to support jumping to errors correctly (if they can support it at all).

Example of the updated error output:

Currently:
```
[error] Unclosed block
╭─[utils.lis:1:25]
│ pub fn func() -> string {
·                         ┬
·                         ╰── opening brace here
│   "func"
╰────
help: Add a closing `}` · code: [parse.unclosed_block]
```
After:
```
[error] Unclosed block
╭─[src/bar/utils.lis:1:25]
│ pub fn func() -> string {
·                         ┬
·                         ╰── opening brace here
│   "func"
╰────
help: Add a closing `}` · code: [parse.unclosed_block]
```

[1] If this change is accepted, I can also open a follow-up PR to improve Vim parsing support for Lisette errors. The current error format is excellent for humans, but a bit tricky for tools to parse robustly.

PS. Congrats for 1K stars 🥳