### PR TITLE
fix: preserve type args on generic interface bounds in bindgen

### DIFF
--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -76,7 +76,7 @@ func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, o
 	if named, isNamed := constraint.(*types.Named); isNamed {
 		obj := named.Obj()
 		if obj.Pkg() != nil && obj.Pkg().Path() == "cmp" && obj.Name() == "Ordered" {
-			return qualifyTypeNameBound(obj, conv)
+			return qualifyTypeNameBound(obj, nil, conv)
 		}
 	}
 
@@ -106,9 +106,9 @@ func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, o
 	if iface.NumMethods() > 0 && iface.NumEmbeddeds() == 0 {
 		switch t := constraint.(type) {
 		case *types.Named:
-			return qualifyTypeNameBound(t.Obj(), conv)
+			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv)
 		case *types.Alias:
-			return qualifyTypeNameBound(t.Obj(), conv)
+			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv)
 		}
 	}
 
@@ -148,18 +148,30 @@ func isOrderedBasicKind(kind types.BasicKind) bool {
 // Renders a Named or Alias bound by its TypeName, qualifying with the package
 // alias when external and tracking the external package on conv. Bounds in the
 // current package render unqualified to avoid a self-import.
-func qualifyTypeNameBound(obj *types.TypeName, conv *Converter) (string, bool) {
+func qualifyTypeNameBound(obj *types.TypeName, typeArgs *types.TypeList, conv *Converter) (string, bool) {
 	pkg := obj.Pkg()
 	if pkg == nil || isInternalPackagePath(pkg.Path()) {
 		return "", false
 	}
-	if conv != nil && pkg.Path() == conv.currentPkgPath {
-		return obj.Name(), true
+	name := obj.Name()
+	if conv == nil || pkg.Path() != conv.currentPkgPath {
+		if conv != nil {
+			conv.trackExternalPkg(pkg.Path(), pkg.Name())
+		}
+		name = PkgRef(pkg.Path()) + "." + obj.Name()
 	}
-	if conv != nil {
-		conv.trackExternalPkg(pkg.Path(), pkg.Name())
+	if typeArgs == nil || typeArgs.Len() == 0 {
+		return name, true
 	}
-	return PkgRef(pkg.Path()) + "." + obj.Name(), true
+	args := make([]string, 0, typeArgs.Len())
+	for arg := range typeArgs.Types() {
+		result := ToLisette(arg, conv)
+		if result.SkipReason != nil {
+			return "", false
+		}
+		args = append(args, result.LisetteType)
+	}
+	return name + "<" + strings.Join(args, ", ") + ">", true
 }
 
 // Unwraps `interface { ~T }` to its inner T, the shared shape of every

--- a/bindgen/tests/testdata/fixtures/generics/generics.go
+++ b/bindgen/tests/testdata/fixtures/generics/generics.go
@@ -149,3 +149,19 @@ func MapEqual[M1, M2 ~map[K]V, K, V comparable](m1 M1, m2 M2) bool {
 func MapEqualFunc[M1 ~map[K]V1, M2 ~map[K]V2, K comparable, V1, V2 any](m1 M1, m2 M2, eq func(V1, V2) bool) bool {
 	return false
 }
+
+// Generic interface used as a bound; type args must round-trip into the bound.
+type Pusher[T any, C any] interface {
+	Push(T, C)
+}
+
+// Generic interface bound with type params from the surrounding scope.
+func PushOne[T any, C any, P Pusher[T, C]](p P, t T, c C) {}
+
+// Generic interface bound with a concrete type arg.
+func PushInts[P Pusher[int, string]](p P) {}
+
+// Generic struct field that binds a type parameter to a generic interface.
+type Driver[T any, C any, P Pusher[T, C]] struct {
+	Inner P
+}

--- a/bindgen/tests/testdata/snapshots/generics.d.lis
+++ b/bindgen/tests/testdata/snapshots/generics.d.lis
@@ -38,6 +38,12 @@ pub fn Min<T: Ordered>(a: T, b: T) -> T
 /// cmp.Ordered constraint (named-identity recognizer)
 pub fn MinOrdered<T: cmp.Ordered>(a: T, b: T) -> T
 
+/// Generic interface bound with a concrete type arg.
+pub fn PushInts<P: Pusher<int, string>>(p: P)
+
+/// Generic interface bound with type params from the surrounding scope.
+pub fn PushOne<T, C, P: Pusher<T, C>>(p: P, t: T, c: C)
+
 /// Bound by an alias of a method-only interface.
 pub fn SalutationsAll<T: Salutation>(xs: Slice<T>)
 
@@ -62,6 +68,11 @@ pub struct ConstrainedPair<K: Comparable, V> {
 
 pub type Container<T>
 
+/// Generic struct field that binds a type parameter to a generic interface.
+pub struct Driver<T, C, P: Pusher<T, C>> {
+  pub Inner: P,
+}
+
 /// Local method-only interface for cross-package and self-package bound tests.
 pub interface Greeter {
   fn Greet() -> string
@@ -73,6 +84,11 @@ pub type Ordered
 pub struct Pair<K, V> {
   pub Key: K,
   pub Value: V,
+}
+
+/// Generic interface used as a bound; type args must round-trip into the bound.
+pub interface Pusher<T, C> {
+  fn Push(t: T, c: C)
 }
 
 /// Type alias to a method-only interface — exercises *types.Alias path.


### PR DESCRIPTION
Bindgen now preserves type arguments when emitting a generic interface used as a type-parameter bound. Without the args, the bound understated its arity, causing `infer.type_arg_count_mismatch` to misfire.

```rs
pub struct FlagBase<T, C, VC: ValueCreator> // before
pub struct FlagBase<T, C, VC: ValueCreator<T, C>> // after
```

Fix #501
