### PR TITLE
feat: reject out-of-bounds slice indexing

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2155,6 +2155,13 @@ pub fn empty_range(span: &Span) -> LisetteDiagnostic {
         .with_help("Swap the bounds.")
 }
 
+pub fn index_out_of_bounds(span: &Span, index_text: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Index out of bounds")
+        .with_infer_code("index_out_of_bounds")
+        .with_span_label(span, "out of bounds")
+        .with_help(format!("Indexing at `{index_text}` will panic at runtime"))
+}
+
 pub fn nan_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic {
     let result = if always_true { "true" } else { "false" };
 

--- a/crates/semantics/src/passes/checks/index_out_of_bounds.rs
+++ b/crates/semantics/src/passes/checks/index_out_of_bounds.rs
@@ -1,0 +1,97 @@
+use diagnostics::LocalSink;
+use syntax::ast::{Expression, Literal};
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, sink: &LocalSink) {
+    check(expression, sink);
+    for child in expression.children() {
+        visit_expression(child, sink);
+    }
+}
+
+fn check(expression: &Expression, sink: &LocalSink) {
+    let Expression::IndexedAccess {
+        expression: receiver,
+        index,
+        from_colon_syntax,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if *from_colon_syntax {
+        return;
+    }
+
+    if !receiver.get_type().is_slice() {
+        return;
+    }
+
+    if let Expression::Literal {
+        literal: Literal::Slice(elements),
+        ..
+    } = receiver.unwrap_parens()
+        && let Expression::Literal {
+            literal: Literal::Integer { value, .. },
+            ..
+        } = index.unwrap_parens()
+        && *value >= elements.len() as u64
+    {
+        sink.push(diagnostics::infer::index_out_of_bounds(
+            span,
+            &value.to_string(),
+        ));
+        return;
+    }
+
+    if let Expression::Call {
+        expression: callee,
+        args,
+        ..
+    } = index.unwrap_parens()
+        && args.is_empty()
+        && let Expression::DotAccess {
+            expression: call_receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        && member == "length"
+        && expressions_equivalent(receiver, call_receiver)
+    {
+        let receiver_text = receiver.root_identifier().unwrap_or("xs");
+        sink.push(diagnostics::infer::index_out_of_bounds(
+            span,
+            &format!("{receiver_text}.length()"),
+        ));
+    }
+}
+
+fn expressions_equivalent(a: &Expression, b: &Expression) -> bool {
+    let a = a.unwrap_parens();
+    let b = b.unwrap_parens();
+    match (a, b) {
+        (Expression::Identifier { value: av, .. }, Expression::Identifier { value: bv, .. }) => {
+            av == bv
+        }
+        (
+            Expression::DotAccess {
+                expression: ae,
+                member: am,
+                ..
+            },
+            Expression::DotAccess {
+                expression: be,
+                member: bm,
+                ..
+            },
+        ) => am == bm && expressions_equivalent(ae, be),
+        _ => false,
+    }
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod duplicate_bindings;
 pub(crate) mod empty_range;
 pub(crate) mod enum_variant_value;
 pub(crate) mod generics;
+pub(crate) mod index_out_of_bounds;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
 pub(crate) mod nan_comparison;
@@ -101,6 +102,7 @@ fn run_file_checks(
     enum_variant_value::run(&file.items, store, sink);
     nan_comparison::run(&file.items, sink);
     empty_range::run(&file.items, sink);
+    index_out_of_bounds::run(&file.items, sink);
     temp_producing::run(&file.items, sink);
     if !file.is_d_lis() {
         const_naming::run(&file.items, sink);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4557,3 +4557,107 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn index_out_of_bounds_past_length() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = [1, 2, 3][5]
+}
+"#
+    );
+}
+
+#[test]
+fn index_out_of_bounds_equal_to_length() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = [10, 20, 30][3]
+}
+"#
+    );
+}
+
+#[test]
+fn index_out_of_bounds_single_element() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = [42][1]
+}
+"#
+    );
+}
+
+#[test]
+fn index_out_of_bounds_empty_slice() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _: int = [][0]
+}
+"#
+    );
+}
+
+#[test]
+fn index_out_of_bounds_length_call() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let xs = [10, 20]
+  let _ = xs[xs.length()]
+}
+"#
+    );
+}
+
+#[test]
+fn index_in_bounds_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = [1, 2, 3][2]
+}
+"#
+    );
+}
+
+#[test]
+fn index_length_minus_one_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let xs = [10, 20]
+  let _ = xs[xs.length() - 1]
+}
+"#
+    );
+}
+
+#[test]
+fn index_dynamic_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3]
+  let i = 0
+  let _ = xs[i]
+}
+"#
+    );
+}
+
+#[test]
+fn index_map_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let m = Map.new<int, string>()
+  let _ = m[5]
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/index_out_of_bounds_empty_slice.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_empty_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Index out of bounds
+   ╭─[test.lis:3:18]
+ 2 │ fn main() {
+ 3 │   let _: int = [][0]
+   ·                  ─┬─
+   ·                   ╰── out of bounds
+ 4 │ }
+   ╰────
+  help: Indexing at `0` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_equal_to_length.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_equal_to_length.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Index out of bounds
+   ╭─[test.lis:3:23]
+ 2 │ fn main() {
+ 3 │   let _ = [10, 20, 30][3]
+   ·                       ─┬─
+   ·                        ╰── out of bounds
+ 4 │ }
+   ╰────
+  help: Indexing at `3` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_length_call.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_length_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Index out of bounds
+   ╭─[test.lis:4:13]
+ 3 │   let xs = [10, 20]
+ 4 │   let _ = xs[xs.length()]
+   ·             ──────┬──────
+   ·                   ╰── out of bounds
+ 5 │ }
+   ╰────
+  help: Indexing at `xs.length()` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_past_length.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_past_length.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Index out of bounds
+   ╭─[test.lis:3:20]
+ 2 │ fn main() {
+ 3 │   let _ = [1, 2, 3][5]
+   ·                    ─┬─
+   ·                     ╰── out of bounds
+ 4 │ }
+   ╰────
+  help: Indexing at `5` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_single_element.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_single_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Index out of bounds
+   ╭─[test.lis:3:15]
+ 2 │ fn main() {
+ 3 │   let _ = [42][1]
+   ·               ─┬─
+   ·                ╰── out of bounds
+ 4 │ }
+   ╰────
+  help: Indexing at `1` will panic at runtime · code: [infer.index_out_of_bounds]


### PR DESCRIPTION
Adds an `index_out_of_bounds` error for slice indexing that is expected to panic at runtime.

```
  [error] Index out of bounds
   ╭─[test.lis:4:13]
 3 │   let xs = [10, 20]
 4 │   let _ = xs[xs.length()]
   ·             ──────┬──────
   ·                   ╰── out of bounds
 5 │ }
   ╰────
  help: Indexing at `xs.length()` will panic at runtime · code: [infer.index_out_of_bounds]
```