### PR TITLE
feat: warn on invisible and bidi chars in strings

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -348,6 +348,31 @@ pub fn unnecessary_raw_string(span: &Span) -> LisetteDiagnostic {
         .with_help("Remove the `r` prefix. A string without backslashes does not need to be raw")
 }
 
+pub fn invisible_in_string(
+    span: &Span,
+    codepoint: u32,
+    name: &str,
+    is_bidi: bool,
+) -> LisetteDiagnostic {
+    let (title, code, help) = if is_bidi {
+        (
+            "Bidirectional character in string",
+            "bidi_in_string",
+            "Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\\u` escape so it is visible in source; otherwise remove it.",
+        )
+    } else {
+        (
+            "Invisible character in string",
+            "invisible_in_string",
+            "Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant.",
+        )
+    };
+    LisetteDiagnostic::warn(title)
+        .with_lint_code(code)
+        .with_span_label(span, format!("contains U+{codepoint:04X} ({name})"))
+        .with_help(help)
+}
+
 pub fn expression_only_fstring(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Expression-only f-string")
         .with_lint_code("expression_only_fstring")

--- a/crates/semantics/src/passes/lints/ast_walk/checks.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks.rs
@@ -589,6 +589,72 @@ pub fn check_unnecessary_raw_string_pattern(
     }
 }
 
+pub fn check_invisible_in_string_expression(
+    expression: &Expression,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let Expression::Literal { literal, span, .. } = expression else {
+        return;
+    };
+    let found = match literal {
+        Literal::String { value, .. } => first_invisible(value),
+        Literal::FormatString(parts) => parts.iter().find_map(|part| match part {
+            FormatStringPart::Text(text) => first_invisible(text),
+            FormatStringPart::Expression(_) => None,
+        }),
+        _ => None,
+    };
+    if let Some((codepoint, name, is_bidi)) = found {
+        diagnostics.push(diagnostics::lint::invisible_in_string(
+            span, codepoint, name, is_bidi,
+        ));
+    }
+}
+
+pub fn check_invisible_in_string_pattern(
+    pattern: &Pattern,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let Pattern::Literal {
+        literal: Literal::String { value, .. },
+        span,
+        ..
+    } = pattern
+    else {
+        return;
+    };
+    if let Some((codepoint, name, is_bidi)) = first_invisible(value) {
+        diagnostics.push(diagnostics::lint::invisible_in_string(
+            span, codepoint, name, is_bidi,
+        ));
+    }
+}
+
+fn first_invisible(text: &str) -> Option<(u32, &'static str, bool)> {
+    text.chars()
+        .find_map(|c| classify_invisible(c).map(|(name, is_bidi)| (c as u32, name, is_bidi)))
+}
+
+fn classify_invisible(c: char) -> Option<(&'static str, bool)> {
+    match c {
+        '\u{00A0}' => Some(("no-break space", false)),
+        '\u{200B}' => Some(("zero-width space", false)),
+        '\u{200C}' => Some(("zero-width non-joiner", false)),
+        '\u{200D}' => Some(("zero-width joiner", false)),
+        '\u{202A}' => Some(("left-to-right embedding", true)),
+        '\u{202B}' => Some(("right-to-left embedding", true)),
+        '\u{202C}' => Some(("pop directional formatting", true)),
+        '\u{202D}' => Some(("left-to-right override", true)),
+        '\u{202E}' => Some(("right-to-left override", true)),
+        '\u{2066}' => Some(("left-to-right isolate", true)),
+        '\u{2067}' => Some(("right-to-left isolate", true)),
+        '\u{2068}' => Some(("first strong isolate", true)),
+        '\u{2069}' => Some(("pop directional isolate", true)),
+        '\u{FEFF}' => Some(("zero-width no-break space", false)),
+        _ => None,
+    }
+}
+
 fn pattern_to_suggestion(pattern: &Pattern) -> String {
     match pattern {
         Pattern::EnumVariant {

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -58,7 +58,8 @@ use attributes::{check_attributes, check_struct_attributes};
 use checks::{
     check_bool_literal_comparison, check_double_negation, check_duplicate_logical_operand,
     check_empty_match_arm, check_excess_parens_on_condition, check_expression_naming,
-    check_identical_if_branches, check_match_literal_collection, check_pattern_naming,
+    check_identical_if_branches, check_invisible_in_string_expression,
+    check_invisible_in_string_pattern, check_match_literal_collection, check_pattern_naming,
     check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
     check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
     check_unnecessary_raw_string_pattern, check_unsigned_comparison,
@@ -89,6 +90,7 @@ impl AstLintGroup {
                 check_single_arm_match(expression, &mut diagnostics.borrow_mut());
                 check_uninterpolated_fstring(expression, &mut diagnostics.borrow_mut());
                 check_unnecessary_raw_string_expression(expression, &mut diagnostics.borrow_mut());
+                check_invisible_in_string_expression(expression, &mut diagnostics.borrow_mut());
                 check_expression_naming(expression, is_d_lis, &mut diagnostics.borrow_mut());
                 check_struct_attributes(expression, &mut diagnostics.borrow_mut());
                 check_attributes(expression, &mut diagnostics.borrow_mut());
@@ -97,6 +99,7 @@ impl AstLintGroup {
                 check_rest_only_slice_pattern(pattern, &mut diagnostics.borrow_mut());
                 check_pattern_naming(pattern, is_d_lis, &mut diagnostics.borrow_mut());
                 check_unnecessary_raw_string_pattern(pattern, &mut diagnostics.borrow_mut());
+                check_invisible_in_string_pattern(pattern, &mut diagnostics.borrow_mut());
             },
         );
 

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4019,3 +4019,100 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn invisible_in_string_zero_width_space() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let _ = \"hello\u{200B}world\"
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_string_right_to_left_override() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let _ = \"admin\u{202E}gnp.exe\"
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_string_no_break_space() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let _ = \"foo\u{00A0}bar\"
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_string_byte_order_mark() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let _ = \"\u{FEFF}leading\"
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_fstring_text_part() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let name = \"world\"
+  let _ = f\"hi\u{200B}{name}!\"
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_string_pattern() {
+    assert_lint_snapshot!(
+        "
+fn main() {
+  let s = \"x\"
+  let _ = match s {
+    \"foo\u{200B}\" => 1,
+    _ => 0,
+  };
+}
+"
+    );
+}
+
+#[test]
+fn invisible_in_string_ascii_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = "hello world"
+  let _ = "tab\there"
+  let _ = "newline\nhere"
+}
+"#
+    );
+}
+
+#[test]
+fn invisible_in_string_unicode_letters_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = "πϊθον"
+  let _ = "日本語"
+  let _ = "emoji: 🦀"
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/invisible_in_fstring_text_part.snap
+++ b/tests/ui/lint/snapshots/invisible_in_fstring_text_part.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Invisible character in string
+   ╭─[test.lis:4:11]
+ 3 │   let name = "world"
+ 4 │   let _ = f"hi​{name}!"
+   ·           ──────┬─────
+   ·                 ╰── contains U+200B (zero-width space)
+ 5 │ }
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]

--- a/tests/ui/lint/snapshots/invisible_in_string_byte_order_mark.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_byte_order_mark.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Invisible character in string
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = "﻿leading"
+   ·           ────┬────
+   ·               ╰── contains U+FEFF (zero-width no-break space)
+ 4 │ }
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]

--- a/tests/ui/lint/snapshots/invisible_in_string_no_break_space.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_no_break_space.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Invisible character in string
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = "foo bar"
+   ·           ────┬────
+   ·               ╰── contains U+00A0 (no-break space)
+ 4 │ }
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]

--- a/tests/ui/lint/snapshots/invisible_in_string_pattern.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Invisible character in string
+   ╭─[test.lis:5:5]
+ 4 │   let _ = match s {
+ 5 │     "foo​" => 1,
+   ·     ──┬──
+   ·       ╰── contains U+200B (zero-width space)
+ 6 │     _ => 0,
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]

--- a/tests/ui/lint/snapshots/invisible_in_string_right_to_left_override.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_right_to_left_override.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Bidirectional character in string
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = "admin‮gnp.exe"
+   ·           ───────┬──────
+   ·                  ╰── contains U+202E (right-to-left override)
+ 4 │ }
+   ╰────
+  help: Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\u` escape so it is visible in source; otherwise remove it · code: [lint.bidi_in_string]

--- a/tests/ui/lint/snapshots/invisible_in_string_zero_width_space.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_zero_width_space.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Invisible character in string
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = "hello​world"
+   ·           ──────┬─────
+   ·                 ╰── contains U+200B (zero-width space)
+ 4 │ }
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]


### PR DESCRIPTION

Adds two warnings to flag string literals containing invisible or bidirectional Unicode codepoints.

```
  [warning] Invisible character in string
   ╭─[test.lis:3:11]
 2 │ fn main() {
 3 │   let _ = "hello​world"
   ·           ──────┬─────
   ·                 ╰── contains U+200B (zero-width space)
 4 │ }
   ╰────
  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]
```
