### PR TITLE
chore: release v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.13](https://github.com/ivov/lisette/compare/lisette-v0.2.12...lisette-v0.2.13) - 2026-05-26
+
+- perf: skip synthetic EOF in token lookup [#500](https://github.com/ivov/lisette/pull/500) [`c9bbdeb`](https://github.com/ivov/lisette/commit/c9bbdeb9f7fb83108d46780998b8c497c57b844f)
+- feat: reject empty range [#499](https://github.com/ivov/lisette/pull/499) [`d74f193`](https://github.com/ivov/lisette/commit/d74f1930e60bf2ec8ccd83f03a72baf794481fcc)
+- perf: introduce simple benchmarking setup [#498](https://github.com/ivov/lisette/pull/498) [`47dd262`](https://github.com/ivov/lisette/commit/47dd2624ba678495305b6a2609f7b80d4d351c18)
+- feat: reject comparison against math.NaN() [#497](https://github.com/ivov/lisette/pull/497) [`e853566`](https://github.com/ivov/lisette/commit/e8535667b80a4e00965bc811d145e51e7f055a6c)
+- feat: warn on verbose failure propagation [#496](https://github.com/ivov/lisette/pull/496) [`0aef44a`](https://github.com/ivov/lisette/commit/0aef44a04095c82dd12f80b2ce34a89b1c9bd7b6)
+- refactor: consolidate in-memory loader impls [#495](https://github.com/ivov/lisette/pull/495) [`207da7f`](https://github.com/ivov/lisette/commit/207da7f4f8a7cb7269c495cc9d649a7dd55e1dda)
+- refactor: prep lint setup for upcoming diagnostics [#494](https://github.com/ivov/lisette/pull/494) [`f0b06b6`](https://github.com/ivov/lisette/commit/f0b06b6743283d09815cc33e98b8f889c720d62d)
+- feat: warn on invisible and bidi chars in strings [#493](https://github.com/ivov/lisette/pull/493) [`24abe4c`](https://github.com/ivov/lisette/commit/24abe4c9263cded785880f4bf1a5a9dbd7900b48)
+- fix: guard interface parent walks against embedding cycles [#492](https://github.com/ivov/lisette/pull/492) [`a1e2001`](https://github.com/ivov/lisette/commit/a1e20019d2468130e0a732f80ee681eb61f7701e)
+- fix: complete interface methods in lsp [#491](https://github.com/ivov/lisette/pull/491) [`079daa1`](https://github.com/ivov/lisette/commit/079daa1a954557818db5c6465a6ae14cc991e79f)
+- feat: reject deferring a mutex lock [#490](https://github.com/ivov/lisette/pull/490) [`04a8a2b`](https://github.com/ivov/lisette/commit/04a8a2bdcf72775d24317428a947b17ff1c34f04)
+- ci: catch lockfile drift [#489](https://github.com/ivov/lisette/pull/489) [`b64b576`](https://github.com/ivov/lisette/commit/b64b576d3ef16f6f806487991ea4d594d872d814)
+- chore: update lockfile [#487](https://github.com/ivov/lisette/pull/487) [`7c175d2`](https://github.com/ivov/lisette/commit/7c175d267f36f04ce65d1beade181f6f9e15225e)
+- feat: warn on unsigned integer compared against zero [#486](https://github.com/ivov/lisette/pull/486) [`d3fb542`](https://github.com/ivov/lisette/commit/d3fb542aeb214a173fb411e8b658247a86f22071)
+- refactor: restructure emit layer [#484](https://github.com/ivov/lisette/pull/484) [`f4757af`](https://github.com/ivov/lisette/commit/f4757af591949eb4650be4d1791c5cb762656740)
 ## [0.2.12](https://github.com/ivov/lisette/compare/lisette-v0.2.11...lisette-v0.2.12) - 2026-05-25
 
 - fix: disambiguate EcoString as_ref calls with as_str [#482](https://github.com/ivov/lisette/pull/482) [`9f16eef`](https://github.com/ivov/lisette/commit/9f16eef49df5a174c9139656ec5e128611758ec1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dashmap 6.1.0",
  "lisette-deps",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bincode",
  "ecow",
@@ -783,11 +783,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.12"
+version = "0.2.13"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.12", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.12", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.12", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.12", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.12", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.12", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.12", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.13", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.13", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.13", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.13", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.12", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.12", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.12", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.12", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.12", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.12", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.13", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.13", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.12", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.12", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.12", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.12", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.13 (upcoming)

- perf: skip synthetic EOF in token lookup [#500](https://github.com/ivov/lisette/pull/500) [`c9bbdeb`](https://github.com/ivov/lisette/commit/c9bbdeb9f7fb83108d46780998b8c497c57b844f)
- feat: reject empty range [#499](https://github.com/ivov/lisette/pull/499) [`d74f193`](https://github.com/ivov/lisette/commit/d74f1930e60bf2ec8ccd83f03a72baf794481fcc)
- perf: introduce simple benchmarking setup [#498](https://github.com/ivov/lisette/pull/498) [`47dd262`](https://github.com/ivov/lisette/commit/47dd2624ba678495305b6a2609f7b80d4d351c18)
- feat: reject comparison against math.NaN() [#497](https://github.com/ivov/lisette/pull/497) [`e853566`](https://github.com/ivov/lisette/commit/e8535667b80a4e00965bc811d145e51e7f055a6c)
- feat: warn on verbose failure propagation [#496](https://github.com/ivov/lisette/pull/496) [`0aef44a`](https://github.com/ivov/lisette/commit/0aef44a04095c82dd12f80b2ce34a89b1c9bd7b6)
- refactor: consolidate in-memory loader impls [#495](https://github.com/ivov/lisette/pull/495) [`207da7f`](https://github.com/ivov/lisette/commit/207da7f4f8a7cb7269c495cc9d649a7dd55e1dda)
- refactor: prep lint setup for upcoming diagnostics [#494](https://github.com/ivov/lisette/pull/494) [`f0b06b6`](https://github.com/ivov/lisette/commit/f0b06b6743283d09815cc33e98b8f889c720d62d)
- feat: warn on invisible and bidi chars in strings [#493](https://github.com/ivov/lisette/pull/493) [`24abe4c`](https://github.com/ivov/lisette/commit/24abe4c9263cded785880f4bf1a5a9dbd7900b48)
- fix: guard interface parent walks against embedding cycles [#492](https://github.com/ivov/lisette/pull/492) [`a1e2001`](https://github.com/ivov/lisette/commit/a1e20019d2468130e0a732f80ee681eb61f7701e)
- fix: complete interface methods in lsp [#491](https://github.com/ivov/lisette/pull/491) [`079daa1`](https://github.com/ivov/lisette/commit/079daa1a954557818db5c6465a6ae14cc991e79f)
- feat: reject deferring a mutex lock [#490](https://github.com/ivov/lisette/pull/490) [`04a8a2b`](https://github.com/ivov/lisette/commit/04a8a2bdcf72775d24317428a947b17ff1c34f04)
- ci: catch lockfile drift [#489](https://github.com/ivov/lisette/pull/489) [`b64b576`](https://github.com/ivov/lisette/commit/b64b576d3ef16f6f806487991ea4d594d872d814)
- chore: update lockfile [#487](https://github.com/ivov/lisette/pull/487) [`7c175d2`](https://github.com/ivov/lisette/commit/7c175d267f36f04ce65d1beade181f6f9e15225e)
- feat: warn on unsigned integer compared against zero [#486](https://github.com/ivov/lisette/pull/486) [`d3fb542`](https://github.com/ivov/lisette/commit/d3fb542aeb214a173fb411e8b658247a86f22071)
- refactor: restructure emit layer [#484](https://github.com/ivov/lisette/pull/484) [`f4757af`](https://github.com/ivov/lisette/commit/f4757af591949eb4650be4d1791c5cb762656740)
