### PR TITLE
feat: flag duplicate args in stdlib calls

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -508,3 +508,13 @@ pub fn unknown_tag_option(span: &Span, option: &str) -> LisetteDiagnostic {
             option
         ))
 }
+
+pub fn duplicate_arguments(span: &Span, module: &str, function: &str) -> LisetteDiagnostic {
+    let display_module = module.strip_prefix("go:").unwrap_or(module);
+    LisetteDiagnostic::warn("Duplicate arguments")
+        .with_lint_code("duplicate_arguments")
+        .with_span_label(span, "identical arguments")
+        .with_help(format!(
+            "Passing the same value twice to `{display_module}.{function}` makes this call a no-op. Did you mean to pass different values?"
+        ))
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/dup_arg.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/dup_arg.rs
@@ -1,0 +1,65 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::Expression;
+
+use super::helpers::{expressions_equivalent, is_side_effect_free};
+
+/// (module_id, function_name, arg index a, arg index b)
+const DUP_ARG_TARGETS: &[(&str, &str, usize, usize)] = &[
+    ("go:math", "Max", 0, 1),
+    ("go:math", "Min", 0, 1),
+    ("go:reflect", "DeepEqual", 0, 1),
+    ("go:bytes", "Equal", 0, 1),
+    ("go:bytes", "Compare", 0, 1),
+    ("go:bytes", "EqualFold", 0, 1),
+    ("go:strings", "Compare", 0, 1),
+    ("go:strings", "EqualFold", 0, 1),
+    ("go:strings", "Replace", 1, 2),
+    ("go:strings", "ReplaceAll", 1, 2),
+];
+
+pub fn check_dup_arg(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let Expression::Call {
+        expression: callee,
+        args,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    let Expression::DotAccess {
+        expression: namespace,
+        member,
+        ..
+    } = callee.unwrap_parens()
+    else {
+        return;
+    };
+
+    let namespace_ty = namespace.get_type();
+    let Some(module_id) = namespace_ty.as_import_namespace() else {
+        return;
+    };
+
+    for (target_module, target_function, a, b) in DUP_ARG_TARGETS {
+        if module_id != *target_module || member != *target_function {
+            continue;
+        }
+        let (Some(arg_a), Some(arg_b)) = (args.get(*a), args.get(*b)) else {
+            return;
+        };
+        if !is_side_effect_free(arg_a) || !is_side_effect_free(arg_b) {
+            return;
+        }
+        if !expressions_equivalent(arg_a, arg_b) {
+            return;
+        }
+        diagnostics.push(diagnostics::lint::duplicate_arguments(
+            span,
+            target_module,
+            target_function,
+        ));
+        return;
+    }
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,5 +1,6 @@
 mod bool_literal_comparison;
 mod double_negation;
+mod dup_arg;
 mod duplicate_logical_operand;
 mod empty_match_arm;
 mod excess_parens_on_condition;
@@ -20,6 +21,7 @@ mod verbose_failure_propagation;
 
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use double_negation::check_double_negation;
+pub use dup_arg::check_dup_arg;
 pub use duplicate_logical_operand::check_duplicate_logical_operand;
 pub use empty_match_arm::check_empty_match_arm;
 pub use excess_parens_on_condition::check_excess_parens_on_condition;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -70,9 +70,9 @@ fn run_module(module: &Module, store: &Store, sink: &LocalSink) {
 
 use attributes::{check_attributes, check_struct_attributes};
 use checks::{
-    check_bool_literal_comparison, check_double_negation, check_duplicate_logical_operand,
-    check_empty_match_arm, check_excess_parens_on_condition, check_expression_naming,
-    check_identical_if_branches, check_invisible_in_string_expression,
+    check_bool_literal_comparison, check_double_negation, check_dup_arg,
+    check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
+    check_expression_naming, check_identical_if_branches, check_invisible_in_string_expression,
     check_invisible_in_string_pattern, check_match_literal_collection, check_pattern_naming,
     check_replaceable_with_zero_fill, check_rest_only_slice_pattern, check_self_assignment,
     check_self_comparison, check_single_arm_match, check_uninterpolated_fstring,
@@ -99,6 +99,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_unnecessary_raw_string_expression,
     check_invisible_in_string_expression,
     check_verbose_failure_propagation,
+    check_dup_arg,
     check_struct_attributes,
     check_attributes,
 ];

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -5110,3 +5110,245 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn dup_arg_math_max() {
+    assert_lint_snapshot!(
+        r#"
+import "go:math"
+
+fn main() {
+  let x: float64 = 1.0
+  let _ = math.Max(x, x)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_math_min() {
+    assert_lint_snapshot!(
+        r#"
+import "go:math"
+
+fn main() {
+  let x: float64 = 1.0
+  let _ = math.Min(x, x)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_reflect_deep_equal() {
+    assert_lint_snapshot!(
+        r#"
+import "go:reflect"
+
+fn main() {
+  let s = "abc"
+  let _ = reflect.DeepEqual(s, s)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_replace() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.Replace(s, s, s, 1)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_replace_all() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.ReplaceAll(s, s, s)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_compare() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.Compare(s, s)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_equal_fold() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.EqualFold(s, s)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_bytes_equal() {
+    assert_lint_snapshot!(
+        r#"
+import "go:bytes"
+
+fn main() {
+  let bs: Slice<byte> = Slice.new<byte>()
+  let _ = bytes.Equal(bs, bs)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_bytes_compare() {
+    assert_lint_snapshot!(
+        r#"
+import "go:bytes"
+
+fn main() {
+  let bs: Slice<byte> = Slice.new<byte>()
+  let _ = bytes.Compare(bs, bs)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_bytes_equal_fold() {
+    assert_lint_snapshot!(
+        r#"
+import "go:bytes"
+
+fn main() {
+  let bs: Slice<byte> = Slice.new<byte>()
+  let _ = bytes.EqualFold(bs, bs)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_parenthesized_args() {
+    assert_lint_snapshot!(
+        r#"
+import "go:math"
+
+fn main() {
+  let x: float64 = 1.0
+  let _ = math.Max((x), x)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_replace_with_search_replace_dup() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let pat = "x"
+  let _ = strings.Replace(s, pat, pat, 1)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_distinct_identifiers_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:math"
+
+fn main() {
+  let x: float64 = 1.0
+  let y: float64 = 2.0
+  let _ = math.Max(x, y)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_distinct_literals_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:math"
+
+fn main() {
+  let _ = math.Max(1.0, 2.0)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_calls_with_side_effects_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:math"
+
+fn next() -> float64 {
+  return 1.0
+}
+
+fn main() {
+  let _ = math.Max(next(), next())
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_strings_replace_different_search_replace_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.Replace(s, "a", "b", 1)
+}
+"#
+    );
+}
+
+#[test]
+fn dup_arg_unrelated_function_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.Contains(s, s)
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/dup_arg_bytes_compare.snap
+++ b/tests/ui/lint/snapshots/dup_arg_bytes_compare.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let bs: Slice<byte> = Slice.new<byte>()
+ 6 │   let _ = bytes.Compare(bs, bs)
+   ·           ──────────┬──────────
+   ·                     ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `bytes.Compare` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_bytes_equal.snap
+++ b/tests/ui/lint/snapshots/dup_arg_bytes_equal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let bs: Slice<byte> = Slice.new<byte>()
+ 6 │   let _ = bytes.Equal(bs, bs)
+   ·           ─────────┬─────────
+   ·                    ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `bytes.Equal` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_bytes_equal_fold.snap
+++ b/tests/ui/lint/snapshots/dup_arg_bytes_equal_fold.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let bs: Slice<byte> = Slice.new<byte>()
+ 6 │   let _ = bytes.EqualFold(bs, bs)
+   ·           ───────────┬───────────
+   ·                      ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `bytes.EqualFold` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_math_max.snap
+++ b/tests/ui/lint/snapshots/dup_arg_math_max.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let x: float64 = 1.0
+ 6 │   let _ = math.Max(x, x)
+   ·           ───────┬──────
+   ·                  ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `math.Max` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_math_min.snap
+++ b/tests/ui/lint/snapshots/dup_arg_math_min.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let x: float64 = 1.0
+ 6 │   let _ = math.Min(x, x)
+   ·           ───────┬──────
+   ·                  ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `math.Min` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_parenthesized_args.snap
+++ b/tests/ui/lint/snapshots/dup_arg_parenthesized_args.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let x: float64 = 1.0
+ 6 │   let _ = math.Max((x), x)
+   ·           ────────┬───────
+   ·                   ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `math.Max` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_reflect_deep_equal.snap
+++ b/tests/ui/lint/snapshots/dup_arg_reflect_deep_equal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let s = "abc"
+ 6 │   let _ = reflect.DeepEqual(s, s)
+   ·           ───────────┬───────────
+   ·                      ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `reflect.DeepEqual` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_strings_compare.snap
+++ b/tests/ui/lint/snapshots/dup_arg_strings_compare.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let s = "abc"
+ 6 │   let _ = strings.Compare(s, s)
+   ·           ──────────┬──────────
+   ·                     ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `strings.Compare` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_strings_equal_fold.snap
+++ b/tests/ui/lint/snapshots/dup_arg_strings_equal_fold.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let s = "abc"
+ 6 │   let _ = strings.EqualFold(s, s)
+   ·           ───────────┬───────────
+   ·                      ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `strings.EqualFold` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_strings_replace.snap
+++ b/tests/ui/lint/snapshots/dup_arg_strings_replace.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let s = "abc"
+ 6 │   let _ = strings.Replace(s, s, s, 1)
+   ·           ─────────────┬─────────────
+   ·                        ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `strings.Replace` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_strings_replace_all.snap
+++ b/tests/ui/lint/snapshots/dup_arg_strings_replace_all.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:6:11]
+ 5 │   let s = "abc"
+ 6 │   let _ = strings.ReplaceAll(s, s, s)
+   ·           ─────────────┬─────────────
+   ·                        ╰── identical arguments
+ 7 │ }
+   ╰────
+  help: Passing the same value twice to `strings.ReplaceAll` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]

--- a/tests/ui/lint/snapshots/dup_arg_strings_replace_with_search_replace_dup.snap
+++ b/tests/ui/lint/snapshots/dup_arg_strings_replace_with_search_replace_dup.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Duplicate arguments
+   ╭─[test.lis:7:11]
+ 6 │   let pat = "x"
+ 7 │   let _ = strings.Replace(s, pat, pat, 1)
+   ·           ───────────────┬───────────────
+   ·                          ╰── identical arguments
+ 8 │ }
+   ╰────
+  help: Passing the same value twice to `strings.Replace` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]


### PR DESCRIPTION
Adds a lint to flag calls to Go stdlib functions where passing the same value to two args makes the call a no-op.

```
  [warning] Duplicate arguments
   ╭─[test.lis:6:11]
 6 │   let _ = math.Max(x, x)
   ·           ───────┬──────
   ·                  ╰── identical arguments
   ╰────
  help: Passing the same value twice to `math.Max` makes this call a no-op. Did you mean to pass different values? · code: [lint.duplicate_arguments]
```
