### PR TITLE
fix: terminate generics parser at eof

### DIFF
--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -167,7 +167,7 @@ impl<'source> Parser<'source> {
 
         let mut generics = vec![];
 
-        while !self.is_right_angle_like() {
+        while !self.is_right_angle_like() && !self.at_eof() {
             generics.push(self.parse_generic());
             self.expect_comma_or(RightAngleBracket);
         }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -862,6 +862,30 @@ fn f<T: Display +>() {}
 }
 
 #[test]
+fn parse_error_function_unclosed_generic_at_eof() {
+    let input = "fn f<";
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_error_struct_unclosed_generic_at_eof() {
+    let input = "struct S<";
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_error_type_alias_unclosed_generic_at_eof() {
+    let input = "type T<";
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_error_impl_unclosed_generic_at_eof() {
+    let input = "impl<";
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_error_local_enum_in_function() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/parse_error_function_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_function_unclosed_generic_at_eof.snap
@@ -1,0 +1,8 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:1:6]
+ 1 │ fn f<
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_impl_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_impl_unclosed_generic_at_eof.snap
@@ -1,0 +1,8 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:1:6]
+ 1 │ impl<
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_struct_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_struct_unclosed_generic_at_eof.snap
@@ -1,0 +1,8 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:1:10]
+ 1 │ struct S<
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_type_alias_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_type_alias_unclosed_generic_at_eof.snap
@@ -1,0 +1,8 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:1:8]
+ 1 │ type T<
+   ╰────
+  help:  · code: [parse.unexpected_token]


### PR DESCRIPTION
The parser was looping allocating empty generic parameters when an unclosed `<` reached EOF inside a `fn`, `struct`, `type`, `impl`, or `interface` definition, eventually OOMing. The loop in `parse_generics` now exits at EOF, surfacing a syntax error instead.

```rs
fn f<
```

Follow-up to #382

Fix #448 
Fix #449