### PR TITLE
fix: adapt lowered fn arg shape at generic call boundary

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -5,12 +5,14 @@ use crate::expressions::context::ExpressionContext;
 use crate::expressions::emission::EmittedExpression;
 use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
+use crate::types::abi_transition::emit_fn_arg_shape_adapter;
 use crate::types::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
 use syntax::ast::{Annotation, Expression};
 use syntax::types::Type;
 
-struct CalleeAnalysis {
+struct CalleeAnalysis<'a> {
     fn_param_types: Vec<Type>,
+    generic_fn_param_types: Option<&'a [Type]>,
     pointer_indices: HashSet<usize>,
     is_go_call: bool,
     is_prelude_dispatch: bool,
@@ -18,6 +20,7 @@ struct CalleeAnalysis {
 
 struct CallArgsContext<'a> {
     fn_param_types: &'a [Type],
+    generic_fn_param_types: Option<&'a [Type]>,
     pointer_indices: &'a HashSet<usize>,
     is_go_call: bool,
     /// Suppresses the Go-fn identity short-circuit on fn-typed params
@@ -102,7 +105,7 @@ fn collapse_fmt_print(
     call_str
 }
 
-impl Emitter<'_> {
+impl<'a> Emitter<'a> {
     pub(super) fn emit_regular_call(
         &mut self,
         output: &mut String,
@@ -152,6 +155,7 @@ impl Emitter<'_> {
         let analysis = self.analyze_callee(function);
         let args_ctx = CallArgsContext {
             fn_param_types: &analysis.fn_param_types,
+            generic_fn_param_types: analysis.generic_fn_param_types,
             pointer_indices: &analysis.pointer_indices,
             is_go_call: analysis.is_go_call,
             is_prelude_dispatch: analysis.is_prelude_dispatch,
@@ -177,12 +181,15 @@ impl Emitter<'_> {
         call_str
     }
 
-    fn analyze_callee(&mut self, function: &Expression) -> CalleeAnalysis {
+    fn analyze_callee(&mut self, function: &Expression) -> CalleeAnalysis<'a> {
         let pointer_indices = self.get_recursive_enum_pointer_indices(function);
-        let fn_param_types: Vec<Type> = match function.get_type().unwrap_forall() {
-            Type::Function { params, .. } => params.clone(),
-            _ => vec![],
-        };
+        let fn_param_types: Vec<Type> = function
+            .get_type()
+            .unwrap_forall()
+            .get_function_params()
+            .map(<[Type]>::to_vec)
+            .unwrap_or_default();
+        let generic_fn_param_types = self.callee_generic_param_types(function);
         let (is_go_call, is_prelude_dispatch) = match function.unwrap_parens() {
             Expression::DotAccess { expression, .. } => {
                 let is_prelude = matches!(
@@ -198,10 +205,26 @@ impl Emitter<'_> {
         };
         CalleeAnalysis {
             fn_param_types,
+            generic_fn_param_types,
             pointer_indices,
             is_go_call,
             is_prelude_dispatch,
         }
+    }
+
+    /// Callee's declared param types from its definition, before instantiation.
+    fn callee_generic_param_types(&self, function: &Expression) -> Option<&'a [Type]> {
+        let Expression::Identifier {
+            qualified: Some(q), ..
+        } = function.unwrap_parens()
+        else {
+            return None;
+        };
+        self.facts
+            .definition(q.as_str())?
+            .ty()
+            .unwrap_forall()
+            .get_function_params()
     }
 
     /// Materialize a Go array-returning call into a variable and reslice it,
@@ -276,7 +299,7 @@ impl Emitter<'_> {
         args: &[Expression],
         ctx: &CallArgsContext<'_>,
     ) -> Vec<String> {
-        let stages: Vec<EmittedExpression> = args
+        let mut stages: Vec<EmittedExpression> = args
             .iter()
             .enumerate()
             .map(|(i, arg)| {
@@ -285,6 +308,22 @@ impl Emitter<'_> {
                 EmittedExpression::new(setup, value, arg)
             })
             .collect();
+
+        if let Some(spread) = ctx.spread
+            && let Some(adapter_stage) = self.try_emit_variadic_spread_adapter(spread, ctx)
+        {
+            stages.push(adapter_stage);
+            let spread_idx = stages.len() - 1;
+            let mut values = self.sequence(output, stages, "_arg");
+            self.finalize_spread_stage(
+                &mut values,
+                spread_idx,
+                ctx.wrap_spread_to_any,
+                ctx.combine_variadic.as_ref().cloned(),
+            );
+            return values;
+        }
+
         self.sequence_with_spread(
             output,
             stages,
@@ -336,10 +375,17 @@ impl Emitter<'_> {
         ctx: &CallArgsContext<'_>,
     ) -> String {
         let effective_param_ty = self.effective_param_type(index, ctx.fn_param_types);
+        let generic_param_ty = ctx
+            .generic_fn_param_types
+            .and_then(|params| self.effective_param_type(index, params));
 
         if ctx.is_go_call
             && let Some(result) = self.try_emit_callback_wrapper(output, arg, effective_param_ty)
         {
+            return result;
+        }
+
+        if let Some(result) = self.try_adapt_lowered_fn_arg_shape(output, arg, generic_param_ty) {
             return result;
         }
 
@@ -387,16 +433,140 @@ impl Emitter<'_> {
         }
     }
 
-    fn effective_param_type<'a>(
+    fn effective_param_type<'p>(
         &self,
         index: usize,
-        fn_param_types: &'a [Type],
-    ) -> Option<&'a Type> {
+        fn_param_types: &'p [Type],
+    ) -> Option<&'p Type> {
         fn_param_types.get(index).or_else(|| {
             fn_param_types
                 .last()
                 .filter(|t| t.get_name() == Some("VarArgs"))
         })
+    }
+
+    /// Adapt a lowered-return fn arg when its shape disagrees with the
+    /// callee's generic-param shape.
+    fn try_adapt_lowered_fn_arg_shape(
+        &mut self,
+        output: &mut String,
+        arg: &Expression,
+        generic_param_ty: Option<&Type>,
+    ) -> Option<String> {
+        if Self::is_tagged_shape_fn_value(arg) {
+            return None;
+        }
+
+        let raw_param_ty = generic_param_ty?;
+        let variadic_inner = (raw_param_ty.get_name() == Some("VarArgs"))
+            .then(|| raw_param_ty.inner())
+            .flatten();
+        let param_ty = variadic_inner.as_ref().unwrap_or(raw_param_ty);
+        let param_fn = self
+            .facts
+            .resolve_to_function_type(param_ty.unwrap_forall())?;
+        let param_ret = param_fn.get_function_ret()?;
+        let param_shape = self.classify_direct_emission(param_ret);
+
+        let arg_ty = arg.get_type();
+        let arg_fn = self
+            .facts
+            .resolve_to_function_type(arg_ty.unwrap_forall())?;
+        let arg_ret = arg_fn.get_function_ret()?;
+        let arg_shape = self.classify_direct_emission(arg_ret)?;
+
+        if param_shape.as_ref() == Some(&arg_shape) {
+            return None;
+        }
+
+        let value = self.emit_value(output, arg, ExpressionContext::value());
+        emit_fn_arg_shape_adapter(
+            self,
+            output,
+            &value,
+            &arg_fn,
+            &arg_shape,
+            param_shape.as_ref(),
+        )
+    }
+
+    /// Adapt `slice...` spread into a generic `VarArgs<fn(…)>` when the
+    /// slice's element fn-shape disagrees with the variadic's element.
+    fn try_emit_variadic_spread_adapter(
+        &mut self,
+        spread: &Expression,
+        ctx: &CallArgsContext<'_>,
+    ) -> Option<EmittedExpression> {
+        let generic_params = ctx.generic_fn_param_types?;
+        let raw_variadic = generic_params.last()?;
+        if raw_variadic.get_name() != Some("VarArgs") {
+            return None;
+        }
+        let variadic_inner = raw_variadic.inner()?;
+        let param_fn = self
+            .facts
+            .resolve_to_function_type(variadic_inner.unwrap_forall())?;
+        let param_ret = param_fn.get_function_ret()?;
+        let param_shape = self.classify_direct_emission(param_ret);
+
+        let spread_ty = spread.get_type();
+        let elem_ty = spread_ty.unwrap_forall().inner()?;
+        let arg_fn = self
+            .facts
+            .resolve_to_function_type(elem_ty.unwrap_forall())?;
+        let arg_ret = arg_fn.get_function_ret()?;
+        let arg_shape = self.classify_direct_emission(arg_ret)?;
+
+        if param_shape.as_ref() == Some(&arg_shape) {
+            return None;
+        }
+
+        let mut setup = String::new();
+        let src_value = self.emit_value(&mut setup, spread, ExpressionContext::value());
+        let src_var = self.hoist_tmp_value(&mut setup, "src", &src_value);
+
+        let target_elem_ret = match param_shape.as_ref() {
+            Some(shape) => self.render_lowered_return_ty(shape, arg_ret),
+            None => self.go_type_as_string(arg_ret),
+        };
+        let arg_fn_params = arg_fn.get_function_params().unwrap_or(&[]);
+        let param_type_strs: Vec<String> = arg_fn_params
+            .iter()
+            .map(|p| self.go_type_as_string(p))
+            .collect();
+        let target_elem_ty = format!("func({}) {}", param_type_strs.join(", "), target_elem_ret);
+
+        let adapted = self.fresh_var(Some("adapted"));
+        self.declare(&adapted);
+        let loop_cb = self.fresh_var(Some("cb"));
+
+        let mut body = String::new();
+        let closure = emit_fn_arg_shape_adapter(
+            self,
+            &mut body,
+            &loop_cb,
+            &arg_fn,
+            &arg_shape,
+            param_shape.as_ref(),
+        )?;
+        crate::write_line!(body, "{}[i] = {}", adapted, closure);
+
+        crate::write_line!(
+            setup,
+            "{} := make([]{}, len({}))",
+            adapted,
+            target_elem_ty,
+            src_var
+        );
+        crate::write_line!(
+            setup,
+            "for i, {} := range {} {{\n{}}}",
+            loop_cb,
+            src_var,
+            body
+        );
+
+        Some(EmittedExpression::new(setup, adapted, spread))
     }
 
     fn try_emit_callback_wrapper(

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -166,23 +166,38 @@ impl Emitter<'_> {
         });
         let mut values = self.sequence(output, stages, prefix);
         if let Some(i) = spread_idx {
-            if wrap_to_any {
-                self.requirements.require_stdlib();
-                values[i] = format!("{}.SliceToAny({})", go_name::GO_STDLIB_PKG, values[i]);
-            }
-            match combine {
-                Some(c) if i > c.fixed_count => {
-                    let elem_go = self.go_type_as_string(&c.elem_ty);
-                    let leading = values[c.fixed_count..i].join(", ");
-                    let spread_value = &values[i];
-                    let combined =
-                        format!("append([]{elem_go}{{{leading}}}, {spread_value}...)...");
-                    values.splice(c.fixed_count..=i, std::iter::once(combined));
-                }
-                _ => values[i].push_str("..."),
-            }
+            self.finalize_spread_stage(&mut values, i, wrap_to_any, combine);
         }
         values
+    }
+
+    /// Post-staging fix-up for the spread slot: optional `any`-wrap, then
+    /// either `append([]T{leading...}, spread...)...` or plain `value...`.
+    pub(crate) fn finalize_spread_stage(
+        &mut self,
+        values: &mut Vec<String>,
+        spread_idx: usize,
+        wrap_to_any: bool,
+        combine: Option<VariadicCombine>,
+    ) {
+        if wrap_to_any {
+            self.requirements.require_stdlib();
+            values[spread_idx] = format!(
+                "{}.SliceToAny({})",
+                go_name::GO_STDLIB_PKG,
+                values[spread_idx]
+            );
+        }
+        match combine {
+            Some(c) if spread_idx > c.fixed_count => {
+                let elem_go = self.go_type_as_string(&c.elem_ty);
+                let leading = values[c.fixed_count..spread_idx].join(", ");
+                let spread_value = &values[spread_idx];
+                let combined = format!("append([]{elem_go}{{{leading}}}, {spread_value}...)...");
+                values.splice(c.fixed_count..=spread_idx, std::iter::once(combined));
+            }
+            _ => values[spread_idx].push_str("..."),
+        }
     }
 
     /// Sequence N staged emissions preserving left-to-right eval order.

--- a/crates/emit/src/types/abi_transition.rs
+++ b/crates/emit/src/types/abi_transition.rs
@@ -436,6 +436,44 @@ pub(crate) fn emit_lisette_callback_wrapper(
     format!("func({params_str}) {go_ret} {{\n{prelude}{body}}}")
 }
 
+/// Wrap a lowered-return fn into a closure re-presenting the return in
+/// `target_shape` (tagged when `None`). Pipes through tagged form so any
+/// (arg, target) shape pair works.
+pub(crate) fn emit_fn_arg_shape_adapter(
+    emitter: &mut Emitter,
+    output: &mut String,
+    fn_value: &str,
+    arg_fn_type: &Type,
+    arg_shape: &AbiShape,
+    target_shape: Option<&AbiShape>,
+) -> Option<String> {
+    let params = arg_fn_type.get_function_params()?;
+    let arg_ret = arg_fn_type.get_function_ret()?;
+
+    let cb_var = emitter.hoist_tmp_value(output, "cb", fn_value);
+    let (param_strs, arg_names) = emitter.build_wrapper_params(params);
+    let inner_call = format!("{}({})", cb_var, arg_names.join(", "));
+
+    let outer_ret = match target_shape {
+        Some(shape) => emitter.render_lowered_return_ty(shape, arg_ret),
+        None => emitter.go_type_as_string(arg_ret),
+    };
+
+    let mut body = String::new();
+    let tagged = emit_callee_abi_wrapping(emitter, &mut body, arg_shape, &inner_call, arg_ret);
+    match target_shape {
+        Some(shape) => emit_lowered_result_return(emitter, &mut body, &tagged, arg_ret, shape),
+        None => write_line!(body, "return {}", tagged),
+    }
+
+    Some(format!(
+        "func({}) {} {{\n{}}}",
+        param_strs.join(", "),
+        outer_ret,
+        body
+    ))
+}
+
 /// Convert a fn-typed wrapper arg from lowered Go ABI back to tagged for
 /// the inner call. Identity for non-fn args and for fn args with no
 /// lowered return.

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4519,6 +4519,192 @@ fn main() {
 }
 
 #[test]
+fn lowered_result_fn_arg_adapts_to_tagged_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
+  f(a)
+}
+
+fn main() {
+  let _ = resolve(42, resultant)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:strconv"
+
+pub fn parser(arg: int) -> Result<int, Ref<strconv.NumError>> {
+  Ok(arg)
+}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
+  f(a)
+}
+
+fn main() {
+  let _ = resolve(0, parser)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn lowered_result_lambda_arg_adapts_to_tagged_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
+  f(a)
+}
+
+fn main() {
+  let _ = resolve(42, |x| -> Result<int, Face> { Ok(x) })
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn lowered_partial_fn_arg_adapts_to_tagged_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn fallible(arg: int) -> Partial<int, Face> {
+  Partial.Ok(arg)
+}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Partial<R, E>) -> Partial<R, E> {
+  f(a)
+}
+
+fn main() {
+  let _ = resolve(42, fallible)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn lowered_result_fn_arg_adapts_through_variadic_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub fn resolve<R, E>(default: R, _fs: VarArgs<fn(int) -> Result<R, E>>) -> Result<R, E> {
+  Ok(default)
+}
+
+fn main() {
+  let _ = resolve(0, resultant)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn spread_slice_into_variadic_generic_param_adapts_each_element() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub fn resolve<R, E>(default: R, _fs: VarArgs<fn(int) -> Result<R, E>>) -> Result<R, E> {
+  Ok(default)
+}
+
+fn main() {
+  let fns = [resultant]
+  let _ = resolve<int, Face>(0, fns...)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn nullable_option_fn_arg_adapts_to_comma_ok_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn lookup(_arg: int) -> Option<Face> {
+  None
+}
+
+pub fn resolve<T, R>(a: T, f: fn(T) -> Option<R>) -> Option<R> {
+  f(a)
+}
+
+fn main() {
+  let _ = resolve(0, lookup)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn fused_match_arm_bindings_dont_leak() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/build/mod.rs
+assertion_line: 4632
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Fallible(arg int) (int, Face) {
+	return arg, nil
+}
+
+func Resolve[T any, R any, E any](a T, f func(T) lisette.Partial[R, E]) lisette.Partial[R, E] {
+	return f(a)
+}
+
+func main() {
+	cb_1 := Fallible
+	Resolve(42, func(arg0 int) lisette.Partial[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Partial[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakePartialBoth[int, Face](ret_2, ret_3)
+		} else {
+			result_4 = lisette.MakePartialOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+}

--- a/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/build/mod.rs
+assertion_line: 4579
+---
+// === main.go ===
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func Parser(arg int) (int, *strconv.NumError) {
+	return arg, nil
+}
+
+func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.Result[R, E] {
+	return f(a)
+}
+
+func main() {
+	cb_1 := Parser
+	Resolve(0, func(arg0 int) lisette.Result[int, *strconv.NumError] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, *strconv.NumError]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, *strconv.NumError](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, *strconv.NumError](ret_2)
+		}
+		return result_4
+	})
+}

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+func Resolve[R any, E any](default_ R, _ ...func(int) lisette.Result[R, E]) lisette.Result[R, E] {
+	return lisette.MakeResultOk[R, E](default_)
+}
+
+func main() {
+	cb_1 := Resultant
+	Resolve(0, func(arg0 int) lisette.Result[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+}

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/build/mod.rs
+assertion_line: 4549
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.Result[R, E] {
+	return f(a)
+}
+
+func main() {
+	cb_1 := Resultant
+	Resolve(42, func(arg0 int) lisette.Result[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+}

--- a/tests/spec/build/snapshots/lowered_result_lambda_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_lambda_arg_adapts_to_tagged_generic_param.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/build/mod.rs
+assertion_line: 4604
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.Result[R, E] {
+	return f(a)
+}
+
+func main() {
+	cb_1 := func(x int) (int, Face) {
+		return x, nil
+	}
+	Resolve(42, func(arg0 int) lisette.Result[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+}

--- a/tests/spec/build/snapshots/nullable_option_fn_arg_adapts_to_comma_ok_generic_param.snap
+++ b/tests/spec/build/snapshots/nullable_option_fn_arg_adapts_to_comma_ok_generic_param.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Lookup(_ int) Face {
+	return nil
+}
+
+func Resolve[T any, R any](a T, f func(T) (R, bool)) (R, bool) {
+	return f(a)
+}
+
+func main() {
+	cb_1 := Lookup
+	Resolve(0, func(arg0 int) (Face, bool) {
+		raw_2 := cb_1(arg0)
+		option_3 := lisette.OptionFromNilable[Face](raw_2, lisette.IsNilInterface(raw_2))
+		if option_3.Tag == lisette.OptionSome {
+			return option_3.SomeVal, true
+		}
+		return *new(Face), false
+	})
+}

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_param_adapts_each_element.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+func Resolve[R any, E any](default_ R, _ ...func(int) lisette.Result[R, E]) lisette.Result[R, E] {
+	return lisette.MakeResultOk[R, E](default_)
+}
+
+func main() {
+	fns := []func(int) (int, Face){Resultant}
+	src_1 := fns
+	adapted_2 := make([]func(int) lisette.Result[int, Face], len(src_1))
+	for i, cb_3 := range src_1 {
+		cb_4 := cb_3
+		adapted_2[i] = func(arg0 int) lisette.Result[int, Face] {
+			ret_5, ret_6 := cb_4(arg0)
+			var result_7 lisette.Result[int, Face]
+			if ret_6 != nil {
+				result_7 = lisette.MakeResultErr[int, Face](ret_6)
+			} else {
+				result_7 = lisette.MakeResultOk[int, Face](ret_5)
+			}
+			return result_7
+		}
+	}
+	_ = Resolve[int, Face](0, adapted_2...)
+}


### PR DESCRIPTION
A function returning `Result<T, F>` where `F` is a user interface lowers `(T, F)` tuple, but a generic parameter typed `fn(T) -> Result<R, E>` was being emitted as `lisette.Result[R, E]`.

At the call site, the compiler now wraps the target in a closure that converts `(int, F)` to `lisette.Result[int, F]`, so the generic call typechecks. The same adpter handles `Partial<T, E>`, `Option<T>` with disagreeing nullable/comma-ok shapes, lambdas with explicit lowered returns, `VarArgs<fn(…)>` params, and `slice...` spread into a `VarArgs<fn(…)>`.

Fix #447
