### PR TITLE
feat: reject decimal file mode literals

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2155,6 +2155,15 @@ pub fn empty_range(span: &Span) -> LisetteDiagnostic {
         .with_help("Swap the bounds.")
 }
 
+pub fn decimal_file_mode(span: &Span, value: u64) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("File permission written in decimal")
+        .with_infer_code("decimal_file_mode")
+        .with_span_label(span, format!("decimal {value} is octal 0o{value:o}"))
+        .with_help(
+            "File permissions are conventionally written in octal. Use a `0o` prefix (for example `0o644`) so the bits line up with the rwx triples.",
+        )
+}
+
 pub fn empty_infinite_loop(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Empty infinite loop")
         .with_infer_code("empty_infinite_loop")

--- a/crates/semantics/src/passes/checks/decimal_file_mode.rs
+++ b/crates/semantics/src/passes/checks/decimal_file_mode.rs
@@ -1,0 +1,28 @@
+use diagnostics::LocalSink;
+use syntax::ast::{Expression, Literal};
+
+const FILE_MODE_ID: &str = "go:io/fs.FileMode";
+const PERM_MASK: u64 = 0o777;
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        visit_expression(item, sink);
+    }
+}
+
+fn visit_expression(expression: &Expression, sink: &LocalSink) {
+    if let Expression::Literal {
+        literal: Literal::Integer { value, text: None },
+        ty,
+        span,
+    } = expression
+        && *value > PERM_MASK
+        && ty.get_qualified_id() == Some(FILE_MODE_ID)
+    {
+        sink.push(diagnostics::infer::decimal_file_mode(span, *value));
+    }
+
+    for child in expression.children() {
+        visit_expression(child, sink);
+    }
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod const_naming;
+pub(crate) mod decimal_file_mode;
 pub(crate) mod duplicate_bindings;
 pub(crate) mod empty_infinite_loop;
 pub(crate) mod empty_range;
@@ -108,6 +109,7 @@ fn run_file_checks(
     empty_infinite_loop::run(&file.items, sink);
     empty_range::run(&file.items, sink);
     empty_select_default::run(&file.items, sink);
+    decimal_file_mode::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);
     repeated_if_condition::run(&file.items, sink);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -5034,3 +5034,79 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn decimal_file_mode_chmod() {
+    assert_lint_snapshot!(
+        r#"
+import "go:os"
+
+fn main() {
+  let _ = os.Chmod("/tmp/foo", 644)
+}
+"#
+    );
+}
+
+#[test]
+fn decimal_file_mode_mkdir_all() {
+    assert_lint_snapshot!(
+        r#"
+import "go:os"
+
+fn main() {
+  let _ = os.MkdirAll("/tmp/foo", 1000)
+}
+"#
+    );
+}
+
+#[test]
+fn decimal_file_mode_octal_prefix_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:os"
+
+fn main() {
+  let _ = os.Chmod("/tmp/foo", 0o755)
+}
+"#
+    );
+}
+
+#[test]
+fn decimal_file_mode_legacy_octal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:os"
+
+fn main() {
+  let _ = os.Chmod("/tmp/foo", 0755)
+}
+"#
+    );
+}
+
+#[test]
+fn decimal_file_mode_below_perm_mask_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:os"
+
+fn main() {
+  let _ = os.Chmod("/tmp/foo", 420)
+}
+"#
+    );
+}
+
+#[test]
+fn decimal_file_mode_non_file_mode_position_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = 1000
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/decimal_file_mode_chmod.snap
+++ b/tests/ui/lint/snapshots/decimal_file_mode_chmod.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] File permission written in decimal
+   ╭─[test.lis:5:32]
+ 4 │ fn main() {
+ 5 │   let _ = os.Chmod("/tmp/foo", 644)
+   ·                                ─┬─
+   ·                                 ╰── decimal 644 is octal 0o1204
+ 6 │ }
+   ╰────
+  help: File permissions are conventionally written in octal. Use a `0o` prefix (for example `0o644`) so the bits line up with the rwx triples · code: [infer.decimal_file_mode]

--- a/tests/ui/lint/snapshots/decimal_file_mode_mkdir_all.snap
+++ b/tests/ui/lint/snapshots/decimal_file_mode_mkdir_all.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] File permission written in decimal
+   ╭─[test.lis:5:35]
+ 4 │ fn main() {
+ 5 │   let _ = os.MkdirAll("/tmp/foo", 1000)
+   ·                                   ──┬─
+   ·                                     ╰── decimal 1000 is octal 0o1750
+ 6 │ }
+   ╰────
+  help: File permissions are conventionally written in octal. Use a `0o` prefix (for example `0o644`) so the bits line up with the rwx triples · code: [infer.decimal_file_mode]


### PR DESCRIPTION
Adds a compile error for file-permission args written as a decimal literal greater than `0o777`, the common bug of writing `644` (decimal `0o1204`, with the sticky bit set) instead of `0o644`.
```
  [error] File permission written in decimal
   ╭─[main.lis:4:32]
 3 │ fn main() {
 4 │   let _ = os.Chmod("/tmp/foo", 644)
   ·                                ─┬─
   ·                                 ╰── decimal 644 is octal 0o1204
 5 │ }
   ╰────
  help: File permissions are conventionally written in octal. Use a `0o`
        prefix (for example `0o644`) so the bits line up with the rwx
        triples · code: [infer.decimal_file_mode]
```
