### PR TITLE
fix: interface not implemented diagnostic for wrapper types

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1747,6 +1747,33 @@ pub fn interface_not_implemented(
         .with_help(help_lines.join("\n"))
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum WrapperKind {
+    Result,
+    Option,
+    Partial,
+}
+
+pub fn wrapper_does_not_implement_interface(
+    interface_name: &str,
+    wrapper: WrapperKind,
+    wrapper_ty: &Type,
+    span: Span,
+) -> LisetteDiagnostic {
+    let help = match wrapper {
+        WrapperKind::Result => "Unwrap the `Result` with `match` or `if let` first.",
+        WrapperKind::Option => "Unwrap the `Option` with `match` or `if let` first.",
+        WrapperKind::Partial => "Unwrap the `Partial` with `match` first.",
+    };
+    LisetteDiagnostic::error("Interface not implemented")
+        .with_infer_code("interface_not_implemented")
+        .with_span_label(
+            &span,
+            format!("`{}` does not implement `{}`", wrapper_ty, interface_name),
+        )
+        .with_help(help)
+}
+
 pub fn pointer_receiver_interface_mismatch(
     interface_name: &str,
     type_name: &str,

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -48,14 +48,34 @@ impl TaskState<'_> {
         if violations.is_empty() {
             Ok(())
         } else {
-            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
-            self.sink
-                .push(diagnostics::infer::interface_not_implemented(
-                    &interface.name,
-                    &type_name,
-                    &violations,
-                    *span,
-                ));
+            let resolved = ty.resolve_in(&self.env);
+            let wrapper = if resolved.is_result() {
+                Some(diagnostics::infer::WrapperKind::Result)
+            } else if resolved.is_option() {
+                Some(diagnostics::infer::WrapperKind::Option)
+            } else if resolved.is_partial() {
+                Some(diagnostics::infer::WrapperKind::Partial)
+            } else {
+                None
+            };
+            if let Some(wrapper) = wrapper {
+                self.sink
+                    .push(diagnostics::infer::wrapper_does_not_implement_interface(
+                        &interface.name,
+                        wrapper,
+                        &resolved,
+                        *span,
+                    ));
+            } else {
+                let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+                self.sink
+                    .push(diagnostics::infer::interface_not_implemented(
+                        &interface.name,
+                        &type_name,
+                        &violations,
+                        *span,
+                    ));
+            }
             Err(violations)
         }
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2427,6 +2427,57 @@ fn test() {
 }
 
 #[test]
+fn infer_result_does_not_implement_interface() {
+    let input = r#"
+struct Ctx {}
+impl Ctx {
+  fn run(self) -> Result<(), error> { Ok(()) }
+  fn fatal(self, e: error) { let _ = e }
+}
+fn test() {
+  let c = Ctx {}
+  c.fatal(c.run())
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_option_does_not_implement_interface() {
+    let input = r#"
+interface Greeter {
+  fn greet() -> string
+}
+struct Hello {}
+impl Hello {
+  fn greet(self) -> string { "hi" }
+}
+fn use_greeter(g: Greeter) -> string { g.greet() }
+fn maybe_hello() -> Option<Hello> { Some(Hello {}) }
+fn test() {
+  let _ = use_greeter(maybe_hello())
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_partial_does_not_implement_interface() {
+    let input = r#"
+struct Ctx {}
+impl Ctx {
+  fn read(self) -> Partial<int, error> { Partial.Ok(0) }
+  fn fatal(self, e: error) { let _ = e }
+}
+fn test() {
+  let c = Ctx {}
+  c.fatal(c.read())
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn builtin_generic_type_satisfies_interface_bound() {
     let input = r#"
 interface HasLength {

--- a/tests/ui/errors/snapshots/infer_option_does_not_implement_interface.snap
+++ b/tests/ui/errors/snapshots/infer_option_does_not_implement_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Interface not implemented
+    ╭─[test.lis:12:23]
+ 11 │ fn test() {
+ 12 │   let _ = use_greeter(maybe_hello())
+    ·                       ──────┬──────
+    ·                             ╰── `Option<Hello>` does not implement `Greeter`
+ 13 │ }
+    ╰────
+  help: Unwrap the `Option` with `match` or `if let` first · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_partial_does_not_implement_interface.snap
+++ b/tests/ui/errors/snapshots/infer_partial_does_not_implement_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Interface not implemented
+    ╭─[test.lis:9:11]
+  8 │   let c = Ctx {}
+  9 │   c.fatal(c.read())
+    ·           ────┬───
+    ·               ╰── `Partial<int, error>` does not implement `error`
+ 10 │ }
+    ╰────
+  help: Unwrap the `Partial` with `match` first · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_result_does_not_implement_interface.snap
+++ b/tests/ui/errors/snapshots/infer_result_does_not_implement_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Interface not implemented
+    ╭─[test.lis:9:11]
+  8 │   let c = Ctx {}
+  9 │   c.fatal(c.run())
+    ·           ───┬───
+    ·              ╰── `Result<(), error>` does not implement `error`
+ 10 │ }
+    ╰────
+  help: Unwrap the `Result` with `match` or `if let` first · code: [infer.interface_not_implemented]


### PR DESCRIPTION
Passing a `Result`, `Option`, or `Partial` where an interface is expected now produces a targeted "unwrap first" hint instead of the generic "missing methods" list, which previously misled the user toward implementing the interface on the wrapper.