### PR TITLE
fix: allow mutually recursive function-type aliases

### DIFF
--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -663,13 +663,14 @@ impl TaskState<'_> {
         self.validate_generic_bounds(&*store, generics, span);
 
         let body_ty = self.convert_to_type(&*store, annotation, span);
+        let is_function_body = matches!(body_ty, Type::Function { .. });
 
-        if self.is_alias_body_circular(&*store, &body_ty, &qualified_name) {
+        if !is_function_body && self.is_alias_body_circular(&*store, &body_ty, &qualified_name) {
             self.sink
                 .push(diagnostics::infer::circular_type_alias(name, *span));
         }
 
-        let body_ty = if matches!(body_ty, Type::Function { .. }) {
+        let body_ty = if is_function_body {
             let params: Vec<Type> = generics
                 .iter()
                 .map(|g| Type::Parameter(g.name.clone()))

--- a/tests/spec/infer/basics.rs
+++ b/tests/spec/infer/basics.rs
@@ -1030,6 +1030,21 @@ fn circular_type_alias_result_param() {
 }
 
 #[test]
+fn circular_type_alias_mutual_function_allowed() {
+    infer(
+        r#"
+    type A = fn(B) -> ()
+    type B = fn(A) -> ()
+
+    fn test(a: A) -> A {
+      return a;
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn reference_to_int() {
     infer(
         r#"


### PR DESCRIPTION
Function-typed alias bodies now skip the circular-alias check, so mutually recursive bindings like the ones bindgen emits for `ebitenui/input` now load.

```rs
pub type A = fn(B) -> ()
pub type B = fn(A) -> ()
```

Addresses the first half of #438.