### PR TITLE
chore: release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
+## [0.2.14](https://github.com/ivov/lisette/compare/lisette-v0.2.13...lisette-v0.2.14) - 2026-05-27
+
+- fix: translate `unknown` to any in explicit type arguments [#513](https://github.com/ivov/lisette/pull/513) [`7d6687a`](https://github.com/ivov/lisette/commit/7d6687a8ae52f122aef8b6341d3de707d01a667f)
+- feat: reject empty select default arm in loop [#515](https://github.com/ivov/lisette/pull/515) [`68e1881`](https://github.com/ivov/lisette/commit/68e1881b9cb1905041103f6debf0a17e52f7088d)
+- ci: split lsp tests from main suite [#514](https://github.com/ivov/lisette/pull/514) [`470d511`](https://github.com/ivov/lisette/commit/470d511e07b68f3e20ae5f796f44632e24557687)
+- ci: drop redundant job, cache golangci-lint, run lsp tests [#512](https://github.com/ivov/lisette/pull/512) [`45c2388`](https://github.com/ivov/lisette/commit/45c2388fdcbe040ae16e495b9577ee185593da31)
+- feat: reject empty infinite loop [#511](https://github.com/ivov/lisette/pull/511) [`fafb988`](https://github.com/ivov/lisette/commit/fafb988a5472e6a2f6b0354c1da865a9a0fccb1c)
+- feat: reject repeated condition in if else if chain [#510](https://github.com/ivov/lisette/pull/510) [`024aab4`](https://github.com/ivov/lisette/commit/024aab48996d8c84c89a7fb9d0478bb64de8e05f)
+- feat: reject shift exceeding integer width [#509](https://github.com/ivov/lisette/pull/509) [`b45378f`](https://github.com/ivov/lisette/commit/b45378f047a8c5d30bb9a0f060057507937796ae)
+- fix: unwrap nested option-slice at Go boundary [#508](https://github.com/ivov/lisette/pull/508) [`4500702`](https://github.com/ivov/lisette/commit/45007023f21ce97cee49e72f593ff3a0b7a7a22a)
+- fix: preserve type args from non-generic alias in struct calls [#507](https://github.com/ivov/lisette/pull/507) [`e9f7161`](https://github.com/ivov/lisette/commit/e9f71616682b06f337e4a294dcbb4ac2054a37df)
+- feat: reject out-of-bounds slice indexing [#506](https://github.com/ivov/lisette/pull/506) [`7ab94ec`](https://github.com/ivov/lisette/commit/7ab94ecc68bd904c6c0dd4172221d59d08c60487)
+- perf: avoid cloning function definition in non-builtin emit path [#505](https://github.com/ivov/lisette/pull/505) [`560678c`](https://github.com/ivov/lisette/commit/560678cb186f7c1c4f3fdf81534d4c93e7e2bc1c)
+- fix: preserve type args on generic interface bounds in bindgen [#503](https://github.com/ivov/lisette/pull/503) [`39ac1b7`](https://github.com/ivov/lisette/commit/39ac1b7729026259d221b3430250277547d6eb83)
+- perf: skip desugar pass when parser produced no desugarables [#502](https://github.com/ivov/lisette/pull/502) [`af8156c`](https://github.com/ivov/lisette/commit/af8156c1531645da32fcd39154ee7f0c52f8056f)
 ## [0.2.13](https://github.com/ivov/lisette/compare/lisette-v0.2.12...lisette-v0.2.13) - 2026-05-26
 
 - perf: skip synthetic EOF in token lookup [#500](https://github.com/ivov/lisette/pull/500) [`c9bbdeb`](https://github.com/ivov/lisette/commit/c9bbdeb9f7fb83108d46780998b8c497c57b844f)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "ecow",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.13"
+version = "0.2.14"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.13", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.13", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.13", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.13", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.14", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.14", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.14", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.14", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.13", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.13", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.14", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.14", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.13", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.13", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.13", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.13", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.14 (upcoming)

- fix: translate `unknown` to any in explicit type arguments [#513](https://github.com/ivov/lisette/pull/513) [`7d6687a`](https://github.com/ivov/lisette/commit/7d6687a8ae52f122aef8b6341d3de707d01a667f)
- feat: reject empty select default arm in loop [#515](https://github.com/ivov/lisette/pull/515) [`68e1881`](https://github.com/ivov/lisette/commit/68e1881b9cb1905041103f6debf0a17e52f7088d)
- ci: split lsp tests from main suite [#514](https://github.com/ivov/lisette/pull/514) [`470d511`](https://github.com/ivov/lisette/commit/470d511e07b68f3e20ae5f796f44632e24557687)
- ci: drop redundant job, cache golangci-lint, run lsp tests [#512](https://github.com/ivov/lisette/pull/512) [`45c2388`](https://github.com/ivov/lisette/commit/45c2388fdcbe040ae16e495b9577ee185593da31)
- feat: reject empty infinite loop [#511](https://github.com/ivov/lisette/pull/511) [`fafb988`](https://github.com/ivov/lisette/commit/fafb988a5472e6a2f6b0354c1da865a9a0fccb1c)
- feat: reject repeated condition in if else if chain [#510](https://github.com/ivov/lisette/pull/510) [`024aab4`](https://github.com/ivov/lisette/commit/024aab48996d8c84c89a7fb9d0478bb64de8e05f)
- feat: reject shift exceeding integer width [#509](https://github.com/ivov/lisette/pull/509) [`b45378f`](https://github.com/ivov/lisette/commit/b45378f047a8c5d30bb9a0f060057507937796ae)
- fix: unwrap nested option-slice at Go boundary [#508](https://github.com/ivov/lisette/pull/508) [`4500702`](https://github.com/ivov/lisette/commit/45007023f21ce97cee49e72f593ff3a0b7a7a22a)
- fix: preserve type args from non-generic alias in struct calls [#507](https://github.com/ivov/lisette/pull/507) [`e9f7161`](https://github.com/ivov/lisette/commit/e9f71616682b06f337e4a294dcbb4ac2054a37df)
- feat: reject out-of-bounds slice indexing [#506](https://github.com/ivov/lisette/pull/506) [`7ab94ec`](https://github.com/ivov/lisette/commit/7ab94ecc68bd904c6c0dd4172221d59d08c60487)
- perf: avoid cloning function definition in non-builtin emit path [#505](https://github.com/ivov/lisette/pull/505) [`560678c`](https://github.com/ivov/lisette/commit/560678cb186f7c1c4f3fdf81534d4c93e7e2bc1c)
- fix: preserve type args on generic interface bounds in bindgen [#503](https://github.com/ivov/lisette/pull/503) [`39ac1b7`](https://github.com/ivov/lisette/commit/39ac1b7729026259d221b3430250277547d6eb83)
- perf: skip desugar pass when parser produced no desugarables [#502](https://github.com/ivov/lisette/pull/502) [`af8156c`](https://github.com/ivov/lisette/commit/af8156c1531645da32fcd39154ee7f0c52f8056f)
