### PR TITLE
ci: guard release workflows from running on forks

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   prepare:
     name: Prepare release PR
-    if: "${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    if: "${{ github.repository == 'ivov/lisette' && (github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   publish:
     name: Publish prelude, bindgen, compiler
-    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: release') }}"
+    if: "${{ github.repository == 'ivov/lisette' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: release')) }}"
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   publish:
+    if: github.repository == 'ivov/lisette'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Prevent [this issue](https://github.com/zKiwiko/lisette/actions/runs/26057981837/job/76610749910), for better contributor experience.