### PR TITLE
ci: drop release.yml fork guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    if: github.repository == 'ivov/lisette'
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}


### PR DESCRIPTION
The `lisette-v0.2.10` release [failed](https://github.com/ivov/lisette/actions/runs/26334564810/job/77526031963) to generate binaries, because `cargo-dist` regenerates `.github/workflows/release.yml` and aborts when the on-disk file does not match, and the diverging line was the fork guard added in #468.
