### PR TITLE
perf: skip desugar pass when parser produced no desugarables

### DIFF
--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -62,6 +62,13 @@ pub fn build_ast(source: &str, file_id: u32) -> AstBuildResult {
         };
     }
 
+    if !parse_result.has_desugarables {
+        return AstBuildResult {
+            ast: parse_result.ast,
+            errors: vec![],
+        };
+    }
+
     let desugar_result = desugar::desugar(parse_result.ast);
     AstBuildResult {
         ast: desugar_result.ast,

--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -126,6 +126,7 @@ impl<'source> Parser<'source> {
     }
 
     fn parse_if_let_expression(&mut self, start: crate::lex::Token) -> Expression {
+        self.has_desugarables = true;
         self.ensure(Let);
 
         let pattern = self.parse_pattern_allowing_or();

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -546,7 +546,10 @@ impl<'source> Parser<'source> {
             NotEqual => BinaryOperator::NotEqual,
             AmpersandDouble => BinaryOperator::And,
             PipeDouble => BinaryOperator::Or,
-            Pipeline => BinaryOperator::Pipeline,
+            Pipeline => {
+                self.has_desugarables = true;
+                BinaryOperator::Pipeline
+            }
 
             _ => {
                 self.track_error(format!(

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -26,6 +26,7 @@ pub use error::ParseError;
 pub struct ParseResult {
     pub ast: Vec<ast::Expression>,
     pub errors: Vec<ParseError>,
+    pub has_desugarables: bool,
 }
 
 impl ParseResult {
@@ -43,6 +44,7 @@ pub struct Parser<'source> {
     in_control_flow_header: bool,
     source: &'source str,
     depth: u32,
+    pub(crate) has_desugarables: bool,
 }
 
 impl<'source> Parser<'source> {
@@ -57,6 +59,7 @@ impl<'source> Parser<'source> {
             return ParseResult {
                 ast: vec![],
                 errors: lex_result.errors,
+                has_desugarables: false,
             };
         }
 
@@ -80,6 +83,7 @@ impl<'source> Parser<'source> {
             in_control_flow_header: false,
             source,
             depth: 0,
+            has_desugarables: false,
         };
 
         parser.skip_comments();
@@ -107,6 +111,7 @@ impl<'source> Parser<'source> {
         ParseResult {
             ast: top_items,
             errors: self.errors,
+            has_desugarables: self.has_desugarables,
         }
     }
 


### PR DESCRIPTION
Parsing now skips the desugaring AST walk on files that use neither `|>` nor `if let`. Yields ~30% parsing gain.