### PR TITLE
fix: reject any/comparable as type or generic names

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2517,6 +2517,16 @@ pub fn prelude_function_shadowed(name: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn predeclared_type_shadowed(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot shadow Go predeclared identifier")
+        .with_infer_code("predeclared_type_shadowed")
+        .with_span_label(&span, format!("`{}` is a Go predeclared identifier", name))
+        .with_help(format!(
+            "Lisette emits `{}` directly in the generated Go, so a user declaration with this name shadows the builtin and the output fails to compile. Choose a different name",
+            name
+        ))
+}
+
 pub fn non_pub_interface_with_pub_impl(
     interface_name: &str,
     struct_name: &str,

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod json_methods;
 pub(crate) mod native_value_usage;
 pub(crate) mod newtype;
 mod pattern_analysis;
+pub(crate) mod predeclared_shadowing;
 pub(crate) mod prelude_shadowing;
 pub(crate) mod receivers;
 pub(crate) mod stringer_signature;
@@ -88,6 +89,7 @@ fn run_file_checks(
     irrefutable_patterns::run(&file.items, sink);
     receivers::run(&file.items, sink);
     stringer_signature::run(&file.items, sink);
+    predeclared_shadowing::run(&file.items, sink);
     prelude_shadowing::run(&file.items, store, sink);
     generics::run(&file.items, &module.id, store, sink);
     newtype::run(&file.items, store, sink);

--- a/crates/semantics/src/passes/checks/predeclared_shadowing.rs
+++ b/crates/semantics/src/passes/checks/predeclared_shadowing.rs
@@ -1,0 +1,71 @@
+//! Reject user type declarations and generic parameters named after the Go
+//! predeclared identifiers `any` and `comparable`. The emitter prints those
+//! names directly for `Unknown` and for unconstrained / map-key generic
+//! constraints, so a user declaration of the same name shadows the builtin and
+//! the generated Go fails to compile.
+
+use diagnostics::LocalSink;
+use syntax::ast::{Expression, Generic};
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit(item, sink);
+    }
+}
+
+fn visit(expression: &Expression, sink: &LocalSink) {
+    check_type_name(expression, sink);
+    for generic in generics_of(expression) {
+        if is_reserved(&generic.name) {
+            sink.push(diagnostics::infer::predeclared_type_shadowed(
+                &generic.name,
+                generic.span,
+            ));
+        }
+    }
+    for child in expression.children() {
+        visit(child, sink);
+    }
+}
+
+fn check_type_name(expression: &Expression, sink: &LocalSink) {
+    let (name, name_span) = match expression {
+        Expression::Enum {
+            name, name_span, ..
+        }
+        | Expression::ValueEnum {
+            name, name_span, ..
+        }
+        | Expression::Struct {
+            name, name_span, ..
+        }
+        | Expression::TypeAlias {
+            name, name_span, ..
+        }
+        | Expression::Interface {
+            name, name_span, ..
+        } => (name, name_span),
+        _ => return,
+    };
+    if is_reserved(name) {
+        sink.push(diagnostics::infer::predeclared_type_shadowed(
+            name, *name_span,
+        ));
+    }
+}
+
+fn generics_of(expression: &Expression) -> &[Generic] {
+    match expression {
+        Expression::Function { generics, .. }
+        | Expression::ImplBlock { generics, .. }
+        | Expression::Enum { generics, .. }
+        | Expression::Struct { generics, .. }
+        | Expression::TypeAlias { generics, .. }
+        | Expression::Interface { generics, .. } => generics,
+        _ => &[],
+    }
+}
+
+fn is_reserved(name: &str) -> bool {
+    matches!(name, "any" | "comparable")
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1971,6 +1971,45 @@ impl Status {
 }
 
 #[test]
+fn infer_struct_shadows_predeclared_any() {
+    let input = r#"
+struct any {}
+
+fn main() {
+  let x: Unknown = 1
+  let _ = x
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_shadows_predeclared_comparable() {
+    let input = r#"
+struct comparable {}
+
+fn main() {
+  let _ = 1
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_generic_param_shadows_predeclared_any() {
+    let input = r#"
+fn id<any>(x: any) -> any {
+  x
+}
+
+fn main() {
+  let _ = id(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_unknown_in_const_annotation() {
     let input = r#"
 const X: Unknown = 42;

--- a/tests/ui/errors/snapshots/infer_generic_param_shadows_predeclared_any.snap
+++ b/tests/ui/errors/snapshots/infer_generic_param_shadows_predeclared_any.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot shadow Go predeclared identifier
+   ╭─[test.lis:2:7]
+ 1 │ 
+ 2 │ fn id<any>(x: any) -> any {
+   ·       ─┬─
+   ·        ╰── `any` is a Go predeclared identifier
+ 3 │   x
+   ╰────
+  help: Lisette emits `any` directly in the generated Go, so a user declaration with this name shadows the builtin and the output fails to compile. Choose a different name · code: [infer.predeclared_type_shadowed]

--- a/tests/ui/errors/snapshots/infer_struct_shadows_predeclared_any.snap
+++ b/tests/ui/errors/snapshots/infer_struct_shadows_predeclared_any.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot shadow Go predeclared identifier
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ struct any {}
+   ·        ─┬─
+   ·         ╰── `any` is a Go predeclared identifier
+ 3 │ 
+   ╰────
+  help: Lisette emits `any` directly in the generated Go, so a user declaration with this name shadows the builtin and the output fails to compile. Choose a different name · code: [infer.predeclared_type_shadowed]

--- a/tests/ui/errors/snapshots/infer_struct_shadows_predeclared_comparable.snap
+++ b/tests/ui/errors/snapshots/infer_struct_shadows_predeclared_comparable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot shadow Go predeclared identifier
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ struct comparable {}
+   ·        ─────┬────
+   ·             ╰── `comparable` is a Go predeclared identifier
+ 3 │ 
+   ╰────
+  help: Lisette emits `comparable` directly in the generated Go, so a user declaration with this name shadows the builtin and the output fails to compile. Choose a different name · code: [infer.predeclared_type_shadowed]


### PR DESCRIPTION
`lis check` now rejects a type declaration or generic parameter named `any` or `comparable`, instead of accepting it and emitting Go that shadows the predeclared identifier and fails to compile.