### PR TITLE
fix: reject public types with non-exportable names

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2517,6 +2517,16 @@ pub fn prelude_function_shadowed(name: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn pub_type_not_exportable(name: &str, suggested: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Public type is not exportable")
+        .with_infer_code("pub_type_not_exportable")
+        .with_span_label(&span, format!("`{}` cannot be exported from Go", name))
+        .with_help(format!(
+            "Public types become exported Go identifiers, which must start with an uppercase letter. Rename to `{}`",
+            suggested
+        ))
+}
+
 pub fn predeclared_type_shadowed(name: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot shadow Go predeclared identifier")
         .with_infer_code("predeclared_type_shadowed")

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod newtype;
 mod pattern_analysis;
 pub(crate) mod predeclared_shadowing;
 pub(crate) mod prelude_shadowing;
+pub(crate) mod pub_type_export;
 pub(crate) mod receivers;
 pub(crate) mod stringer_signature;
 pub(crate) mod temp_producing;
@@ -91,6 +92,7 @@ fn run_file_checks(
     stringer_signature::run(&file.items, sink);
     predeclared_shadowing::run(&file.items, sink);
     prelude_shadowing::run(&file.items, store, sink);
+    pub_type_export::run(&file.items, sink);
     generics::run(&file.items, &module.id, store, sink);
     newtype::run(&file.items, store, sink);
     native_value_usage::run(&file.items, &module.id, store, sink);

--- a/crates/semantics/src/passes/checks/pub_type_export.rs
+++ b/crates/semantics/src/passes/checks/pub_type_export.rs
@@ -1,0 +1,72 @@
+//! Reject public type declarations whose name cannot be exported from Go.
+//! Lisette maps a `pub` type to an exported Go identifier, which must begin
+//! with an uppercase letter. A public type with a lowercase name emits an
+//! unexported Go definition while cross-module references reach for the
+//! exported spelling, so downstream packages fail to compile.
+
+use diagnostics::LocalSink;
+use syntax::ast::{Expression, Span, Visibility};
+
+use crate::passes::lints::ast_walk::casing::to_pascal_case;
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit(item, sink);
+    }
+}
+
+fn visit(expression: &Expression, sink: &LocalSink) {
+    if let Some((name, name_span, visibility)) = type_declaration(expression)
+        && visibility.is_public()
+        && !is_exportable(name)
+    {
+        sink.push(diagnostics::infer::pub_type_not_exportable(
+            name,
+            &to_pascal_case(name),
+            *name_span,
+        ));
+    }
+    for child in expression.children() {
+        visit(child, sink);
+    }
+}
+
+fn type_declaration(expression: &Expression) -> Option<(&str, &Span, &Visibility)> {
+    match expression {
+        Expression::Struct {
+            name,
+            name_span,
+            visibility,
+            ..
+        }
+        | Expression::Enum {
+            name,
+            name_span,
+            visibility,
+            ..
+        }
+        | Expression::ValueEnum {
+            name,
+            name_span,
+            visibility,
+            ..
+        }
+        | Expression::TypeAlias {
+            name,
+            name_span,
+            visibility,
+            ..
+        }
+        | Expression::Interface {
+            name,
+            name_span,
+            visibility,
+            ..
+        } => Some((name.as_str(), name_span, visibility)),
+        _ => None,
+    }
+}
+
+fn is_exportable(name: &str) -> bool {
+    name.chars().next().unwrap_or('A').is_uppercase()
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks.rs
@@ -583,9 +583,12 @@ pub fn check_expression_naming(
             name_span,
             generics,
             fields,
+            visibility,
             ..
         } => {
-            check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            if !visibility.is_public() {
+                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            }
 
             for generic in generics {
                 check_type_parameter(generic, diagnostics);
@@ -608,9 +611,12 @@ pub fn check_expression_naming(
             name_span,
             generics,
             variants,
+            visibility,
             ..
         } => {
-            check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            if !visibility.is_public() {
+                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            }
 
             for generic in generics {
                 check_type_parameter(generic, diagnostics);
@@ -630,9 +636,12 @@ pub fn check_expression_naming(
             name,
             name_span,
             generics,
+            visibility,
             ..
         } => {
-            check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            if !visibility.is_public() {
+                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            }
 
             for generic in generics {
                 check_type_parameter(generic, diagnostics);
@@ -643,9 +652,12 @@ pub fn check_expression_naming(
             name,
             name_span,
             generics,
+            visibility,
             ..
         } => {
-            check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            if !visibility.is_public() {
+                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+            }
 
             for generic in generics {
                 check_type_parameter(generic, diagnostics);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2010,6 +2010,58 @@ fn main() {
 }
 
 #[test]
+fn infer_pub_struct_not_exportable() {
+    let input = r#"
+pub struct widget {
+  pub x: int,
+}
+
+fn main() {
+  let w = widget { x: 1 }
+  let _ = w.x
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_pub_type_alias_not_exportable() {
+    let input = r#"
+pub type widget = int
+
+fn main() {
+  let w: widget = 1
+  let _ = w
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_pub_enum_not_exportable() {
+    let input = r#"
+pub enum status {
+  Ready,
+}
+
+fn main() {
+  let _ = status.Ready
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_pub_interface_not_exportable() {
+    let input = r#"
+pub interface reader {
+  fn read() -> int
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_unknown_in_const_annotation() {
     let input = r#"
 const X: Unknown = 42;

--- a/tests/ui/errors/snapshots/infer_pub_enum_not_exportable.snap
+++ b/tests/ui/errors/snapshots/infer_pub_enum_not_exportable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Public type is not exportable
+   ╭─[test.lis:2:10]
+ 1 │ 
+ 2 │ pub enum status {
+   ·          ───┬──
+   ·             ╰── `status` cannot be exported from Go
+ 3 │   Ready,
+   ╰────
+  help: Public types become exported Go identifiers, which must start with an uppercase letter. Rename to `Status` · code: [infer.pub_type_not_exportable]

--- a/tests/ui/errors/snapshots/infer_pub_interface_not_exportable.snap
+++ b/tests/ui/errors/snapshots/infer_pub_interface_not_exportable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Public type is not exportable
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ pub interface reader {
+   ·               ───┬──
+   ·                  ╰── `reader` cannot be exported from Go
+ 3 │   fn read() -> int
+   ╰────
+  help: Public types become exported Go identifiers, which must start with an uppercase letter. Rename to `Reader` · code: [infer.pub_type_not_exportable]

--- a/tests/ui/errors/snapshots/infer_pub_struct_not_exportable.snap
+++ b/tests/ui/errors/snapshots/infer_pub_struct_not_exportable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Public type is not exportable
+   ╭─[test.lis:2:12]
+ 1 │ 
+ 2 │ pub struct widget {
+   ·            ───┬──
+   ·               ╰── `widget` cannot be exported from Go
+ 3 │   pub x: int,
+   ╰────
+  help: Public types become exported Go identifiers, which must start with an uppercase letter. Rename to `Widget` · code: [infer.pub_type_not_exportable]

--- a/tests/ui/errors/snapshots/infer_pub_type_alias_not_exportable.snap
+++ b/tests/ui/errors/snapshots/infer_pub_type_alias_not_exportable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Public type is not exportable
+   ╭─[test.lis:2:10]
+ 1 │ 
+ 2 │ pub type widget = int
+   ·          ───┬──
+   ·             ╰── `widget` cannot be exported from Go
+ 3 │ 
+   ╰────
+  help: Public types become exported Go identifiers, which must start with an uppercase letter. Rename to `Widget` · code: [infer.pub_type_not_exportable]


### PR DESCRIPTION
`lis check` now rejects a `pub` type whose name does not start with an uppercase letter, instead of accepting it and emitting an unexported Go definition that downstream packages cannot reach.