### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.2.15](https://github.com/ivov/lisette/compare/lisette-v0.2.14...lisette-v0.2.15) - 2026-05-28
+
+- fix: emit middle index for capped range-from slice [#527](https://github.com/ivov/lisette/pull/527) [`00f3b56`](https://github.com/ivov/lisette/commit/00f3b562a9e0887655766e7ebaf75828fe85da72)
+- fix: enforce consistent evaluation order in emit [#526](https://github.com/ivov/lisette/pull/526) [`749ada5`](https://github.com/ivov/lisette/commit/749ada5067df054f62a08e4a563621aaa6450fb5)
+- feat: reject channel and function fields in json types [#525](https://github.com/ivov/lisette/pull/525) [`317647b`](https://github.com/ivov/lisette/commit/317647b224de687e1d451ef3b9c75049235382ac)
+- fix: evaluate deferred native-method operands at defer site [#524](https://github.com/ivov/lisette/pull/524) [`c905f1c`](https://github.com/ivov/lisette/commit/c905f1cc94e630b6324c315bc51eec9cb937106a)
+- feat: flag charset misuse in strings.Trim calls [#523](https://github.com/ivov/lisette/pull/523) [`b6b3d43`](https://github.com/ivov/lisette/commit/b6b3d43ec4c61ddffa9f5edd5c12b0b97f755276)
+- ci: harden release body and notes generation [#522](https://github.com/ivov/lisette/pull/522) [`5dd023e`](https://github.com/ivov/lisette/commit/5dd023e89b9d970075a95f64af883a57a5159cd4)
+- docs: restore blank lines between changelog releases [#521](https://github.com/ivov/lisette/pull/521) [`e9f267e`](https://github.com/ivov/lisette/commit/e9f267e6c3a0485c900ceca46f58a108d2d68544)
+- feat: flag duplicate args in stdlib calls [#520](https://github.com/ivov/lisette/pull/520) [`6b5e3e4`](https://github.com/ivov/lisette/commit/6b5e3e4199f03a92d6213dae3db6547274483a4b)
+- feat: reject decimal file mode literals [#518](https://github.com/ivov/lisette/pull/518) [`b8a2bdd`](https://github.com/ivov/lisette/commit/b8a2bdd45ecd31c59b52edbe0a43effbbc5c24e7)
+- fix: track function return context for nested ? propagation [#517](https://github.com/ivov/lisette/pull/517) [`00316bf`](https://github.com/ivov/lisette/commit/00316bf8f68467895407f9868800fca414867afd)
+
 ## [0.2.14](https://github.com/ivov/lisette/compare/lisette-v0.2.13...lisette-v0.2.14) - 2026-05-27
 
 - fix: translate `unknown` to any in explicit type arguments [#513](https://github.com/ivov/lisette/pull/513) [`7d6687a`](https://github.com/ivov/lisette/commit/7d6687a8ae52f122aef8b6341d3de707d01a667f)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bincode",
  "ecow",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.14", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.14", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.14", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.14", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.15", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.15", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.15", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.15", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.14", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.14", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.15", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.15", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.14", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.14", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.14", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.14", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.15 (upcoming)

- fix: emit middle index for capped range-from slice [#527](https://github.com/ivov/lisette/pull/527) [`00f3b56`](https://github.com/ivov/lisette/commit/00f3b562a9e0887655766e7ebaf75828fe85da72)
- fix: enforce consistent evaluation order in emit [#526](https://github.com/ivov/lisette/pull/526) [`749ada5`](https://github.com/ivov/lisette/commit/749ada5067df054f62a08e4a563621aaa6450fb5)
- feat: reject channel and function fields in json types [#525](https://github.com/ivov/lisette/pull/525) [`317647b`](https://github.com/ivov/lisette/commit/317647b224de687e1d451ef3b9c75049235382ac)
- fix: evaluate deferred native-method operands at defer site [#524](https://github.com/ivov/lisette/pull/524) [`c905f1c`](https://github.com/ivov/lisette/commit/c905f1cc94e630b6324c315bc51eec9cb937106a)
- feat: flag charset misuse in strings.Trim calls [#523](https://github.com/ivov/lisette/pull/523) [`b6b3d43`](https://github.com/ivov/lisette/commit/b6b3d43ec4c61ddffa9f5edd5c12b0b97f755276)
- ci: harden release body and notes generation [#522](https://github.com/ivov/lisette/pull/522) [`5dd023e`](https://github.com/ivov/lisette/commit/5dd023e89b9d970075a95f64af883a57a5159cd4)
- docs: restore blank lines between changelog releases [#521](https://github.com/ivov/lisette/pull/521) [`e9f267e`](https://github.com/ivov/lisette/commit/e9f267e6c3a0485c900ceca46f58a108d2d68544)
- feat: flag duplicate args in stdlib calls [#520](https://github.com/ivov/lisette/pull/520) [`6b5e3e4`](https://github.com/ivov/lisette/commit/6b5e3e4199f03a92d6213dae3db6547274483a4b)
- feat: reject decimal file mode literals [#518](https://github.com/ivov/lisette/pull/518) [`b8a2bdd`](https://github.com/ivov/lisette/commit/b8a2bdd45ecd31c59b52edbe0a43effbbc5c24e7)
- fix: track function return context for nested ? propagation [#517](https://github.com/ivov/lisette/pull/517) [`00316bf`](https://github.com/ivov/lisette/commit/00316bf8f68467895407f9868800fca414867afd)
