### PR TITLE
feat: relative paths in diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -6,11 +6,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use semantics::loader::{Files, Loader};
+use semantics::loader::{FileContent, Files, Loader};
+use semantics::path::relative_to_cwd_with;
 use semantics::store::ENTRY_MODULE_ID;
+
+pub use semantics::path::relative_to_cwd;
 
 pub struct LocalFileSystem {
     search_paths: Vec<PathBuf>,
+    display_cwd: Option<PathBuf>,
 }
 
 impl LocalFileSystem {
@@ -22,6 +26,7 @@ impl LocalFileSystem {
 
         Self {
             search_paths: vec![current_path, stdlib_path],
+            display_cwd: std::env::current_dir().ok(),
         }
     }
 
@@ -36,10 +41,12 @@ impl LocalFileSystem {
             let path = entry.path();
 
             if path.extension().is_some_and(|e| e == "lis")
-                && let Some(filename) = path.file_name().and_then(|s| s.to_str())
                 && let Ok(source) = read_to_string(&path)
+                && let Some(name) = path.file_name().and_then(|s| s.to_str())
             {
-                files.insert(filename.to_string(), source);
+                let display_path = relative_to_cwd_with(&path, self.display_cwd.as_deref())
+                    .unwrap_or_else(|| name.to_string());
+                files.insert(name.to_string(), FileContent::new(source, display_path));
             }
         }
 
@@ -47,10 +54,9 @@ impl LocalFileSystem {
     }
 }
 
-/// Translate module ID to filesystem path (entry module maps to current directory)
 fn to_fs_path(folder_name: &str) -> &str {
     if folder_name == ENTRY_MODULE_ID {
-        "."
+        ""
     } else {
         folder_name
     }
@@ -152,9 +158,13 @@ pub fn collect_lis_filepaths_recursive(dir: &Path) -> Vec<PathBuf> {
 
 impl Loader for LocalFileSystem {
     fn scan_folder(&self, folder_name: &str) -> Files {
-        let folder_name = to_fs_path(folder_name);
+        let fs_name = to_fs_path(folder_name);
         for search_path in &self.search_paths {
-            let folder_path = search_path.join(folder_name);
+            let folder_path = if fs_name.is_empty() {
+                search_path.clone()
+            } else {
+                search_path.join(fs_name)
+            };
             let files = self.collect_files(&folder_path);
 
             if !files.is_empty() {

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -110,12 +110,13 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
         }
     };
 
-    let display_path = std::env::current_dir()
-        .ok()
-        .and_then(|cwd| main_lis.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
-        .unwrap_or_else(|| main_lis.to_path_buf());
-
-    let filename = "main.lis";
+    let entry_name = main_lis
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("main.lis")
+        .to_string();
+    let entry_display =
+        lisette::fs::relative_to_cwd(&main_lis).unwrap_or_else(|| entry_name.clone());
 
     let project_name = go_module_name.rsplit('/').next().unwrap_or(go_module_name);
 
@@ -146,9 +147,14 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
     let source_dir = main_lis.parent().and_then(|p| p.to_str()).unwrap_or(".");
     let local_fs = LocalFileSystem::new(source_dir);
 
-    let result = compile(&main_lis_source, filename, &compile_config, &local_fs);
+    let result = compile(
+        &main_lis_source,
+        &entry_name,
+        &entry_display,
+        &compile_config,
+        &local_fs,
+    );
 
-    let filename = display_path.display().to_string();
     let filter = Filter {
         errors_only: false,
         warnings_only: false,
@@ -166,7 +172,7 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
         result.user_file_count,
         &filter,
         &main_lis_source,
-        &filename,
+        &entry_display,
     );
 
     if counts.errors > 0 {
@@ -174,6 +180,24 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
     }
 
     let heading = "Failed to compile Lisette project to Go";
+
+    if debug
+        && let Err(e) = semantics::cache::apply_emit_stamps(
+            &prep.project_path,
+            &result
+                .emit_stamps
+                .iter()
+                .map(|s| (s.clone(), None))
+                .collect::<Vec<_>>(),
+        )
+    {
+        cli_error!(
+            heading,
+            format!("Failed to invalidate emit stamps before debug write: {e}"),
+            "Check file permissions on `target/cache`, or delete the directory and retry"
+        );
+        return 1;
+    }
 
     let emit = match go_cli::write_go_outputs(&prep.target_dir, &result.output) {
         Ok(emit) => emit,
@@ -221,6 +245,19 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
     ) {
         cli_error!(heading, e.message, e.hint);
         return 1;
+    }
+
+    if !debug
+        && let Err(e) = semantics::cache::apply_emit_stamps(
+            &prep.project_path,
+            &result
+                .emit_stamps
+                .iter()
+                .map(|s| (s.clone(), Some(s.artifact_hash)))
+                .collect::<Vec<_>>(),
+        )
+    {
+        eprintln!("warning: failed to write emit stamps: {e}");
     }
 
     // Committed only after gofmt + tidy succeed.

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -161,10 +161,13 @@ fn compile_single_file(
         }
     };
 
-    let filename = file_path
+    let entry_name = file_path
         .file_name()
         .and_then(|s| s.to_str())
-        .unwrap_or("main.lis");
+        .unwrap_or("main.lis")
+        .to_string();
+    let entry_display =
+        lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| entry_name.clone());
 
     let config = CompileConfig {
         target_phase: CompilePhase::Check,
@@ -179,10 +182,9 @@ fn compile_single_file(
     let working_dir = file_path.parent().and_then(|p| p.to_str()).unwrap_or(".");
 
     let fs = LocalFileSystem::new(working_dir);
-    let result = compile(&source, filename, &config, &fs);
-    let display_filename = file_path.display().to_string();
+    let result = compile(&source, &entry_name, &entry_display, &config, &fs);
 
-    Some((result, source, display_filename))
+    Some((result, source, entry_display))
 }
 
 fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -239,11 +239,6 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         return 1;
     }
 
-    let filename = file_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("main.lis");
-
     let compile_config = CompileConfig {
         target_phase: CompilePhase::Emit,
         go_module: "lis-standalone".to_string(),
@@ -256,13 +251,26 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
 
     struct NoLoader;
     impl Loader for NoLoader {
-        fn scan_folder(&self, _folder_name: &str) -> rustc_hash::FxHashMap<String, String> {
+        fn scan_folder(&self, _folder_name: &str) -> semantics::loader::Files {
             rustc_hash::FxHashMap::default()
         }
     }
 
+    let entry_name = file_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file)
+        .to_string();
+    let entry_display = lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file.to_string());
+
     let no_loader = NoLoader;
-    let result = compile(&source, filename, &compile_config, &no_loader);
+    let result = compile(
+        &source,
+        &entry_name,
+        &entry_display,
+        &compile_config,
+        &no_loader,
+    );
 
     let filter = Filter {
         errors_only: false,
@@ -281,7 +289,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         result.user_file_count,
         &filter,
         &source,
-        file,
+        &entry_display,
     );
 
     if counts.errors > 0 {

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -6,6 +6,7 @@ use diagnostics::LisetteDiagnostic;
 use emit::{EmitOptions, Emitter, OutputFile};
 
 use semantics::analyze::{AnalyzeInput, SemanticConfig, analyze};
+use semantics::cache::EmitStamp;
 
 pub use semantics::analyze::CompilePhase;
 use semantics::loader::Loader;
@@ -36,11 +37,13 @@ pub struct CompileResult {
     pub lints: Vec<LisetteDiagnostic>,
     pub sources: HashMap<u32, SourceInfo>,
     pub user_file_count: usize,
+    pub emit_stamps: Vec<EmitStamp>,
 }
 
 pub fn compile(
     source: &str,
     filename: &str,
+    display_path: &str,
     config: &CompileConfig,
     fs: &dyn Loader,
 ) -> CompileResult {
@@ -52,7 +55,7 @@ pub fn compile(
             ENTRY_FILE_ID,
             SourceInfo {
                 source: source.to_string(),
-                filename: filename.to_string(),
+                filename: display_path.to_string(),
             },
         );
         return CompileResult {
@@ -61,10 +64,13 @@ pub fn compile(
             lints: vec![],
             sources,
             user_file_count: 1,
+            emit_stamps: vec![],
         };
     }
 
-    let (semantic_result, _facts) = analyze(AnalyzeInput {
+    let disable_cache = config.debug && config.target_phase == CompilePhase::Emit;
+
+    let analyze_output = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
             standalone_mode: config.standalone_mode,
@@ -73,11 +79,16 @@ pub fn compile(
         loader: fs,
         source: source.to_string(),
         filename: filename.to_string(),
+        display_path: display_path.to_string(),
         ast: syntax_result.ast,
         project_root: config.project_root.clone(),
         compile_phase: config.target_phase,
         locator: config.locator.clone(),
+        go_module: config.go_module.clone(),
+        disable_cache,
     });
+    let semantic_result = analyze_output.result;
+    let emit_stamps = analyze_output.emit_stamps;
 
     let user_file_count = semantic_result.files.len();
 
@@ -89,7 +100,7 @@ pub fn compile(
                 *file_id,
                 SourceInfo {
                     source: file.source.clone(),
-                    filename: file.name.clone(),
+                    filename: file.display_path.clone(),
                 },
             )
         })
@@ -106,6 +117,7 @@ pub fn compile(
             lints,
             sources,
             user_file_count,
+            emit_stamps,
         };
     }
 
@@ -128,6 +140,7 @@ pub fn compile(
             lints,
             sources,
             user_file_count,
+            emit_stamps,
         };
     }
 
@@ -137,6 +150,7 @@ pub fn compile(
         lints,
         sources,
         user_file_count,
+        emit_stamps,
     }
 }
 
@@ -165,7 +179,7 @@ mod tests {
             .and_then(|p| p.to_str())
             .expect("temp project path is valid utf-8");
         let fs_loader = LocalFileSystem::new(working_dir);
-        let result = compile(&source, "main.lis", &config, &fs_loader);
+        let result = compile(&source, "main.lis", "src/main.lis", &config, &fs_loader);
 
         let mut diags: Vec<(bool, Option<String>)> = result
             .errors

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -235,12 +235,10 @@ impl<'a> Emitter<'a> {
                 .files
                 .iter()
                 .map(|(file_id, file)| {
-                    let path = if file.module_id == analysis.entry_module_id {
-                        format!("src/{}", file.name)
-                    } else {
-                        format!("{}/{}", file.module_id, file.name)
-                    };
-                    (*file_id, LineIndex::from_source(path, &file.source))
+                    (
+                        *file_id,
+                        LineIndex::from_source(file.display_path.clone(), &file.source),
+                    )
                 })
                 .collect()
         } else {

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -124,7 +124,7 @@ impl SharedState {
                 (locator, None, None)
             };
 
-        let (mut result, facts) = analyze(AnalyzeInput {
+        let analyze_output = analyze(AnalyzeInput {
             config: SemanticConfig {
                 run_lints: !has_parse_errors,
                 standalone_mode: config.standalone_mode,
@@ -132,6 +132,7 @@ impl SharedState {
             },
             loader: &loader_clone,
             source,
+            display_path: filename.clone(),
             filename,
             ast: desugar_result.ast,
             project_root: if config.standalone_mode {
@@ -141,7 +142,11 @@ impl SharedState {
             },
             compile_phase: CompilePhase::Check,
             locator,
+            go_module: String::new(),
+            disable_cache: false,
         });
+        let mut result = analyze_output.result;
+        let facts = analyze_output.facts;
 
         if has_parse_errors {
             let mut all_errors = parse_errors;

--- a/crates/lsp/src/loader.rs
+++ b/crates/lsp/src/loader.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap as HashMap;
 use std::fs::{read_dir, read_to_string};
 use std::path::{Path, PathBuf};
 
-use semantics::loader::{Files, Loader};
+use semantics::loader::{FileContent, Files, Loader};
 
 use crate::paths::{ENTRY_MODULE_ID, module_id_to_dir};
 use crate::project::ProjectConfig;
@@ -69,7 +69,10 @@ impl Loader for OverlayLoader {
                     && filename.ends_with(".lis")
                     && let Ok(content) = read_to_string(&path)
                 {
-                    files.insert(filename.to_string(), content);
+                    files.insert(
+                        filename.to_string(),
+                        FileContent::new(content, filename.to_string()),
+                    );
                 }
             }
         }
@@ -80,17 +83,26 @@ impl Loader for OverlayLoader {
                     && let Some(module_overlays) = self.overlays.get(&actual_module_id)
                 {
                     for (filename, content) in module_overlays {
-                        files.insert(filename.clone(), content.clone());
+                        files.insert(
+                            filename.clone(),
+                            FileContent::new(content.clone(), filename.clone()),
+                        );
                     }
                 }
             } else if let Some(module_overlays) = self.overlays.get(ENTRY_MODULE_ID) {
                 for (filename, content) in module_overlays {
-                    files.insert(filename.clone(), content.clone());
+                    files.insert(
+                        filename.clone(),
+                        FileContent::new(content.clone(), filename.clone()),
+                    );
                 }
             }
         } else if let Some(module_overlays) = self.overlays.get(module_id) {
             for (filename, content) in module_overlays {
-                files.insert(filename.clone(), content.clone());
+                files.insert(
+                    filename.clone(),
+                    FileContent::new(content.clone(), filename.clone()),
+                );
             }
         }
 

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -22,3 +22,6 @@ ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -10,7 +10,8 @@ use syntax::program::{File, ModuleInfo, MutationInfo, UnusedInfo};
 use deps::TypedefLocator;
 
 use crate::cache::{
-    CompiledModule, compute_module_hash, get_dependency_module_hashes,
+    CompiledModule, EmitStamp, compute_emit_artifact_hash, compute_module_hash,
+    get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
     hash_module_sources, is_cache_disabled, prelude as prelude_cache, register_cached_module,
     save_module_cache, try_load_cache,
@@ -42,23 +43,46 @@ pub struct AnalyzeInput<'a> {
     pub config: SemanticConfig,
     pub loader: &'a dyn Loader,
     pub source: String,
+    /// Bare identity name of the entry file (e.g. `main.lis`).
     pub filename: String,
+    /// Cwd-relative display path for the entry file (e.g. `src/main.lis`);
+    /// equals `filename` when there is no separate display path.
+    pub display_path: String,
     pub ast: Vec<Expression>,
     pub project_root: Option<PathBuf>,
     pub compile_phase: CompilePhase,
     pub locator: TypedefLocator,
+    /// Go module path (from `lisette.toml`); folded into the cache emit-artifact
+    /// hash so a project rename invalidates Go outputs.
+    pub go_module: String,
+    /// When true, `analyze` skips both cache load and save. Set by the CLI for
+    /// `--debug` Emit so cwd-decorated Go files are not reused across cwds.
+    pub disable_cache: bool,
 }
 
-pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
+/// Wraps `SemanticResult` plus per-module emit stamps the CLI uses to update
+/// the cache after a successful artifact write.
+pub struct AnalyzeOutput {
+    pub result: SemanticResult,
+    pub facts: Facts,
+    pub emit_stamps: Vec<EmitStamp>,
+}
+
+pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
     let mut store = Store::new();
 
     store.init_entry_module();
-    store.store_entry_file(&input.filename, &input.source, input.ast);
+    store.store_entry_file(
+        &input.filename,
+        &input.display_path,
+        &input.source,
+        input.ast,
+    );
 
     let sink = LocalSink::new();
 
     if input.config.load_siblings {
-        for (filename, source) in input.loader.scan_folder(ENTRY_MODULE_ID) {
+        for (filename, content) in input.loader.scan_folder(ENTRY_MODULE_ID) {
             if filename == input.filename
                 || !filename.ends_with(".lis")
                 || filename.ends_with(".d.lis")
@@ -66,11 +90,18 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                 continue;
             }
             let file_id = store.new_file_id();
-            let result = syntax::build_ast(&source, file_id);
+            let result = syntax::build_ast(&content.source, file_id);
             sink.extend_parse_errors(result.errors);
             store.store_file(
                 ENTRY_MODULE_ID,
-                File::new(ENTRY_MODULE_ID, &filename, &source, result.ast, file_id),
+                File::new(
+                    ENTRY_MODULE_ID,
+                    &filename,
+                    &content.display_path,
+                    &content.source,
+                    result.ast,
+                    file_id,
+                ),
             );
         }
     }
@@ -106,7 +137,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
         parse_and_register_prelude(&mut store, &sink);
     }
 
-    let cache_enabled = input.project_root.is_some() && !cache_disabled;
+    let cache_enabled = input.project_root.is_some() && !cache_disabled && !input.disable_cache;
     let check_go_files = input.compile_phase == CompilePhase::Emit;
 
     let binding_ids = Arc::new(BindingIdAllocator::new());
@@ -185,6 +216,9 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
 
             let is_entry = module_id == ENTRY_MODULE_ID;
 
+            let expected_artifact_hash =
+                check_go_files.then(|| compute_emit_artifact_hash(source_hash, &input.go_module));
+
             if cache_enabled
                 && !is_entry
                 && let Some(ref project_root) = input.project_root
@@ -192,6 +226,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                     &module_id,
                     source_hash,
                     &dep_hashes,
+                    expected_artifact_hash,
                     project_root,
                     check_go_files,
                 )
@@ -199,7 +234,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
                 checker
                     .ufcs_methods
                     .extend(cached.ufcs_methods.iter().cloned());
-                register_cached_module(&mut store, &module_id, cached);
+                register_cached_module(&mut store, &module_id, cached, project_root);
                 cached_modules.insert(module_id.clone());
                 continue;
             }
@@ -207,7 +242,7 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
             store.store_module(&module_id, files);
             checker.register_module(&mut store, &module_id);
 
-            if cache_enabled && !is_entry {
+            if !is_entry {
                 compiled_modules.push(CompiledModule {
                     module_id: module_id.clone(),
                     source_hash,
@@ -323,6 +358,14 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
     all_diagnostics.sort_by(diagnostics::LisetteDiagnostic::sort_key);
     let (errors, lints): (Vec<_>, Vec<_>) = all_diagnostics.into_iter().partition(|d| d.is_error());
 
+    let emit_stamps: Vec<EmitStamp> = compiled_modules
+        .iter()
+        .map(|c| EmitStamp {
+            module_id: c.module_id.clone(),
+            artifact_hash: compute_emit_artifact_hash(c.source_hash, &input.go_module),
+        })
+        .collect();
+
     if cache_enabled && let Some(ref project_root) = input.project_root {
         let has_errors = errors.iter().any(|e| e.is_error());
         if !has_errors {
@@ -404,5 +447,9 @@ pub fn analyze(input: AnalyzeInput) -> (SemanticResult, Facts) {
         go_module_ids,
     };
 
-    (result, facts)
+    AnalyzeOutput {
+        result,
+        facts,
+        emit_stamps,
+    }
 }

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -91,6 +91,12 @@ pub struct ModuleInterface {
 
     /// UFCS method pairs for this module, computed during registration.
     pub ufcs_methods: Vec<(String, String)>,
+
+    /// Artifact hash of the on-disk Go files produced for this module.
+    /// `None` after a Check-phase save or before the post-write stamp call;
+    /// `Some(h)` when the on-disk Go files came from a successful Emit for
+    /// artifact hash `h`.
+    pub emit_stamp: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,11 +105,25 @@ pub struct CachedFile {
     pub source: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompiledModule {
     pub module_id: String,
     pub source_hash: u64,
     pub dep_hashes: HashMap<String, u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EmitStamp {
+    pub module_id: String,
+    pub artifact_hash: u64,
+}
+
+/// Hash over the non-debug Go-artifact inputs for one module.
+pub fn compute_emit_artifact_hash(source_hash: u64, go_module: &str) -> u64 {
+    let mut hasher = FnvHasher::new();
+    source_hash.hash(&mut hasher);
+    go_module.hash(&mut hasher);
+    hasher.finish()
 }
 
 pub fn hash_module_sources(files: &[File]) -> u64 {
@@ -181,21 +201,32 @@ pub fn try_load_cache(
     module_id: &str,
     expected_source_hash: u64,
     expected_dep_hashes: &HashMap<String, u64>,
+    expected_artifact_hash: Option<u64>,
     project_root: &Path,
     check_go_files: bool,
 ) -> Option<ModuleInterface> {
     let path = cache_path(project_root, module_id);
     let bytes = fs::read(&path).ok()?;
-    let interface: ModuleInterface = bincode::deserialize(&bytes).ok()?;
+    let interface: ModuleInterface = match bincode::deserialize(&bytes) {
+        Ok(i) => i,
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    };
 
     if !is_cache_valid(&interface, expected_source_hash, expected_dep_hashes) {
         let _ = fs::remove_file(&path);
         return None;
     }
 
-    if check_go_files && !all_go_outputs_exist(module_id, &interface.files, project_root) {
-        let _ = fs::remove_file(&path);
-        return None;
+    if check_go_files {
+        if interface.emit_stamp != expected_artifact_hash {
+            return None;
+        }
+        if !all_go_outputs_exist(module_id, &interface.files, project_root) {
+            return None;
+        }
     }
 
     Some(interface)
@@ -268,6 +299,7 @@ pub fn save_module_cache(
                 .cloned()
                 .collect()
         },
+        emit_stamp: None,
     };
 
     let path = cache_path(project_root, &compiled.module_id);
@@ -307,8 +339,15 @@ fn extract_public_definitions(
 }
 
 /// Register a cached module in the store.
-/// This loads the cached definitions and source files without running inference.
-pub fn register_cached_module(store: &mut Store, module_id: &str, cached: ModuleInterface) {
+/// `display_path` for each cached file is recomputed from the project layout
+/// against the current cwd, so warm and cold builds render the same diagnostic
+/// paths even though the cache stores only bare names.
+pub fn register_cached_module(
+    store: &mut Store,
+    module_id: &str,
+    cached: ModuleInterface,
+    project_root: &Path,
+) {
     store.add_module(module_id);
 
     let mut file_ids: Vec<u32> = vec![];
@@ -316,7 +355,14 @@ pub fn register_cached_module(store: &mut Store, module_id: &str, cached: Module
         let file_id = store.new_file_id();
         file_ids.push(file_id);
 
-        let file = File::new_cached(module_id, &cached_file.name, &cached_file.source, file_id);
+        let display_path = cached_file_display_path(project_root, module_id, &cached_file.name);
+        let file = File::new_cached(
+            module_id,
+            &cached_file.name,
+            &display_path,
+            &cached_file.source,
+            file_id,
+        );
 
         store.store_file(module_id, file);
     }
@@ -328,6 +374,47 @@ pub fn register_cached_module(store: &mut Store, module_id: &str, cached: Module
     }
 
     store.mark_visited(module_id);
+}
+
+fn cached_file_display_path(project_root: &Path, module_id: &str, bare_name: &str) -> String {
+    let on_disk = if module_id == ENTRY_MODULE_ID {
+        project_root.join("src").join(bare_name)
+    } else {
+        project_root.join("src").join(module_id).join(bare_name)
+    };
+    crate::path::relative_to_cwd(&on_disk).unwrap_or_else(|| bare_name.to_string())
+}
+
+/// Set or clear the `emit_stamp` for each module's cache file. Missing files
+/// are skipped; undecodable (e.g. pre-bump) files are unlinked and skipped;
+/// other read errors propagate so the debug pre-write clear can hard-fail
+/// rather than leave a stale stamp over freshly-overwritten Go.
+pub fn apply_emit_stamps(
+    project_root: &Path,
+    updates: &[(EmitStamp, Option<u64>)],
+) -> io::Result<()> {
+    for (stamp, value) in updates {
+        let path = cache_path(project_root, &stamp.module_id);
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+        let mut interface: ModuleInterface = match bincode::deserialize(&bytes) {
+            Ok(i) => i,
+            Err(_) => {
+                let _ = fs::remove_file(&path);
+                continue;
+            }
+        };
+        interface.emit_stamp = *value;
+
+        let temp_path = path.with_extension("cache.tmp");
+        let new_bytes = bincode::serialize(&interface).map_err(io::Error::other)?;
+        fs::write(&temp_path, new_bytes)?;
+        fs::rename(&temp_path, &path)?;
+    }
+    Ok(())
 }
 
 pub fn is_cache_disabled() -> bool {
@@ -343,8 +430,8 @@ mod tests {
 
     #[test]
     fn test_hash_module_sources_deterministic() {
-        let file1 = File::new_cached("mod", "a.lis", "fn foo() {}", 1);
-        let file2 = File::new_cached("mod", "b.lis", "fn bar() {}", 2);
+        let file1 = File::new_cached("mod", "a.lis", "a.lis", "fn foo() {}", 1);
+        let file2 = File::new_cached("mod", "b.lis", "b.lis", "fn bar() {}", 2);
 
         let hash1 = hash_module_sources(&[file1.clone(), file2.clone()]);
         let hash2 = hash_module_sources(&[file2.clone(), file1.clone()]);
@@ -354,8 +441,8 @@ mod tests {
 
     #[test]
     fn test_hash_module_sources_content_sensitive() {
-        let file1 = File::new_cached("mod", "a.lis", "fn foo() {}", 1);
-        let file2 = File::new_cached("mod", "a.lis", "fn bar() {}", 1);
+        let file1 = File::new_cached("mod", "a.lis", "a.lis", "fn foo() {}", 1);
+        let file2 = File::new_cached("mod", "a.lis", "a.lis", "fn bar() {}", 1);
 
         let hash1 = hash_module_sources(&[file1]);
         let hash2 = hash_module_sources(&[file2]);
@@ -403,6 +490,7 @@ mod tests {
             files: vec![],
             definitions: HashMap::default(),
             ufcs_methods: vec![],
+            emit_stamp: None,
         };
 
         assert!(!is_cache_valid(&cache, 100, &HashMap::default()));
@@ -420,6 +508,7 @@ mod tests {
             files: vec![],
             definitions: HashMap::default(),
             ufcs_methods: vec![],
+            emit_stamp: None,
         };
 
         assert!(!is_cache_valid(&cache, 100, &HashMap::default()));
@@ -437,6 +526,7 @@ mod tests {
             files: vec![],
             definitions: HashMap::default(),
             ufcs_methods: vec![],
+            emit_stamp: None,
         };
 
         assert!(!is_cache_valid(&cache, 200, &HashMap::default()));
@@ -458,6 +548,7 @@ mod tests {
             files: vec![],
             definitions: HashMap::default(),
             ufcs_methods: vec![],
+            emit_stamp: None,
         };
 
         let mut different_deps = HashMap::default();
@@ -518,5 +609,199 @@ mod tests {
         assert_eq!(result.get("go:fmt"), Some(&STDLIB_HASH));
         assert_eq!(result.get("prelude"), Some(&STDLIB_HASH));
         assert_eq!(result.get("user_mod"), Some(&12345u64));
+    }
+
+    #[test]
+    fn hash_module_sources_independent_of_display_path() {
+        let cli_file = File::new(
+            "greet",
+            "greet.lis",
+            "src/greet/greet.lis",
+            "pub fn x() -> int { 1 }",
+            vec![],
+            1,
+        );
+        let lsp_file = File::new(
+            "greet",
+            "greet.lis",
+            "greet.lis",
+            "pub fn x() -> int { 1 }",
+            vec![],
+            1,
+        );
+
+        assert_eq!(
+            hash_module_sources(&[cli_file]),
+            hash_module_sources(&[lsp_file]),
+        );
+    }
+
+    #[test]
+    fn cache_file_purity_no_src_prefix() {
+        let cached = CachedFile {
+            name: "greet.lis".to_string(),
+            source: "pub fn x() -> int { 1 }".to_string(),
+        };
+        let bytes = bincode::serialize(&cached).unwrap();
+        let serialized = String::from_utf8_lossy(&bytes);
+        assert!(
+            !serialized.contains("src/"),
+            "CachedFile must not contain `src/` prefix; got: {serialized:?}"
+        );
+    }
+
+    #[test]
+    fn artifact_hash_depends_on_go_module() {
+        let h1 = compute_emit_artifact_hash(100, "github.com/old/proj");
+        let h2 = compute_emit_artifact_hash(100, "github.com/new/proj");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn apply_emit_stamps_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("target").join("cache")).unwrap();
+
+        let interface = ModuleInterface {
+            version: CACHE_FORMAT_VERSION,
+            compiler_version: COMPILER_VERSION_HASH,
+            stdlib_hash: STDLIB_HASH,
+            module_hash: 0,
+            source_hash: 100,
+            dependency_hashes: HashMap::default(),
+            files: vec![],
+            definitions: HashMap::default(),
+            ufcs_methods: vec![],
+            emit_stamp: None,
+        };
+        let path = cache_path(root, "greet");
+        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+
+        let stamp = EmitStamp {
+            module_id: "greet".to_string(),
+            artifact_hash: 999,
+        };
+        apply_emit_stamps(root, &[(stamp.clone(), Some(999))]).unwrap();
+        let reread: ModuleInterface = bincode::deserialize(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(reread.emit_stamp, Some(999));
+        assert_eq!(reread.source_hash, 100);
+
+        apply_emit_stamps(root, &[(stamp, None)]).unwrap();
+        let reread: ModuleInterface = bincode::deserialize(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(reread.emit_stamp, None);
+    }
+
+    #[test]
+    fn apply_emit_stamps_missing_cache_is_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stamp = EmitStamp {
+            module_id: "absent".to_string(),
+            artifact_hash: 0,
+        };
+        let result = apply_emit_stamps(tmp.path(), &[(stamp, None)]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_load_cache_rejects_unstamped_for_emit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("target").join("cache")).unwrap();
+        std::fs::create_dir_all(root.join("target").join("greet")).unwrap();
+        std::fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
+
+        let interface = ModuleInterface {
+            version: CACHE_FORMAT_VERSION,
+            compiler_version: COMPILER_VERSION_HASH,
+            stdlib_hash: STDLIB_HASH,
+            module_hash: 0,
+            source_hash: 100,
+            dependency_hashes: HashMap::default(),
+            files: vec![CachedFile {
+                name: "greet.lis".to_string(),
+                source: String::new(),
+            }],
+            definitions: HashMap::default(),
+            ufcs_methods: vec![],
+            emit_stamp: None,
+        };
+        let path = cache_path(root, "greet");
+        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+
+        let loaded = try_load_cache("greet", 100, &HashMap::default(), None, root, false);
+        assert!(loaded.is_some(), "Check phase must accept unstamped cache");
+
+        let loaded = try_load_cache(
+            "greet",
+            100,
+            &HashMap::default(),
+            Some(compute_emit_artifact_hash(100, "github.com/test/x")),
+            root,
+            true,
+        );
+        assert!(
+            loaded.is_none(),
+            "Emit phase must reject cache with emit_stamp = None"
+        );
+    }
+
+    #[test]
+    fn try_load_cache_rejects_after_debug_invalidation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("target").join("cache")).unwrap();
+        std::fs::create_dir_all(root.join("target").join("greet")).unwrap();
+        std::fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
+
+        let artifact_hash = compute_emit_artifact_hash(100, "github.com/test/x");
+
+        let interface = ModuleInterface {
+            version: CACHE_FORMAT_VERSION,
+            compiler_version: COMPILER_VERSION_HASH,
+            stdlib_hash: STDLIB_HASH,
+            module_hash: 0,
+            source_hash: 100,
+            dependency_hashes: HashMap::default(),
+            files: vec![CachedFile {
+                name: "greet.lis".to_string(),
+                source: String::new(),
+            }],
+            definitions: HashMap::default(),
+            ufcs_methods: vec![],
+            emit_stamp: Some(artifact_hash),
+        };
+        let path = cache_path(root, "greet");
+        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+
+        assert!(
+            try_load_cache(
+                "greet",
+                100,
+                &HashMap::default(),
+                Some(artifact_hash),
+                root,
+                true,
+            )
+            .is_some()
+        );
+
+        let stamp = EmitStamp {
+            module_id: "greet".to_string(),
+            artifact_hash,
+        };
+        apply_emit_stamps(root, &[(stamp, None)]).unwrap();
+
+        assert!(
+            try_load_cache(
+                "greet",
+                100,
+                &HashMap::default(),
+                Some(artifact_hash),
+                root,
+                true,
+            )
+            .is_none()
+        );
     }
 }

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -94,6 +94,7 @@ pub fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
             id: PRELUDE_FILE_ID,
             module_id: PRELUDE_MODULE_ID.to_string(),
             name: "prelude.d.lis".to_string(),
+            display_path: "prelude.d.lis".to_string(),
             source: stdlib::LIS_PRELUDE_SOURCE.to_string(),
             items: vec![],
         },

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -68,6 +68,7 @@ impl TaskState<'_> {
                     id: file_id,
                     module_id: file.module_id,
                     name: file.name,
+                    display_path: file.display_path,
                     source: file.source,
                     items: frozen_items,
                 };

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -147,7 +147,8 @@ impl TaskState<'_> {
         let file = File {
             id: file_id,
             module_id: module_id.to_string(),
-            name: filename,
+            name: filename.clone(),
+            display_path: filename,
             source: source.to_string(),
             items: build_result.ast,
         };

--- a/crates/semantics/src/lib.rs
+++ b/crates/semantics/src/lib.rs
@@ -8,6 +8,7 @@ pub mod facts;
 pub mod loader;
 pub mod module_graph;
 pub mod passes;
+pub mod path;
 pub mod prelude;
 pub mod store;
 

--- a/crates/semantics/src/loader.rs
+++ b/crates/semantics/src/loader.rs
@@ -1,8 +1,27 @@
 use rustc_hash::FxHashMap as HashMap;
 
-pub type Files = HashMap<String, String>; // filename -> content
+/// Source content plus a cwd-relative display path for diagnostics.
+/// `display_path` matches `name` for loaders that have no notion of cwd
+/// (test/overlay loaders); the CLI's filesystem loader sets it to the path
+/// relative to the process cwd.
+#[derive(Debug, Clone)]
+pub struct FileContent {
+    pub source: String,
+    pub display_path: String,
+}
+
+impl FileContent {
+    pub fn new(source: impl Into<String>, display_path: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            display_path: display_path.into(),
+        }
+    }
+}
+
+pub type Files = HashMap<String, FileContent>;
 
 pub trait Loader {
-    /// Scans a folder and returns all `.lis` files as a map of filename to content
+    /// Scans a folder and returns all `.lis` files keyed by bare filename.
     fn scan_folder(&self, folder: &str) -> Files;
 }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -7,6 +7,7 @@ use syntax::ast::{ImportAlias, Span};
 use syntax::program::File;
 
 use crate::diagnostics::{emit_for_declaration_status, emit_for_locator_result};
+use crate::loader as semantics_loader;
 use crate::loader::Loader;
 use crate::store::Store;
 use diagnostics::LocalSink;
@@ -158,6 +159,7 @@ struct ParseJob {
     module_id: ModuleId,
     file_id: u32,
     filename: String,
+    display_path: String,
     source: String,
 }
 
@@ -176,12 +178,13 @@ fn batch_parse_modules(
         if store.has(module_id) {
             continue;
         }
-        let mut entries: Vec<(String, String)> = fs.scan_folder(module_id).into_iter().collect();
+        let mut entries: Vec<(String, semantics_loader::FileContent)> =
+            fs.scan_folder(module_id).into_iter().collect();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
-        for (filename, source) in entries {
+        for (filename, content) in entries {
             if filename.ends_with("_test.lis") {
                 sink.push(diagnostics::module_graph::test_file_not_supported(
-                    &filename,
+                    &content.display_path,
                 ));
                 continue;
             }
@@ -190,7 +193,8 @@ fn batch_parse_modules(
                 module_id: module_id.clone(),
                 file_id,
                 filename,
-                source,
+                display_path: content.display_path,
+                source: content.source,
             });
         }
     }
@@ -217,6 +221,7 @@ fn parse_one(job: ParseJob) -> (ModuleId, File, Vec<syntax::ParseError>) {
     let file = File::new(
         &job.module_id,
         &job.filename,
+        &job.display_path,
         &job.source,
         result.ast,
         job.file_id,

--- a/crates/semantics/src/path.rs
+++ b/crates/semantics/src/path.rs
@@ -1,0 +1,113 @@
+use std::path::{Component, Path};
+
+/// Returns path relative to the cwd as a forward-slash string.
+/// Returns None if the cwd is unknown or the path lies outside it.
+pub fn relative_to_cwd(path: &Path) -> Option<String> {
+    relative_to_cwd_with(path, std::env::current_dir().ok().as_deref())
+}
+
+pub fn relative_to_cwd_with(path: &Path, cwd: Option<&Path>) -> Option<String> {
+    let cwd = cwd?;
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+
+    if let (Ok(base), Ok(target)) = (cwd.canonicalize(), absolute.canonicalize()) {
+        return relativize(target.strip_prefix(&base).ok()?);
+    }
+    relativize(absolute.strip_prefix(cwd).ok()?)
+}
+
+fn relativize(rel: &Path) -> Option<String> {
+    let mut segments = Vec::new();
+    for component in rel.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => segments.push(segment.to_str()?),
+            _ => return None,
+        }
+    }
+    (!segments.is_empty()).then(|| segments.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs as stdfs;
+
+    #[test]
+    fn plain_path_inside_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("src/main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn file_at_cwd_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("main.lis"), Some(cwd)),
+            Some("main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_leading_dot_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("./src/main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_mid_path_dot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        assert_eq!(
+            relative_to_cwd_with(&cwd.join("src/./main.lis"), Some(cwd)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn path_outside_cwd_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        assert_eq!(
+            relative_to_cwd_with(&other.path().join("main.lis"), Some(tmp.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_cwd_returns_none() {
+        assert_eq!(
+            relative_to_cwd_with(Path::new("/any/path/main.lis"), None),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absolute_path_under_symlinked_cwd_strips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        stdfs::create_dir_all(real.join("src")).unwrap();
+        stdfs::write(real.join("src/main.lis"), "").unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            relative_to_cwd_with(&real.join("src/main.lis"), Some(&link)),
+            Some("src/main.lis".to_string())
+        );
+    }
+}

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -21,6 +21,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
             id: PRELUDE_FILE_ID,
             module_id: PRELUDE_MODULE_ID.to_string(),
             name: "prelude.d.lis".to_string(),
+            display_path: "prelude.d.lis".to_string(),
             source: LIS_PRELUDE_SOURCE.to_string(),
             items: result.ast,
         },

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -77,13 +77,20 @@ impl Store {
         self.register_file(ENTRY_FILE_ID, ENTRY_MODULE_ID);
     }
 
-    pub fn store_entry_file(&mut self, filename: &str, source: &str, ast: Vec<Expression>) {
+    pub fn store_entry_file(
+        &mut self,
+        filename: &str,
+        display_path: &str,
+        source: &str,
+        ast: Vec<Expression>,
+    ) {
         self.store_file(
             ENTRY_MODULE_ID,
             File {
                 id: ENTRY_FILE_ID,
                 module_id: ENTRY_MODULE_ID.to_string(),
                 name: filename.to_string(),
+                display_path: display_path.to_string(),
                 source: source.to_string(),
                 items: ast,
             },

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -9,7 +9,12 @@ use crate::ast::{Expression, ImportAlias, Span};
 pub struct File {
     pub id: u32,
     pub module_id: String,
+    /// Stable bare filename (e.g. `greet.lis`); identity key for caching and
+    /// LSP path reconstruction.
     pub name: String,
+    /// Cwd-relative path for diagnostics and `--debug` directives; equals
+    /// `name` for synthetic/test loaders that have no notion of cwd.
+    pub display_path: String,
     pub source: String,
     pub items: Vec<Expression>,
 }
@@ -49,21 +54,36 @@ impl FileImport {
 }
 
 impl File {
-    pub fn new(module_id: &str, name: &str, source: &str, items: Vec<Expression>, id: u32) -> Self {
+    pub fn new(
+        module_id: &str,
+        name: &str,
+        display_path: &str,
+        source: &str,
+        items: Vec<Expression>,
+        id: u32,
+    ) -> Self {
         File {
             id,
             module_id: module_id.to_string(),
             name: name.to_string(),
+            display_path: display_path.to_string(),
             source: source.to_string(),
             items,
         }
     }
 
-    pub fn new_cached(module_id: &str, name: &str, source: &str, id: u32) -> Self {
+    pub fn new_cached(
+        module_id: &str,
+        name: &str,
+        display_path: &str,
+        source: &str,
+        id: u32,
+    ) -> Self {
         Self {
             id,
             module_id: module_id.to_string(),
             name: name.to_string(),
+            display_path: display_path.to_string(),
             source: source.to_string(),
             items: vec![],
         }

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 
 use std::sync::Arc;
 
-use lisette_semantics::loader::{Files, Loader};
+use lisette_semantics::loader::{FileContent, Files, Loader};
 use lisette_semantics::analyze::{analyze, AnalyzeInput, CompilePhase, SemanticConfig};
 use lisette_semantics::facts::{BindingIdAllocator, Facts};
 use lisette_syntax::ast::{Expression, Span, StructSpread};
@@ -113,8 +113,11 @@ struct MemoryLoader {
 impl Loader for MemoryLoader {
     fn scan_folder(&self, folder: &str) -> Files {
         if folder == "_entry_" {
-            let mut map: FxHashMap<String, String> = FxHashMap::default();
-            map.insert(self.filename.clone(), self.source.clone());
+            let mut map: Files = FxHashMap::default();
+            map.insert(
+                self.filename.clone(),
+                FileContent::new(self.source.clone(), self.filename.clone()),
+            );
             map
         } else {
             FxHashMap::default()
@@ -223,13 +226,18 @@ fn run_analysis(code: &str) -> AnalysisResult {
         loader: &loader,
         source: code.to_string(),
         filename: PLAYGROUND_FILE.to_string(),
+        display_path: PLAYGROUND_FILE.to_string(),
         ast: ast_result.ast,
         project_root: None,
         locator: lisette_deps::TypedefLocator::default(),
         compile_phase: CompilePhase::Check,
+        go_module: String::new(),
+        disable_cache: false,
     };
 
-    let (sem_result, facts) = analyze(input);
+    let analyze_output = analyze(input);
+    let sem_result = analyze_output.result;
+    let facts = analyze_output.facts;
 
     for e in &sem_result.errors {
         diagnostics.push(convert_lisette_diag(e, code));
@@ -276,13 +284,16 @@ fn run_pipeline(
         loader: &loader,
         source: code.to_string(),
         filename: PLAYGROUND_FILE.to_string(),
+        display_path: PLAYGROUND_FILE.to_string(),
         ast: ast_result.ast,
         project_root: None,
         compile_phase: phase.clone(),
         locator: lisette_deps::TypedefLocator::default(),
+        go_module: String::new(),
+        disable_cache: false,
     };
 
-    let (sem_result, _facts) = analyze(input);
+    let sem_result = analyze(input).result;
 
     for e in &sem_result.errors {
         diagnostics.push(convert_lisette_diag(e, code));

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -16,7 +16,7 @@ fn compile_with(
     let main_source = fs
         .scan_folder(ENTRY_MODULE_ID)
         .get("main.lis")
-        .cloned()
+        .map(|c| c.source.clone())
         .expect("main.lis must exist");
 
     let build_result = syntax::build_ast(&main_source, ENTRY_FILE_ID);
@@ -29,12 +29,15 @@ fn compile_with(
         loader: &fs,
         source: main_source,
         filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
         locator,
         compile_phase: semantics::analyze::CompilePhase::Check,
+        go_module: String::new(),
+        disable_cache: false,
     })
-    .0
+    .result
 }
 
 pub fn compile_check(fs: MockFileSystem) -> SemanticResult {
@@ -88,11 +91,15 @@ pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLoc
     deps::TypedefLocator::new(go_deps, None, stdlib::Target::host())
 }
 
-pub fn compile_project_files(fs: MockFileSystem, go_module: &str) -> Vec<emit::OutputFile> {
+pub fn compile_project_files(
+    fs: MockFileSystem,
+    go_module: &str,
+    debug: bool,
+) -> Vec<emit::OutputFile> {
     let main_source = fs
         .scan_folder(ENTRY_MODULE_ID)
         .get("main.lis")
-        .cloned()
+        .map(|c| c.source.clone())
         .expect("main.lis must exist");
 
     let build_result = syntax::build_ast(&main_source, ENTRY_FILE_ID);
@@ -102,7 +109,7 @@ pub fn compile_project_files(fs: MockFileSystem, go_module: &str) -> Vec<emit::O
         build_result.errors
     );
 
-    let (analysis, _facts) = analyze(AnalyzeInput {
+    let analyze_output = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
             standalone_mode: false,
@@ -111,11 +118,15 @@ pub fn compile_project_files(fs: MockFileSystem, go_module: &str) -> Vec<emit::O
         loader: &fs,
         source: main_source,
         filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
         locator: deps::TypedefLocator::default(),
         compile_phase: semantics::analyze::CompilePhase::Emit,
+        go_module: go_module.to_string(),
+        disable_cache: true,
     });
+    let analysis = analyze_output.result;
 
     assert!(
         analysis.errors.is_empty(),
@@ -126,12 +137,12 @@ pub fn compile_project_files(fs: MockFileSystem, go_module: &str) -> Vec<emit::O
     Emitter::emit(
         &analysis.into_emit_input(),
         go_module,
-        EmitOptions { debug: false },
+        EmitOptions { debug },
     )
 }
 
 pub fn compile_project(fs: MockFileSystem, go_module: &str) -> String {
-    let mut files = compile_project_files(fs, go_module);
+    let mut files = compile_project_files(fs, go_module, false);
     files.sort_by(|a, b| a.name.cmp(&b.name));
 
     use std::fmt::Write;

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -36,6 +36,7 @@ fn emit_inner(
         id: 0,
         module_id: result.module_id.clone(),
         name: "test.lis".to_string(),
+        display_path: "src/test.lis".to_string(),
         source: source_for_debug.unwrap_or("").to_string(),
         items: result.ast,
     };

--- a/tests/_harness/filesystem.rs
+++ b/tests/_harness/filesystem.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use semantics::loader::{Files, Loader};
+use semantics::loader::{FileContent, Files, Loader};
 
 #[derive(Clone, Default)]
 pub struct MockFileSystem {
@@ -15,10 +15,20 @@ impl MockFileSystem {
     }
 
     pub fn add_file(&mut self, folder: &str, filename: &str, content: &str) {
-        self.folders
-            .entry(folder.to_string())
-            .or_default()
-            .insert(filename.to_string(), content.to_string());
+        self.add_file_with_display(folder, filename, filename, content);
+    }
+
+    pub fn add_file_with_display(
+        &mut self,
+        folder: &str,
+        filename: &str,
+        display_path: &str,
+        content: &str,
+    ) {
+        self.folders.entry(folder.to_string()).or_default().insert(
+            filename.to_string(),
+            FileContent::new(content.to_string(), display_path.to_string()),
+        );
     }
 
     pub(super) fn get_folders(&self) -> Vec<String> {

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -77,6 +77,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
         id: file_id,
         module_id: TEST_MODULE_ID.to_string(),
         name: "test.lis".to_string(),
+        display_path: "test.lis".to_string(),
         source: source.to_string(),
         items: typed_ast,
     };

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -163,6 +163,7 @@ impl CompiledTest {
                 File::new(
                     TEST_MODULE_ID,
                     "test.lis",
+                    "test.lis",
                     "",
                     self.ast.clone(),
                     test_file_id,
@@ -203,6 +204,7 @@ impl CompiledTest {
                     TEST_MODULE_ID,
                     File::new(
                         TEST_MODULE_ID,
+                        "test.lis",
                         "test.lis",
                         "",
                         typed_ast.clone(),

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -49,6 +49,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         id: 0,
         module_id: result.module_id.clone(),
         name: "test.lis".to_string(),
+        display_path: "test.lis".to_string(),
         source: String::new(),
         items: result.ast,
     };

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -5591,7 +5591,7 @@ fn main() {
 "#,
     );
 
-    let files = compile_project_files(fs, "github.com/user/myproject");
+    let files = compile_project_files(fs, "github.com/user/myproject", false);
     let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
     assert_eq!(
         names,
@@ -5654,4 +5654,46 @@ fn main() {
     );
 
     assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn module_file_diagnostic_source_uses_relative_path() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"greet\"
+
+fn main() {
+  let _ = greet.value()
+}
+",
+    );
+    fs.add_file_with_display(
+        "greet",
+        "greet.lis",
+        "src/greet/greet.lis",
+        "pub fn value() -> int {
+  42
+}
+",
+    );
+
+    let result = compile_check(fs);
+
+    let displays: Vec<&str> = result
+        .files
+        .values()
+        .map(|f| f.display_path.as_str())
+        .collect();
+    assert!(
+        displays.contains(&"src/greet/greet.lis"),
+        "module file must carry its relative path on display_path; got: {displays:?}"
+    );
+
+    let names: Vec<&str> = result.files.values().map(|f| f.name.as_str()).collect();
+    assert!(
+        names.contains(&"greet.lis"),
+        "module file must keep bare identity name; got: {names:?}"
+    );
 }

--- a/tests/spec/emit/line_directives.rs
+++ b/tests/spec/emit/line_directives.rs
@@ -61,3 +61,42 @@ fn line_directive_includes_column() {
         go_code
     );
 }
+
+#[test]
+fn module_file_line_directive_uses_relative_path_not_doubled() {
+    use crate::_harness::MockFileSystem;
+    use crate::_harness::build::compile_project_files;
+    use semantics::store::ENTRY_MODULE_ID;
+
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"greet\"\n\nfn main() {\n  let _ = greet.value()\n}\n",
+    );
+    fs.add_file_with_display(
+        "greet",
+        "greet.lis",
+        "src/greet/greet.lis",
+        "pub fn value() -> int {\n  42\n}\n",
+    );
+
+    let files = compile_project_files(fs, "github.com/user/myproject", true);
+    let greet = files
+        .iter()
+        .find(|f| f.name == "greet/greet.go")
+        .unwrap_or_else(|| {
+            let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
+            panic!("greet/greet.go must be emitted; got: {names:?}")
+        });
+    let go = greet.to_go();
+
+    assert!(
+        go.contains("//line src/greet/greet.lis:"),
+        "module file directive should use its relative path, got:\n{go}"
+    );
+    assert!(
+        !go.contains("//line greet/src/greet/greet.lis"),
+        "module file path must not be doubled, got:\n{go}"
+    );
+}

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -504,13 +504,13 @@ fn main() {
 
     struct NoLoader;
     impl Loader for NoLoader {
-        fn scan_folder(&self, _: &str) -> rustc_hash::FxHashMap<String, String> {
+        fn scan_folder(&self, _: &str) -> semantics::loader::Files {
             rustc_hash::FxHashMap::default()
         }
     }
 
     let build_result = syntax::build_ast(source, 0);
-    let (result, _) = analyze(AnalyzeInput {
+    let result = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: false,
             standalone_mode: false,
@@ -519,11 +519,15 @@ fn main() {
         loader: &NoLoader,
         source: source.to_string(),
         filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
         compile_phase: CompilePhase::Check,
         locator: resolver,
-    });
+        go_module: String::new(),
+        disable_cache: false,
+    })
+    .result;
 
     let impl_errors: Vec<_> = result
         .errors
@@ -592,7 +596,7 @@ fn main() {
 
     struct NoLoader;
     impl Loader for NoLoader {
-        fn scan_folder(&self, _: &str) -> rustc_hash::FxHashMap<String, String> {
+        fn scan_folder(&self, _: &str) -> semantics::loader::Files {
             rustc_hash::FxHashMap::default()
         }
     }
@@ -600,7 +604,7 @@ fn main() {
     let build_result = syntax::build_ast(source, 0);
 
     // First run — registers third-party module
-    let (result1, _) = analyze(AnalyzeInput {
+    let result1 = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: false,
             standalone_mode: false,
@@ -609,11 +613,15 @@ fn main() {
         loader: &NoLoader,
         source: source.to_string(),
         filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
         ast: build_result.ast.clone(),
         project_root: None,
         compile_phase: CompilePhase::Check,
         locator: resolver.clone(),
-    });
+        go_module: String::new(),
+        disable_cache: false,
+    })
+    .result;
 
     assert!(
         result1.errors.is_empty(),
@@ -622,7 +630,7 @@ fn main() {
     );
 
     // Second run — must still succeed (not load stale cache for third-party)
-    let (result2, _) = analyze(AnalyzeInput {
+    let result2 = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: false,
             standalone_mode: false,
@@ -631,11 +639,15 @@ fn main() {
         loader: &NoLoader,
         source: source.to_string(),
         filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
         ast: build_result.ast,
         project_root: None,
         compile_phase: CompilePhase::Check,
         locator: resolver,
-    });
+        go_module: String::new(),
+        disable_cache: false,
+    })
+    .result;
 
     assert!(
         result2.errors.is_empty(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2908,6 +2908,43 @@ fn main() {
 }
 
 #[test]
+fn test_file_not_supported_uses_display_path() {
+    use crate::_harness::MockFileSystem;
+    use crate::_harness::infer::infer_module;
+
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "_entry_",
+        "main.lis",
+        r#"import "math"
+
+fn main() {
+  let _ = math.add(1, 2)
+}"#,
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file_with_display(
+        "math",
+        "helpers_test.lis",
+        "src/math/helpers_test.lis",
+        "pub fn sub(a: int, b: int) -> int { a - b }",
+    );
+
+    let result = infer_module("_entry_", fs);
+
+    assert_eq!(result.errors.len(), 1);
+    let msg = format!("{:?}", result.errors[0]);
+    assert!(
+        msg.contains("src/math/helpers_test.lis"),
+        "diagnostic must use the loader's display_path, got: {msg}"
+    );
+}
+
+#[test]
 fn infer_pattern_missing_field() {
     let input = r#"
 struct Point { x: int, y: int }


### PR DESCRIPTION
Splits a file's identity (bare name used for cache keys, LSP file lookup, etc.) from its display path (the cwd-relative path shown in diagnostics). Errors, warnings and `--debug` line directives now show a path relative to the cwd, while the compile cache stays stable across working dirs and across LSP runs.

```rs
// before
[error] ...
╭─[greet.lis:2:31]

// after
[error] ...
╭─[src/my_module/greet.lis:2:31]
```

Motivated by #440