### PR TITLE
feat: reject deferring a mutex lock

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2148,6 +2148,15 @@ pub fn defer_in_loop(span: Span) -> LisetteDiagnostic {
         .with_help("Wrap the loop body in a helper function, e.g. `fn process(file: File) { defer file.close(); ... }` and call it in the loop: `for f in files { process(f); }`")
 }
 
+pub fn deferred_lock(span: Span, locked: &str, unlock: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Deferred `{locked}` instead of `{unlock}`"))
+        .with_infer_code("deferred_lock")
+        .with_span_label(&span, "re-locks at function exit")
+        .with_help(format!(
+            "Deferring `{locked}` re-acquires the lock when the function returns, deadlocking the next caller. Did you mean `{unlock}`?"
+        ))
+}
+
 pub fn propagate_in_condition(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`?` cannot be used inside a condition")
         .with_infer_code("propagate_in_condition")

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -723,6 +723,8 @@ impl TaskState<'_> {
                 .push(diagnostics::infer::propagate_in_defer(propagate_span));
         }
 
+        self.check_deferred_lock(&new_expression);
+
         Expression::Defer {
             expression: new_expression.into(),
             ty: self.type_unit(),

--- a/crates/semantics/src/checker/infer/validation/control_flow.rs
+++ b/crates/semantics/src/checker/infer/validation/control_flow.rs
@@ -1,8 +1,55 @@
-use syntax::ast::Span;
+use syntax::ast::{Expression, Span};
+use syntax::types::Type;
 
 use crate::checker::TaskState;
 
+fn is_sync_lock_type(ty: &Type) -> bool {
+    matches!(
+        ty.strip_refs(),
+        Type::Nominal { id, .. }
+            if matches!(id.as_str(), "go:sync.Mutex" | "go:sync.RWMutex" | "go:sync.Locker")
+    )
+}
+
 impl TaskState<'_> {
+    pub(crate) fn check_deferred_lock(&mut self, deferred: &Expression) {
+        let Expression::Call {
+            expression: callee,
+            args,
+            span,
+            ..
+        } = deferred.unwrap_parens()
+        else {
+            return;
+        };
+
+        if !args.is_empty() {
+            return;
+        }
+
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return;
+        };
+
+        let (locked, unlock) = match member.as_str() {
+            "Lock" => ("Lock", "Unlock"),
+            "RLock" => ("RLock", "RUnlock"),
+            _ => return,
+        };
+
+        if !is_sync_lock_type(&receiver.get_type()) {
+            return;
+        }
+
+        self.sink
+            .push(diagnostics::infer::deferred_lock(*span, locked, unlock));
+    }
+
     pub(crate) fn check_return_in_try_block(&mut self, span: Span) {
         if self.scopes.lookup_try_block_context().is_some() {
             self.sink

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3969,6 +3969,139 @@ fn f() {
 }
 
 #[test]
+fn infer_deferred_mutex_lock() {
+    let input = r#"
+import "go:sync"
+
+struct Counter {
+  mu: sync.Mutex,
+}
+
+impl Counter {
+  fn inc(self: Ref<Counter>) {
+    self.mu.Lock()
+    defer self.mu.Lock()
+  }
+}
+
+fn main() {
+  let mut c = Counter { mu: sync.Mutex {} }
+  c.inc()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_deferred_rwmutex_rlock() {
+    let input = r#"
+import "go:sync"
+
+struct Cache {
+  rw: sync.RWMutex,
+}
+
+impl Cache {
+  fn read(self: Ref<Cache>) {
+    self.rw.RLock()
+    defer self.rw.RLock()
+  }
+}
+
+fn main() {
+  let mut c = Cache { rw: sync.RWMutex {} }
+  c.read()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_deferred_locker_lock() {
+    let input = r#"
+import "go:sync"
+
+fn run(l: sync.Locker) {
+  l.Lock()
+  defer l.Lock()
+}
+
+fn main() {
+  let mu = sync.Mutex {}
+  run(&mu)
+}
+"#;
+    crate::_harness::infer::infer(input).assert_infer_code("deferred_lock");
+}
+
+#[test]
+fn infer_deferred_unlock_is_allowed() {
+    let input = r#"
+import "go:sync"
+
+struct Counter {
+  mu: sync.Mutex,
+}
+
+impl Counter {
+  fn inc(self: Ref<Counter>) {
+    self.mu.Lock()
+    defer self.mu.Unlock()
+  }
+}
+
+fn main() {
+  let mut c = Counter { mu: sync.Mutex {} }
+  c.inc()
+}
+"#;
+    crate::_harness::infer::infer(input).assert_no_errors();
+}
+
+#[test]
+fn infer_deferred_lock_on_user_type_is_allowed() {
+    let input = r#"
+struct Resource {
+  id: int,
+}
+
+impl Resource {
+  fn Lock(self) {}
+}
+
+fn main() {
+  let r = Resource { id: 1 }
+  defer r.Lock()
+}
+"#;
+    crate::_harness::infer::infer(input).assert_no_errors();
+}
+
+#[test]
+fn infer_non_deferred_lock_is_allowed() {
+    let input = r#"
+import "go:sync"
+
+struct Counter {
+  mu: sync.Mutex,
+}
+
+impl Counter {
+  fn inc(self: Ref<Counter>) {
+    self.mu.Lock()
+    self.mu.Unlock()
+  }
+}
+
+fn main() {
+  let mut c = Counter { mu: sync.Mutex {} }
+  c.inc()
+}
+"#;
+    crate::_harness::infer::infer(input).assert_no_errors();
+}
+
+#[test]
 fn infer_defer_in_while_loop() {
     let input = r#"
 fn cleanup() {}

--- a/tests/ui/errors/snapshots/infer_deferred_mutex_lock.snap
+++ b/tests/ui/errors/snapshots/infer_deferred_mutex_lock.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Deferred `Lock` instead of `Unlock`
+    ╭─[test.lis:11:11]
+ 10 │     self.mu.Lock()
+ 11 │     defer self.mu.Lock()
+    ·           ───────┬──────
+    ·                  ╰── re-locks at function exit
+ 12 │   }
+    ╰────
+  help: Deferring `Lock` re-acquires the lock when the function returns, deadlocking the next caller. Did you mean `Unlock`? · code: [infer.deferred_lock]

--- a/tests/ui/errors/snapshots/infer_deferred_rwmutex_rlock.snap
+++ b/tests/ui/errors/snapshots/infer_deferred_rwmutex_rlock.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Deferred `RLock` instead of `RUnlock`
+    ╭─[test.lis:11:11]
+ 10 │     self.rw.RLock()
+ 11 │     defer self.rw.RLock()
+    ·           ───────┬───────
+    ·                  ╰── re-locks at function exit
+ 12 │   }
+    ╰────
+  help: Deferring `RLock` re-acquires the lock when the function returns, deadlocking the next caller. Did you mean `RUnlock`? · code: [infer.deferred_lock]


### PR DESCRIPTION
Adds a compile-time error for deferring a `sync` lock acquisition instead of releasing it.

```
  [error] Deferred `Lock` instead of `Unlock`
    ╭─[test.lis:11:11]
 10 │     self.mu.Lock()
 11 │     defer self.mu.Lock()
    ·           ───────┬──────
    ·                  ╰── re-locks at function exit
 12 │   }
    ╰────
  help: Deferring `Lock` re-acquires the lock when the function returns, deadlocking the next caller.
        Did you mean `Unlock`? · code: [infer.deferred_lock]
```
