### PR TITLE
fix: translate `unknown` to any in explicit type arguments

### DIFF
--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -277,6 +277,9 @@ impl Planner<'_> {
     }
 
     fn unqualify_name(&self, id: &str) -> String {
+        if id == "Unknown" {
+            return "any".to_string();
+        }
         let (module, unqualified) = if let Some(rest) = id.strip_prefix(go_name::GO_IMPORT_PREFIX) {
             let Some((path, ty)) = rest.rsplit_once('.') else {
                 return go_name::escape_keyword(id).into_owned();

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -126,6 +126,17 @@ fn test() -> Slice<int> {
 }
 
 #[test]
+fn slice_new_unknown_element_explicit_type_arg() {
+    let input = r#"
+fn test() {
+  let mut s = Slice.new<Unknown>()
+  s = s.append("Lilian")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_new_with_void_function_element() {
     let input = r#"
 fn test() -> Slice<fn(int)> {
@@ -420,6 +431,17 @@ fn map_new() {
     let input = r#"
 fn test() -> Map<string, int> {
   Map.new<string, int>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_new_unknown_value_explicit_type_args() {
+    let input = r#"
+fn test() {
+  let mut m = Map.new<string, Unknown>()
+  m["key"] = "value"
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/generic_fn_explicit_unknown_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_fn_explicit_unknown_type_arg.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/types.rs
+assertion_line: 342
+description: "input: \nfn foo<T>(args: T) -> T {\n  args\n}\n\nfn test() {\n  let result = foo<Unknown>(\"Lilian\")\n}\n"
+---
+package main
+
+func foo[T any](args T) T {
+	return args
+}
+
+func test() {
+	_ = foo[any]("Lilian")
+}

--- a/tests/spec/emit/snapshots/map_new_unknown_value_explicit_type_args.snap
+++ b/tests/spec/emit/snapshots/map_new_unknown_value_explicit_type_args.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 436
+description: "input: \nfn test() {\n  let mut m = Map.new<string, Unknown>()\n  m[\"key\"] = \"value\"\n}\n"
+---
+package main
+
+func test() {
+	m := make(map[string]any)
+	m["key"] = "value"
+}

--- a/tests/spec/emit/snapshots/slice_new_unknown_element_explicit_type_arg.snap
+++ b/tests/spec/emit/snapshots/slice_new_unknown_element_explicit_type_arg.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+assertion_line: 136
+description: "input: \nfn test() {\n  let mut s = Slice.new<Unknown>()\n  s = s.append(\"Lilian\")\n}\n"
+---
+package main
+
+func test() {
+	s := []any{}
+	s = append(s, "Lilian")
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -343,6 +343,20 @@ fn main() -> int {
 }
 
 #[test]
+fn generic_fn_explicit_unknown_type_arg() {
+    let input = r#"
+fn foo<T>(args: T) -> T {
+  args
+}
+
+fn test() {
+  let result = foo<Unknown>("Lilian")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn generic_enum_variant_non_t_data_needs_type_arg() {
     let input = r#"
 enum MyResult<T> {


### PR DESCRIPTION
When you pass explicit types to a function (or map/slice etc) the compiler emits invalid go code, when the type is `Unknown`.

Example:

```rust
fn foo<T>(args: T) -> T {
  args
}

// These are ok
let _: Map<string, Unknown> = Map.new()
let _: Slice<Unknown> = Slice.new()
let _: Unknown = foo("Lilian")

// But these produce invalid go code
let _ = Map.new<string, Unknown>()
let _ = Slice.new<Unknown>()
let _ = foo<Unknown>("Lilian")

```
The above compile to:
```go
// ok
_ = make(map[string]any)
_ = []any{}
_ = foo("Lilian")

// invalid code
_ = make(map[string]Unknown)
_ = []Unknown{}
_ = foo[Unknown]("Lilian")
```