### PR TITLE
feat: reject empty infinite loop

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2155,6 +2155,15 @@ pub fn empty_range(span: &Span) -> LisetteDiagnostic {
         .with_help("Swap the bounds.")
 }
 
+pub fn empty_infinite_loop(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Empty infinite loop")
+        .with_infer_code("empty_infinite_loop")
+        .with_span_label(span, "spins forever")
+        .with_help(
+            "An empty `loop` spins forever at 100% CPU. Block on a channel, call `time.Sleep`, or add a `break`.",
+        )
+}
+
 pub fn repeated_if_condition(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`if` condition repeated in `else if`")
         .with_infer_code("repeated_if_condition")

--- a/crates/semantics/src/passes/checks/empty_infinite_loop.rs
+++ b/crates/semantics/src/passes/checks/empty_infinite_loop.rs
@@ -1,0 +1,21 @@
+use diagnostics::LocalSink;
+use syntax::ast::Expression;
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, sink: &LocalSink) {
+    if let Expression::Loop { body, span, .. } = expression
+        && let Expression::Block { items, .. } = body.as_ref()
+        && items.is_empty()
+    {
+        sink.push(diagnostics::infer::empty_infinite_loop(span));
+    }
+
+    for child in expression.children() {
+        visit_expression(child, sink);
+    }
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod const_naming;
 pub(crate) mod duplicate_bindings;
+pub(crate) mod empty_infinite_loop;
 pub(crate) mod empty_range;
 pub(crate) mod enum_variant_value;
 pub(crate) mod generics;
@@ -103,6 +104,7 @@ fn run_file_checks(
     native_value_usage::run(&file.items, &module.id, store, sink);
     enum_variant_value::run(&file.items, store, sink);
     nan_comparison::run(&file.items, sink);
+    empty_infinite_loop::run(&file.items, sink);
     empty_range::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);

--- a/tests/e2e_suite/skip.txt
+++ b/tests/e2e_suite/skip.txt
@@ -27,12 +27,12 @@ nested_block_continue_in_if_branch          # hang/block: continue in always-tru
 nested_block_continue_in_let                # hang/block: continue in let-bound block loops forever
 select_match_receive_unused_binding         # hang/block: select on channel with no sender
 select_send_value_eval_order                # hang/block: select-send with no receiver
-try_block_diverging_final_expression        # hang/block: try-block contains `loop {}`
 
 # --- intentional panic ---
 builtin_panic                               # intentional: explicit panic("...") in test body
 if_with_user_never_branch_tail              # intentional: if-branch calls Never-returning fn
 never_returning_user_function_in_body       # intentional: test body calls Never-returning fn
+try_block_diverging_final_expression        # intentional: loop body panics
 try_block_panic_tail_option_context         # intentional: explicit panic in try-block tail
 try_block_panic_tail_result_context         # intentional: explicit panic in try-block tail
 try_block_user_never_tail_result_context    # intentional: tail calls Never-returning fn

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -1771,7 +1771,7 @@ fn risky() -> Result<int, string> { Ok(1) }
 fn test() {
   let result: Result<int, string> = try {
     let _ = risky()?;
-    loop {}
+    loop { panic("unreachable") }
   };
   let _ = result;
 }

--- a/tests/spec/emit/snapshots/try_block_diverging_final_expression.snap
+++ b/tests/spec/emit/snapshots/try_block_diverging_final_expression.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/control_flow.rs
-description: "input: \nfn risky() -> Result<int, string> { Ok(1) }\n\nfn test() {\n  let result: Result<int, string> = try {\n    let _ = risky()?;\n    loop {}\n  };\n  let _ = result;\n}\n"
+description: "input: \nfn risky() -> Result<int, string> { Ok(1) }\n\nfn test() {\n  let result: Result<int, string> = try {\n    let _ = risky()?;\n    loop { panic(\"unreachable\") }\n  };\n  let _ = result;\n}\n"
 ---
 package main
 
@@ -18,6 +18,7 @@ func test() {
 			return lisette.MakeResultErr[struct{}, string](check_2.ErrVal)
 		}
 		for {
+			panic("unreachable")
 		}
 		panic("unreachable")
 	}()

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4845,3 +4845,53 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn empty_infinite_loop_fires() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  loop {}
+}
+"#
+    );
+}
+
+#[test]
+fn empty_infinite_loop_with_break_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  loop {
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_infinite_loop_non_empty_body_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut i = 0
+  loop {
+    i = i + 1
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_infinite_loop_while_false_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  while false {}
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/empty_infinite_loop_fires.snap
+++ b/tests/ui/lint/snapshots/empty_infinite_loop_fires.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Empty infinite loop
+   ╭─[test.lis:3:3]
+ 2 │ fn main() {
+ 3 │   loop {}
+   ·   ───┬───
+   ·      ╰── spins forever
+ 4 │ }
+   ╰────
+  help: An empty `loop` spins forever at 100% CPU. Block on a channel, call `time.Sleep`, or add a `break` · code: [infer.empty_infinite_loop]


### PR DESCRIPTION
Adds an error for an empty `loop` body.

```
  [error] Empty infinite loop
   ╭─[test.lis:3:3]
 2 │ fn main() {
 3 │   loop {}
   ·   ───┬───
   ·      ╰── spins forever
 4 │ }
   ╰────
  help: An empty `loop` spins forever at 100% CPU. Block on a channel, call `time.Sleep`, or add a `break` · code: [infer.empty_infinite_loop]
```