### PR TITLE
fix: drop redundant block around irrefutable match arm

### DIFF
--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -148,20 +148,23 @@ impl<'a, 'e> TreeEmitter<'a, 'e> {
         plan: &SingleCatchallPlan,
         place: &BodyPlace,
     ) {
-        let emits_any_binding = plan.bindings.iter().any(|b| b.go_name.is_some());
-        let needs_block = emits_any_binding || plan.pattern_has_collisions;
         let arm_body = &*self.arms[plan.arm_index].expression;
+
+        self.emitter.enter_scope();
+        let mut buf = String::new();
+        let inlines = self.emit_bindings(&mut buf, &plan.bindings, &[arm_body], None);
+        self.emit_arm_body(&mut buf, plan.arm_index, place);
+        self.drop_inline_bindings(&inlines);
+        let needs_block =
+            self.emitter.scope.current_block_declared_nonempty() || plan.pattern_has_collisions;
+        self.emitter.exit_scope();
 
         if needs_block {
             output.push_str("{\n");
-            self.emitter.enter_scope();
-        }
-        let inlines = self.emit_bindings(output, &plan.bindings, &[arm_body], None);
-        self.emit_arm_body(output, plan.arm_index, place);
-        self.drop_inline_bindings(&inlines);
-        if needs_block {
-            self.emitter.exit_scope();
+            output.push_str(&buf);
             output.push_str("}\n");
+        } else {
+            output.push_str(&buf);
         }
     }
 

--- a/crates/emit/src/scope.rs
+++ b/crates/emit/src/scope.rs
@@ -123,6 +123,10 @@ impl ScopeState {
         self.declared.iter().any(|s| s.contains(go_name))
     }
 
+    pub(crate) fn current_block_declared_nonempty(&self) -> bool {
+        self.declared.last().is_some_and(|s| !s.is_empty())
+    }
+
     pub(crate) fn enter_block(&mut self) {
         self.scope_depth += 1;
         self.bindings.save();

--- a/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
@@ -16,7 +16,5 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
-	{
-		return p.x + p.y
-	}
+	return p.x + p.y
 }

--- a/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
@@ -19,7 +19,5 @@ func (p Point) String() string {
 }
 
 func test(pair lisette.Tuple2[Point, int]) int {
-	{
-		return pair.First.x + pair.Second
-	}
+	return pair.First.x + pair.Second
 }

--- a/tests/spec/emit/snapshots/as_binding_unused_elided.snap
+++ b/tests/spec/emit/snapshots/as_binding_unused_elided.snap
@@ -16,7 +16,5 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
-	{
-		return p.x
-	}
+	return p.x
 }

--- a/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
@@ -15,7 +15,5 @@ func (b Box[T]) String() string {
 }
 
 func test(b Box[int]) int {
-	{
-		return b.F0
-	}
+	return b.F0
 }

--- a/tests/spec/emit/snapshots/gopkg_in_struct_pattern_match_emits_correct_qualifier.snap
+++ b/tests/spec/emit/snapshots/gopkg_in_struct_pattern_match_emits_correct_qualifier.snap
@@ -7,7 +7,5 @@ package main
 import yaml "gopkg.in/yaml.v3"
 
 func describe(e yaml.TypeError) int {
-	{
-		return len(e.Errors)
-	}
+	return len(e.Errors)
 }

--- a/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_with_else.snap
@@ -5,7 +5,5 @@ description: "input: \nfn test(x: int) -> int {\n  if let y = x {\n    y * 2\n  
 package main
 
 func test(x int) int {
-	{
-		return x * 2
-	}
+	return x * 2
 }

--- a/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
+++ b/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
@@ -17,9 +17,7 @@ func (p Point) String() string {
 
 func test(p Point) int {
 	var result int
-	{
-		result = p.x + p.x
-	}
+	result = p.x + p.x
 	fmt.Println(result)
 	return result
 }

--- a/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
+++ b/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
@@ -9,13 +9,9 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() int {
 	pair := lisette.MakeTuple2(10, 20)
 	var first int
-	{
-		first = pair.First + pair.Second
-	}
+	first = pair.First + pair.Second
 	nested := lisette.MakeTuple2(lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4))
 	var second int
-	{
-		second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
-	}
+	second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
 	return first + second
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
@@ -23,8 +23,6 @@ func test() int {
 		F1: 2,
 	}
 	var sum int
-	{
-		sum = p.F0 + p.F1
-	}
+	sum = p.F0 + p.F1
 	return a + b + sum
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
@@ -26,13 +26,9 @@ func test() string {
 		F0: 1,
 		F1: 2,
 	}
-	{
-		_ = p.F0 + p.F1
-	}
+	_ = p.F0 + p.F1
 	n := Name("hello")
 	var b string
-	{
-		b = string(n)
-	}
+	b = string(n)
 	return b
 }

--- a/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
@@ -16,7 +16,5 @@ func (p Point) String() string {
 }
 
 func test(p Point) int {
-	{
-		return p.x * p.y
-	}
+	return p.x * p.y
 }

--- a/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_ref_struct_pattern_match.snap
@@ -7,7 +7,5 @@ package main
 type Wrap *int
 
 func test(w Wrap) int {
-	{
-		return *(*int)(w)
-	}
+	return *(*int)(w)
 }

--- a/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
@@ -13,7 +13,5 @@ func (u UserId) String() string {
 }
 
 func test(uid UserId) int {
-	{
-		return int(uid)
-	}
+	return int(uid)
 }

--- a/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
@@ -25,7 +25,5 @@ func test() int {
 		d: 4,
 	}
 	subject_1 := b
-	{
-		return subject_1.a + subject_1.b
-	}
+	return subject_1.a + subject_1.b
 }

--- a/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
@@ -16,7 +16,5 @@ func (p Pair) String() string {
 }
 
 func test(p Pair) int {
-	{
-		return p.F0 + p.F1
-	}
+	return p.F0 + p.F1
 }


### PR DESCRIPTION
A `match` with a single irrefutable arm no longer wraps its body in a redundant block when the arm declares no locals.