### PR TITLE
chore: release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.8](https://github.com/ivov/lisette/compare/lisette-v0.2.7...lisette-v0.2.8) - 2026-05-19
+
+- fix: adapt lowered fn arg shape at generic call boundary [#459](https://github.com/ivov/lisette/pull/459) [`ee69def`](https://github.com/ivov/lisette/commit/ee69deff9510071418c1ac66c104606af0507f36)
+- fix: wrap go interface returns as option [#458](https://github.com/ivov/lisette/pull/458) [`79892a4`](https://github.com/ivov/lisette/commit/79892a426ed11a59df43329a0470214dfdf85e02)
+- ci: require IDE extension version bump on grammar change [#457](https://github.com/ivov/lisette/pull/457) [`d6613a0`](https://github.com/ivov/lisette/commit/d6613a072757418585868cf5a65ec10fd3bb6a60)
+- ci: add tree-sitter drift and test checks [#454](https://github.com/ivov/lisette/pull/454) [`5469274`](https://github.com/ivov/lisette/commit/5469274bebe8d452a8a10ed19233a55bd6593f1e)
+- fix: bitwise tokens missing from tree-sitter parser [#453](https://github.com/ivov/lisette/pull/453) [`1748f26`](https://github.com/ivov/lisette/commit/1748f26d221c5f2f10f86cb3f7e7bfb373d9e7dc)
+- fix: align Go interface and impl pointer-return nilability [#451](https://github.com/ivov/lisette/pull/451) [`dba4c74`](https://github.com/ivov/lisette/commit/dba4c741a38086fbae97d85e6f9f0fc170df3732)
+- fix: terminate generics parser at eof [#450](https://github.com/ivov/lisette/pull/450) [`6a8d718`](https://github.com/ivov/lisette/commit/6a8d7184ec1646d067a10819742a81fc5c0ebe7f)
+- chore: rebuild playground [#446](https://github.com/ivov/lisette/pull/446) [`126dd8e`](https://github.com/ivov/lisette/commit/126dd8e56aa62c66b6580a4b0536e8e3c30fb3c6)
+- fix: allow mutually recursive function-type aliases [#445](https://github.com/ivov/lisette/pull/445) [`14ac9f4`](https://github.com/ivov/lisette/commit/14ac9f40e7a904ae1436aae970ca46397dffaa71)
+- ci: guard release workflows from running on forks [#444](https://github.com/ivov/lisette/pull/444) [`7f9c583`](https://github.com/ivov/lisette/commit/7f9c58357fbdc4e882bc1c7c67dd6d8774554642)
+- feat: bitwise operators [#382](https://github.com/ivov/lisette/pull/382) [`bb5de34`](https://github.com/ivov/lisette/commit/bb5de3434223f0ef4fa62cabf7ed11519c87dfdc)
+- fix: qualify imported enum in variant-not-found diagnostic [#442](https://github.com/ivov/lisette/pull/442) [`4a02f60`](https://github.com/ivov/lisette/commit/4a02f60db605731729688f21644fd8b8c8754033)
 ## [0.2.7](https://github.com/ivov/lisette/compare/lisette-v0.2.6...lisette-v0.2.7) - 2026-05-17
 
 - fix: unwrap option at go any and honor tail-return hints [#437](https://github.com/ivov/lisette/pull/437) [`afcf72c`](https://github.com/ivov/lisette/commit/afcf72ccfc6258e0c986de233cb299485c161f05)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bincode",
  "ecow",
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.7"
+version = "0.2.8"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.7", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.7", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.7", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.7", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.8", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.8", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.8", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.8", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.7", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.7", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.8", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.8", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.7", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.7", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.7", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.7", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.8 (upcoming)

- fix: adapt lowered fn arg shape at generic call boundary [#459](https://github.com/ivov/lisette/pull/459) [`ee69def`](https://github.com/ivov/lisette/commit/ee69deff9510071418c1ac66c104606af0507f36)
- fix: wrap go interface returns as option [#458](https://github.com/ivov/lisette/pull/458) [`79892a4`](https://github.com/ivov/lisette/commit/79892a426ed11a59df43329a0470214dfdf85e02)
- ci: require IDE extension version bump on grammar change [#457](https://github.com/ivov/lisette/pull/457) [`d6613a0`](https://github.com/ivov/lisette/commit/d6613a072757418585868cf5a65ec10fd3bb6a60)
- ci: add tree-sitter drift and test checks [#454](https://github.com/ivov/lisette/pull/454) [`5469274`](https://github.com/ivov/lisette/commit/5469274bebe8d452a8a10ed19233a55bd6593f1e)
- fix: bitwise tokens missing from tree-sitter parser [#453](https://github.com/ivov/lisette/pull/453) [`1748f26`](https://github.com/ivov/lisette/commit/1748f26d221c5f2f10f86cb3f7e7bfb373d9e7dc)
- fix: align Go interface and impl pointer-return nilability [#451](https://github.com/ivov/lisette/pull/451) [`dba4c74`](https://github.com/ivov/lisette/commit/dba4c741a38086fbae97d85e6f9f0fc170df3732)
- fix: terminate generics parser at eof [#450](https://github.com/ivov/lisette/pull/450) [`6a8d718`](https://github.com/ivov/lisette/commit/6a8d7184ec1646d067a10819742a81fc5c0ebe7f)
- chore: rebuild playground [#446](https://github.com/ivov/lisette/pull/446) [`126dd8e`](https://github.com/ivov/lisette/commit/126dd8e56aa62c66b6580a4b0536e8e3c30fb3c6)
- fix: allow mutually recursive function-type aliases [#445](https://github.com/ivov/lisette/pull/445) [`14ac9f4`](https://github.com/ivov/lisette/commit/14ac9f40e7a904ae1436aae970ca46397dffaa71)
- ci: guard release workflows from running on forks [#444](https://github.com/ivov/lisette/pull/444) [`7f9c583`](https://github.com/ivov/lisette/commit/7f9c58357fbdc4e882bc1c7c67dd6d8774554642)
- feat: bitwise operators [#382](https://github.com/ivov/lisette/pull/382) [`bb5de34`](https://github.com/ivov/lisette/commit/bb5de3434223f0ef4fa62cabf7ed11519c87dfdc)
- fix: qualify imported enum in variant-not-found diagnostic [#442](https://github.com/ivov/lisette/pull/442) [`4a02f60`](https://github.com/ivov/lisette/commit/4a02f60db605731729688f21644fd8b8c8754033)
