### PR TITLE
fix: preserve type args from non-generic alias in struct calls

### DIFF
--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -439,7 +439,9 @@ impl Planner<'_> {
             let parts: Vec<&str> = name.split('.').collect();
             let emits_qualified = (is_enum && parts.len() == 3) || (!is_enum && parts.len() == 2);
             if emits_qualified && !self.facts.is_current_module(parts[0]) {
-                let type_args = if let Type::Nominal { params, .. } = ty {
+                let type_args = if self.is_non_generic_alias_call(parts[1], ty) {
+                    String::new()
+                } else if let Type::Nominal { params, .. } = ty {
                     self.format_type_args(params, fx)
                 } else {
                     String::new()
@@ -450,6 +452,22 @@ impl Planner<'_> {
         }
 
         self.go_type_string(ty, fx)
+    }
+
+    /// True when `type_name` (e.g., `StringFlag`) is a non-generic alias in the
+    /// same module as the underlying struct `ty`.
+    fn is_non_generic_alias_call(&self, type_name: &str, ty: &Type) -> bool {
+        let Type::Nominal { id: struct_id, .. } = ty else {
+            return false;
+        };
+        let Some(module) = self.facts.module_for_qualified_name(struct_id) else {
+            return false;
+        };
+        let alias_id = format!("{}.{}", module, type_name);
+        matches!(
+            self.facts.definition(&alias_id).map(|d| &d.body),
+            Some(DefinitionBody::TypeAlias { generics, .. }) if generics.is_empty()
+        )
     }
 
     /// Compute the enum-specific context for a struct call.

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -81,6 +81,7 @@ impl TaskState<'_> {
                 spread,
                 span,
                 expected_ty,
+                None,
             );
         }
 
@@ -112,6 +113,11 @@ impl TaskState<'_> {
                 let struct_ty = struct_ty.clone();
                 let struct_fields = struct_fields.clone();
                 let struct_id_str = struct_id.to_string();
+                let alias_underlying = if matches!(&alias_ty, Type::Forall { .. }) {
+                    None
+                } else {
+                    Some(underlying)
+                };
                 return self.infer_struct_call_for_struct(
                     store,
                     struct_name,
@@ -122,6 +128,7 @@ impl TaskState<'_> {
                     spread,
                     span,
                     expected_ty,
+                    alias_underlying,
                 );
             }
 
@@ -251,8 +258,13 @@ impl TaskState<'_> {
         spread: StructSpread,
         span: Span,
         expected_ty: &Type,
+        alias_underlying: Option<Type>,
     ) -> Expression {
         let (struct_call_ty, map) = self.instantiate(&struct_ty);
+
+        if let Some(underlying) = alias_underlying {
+            self.unify(store, &struct_call_ty, &underlying, &span);
+        }
 
         let peeled_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
         if same_nominal(&peeled_expected, &struct_call_ty) && !peeled_expected.contains_unknown() {

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -494,3 +494,24 @@ pub struct TypeError {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:gopkg.in/yaml.v3", typedef)]);
 }
+
+#[test]
+fn cross_module_non_generic_alias_call_emits_without_type_args() {
+    let input = r#"
+import "go:example.com/cli"
+
+fn make() -> Ref<cli.StringFlag> {
+  &cli.StringFlag { Name: "n", Value: "v", .. }
+}
+"#;
+    let typedef = r#"
+pub struct FlagBase<T, C> {
+  pub Name: string,
+  pub Value: T,
+  pub Config: C,
+}
+
+pub type StringFlag = FlagBase<string, int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cli", typedef)]);
+}

--- a/tests/spec/emit/snapshots/cross_module_non_generic_alias_call_emits_without_type_args.snap
+++ b/tests/spec/emit/snapshots/cross_module_non_generic_alias_call_emits_without_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/imports.rs
+description: "input: \nimport \"go:example.com/cli\"\n\nfn make() -> Ref<cli.StringFlag> {\n  &cli.StringFlag { Name: \"n\", Value: \"v\", .. }\n}\n"
+---
+package main
+
+import "example.com/cli"
+
+func make_() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:  "n",
+		Value: "v",
+	}
+}

--- a/tests/spec/emit/snapshots/non_generic_alias_pins_unconstrained_type_param.snap
+++ b/tests/spec/emit/snapshots/non_generic_alias_pins_unconstrained_type_param.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Phantom<T, P> { pub value: T }\n\ntype IntPhantom = Phantom<int, string>\n\nfn make() -> IntPhantom {\n  IntPhantom { value: 7, .. }\n}\n"
+---
+package main
+
+import "fmt"
+
+type Phantom[T any, P any] struct {
+	Value T
+}
+
+func (p Phantom[T, P]) String() string {
+	return fmt.Sprintf("Phantom { value: %v }", p.Value)
+}
+
+type IntPhantom = Phantom[int, string]
+
+func make_() IntPhantom {
+	return Phantom[int, string]{Value: 7}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -143,6 +143,20 @@ struct Box<T> { value: T }
 }
 
 #[test]
+fn non_generic_alias_pins_unconstrained_type_param() {
+    let input = r#"
+struct Phantom<T, P> { pub value: T }
+
+type IntPhantom = Phantom<int, string>
+
+fn make() -> IntPhantom {
+  IntPhantom { value: 7, .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn type_alias_field_access() {
     let input = r#"
 struct Point { pub x: int, pub y: int }


### PR DESCRIPTION
Constructing a Go-imported non-generic type alias to a generic struct now compiles. We previously lost the alias's type arguments during inference, which caused the output to miscompile in Go

```rs
import "go:github.com/urfave/cli/v3"

fn main() {
  let f = &cli.StringFlag {
    Name: "name",
    Value: "world",
    ..,
  }
  // before: go build failed with "cli.StringFlag is not a generic type"
  // after:  emits `&cli.StringFlag{Name: "name", Value: "world"}`
}
```