### PR TITLE
feat: warn on unsigned integer compared against zero

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -259,6 +259,17 @@ pub fn tautological_comparison(span: &Span, always_true: bool) -> LisetteDiagnos
         ))
 }
 
+pub fn unsigned_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic {
+    let result = if always_true { "true" } else { "false" };
+
+    LisetteDiagnostic::warn(format!("Comparison is always {result}"))
+        .with_lint_code("unsigned_comparison")
+        .with_span_label(span, format!("always {result}"))
+        .with_help(
+            "An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value?",
+        )
+}
+
 pub fn self_assignment(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Self-assignment")
         .with_lint_code("self_assignment")

--- a/crates/semantics/src/passes/lints/ast_walk/checks.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks.rs
@@ -95,6 +95,68 @@ pub fn check_self_comparison(expression: &Expression, diagnostics: &mut Vec<Lise
     ));
 }
 
+pub fn check_unsigned_comparison(
+    expression: &Expression,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    use BinaryOperator::*;
+    if !matches!(
+        operator,
+        Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual
+    ) {
+        return;
+    }
+
+    let operator = match (
+        is_zero_literal(left.unwrap_parens()),
+        is_zero_literal(right.unwrap_parens()),
+    ) {
+        (true, false) if right.get_type().is_unsigned_int() => flip_comparison(*operator),
+        (false, true) if left.get_type().is_unsigned_int() => *operator,
+        _ => return,
+    };
+
+    let always_true = match operator {
+        LessThan => false,
+        GreaterThanOrEqual => true,
+        _ => return,
+    };
+
+    diagnostics.push(diagnostics::lint::unsigned_comparison(span, always_true));
+}
+
+fn is_zero_literal(expression: &Expression) -> bool {
+    matches!(
+        expression,
+        Expression::Literal {
+            literal: Literal::Integer { value: 0, .. },
+            ..
+        }
+    )
+}
+
+fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
+    use BinaryOperator::*;
+    match operator {
+        LessThan => GreaterThan,
+        LessThanOrEqual => GreaterThanOrEqual,
+        GreaterThan => LessThan,
+        GreaterThanOrEqual => LessThanOrEqual,
+        other => other,
+    }
+}
+
 pub fn check_duplicate_logical_operand(
     expression: &Expression,
     files: &HashMap<u32, File>,

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -61,7 +61,7 @@ use checks::{
     check_identical_if_branches, check_match_literal_collection, check_pattern_naming,
     check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
     check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
-    check_unnecessary_raw_string_pattern,
+    check_unnecessary_raw_string_pattern, check_unsigned_comparison,
 };
 use visitor::visit_ast;
 
@@ -78,6 +78,7 @@ impl AstLintGroup {
             &mut |expression| {
                 check_double_negation(expression, &mut diagnostics.borrow_mut());
                 check_self_comparison(expression, &mut diagnostics.borrow_mut());
+                check_unsigned_comparison(expression, &mut diagnostics.borrow_mut());
                 check_self_assignment(expression, &mut diagnostics.borrow_mut());
                 check_duplicate_logical_operand(expression, files, &mut diagnostics.borrow_mut());
                 check_bool_literal_comparison(expression, &mut diagnostics.borrow_mut());

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -559,6 +559,114 @@ fn main() {
 }
 
 #[test]
+fn unsigned_comparison_less_than_zero() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = n < 0
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_comparison_greater_than_or_equal_zero() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = n >= 0
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_comparison_zero_on_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = 0 > n
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_comparison_byte() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let b: byte = 5;
+  let _ = b < 0
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_comparison_with_parens() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = (n) >= (0)
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_equality_with_zero_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = n == 0
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_less_than_or_equal_zero_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = n <= 0
+}
+"#
+    );
+}
+
+#[test]
+fn signed_comparison_with_zero_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n: int = 5;
+  let _ = n < 0
+}
+"#
+    );
+}
+
+#[test]
+fn unsigned_comparison_with_nonzero_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n: uint = 5;
+  let _ = n < 10
+}
+"#
+    );
+}
+
+#[test]
 fn double_bool_negation() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/unsigned_comparison_byte.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_byte.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Comparison is always false
+   ╭─[test.lis:4:11]
+ 3 │   let b: byte = 5;
+ 4 │   let _ = b < 0
+   ·           ──┬──
+   ·             ╰── always false
+ 5 │ }
+   ╰────
+  help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_greater_than_or_equal_zero.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_greater_than_or_equal_zero.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Comparison is always true
+   ╭─[test.lis:4:11]
+ 3 │   let n: uint = 5;
+ 4 │   let _ = n >= 0
+   ·           ───┬──
+   ·              ╰── always true
+ 5 │ }
+   ╰────
+  help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_less_than_zero.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_less_than_zero.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Comparison is always false
+   ╭─[test.lis:4:11]
+ 3 │   let n: uint = 5;
+ 4 │   let _ = n < 0
+   ·           ──┬──
+   ·             ╰── always false
+ 5 │ }
+   ╰────
+  help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_with_parens.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_with_parens.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Comparison is always true
+   ╭─[test.lis:4:11]
+ 3 │   let n: uint = 5;
+ 4 │   let _ = (n) >= (0)
+   ·           ─────┬────
+   ·                ╰── always true
+ 5 │ }
+   ╰────
+  help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_zero_on_left.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_zero_on_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Comparison is always false
+   ╭─[test.lis:4:11]
+ 3 │   let n: uint = 5;
+ 4 │   let _ = 0 > n
+   ·           ──┬──
+   ·             ╰── always false
+ 5 │ }
+   ╰────
+  help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]


### PR DESCRIPTION
Adds a lint that flags comparing an unsigned integer against zero when the result is constant.

```
  [warning] Comparison is always false
   ╭─[test.lis:4:11]
 3 │   let n: uint = 5;
 4 │   let _ = n < 0
   ·           ──┬──
   ·             ╰── always false
 5 │ }
   ╰────
  help: An unsigned integer is never negative, so this comparison always has the same result. 
        Did you mean to compare against a different value? · code: [lint.unsigned_comparison]
```