### PR TITLE
fix: derive generic method call shapes from declarations

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -226,8 +226,15 @@ impl<'a> Emitter<'a> {
                 ..
             } => {
                 let receiver_ty = receiver.get_type();
-                let module = receiver_ty.as_import_namespace()?;
-                self.facts.definition(&format!("{}.{}", module, member))
+                if let Some(module) = receiver_ty.as_import_namespace() {
+                    return self.facts.definition(&format!("{}.{}", module, member));
+                }
+                match receiver_ty.strip_refs() {
+                    Type::Nominal { id, .. } => {
+                        self.facts.definition(&format!("{}.{}", id, member))
+                    }
+                    _ => None,
+                }
             }
             _ => None,
         }
@@ -316,7 +323,8 @@ impl<'a> Emitter<'a> {
             .collect();
 
         if let Some(spread) = ctx.spread
-            && let Some(adapter_stage) = self.try_emit_variadic_spread_adapter(spread, ctx)
+            && let Some(adapter_stage) =
+                self.try_emit_variadic_spread_adapter(spread, ctx.generic_fn_param_types)
         {
             stages.push(adapter_stage);
             let spread_idx = stages.len() - 1;
@@ -439,7 +447,7 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    fn effective_param_type<'p>(
+    pub(crate) fn effective_param_type<'p>(
         &self,
         index: usize,
         fn_param_types: &'p [Type],
@@ -453,7 +461,7 @@ impl<'a> Emitter<'a> {
 
     /// Adapt a lowered-return fn arg when its shape disagrees with the
     /// callee's generic-param shape.
-    fn try_adapt_lowered_fn_arg_shape(
+    pub(crate) fn try_adapt_lowered_fn_arg_shape(
         &mut self,
         output: &mut String,
         arg: &Expression,
@@ -498,12 +506,12 @@ impl<'a> Emitter<'a> {
 
     /// Adapt `slice...` spread into a generic `VarArgs<fn(…)>` when the
     /// slice's element fn-shape disagrees with the variadic's element.
-    fn try_emit_variadic_spread_adapter(
+    pub(crate) fn try_emit_variadic_spread_adapter(
         &mut self,
         spread: &Expression,
-        ctx: &CallArgsContext<'_>,
+        generic_params: Option<&[Type]>,
     ) -> Option<EmittedExpression> {
-        let generic_params = ctx.generic_fn_param_types?;
+        let generic_params = generic_params?;
         let raw_variadic = generic_params.last()?;
         if raw_variadic.get_name() != Some("VarArgs") {
             return None;

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -135,18 +135,48 @@ impl Emitter<'_> {
             Type::Function { params, .. } => params.clone(),
             _ => Vec::new(),
         };
+        let declared_params =
+            self.ufcs_declared_user_params(receiver, function, formal_params.len());
         let mut all_stages: Vec<EmittedExpression> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
         all_stages.push(self.stage_operand(receiver, ExpressionContext::value()));
         for (i, arg) in args.iter().enumerate() {
-            all_stages.push(self.stage_prelude_arg(arg, formal_params.get(i)));
+            let declared = declared_params.and_then(|p| self.effective_param_type(i, p));
+            all_stages.push(self.stage_ufcs_arg(arg, declared, formal_params.get(i)));
         }
         let combine = Self::variadic_combine_for(function, spread, 1);
-        let all_values =
-            self.sequence_with_spread(output, all_stages, spread, false, "_arg", combine);
+
+        let all_values = if let Some(spread) = spread
+            && let Some(adapter_stage) =
+                self.try_emit_variadic_spread_adapter(spread, declared_params)
+        {
+            all_stages.push(adapter_stage);
+            let spread_idx = all_stages.len() - 1;
+            let mut all_values = self.sequence(output, all_stages, "_arg");
+            self.finalize_spread_stage(&mut all_values, spread_idx, false, combine);
+            all_values
+        } else {
+            self.sequence_with_spread(output, all_stages, spread, false, "_arg", combine)
+        };
         let receiver_arg = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
         (receiver_arg, emitted_args)
+    }
+
+    fn stage_ufcs_arg(
+        &mut self,
+        arg: &Expression,
+        declared_param: Option<&Type>,
+        formal_param: Option<&Type>,
+    ) -> EmittedExpression {
+        let Some(declared) = declared_param else {
+            return self.stage_prelude_arg(arg, formal_param);
+        };
+        let mut setup = String::new();
+        if let Some(value) = self.try_adapt_lowered_fn_arg_shape(&mut setup, arg, Some(declared)) {
+            return EmittedExpression::new(setup, value, arg);
+        }
+        self.stage_composite(arg, ExpressionContext::value())
     }
 
     fn build_ufcs_qualified_call(
@@ -282,5 +312,29 @@ impl Emitter<'_> {
                     ..
                 }
         )
+    }
+}
+
+impl<'a> Emitter<'a> {
+    fn ufcs_declared_user_params(
+        &self,
+        receiver: &Expression,
+        function: &Expression,
+        arg_count: usize,
+    ) -> Option<&'a [Type]> {
+        let receiver_ty = receiver.get_type().strip_refs();
+        let Type::Nominal { id, .. } = &receiver_ty else {
+            return None;
+        };
+        if id.starts_with("prelude.") || go_name::is_go_import(id.as_str()) {
+            return None;
+        }
+        let declared = self
+            .callee_definition(function)?
+            .ty()
+            .unwrap_forall()
+            .get_function_params()?;
+        let self_offset = declared.len().saturating_sub(arg_count);
+        declared.get(self_offset..)
     }
 }

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -4797,6 +4797,161 @@ fn main() {
 }
 
 #[test]
+fn bound_result_from_generic_method_keeps_tagged_return() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub struct Holder { pub n: int }
+
+impl Holder {
+  pub fn resolve<R, E>(self, f: fn(int) -> Result<R, E>) -> Result<R, E> {
+    f(self.n)
+  }
+}
+
+fn main() {
+  let rez = Holder { n: 4 }.resolve(resultant)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn bound_partial_from_generic_method_keeps_tagged_return() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn fallible(arg: int) -> Partial<int, Face> {
+  Partial.Ok(arg)
+}
+
+pub struct Holder<T> { pub val: T }
+
+impl<T> Holder<T> {
+  pub fn resolve<R, E>(self, f: fn(T) -> Partial<R, E>) -> Partial<R, E> {
+    f(self.val)
+  }
+}
+
+fn main() {
+  let rez = Holder { val: 4 }.resolve(fallible)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn option_fn_arg_adapts_to_comma_ok_generic_method_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn lookup(_arg: int) -> Option<Face> {
+  None
+}
+
+pub struct Holder { pub n: int }
+
+impl Holder {
+  pub fn resolve<R>(self, f: fn(int) -> Option<R>) -> Option<R> {
+    f(self.n)
+  }
+}
+
+fn main() {
+  let rez = Holder { n: 4 }.resolve(lookup)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn comma_ok_fn_arg_emits_lowered_for_generic_method_param() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub struct Holder { pub n: int }
+
+impl Holder {
+  pub fn resolve<R>(self, f: fn(int) -> Option<R>) -> Option<R> {
+    f(self.n)
+  }
+}
+
+fn main() {
+  let rez = Holder { n: 5 }.resolve(|x| -> Option<int> { Some(x) })
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn spread_slice_into_variadic_generic_method_param_adapts_each_element() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Face {}
+
+pub fn resultant(arg: int) -> Result<int, Face> {
+  Ok(arg)
+}
+
+pub struct Holder {}
+
+impl Holder {
+  pub fn resolve<R, E>(self, default: R, _fs: VarArgs<fn(int) -> Result<R, E>>) -> Result<R, E> {
+    Ok(default)
+  }
+}
+
+fn main() {
+  let fns = [resultant]
+  let rez = Holder {}.resolve<int, Face>(0, fns...)
+  let _ = rez
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn fused_match_arm_bindings_dont_leak() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Face interface {
+}
+
+func Fallible(arg int) (int, Face) {
+	return arg, nil
+}
+
+type Holder[T any] struct {
+	Val T
+}
+
+func (h Holder[T]) String() string {
+	return fmt.Sprintf("Holder { val: %v }", h.Val)
+}
+
+func Holder_Resolve[T any, R any, E any](self Holder[T], f func(T) lisette.Partial[R, E]) lisette.Partial[R, E] {
+	return f(self.Val)
+}
+
+func main() {
+	_arg_5 := Holder[int]{Val: 4}
+	cb_1 := Fallible
+	rez := Holder_Resolve(_arg_5, func(arg0 int) lisette.Partial[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Partial[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakePartialBoth[int, Face](ret_2, ret_3)
+		} else {
+			result_4 = lisette.MakePartialOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+	_ = rez
+}

--- a/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+type Holder struct {
+	N int
+}
+
+func (h Holder) String() string {
+	return fmt.Sprintf("Holder { n: %v }", h.N)
+}
+
+func Holder_Resolve[R any, E any](self Holder, f func(int) lisette.Result[R, E]) lisette.Result[R, E] {
+	return f(self.N)
+}
+
+func main() {
+	_arg_5 := Holder{N: 4}
+	cb_1 := Resultant
+	rez := Holder_Resolve(_arg_5, func(arg0 int) lisette.Result[int, Face] {
+		ret_2, ret_3 := cb_1(arg0)
+		var result_4 lisette.Result[int, Face]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+		}
+		return result_4
+	})
+	_ = rez
+}

--- a/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
+++ b/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Holder struct {
+	N int
+}
+
+func (h Holder) String() string {
+	return fmt.Sprintf("Holder { n: %v }", h.N)
+}
+
+func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {
+	return f(self.N)
+}
+
+func main() {
+	option_1 := lisette.OptionFromCommaOk[int](Holder_Resolve(Holder{N: 5}, func(x int) (int, bool) {
+		return x, true
+	}))
+	rez := option_1
+	_ = rez
+}

--- a/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
+++ b/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
@@ -1,0 +1,50 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Face interface {
+}
+
+func Lookup(_ int) Face {
+	return nil
+}
+
+type Holder struct {
+	N int
+}
+
+func (h Holder) String() string {
+	return fmt.Sprintf("Holder { n: %v }", h.N)
+}
+
+func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {
+	return f(self.N)
+}
+
+func main() {
+	_arg_4 := Holder{N: 4}
+	cb_1 := Lookup
+	ret_5, ret_6 := Holder_Resolve(_arg_4, func(arg0 int) (Face, bool) {
+		raw_2 := cb_1(arg0)
+		option_3 := lisette.OptionFromNilable[Face](raw_2, lisette.IsNilInterface(raw_2))
+		if option_3.Tag == lisette.OptionSome {
+			return option_3.SomeVal, true
+		}
+		return *new(Face), false
+	})
+	var option_7 lisette.Option[Face]
+	if ret_6 && !lisette.IsNilInterface(ret_5) {
+		option_7 = lisette.MakeOptionSome[Face](ret_5)
+	} else {
+		option_7 = lisette.MakeOptionNone[Face]()
+	}
+	rez := option_7
+	_ = rez
+}

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Face interface {
+}
+
+func Resultant(arg int) (int, Face) {
+	return arg, nil
+}
+
+type Holder struct{}
+
+func (h Holder) String() string {
+	return "Holder"
+}
+
+func Holder_Resolve[R any, E any](_ Holder, default_ R, _ ...func(int) lisette.Result[R, E]) lisette.Result[R, E] {
+	return lisette.MakeResultOk[R, E](default_)
+}
+
+func main() {
+	fns := []func(int) (int, Face){Resultant}
+	_arg_8 := Holder{}
+	src_1 := fns
+	adapted_2 := make([]func(int) lisette.Result[int, Face], len(src_1))
+	for i, cb_3 := range src_1 {
+		cb_4 := cb_3
+		adapted_2[i] = func(arg0 int) lisette.Result[int, Face] {
+			ret_5, ret_6 := cb_4(arg0)
+			var result_7 lisette.Result[int, Face]
+			if ret_6 != nil {
+				result_7 = lisette.MakeResultErr[int, Face](ret_6)
+			} else {
+				result_7 = lisette.MakeResultOk[int, Face](ret_5)
+			}
+			return result_7
+		}
+	}
+	rez := Holder_Resolve[int, Face](_arg_8, 0, adapted_2...)
+	_ = rez
+}


### PR DESCRIPTION
Generic method calls now compile when the result is bound and when function or spread arguments need shape adaptation, using the method's declared shape instead of the instantiated type. This extends #461 from free functions to methods.

```rs
pub interface Face {}

pub fn resultant(arg: int) -> Result<int, Face> {
  Ok(arg)
}

pub struct Holder { pub n: int }

impl Holder {
  pub fn resolve<R, E>(self, f: fn(int) -> Result<R, E>) -> Result<R, E> {
    f(self.n)
  }
}

fn main() {
  let rez = Holder { n: 4 }.resolve(resultant)
  let _ = rez
}
```

