### PR TITLE
feat: unix diagnostic format for lis check

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -1,3 +1,5 @@
+use diagnostics::render::OutputFormat;
+
 #[derive(Debug)]
 pub enum Command {
     New {
@@ -20,6 +22,7 @@ pub enum Command {
         path: Option<String>,
         errors_only: bool,
         warnings_only: bool,
+        format: OutputFormat,
     },
     Overview,
     Help {
@@ -62,6 +65,17 @@ pub enum ParseError {
         reason: String,
         hint: String,
     },
+}
+
+fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
+    match value {
+        "unix" => Ok(OutputFormat::Unix),
+        other => Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected value `{}` for `--format`", other),
+            reason: "`--format` accepts `unix`".to_string(),
+            hint: "Use `lis check --format unix`".to_string(),
+        }),
+    }
 }
 
 impl Command {
@@ -150,11 +164,24 @@ impl Command {
                 let mut path = None;
                 let mut errors_only = false;
                 let mut warnings_only = false;
+                let mut format = OutputFormat::Graphical;
 
-                for arg in arguments {
+                while let Some(arg) = arguments.next() {
                     match arg.as_str() {
                         "--errors-only" => errors_only = true,
                         "--warnings-only" => warnings_only = true,
+                        "--format" => {
+                            let Some(value) = arguments.next() else {
+                                return Err(ParseError::MissingArgument {
+                                    command: "check",
+                                    argument: "--format <value>",
+                                });
+                            };
+                            format = parse_format(&value)?;
+                        }
+                        s if s.starts_with("--format=") => {
+                            format = parse_format(s.split_once('=').unwrap().1)?;
+                        }
                         s if s.starts_with('-') => {
                             return Err(ParseError::UnknownFlag(s.to_string()));
                         }
@@ -166,6 +193,7 @@ impl Command {
                     path,
                     errors_only,
                     warnings_only,
+                    format,
                 })
             }
 
@@ -297,5 +325,73 @@ impl Command {
         ];
         let candidates: Vec<String> = COMMANDS.iter().map(|s| s.to_string()).collect();
         diagnostics::infer::find_similar_name(typo, &candidates)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(parts: &[&str]) -> Result<Command, ParseError> {
+        Command::parse(parts.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn check_defaults_to_graphical_format() {
+        let Ok(Command::Check { format, .. }) = parse(&["lis", "check"]) else {
+            panic!("expected Check command");
+        };
+        assert_eq!(format, OutputFormat::Graphical);
+    }
+
+    #[test]
+    fn check_format_unix_space_form() {
+        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--format", "unix"]) else {
+            panic!("expected Check command");
+        };
+        assert_eq!(format, OutputFormat::Unix);
+    }
+
+    #[test]
+    fn check_format_unix_equals_form() {
+        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--format=unix"]) else {
+            panic!("expected Check command");
+        };
+        assert_eq!(format, OutputFormat::Unix);
+    }
+
+    #[test]
+    fn check_format_missing_value() {
+        assert!(matches!(
+            parse(&["lis", "check", "--format"]),
+            Err(ParseError::MissingArgument {
+                command: "check",
+                argument: "--format <value>",
+            })
+        ));
+    }
+
+    #[test]
+    fn check_format_invalid_value() {
+        assert!(matches!(
+            parse(&["lis", "check", "--format", "json"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn check_format_composes_with_errors_only() {
+        let Ok(Command::Check {
+            format,
+            errors_only,
+            warnings_only,
+            ..
+        }) = parse(&["lis", "check", "--format", "unix", "--errors-only"])
+        else {
+            panic!("expected Check command");
+        };
+        assert_eq!(format, OutputFormat::Unix);
+        assert!(errors_only);
+        assert!(!warnings_only);
     }
 }

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use deps::TypedefLocator;
-use diagnostics::render::{self, Filter};
+use diagnostics::render::{self, Filter, OutputFormat};
 use lisette::fs::LocalFileSystem;
 use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
@@ -13,7 +13,12 @@ use crate::cli_error;
 use crate::lock::acquire_target_lock;
 use crate::workspace::WorkspaceBindgen;
 
-pub fn check(path: Option<String>, errors_only: bool, warnings_only: bool) -> i32 {
+pub fn check(
+    path: Option<String>,
+    errors_only: bool,
+    warnings_only: bool,
+    format: OutputFormat,
+) -> i32 {
     let target = path.unwrap_or_else(|| ".".to_string());
     let target_path = Path::new(&target);
 
@@ -32,17 +37,23 @@ pub fn check(path: Option<String>, errors_only: bool, warnings_only: bool) -> i3
     };
 
     if !target_path.is_dir() {
-        return check_single_file(target_path, &filter, false, TypedefLocator::default());
+        return check_single_file(
+            target_path,
+            &filter,
+            false,
+            TypedefLocator::default(),
+            format,
+        );
     }
 
     if target_path.join("lisette.toml").exists() {
-        return check_project(target_path, &filter);
+        return check_project(target_path, &filter, format);
     }
 
-    check_loose_dir(target_path, &filter)
+    check_loose_dir(target_path, &filter, format)
 }
 
-fn check_project(project_path: &Path, filter: &Filter) -> i32 {
+fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat) -> i32 {
     let root_main = project_path.join("main.lis");
     let src_main = project_path.join("src/main.lis");
 
@@ -104,7 +115,7 @@ fn check_project(project_path: &Path, filter: &Filter) -> i32 {
     ));
     let locator = locator.with_bindgen(bindgen);
 
-    let result = check_single_file(&src_main, filter, true, locator);
+    let result = check_single_file(&src_main, filter, true, locator, format);
     drop(target_lock);
     result
 }
@@ -114,33 +125,54 @@ fn check_single_file(
     filter: &Filter,
     load_siblings: bool,
     locator: TypedefLocator,
+    format: OutputFormat,
 ) -> i32 {
     let start = Instant::now();
-    eprintln!();
+    let unix = matches!(format, OutputFormat::Unix);
+    if !unix {
+        eprintln!();
+    }
     let Some((result, source, filename)) = compile_single_file(file_path, load_siblings, locator)
     else {
         return 1; // Read error already reported by compile_single_file
     };
-    let counts = render::render_all(
-        &result.errors,
-        &result.lints,
-        |file_id| {
-            result
-                .sources
-                .get(&file_id)
-                .map(|info| (info.source.clone(), info.filename.clone()))
-        },
-        result.user_file_count,
-        filter,
-        &source,
-        &filename,
-    );
-    render::print_summary(
-        counts.files,
-        start.elapsed(),
-        counts.errors,
-        counts.warnings,
-    );
+    let get_source = |file_id: u32| {
+        result
+            .sources
+            .get(&file_id)
+            .map(|info| (info.source.clone(), info.filename.clone()))
+    };
+    let counts = if unix {
+        let (output, counts) = render::render_unix(
+            &result.errors,
+            &result.lints,
+            get_source,
+            result.user_file_count,
+            filter,
+            &source,
+            &filename,
+        );
+        print!("{}", output);
+        counts
+    } else {
+        render::render_all(
+            &result.errors,
+            &result.lints,
+            get_source,
+            result.user_file_count,
+            filter,
+            &source,
+            &filename,
+        )
+    };
+    if !unix {
+        render::print_summary(
+            counts.files,
+            start.elapsed(),
+            counts.errors,
+            counts.warnings,
+        );
+    }
     counts.errors
 }
 
@@ -187,7 +219,7 @@ fn compile_single_file(
     Some((result, source, entry_display))
 }
 
-fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
+fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
     let mut files = lisette::fs::collect_lis_filepaths_recursive(dir);
     files.sort();
 
@@ -214,8 +246,11 @@ fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
     let mut total_files = 0;
     let mut read_failures = 0;
 
+    let unix = matches!(format, OutputFormat::Unix);
     let start = Instant::now();
-    eprintln!();
+    if !unix {
+        eprintln!();
+    }
 
     for dir_files in dirs.values() {
         let mut compiled = None;
@@ -232,20 +267,35 @@ fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
             read_failures += dir_read_failures;
             continue;
         };
-        let counts = render::render_all(
-            &result.errors,
-            &result.lints,
-            |file_id| {
-                result
-                    .sources
-                    .get(&file_id)
-                    .map(|info| (info.source.clone(), info.filename.clone()))
-            },
-            result.user_file_count,
-            filter,
-            &source,
-            &filename,
-        );
+        let get_source = |file_id: u32| {
+            result
+                .sources
+                .get(&file_id)
+                .map(|info| (info.source.clone(), info.filename.clone()))
+        };
+        let counts = if unix {
+            let (output, counts) = render::render_unix(
+                &result.errors,
+                &result.lints,
+                get_source,
+                result.user_file_count,
+                filter,
+                &source,
+                &filename,
+            );
+            print!("{}", output);
+            counts
+        } else {
+            render::render_all(
+                &result.errors,
+                &result.lints,
+                get_source,
+                result.user_file_count,
+                filter,
+                &source,
+                &filename,
+            )
+        };
         total_errors += counts.errors;
         total_warnings += counts.warnings;
         total_files += result.user_file_count;
@@ -254,7 +304,9 @@ fn check_loose_dir(dir: &Path, filter: &Filter) -> i32 {
     let elapsed = start.elapsed();
 
     let all_errors = total_errors + read_failures;
-    render::print_summary(total_files, elapsed, all_errors, total_warnings);
+    if !unix {
+        render::print_summary(total_files, elapsed, all_errors, total_warnings);
+    }
 
     all_errors
 }

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -56,7 +56,11 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         check)
-            COMPREPLY=( $(compgen -W "--errors-only --warnings-only" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --format" -- "$cur") )
+            return 0
+            ;;
+        --format)
+            COMPREPLY=( $(compgen -W "unix" -- "$cur") )
             return 0
             ;;
         doc)
@@ -120,7 +124,8 @@ _lis() {
                 check)
                     _arguments \
                         '--errors-only[Show only errors]' \
-                        '--warnings-only[Show only warnings]'
+                        '--warnings-only[Show only warnings]' \
+                        '--format[Machine-readable output]:format:(unix)'
                     ;;
                 doc)
                     _arguments {-s,--search}'[Search across prelude and Go stdlib]'
@@ -162,6 +167,7 @@ complete -c lis -n '__fish_seen_subcommand_from run' -l debug -d 'Include line d
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'
+complete -c lis -n '__fish_seen_subcommand_from check' -l format -r -a unix -d 'Machine-readable output'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'
 complete -c lis -n '__fish_seen_subcommand_from complete' -a 'bash zsh fish' -d 'Shell type'
 complete -c lis -n '__fish_seen_subcommand_from help' -a 'new build run format check add sync learn doc help complete version' -d 'Command'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -121,17 +121,23 @@ Examples:
         ),
 
         "check" | "c" => print_help(
-            "`lis check` [path]
+            "`lis check` [path] [options]
 
 Find errors and warnings in Lisette source files.
 
 Arguments:
     [path]    Path to file or dir (default: current dir)
 
+Options:
+    `--errors-only`      Show only errors
+    `--warnings-only`    Show only warnings
+    `--format` <unix>    Machine-readable output, one diagnostic per line
+
 Examples:
     `lis check`                          Check project in current dir
     `lis check` {path/to/project/dir:g}      Check project in specific dir
-    `lis check` {script.lis:g}               Check single file",
+    `lis check` {script.lis:g}               Check single file
+    `lis check` {--format unix:g}            One diagnostic per line, for editors",
         ),
 
         "add" => print_help(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,7 +68,8 @@ fn main() {
             path,
             errors_only,
             warnings_only,
-        } => handlers::check(path, errors_only, warnings_only),
+            format,
+        } => handlers::check(path, errors_only, warnings_only, format),
         Command::Overview => {
             handlers::help::print_main_help();
             0

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -26,6 +26,14 @@ impl IndexedSource {
             line_starts: Arc::from(line_starts),
         }
     }
+
+    pub fn line_col(&self, offset: usize) -> (usize, usize) {
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(exact) => exact,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        (line + 1, offset - self.line_starts[line] + 1)
+    }
 }
 
 impl miette::SourceCode for IndexedSource {
@@ -433,6 +441,22 @@ impl LisetteDiagnostic {
 
     pub fn primary_offset(&self) -> usize {
         self.labels.first().map(|l| l.offset()).unwrap_or(0)
+    }
+
+    pub fn location_offset(&self) -> Option<usize> {
+        self.labels
+            .iter()
+            .find(|l| l.primary())
+            .or_else(|| self.labels.first())
+            .map(|l| l.offset())
+    }
+
+    pub fn severity_word(&self) -> &'static str {
+        match self.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Advice => "note",
+        }
     }
 
     pub fn file_id(&self) -> Option<u32> {

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -7,6 +7,13 @@ use crate::diagnostic::IndexedSource;
 use miette::{GraphicalReportHandler, GraphicalTheme, ThemeCharacters, ThemeStyles};
 use owo_colors::{OwoColorize, Style};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    #[default]
+    Graphical,
+    Unix,
+}
+
 pub struct Filter {
     pub errors_only: bool,
     pub warnings_only: bool,
@@ -128,6 +135,60 @@ pub struct Counts {
     pub warnings: i32,
 }
 
+/// Resolves a `file_id` to its source, falling back to the entry file.
+struct SourceCache<F> {
+    get_source: F,
+    default_source: IndexedSource,
+    default_filename: String,
+    cache: FxHashMap<u32, (IndexedSource, String)>,
+}
+
+impl<F: Fn(u32) -> Option<(String, String)>> SourceCache<F> {
+    fn new(get_source: F, default_source: &str, default_filename: &str) -> Self {
+        Self {
+            get_source,
+            default_source: IndexedSource::new(default_source),
+            default_filename: default_filename.to_string(),
+            cache: FxHashMap::default(),
+        }
+    }
+
+    fn get(&mut self, file_id: Option<u32>) -> (IndexedSource, String) {
+        let Some(fid) = file_id else {
+            return (self.default_source.clone(), self.default_filename.clone());
+        };
+        let default_source = &self.default_source;
+        let default_filename = &self.default_filename;
+        let get_source = &self.get_source;
+        let entry = self.cache.entry(fid).or_insert_with(|| {
+            get_source(fid)
+                .map(|(src, name)| (IndexedSource::new(&src), name))
+                .unwrap_or_else(|| (default_source.clone(), default_filename.clone()))
+        });
+        (entry.0.clone(), entry.1.clone())
+    }
+}
+
+fn partition_diagnostics<'a>(
+    errors: &'a [LisetteDiagnostic],
+    lints: &'a [LisetteDiagnostic],
+    filter: &Filter,
+) -> (Vec<&'a LisetteDiagnostic>, Vec<&'a LisetteDiagnostic>) {
+    let (errors, infer_warnings): (Vec<_>, Vec<_>) = if filter.show_errors() {
+        errors.iter().partition(|d| d.is_error())
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    let warnings: Vec<_> = if filter.show_warnings() {
+        infer_warnings.into_iter().chain(lints.iter()).collect()
+    } else {
+        Vec::new()
+    };
+
+    (errors, warnings)
+}
+
 pub fn render_all(
     errors: &[LisetteDiagnostic],
     lints: &[LisetteDiagnostic],
@@ -137,20 +198,7 @@ pub fn render_all(
     default_source: &str,
     default_filename: &str,
 ) -> Counts {
-    let show_errors = filter.show_errors();
-    let show_warnings = filter.show_warnings();
-
-    let (errors, infer_warnings): (Vec<_>, Vec<_>) = if show_errors {
-        errors.iter().partition(|d| d.is_error())
-    } else {
-        (Vec::new(), Vec::new())
-    };
-
-    let warnings: Vec<_> = if show_warnings {
-        infer_warnings.into_iter().chain(lints.iter()).collect()
-    } else {
-        Vec::new()
-    };
+    let (errors, warnings) = partition_diagnostics(errors, lints, filter);
 
     let has_diagnostics = !errors.is_empty() || !warnings.is_empty();
     if has_diagnostics {
@@ -158,23 +206,7 @@ pub fn render_all(
     }
 
     let use_color = std::env::var("NO_COLOR").is_err();
-
-    let default_source = IndexedSource::new(default_source);
-    let default_filename = default_filename.to_string();
-    let mut source_cache: FxHashMap<u32, (IndexedSource, String)> = FxHashMap::default();
-    let get_cached_source =
-        |file_id: Option<u32>, cache: &mut FxHashMap<u32, (IndexedSource, String)>| {
-            if let Some(fid) = file_id {
-                let entry = cache.entry(fid).or_insert_with(|| {
-                    get_source(fid)
-                        .map(|(src, name)| (IndexedSource::new(&src), name))
-                        .unwrap_or_else(|| (default_source.clone(), default_filename.clone()))
-                });
-                (entry.0.clone(), entry.1.clone())
-            } else {
-                (default_source.clone(), default_filename.clone())
-            }
-        };
+    let mut sources = SourceCache::new(get_source, default_source, default_filename);
 
     if !errors.is_empty() {
         let handler = if use_color {
@@ -183,7 +215,7 @@ pub fn render_all(
             nocolor_handler()
         };
         for error in &errors {
-            let (src, name) = get_cached_source(error.file_id(), &mut source_cache);
+            let (src, name) = sources.get(error.file_id());
             render(&handler, error, &src, &name, use_color);
         }
     }
@@ -195,7 +227,7 @@ pub fn render_all(
             nocolor_handler()
         };
         for warning in &warnings {
-            let (src, name) = get_cached_source(warning.file_id(), &mut source_cache);
+            let (src, name) = sources.get(warning.file_id());
             render(&handler, warning, &src, &name, use_color);
         }
     }
@@ -205,4 +237,49 @@ pub fn render_all(
         errors: errors.len() as i32,
         warnings: warnings.len() as i32,
     }
+}
+
+/// Renders one diagnostic as `file:line:col: severity: message [code]`.
+pub fn unix_line(diagnostic: &LisetteDiagnostic, source: &IndexedSource, filename: &str) -> String {
+    let mut line = String::new();
+    if let Some(offset) = diagnostic.location_offset() {
+        let (lineno, col) = source.line_col(offset);
+        line.push_str(&format!("{}:{}:{}: ", filename, lineno, col));
+    }
+    line.push_str(diagnostic.severity_word());
+    line.push_str(": ");
+    line.push_str(diagnostic.plain_message());
+    if let Some(code) = diagnostic.code_str() {
+        line.push_str(&format!(" [{}]", code));
+    }
+    line
+}
+
+/// Builds the stdout text (one diagnostic per line, no color, no banner) and the
+/// counts the caller needs for the stderr summary and exit code.
+pub fn render_unix(
+    errors: &[LisetteDiagnostic],
+    lints: &[LisetteDiagnostic],
+    get_source: impl Fn(u32) -> Option<(String, String)>,
+    file_count: usize,
+    filter: &Filter,
+    default_source: &str,
+    default_filename: &str,
+) -> (String, Counts) {
+    let (errors, warnings) = partition_diagnostics(errors, lints, filter);
+
+    let mut sources = SourceCache::new(get_source, default_source, default_filename);
+    let mut output = String::new();
+    for diagnostic in errors.iter().chain(warnings.iter()) {
+        let (src, name) = sources.get(diagnostic.file_id());
+        output.push_str(&unix_line(diagnostic, &src, &name));
+        output.push('\n');
+    }
+
+    let counts = Counts {
+        files: file_count.max(1),
+        errors: errors.len() as i32,
+        warnings: warnings.len() as i32,
+    };
+    (output, counts)
 }

--- a/tests/_harness/formatting.rs
+++ b/tests/_harness/formatting.rs
@@ -36,6 +36,19 @@ pub fn format_parse_error_for_snapshot(error: &ParseError, source: &str, filenam
     format_diagnostic_for_snapshot(&diagnostic, source, filename)
 }
 
+pub fn format_diagnostic_unix(
+    diagnostic: &LisetteDiagnostic,
+    source: &str,
+    filename: &str,
+) -> String {
+    diagnostics::render::unix_line(diagnostic, &IndexedSource::new(source), filename)
+}
+
+pub fn format_parse_error_unix(error: &ParseError, source: &str, filename: &str) -> String {
+    let diagnostic: LisetteDiagnostic = error.clone().into();
+    format_diagnostic_unix(&diagnostic, source, filename)
+}
+
 pub fn format_diagnostic_standalone(diagnostic: &LisetteDiagnostic) -> String {
     let handler = GraphicalReportHandler::new()
         .with_theme(snapshot_theme())

--- a/tests/ui/mod.rs
+++ b/tests/ui/mod.rs
@@ -1,2 +1,3 @@
 mod errors;
 mod lint;
+mod unix;

--- a/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
+++ b/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
@@ -1,0 +1,4 @@
+---
+source: tests/ui/unix.rs
+---
+src/main.lis:3:19: error: Type mismatch [infer.type_mismatch]

--- a/tests/ui/snapshots/unix_parse_error_shape.snap
+++ b/tests/ui/snapshots/unix_parse_error_shape.snap
@@ -1,0 +1,4 @@
+---
+source: tests/ui/unix.rs
+---
+src/main.lis:2:11: error: Unclosed block [parse.unclosed_block]

--- a/tests/ui/unix.rs
+++ b/tests/ui/unix.rs
@@ -1,0 +1,116 @@
+use crate::_harness::formatting::{format_diagnostic_unix, format_parse_error_unix};
+use crate::_harness::infer::infer;
+
+use diagnostics::LisetteDiagnostic;
+use diagnostics::render::{self, Filter};
+use syntax::ast::Span;
+use syntax::lex::Lexer;
+use syntax::parse::Parser;
+
+fn unfiltered() -> Filter {
+    Filter {
+        errors_only: false,
+        warnings_only: false,
+    }
+}
+
+#[test]
+fn unix_parse_error_shape() {
+    let source = r#"
+fn main() {
+  let x = 42;
+"#;
+    let lex_result = Lexer::new(source, 0).lex();
+    let parse_result = Parser::new(lex_result.tokens, source).parse();
+    assert!(!parse_result.errors.is_empty());
+
+    let output = format_parse_error_unix(&parse_result.errors[0], source, "src/main.lis");
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        omit_expression => true,
+    }, {
+        insta::assert_snapshot!(output);
+    });
+}
+
+#[test]
+fn unix_multi_label_emits_single_location() {
+    let source = r#"
+fn test() {
+  let x = if true { 42 } else { "hello" };
+}
+"#;
+    let result = infer(source);
+    assert!(!result.errors.is_empty());
+
+    let output = format_diagnostic_unix(&result.errors[0], source, "src/main.lis");
+
+    assert_eq!(output.lines().count(), 1);
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        omit_expression => true,
+    }, {
+        insta::assert_snapshot!(output);
+    });
+}
+
+#[test]
+fn unix_diagnostic_without_code_omits_bracket() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::error("Custom message").with_span_label(&span, "here");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output, "src/main.lis:1:5: error: Custom message");
+}
+
+#[test]
+fn unix_column_is_byte_offset_within_line() {
+    let source = "café x";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 6,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::error("Bad token").with_span_label(&span, "here");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output, "src/main.lis:1:7: error: Bad token");
+}
+
+#[test]
+fn unix_render_emits_only_diagnostic_lines() {
+    let source = r#"
+fn test() {
+  let x: int = "hello";
+  let y = unknown_variable;
+}
+"#;
+    let result = infer(source);
+    assert!(!result.errors.is_empty());
+
+    let (output, counts) = render::render_unix(
+        &result.errors,
+        &[],
+        |_| None,
+        1,
+        &unfiltered(),
+        source,
+        "src/main.lis",
+    );
+
+    assert!(!output.contains('\u{1b}'));
+    for line in output.lines() {
+        assert!(line.starts_with("src/main.lis:"));
+        assert!(line.contains(": error: "));
+    }
+    assert_eq!(output.lines().count() as i32, counts.errors);
+}


### PR DESCRIPTION
Adds a `--format unix` option to `lis check` that emits one machine-readable line per diagnostic, so editor integrations like Vim quickfix and Emacs compilation-mode can build a navigable list of error locations.

```sh
lis check --format unix
src/main.lis:4:20: error: Type mismatch [infer.type_mismatch]
src/geometry/geo.lis:2:20: error: Type mismatch [infer.type_mismatch]
src/main.lis:4:7: warning: Unused variable [lint.unused_variable]
```

Each line is `file:line:col: severity: message [code]` anchored at the diagnostic's primary span. `stdout` carries only these lines, with no banner, summary, or color. No flag defaults to the current human-friendly rendering.

Motivated by #440