### PR TITLE
fix: bound global prelude and stdlib defs cache

### DIFF
--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -24,26 +24,30 @@ pub struct GoModuleCache {
     pub go_imports: Vec<String>,
 }
 
+fn cache_file_name(target: Target) -> String {
+    format!("stdlib_defs_{}.bin", target.cache_segment())
+}
+
 fn cache_path(target: Target) -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
     Some(
         PathBuf::from(home)
             .join(".lisette")
             .join("cache")
-            .join(format!(
-                "stdlib_defs_{:x}_compiler_{:x}_{}_{}.bin",
-                GO_STDLIB_HASH & 0xFFFFFF,
-                COMPILER_VERSION_HASH & 0xFFFFFF,
-                target.goos,
-                target.goarch,
-            )),
+            .join(cache_file_name(target)),
     )
 }
 
 pub fn try_load_go_stdlib_cache(target: Target) -> Option<GoStdlibCache> {
     let path = cache_path(target)?;
     let bytes = fs::read(&path).ok()?;
-    let cache: GoStdlibCache = bincode::deserialize(&bytes).ok()?;
+    let cache: GoStdlibCache = match bincode::deserialize(&bytes) {
+        Ok(cache) => cache,
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    };
 
     if cache.content_hash != GO_STDLIB_HASH || cache.compiler_version != COMPILER_VERSION_HASH {
         let _ = fs::remove_file(&path);
@@ -97,14 +101,20 @@ pub fn save_go_stdlib_cache(store: &Store, go_module_ids: &[String], target: Tar
         return;
     };
 
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let _ = fs::create_dir_all(parent);
 
-    let temp_path = path.with_extension("bin.tmp");
-    if fs::write(&temp_path, bytes).is_ok() {
-        let _ = fs::rename(&temp_path, &path);
+    let temp_path = super::global_cache_temp_path(&path);
+    if fs::write(&temp_path, &bytes).is_err() {
+        return;
     }
+    if fs::rename(&temp_path, &path).is_err() {
+        let _ = fs::remove_file(&temp_path);
+        return;
+    }
+    super::prune_legacy_global_caches(parent, "stdlib_defs");
 }
 
 /// Load a Go module and its transitive deps from cache, recursively.
@@ -185,4 +195,15 @@ fn get_go_imports_from_source(module_id: &str, target: Target) -> Vec<String> {
             Some(format!("go:{pkg}"))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_file_name_includes_target_only() {
+        let target = Target::new("darwin", "arm64");
+        assert_eq!(cache_file_name(target), "stdlib_defs_darwin_arm64.bin");
+    }
 }

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use syntax::program::File;
@@ -427,6 +428,26 @@ pub fn is_cache_disabled() -> bool {
         .unwrap_or(false)
 }
 
+static GLOBAL_CACHE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn global_cache_temp_path(final_path: &Path) -> PathBuf {
+    let counter = GLOBAL_CACHE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    final_path.with_extension(format!("tmp.{}.{}", std::process::id(), counter))
+}
+
+pub(crate) fn prune_legacy_global_caches(dir: &Path, prefix: &str) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(prefix) && name.contains("_compiler_") {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -807,5 +828,48 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn prune_legacy_global_caches_removes_only_hashed_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let legacy_prelude = dir.join("prelude_defs_4330e9_compiler_f709f8.bin");
+        let legacy_stdlib = dir.join("stdlib_defs_151b6b_compiler_f709f8_darwin_arm64.bin");
+        let stable_prelude = dir.join("prelude_defs.bin");
+        let stable_stdlib = dir.join("stdlib_defs_darwin_arm64.bin");
+        let other_stdlib = dir.join("stdlib_defs_linux_amd64.bin");
+        for path in [
+            &legacy_prelude,
+            &legacy_stdlib,
+            &stable_prelude,
+            &stable_stdlib,
+            &other_stdlib,
+        ] {
+            std::fs::write(path, b"x").unwrap();
+        }
+
+        prune_legacy_global_caches(dir, "prelude_defs");
+        prune_legacy_global_caches(dir, "stdlib_defs");
+
+        assert!(!legacy_prelude.exists());
+        assert!(!legacy_stdlib.exists());
+        assert!(stable_prelude.exists());
+        assert!(stable_stdlib.exists());
+        assert!(other_stdlib.exists());
+    }
+
+    #[test]
+    fn prune_legacy_global_caches_missing_dir_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        prune_legacy_global_caches(&tmp.path().join("does_not_exist"), "prelude_defs");
+    }
+
+    #[test]
+    fn global_cache_temp_paths_are_unique() {
+        let base = Path::new("/cache/prelude_defs.bin");
+        let first = global_cache_temp_path(base);
+        let second = global_cache_temp_path(base);
+        assert_ne!(first, second);
     }
 }

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -16,24 +16,30 @@ pub struct PreludeCache {
     pub definitions: HashMap<String, CachedDefinition>,
 }
 
+fn cache_file_name() -> &'static str {
+    "prelude_defs.bin"
+}
+
 fn cache_path() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
     Some(
         PathBuf::from(home)
             .join(".lisette")
             .join("cache")
-            .join(format!(
-                "prelude_defs_{:x}_compiler_{:x}.bin",
-                PRELUDE_HASH & 0xFFFFFF,
-                COMPILER_VERSION_HASH & 0xFFFFFF
-            )),
+            .join(cache_file_name()),
     )
 }
 
 pub fn try_load_prelude_cache() -> Option<PreludeCache> {
     let path = cache_path()?;
     let bytes = fs::read(&path).ok()?;
-    let cache: PreludeCache = bincode::deserialize(&bytes).ok()?;
+    let cache: PreludeCache = match bincode::deserialize(&bytes) {
+        Ok(cache) => cache,
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    };
 
     if cache.content_hash != PRELUDE_HASH || cache.compiler_version != COMPILER_VERSION_HASH {
         let _ = fs::remove_file(&path);
@@ -72,14 +78,20 @@ pub fn save_prelude_cache(store: &Store) {
         return;
     };
 
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let _ = fs::create_dir_all(parent);
 
-    let temp_path = path.with_extension("bin.tmp");
-    if fs::write(&temp_path, bytes).is_ok() {
-        let _ = fs::rename(&temp_path, &path);
+    let temp_path = super::global_cache_temp_path(&path);
+    if fs::write(&temp_path, &bytes).is_err() {
+        return;
     }
+    if fs::rename(&temp_path, &path).is_err() {
+        let _ = fs::remove_file(&temp_path);
+        return;
+    }
+    super::prune_legacy_global_caches(parent, "prelude_defs");
 }
 
 pub fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
@@ -107,5 +119,15 @@ pub fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
     for (qualified_name, cached_definition) in cached.definitions {
         let definition = cached_definition.to_definition(file_ids);
         module.definitions.insert(qualified_name.into(), definition);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_file_name_is_stable() {
+        assert_eq!(cache_file_name(), "prelude_defs.bin");
     }
 }


### PR DESCRIPTION
The prelude and Go stdlib definition caches at `~/.lisette/cache` no longer grow unbounded.

Previously, filenames at that dir embedded the content and compiler-version hashes, so every compiler release or stdlib change created a new file and never removed the old ones. They're now stable, so the dir holds 1 prelude file + 1 stdlib file per build target, and stale files from older versions are pruned on next build.