### PR TITLE
feat: reject channel and function fields in json types

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -387,6 +387,18 @@ pub fn json_method_override(method_name: &str, span: Span) -> LisetteDiagnostic 
         )
 }
 
+pub fn json_non_serializable_field(span: &Span, kind: &str, skippable: bool) -> LisetteDiagnostic {
+    let fix = if skippable {
+        " Drop the field, or exclude it with `#[json(skip)]`."
+    } else {
+        " Remove it from the variant."
+    };
+    LisetteDiagnostic::error("Non-serializable field in a `#[json]` type")
+        .with_infer_code("json_non_serializable_field")
+        .with_span_label(span, format!("a {kind} cannot be JSON-encoded"))
+        .with_help(format!("Go's `encoding/json` cannot marshal {kind}s.{fix}"))
+}
+
 pub fn disallowed_mutation(
     variable_name: &str,
     span: Span,

--- a/crates/semantics/src/passes/checks/json_serializable_fields.rs
+++ b/crates/semantics/src/passes/checks/json_serializable_fields.rs
@@ -1,0 +1,85 @@
+//! Reject channel- and function-typed fields on a `#[json]` struct or enum.
+//! Go's `encoding/json` cannot marshal channels or functions, so such a type
+//! fails to serialize at runtime.
+
+use diagnostics::LocalSink;
+use syntax::ast::{Annotation, AttributeArg, Expression, StructFieldDefinition};
+
+pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
+    for item in typed_ast {
+        check_item(item, sink);
+    }
+}
+
+fn check_item(expression: &Expression, sink: &LocalSink) {
+    match expression {
+        Expression::Struct {
+            attributes, fields, ..
+        } if attributes.iter().any(|a| a.name == "json") => {
+            for field in fields {
+                if let Some(kind) = unserializable_kind(&field.annotation)
+                    && !is_json_skipped(field)
+                {
+                    sink.push(diagnostics::infer::json_non_serializable_field(
+                        &field.annotation.get_span(),
+                        kind,
+                        true,
+                    ));
+                }
+            }
+        }
+        Expression::Enum {
+            attributes,
+            variants,
+            ..
+        } if attributes.iter().any(|a| a.name == "json") => {
+            for variant in variants {
+                for field in &variant.fields {
+                    if let Some(kind) = unserializable_kind(&field.annotation) {
+                        sink.push(diagnostics::infer::json_non_serializable_field(
+                            &field.annotation.get_span(),
+                            kind,
+                            false,
+                        ));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn unserializable_kind(annotation: &Annotation) -> Option<&'static str> {
+    match annotation {
+        Annotation::Function { .. } => Some("function"),
+        Annotation::Constructor { name, .. }
+            if matches!(name.as_str(), "Channel" | "Sender" | "Receiver") =>
+        {
+            Some("channel")
+        }
+        _ => None,
+    }
+}
+
+fn is_json_skipped(field: &StructFieldDefinition) -> bool {
+    field
+        .attributes
+        .iter()
+        .any(|attribute| match attribute.name.as_str() {
+            "json" => attribute.args.iter().any(skips_field),
+            "tag" => {
+                matches!(attribute.args.first(), Some(AttributeArg::String(key)) if key == "json")
+                    && attribute.args.iter().skip(1).any(skips_field)
+            }
+            _ => false,
+        })
+}
+
+fn skips_field(arg: &AttributeArg) -> bool {
+    match arg {
+        AttributeArg::Flag(flag) => flag == "skip",
+        AttributeArg::String(value) => value == "-",
+        AttributeArg::Raw(raw) => raw.contains("\"-\""),
+        AttributeArg::NegatedFlag(_) => false,
+    }
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod generics;
 pub(crate) mod index_out_of_bounds;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
+pub(crate) mod json_serializable_fields;
 pub(crate) mod nan_comparison;
 pub(crate) mod native_value_usage;
 pub(crate) mod newtype;
@@ -111,6 +112,7 @@ fn run_file_checks(
     empty_select_default::run(&file.items, sink);
     decimal_file_mode::run(&file.items, sink);
     index_out_of_bounds::run(&file.items, sink);
+    json_serializable_fields::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);
     repeated_if_condition::run(&file.items, sink);
     temp_producing::run(&file.items, sink);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -5352,3 +5352,115 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn json_non_serializable_channel_field() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub struct Job {
+  id: int,
+  ch: Channel<int>,
+}
+"#
+    );
+}
+
+#[test]
+fn json_non_serializable_function_field() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub struct Task {
+  handler: fn(int) -> int,
+}
+"#
+    );
+}
+
+#[test]
+fn json_non_serializable_sender_field() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub struct Pipe {
+  tx: Sender<int>,
+}
+"#
+    );
+}
+
+#[test]
+fn json_non_serializable_receiver_field() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub struct Pipe {
+  rx: Receiver<int>,
+}
+"#
+    );
+}
+
+#[test]
+fn json_non_serializable_enum_tuple_payload() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub enum Event {
+  Tick,
+  Data(Channel<int>),
+}
+"#
+    );
+}
+
+#[test]
+fn json_non_serializable_enum_struct_field() {
+    assert_lint_snapshot!(
+        r#"
+#[json]
+pub enum Event {
+  Run { cb: fn() -> int },
+}
+"#
+    );
+}
+
+#[test]
+fn json_skipped_channel_field_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+#[json]
+pub struct Job {
+  #[json(skip)]
+  ch: Channel<int>,
+  id: int,
+}
+"#
+    );
+}
+
+#[test]
+fn json_serializable_struct_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+#[json]
+pub struct Job {
+  id: int,
+  name: string,
+}
+"#
+    );
+}
+
+#[test]
+fn non_json_channel_field_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Job {
+  ch: Channel<int>,
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/json_non_serializable_channel_field.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_channel_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:5:7]
+ 4 │   id: int,
+ 5 │   ch: Channel<int>,
+   ·       ──────┬─────
+   ·             ╰── a channel cannot be JSON-encoded
+ 6 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal channels. Drop the field, or exclude it with `#[json(skip)]` · code: [infer.json_non_serializable_field]

--- a/tests/ui/lint/snapshots/json_non_serializable_enum_struct_field.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_enum_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:4:13]
+ 3 │ pub enum Event {
+ 4 │   Run { cb: fn() -> int },
+   ·             ─────┬─────
+   ·                  ╰── a function cannot be JSON-encoded
+ 5 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal functions. Remove it from the variant · code: [infer.json_non_serializable_field]

--- a/tests/ui/lint/snapshots/json_non_serializable_enum_tuple_payload.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_enum_tuple_payload.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:5:8]
+ 4 │   Tick,
+ 5 │   Data(Channel<int>),
+   ·        ──────┬─────
+   ·              ╰── a channel cannot be JSON-encoded
+ 6 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal channels. Remove it from the variant · code: [infer.json_non_serializable_field]

--- a/tests/ui/lint/snapshots/json_non_serializable_function_field.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_function_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:4:12]
+ 3 │ pub struct Task {
+ 4 │   handler: fn(int) -> int,
+   ·            ───────┬──────
+   ·                   ╰── a function cannot be JSON-encoded
+ 5 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal functions. Drop the field, or exclude it with `#[json(skip)]` · code: [infer.json_non_serializable_field]

--- a/tests/ui/lint/snapshots/json_non_serializable_receiver_field.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_receiver_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:4:7]
+ 3 │ pub struct Pipe {
+ 4 │   rx: Receiver<int>,
+   ·       ──────┬──────
+   ·             ╰── a channel cannot be JSON-encoded
+ 5 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal channels. Drop the field, or exclude it with `#[json(skip)]` · code: [infer.json_non_serializable_field]

--- a/tests/ui/lint/snapshots/json_non_serializable_sender_field.snap
+++ b/tests/ui/lint/snapshots/json_non_serializable_sender_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Non-serializable field in a `#[json]` type
+   ╭─[test.lis:4:7]
+ 3 │ pub struct Pipe {
+ 4 │   tx: Sender<int>,
+   ·       ─────┬─────
+   ·            ╰── a channel cannot be JSON-encoded
+ 5 │ }
+   ╰────
+  help: Go's `encoding/json` cannot marshal channels. Drop the field, or exclude it with `#[json(skip)]` · code: [infer.json_non_serializable_field]


### PR DESCRIPTION
Adds an error for `#[json]` structs and enums with a channel- or function-typed field.

```
  [error] Non-serializable field in a `#[json]` type
   ╭─[test.lis:4:7]
 3 │ pub struct Pipe {
 4 │   tx: Sender<int>,
   ·       ─────┬─────
   ·            ╰── a channel cannot be JSON-encoded
 5 │ }
   ╰────
  help: Go's `encoding/json` cannot marshal channels. Drop the field, or exclude it with `#[json(skip)]` · code: [infer.json_non_serializable_field]
```
