### PR TITLE
fix: evaluate deferred native-method operands at defer site

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -407,11 +407,15 @@ impl Planner<'_> {
 
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
-        all_stages.push(self.stage_operand(
+        let mut receiver_stage = self.stage_operand(
             expression,
             ExpressionContext::value().with_ambient_return_ctx_opt(ctx.ambient_return_ctx),
             fx,
-        ));
+        );
+        if expression.get_type().is_ref() {
+            receiver_stage.value = format!("*{}", receiver_stage.value);
+        }
+        all_stages.push(receiver_stage);
         all_stages.extend(self.stage_native_method_args(
             ctx.function,
             ctx.args,
@@ -430,14 +434,8 @@ impl Planner<'_> {
             fx,
         );
 
-        let raw_receiver = all_values[0].clone();
+        let receiver = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
-
-        let receiver = if expression.get_type().is_ref() {
-            format!("*{}", raw_receiver)
-        } else {
-            raw_receiver
-        };
         (setup, receiver, emitted_args)
     }
 

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -83,6 +83,7 @@ impl Planner<'_> {
             value: format!("(*{})", s.value),
             setup: s.setup,
             capture: s.capture,
+            non_literal: s.non_literal,
         }
     }
 

--- a/crates/emit/src/expressions/emission.rs
+++ b/crates/emit/src/expressions/emission.rs
@@ -19,6 +19,7 @@ pub(crate) struct StagedExpression {
     pub setup: Vec<LoweredStatement>,
     pub value: String,
     pub capture: CapturePolicy,
+    pub non_literal: bool,
 }
 
 impl StagedExpression {
@@ -33,6 +34,7 @@ impl StagedExpression {
             setup: setup_from_string(setup),
             value,
             capture,
+            non_literal: observable_after_mutation(expression),
         }
     }
 
@@ -51,6 +53,7 @@ impl StagedExpression {
             setup,
             value,
             capture,
+            non_literal: observable_after_mutation(expression),
         }
     }
 
@@ -61,6 +64,7 @@ impl StagedExpression {
                 setup,
                 value,
                 capture: CapturePolicy::Never,
+                non_literal: observable_after_mutation(expression),
             },
             ValuePlan::Operand(value) => {
                 let capture = if observable_after_mutation(expression) {
@@ -72,6 +76,7 @@ impl StagedExpression {
                     setup: Vec::new(),
                     value,
                     capture,
+                    non_literal: observable_after_mutation(expression),
                 }
             }
             other => {

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -42,6 +42,7 @@ impl Planner<'_> {
             setup,
             value: temp_var,
             capture: CapturePolicy::Never,
+            non_literal: false,
         }
     }
 
@@ -239,7 +240,8 @@ impl Planner<'_> {
         mut stages: Vec<StagedExpression>,
         prefix: &str,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
-        if stages.iter().all(|s| s.setup.is_empty()) {
+        let eager = self.function_state.eager_operand_capture();
+        if !eager && stages.iter().all(|s| s.setup.is_empty()) {
             return (Vec::new(), stages.into_iter().map(|s| s.value).collect());
         }
 
@@ -248,12 +250,15 @@ impl Planner<'_> {
         for i in 0..stages.len() {
             let later_has_setup = stages[i + 1..].iter().any(|s| !s.setup.is_empty());
             let s_capture = stages[i].capture;
+            let s_non_literal = stages[i].non_literal;
             let s_value = std::mem::take(&mut stages[i].value);
             let s_setup = std::mem::take(&mut stages[i].setup);
 
             setup.extend(s_setup);
 
-            if later_has_setup && matches!(s_capture, CapturePolicy::IfLaterSetup) {
+            let capture_for_later =
+                later_has_setup && matches!(s_capture, CapturePolicy::IfLaterSetup);
+            if capture_for_later || (eager && s_non_literal) {
                 let tmp = self.fresh_var(Some(prefix));
                 self.declare(&tmp);
                 setup.push(LoweredStatement::TempBind {

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -595,6 +595,17 @@ impl Planner<'_> {
         result
     }
 
+    fn with_eager_operand_capture<R>(
+        &mut self,
+        enabled: bool,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let previous = self.function_state.set_eager_operand_capture(enabled);
+        let result = f(self);
+        self.function_state.set_eager_operand_capture(previous);
+        result
+    }
+
     /// Plan a `Task`/`Defer` operand.
     pub(crate) fn plan_async_wrapper(
         &mut self,
@@ -629,8 +640,11 @@ impl Planner<'_> {
             );
         }
 
-        let (mut setup, inner) = self.lower_value(expression, ExpressionContext::value(), fx);
+        let (setup, inner) = self.lower_value(expression, ExpressionContext::value(), fx);
         if needs_iife_for_async(expression, &inner) {
+            let (mut setup, inner) = self.with_eager_operand_capture(true, |planner| {
+                planner.lower_value(expression, ExpressionContext::value(), fx)
+            });
             let mut body_statements = Vec::new();
             if !inner.is_empty() {
                 let line = if expression.get_type().is_unit() {
@@ -710,14 +724,18 @@ impl Planner<'_> {
     }
 }
 
+fn is_native_method_call(expression: &Expression) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::Call {
+            call_kind: Some(CallKind::NativeMethod(_) | CallKind::NativeMethodIdentifier(_)),
+            ..
+        }
+    )
+}
+
 fn needs_iife_for_async(expression: &Expression, emitted: &str) -> bool {
-    let Expression::Call { call_kind, .. } = expression.unwrap_parens() else {
-        return false;
-    };
-    if !matches!(
-        call_kind,
-        Some(CallKind::NativeMethod(_) | CallKind::NativeMethodIdentifier(_))
-    ) {
+    if !is_native_method_call(expression) {
         return false;
     }
     !is_valid_go_async_target(emitted)

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -88,6 +88,7 @@ impl ModuleState {
 #[derive(Default)]
 pub(crate) struct FunctionEmissionState {
     absorbed_ref_generics: HashSet<String>,
+    eager_operand_capture: bool,
 }
 
 impl FunctionEmissionState {
@@ -97,5 +98,13 @@ impl FunctionEmissionState {
 
     pub(crate) fn record_absorbed_ref_generic(&mut self, name: impl Into<String>) {
         self.absorbed_ref_generics.insert(name.into());
+    }
+
+    pub(crate) fn eager_operand_capture(&self) -> bool {
+        self.eager_operand_capture
+    }
+
+    pub(crate) fn set_eager_operand_capture(&mut self, value: bool) -> bool {
+        std::mem::replace(&mut self.eager_operand_capture, value)
     }
 }

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -1095,6 +1095,59 @@ fn test() {
 }
 
 #[test]
+fn defer_native_method_iife_evaluates_argument_eagerly() {
+    let input = r#"
+fn mark() -> int {
+  2
+}
+
+fn test() {
+  let mut xs = [1]
+  defer xs.append(mark())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_native_method_iife_evaluates_receiver_eagerly() {
+    let input = r#"
+fn get_items() -> Slice<int> {
+  [1]
+}
+
+fn test() {
+  defer get_items().length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_native_method_iife_snapshots_mutable_identifier_argument() {
+    let input = r#"
+fn run() {
+  let mut dst = [0, 0, 0]
+  let mut src = [1, 2, 3]
+  defer dst.copy_from(src)
+  src = [9, 9, 9]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_native_method_iife_snapshots_deref_receiver() {
+    let input = r#"
+fn run(out: Ref<Slice<int>>) {
+  defer out.copy_from([1, 2, 3])
+  out.* = [7, 7, 7, 7, 7]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn task_native_method_inlined_to_non_call_wraps_in_iife() {
     let input = r#"
 fn test() {
@@ -1158,6 +1211,30 @@ fn test() {
   }
   let send_val_2 = result + 1
   fmt.Println(send_val_2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_static_native_method_iife_captures_value_receiver() {
+    let input = r#"
+fn test() {
+  let items = [1, 2, 3]
+  defer Slice.length(items)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defer_static_native_method_iife_on_alias_captures_value_receiver() {
+    let input = r#"
+type MyString = string
+
+fn test() {
+  let s = "hi"
+  defer MyString.length(s)
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn mark() -> int {\n  2\n}\n\nfn test() {\n  let mut xs = [1]\n  defer xs.append(mark())\n}\n"
+---
+package main
+
+func mark() int {
+	return 2
+}
+
+func test() {
+	xs := []int{1}
+	_arg_1 := xs
+	_arg_2 := mark()
+	defer func() {
+		_ = append(_arg_1, _arg_2)
+	}()
+}

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn get_items() -> Slice<int> {\n  [1]\n}\n\nfn test() {\n  defer get_items().length()\n}\n"
+---
+package main
+
+func get_items() []int {
+	return []int{1}
+}
+
+func test() {
+	_arg_1 := get_items()
+	defer func() {
+		_ = len(_arg_1)
+	}()
+}

--- a/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn run(out: Ref<Slice<int>>) {\n  defer out.copy_from([1, 2, 3])\n  out.* = [7, 7, 7, 7, 7]\n}\n"
+---
+package main
+
+func run(out *[]int) {
+	_arg_1 := *out
+	defer func() {
+		_ = copy(_arg_1, []int{1, 2, 3})
+	}()
+	*out = []int{7, 7, 7, 7, 7}
+}

--- a/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_mutable_identifier_argument.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_mutable_identifier_argument.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn run() {\n  let mut dst = [0, 0, 0]\n  let mut src = [1, 2, 3]\n  defer dst.copy_from(src)\n  src = [9, 9, 9]\n}\n"
+---
+package main
+
+func run() {
+	dst := []int{0, 0, 0}
+	src := []int{1, 2, 3}
+	_arg_1 := dst
+	_arg_2 := src
+	defer func() {
+		_ = copy(_arg_1, _arg_2)
+	}()
+	src = []int{9, 9, 9}
+}

--- a/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
@@ -6,7 +6,8 @@ package main
 
 func test() {
 	xs := []int{1}
+	_arg_1 := xs
 	defer func() {
-		_ = len(xs)
+		_ = len(_arg_1)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_static_native_method_iife_captures_value_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_static_native_method_iife_captures_value_receiver.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \nfn test() {\n  let items = [1, 2, 3]\n  defer Slice.length(items)\n}\n"
+---
+package main
+
+func test() {
+	items := []int{1, 2, 3}
+	_arg_1 := items
+	defer func() {
+		_ = len(_arg_1)
+	}()
+}

--- a/tests/spec/emit/snapshots/defer_static_native_method_iife_on_alias_captures_value_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_static_native_method_iife_on_alias_captures_value_receiver.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: "input: \ntype MyString = string\n\nfn test() {\n  let s = \"hi\"\n  defer MyString.length(s)\n}\n"
+---
+package main
+
+type MyString = string
+
+func test() {
+	s := "hi"
+	_arg_1 := s
+	defer func() {
+		_ = len(_arg_1)
+	}()
+}

--- a/tests/spec/emit/snapshots/task_native_method_inlined_to_builtin_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlined_to_builtin_wraps_in_iife.snap
@@ -6,7 +6,8 @@ package main
 
 func test() {
 	xs := []int{1}
+	_arg_1 := xs
 	go func() {
-		_ = len(xs)
+		_ = len(_arg_1)
 	}()
 }

--- a/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
@@ -6,7 +6,8 @@ package main
 
 func test() {
 	xs := []int{1}
+	_arg_1 := xs
 	go func() {
-		_ = len(xs) == 0
+		_ = len(_arg_1) == 0
 	}()
 }


### PR DESCRIPTION
A `defer` or `task` whose native method lowers to a Go builtin (`len`, `append`, `copy`) is now wrapped in a closure, since those builtins are not valid `defer` or `task` targets. The receiver and arguments are now snapshotted at the defer/task site rather than read when the closure runs, matching Go's rule that a deferred call's operands are evaluated where the `defer` appears.

```rs
fn mark() -> int {
  fmt.Println("mark")
  2
}

fn main() {
  let mut xs = [1]
  defer xs.append(mark())
  fmt.Println("after")
}

// before: prints "after" then "mark"
// after: prints "mark" then "after"
```