### PR TITLE
feat: reject shift exceeding integer width

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2162,6 +2162,20 @@ pub fn index_out_of_bounds(span: &Span, index_text: &str) -> LisetteDiagnostic {
         .with_help(format!("Indexing at `{index_text}` will panic at runtime"))
 }
 
+pub fn oversized_shift(
+    span: &Span,
+    type_name: &str,
+    bit_width: u32,
+    shift_amount: u64,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Shift amount exceeds integer width")
+        .with_infer_code("oversized_shift")
+        .with_span_label(span, "shift exceeds width")
+        .with_help(format!(
+            "`{type_name}` is {bit_width} bits wide, so shifting by {shift_amount} discards every bit of the value."
+        ))
+}
+
 pub fn nan_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic {
     let result = if always_true { "true" } else { "false" };
 

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod json_methods;
 pub(crate) mod nan_comparison;
 pub(crate) mod native_value_usage;
 pub(crate) mod newtype;
+pub(crate) mod oversized_shift;
 mod pattern_analysis;
 pub(crate) mod predeclared_shadowing;
 pub(crate) mod prelude_shadowing;
@@ -103,6 +104,7 @@ fn run_file_checks(
     nan_comparison::run(&file.items, sink);
     empty_range::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
+    oversized_shift::run(&file.items, sink);
     temp_producing::run(&file.items, sink);
     if !file.is_d_lis() {
         const_naming::run(&file.items, sink);

--- a/crates/semantics/src/passes/checks/oversized_shift.rs
+++ b/crates/semantics/src/passes/checks/oversized_shift.rs
@@ -1,0 +1,52 @@
+use diagnostics::LocalSink;
+use syntax::ast::{BinaryOperator, Expression, Literal};
+use syntax::types::SimpleKind;
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, sink: &LocalSink) {
+    if let Expression::Binary {
+        operator,
+        left,
+        right,
+        span,
+        ..
+    } = expression
+        && matches!(
+            operator,
+            BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight
+        )
+        && let Some(kind) = left.get_type().as_simple()
+        && let Some(bit_width) = fixed_bit_width(kind)
+        && let Expression::Literal {
+            literal: Literal::Integer { value, .. },
+            ..
+        } = right.unwrap_parens()
+        && *value >= u64::from(bit_width)
+    {
+        sink.push(diagnostics::infer::oversized_shift(
+            span,
+            kind.leaf_name(),
+            bit_width,
+            *value,
+        ));
+    }
+
+    for child in expression.children() {
+        visit_expression(child, sink);
+    }
+}
+
+fn fixed_bit_width(kind: SimpleKind) -> Option<u32> {
+    match kind {
+        SimpleKind::Int8 | SimpleKind::Uint8 | SimpleKind::Byte => Some(8),
+        SimpleKind::Int16 | SimpleKind::Uint16 => Some(16),
+        SimpleKind::Int32 | SimpleKind::Uint32 | SimpleKind::Rune => Some(32),
+        SimpleKind::Int64 | SimpleKind::Uint64 => Some(64),
+        _ => None,
+    }
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4661,3 +4661,100 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn oversized_shift_uint32_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: uint32 = 1
+  let _ = x << 40
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_int8_at_width() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int8 = 1
+  let _ = x << 8
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_int64_right() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int64 = 1
+  let _ = x >> 64
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_byte() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: byte = 1
+  let _ = x << 8
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_in_bounds_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: uint16 = 1
+  let _ = x << 15
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_platform_int_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: uint = 1
+  let _ = x << 64
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_uintptr_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: uintptr = 1
+  let _ = x << 64
+}
+"#
+    );
+}
+
+#[test]
+fn oversized_shift_non_literal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: uint32 = 1
+  let n: uint = 40
+  let _ = x << n
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/oversized_shift_byte.snap
+++ b/tests/ui/lint/snapshots/oversized_shift_byte.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Shift amount exceeds integer width
+   ╭─[test.lis:4:11]
+ 3 │   let x: byte = 1
+ 4 │   let _ = x << 8
+   ·           ───┬──
+   ·              ╰── shift exceeds width
+ 5 │ }
+   ╰────
+  help: `byte` is 8 bits wide, so shifting by 8 discards every bit of the value · code: [infer.oversized_shift]

--- a/tests/ui/lint/snapshots/oversized_shift_int64_right.snap
+++ b/tests/ui/lint/snapshots/oversized_shift_int64_right.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Shift amount exceeds integer width
+   ╭─[test.lis:4:11]
+ 3 │   let x: int64 = 1
+ 4 │   let _ = x >> 64
+   ·           ───┬───
+   ·              ╰── shift exceeds width
+ 5 │ }
+   ╰────
+  help: `int64` is 64 bits wide, so shifting by 64 discards every bit of the value · code: [infer.oversized_shift]

--- a/tests/ui/lint/snapshots/oversized_shift_int8_at_width.snap
+++ b/tests/ui/lint/snapshots/oversized_shift_int8_at_width.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Shift amount exceeds integer width
+   ╭─[test.lis:4:11]
+ 3 │   let x: int8 = 1
+ 4 │   let _ = x << 8
+   ·           ───┬──
+   ·              ╰── shift exceeds width
+ 5 │ }
+   ╰────
+  help: `int8` is 8 bits wide, so shifting by 8 discards every bit of the value · code: [infer.oversized_shift]

--- a/tests/ui/lint/snapshots/oversized_shift_uint32_left.snap
+++ b/tests/ui/lint/snapshots/oversized_shift_uint32_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Shift amount exceeds integer width
+   ╭─[test.lis:4:11]
+ 3 │   let x: uint32 = 1
+ 4 │   let _ = x << 40
+   ·           ───┬───
+   ·              ╰── shift exceeds width
+ 5 │ }
+   ╰────
+  help: `uint32` is 32 bits wide, so shifting by 40 discards every bit of the value · code: [infer.oversized_shift]


### PR DESCRIPTION
Adds a compile-time error when a fixed-width integer is shifted by a literal amount gte its bit width.

```
  [error] Shift amount exceeds integer width
   ╭─[test.lis:4:11]
 3 │   let x: int8 = 1
 4 │   let _ = x << 8
   ·           ───┬──
   ·              ╰── shift exceeds width
 5 │ }
   ╰────
  help: `int8` is 8 bits wide, so shifting by 8 discards every bit of the value · code: [infer.oversized_shift]
```