### PR TITLE
fix: unwrap nested option-slice at Go boundary

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -6,6 +6,7 @@ use crate::Planner;
 use crate::calls::go_interop::WrapperTarget;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::plan::bodies::LoweredStatement;
+use crate::types::shape::NullableCollectionShape;
 
 pub(crate) struct Coercion {
     kind: CoercionKind,
@@ -14,14 +15,30 @@ pub(crate) struct Coercion {
 pub(crate) enum CoercionKind {
     Identity,
     WrapAsInterface(AdapterPlan),
-    WrapNewtype { ty: Type },
-    UnwrapNullableOption { ty: Type },
-    UnwrapPointerOption { ty: Type },
-    UnwrapNullableCollection { ty: Type, element_option_ty: Type },
+    WrapNewtype {
+        ty: Type,
+    },
+    UnwrapNullableOption {
+        ty: Type,
+    },
+    UnwrapPointerOption {
+        ty: Type,
+    },
+    UnwrapNullableCollection {
+        ty: Type,
+        shape: NullableCollectionShape,
+    },
     UnwrapOptionToAny,
-    WrapNullableOption { ty: Type },
-    WrapPointerOption { ty: Type },
-    WrapNullableCollection { ty: Type, element_option_ty: Type },
+    WrapNullableOption {
+        ty: Type,
+    },
+    WrapPointerOption {
+        ty: Type,
+    },
+    WrapNullableCollection {
+        ty: Type,
+        shape: NullableCollectionShape,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -71,11 +88,8 @@ impl Coercion {
                 let ptr = format!("*{}", planner.go_type_string(&ty.ok_type(), fx));
                 planner.emit_option_projection(output, &value, "ptr", &ptr, true, fx)
             }
-            CoercionKind::UnwrapNullableCollection {
-                ty,
-                element_option_ty,
-            } => {
-                planner.emit_collection_nullable_unwrap(output, &value, &ty, &element_option_ty, fx)
+            CoercionKind::UnwrapNullableCollection { ty, shape } => {
+                planner.emit_collection_nullable_unwrap(output, &value, &ty, &shape, fx)
             }
             CoercionKind::UnwrapOptionToAny => {
                 planner.emit_option_projection(output, &value, "unwrap", "any", false, fx)
@@ -86,10 +100,9 @@ impl Coercion {
             CoercionKind::WrapPointerOption { ty } => {
                 planner.emit_pointer_to_option_wrap(output, &value, &ty, fx)
             }
-            CoercionKind::WrapNullableCollection {
-                ty,
-                element_option_ty,
-            } => planner.emit_collection_nullable_wrap(output, &value, &ty, &element_option_ty, fx),
+            CoercionKind::WrapNullableCollection { ty, shape } => {
+                planner.emit_collection_nullable_wrap(output, &value, &ty, &shape, fx)
+            }
         }
     }
 
@@ -122,32 +135,18 @@ impl Coercion {
             CoercionKind::UnwrapOptionToAny => {
                 planner.plan_option_projection(&mut statements, &value, "unwrap", "any", false, fx)
             }
-            CoercionKind::UnwrapNullableCollection {
-                ty,
-                element_option_ty,
-            } => planner.plan_collection_nullable_unwrap(
-                &mut statements,
-                &value,
-                &ty,
-                &element_option_ty,
-                fx,
-            ),
+            CoercionKind::UnwrapNullableCollection { ty, shape } => {
+                planner.plan_collection_nullable_unwrap(&mut statements, &value, &ty, &shape, fx)
+            }
             CoercionKind::WrapNullableOption { ty } => {
                 planner.plan_nil_check_option_wrap(&mut statements, &value, &ty, fx)
             }
             CoercionKind::WrapPointerOption { ty } => {
                 planner.plan_pointer_to_option_wrap(&mut statements, &value, &ty, fx)
             }
-            CoercionKind::WrapNullableCollection {
-                ty,
-                element_option_ty,
-            } => planner.plan_collection_nullable_wrap(
-                &mut statements,
-                &value,
-                &ty,
-                &element_option_ty,
-                fx,
-            ),
+            CoercionKind::WrapNullableCollection { ty, shape } => {
+                planner.plan_collection_nullable_wrap(&mut statements, &value, &ty, &shape, fx)
+            }
         };
         (statements, value)
     }
@@ -196,7 +195,7 @@ pub(crate) enum OptionShape {
     /// uses `*T` and bridges nil ↔ `None`.
     PointerBridged,
     NullableCollection {
-        element_option_ty: Type,
+        shape: NullableCollectionShape,
     },
 }
 
@@ -206,9 +205,7 @@ pub(crate) fn classify_option_shape(planner: &Planner, ty: &Type) -> OptionShape
     } else if planner.is_non_nilable_option(ty) {
         OptionShape::PointerBridged
     } else if let Some(shape) = planner.nullable_collection_shape(ty) {
-        OptionShape::NullableCollection {
-            element_option_ty: shape.element_option_ty,
-        }
+        OptionShape::NullableCollection { shape }
     } else {
         OptionShape::Plain
     }
@@ -228,9 +225,9 @@ fn resolve_to_go(planner: &Planner, from: &Type, to: &Type) -> CoercionKind {
             CoercionKind::UnwrapPointerOption { ty: from.clone() }
         }
         PointerBridged => CoercionKind::Identity,
-        NullableCollection { element_option_ty } => CoercionKind::UnwrapNullableCollection {
+        NullableCollection { shape } => CoercionKind::UnwrapNullableCollection {
             ty: from.clone(),
-            element_option_ty,
+            shape,
         },
     }
 }
@@ -241,9 +238,9 @@ fn resolve_from_go(planner: &Planner, from: &Type) -> CoercionKind {
         Plain => CoercionKind::Identity,
         Nullable => CoercionKind::WrapNullableOption { ty: from.clone() },
         PointerBridged => CoercionKind::WrapPointerOption { ty: from.clone() },
-        NullableCollection { element_option_ty } => CoercionKind::WrapNullableCollection {
+        NullableCollection { shape } => CoercionKind::WrapNullableCollection {
             ty: from.clone(),
-            element_option_ty,
+            shape,
         },
     }
 }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -6,16 +6,10 @@ use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_blo
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
-use crate::types::shape::CollectionKind;
+use crate::types::shape::{CollectionKind, NullableCollectionElement, NullableCollectionShape};
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
-
-struct CollectionUnwrapShape {
-    raw_collection_ty: String,
-    is_pointer_bridged: bool,
-    emit_nil_else: bool,
-}
 
 impl Planner<'_> {
     pub(super) fn lower_go_option_call_wrapped(
@@ -374,7 +368,7 @@ impl Planner<'_> {
         output: &mut String,
         raw_value: &str,
         collection_ty: &Type,
-        element_option_ty: &Type,
+        shape: &NullableCollectionShape,
         fx: &mut EmitEffects,
     ) -> String {
         fx.require_stdlib();
@@ -406,28 +400,42 @@ impl Planner<'_> {
             src_var
         );
 
-        let fallible = Fallible::from_type(element_option_ty).expect("Option type expected");
-        let is_pointer_bridged = self.is_non_nilable_option(element_option_ty);
-
-        let is_interface = self.is_interface_option(element_option_ty);
-        if is_interface {
-            write_line!(output, "if !lisette.IsNilInterface({}) {{", val_var);
-        } else {
-            write_line!(output, "if {} != nil {{", val_var);
+        match &shape.element {
+            NullableCollectionElement::Option(opt_ty) => {
+                let fallible = Fallible::from_type(opt_ty).expect("Option type expected");
+                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
+                let is_interface = self.is_interface_option(opt_ty);
+                if is_interface {
+                    write_line!(output, "if !lisette.IsNilInterface({}) {{", val_var);
+                } else {
+                    write_line!(output, "if {} != nil {{", val_var);
+                }
+                let some_input = if is_pointer_bridged {
+                    format!("*{}", val_var)
+                } else {
+                    val_var.clone()
+                };
+                let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                let some_wrapper = fe.emit_success(&some_input);
+                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, some_wrapper);
+                output.push_str("} else {\n");
+                let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                let none_wrapper = fe.emit_failure(None);
+                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, none_wrapper);
+                output.push_str("}\n");
+            }
+            NullableCollectionElement::Nested(inner_shape) => {
+                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
+                let inner_var = self.emit_collection_nullable_wrap(
+                    output,
+                    &val_var,
+                    &inner_lisette_ty,
+                    inner_shape,
+                    fx,
+                );
+                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, inner_var);
+            }
         }
-        let some_input = if is_pointer_bridged {
-            format!("*{}", val_var)
-        } else {
-            val_var.clone()
-        };
-        let mut fe = FalliblePlanner::new(self, &fallible, fx);
-        let some_wrapper = fe.emit_success(&some_input);
-        write_line!(output, "{}[{}] = {}", wrapped_var, index_var, some_wrapper);
-        output.push_str("} else {\n");
-        let mut fe = FalliblePlanner::new(self, &fallible, fx);
-        let none_wrapper = fe.emit_failure(None);
-        write_line!(output, "{}[{}] = {}", wrapped_var, index_var, none_wrapper);
-        output.push_str("}\n");
 
         output.push_str("}\n");
 
@@ -440,7 +448,7 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         raw_value: &str,
         collection_ty: &Type,
-        element_option_ty: &Type,
+        shape: &NullableCollectionShape,
         fx: &mut EmitEffects,
     ) -> String {
         fx.require_stdlib();
@@ -457,54 +465,75 @@ impl Planner<'_> {
         let val_var = self.fresh_var(Some("v"));
         self.declare(&val_var);
 
-        let fallible = Fallible::from_type(element_option_ty).expect("Option type expected");
-        let is_pointer_bridged = self.is_non_nilable_option(element_option_ty);
-        let is_interface = self.is_interface_option(element_option_ty);
+        let loop_body = match &shape.element {
+            NullableCollectionElement::Option(opt_ty) => {
+                let fallible = Fallible::from_type(opt_ty).expect("Option type expected");
+                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
+                let is_interface = self.is_interface_option(opt_ty);
+                let some_input = if is_pointer_bridged {
+                    format!("*{}", val_var)
+                } else {
+                    val_var.clone()
+                };
+                let some_wrapper = {
+                    let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                    fe.emit_success(&some_input)
+                };
+                let none_wrapper = {
+                    let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                    fe.emit_failure(None)
+                };
+                let condition = if is_interface {
+                    format!("!lisette.IsNilInterface({})", val_var)
+                } else {
+                    format!("{} != nil", val_var)
+                };
+                let then_body = LoweredBlock {
+                    statements: vec![LoweredStatement::RawGo(format!(
+                        "{}[{}] = {}\n",
+                        wrapped_var, index_var, some_wrapper
+                    ))],
+                };
+                let else_body = LoweredBlock {
+                    statements: vec![LoweredStatement::RawGo(format!(
+                        "{}[{}] = {}\n",
+                        wrapped_var, index_var, none_wrapper
+                    ))],
+                };
+                let if_plan = IfPlan {
+                    directive: String::new(),
+                    condition_setup: String::new(),
+                    condition,
+                    then_body,
+                    else_arm: ElseArm::Else {
+                        body: else_body,
+                        inline: false,
+                    },
+                };
+                LoweredBlock {
+                    statements: vec![LoweredStatement::If(if_plan)],
+                }
+            }
+            NullableCollectionElement::Nested(inner_shape) => {
+                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
+                let mut inner_statements = Vec::new();
+                let inner_var = self.plan_collection_nullable_wrap(
+                    &mut inner_statements,
+                    &val_var,
+                    &inner_lisette_ty,
+                    inner_shape,
+                    fx,
+                );
+                inner_statements.push(LoweredStatement::RawGo(format!(
+                    "{}[{}] = {}\n",
+                    wrapped_var, index_var, inner_var
+                )));
+                LoweredBlock {
+                    statements: inner_statements,
+                }
+            }
+        };
 
-        let some_input = if is_pointer_bridged {
-            format!("*{}", val_var)
-        } else {
-            val_var.clone()
-        };
-        let some_wrapper = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
-            fe.emit_success(&some_input)
-        };
-        let none_wrapper = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
-            fe.emit_failure(None)
-        };
-
-        let condition = if is_interface {
-            format!("!lisette.IsNilInterface({})", val_var)
-        } else {
-            format!("{} != nil", val_var)
-        };
-        let then_body = LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(format!(
-                "{}[{}] = {}\n",
-                wrapped_var, index_var, some_wrapper
-            ))],
-        };
-        let else_body = LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(format!(
-                "{}[{}] = {}\n",
-                wrapped_var, index_var, none_wrapper
-            ))],
-        };
-        let if_plan = IfPlan {
-            directive: String::new(),
-            condition_setup: String::new(),
-            condition,
-            then_body,
-            else_arm: ElseArm::Else {
-                body: else_body,
-                inline: false,
-            },
-        };
-        let loop_body = LoweredBlock {
-            statements: vec![LoweredStatement::If(if_plan)],
-        };
         statements.push(LoweredStatement::Loop(LoopPlan {
             directive: String::new(),
             prologue: String::new(),
@@ -521,11 +550,11 @@ impl Planner<'_> {
         output: &mut String,
         lisette_value: &str,
         collection_ty: &Type,
-        element_option_ty: &Type,
+        shape: &NullableCollectionShape,
         fx: &mut EmitEffects,
     ) -> String {
         fx.require_stdlib();
-        let shape = self.classify_collection_unwrap_shape(collection_ty, element_option_ty, fx);
+        let raw_collection_ty = self.shape_raw_collection_ty(shape, fx);
 
         let src_var = self.fresh_var(Some("src"));
         self.declare(&src_var);
@@ -541,7 +570,7 @@ impl Planner<'_> {
             output,
             "{} := make({}, len({}))",
             unwrapped_var,
-            shape.raw_collection_ty,
+            raw_collection_ty,
             src_var
         );
 
@@ -553,24 +582,42 @@ impl Planner<'_> {
             src_var
         );
 
-        let some_assignment = if shape.is_pointer_bridged {
-            format!("&{}.SomeVal", val_var)
-        } else {
-            format!("{}.SomeVal", val_var)
-        };
-        write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
-        write_line!(
-            output,
-            "{}[{}] = {}",
-            unwrapped_var,
-            index_var,
-            some_assignment
-        );
-        if shape.emit_nil_else {
-            output.push_str("} else {\n");
-            write_line!(output, "{}[{}] = nil", unwrapped_var, index_var);
+        match &shape.element {
+            NullableCollectionElement::Option(opt_ty) => {
+                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
+                let is_map = matches!(shape.kind, CollectionKind::Map);
+                let emit_nil_else = is_map || is_pointer_bridged;
+                let some_assignment = if is_pointer_bridged {
+                    format!("&{}.SomeVal", val_var)
+                } else {
+                    format!("{}.SomeVal", val_var)
+                };
+                write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
+                write_line!(
+                    output,
+                    "{}[{}] = {}",
+                    unwrapped_var,
+                    index_var,
+                    some_assignment
+                );
+                if emit_nil_else {
+                    output.push_str("} else {\n");
+                    write_line!(output, "{}[{}] = nil", unwrapped_var, index_var);
+                }
+                output.push_str("}\n");
+            }
+            NullableCollectionElement::Nested(inner_shape) => {
+                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
+                let inner_var = self.emit_collection_nullable_unwrap(
+                    output,
+                    &val_var,
+                    &inner_lisette_ty,
+                    inner_shape,
+                    fx,
+                );
+                write_line!(output, "{}[{}] = {}", unwrapped_var, index_var, inner_var);
+            }
         }
-        output.push_str("}\n");
         output.push_str("}\n");
 
         unwrapped_var
@@ -582,57 +629,83 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         lisette_value: &str,
         collection_ty: &Type,
-        element_option_ty: &Type,
+        shape: &NullableCollectionShape,
         fx: &mut EmitEffects,
     ) -> String {
         fx.require_stdlib();
-        let shape = self.classify_collection_unwrap_shape(collection_ty, element_option_ty, fx);
+        let raw_collection_ty = self.shape_raw_collection_ty(shape, fx);
 
         let src_var = self.hoist_tmp_value_statement(statements, "src", lisette_value);
         let unwrapped_var = self.hoist_tmp_value_statement(
             statements,
             "unwrapped",
-            &format!("make({}, len({}))", shape.raw_collection_ty, src_var),
+            &format!("make({}, len({}))", raw_collection_ty, src_var),
         );
         let index_var = self.fresh_var(Some("i"));
         self.declare(&index_var);
         let val_var = self.fresh_var(Some("v"));
         self.declare(&val_var);
 
-        let some_assignment = if shape.is_pointer_bridged {
-            format!("&{}.SomeVal", val_var)
-        } else {
-            format!("{}.SomeVal", val_var)
-        };
-        let then_body = LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(format!(
-                "{}[{}] = {}\n",
-                unwrapped_var, index_var, some_assignment
-            ))],
-        };
-        let else_arm = if shape.emit_nil_else {
-            ElseArm::Else {
-                body: LoweredBlock {
+        let loop_body = match &shape.element {
+            NullableCollectionElement::Option(opt_ty) => {
+                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
+                let is_map = matches!(shape.kind, CollectionKind::Map);
+                let emit_nil_else = is_map || is_pointer_bridged;
+                let some_assignment = if is_pointer_bridged {
+                    format!("&{}.SomeVal", val_var)
+                } else {
+                    format!("{}.SomeVal", val_var)
+                };
+                let then_body = LoweredBlock {
                     statements: vec![LoweredStatement::RawGo(format!(
-                        "{}[{}] = nil\n",
-                        unwrapped_var, index_var
+                        "{}[{}] = {}\n",
+                        unwrapped_var, index_var, some_assignment
                     ))],
-                },
-                inline: false,
+                };
+                let else_arm = if emit_nil_else {
+                    ElseArm::Else {
+                        body: LoweredBlock {
+                            statements: vec![LoweredStatement::RawGo(format!(
+                                "{}[{}] = nil\n",
+                                unwrapped_var, index_var
+                            ))],
+                        },
+                        inline: false,
+                    }
+                } else {
+                    ElseArm::None
+                };
+                let if_plan = IfPlan {
+                    directive: String::new(),
+                    condition_setup: String::new(),
+                    condition: format!("{}.Tag == {}", val_var, OPTION_SOME_TAG),
+                    then_body,
+                    else_arm,
+                };
+                LoweredBlock {
+                    statements: vec![LoweredStatement::If(if_plan)],
+                }
             }
-        } else {
-            ElseArm::None
+            NullableCollectionElement::Nested(inner_shape) => {
+                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
+                let mut inner_statements = Vec::new();
+                let inner_var = self.plan_collection_nullable_unwrap(
+                    &mut inner_statements,
+                    &val_var,
+                    &inner_lisette_ty,
+                    inner_shape,
+                    fx,
+                );
+                inner_statements.push(LoweredStatement::RawGo(format!(
+                    "{}[{}] = {}\n",
+                    unwrapped_var, index_var, inner_var
+                )));
+                LoweredBlock {
+                    statements: inner_statements,
+                }
+            }
         };
-        let if_plan = IfPlan {
-            directive: String::new(),
-            condition_setup: String::new(),
-            condition: format!("{}.Tag == {}", val_var, OPTION_SOME_TAG),
-            then_body,
-            else_arm,
-        };
-        let loop_body = LoweredBlock {
-            statements: vec![LoweredStatement::If(if_plan)],
-        };
+
         statements.push(LoweredStatement::Loop(LoopPlan {
             directive: String::new(),
             prologue: String::new(),
@@ -644,34 +717,47 @@ impl Planner<'_> {
         unwrapped_var
     }
 
-    fn classify_collection_unwrap_shape(
-        &mut self,
-        collection_ty: &Type,
-        element_option_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> CollectionUnwrapShape {
-        let shape = self
-            .nullable_collection_shape(collection_ty)
-            .expect("nullable collection unwrap requires alias-aware shape");
-        let is_map = matches!(shape.kind, CollectionKind::Map);
-        let is_pointer_bridged = self.is_non_nilable_option(element_option_ty);
-        let inner_ty = element_option_ty.ok_type();
-        let inner_ty_str = self.go_type_string(&inner_ty, fx);
-        let raw_element_ty = if is_pointer_bridged {
-            format!("*{}", inner_ty_str)
+    /// Lisette element type of a collection: `Slice<X>` to `X`, `Map<K, V>` to `V`.
+    fn collection_element_ty(&self, collection_ty: &Type, shape: &NullableCollectionShape) -> Type {
+        let resolved = self.emit_shape_ty(collection_ty);
+        let params = resolved
+            .get_type_params()
+            .expect("native collection has type params");
+        let index = if matches!(shape.kind, CollectionKind::Map) {
+            1
         } else {
-            inner_ty_str
+            0
         };
-        let raw_collection_ty = if let Some(key_ty) = shape.key_ty.as_ref() {
+        params[index].clone()
+    }
+
+    /// Raw Go type for an unwrapped collection; walks the shape recursively so
+    /// nested options lower past the outer `[]` (e.g. to `[][]*T`).
+    fn shape_raw_collection_ty(
+        &mut self,
+        shape: &NullableCollectionShape,
+        fx: &mut EmitEffects,
+    ) -> String {
+        let raw_element_ty = match &shape.element {
+            NullableCollectionElement::Option(opt_ty) => {
+                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
+                let inner_ty = opt_ty.ok_type();
+                let inner_ty_str = self.go_type_string(&inner_ty, fx);
+                if is_pointer_bridged {
+                    format!("*{}", inner_ty_str)
+                } else {
+                    inner_ty_str
+                }
+            }
+            NullableCollectionElement::Nested(inner_shape) => {
+                self.shape_raw_collection_ty(inner_shape, fx)
+            }
+        };
+        if let Some(key_ty) = shape.key_ty.as_ref() {
             let key_ty_str = self.go_type_string(key_ty, fx);
             format!("map[{}]{}", key_ty_str, raw_element_ty)
         } else {
             format!("[]{}", raw_element_ty)
-        };
-        CollectionUnwrapShape {
-            raw_collection_ty,
-            is_pointer_bridged,
-            emit_nil_else: is_map || is_pointer_bridged,
         }
     }
 }

--- a/crates/emit/src/types/shape.rs
+++ b/crates/emit/src/types/shape.rs
@@ -35,7 +35,13 @@ pub(crate) enum CollectionKind {
 pub(crate) struct NullableCollectionShape {
     pub(crate) kind: CollectionKind,
     pub(crate) key_ty: Option<Type>,
-    pub(crate) element_option_ty: Type,
+    pub(crate) element: NullableCollectionElement,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum NullableCollectionElement {
+    Option(Type),
+    Nested(Box<NullableCollectionShape>),
 }
 
 impl Planner<'_> {
@@ -122,32 +128,41 @@ impl Planner<'_> {
 
     /// Classify a type as a nullable collection (`Slice<Option<...>>` or
     /// `Map<K, Option<...>>`) after alias peeling. Element option types are
-    /// also alias-aware via the inner option classifier.
+    /// also alias-aware via the inner option classifier. Nested collections
+    /// (e.g. `Slice<Slice<Option<T>>>`) are detected recursively.
     pub(crate) fn nullable_collection_shape(&self, ty: &Type) -> Option<NullableCollectionShape> {
         let shape = self.native_shape(ty)?;
         match shape.kind {
             NativeGoType::Slice => {
                 let element_ty = shape.params.into_iter().next()?;
-                let resolved_option = self.pointer_bridged_option_ty(&element_ty)?;
+                let element = self.classify_nullable_element(&element_ty)?;
                 Some(NullableCollectionShape {
                     kind: CollectionKind::Slice,
                     key_ty: None,
-                    element_option_ty: resolved_option,
+                    element,
                 })
             }
             NativeGoType::Map => {
                 let mut iter = shape.params.into_iter();
                 let key_ty = iter.next()?;
                 let val_ty = iter.next()?;
-                let resolved_option = self.pointer_bridged_option_ty(&val_ty)?;
+                let element = self.classify_nullable_element(&val_ty)?;
                 Some(NullableCollectionShape {
                     kind: CollectionKind::Map,
                     key_ty: Some(key_ty),
-                    element_option_ty: resolved_option,
+                    element,
                 })
             }
             _ => None,
         }
+    }
+
+    fn classify_nullable_element(&self, element_ty: &Type) -> Option<NullableCollectionElement> {
+        if let Some(opt) = self.pointer_bridged_option_ty(element_ty) {
+            return Some(NullableCollectionElement::Option(opt));
+        }
+        let nested = self.nullable_collection_shape(element_ty)?;
+        Some(NullableCollectionElement::Nested(Box::new(nested)))
     }
 
     fn pointer_bridged_option_ty(&self, ty: &Type) -> Option<Type> {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1563,3 +1563,30 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn interop_nested_slice_of_option_unwrapped_at_go_field() {
+    let input = r#"
+import "go:example.com/cli"
+
+fn main() {
+  let f1 = &cli.Flag { Name: "a", .. }
+  let f2 = &cli.Flag { Name: "b", .. }
+  let g = cli.Group {
+    Flags: [[Some(f1), Some(f2)]],
+    ..,
+  }
+  let _ = g
+}
+"#;
+    let typedef = r#"
+pub struct Flag {
+  pub Name: string,
+}
+
+pub struct Group {
+  pub Flags: Slice<Slice<Option<Ref<Flag>>>>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cli", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
+++ b/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "input: \nimport \"go:example.com/cli\"\n\nfn main() {\n  let f1 = &cli.Flag { Name: \"a\", .. }\n  let f2 = &cli.Flag { Name: \"b\", .. }\n  let g = cli.Group {\n    Flags: [[Some(f1), Some(f2)]],\n    ..,\n  }\n  let _ = g\n}\n"
+---
+package main
+
+import (
+	"example.com/cli"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	f1 := &cli.Flag{Name: "a"}
+	f2 := &cli.Flag{Name: "b"}
+	src_1 := [][]lisette.Option[*cli.Flag]{[]lisette.Option[*cli.Flag]{lisette.MakeOptionSome(f1), lisette.MakeOptionSome(f2)}}
+	unwrapped_2 := make([][]*cli.Flag, len(src_1))
+	for i_3, v_4 := range src_1 {
+		src_5 := v_4
+		unwrapped_6 := make([]*cli.Flag, len(src_5))
+		for i_7, v_8 := range src_5 {
+			if v_8.Tag == lisette.OptionSome {
+				unwrapped_6[i_7] = v_8.SomeVal
+			}
+		}
+		unwrapped_2[i_3] = unwrapped_6
+	}
+	g := cli.Group{Flags: unwrapped_2}
+	_ = g
+}


### PR DESCRIPTION
Assigning a `Slice<Slice<Option<T>>>` literal to a Go field of type `[][]T` now compiles. Lisette previously emitted `[][]lisette.Option[T]{...}` for the literal, which Go rejects against the `[][]T` field.

```rs
import "go:github.com/urfave/cli/v3"

fn main() {
  let json = &cli.BoolFlag { Name: "json", .. }
  let yaml = &cli.BoolFlag { Name: "yaml", .. }
  let mex = cli.MutuallyExclusiveFlags {
    Flags: [[Some(json)], [Some(yaml)]],
    ..,
  }
}
```