### PR TITLE
fix: qualify imported enum in variant-not-found diagnostic

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -739,8 +739,25 @@ impl TaskState<'_> {
         };
         let variants = store.variants_of(&id)?;
         let variant_names: Vec<String> = variants.iter().map(|v| v.name.to_string()).collect();
-        let simple_name = unqualified_name(&id);
-        Some((simple_name.to_string(), variant_names))
+        let display_name = self.enum_display_name(store, id.as_str());
+        Some((display_name, variant_names))
+    }
+
+    fn enum_display_name(&self, store: &Store, id: &str) -> String {
+        let simple = unqualified_name(id);
+        let Some(module_id) = store.module_for_qualified_name(id) else {
+            return simple.to_string();
+        };
+        if module_id == self.cursor.module_id || self.imports.unprefixed_imports.contains(module_id)
+        {
+            return simple.to_string();
+        }
+        for (prefix, imported_module_id) in &self.imports.prefix_to_module {
+            if imported_module_id == module_id {
+                return format!("{}.{}", prefix, simple);
+            }
+        }
+        simple.to_string()
     }
 
     /// Tries to resolve an identifier like `api.UIEvent.Click` through a type alias.

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_close_match.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_close_match.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·         ╰── not found
  8 │   }
    ╰────
-  help: Did you mean `Shape.Circle`? · code: [resolve.variant_not_found]
+  help: Did you mean `shapes.Shape.Circle`? · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_unqualified.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_unqualified.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·         ╰── not found
  8 │   }
    ╰────
-  help: Use `Shape.Circle` to match this variant · code: [resolve.variant_not_found]
+  help: Use `shapes.Shape.Circle` to match this variant · code: [resolve.variant_not_found]


### PR DESCRIPTION
Fix #439