### PR TITLE
fix: track function return context for nested ? propagation

### DIFF
--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -23,7 +23,8 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String) {
         fx.require_stdlib();
 
-        let effective_ty = resolve_fallible_block_type(items, ty, outer);
+        let fallback = self.current_return_ctx().cloned();
+        let effective_ty = resolve_fallible_block_type(items, ty, outer.or(fallback.as_ref()));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("`try` block must have Result or Option type");
 
@@ -35,8 +36,10 @@ impl Planner<'_> {
         };
 
         let body_ctx = ReturnContext::TaggedBlock(effective_ty);
+        self.push_return_ctx(body_ctx.clone());
         let body = self
             .with_fresh_scope(|planner| planner.lower_try_body(items, &fallible, &body_ctx, fx));
+        self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
             name: result_var.clone(),
@@ -216,7 +219,8 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String) {
         fx.require_stdlib();
 
-        let effective_ty = resolve_fallible_block_type(items, ty, outer);
+        let fallback = self.current_return_ctx().cloned();
+        let effective_ty = resolve_fallible_block_type(items, ty, outer.or(fallback.as_ref()));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("recover block type must be Result<T, PanicValue>");
 
@@ -225,9 +229,11 @@ impl Planner<'_> {
         let inner_ty_str = self.go_type_string(fallible.ok_ty(), fx);
 
         let body_return_ctx = self.return_context_for_type(fallible.ok_ty().clone());
+        self.push_return_ctx(body_return_ctx.clone());
         let body = self.with_fresh_scope(|planner| {
             planner.lower_recover_body_block(items, &fallible, &body_return_ctx, fx)
         });
+        self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
             name: result_var.clone(),

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -46,7 +46,9 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) {
         self.push_const_frame();
+        self.push_return_ctx(return_ctx.clone());
         self.emit_function_body_inner(output, body, should_return, return_ctx, fx);
+        self.pop_return_ctx();
         self.pop_const_frame();
     }
 

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -94,10 +94,9 @@ impl Planner<'_> {
                 // Never-typed spread base diverges — emit as statement and
                 // return a zero-value struct literal (dead code follows).
                 if base.get_type().is_never() {
-                    let return_ctx = expression_ctx
-                        .ambient_return_ctx()
-                        .expect("never-typed spread base requires a threaded return context")
-                        .clone();
+                    let return_ctx = self
+                        .resolve_ambient_return_ctx(expression_ctx)
+                        .expect("never-typed spread base requires an enclosing return context");
                     self.emit_statement(&mut tail, base, &return_ctx, fx);
                     format!("{}{{}}", ctx.go_type)
                 } else {

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -270,10 +270,9 @@ impl Planner<'_> {
                 params, body, ty, ..
             } => self.emit_lambda(params, body, ty, ctx, fx),
             Expression::Propagate { expression, .. } => {
-                let return_ctx = ctx
-                    .ambient_return_ctx()
-                    .expect("operand-position propagate requires a threaded return context")
-                    .clone();
+                let return_ctx = self
+                    .resolve_ambient_return_ctx(ctx)
+                    .expect("operand-position propagate requires an enclosing return context");
                 self.emit_propagate(output, expression, None, &return_ctx, fx)
             }
             Expression::TryBlock { .. } => {
@@ -306,10 +305,9 @@ impl Planner<'_> {
                 expression: return_expression,
                 ..
             } => {
-                let return_ctx = ctx
-                    .ambient_return_ctx()
-                    .expect("operand-position return requires a threaded return context")
-                    .clone();
+                let return_ctx = self
+                    .resolve_ambient_return_ctx(ctx)
+                    .expect("operand-position return requires an enclosing return context");
                 self.emit_return(output, return_expression, &return_ctx, fx);
                 String::new()
             }
@@ -607,8 +605,9 @@ impl Planner<'_> {
     ) -> ValuePlan {
         if let Expression::Block { .. } = expression {
             let return_ctx = ambient
-                .expect("async block body requires a threaded return context")
-                .clone();
+                .cloned()
+                .or_else(|| self.current_return_ctx().cloned())
+                .expect("async block body requires an enclosing return context");
             let body = self.with_fresh_scope(|planner| {
                 planner.lower_block_as_body(expression, &return_ctx, fx)
             });

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -37,6 +37,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
+use context::expression::ExpressionContext;
 use output::imports::ImportBuilder;
 use plan::ModulePlan;
 use plan::bodies::{LoweredBlock, LoweredStatement};
@@ -319,6 +320,35 @@ impl<'a> Planner<'a> {
 
     pub(crate) fn current_loop_label(&self) -> Option<&str> {
         self.scope.current_loop_label()
+    }
+
+    /// Scope-guarded push of the enclosing function/lambda/try/recover return
+    /// context. Operand-position `?` and `return` fall back to this stack when
+    /// the threaded `ExpressionContext::ambient_return_ctx` is absent.
+    pub(crate) fn push_return_ctx(&mut self, ctx: ReturnContext) {
+        self.scope.push_return_ctx(ctx);
+    }
+
+    pub(crate) fn pop_return_ctx(&mut self) {
+        self.scope.pop_return_ctx();
+    }
+
+    pub(crate) fn current_return_ctx(&self) -> Option<&ReturnContext> {
+        self.scope.current_return_ctx()
+    }
+
+    /// Prefer the explicitly-threaded ambient context (carries any local
+    /// override), then fall back to the enclosing function/lambda/try/recover
+    /// context maintained on the scope stack. Returns an owned clone since
+    /// callers typically need a `ReturnContext` value, not a borrow that
+    /// conflicts with later `&mut self` calls.
+    pub(crate) fn resolve_ambient_return_ctx(
+        &self,
+        ctx: ExpressionContext<'_>,
+    ) -> Option<ReturnContext> {
+        ctx.ambient_return_ctx()
+            .cloned()
+            .or_else(|| self.current_return_ctx().cloned())
     }
 
     /// `true` if this is a new declaration in the current block (use `:=`),

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -52,8 +52,9 @@ impl Planner<'_> {
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let return_ctx = ambient
-            .expect("operand-position control flow requires a threaded return context")
-            .clone();
+            .cloned()
+            .or_else(|| self.current_return_ctx().cloned())
+            .expect("operand-position control flow requires an enclosing return context");
         let plan = self.lower_if(
             String::new(),
             condition,
@@ -81,8 +82,9 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String) {
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let return_ctx = ambient
-            .expect("operand-position control flow requires a threaded return context")
-            .clone();
+            .cloned()
+            .or_else(|| self.current_return_ctx().cloned())
+            .expect("operand-position control flow requires an enclosing return context");
         let block = self.lower_branching_to_block(
             expression,
             &PlacePlan::Assign {
@@ -115,8 +117,9 @@ impl Planner<'_> {
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let return_ctx = ambient
-            .expect("operand-position control flow requires a threaded return context")
-            .clone();
+            .cloned()
+            .or_else(|| self.current_return_ctx().cloned())
+            .expect("operand-position control flow requires an enclosing return context");
         self.push_loop(result_var.clone());
         let plan = self.lower_loop_with_header(
             String::new(),

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -669,8 +669,9 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> String {
         let return_ctx = ambient
-            .expect("operand-temp emission requires a threaded return context")
-            .clone();
+            .cloned()
+            .or_else(|| self.current_return_ctx().cloned())
+            .expect("operand-temp emission requires an enclosing return context");
         if let Expression::Block { items, .. } = expression {
             if ty.is_never() || ty.is_unit() || matches!(ty, Type::Var { .. } | Type::Forall { .. })
             {

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::Bindings;
+use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::escape_reserved;
 use crate::state::bindings::{BindingValue, InlineExpr};
@@ -12,6 +13,7 @@ pub(crate) struct ScopeState {
     declared: Vec<HashSet<String>>,
     scope_depth: usize,
     loop_stack: Vec<LoopContext>,
+    return_ctx_stack: Vec<ReturnContext>,
     assign_targets: HashSet<String>,
     go_const_bindings: Vec<HashSet<String>>,
 }
@@ -33,6 +35,7 @@ impl ScopeState {
             declared: vec![HashSet::default()],
             scope_depth: 0,
             loop_stack: Vec::new(),
+            return_ctx_stack: Vec::new(),
             assign_targets: HashSet::default(),
             go_const_bindings: vec![HashSet::default()],
         }
@@ -177,6 +180,18 @@ impl ScopeState {
 
     pub(crate) fn pop_loop(&mut self) {
         self.loop_stack.pop();
+    }
+
+    pub(crate) fn push_return_ctx(&mut self, ctx: ReturnContext) {
+        self.return_ctx_stack.push(ctx);
+    }
+
+    pub(crate) fn pop_return_ctx(&mut self) {
+        self.return_ctx_stack.pop();
+    }
+
+    pub(crate) fn current_return_ctx(&self) -> Option<&ReturnContext> {
+        self.return_ctx_stack.last()
     }
 
     pub(crate) fn current_loop_result_var(&self) -> Option<&str> {

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -425,6 +425,140 @@ fn test() -> Result<int, string> {
 }
 
 #[test]
+fn propagate_in_struct_literal_field() {
+    let input = r#"
+struct User {
+  id: int,
+  name: string,
+}
+
+fn get_id() -> Result<int, string> { Ok(1) }
+fn get_name() -> Result<string, string> { Ok("Ada") }
+
+fn make_user() -> Result<User, string> {
+  Ok(User {
+    id: get_id()?,
+    name: get_name()?,
+  })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_struct_literal_spread_base() {
+    let input = r#"
+struct User {
+  id: int,
+  name: string,
+}
+
+fn get_base() -> Result<User, string> {
+  Ok(User { id: 1, name: "a" })
+}
+
+fn override_id() -> Result<User, string> {
+  Ok(User { id: 2, ..get_base()? })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_match_subject() {
+    let input = r#"
+fn g() -> Result<int, string> { Ok(1) }
+
+fn f() -> Result<int, string> {
+  match g()? {
+    0 => Ok(10),
+    x => Ok(x),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_range_start() {
+    let input = r#"
+fn g() -> Result<int, string> { Ok(0) }
+
+fn f() -> Result<int, string> {
+  let mut s = 0
+  for i in g()?..5 { s = s + i }
+  Ok(s)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_range_end() {
+    let input = r#"
+fn g() -> Result<int, string> { Ok(5) }
+
+fn f() -> Result<int, string> {
+  let mut s = 0
+  for i in 0..g()? { s = s + i }
+  Ok(s)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_for_iterable() {
+    let input = r#"
+fn g() -> Result<Slice<int>, string> { Ok([1, 2, 3]) }
+
+fn f() -> Result<int, string> {
+  let mut s = 0
+  for i in g()? { s = s + i }
+  Ok(s)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_loop_break_value() {
+    let input = r#"
+fn g() -> Result<int, string> { Ok(5) }
+
+fn f() -> Result<int, string> {
+  let x = loop { break g()? }
+  Ok(x)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_in_if_let_subject() {
+    let input = r#"
+fn g() -> Result<Option<int>, string> { Ok(Some(1)) }
+
+fn f() -> Result<int, string> {
+  if let Some(n) = g()? { Ok(n) } else { Ok(0) }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_chained_double() {
+    let input = r#"
+fn h() -> Result<Result<int, string>, string> { Ok(Ok(1)) }
+
+fn f() -> Result<int, string> {
+  Ok(h()??)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn const_simple() {
     let input = r#"
 const MAX_SIZE = 100

--- a/tests/spec/emit/snapshots/propagate_chained_double.snap
+++ b/tests/spec/emit/snapshots/propagate_chained_double.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn h() -> Result<Result<int, string>, string> { Ok(Ok(1)) }\n\nfn f() -> Result<int, string> {\n  Ok(h()??)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func h() lisette.Result[lisette.Result[int, string], string] {
+	return lisette.MakeResultOk[lisette.Result[int, string], string](lisette.MakeResultOk[int, string](1))
+}
+
+func f() lisette.Result[int, string] {
+	check_1 := h()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
+	}
+	check_2 := check_1.OkVal
+	if check_2.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	}
+	return lisette.MakeResultOk[int, string](check_2.OkVal)
+}

--- a/tests/spec/emit/snapshots/propagate_in_for_iterable.snap
+++ b/tests/spec/emit/snapshots/propagate_in_for_iterable.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<Slice<int>, string> { Ok([1, 2, 3]) }\n\nfn f() -> Result<int, string> {\n  let mut s = 0\n  for i in g()? { s = s + i }\n  Ok(s)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[[]int, string] {
+	return lisette.MakeResultOk[[]int, string]([]int{1, 2, 3})
+}
+
+func f() lisette.Result[int, string] {
+	s := 0
+	check_1 := g()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
+	}
+	for _, i := range check_1.OkVal {
+		s += i
+	}
+	return lisette.MakeResultOk[int, string](s)
+}

--- a/tests/spec/emit/snapshots/propagate_in_if_let_subject.snap
+++ b/tests/spec/emit/snapshots/propagate_in_if_let_subject.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<Option<int>, string> { Ok(Some(1)) }\n\nfn f() -> Result<int, string> {\n  if let Some(n) = g()? { Ok(n) } else { Ok(0) }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[lisette.Option[int], string] {
+	return lisette.MakeResultOk[lisette.Option[int], string](lisette.MakeOptionSome(1))
+}
+
+func f() lisette.Result[int, string] {
+	check_2 := g()
+	if check_2.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	}
+	subject_1 := check_2.OkVal
+	if subject_1.Tag == lisette.OptionSome {
+		return lisette.MakeResultOk[int, string](subject_1.SomeVal)
+	}
+	return lisette.MakeResultOk[int, string](0)
+}

--- a/tests/spec/emit/snapshots/propagate_in_loop_break_value.snap
+++ b/tests/spec/emit/snapshots/propagate_in_loop_break_value.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<int, string> { Ok(5) }\n\nfn f() -> Result<int, string> {\n  let x = loop { break g()? }\n  Ok(x)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[int, string] {
+	return lisette.MakeResultOk[int, string](5)
+}
+
+func f() lisette.Result[int, string] {
+	var x int
+	for {
+		check_1 := g()
+		if check_1.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, string](check_1.ErrVal)
+		}
+		x = check_1.OkVal
+		break
+	}
+	return lisette.MakeResultOk[int, string](x)
+}

--- a/tests/spec/emit/snapshots/propagate_in_match_subject.snap
+++ b/tests/spec/emit/snapshots/propagate_in_match_subject.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<int, string> { Ok(1) }\n\nfn f() -> Result<int, string> {\n  match g()? {\n    0 => Ok(10),\n    x => Ok(x),\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[int, string] {
+	return lisette.MakeResultOk[int, string](1)
+}
+
+func f() lisette.Result[int, string] {
+	check_2 := g()
+	if check_2.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	}
+	subject_1 := check_2.OkVal
+	if subject_1 == 0 {
+		return lisette.MakeResultOk[int, string](10)
+	}
+	return lisette.MakeResultOk[int, string](subject_1)
+}

--- a/tests/spec/emit/snapshots/propagate_in_range_end.snap
+++ b/tests/spec/emit/snapshots/propagate_in_range_end.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<int, string> { Ok(5) }\n\nfn f() -> Result<int, string> {\n  let mut s = 0\n  for i in 0..g()? { s = s + i }\n  Ok(s)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[int, string] {
+	return lisette.MakeResultOk[int, string](5)
+}
+
+func f() lisette.Result[int, string] {
+	s := 0
+	check_2 := g()
+	if check_2.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	}
+	_bound_1 := check_2.OkVal
+	for i := 0; i < _bound_1; i++ {
+		s += i
+	}
+	return lisette.MakeResultOk[int, string](s)
+}

--- a/tests/spec/emit/snapshots/propagate_in_range_start.snap
+++ b/tests/spec/emit/snapshots/propagate_in_range_start.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn g() -> Result<int, string> { Ok(0) }\n\nfn f() -> Result<int, string> {\n  let mut s = 0\n  for i in g()?..5 { s = s + i }\n  Ok(s)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g() lisette.Result[int, string] {
+	return lisette.MakeResultOk[int, string](0)
+}
+
+func f() lisette.Result[int, string] {
+	s := 0
+	check_1 := g()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
+	}
+	for i := check_1.OkVal; i < 5; i++ {
+		s += i
+	}
+	return lisette.MakeResultOk[int, string](s)
+}

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct User {\n  id: int,\n  name: string,\n}\n\nfn get_id() -> Result<int, string> { Ok(1) }\nfn get_name() -> Result<string, string> { Ok(\"Ada\") }\n\nfn make_user() -> Result<User, string> {\n  Ok(User {\n    id: get_id()?,\n    name: get_name()?,\n  })\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type User struct {
+	id   int
+	name string
+}
+
+func (u User) String() string {
+	return fmt.Sprintf("User { id: %v, name: %v }", u.id, u.name)
+}
+
+func get_id() lisette.Result[int, string] {
+	return lisette.MakeResultOk[int, string](1)
+}
+
+func get_name() lisette.Result[string, string] {
+	return lisette.MakeResultOk[string, string]("Ada")
+}
+
+func make_user() lisette.Result[User, string] {
+	check_1 := get_id()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[User, string](check_1.ErrVal)
+	}
+	check_2 := get_name()
+	if check_2.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[User, string](check_2.ErrVal)
+	}
+	return lisette.MakeResultOk[User, string](User{
+		id:   check_1.OkVal,
+		name: check_2.OkVal,
+	})
+}

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct User {\n  id: int,\n  name: string,\n}\n\nfn get_base() -> Result<User, string> {\n  Ok(User { id: 1, name: \"a\" })\n}\n\nfn override_id() -> Result<User, string> {\n  Ok(User { id: 2, ..get_base()? })\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type User struct {
+	id   int
+	name string
+}
+
+func (u User) String() string {
+	return fmt.Sprintf("User { id: %v, name: %v }", u.id, u.name)
+}
+
+func get_base() lisette.Result[User, string] {
+	return lisette.MakeResultOk[User, string](User{
+		id:   1,
+		name: "a",
+	})
+}
+
+func override_id() lisette.Result[User, string] {
+	check_1 := get_base()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[User, string](check_1.ErrVal)
+	}
+	copy_2 := check_1.OkVal
+	copy_2.id = 2
+	return lisette.MakeResultOk[User, string](copy_2)
+}


### PR DESCRIPTION
Fixes an ICE when `?` appears in operand position outside the tail.

```rs
fn make_user() -> Result<User, string> {
  Ok(User {
    id: get_id()?,
    name: get_name()?,
  })
}
```

Close #516
