### PR TITLE
fix: classify generic callee shape from its declaration

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -8,6 +8,7 @@ use crate::names::go_name;
 use crate::types::abi_transition::emit_fn_arg_shape_adapter;
 use crate::types::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
 use syntax::ast::{Annotation, Expression};
+use syntax::program::Definition;
 use syntax::types::Type;
 
 struct CalleeAnalysis<'a> {
@@ -189,7 +190,9 @@ impl<'a> Emitter<'a> {
             .get_function_params()
             .map(<[Type]>::to_vec)
             .unwrap_or_default();
-        let generic_fn_param_types = self.callee_generic_param_types(function);
+        let generic_fn_param_types = self
+            .callee_definition(function)
+            .and_then(|definition| definition.ty().unwrap_forall().get_function_params());
         let (is_go_call, is_prelude_dispatch) = match function.unwrap_parens() {
             Expression::DotAccess { expression, .. } => {
                 let is_prelude = matches!(
@@ -212,19 +215,22 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    /// Callee's declared param types from its definition, before instantiation.
-    fn callee_generic_param_types(&self, function: &Expression) -> Option<&'a [Type]> {
-        let Expression::Identifier {
-            qualified: Some(q), ..
-        } = function.unwrap_parens()
-        else {
-            return None;
-        };
-        self.facts
-            .definition(q.as_str())?
-            .ty()
-            .unwrap_forall()
-            .get_function_params()
+    pub(crate) fn callee_definition(&self, function: &Expression) -> Option<&'a Definition> {
+        match function.unwrap_parens() {
+            Expression::Identifier {
+                qualified: Some(q), ..
+            } => self.facts.definition(q.as_str()),
+            Expression::DotAccess {
+                expression: receiver,
+                member,
+                ..
+            } => {
+                let receiver_ty = receiver.get_type();
+                let module = receiver_ty.as_import_namespace()?;
+                self.facts.definition(&format!("{}.{}", module, member))
+            }
+            _ => None,
+        }
     }
 
     /// Materialize a Go array-returning call into a variable and reslice it,

--- a/crates/emit/src/types/abi.rs
+++ b/crates/emit/src/types/abi.rs
@@ -363,7 +363,12 @@ impl Emitter<'_> {
         {
             return None;
         }
-        self.classify_direct_emission(&return_type)
+        let declared_return = self
+            .callee_definition(callee)
+            .and_then(|definition| definition.ty().unwrap_forall().get_function_ret());
+        let classify_ty = declared_return.unwrap_or(return_type.as_ref());
+
+        self.classify_direct_emission(classify_ty)
     }
 }
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4705,6 +4705,98 @@ fn main() {
 }
 
 #[test]
+fn bound_result_from_generic_callee_keeps_tagged_return() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
+  f(a)
+}
+
+fn main() {
+  let rez = resolve(42, resultant)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn bound_option_from_generic_callee_keeps_tagged_return() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn lookup(_arg: int) -> Option<Face> {
+  None
+}
+
+pub fn resolve<T, R>(a: T, f: fn(T) -> Option<R>) -> Option<R> {
+  f(a)
+}
+
+fn main() {
+  let rez = resolve(0, lookup)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn cross_module_result_fn_arg_adapts_to_tagged_generic_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "resolver",
+        "resolver.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
+  f(a)
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "resolver"
+
+fn main() {
+  let rez = resolver.resolve(42, resolver.resultant)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn fused_match_arm_bindings_dont_leak() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Lookup(_ int) Face {
+	return nil
+}
+
+func Resolve[T any, R any](a T, f func(T) (R, bool)) (R, bool) {
+	return f(a)
+}
+
+func main() {
+	cb_1 := Lookup
+	ret_4, ret_5 := Resolve(0, func(arg0 int) (Face, bool) {
+		raw_2 := cb_1(arg0)
+		option_3 := lisette.OptionFromNilable[Face](raw_2, lisette.IsNilInterface(raw_2))
+		if option_3.Tag == lisette.OptionSome {
+			return option_3.SomeVal, true
+		}
+		return *new(Face), false
+	})
+	var option_6 lisette.Option[Face]
+	if ret_5 && !lisette.IsNilInterface(ret_4) {
+		option_6 = lisette.MakeOptionSome[Face](ret_4)
+	} else {
+		option_6 = lisette.MakeOptionNone[Face]()
+	}
+	rez := option_6
+	_ = rez
+}

--- a/tests/spec/build/snapshots/bound_result_from_generic_callee_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_callee_keeps_tagged_return.snap
@@ -9,15 +9,17 @@ import lisette "github.com/ivov/lisette/prelude"
 type Face interface {
 }
 
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
 func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.Result[R, E] {
 	return f(a)
 }
 
 func main() {
-	cb_1 := func(x int) (int, Face) {
-		return x, nil
-	}
-	_ = Resolve(42, func(arg0 int) lisette.Result[int, Face] {
+	cb_1 := Resultant
+	rez := Resolve(42, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
@@ -27,4 +29,5 @@ func main() {
 		}
 		return result_4
 	})
+	_ = rez
 }

--- a/tests/spec/build/snapshots/cross_module_result_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/cross_module_result_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"github.com/user/myproject/resolver"
+)
+
+func main() {
+	cb_1 := resolver.Resultant
+	rez := resolver.Resolve(42, func(arg0 int) lisette.Result[int, resolver.Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, resolver.Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, resolver.Face](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, resolver.Face](ret_2)
+		}
+		return result_4
+	})
+	_ = rez
+}
+
+
+// === resolver/resolver.go ===
+package resolver
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.Result[R, E] {
+	return f(a)
+}

--- a/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/build/mod.rs
-assertion_line: 4632
 ---
 // === main.go ===
 package main
@@ -20,7 +19,7 @@ func Resolve[T any, R any, E any](a T, f func(T) lisette.Partial[R, E]) lisette.
 
 func main() {
 	cb_1 := Fallible
-	Resolve(42, func(arg0 int) lisette.Partial[int, Face] {
+	_ = Resolve(42, func(arg0 int) lisette.Partial[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		var result_4 lisette.Partial[int, Face]
 		if ret_3 != nil {

--- a/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/build/mod.rs
-assertion_line: 4579
 ---
 // === main.go ===
 package main
@@ -20,7 +19,7 @@ func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.R
 
 func main() {
 	cb_1 := Parser
-	Resolve(0, func(arg0 int) lisette.Result[int, *strconv.NumError] {
+	_ = Resolve(0, func(arg0 int) lisette.Result[int, *strconv.NumError] {
 		ret_2, ret_3 := cb_1(arg0)
 		var result_4 lisette.Result[int, *strconv.NumError]
 		if ret_3 != nil {

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
@@ -19,7 +19,7 @@ func Resolve[R any, E any](default_ R, _ ...func(int) lisette.Result[R, E]) lise
 
 func main() {
 	cb_1 := Resultant
-	Resolve(0, func(arg0 int) lisette.Result[int, Face] {
+	_ = Resolve(0, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec/build/mod.rs
-assertion_line: 4549
 ---
 // === main.go ===
 package main
@@ -20,7 +19,7 @@ func Resolve[T any, R any, E any](a T, f func(T) lisette.Result[R, E]) lisette.R
 
 func main() {
 	cb_1 := Resultant
-	Resolve(42, func(arg0 int) lisette.Result[int, Face] {
+	_ = Resolve(42, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {


### PR DESCRIPTION
Assigning the result of a generic function call now compiles when the call's error type resolves to a Go-nilable type, including when the function is imported from another module. Previously the call site read the result as a `(value, error)` pair while the generic function returned a single tagged `Result`, so the binding failed to compile.

```rs
interface Face {}

pub fn resultant(arg: int) -> Result<int, Face> {
  Ok(arg)
}

pub fn resolve<T, R, E>(a: T, f: fn(T) -> Result<R, E>) -> Result<R, E> {
  f(a)
}

fn main() {
  let rez = resolve(42, resultant)
  let _ = rez
}
```

Follow-up fix for #447