### PR TITLE
chore: release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.10](https://github.com/ivov/lisette/compare/lisette-v0.2.9...lisette-v0.2.10) - 2026-05-23
+
+- fix: bind more value-plus-error returns as Partial [#475](https://github.com/ivov/lisette/pull/475) [`e1c3772`](https://github.com/ivov/lisette/commit/e1c377254a1bd844d49fb5d4297fc362fb76b70c)
+- fix: bind WriteString, ReadFrom and WriteTo as Partial [#474](https://github.com/ivov/lisette/pull/474) [`36ab5d3`](https://github.com/ivov/lisette/commit/36ab5d33b4907b8f92073bbc2e4e0bc658191e38)
+- fix: interface not implemented diagnostic for wrapper types [#473](https://github.com/ivov/lisette/pull/473) [`25b2035`](https://github.com/ivov/lisette/commit/25b20359005700d4676b65e5652b5375a780612a)
+- test: gate e2e suite on zero re-emit failures [#472](https://github.com/ivov/lisette/pull/472) [`2dfb714`](https://github.com/ivov/lisette/commit/2dfb714a3fb56107ad8f7923aa2b00ca3da8cccb)
+- fix: bound global prelude and stdlib defs cache [#471](https://github.com/ivov/lisette/pull/471) [`bb0bf4f`](https://github.com/ivov/lisette/commit/bb0bf4ffab25bd397ea3b9d4186510ee40d502f0)
+- feat: unix diagnostic format for lis check [#470](https://github.com/ivov/lisette/pull/470) [`308e859`](https://github.com/ivov/lisette/commit/308e85939326a85e0b5caf053c4dbac0e60462dd)
+- fix: prune go output and caches for removed modules [#469](https://github.com/ivov/lisette/pull/469) [`d6a2232`](https://github.com/ivov/lisette/commit/d6a2232f88a03f12a06863c982ce53756ddbd729)
+- ci: skip fuzz and release workflows on forks [#468](https://github.com/ivov/lisette/pull/468) [`2a8a152`](https://github.com/ivov/lisette/commit/2a8a152290163a86faa7b5086415f4448ade0a49)
+- feat: relative paths in diagnostics [#467](https://github.com/ivov/lisette/pull/467) [`39830a0`](https://github.com/ivov/lisette/commit/39830a045e3c9c1023fadf69f975e028d9450b31)
+- feat: bare variants in match arms [#465](https://github.com/ivov/lisette/pull/465) [`2faa0f6`](https://github.com/ivov/lisette/commit/2faa0f6bbcecefc20bcdb7cfb767c8335a72260a)
 ## [0.2.9](https://github.com/ivov/lisette/compare/lisette-v0.2.8...lisette-v0.2.9) - 2026-05-20
 
 - fix: drop redundant block around irrefutable match arm [#464](https://github.com/ivov/lisette/pull/464) [`6e3e211`](https://github.com/ivov/lisette/commit/6e3e2112860d3183ecf51757987ae9e85a3b5fc5)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bincode",
  "ecow",
@@ -610,11 +610,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.9"
+version = "0.2.10"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.9", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.9", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.9", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.9", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.10", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.10", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.10", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.10", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.10", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.10", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.10", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.10", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.10", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.9", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.9", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.10", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.10", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.10", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.10", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.9", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.9", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.9", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.9", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.10", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.10", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.10", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.10", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.10 (upcoming)

- fix: bind more value-plus-error returns as Partial [#475](https://github.com/ivov/lisette/pull/475) [`e1c3772`](https://github.com/ivov/lisette/commit/e1c377254a1bd844d49fb5d4297fc362fb76b70c)
- fix: bind WriteString, ReadFrom and WriteTo as Partial [#474](https://github.com/ivov/lisette/pull/474) [`36ab5d3`](https://github.com/ivov/lisette/commit/36ab5d33b4907b8f92073bbc2e4e0bc658191e38)
- fix: interface not implemented diagnostic for wrapper types [#473](https://github.com/ivov/lisette/pull/473) [`25b2035`](https://github.com/ivov/lisette/commit/25b20359005700d4676b65e5652b5375a780612a)
- test: gate e2e suite on zero re-emit failures [#472](https://github.com/ivov/lisette/pull/472) [`2dfb714`](https://github.com/ivov/lisette/commit/2dfb714a3fb56107ad8f7923aa2b00ca3da8cccb)
- fix: bound global prelude and stdlib defs cache [#471](https://github.com/ivov/lisette/pull/471) [`bb0bf4f`](https://github.com/ivov/lisette/commit/bb0bf4ffab25bd397ea3b9d4186510ee40d502f0)
- feat: unix diagnostic format for lis check [#470](https://github.com/ivov/lisette/pull/470) [`308e859`](https://github.com/ivov/lisette/commit/308e85939326a85e0b5caf053c4dbac0e60462dd)
- fix: prune go output and caches for removed modules [#469](https://github.com/ivov/lisette/pull/469) [`d6a2232`](https://github.com/ivov/lisette/commit/d6a2232f88a03f12a06863c982ce53756ddbd729)
- ci: skip fuzz and release workflows on forks [#468](https://github.com/ivov/lisette/pull/468) [`2a8a152`](https://github.com/ivov/lisette/commit/2a8a152290163a86faa7b5086415f4448ade0a49)
- feat: relative paths in diagnostics [#467](https://github.com/ivov/lisette/pull/467) [`39830a0`](https://github.com/ivov/lisette/commit/39830a045e3c9c1023fadf69f975e028d9450b31)
- feat: bare variants in match arms [#465](https://github.com/ivov/lisette/pull/465) [`2faa0f6`](https://github.com/ivov/lisette/commit/2faa0f6bbcecefc20bcdb7cfb767c8335a72260a)
