### PR TITLE
feat: warn on verbose failure propagation

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -270,6 +270,13 @@ pub fn unsigned_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic 
         )
 }
 
+pub fn verbose_failure_propagation(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Verbose failure propagation")
+        .with_lint_code("verbose_failure_propagation")
+        .with_span_label(span, "verbose")
+        .with_help("Use `?` to propagate the failure concisely")
+}
+
 pub fn self_assignment(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Self-assignment")
         .with_lint_code("self_assignment")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -16,6 +16,7 @@ mod single_arm_match;
 mod uninterpolated_fstring;
 mod unnecessary_raw_string;
 mod unsigned_comparison;
+mod verbose_failure_propagation;
 
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use double_negation::check_double_negation;
@@ -38,3 +39,4 @@ pub use unnecessary_raw_string::{
     check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
 };
 pub use unsigned_comparison::check_unsigned_comparison;
+pub use verbose_failure_propagation::check_verbose_failure_propagation;

--- a/crates/semantics/src/passes/lints/ast_walk/checks/verbose_failure_propagation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/verbose_failure_propagation.rs
@@ -1,0 +1,157 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
+use syntax::types::unqualified_name;
+
+pub fn check_verbose_failure_propagation(
+    expression: &Expression,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let Expression::Match {
+        subject,
+        arms,
+        origin,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if arms.len() != 2 || arms.iter().any(MatchArm::has_guard) {
+        return;
+    }
+
+    let subject_ty = subject.get_type();
+    let fires = if subject_ty.is_option() {
+        check_option_propagation(&arms[0], &arms[1])
+    } else if subject_ty.is_result() {
+        check_result_propagation(&arms[0], &arms[1])
+    } else {
+        false
+    };
+
+    if fires {
+        let keyword_len = match origin {
+            MatchOrigin::Explicit => 5,
+            MatchOrigin::IfLet { .. } => 2,
+        };
+        let keyword_span = Span::new(span.file_id, span.byte_offset, keyword_len);
+        diagnostics.push(diagnostics::lint::verbose_failure_propagation(
+            &keyword_span,
+        ));
+    }
+}
+
+fn check_option_propagation(arm_a: &MatchArm, arm_b: &MatchArm) -> bool {
+    let try_pair = |some_arm: &MatchArm, fail_arm: &MatchArm| {
+        let Some(name) = enum_variant_binding(&some_arm.pattern, "Some") else {
+            return false;
+        };
+        is_none_or_wildcard(&fail_arm.pattern)
+            && body_is_identifier(&some_arm.expression, &name)
+            && body_is_return_none(&fail_arm.expression)
+    };
+    try_pair(arm_a, arm_b) || try_pair(arm_b, arm_a)
+}
+
+fn check_result_propagation(arm_a: &MatchArm, arm_b: &MatchArm) -> bool {
+    let try_pair = |ok_arm: &MatchArm, err_arm: &MatchArm| {
+        let Some(ok_name) = enum_variant_binding(&ok_arm.pattern, "Ok") else {
+            return false;
+        };
+        let Some(err_name) = enum_variant_binding(&err_arm.pattern, "Err") else {
+            return false;
+        };
+        body_is_identifier(&ok_arm.expression, &ok_name)
+            && body_is_return_err(&err_arm.expression, &err_name)
+    };
+    try_pair(arm_a, arm_b) || try_pair(arm_b, arm_a)
+}
+
+fn enum_variant_binding(pattern: &Pattern, variant: &str) -> Option<String> {
+    let Pattern::EnumVariant {
+        identifier,
+        fields,
+        rest,
+        ..
+    } = pattern
+    else {
+        return None;
+    };
+    if unqualified_name(identifier) != variant || *rest || fields.len() != 1 {
+        return None;
+    }
+    let Pattern::Identifier {
+        identifier: name, ..
+    } = &fields[0]
+    else {
+        return None;
+    };
+    Some(name.to_string())
+}
+
+fn is_none_or_wildcard(pattern: &Pattern) -> bool {
+    match pattern {
+        Pattern::WildCard { .. } => true,
+        Pattern::EnumVariant {
+            identifier,
+            fields,
+            rest,
+            ..
+        } => unqualified_name(identifier) == "None" && fields.is_empty() && !*rest,
+        _ => false,
+    }
+}
+
+fn body_is_identifier(expression: &Expression, name: &str) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Identifier { value, .. } => value.as_str() == name,
+        Expression::Block { items, .. } => items.len() == 1 && body_is_identifier(&items[0], name),
+        _ => false,
+    }
+}
+
+fn body_is_return_none(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Return {
+            expression: inner, ..
+        } => matches!(inner.unwrap_parens(), Expression::Identifier { value, .. }
+            if value.as_str() == "None"),
+        Expression::Block { items, .. } => items.len() == 1 && body_is_return_none(&items[0]),
+        _ => false,
+    }
+}
+
+fn body_is_return_err(expression: &Expression, binding: &str) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Return {
+            expression: inner, ..
+        } => is_err_of_binding(inner, binding),
+        Expression::Block { items, .. } => {
+            items.len() == 1 && body_is_return_err(&items[0], binding)
+        }
+        _ => false,
+    }
+}
+
+fn is_err_of_binding(expression: &Expression, binding: &str) -> bool {
+    let Expression::Call {
+        expression: callee,
+        args,
+        ..
+    } = expression.unwrap_parens()
+    else {
+        return false;
+    };
+    if args.len() != 1 {
+        return false;
+    }
+    let Expression::Identifier { value, .. } = callee.unwrap_parens() else {
+        return false;
+    };
+    if unqualified_name(value) != "Err" {
+        return false;
+    }
+    matches!(args[0].unwrap_parens(), Expression::Identifier { value, .. }
+        if value.as_str() == binding)
+}

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -77,7 +77,7 @@ use checks::{
     check_replaceable_with_zero_fill, check_rest_only_slice_pattern, check_self_assignment,
     check_self_comparison, check_single_arm_match, check_uninterpolated_fstring,
     check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
-    check_unsigned_comparison,
+    check_unsigned_comparison, check_verbose_failure_propagation,
 };
 use visitor::visit_ast;
 
@@ -98,6 +98,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_uninterpolated_fstring,
     check_unnecessary_raw_string_expression,
     check_invisible_in_string_expression,
+    check_verbose_failure_propagation,
     check_struct_attributes,
     check_attributes,
 ];

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4116,3 +4116,213 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn verbose_failure_propagation_option_match() {
+    assert_lint_snapshot!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    Some(v) => v,
+    None => return None,
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_option_match_reversed_arms() {
+    assert_lint_snapshot!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    None => return None,
+    Some(v) => v,
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_option_match_wildcard_arm() {
+    assert_lint_snapshot!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    Some(v) => v,
+    _ => return None,
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_result_match() {
+    assert_lint_snapshot!(
+        r#"
+fn first(x: Result<int, string>) -> Result<int, string> {
+  let v = match x {
+    Ok(v) => v,
+    Err(e) => return Err(e),
+  }
+  Ok(v + 1)
+}
+
+fn main() {
+  let _ = first(Ok(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_if_let_option() {
+    assert_lint_snapshot!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = if let Some(v) = x {
+    v
+  } else {
+    return None
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_option_unwrap_or_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: Option<int> = Some(1)
+  let _ = match x {
+    Some(v) => v,
+    None => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_option_fallback_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    Some(v) => v,
+    None => return Some(99),
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_option_transform_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    Some(v) => v + 1,
+    None => return None,
+  }
+  Some(v)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_result_replaced_error_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+const OTHER_ERROR: string = "oops"
+
+fn first(x: Result<int, string>) -> Result<int, string> {
+  let v = match x {
+    Ok(v) => v,
+    Err(e) => return Err(OTHER_ERROR),
+  }
+  Ok(v + 1)
+}
+
+fn main() {
+  let _ = first(Ok(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_result_via_wildcard_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+const OTHER_ERROR: string = "oops"
+
+fn first(x: Result<int, string>) -> Result<int, string> {
+  let v = match x {
+    Ok(v) => v,
+    _ => return Err(OTHER_ERROR),
+  }
+  Ok(v + 1)
+}
+
+fn main() {
+  let _ = first(Ok(1))
+}
+"#
+    );
+}
+
+#[test]
+fn verbose_failure_propagation_guard_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn first(x: Option<int>) -> Option<int> {
+  let v = match x {
+    Some(v) if v > 0 => v,
+    _ => return None,
+  }
+  Some(v + 1)
+}
+
+fn main() {
+  let _ = first(Some(1))
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_if_let_option.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_if_let_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Verbose failure propagation
+   ╭─[test.lis:3:11]
+ 2 │ fn first(x: Option<int>) -> Option<int> {
+ 3 │   let v = if let Some(v) = x {
+   ·           ─┬
+   ·            ╰── verbose
+ 4 │     v
+   ╰────
+  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Verbose failure propagation
+   ╭─[test.lis:3:11]
+ 2 │ fn first(x: Option<int>) -> Option<int> {
+ 3 │   let v = match x {
+   ·           ──┬──
+   ·             ╰── verbose
+ 4 │     Some(v) => v,
+   ╰────
+  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_reversed_arms.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_reversed_arms.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Verbose failure propagation
+   ╭─[test.lis:3:11]
+ 2 │ fn first(x: Option<int>) -> Option<int> {
+ 3 │   let v = match x {
+   ·           ──┬──
+   ·             ╰── verbose
+ 4 │     None => return None,
+   ╰────
+  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_wildcard_arm.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_wildcard_arm.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Verbose failure propagation
+   ╭─[test.lis:3:11]
+ 2 │ fn first(x: Option<int>) -> Option<int> {
+ 3 │   let v = match x {
+   ·           ──┬──
+   ·             ╰── verbose
+ 4 │     Some(v) => v,
+   ╰────
+  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_result_match.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_result_match.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Verbose failure propagation
+   ╭─[test.lis:3:11]
+ 2 │ fn first(x: Result<int, string>) -> Result<int, string> {
+ 3 │   let v = match x {
+   ·           ──┬──
+   ·             ╰── verbose
+ 4 │     Ok(v) => v,
+   ╰────
+  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]


### PR DESCRIPTION
Adds a  lint that flags `match` and `if let` shapes that can be trivially replaced with `?`

```
  [warning] Verbose failure propagation
   ╭─[test.lis:3:11]
 2 │ fn first(x: Result<int, string>) -> Result<int, string> {
 3 │   let v = match x {
   ·           ──┬──
   ·             ╰── verbose
 4 │     Ok(v) => v,
   ╰────
  help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]
```