### PR TITLE
feat: reject repeated condition in if else if chain

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2155,6 +2155,15 @@ pub fn empty_range(span: &Span) -> LisetteDiagnostic {
         .with_help("Swap the bounds.")
 }
 
+pub fn repeated_if_condition(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`if` condition repeated in `else if`")
+        .with_infer_code("repeated_if_condition")
+        .with_span_label(span, "same as prior condition")
+        .with_help(
+            "This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition?",
+        )
+}
+
 pub fn index_out_of_bounds(span: &Span, index_text: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Index out of bounds")
         .with_infer_code("index_out_of_bounds")

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod predeclared_shadowing;
 pub(crate) mod prelude_shadowing;
 pub(crate) mod pub_type_export;
 pub(crate) mod receivers;
+pub(crate) mod repeated_if_condition;
 pub(crate) mod stringer_signature;
 pub(crate) mod temp_producing;
 pub(crate) mod visibility;
@@ -105,6 +106,7 @@ fn run_file_checks(
     empty_range::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);
+    repeated_if_condition::run(&file.items, sink);
     temp_producing::run(&file.items, sink);
     if !file.is_d_lis() {
         const_naming::run(&file.items, sink);

--- a/crates/semantics/src/passes/checks/repeated_if_condition.rs
+++ b/crates/semantics/src/passes/checks/repeated_if_condition.rs
@@ -1,0 +1,100 @@
+use diagnostics::LocalSink;
+use syntax::ast::Expression;
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, sink: &LocalSink) {
+    if let Expression::If {
+        condition,
+        alternative,
+        ..
+    } = expression
+        && let Expression::If {
+            condition: next_condition,
+            ..
+        } = alternative.as_ref()
+        && is_side_effect_free(condition)
+        && is_side_effect_free(next_condition)
+        && expressions_equivalent(condition, next_condition)
+    {
+        sink.push(diagnostics::infer::repeated_if_condition(
+            &next_condition.get_span(),
+        ));
+    }
+
+    for child in expression.children() {
+        visit_expression(child, sink);
+    }
+}
+
+fn is_side_effect_free(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Identifier { .. } | Expression::Literal { .. } => true,
+        Expression::Unary {
+            expression: inner, ..
+        } => is_side_effect_free(inner),
+        Expression::Binary { left, right, .. } => {
+            is_side_effect_free(left) && is_side_effect_free(right)
+        }
+        Expression::DotAccess {
+            expression: inner, ..
+        } => is_side_effect_free(inner),
+        _ => false,
+    }
+}
+
+fn expressions_equivalent(a: &Expression, b: &Expression) -> bool {
+    let a = a.unwrap_parens();
+    let b = b.unwrap_parens();
+    match (a, b) {
+        (Expression::Identifier { value: av, .. }, Expression::Identifier { value: bv, .. }) => {
+            av == bv
+        }
+        (Expression::Literal { literal: al, .. }, Expression::Literal { literal: bl, .. }) => {
+            al == bl
+        }
+        (
+            Expression::Unary {
+                operator: ao,
+                expression: ae,
+                ..
+            },
+            Expression::Unary {
+                operator: bo,
+                expression: be,
+                ..
+            },
+        ) => ao == bo && expressions_equivalent(ae, be),
+        (
+            Expression::Binary {
+                operator: ao,
+                left: al,
+                right: ar,
+                ..
+            },
+            Expression::Binary {
+                operator: bo,
+                left: bl,
+                right: br,
+                ..
+            },
+        ) => ao == bo && expressions_equivalent(al, bl) && expressions_equivalent(ar, br),
+        (
+            Expression::DotAccess {
+                expression: ae,
+                member: am,
+                ..
+            },
+            Expression::DotAccess {
+                expression: be,
+                member: bm,
+                ..
+            },
+        ) => am == bm && expressions_equivalent(ae, be),
+        _ => false,
+    }
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -913,6 +913,93 @@ fn main() {
 }
 
 #[test]
+fn repeated_if_condition_simple() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = if x > 0 { 1 } else if x > 0 { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_with_parens() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = if x > (0) { 1 } else if x > 0 { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_identifier() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let flag = true;
+  let _ = if flag { 1 } else if flag { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_dot_access() {
+    assert_lint_snapshot!(
+        r#"
+struct Config { enabled: bool }
+
+fn main() {
+  let c = Config { enabled: true };
+  let _ = if c.enabled { 1 } else if c.enabled { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_distinct_conditions_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = if x > 0 { 1 } else if x < 0 { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_with_side_effects_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn side_effect() -> bool { true }
+
+fn main() {
+  let _ = if side_effect() { 1 } else if side_effect() { 2 } else { 3 }
+}
+"#
+    );
+}
+
+#[test]
+fn repeated_if_condition_simple_if_else_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = if x > 0 { 1 } else { 2 }
+}
+"#
+    );
+}
+
+#[test]
 fn unused_function() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/repeated_if_condition_dot_access.snap
+++ b/tests/ui/lint/snapshots/repeated_if_condition_dot_access.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] `if` condition repeated in `else if`
+   ╭─[test.lis:6:38]
+ 5 │   let c = Config { enabled: true };
+ 6 │   let _ = if c.enabled { 1 } else if c.enabled { 2 } else { 3 }
+   ·                                      ────┬────
+   ·                                          ╰── same as prior condition
+ 7 │ }
+   ╰────
+  help: This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition? · code: [infer.repeated_if_condition]

--- a/tests/ui/lint/snapshots/repeated_if_condition_identifier.snap
+++ b/tests/ui/lint/snapshots/repeated_if_condition_identifier.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] `if` condition repeated in `else if`
+   ╭─[test.lis:4:33]
+ 3 │   let flag = true;
+ 4 │   let _ = if flag { 1 } else if flag { 2 } else { 3 }
+   ·                                 ──┬─
+   ·                                   ╰── same as prior condition
+ 5 │ }
+   ╰────
+  help: This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition? · code: [infer.repeated_if_condition]

--- a/tests/ui/lint/snapshots/repeated_if_condition_simple.snap
+++ b/tests/ui/lint/snapshots/repeated_if_condition_simple.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] `if` condition repeated in `else if`
+   ╭─[test.lis:4:34]
+ 3 │   let x = 5;
+ 4 │   let _ = if x > 0 { 1 } else if x > 0 { 2 } else { 3 }
+   ·                                  ──┬──
+   ·                                    ╰── same as prior condition
+ 5 │ }
+   ╰────
+  help: This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition? · code: [infer.repeated_if_condition]

--- a/tests/ui/lint/snapshots/repeated_if_condition_with_parens.snap
+++ b/tests/ui/lint/snapshots/repeated_if_condition_with_parens.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] `if` condition repeated in `else if`
+   ╭─[test.lis:4:36]
+ 3 │   let x = 5;
+ 4 │   let _ = if x > (0) { 1 } else if x > 0 { 2 } else { 3 }
+   ·                                    ──┬──
+   ·                                      ╰── same as prior condition
+ 5 │ }
+   ╰────
+  help: This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition? · code: [infer.repeated_if_condition]


### PR DESCRIPTION
Adds a compile error for a repeated condition in an `if else if` chain.

```
  [error] `if` condition repeated in `else if`
   ╭─[test.lis:4:34]
 3 │   let x = 5;
 4 │   let _ = if x > 0 { 1 } else if x > 0 { 2 } else { 3 }
   ·                                  ──┬──
   ·                                    ╰── same as prior condition
 5 │ }
   ╰────
  help: This branch is unreachable, because its condition duplicates the preceding condition. Did you mean a different condition? · code: [infer.repeated_if_condition]
```