### PR TITLE
feat: flag charset misuse in strings.Trim calls

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -509,6 +509,15 @@ pub fn unknown_tag_option(span: &Span, option: &str) -> LisetteDiagnostic {
         ))
 }
 
+pub fn trim_charset_misuse(span: &Span, function: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn(format!("Misuse of `{function}`"))
+        .with_lint_code("trim_charset_misuse")
+        .with_span_label(span, "treated as charset")
+        .with_help(format!(
+            "`strings.{function}` removes a set of characters, not a substring. Did you mean `strings.TrimPrefix` or `strings.TrimSuffix`?"
+        ))
+}
+
 pub fn duplicate_arguments(span: &Span, module: &str, function: &str) -> LisetteDiagnostic {
     let display_module = module.strip_prefix("go:").unwrap_or(module);
     LisetteDiagnostic::warn("Duplicate arguments")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_cutset.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_cutset.rs
@@ -1,0 +1,51 @@
+use diagnostics::LisetteDiagnostic;
+use rustc_hash::FxHashSet as HashSet;
+use syntax::ast::{Expression, Literal};
+
+const CUTSET_FUNCTIONS: &[&str] = &["Trim", "TrimLeft", "TrimRight"];
+
+pub fn check_duplicate_cutset(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let Expression::Call {
+        expression: callee,
+        args,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    let Expression::DotAccess {
+        expression: namespace,
+        member,
+        ..
+    } = callee.unwrap_parens()
+    else {
+        return;
+    };
+
+    if !CUTSET_FUNCTIONS.contains(&member.as_str()) {
+        return;
+    }
+
+    if namespace.get_type().as_import_namespace() != Some("go:strings") {
+        return;
+    }
+
+    let Some(Expression::Literal {
+        literal: Literal::String { value, .. },
+        span,
+        ..
+    }) = args.get(1).map(Expression::unwrap_parens)
+    else {
+        return;
+    };
+
+    if has_duplicate_char(value) {
+        diagnostics.push(diagnostics::lint::trim_charset_misuse(span, member));
+    }
+}
+
+fn has_duplicate_char(cutset: &str) -> bool {
+    let mut seen = HashSet::default();
+    !cutset.chars().all(|c| seen.insert(c))
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,6 +1,7 @@
 mod bool_literal_comparison;
 mod double_negation;
 mod dup_arg;
+mod duplicate_cutset;
 mod duplicate_logical_operand;
 mod empty_match_arm;
 mod excess_parens_on_condition;
@@ -22,6 +23,7 @@ mod verbose_failure_propagation;
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use double_negation::check_double_negation;
 pub use dup_arg::check_dup_arg;
+pub use duplicate_cutset::check_duplicate_cutset;
 pub use duplicate_logical_operand::check_duplicate_logical_operand;
 pub use empty_match_arm::check_empty_match_arm;
 pub use excess_parens_on_condition::check_excess_parens_on_condition;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -70,7 +70,7 @@ fn run_module(module: &Module, store: &Store, sink: &LocalSink) {
 
 use attributes::{check_attributes, check_struct_attributes};
 use checks::{
-    check_bool_literal_comparison, check_double_negation, check_dup_arg,
+    check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
     check_expression_naming, check_identical_if_branches, check_invisible_in_string_expression,
     check_invisible_in_string_pattern, check_match_literal_collection, check_pattern_naming,
@@ -100,6 +100,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_invisible_in_string_expression,
     check_verbose_failure_propagation,
     check_dup_arg,
+    check_duplicate_cutset,
     check_struct_attributes,
     check_attributes,
 ];

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -5352,3 +5352,102 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn duplicate_cutset_trim() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let url = "https://example.com"
+  let _ = strings.Trim(url, "https://")
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_trim_left() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "//path"
+  let _ = strings.TrimLeft(s, "//")
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_trim_right() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "value.."
+  let _ = strings.TrimRight(s, "..")
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_no_duplicate_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let _ = strings.Trim(s, "abc")
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_non_literal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "abc"
+  let cutset = "aa"
+  let _ = strings.Trim(s, cutset)
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_trim_prefix_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let url = "https://example.com"
+  let _ = strings.TrimPrefix(url, "https://")
+}
+"#
+    );
+}
+
+#[test]
+fn duplicate_cutset_trim_space_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "  hi  "
+  let _ = strings.TrimSpace(s)
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/duplicate_cutset_trim.snap
+++ b/tests/ui/lint/snapshots/duplicate_cutset_trim.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Misuse of `Trim`
+   ╭─[test.lis:6:29]
+ 5 │   let url = "https://example.com"
+ 6 │   let _ = strings.Trim(url, "https://")
+   ·                             ─────┬────
+   ·                                  ╰── treated as charset
+ 7 │ }
+   ╰────
+  help: `strings.Trim` removes a set of characters, not a substring. Did you mean `strings.TrimPrefix` or `strings.TrimSuffix`? · code: [lint.trim_charset_misuse]

--- a/tests/ui/lint/snapshots/duplicate_cutset_trim_left.snap
+++ b/tests/ui/lint/snapshots/duplicate_cutset_trim_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Misuse of `TrimLeft`
+   ╭─[test.lis:6:31]
+ 5 │   let s = "//path"
+ 6 │   let _ = strings.TrimLeft(s, "//")
+   ·                               ──┬─
+   ·                                 ╰── treated as charset
+ 7 │ }
+   ╰────
+  help: `strings.TrimLeft` removes a set of characters, not a substring. Did you mean `strings.TrimPrefix` or `strings.TrimSuffix`? · code: [lint.trim_charset_misuse]

--- a/tests/ui/lint/snapshots/duplicate_cutset_trim_right.snap
+++ b/tests/ui/lint/snapshots/duplicate_cutset_trim_right.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Misuse of `TrimRight`
+   ╭─[test.lis:6:32]
+ 5 │   let s = "value.."
+ 6 │   let _ = strings.TrimRight(s, "..")
+   ·                                ──┬─
+   ·                                  ╰── treated as charset
+ 7 │ }
+   ╰────
+  help: `strings.TrimRight` removes a set of characters, not a substring. Did you mean `strings.TrimPrefix` or `strings.TrimSuffix`? · code: [lint.trim_charset_misuse]


### PR DESCRIPTION
Adds a lint that flags misuse of `strings.Trim`, `strings.TrimLeft`, and `strings.TrimRight` where the arg is a string literal with a repeated character, signalling the author expected substring removal rather than charset stripping.

```
  [warning] Misuse of `Trim`
   ╭─[main.lis:6:27]
 5 │   let url = "https://example.com"
 6 │   let host = strings.Trim(url, "https://")
   ·                                ─────┬────
   ·                                     ╰── treated as charset
 7 │ }
   ╰────
  help: `strings.Trim` removes a set of characters, not a substring. Did you mean `strings.TrimPrefix` or `strings.TrimSuffix`? · code: [lint.trim_charset_misuse]
```
