### PR TITLE
feat: reject empty select default arm in loop

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2158,10 +2158,17 @@ pub fn empty_range(span: &Span) -> LisetteDiagnostic {
 pub fn empty_infinite_loop(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Empty infinite loop")
         .with_infer_code("empty_infinite_loop")
-        .with_span_label(span, "spins forever")
+        .with_span_label(span, "busy-spins")
         .with_help(
             "An empty `loop` spins forever at 100% CPU. Block on a channel, call `time.Sleep`, or add a `break`.",
         )
+}
+
+pub fn empty_select_default(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Empty `select` default arm in a loop")
+        .with_infer_code("empty_select_default")
+        .with_span_label(span, "busy-spins")
+        .with_help("Drop the `_ =>` arm to block, or do work in it.")
 }
 
 pub fn repeated_if_condition(span: &Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/passes/checks/empty_select_default.rs
+++ b/crates/semantics/src/passes/checks/empty_select_default.rs
@@ -1,0 +1,64 @@
+use diagnostics::LocalSink;
+use syntax::ast::{Expression, SelectArmPattern};
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, false, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, in_loop: bool, sink: &LocalSink) {
+    if in_loop && let Expression::Select { arms, .. } = expression {
+        for arm in arms {
+            if let SelectArmPattern::WildCard { body } = &arm.pattern
+                && is_empty_body(body)
+            {
+                sink.push(diagnostics::infer::empty_select_default(&body.get_span()));
+                break;
+            }
+        }
+    }
+
+    match expression {
+        Expression::Function { body, .. } | Expression::Lambda { body, .. } => {
+            visit_expression(body, false, sink);
+        }
+        Expression::Task {
+            expression: inner, ..
+        }
+        | Expression::Defer {
+            expression: inner, ..
+        } => {
+            visit_expression(inner, false, sink);
+        }
+        Expression::Loop { body, .. } => {
+            visit_expression(body, true, sink);
+        }
+        Expression::While {
+            condition, body, ..
+        } => {
+            visit_expression(condition, true, sink);
+            visit_expression(body, true, sink);
+        }
+        Expression::WhileLet {
+            scrutinee, body, ..
+        } => {
+            visit_expression(scrutinee, true, sink);
+            visit_expression(body, true, sink);
+        }
+        Expression::For { iterable, body, .. } => {
+            visit_expression(iterable, in_loop, sink);
+            visit_expression(body, true, sink);
+        }
+        _ => {
+            for child in expression.children() {
+                visit_expression(child, in_loop, sink);
+            }
+        }
+    }
+}
+
+fn is_empty_body(expression: &Expression) -> bool {
+    matches!(expression, Expression::Block { items, .. } if items.is_empty())
+        || matches!(expression, Expression::Unit { .. })
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod const_naming;
 pub(crate) mod duplicate_bindings;
 pub(crate) mod empty_infinite_loop;
 pub(crate) mod empty_range;
+pub(crate) mod empty_select_default;
 pub(crate) mod enum_variant_value;
 pub(crate) mod generics;
 pub(crate) mod index_out_of_bounds;
@@ -106,6 +107,7 @@ fn run_file_checks(
     nan_comparison::run(&file.items, sink);
     empty_infinite_loop::run(&file.items, sink);
     empty_range::run(&file.items, sink);
+    empty_select_default::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);
     repeated_if_condition::run(&file.items, sink);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4895,3 +4895,142 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn empty_select_default_fires_in_loop() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  loop {
+    select {
+      let Some(v) = ch.receive() => fmt.Println(v),
+      _ => {},
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_fires_in_while() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  let done = false
+  while !done {
+    select {
+      let Some(v) = ch.receive() => fmt.Println(v),
+      _ => {},
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_outside_loop_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  select {
+    let Some(v) = ch.receive() => fmt.Println(v),
+    _ => {},
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_non_empty_body_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+import "go:time"
+
+fn main() {
+  let ch = Channel.new<int>()
+  loop {
+    select {
+      let Some(v) = ch.receive() => fmt.Println(v),
+      _ => time.Sleep(time.Millisecond),
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_inside_lambda_in_loop_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  loop {
+    let _ = || {
+      select {
+        let Some(v) = ch.receive() => fmt.Println(v),
+        _ => {},
+      }
+    }
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_unit_body_fires() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  loop {
+    select {
+      let Some(v) = ch.receive() => fmt.Println(v),
+      _ => (),
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn empty_select_default_inside_task_in_loop_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let ch = Channel.new<int>()
+  loop {
+    task {
+      select {
+        let Some(v) = ch.receive() => fmt.Println(v),
+        _ => {},
+      }
+    }
+    break
+  }
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/empty_infinite_loop_fires.snap
+++ b/tests/ui/lint/snapshots/empty_infinite_loop_fires.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   loop {}
    ·   ───┬───
-   ·      ╰── spins forever
+   ·      ╰── busy-spins
  4 │ }
    ╰────
   help: An empty `loop` spins forever at 100% CPU. Block on a channel, call `time.Sleep`, or add a `break` · code: [infer.empty_infinite_loop]

--- a/tests/ui/lint/snapshots/empty_select_default_fires_in_loop.snap
+++ b/tests/ui/lint/snapshots/empty_select_default_fires_in_loop.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Empty `select` default arm in a loop
+    ╭─[test.lis:9:12]
+  8 │       let Some(v) = ch.receive() => fmt.Println(v),
+  9 │       _ => {},
+    ·            ─┬
+    ·             ╰── busy-spins
+ 10 │     }
+    ╰────
+  help: Drop the `_ =>` arm to block, or do work in it · code: [infer.empty_select_default]

--- a/tests/ui/lint/snapshots/empty_select_default_fires_in_while.snap
+++ b/tests/ui/lint/snapshots/empty_select_default_fires_in_while.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Empty `select` default arm in a loop
+    ╭─[test.lis:10:12]
+  9 │       let Some(v) = ch.receive() => fmt.Println(v),
+ 10 │       _ => {},
+    ·            ─┬
+    ·             ╰── busy-spins
+ 11 │     }
+    ╰────
+  help: Drop the `_ =>` arm to block, or do work in it · code: [infer.empty_select_default]

--- a/tests/ui/lint/snapshots/empty_select_default_unit_body_fires.snap
+++ b/tests/ui/lint/snapshots/empty_select_default_unit_body_fires.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Empty `select` default arm in a loop
+    ╭─[test.lis:9:12]
+  8 │       let Some(v) = ch.receive() => fmt.Println(v),
+  9 │       _ => (),
+    ·            ─┬
+    ·             ╰── busy-spins
+ 10 │     }
+    ╰────
+  help: Drop the `_ =>` arm to block, or do work in it · code: [infer.empty_select_default]


### PR DESCRIPTION
Adds an error for a `select` with an empty `_ =>` default arm inside a loop. The arm makes the select non-blocking, so the surrounding loop pegs a core.

```
  [error] Empty `select` default arm in a loop
    ╭─[test.lis:9:12]
  8 │       let Some(v) = ch.receive() => fmt.Println(v),
  9 │       _ => {},
    ·            ─┬
    ·             ╰── busy-spins
 10 │     }
    ╰────
  help: Drop the `_ =>` arm to block, or do work in it · code: [infer.empty_select_default]
```