### PR TITLE
fix: guard interface parent walks against embedding cycles

### DIFF
--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -32,6 +32,7 @@ impl TaskState<'_> {
         }
 
         let mut violations = Vec::new();
+        let mut visited = rustc_hash::FxHashSet::default();
         self.collect_interface_violations(
             store,
             ty,
@@ -41,6 +42,7 @@ impl TaskState<'_> {
             None,
             span,
             &mut violations,
+            &mut visited,
         );
 
         self.satisfying_stack.remove(&pair);
@@ -89,6 +91,7 @@ impl TaskState<'_> {
         store: &Store,
         ty: &Type,
         interface: &Interface,
+        interface_qualified_id: &str,
         span: &Span,
     ) -> Result<(), Vec<InterfaceViolation>> {
         if ty.is_ref() {
@@ -97,8 +100,16 @@ impl TaskState<'_> {
 
         let methods = self.get_all_methods(store, ty);
         let mut ptr_methods = Vec::new();
+        let mut visited = rustc_hash::FxHashSet::default();
 
-        self.collect_pointer_receiver_methods(store, interface, &methods, &mut ptr_methods);
+        self.collect_pointer_receiver_methods(
+            store,
+            interface,
+            interface_qualified_id,
+            &methods,
+            &mut ptr_methods,
+            &mut visited,
+        );
 
         if ptr_methods.is_empty() {
             return Ok(());
@@ -119,9 +130,14 @@ impl TaskState<'_> {
         &self,
         store: &Store,
         interface: &Interface,
+        interface_qualified_id: &str,
         methods: &MethodSignatures,
         out: &mut Vec<String>,
+        visited: &mut rustc_hash::FxHashSet<String>,
     ) {
+        if !visited.insert(interface_qualified_id.to_string()) {
+            return;
+        }
         for name in interface.methods.keys() {
             if let Some(method_ty) = methods.get(name) {
                 let func = match method_ty {
@@ -138,9 +154,17 @@ impl TaskState<'_> {
         for parent in &interface.parents {
             let parent_name = parent.get_qualified_name();
             if let Some(parent_interface) = store.get_interface(&parent_name) {
-                self.collect_pointer_receiver_methods(store, parent_interface, methods, out);
+                self.collect_pointer_receiver_methods(
+                    store,
+                    parent_interface,
+                    parent_name.as_str(),
+                    methods,
+                    out,
+                    visited,
+                );
             }
         }
+        visited.remove(interface_qualified_id);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -154,7 +178,12 @@ impl TaskState<'_> {
         parent_of: Option<&str>,
         span: &Span,
         violations: &mut Vec<InterfaceViolation>,
+        visited: &mut rustc_hash::FxHashSet<String>,
     ) {
+        if !visited.insert(interface_qualified_id.to_string()) {
+            return;
+        }
+
         let symbol_methods = self.get_all_methods(store, ty);
 
         let map: SubstitutionMap = interface
@@ -306,9 +335,12 @@ impl TaskState<'_> {
                     Some(&interface.name),
                     span,
                     violations,
+                    visited,
                 );
             }
         }
+
+        visited.remove(interface_qualified_id);
     }
 
     fn remove_first_param(ty: &Type) -> Type {

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -462,14 +462,14 @@ impl TaskState<'_> {
         if let Some(interface) = store.get_interface(symbol1).cloned() {
             return self
                 .satisfies_interface(store, t2, &interface, symbol1, params1, span)
-                .and_then(|()| self.check_pointer_receivers(store, t2, &interface, span))
+                .and_then(|()| self.check_pointer_receivers(store, t2, &interface, symbol1, span))
                 .map_err(|_| UnifyError::AlreadyReported);
         }
 
         if let Some(interface) = store.get_interface(symbol2).cloned() {
             return self
                 .satisfies_interface(store, t1, &interface, symbol2, params2, span)
-                .and_then(|()| self.check_pointer_receivers(store, t1, &interface, span))
+                .and_then(|()| self.check_pointer_receivers(store, t1, &interface, symbol2, span))
                 .map_err(|_| UnifyError::AlreadyReported);
         }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -348,10 +348,25 @@ impl Store {
         ty: &Type,
         trait_bounds: &HashMap<Symbol, Vec<Type>>,
     ) -> MethodSignatures {
+        let mut visited = HashSet::default();
+        self.get_all_methods_recursive(ty, trait_bounds, &mut visited)
+    }
+
+    fn get_all_methods_recursive(
+        &self,
+        ty: &Type,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
+        visited: &mut HashSet<String>,
+    ) -> MethodSignatures {
         let stripped = ty.strip_refs();
         let Some(qualified_name) = method_lookup_key(&stripped) else {
             return MethodSignatures::default();
         };
+
+        // Cyclic embeddings survive registration as an error with parents intact; guard the walk.
+        if !visited.insert(qualified_name.as_str().to_string()) {
+            return MethodSignatures::default();
+        }
 
         if let Some(interface) = self.get_interface(&qualified_name) {
             let mut all_interface_methods = MethodSignatures::default();
@@ -370,7 +385,9 @@ impl Store {
             }
 
             for parent in &interface.parents {
-                for (name, method_ty) in self.get_all_methods(parent, trait_bounds) {
+                for (name, method_ty) in
+                    self.get_all_methods_recursive(parent, trait_bounds, visited)
+                {
                     all_interface_methods.insert(name, method_ty);
                 }
             }
@@ -381,7 +398,9 @@ impl Store {
         if let Some(bound_types) = trait_bounds.get(&qualified_name) {
             return bound_types
                 .iter()
-                .flat_map(|interface_ty| self.get_all_methods(interface_ty, trait_bounds))
+                .flat_map(|interface_ty| {
+                    self.get_all_methods_recursive(interface_ty, trait_bounds, visited)
+                })
                 .collect();
         }
 
@@ -412,7 +431,9 @@ impl Store {
                 && k != qualified_name.as_str()
             {
                 let alias_ty = alias_ty.clone();
-                for (name, method_ty) in self.get_all_methods(&alias_ty, trait_bounds) {
+                for (name, method_ty) in
+                    self.get_all_methods_recursive(&alias_ty, trait_bounds, visited)
+                {
                     methods.entry(name).or_insert(method_ty);
                 }
             }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -3667,6 +3667,139 @@ fn interface_three_way_cycle_rejected() {
 }
 
 #[test]
+fn interface_cycle_with_dot_access_does_not_crash() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface P {
+  impl Q
+  fn foo(self) -> int
+}
+
+interface Q {
+  impl P
+  fn bar(self) -> int
+}
+
+fn use_it(p: P) -> int { p.foo() }
+
+fn main() {}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("interface_cycle");
+}
+
+#[test]
+fn interface_cycle_with_satisfaction_does_not_crash() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface P {
+  impl Q
+  fn foo(self) -> int
+}
+
+interface Q {
+  impl P
+  fn bar(self) -> int
+}
+
+struct S {}
+
+impl S {
+  fn foo(self) -> int { 1 }
+  fn bar(self) -> int { 2 }
+}
+
+fn take(p: P) {}
+
+fn main() { take(S {}) }
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("interface_cycle");
+}
+
+#[test]
+fn interface_diamond_conflicting_type_args_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface Base<T> {
+  fn get(self) -> T
+}
+
+interface A {
+  impl Base<int>
+}
+
+interface B {
+  impl Base<string>
+}
+
+interface C {
+  impl A
+  impl B
+}
+
+struct S {}
+
+impl S {
+  fn get(self) -> int { 1 }
+}
+
+fn take(c: C) {}
+
+fn main() { take(S {}) }
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn pointer_receiver_through_same_named_parent_interface_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "lib.lis",
+        r#"
+pub interface Worker {
+  fn work(self) -> int
+}
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "shapes"
+
+interface Worker {
+  impl shapes.Worker
+  fn name(self) -> string
+}
+
+struct MyWorker {}
+
+impl MyWorker {
+  fn name(self) -> string { "x" }
+  fn work(self: Ref<MyWorker>) -> int { 0 }
+}
+
+fn test() { let _w: Worker = MyWorker {} }
+
+fn main() {}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("interface_not_implemented");
+}
+
+#[test]
 fn interface_method_conflict_rejected() {
     infer(
         r#"


### PR DESCRIPTION
Cyclic interface embeddings no longer crash the compiler with a stack overflow during inference.

```rs
interface P {
  impl Q
  fn foo(self) -> int
}

interface Q {
  impl P
  fn bar(self) -> int
}

fn use_it(p: P) -> int { p.foo() }   // previously overflowed the stack; now reports P → Q → P
```
