### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.9](https://github.com/ivov/lisette/compare/lisette-v0.2.8...lisette-v0.2.9) - 2026-05-20
+
+- fix: drop redundant block around irrefutable match arm [#464](https://github.com/ivov/lisette/pull/464) [`6e3e211`](https://github.com/ivov/lisette/commit/6e3e2112860d3183ecf51757987ae9e85a3b5fc5)
+- fix: derive generic method call shapes from declarations [#463](https://github.com/ivov/lisette/pull/463) [`b4c22b5`](https://github.com/ivov/lisette/commit/b4c22b593da837f60698ea513b1c45ee4ec84ff9)
+- fix: classify generic callee shape from its declaration [#461](https://github.com/ivov/lisette/pull/461) [`07914a1`](https://github.com/ivov/lisette/commit/07914a1bda37687197c4fe254e01f567324b003b)
 ## [0.2.8](https://github.com/ivov/lisette/compare/lisette-v0.2.7...lisette-v0.2.8) - 2026-05-19
 
 - fix: adapt lowered fn arg shape at generic call boundary [#459](https://github.com/ivov/lisette/pull/459) [`ee69def`](https://github.com/ivov/lisette/commit/ee69deff9510071418c1ac66c104606af0507f36)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bincode",
  "ecow",
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.8"
+version = "0.2.9"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.8", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.8", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.8", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.8", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.9", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.9", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.9", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.9", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.8", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.8", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.9", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.9", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.8", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.8", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.8", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.8", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.9 (upcoming)

- fix: drop redundant block around irrefutable match arm [#464](https://github.com/ivov/lisette/pull/464) [`6e3e211`](https://github.com/ivov/lisette/commit/6e3e2112860d3183ecf51757987ae9e85a3b5fc5)
- fix: derive generic method call shapes from declarations [#463](https://github.com/ivov/lisette/pull/463) [`b4c22b5`](https://github.com/ivov/lisette/commit/b4c22b593da837f60698ea513b1c45ee4ec84ff9)
- fix: classify generic callee shape from its declaration [#461](https://github.com/ivov/lisette/pull/461) [`07914a1`](https://github.com/ivov/lisette/commit/07914a1bda37687197c4fe254e01f567324b003b)
