### PR TITLE
fix: enforce consistent evaluation order in emit

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -10,6 +10,7 @@ use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::plan_variadic_spread;
 use crate::types::native::NativeGoType;
+use crate::utils::{contains_call, reads_mutable_operand};
 use syntax::ast::Expression;
 use syntax::types::peel_to_range_type;
 
@@ -405,13 +406,23 @@ impl Planner<'_> {
             unreachable!("expected DotAccess for native method call")
         };
 
-        let mut all_stages: Vec<StagedExpression> =
-            Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
-        all_stages.push(self.stage_operand(
+        let mut receiver_staged = self.stage_operand(
             expression,
             ExpressionContext::value().with_ambient_return_ctx_opt(ctx.ambient_return_ctx),
             fx,
-        ));
+        );
+        let receiver_is_call = matches!(expression.unwrap_parens(), Expression::Call { .. });
+        if !receiver_is_call
+            && reads_mutable_operand(expression)
+            && receiver_staged.setup.is_empty()
+            && (ctx.args.iter().any(contains_call) || ctx.spread.is_some_and(contains_call))
+        {
+            self.pin_staged(&mut receiver_staged, "recv");
+        }
+
+        let mut all_stages: Vec<StagedExpression> =
+            Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
+        all_stages.push(receiver_staged);
         all_stages.extend(self.stage_native_method_args(
             ctx.function,
             ctx.args,
@@ -504,8 +515,16 @@ impl Planner<'_> {
         ctx: &NativeCallContext,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
-        let stages =
+        let mut stages =
             self.stage_native_method_args(ctx.function, ctx.args, ctx.ambient_return_ctx, fx);
+        if let Some(receiver) = ctx.args.first()
+            && !matches!(receiver.unwrap_parens(), Expression::Call { .. })
+            && reads_mutable_operand(receiver)
+            && stages[0].setup.is_empty()
+            && (ctx.args[1..].iter().any(contains_call) || ctx.spread.is_some_and(contains_call))
+        {
+            self.pin_staged(&mut stages[0], "recv");
+        }
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(0));
         self.sequence_with_spread_structured(
             stages,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -15,6 +15,7 @@ use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallbackWrapperKind, NullableCoerceKind};
+use crate::utils::{contains_call, reads_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Annotation, Expression};
 use syntax::program::Definition;
@@ -188,6 +189,18 @@ impl<'a> Planner<'a> {
         };
         let (args_setup, args_strings) = self.emit_call_args(args, &args_ctx, fx);
 
+        let mut setup = callee_staged.setup;
+        let callee_needs_pin = setup.is_empty()
+            && type_args_string.is_empty()
+            && reads_mutable_operand(function)
+            && (!args_setup.is_empty()
+                || (!matches!(function, Expression::Call { .. })
+                    && (args.iter().any(contains_call) || spread.is_some_and(contains_call))));
+        if callee_needs_pin {
+            function_string =
+                self.hoist_tmp_value_statement(&mut setup, "callee", &function_string);
+        }
+
         let call_str = format!(
             "{}{}({})",
             function_string,
@@ -196,7 +209,6 @@ impl<'a> Planner<'a> {
         );
         let call_str = collapse_fmt_print(&function_string, args, &args_strings, call_str);
 
-        let mut setup = callee_staged.setup;
         setup.extend(args_setup);
 
         let has_array_return = call_plan.has_go_array_return();

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -6,6 +6,7 @@ use crate::Planner;
 use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
+use crate::is_order_sensitive;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::types::native::NativeGoType;
@@ -117,12 +118,12 @@ impl Planner<'_> {
             ));
         }
         let (mut setup, values) = self.sequence_structured(all_stages, "_base");
-        let base_str = &values[0];
+        let base_str = values[0].clone();
 
         let (start_str, end_expression) = if start.is_some() {
-            (values[1].as_str(), values.get(2).map(|s| s.as_str()))
+            (values[1].clone(), values.get(2).map(String::as_str))
         } else {
-            ("", values.get(1).map(|s| s.as_str()))
+            (String::new(), values.get(1).map(String::as_str))
         };
 
         let end_str = match (end_expression, inclusive) {
@@ -135,16 +136,30 @@ impl Planner<'_> {
             return (setup, format!("{}[{}:{}]", base_str, start_str, end_str));
         }
 
-        if end_str.is_empty() {
-            let len_var =
-                self.hoist_tmp_value_statement(&mut setup, "len", &format!("len({})", base_str));
-            return (
-                setup,
-                format!("{}[{}:{}:{}]", base_str, start_str, len_var, len_var),
-            );
-        }
-
-        if end_str.contains('(') {
+        if end_str.is_empty() || end_str.contains('(') {
+            let base_expr = expression.deref_inner().unwrap_or(expression);
+            let base_str = if is_order_sensitive(base_expr) {
+                self.hoist_tmp_value_statement(&mut setup, "base", &base_str)
+            } else {
+                base_str
+            };
+            if end_str.is_empty() {
+                let len_var = self.hoist_tmp_value_statement(
+                    &mut setup,
+                    "len",
+                    &format!("len({})", base_str),
+                );
+                return (
+                    setup,
+                    format!("{}[{}:{}:{}]", base_str, start_str, len_var, len_var),
+                );
+            }
+            let start_str = match start {
+                Some(s) if is_order_sensitive(s) => {
+                    self.hoist_tmp_value_statement(&mut setup, "start", &start_str)
+                }
+                _ => start_str,
+            };
             let end_var = self.hoist_tmp_value_statement(&mut setup, "end", &end_str);
             return (
                 setup,

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -45,6 +45,15 @@ impl Planner<'_> {
         }
     }
 
+    /// Pin a staged operand's value into a temp so it evaluates before any
+    /// later sibling.
+    pub(crate) fn pin_staged(&mut self, staged: &mut StagedExpression, prefix: &str) {
+        let value = std::mem::take(&mut staged.value);
+        let tmp = self.hoist_tmp_value_statement(&mut staged.setup, prefix, &value);
+        staged.value = tmp;
+        staged.capture = CapturePolicy::Never;
+    }
+
     pub(crate) fn emit_force_capture(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -14,6 +14,7 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{ValuePlan, setup_from_string, value_plan_from_statements};
 use crate::statements::assignments::is_lvalue_chain;
 use crate::types::native::NativeGoType;
+use crate::utils::contains_call;
 use crate::write_line;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
@@ -566,9 +567,9 @@ impl Planner<'_> {
 
         let mut buffer = String::new();
         let value = if receiver_is_lvalue {
-            let receiver_lv = self.emit_left_value_capturing(&mut buffer, unwrapped, false, fx);
+            let mut args_buffer = String::new();
             let args_str = self.emit_append_args(
-                &mut buffer,
+                &mut args_buffer,
                 func,
                 args,
                 (**spread).as_ref(),
@@ -576,6 +577,12 @@ impl Planner<'_> {
                 return_ctx,
                 fx,
             );
+            let rhs_has_setup = !args_buffer.is_empty()
+                || args.iter().any(contains_call)
+                || (**spread).as_ref().is_some_and(contains_call);
+            let receiver_lv =
+                self.emit_left_value_capturing(&mut buffer, unwrapped, rhs_has_setup, fx);
+            buffer.push_str(&args_buffer);
             format!("append({}, {})", receiver_lv, args_str)
         } else {
             self.emit_value(

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -9,7 +9,8 @@ use crate::names::go_name;
 use crate::plan::bodies::{AssignForm, AssignPlan, CompoundKind, LoweredBlock, LoweredStatement};
 use crate::plan::values::value_plan_from_statements;
 use crate::state::bindings::BindingValue;
-use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
+use crate::utils::observable_after_mutation;
+use syntax::ast::{BinaryOperator, Expression, FormatStringPart, Literal, UnaryOperator};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
@@ -61,28 +62,32 @@ impl Planner<'_> {
         }
 
         if let Some((op, rhs)) = detect_compound_assignment(target, value, compound_operator) {
+            let is_inc_dec = is_literal_one(rhs)
+                && matches!(op, BinaryOperator::Addition | BinaryOperator::Subtraction);
+            let (kind, rhs_has_setup) = if is_inc_dec {
+                let kind = if *op == BinaryOperator::Addition {
+                    CompoundKind::Increment
+                } else {
+                    CompoundKind::Decrement
+                };
+                (kind, false)
+            } else {
+                let staged = self.stage_operand(rhs, ExpressionContext::value(), fx);
+                let rhs_has_setup =
+                    !staged.setup.is_empty() || self.rhs_contains_effectful_call(rhs);
+                let kind = CompoundKind::OpAssign {
+                    op_text: format!("{}", op),
+                    rhs: value_plan_from_statements(staged.setup, staged.value),
+                };
+                (kind, rhs_has_setup)
+            };
             let mut target_setup = String::new();
             let target_str = if is_order_sensitive(target) {
-                self.emit_left_value_capturing(&mut target_setup, target, false, fx)
+                self.emit_left_value_capturing(&mut target_setup, target, rhs_has_setup, fx)
             } else {
                 self.emit_left_value(&mut target_setup, target, fx)
             };
             let target_capture = capture_to_vec(target_setup);
-            let is_inc_dec = is_literal_one(rhs)
-                && matches!(op, BinaryOperator::Addition | BinaryOperator::Subtraction);
-            let kind = if is_inc_dec {
-                if *op == BinaryOperator::Addition {
-                    CompoundKind::Increment
-                } else {
-                    CompoundKind::Decrement
-                }
-            } else {
-                let staged = self.stage_operand(rhs, ExpressionContext::value(), fx);
-                CompoundKind::OpAssign {
-                    op_text: format!("{}", op),
-                    rhs: value_plan_from_statements(staged.setup, staged.value),
-                }
-            };
             return AssignPlan {
                 directive,
                 form: AssignForm::Compound {
@@ -141,7 +146,7 @@ impl Planner<'_> {
             ExpressionContext::value().with_ambient_return_ctx(return_ctx),
             fx,
         );
-        let rhs_has_setup = !rhs_staged.setup.is_empty();
+        let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
         let mut target_setup = String::new();
         let target_str = if is_order_sensitive(target) {
             self.emit_left_value_capturing(&mut target_setup, target, rhs_has_setup, fx)
@@ -174,6 +179,89 @@ impl Planner<'_> {
                 value: value_plan_from_statements(value_setup, final_value),
             },
         }
+    }
+
+    fn rhs_contains_effectful_call(&self, expression: &Expression) -> bool {
+        match expression.unwrap_parens() {
+            Expression::Call {
+                expression: callee,
+                args,
+                spread,
+                ..
+            } => {
+                if self.is_pure_constructor_callee(callee) {
+                    args.iter().any(|a| self.rhs_contains_effectful_call(a))
+                        || (**spread)
+                            .as_ref()
+                            .is_some_and(|s| self.rhs_contains_effectful_call(s))
+                } else {
+                    true
+                }
+            }
+            Expression::Binary { left, right, .. } => {
+                self.rhs_contains_effectful_call(left) || self.rhs_contains_effectful_call(right)
+            }
+            Expression::Unary { expression, .. }
+            | Expression::DotAccess { expression, .. }
+            | Expression::Cast { expression, .. }
+            | Expression::Reference { expression, .. } => {
+                self.rhs_contains_effectful_call(expression)
+            }
+            Expression::IndexedAccess {
+                expression, index, ..
+            } => {
+                self.rhs_contains_effectful_call(expression)
+                    || self.rhs_contains_effectful_call(index)
+            }
+            Expression::Tuple { elements, .. } => {
+                elements.iter().any(|e| self.rhs_contains_effectful_call(e))
+            }
+            Expression::StructCall {
+                field_assignments,
+                spread,
+                ..
+            } => {
+                field_assignments
+                    .iter()
+                    .any(|f| self.rhs_contains_effectful_call(&f.value))
+                    || spread
+                        .as_expression()
+                        .is_some_and(|s| self.rhs_contains_effectful_call(s))
+            }
+            Expression::Literal {
+                literal: Literal::Slice(elements),
+                ..
+            } => elements.iter().any(|e| self.rhs_contains_effectful_call(e)),
+            Expression::Literal {
+                literal: Literal::FormatString(parts),
+                ..
+            } => parts.iter().any(|part| match part {
+                FormatStringPart::Expression(e) => self.rhs_contains_effectful_call(e),
+                FormatStringPart::Text(_) => false,
+            }),
+            Expression::Range { start, end, .. } => {
+                start
+                    .as_deref()
+                    .is_some_and(|e| self.rhs_contains_effectful_call(e))
+                    || end
+                        .as_deref()
+                        .is_some_and(|e| self.rhs_contains_effectful_call(e))
+            }
+            _ => false,
+        }
+    }
+
+    fn is_pure_constructor_callee(&self, callee: &Expression) -> bool {
+        let name = match callee.unwrap_parens() {
+            Expression::Identifier { value, .. } => Some(value.as_str()),
+            Expression::DotAccess { member, .. } => Some(member.as_str()),
+            _ => None,
+        };
+        if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
+            return true;
+        }
+        self.callee_definition(callee)
+            .is_some_and(|definition| definition.is_type_definition())
     }
 
     fn target_binds_to_discard(&self, target: &Expression) -> bool {
@@ -228,7 +316,7 @@ impl Planner<'_> {
                 operator: UnaryOperator::Deref,
                 expression,
                 ..
-            } => self.emit_deref_lvalue(output, expression, fx),
+            } => self.emit_deref_lvalue(output, expression, false, fx),
             Expression::Call { .. } if expression.get_type().is_ref() => {
                 let call_str =
                     self.emit_operand(output, expression, ExpressionContext::value(), fx);
@@ -239,15 +327,19 @@ impl Planner<'_> {
     }
 
     /// Emit `*X` lvalue form, capturing the pointee into a temp if it's a
-    /// call (Go requires an addressable operand for deref-assignment).
+    /// call (Go requires an addressable operand for deref-assignment) or when
+    /// RHS setup could reassign the pointer before the write executes.
     fn emit_deref_lvalue(
         &mut self,
         output: &mut String,
         pointee: &Expression,
+        rhs_has_setup: bool,
         fx: &mut EmitEffects,
     ) -> String {
         let pointee_string = self.emit_operand(output, pointee, ExpressionContext::value(), fx);
-        if matches!(pointee.unwrap_parens(), Expression::Call { .. }) {
+        let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
+            || (rhs_has_setup && observable_after_mutation(pointee));
+        if needs_capture {
             let tmp = self.hoist_tmp_value(output, "ref", &pointee_string);
             return format!("*{}", tmp);
         }
@@ -308,9 +400,15 @@ impl Planner<'_> {
                 ..
             } => {
                 let base_str = if let Some(inner) = base.deref_inner() {
-                    self.emit_operand(output, inner, ExpressionContext::value(), fx)
+                    if rhs_has_setup {
+                        self.emit_force_capture(output, inner, "ref", fx)
+                    } else {
+                        self.emit_operand(output, inner, ExpressionContext::value(), fx)
+                    }
                 } else if is_order_sensitive(base) {
                     self.emit_left_value_capturing(output, base, rhs_has_setup, fx)
+                } else if rhs_has_setup && base.get_type().is_ref() {
+                    self.emit_force_capture(output, base, "ref", fx)
                 } else {
                     self.emit_left_value(output, base, fx)
                 };
@@ -321,7 +419,7 @@ impl Planner<'_> {
                 operator: UnaryOperator::Deref,
                 expression: inner,
                 ..
-            } => self.emit_deref_lvalue(output, inner, fx),
+            } => self.emit_deref_lvalue(output, inner, rhs_has_setup, fx),
             _ => self.emit_left_value(output, expression, fx),
         }
     }

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use syntax::ast::Expression;
+use syntax::ast::{Expression, FormatStringPart, Literal, UnaryOperator};
+use syntax::program::DotAccessKind;
 
 macro_rules! write_line {
     ($dst:expr, $($arg:tt)*) => {
@@ -129,6 +130,28 @@ pub(crate) fn contains_call(expression: &Expression) -> bool {
             expression, index, ..
         } => contains_call(expression) || contains_call(index),
         Expression::Tuple { elements, .. } => elements.iter().any(contains_call),
+        Expression::StructCall {
+            field_assignments,
+            spread,
+            ..
+        } => {
+            field_assignments.iter().any(|f| contains_call(&f.value))
+                || spread.as_expression().is_some_and(contains_call)
+        }
+        Expression::Literal {
+            literal: Literal::Slice(elements),
+            ..
+        } => elements.iter().any(contains_call),
+        Expression::Literal {
+            literal: Literal::FormatString(parts),
+            ..
+        } => parts.iter().any(|part| match part {
+            FormatStringPart::Expression(e) => contains_call(e),
+            FormatStringPart::Text(_) => false,
+        }),
+        Expression::Range { start, end, .. } => {
+            start.as_deref().is_some_and(contains_call) || end.as_deref().is_some_and(contains_call)
+        }
         Expression::If { .. }
         | Expression::IfLet { .. }
         | Expression::Match { .. }
@@ -153,6 +176,29 @@ pub(crate) fn is_order_sensitive(expression: &Expression) -> bool {
 /// re-evaluate.
 pub(crate) fn observable_after_mutation(expression: &Expression) -> bool {
     !matches!(expression.unwrap_parens(), Expression::Literal { .. })
+}
+
+pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::IndexedAccess { .. } | Expression::Call { .. } => true,
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            ..
+        } => true,
+        Expression::DotAccess {
+            expression,
+            dot_access_kind,
+            ..
+        } => match dot_access_kind {
+            Some(
+                DotAccessKind::StructField { .. }
+                | DotAccessKind::TupleStructField { .. }
+                | DotAccessKind::TupleElement,
+            ) => true,
+            _ => reads_mutable_operand(expression),
+        },
+        _ => false,
+    }
 }
 
 /// True when the last emitted Go line is `break`, `continue`, `return`, or `panic`.

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4193,3 +4193,319 @@ fn run() -> Result<int, error> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn slice_range_capped_callable_bounds_eval_order() {
+    let input = r#"
+fn start() -> int { 1 }
+fn end() -> int { 3 }
+
+fn test() -> int {
+  let xs = [10, 20, 30, 40]
+  let ys = xs[start()..end()]
+  ys.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_range_capped_open_base_evaluated_once() {
+    let input = r#"
+fn make_items() -> Slice<int> { [10, 20, 30] }
+
+fn test() -> int {
+  let ys = make_items()[1..]
+  ys.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_receiver_append_arg_mutates_index() {
+    let input = r#"
+fn bump(i: Ref<int>) -> int {
+  i.* = 1
+  99
+}
+
+fn test() -> int {
+  let xss = [[10], [20]]
+  let mut i = 0
+  let ys = xss[i].append(bump(&i))
+  ys[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_receiver_extend_arg_mutates_index() {
+    let input = r#"
+fn bump_and_make(i: Ref<int>) -> Slice<int> {
+  i.* = 1
+  [99]
+}
+
+fn test() -> int {
+  let xss = [[10], [20]]
+  let mut i = 0
+  let ys = xss[i].extend(bump_and_make(&i))
+  ys[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn call_callee_eval_order_propagate_arg() {
+    let input = r#"
+fn make_f(i: Ref<int>) -> fn(int) -> int {
+  |x: int| -> int { x }
+}
+
+fn get(i: Ref<int>) -> Result<int, string> {
+  i.* = 1
+  Ok(7)
+}
+
+fn run() -> Result<int, string> {
+  let mut i = 0
+  let y = make_f(&i)(get(&i)?)
+  Ok(y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn compound_index_target_frozen_before_rhs() {
+    let input = r#"
+fn run() -> Result<(), string> {
+  let mut xs = [10, 20]
+  let mut i = 0
+  let bump = || -> Result<int, string> {
+    i = 1
+    Ok(5)
+  }
+  xs[i] += bump()?
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pointer_deref_target_frozen_before_rhs() {
+    let input = r#"
+fn run() -> Result<(), string> {
+  let mut a = 10
+  let mut b = 20
+  let mut p = &a
+  let bump = || -> Result<int, string> {
+    p = &b
+    Ok(5)
+  }
+  p.* = bump()?
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pointer_deref_field_target_frozen_before_rhs() {
+    let input = r#"
+struct Box { value: int }
+
+fn run() -> Result<(), string> {
+  let mut a = Box { value: 10 }
+  let mut b = Box { value: 20 }
+  let mut p = &a
+  let bump = || -> Result<int, string> {
+    p = &b
+    Ok(5)
+  }
+  p.*.value = bump()?
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pointer_implicit_field_target_frozen_before_rhs() {
+    let input = r#"
+struct Box { value: int }
+
+fn run() -> Result<(), string> {
+  let mut a = Box { value: 10 }
+  let mut b = Box { value: 20 }
+  let mut p = &a
+  let bump = || -> Result<int, string> {
+    p = &b
+    Ok(5)
+  }
+  p.value = bump()?
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn compound_index_target_frozen_before_call_rhs() {
+    let input = r#"
+fn run() -> int {
+  let mut xs = [10, 20]
+  let mut i = 0
+  let bump = || -> int { i = 1; 5 }
+  xs[i] += bump()
+  xs[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pointer_deref_target_frozen_before_call_rhs() {
+    let input = r#"
+fn run() -> int {
+  let mut a = 10
+  let mut b = 20
+  let mut p = &a
+  let repoint = || -> int { p = &b; 5 }
+  p.* = repoint()
+  a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selector_callee_eval_order_captured() {
+    let input = r#"
+fn f0(x: int) -> int { x + 10 }
+fn f1(x: int) -> int { x + 20 }
+struct Handler { f: fn(int) -> int }
+
+fn run() -> Result<int, string> {
+  let hs = [Handler { f: f0 }, Handler { f: f1 }]
+  let mut i = 0
+  let get = || -> Result<int, string> { i = 1; Ok(7) }
+  let y = hs[i].f(get()?)
+  Ok(y)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selector_receiver_append_arg_mutates_index() {
+    let input = r#"
+struct Holder { slc: Slice<int> }
+fn bump(i: Ref<int>) -> int { i.* = 1; 99 }
+
+fn run() -> int {
+  let hs = [Holder { slc: [10] }, Holder { slc: [20] }]
+  let mut i = 0
+  let ys = hs[i].slc.append(bump(&i))
+  ys[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn index_target_constructor_rhs_not_frozen() {
+    let input = r#"
+struct Wrap(int)
+
+fn run() -> int {
+  let mut xs = [Wrap(0), Wrap(0)]
+  let i = 0
+  xs[i] = Wrap(5)
+  xs[0].0
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_literal_arg_callee_eval_order() {
+    let input = r#"
+struct Box { v: int }
+fn f0(b: Box) -> int { b.v }
+fn f1(b: Box) -> int { b.v }
+
+fn run() -> int {
+  let fs = [f0, f1]
+  let mut i = 0
+  let bump = || -> int { i = 1; 7 }
+  let y = fs[i](Box { v: bump() })
+  y
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_literal_rhs_index_target_frozen() {
+    let input = r#"
+fn run() -> int {
+  let mut xs = [[0], [0]]
+  let mut i = 0
+  let bump = || -> int { i = 1; 5 }
+  xs[i] = [bump()]
+  xs[0][0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn field_receiver_append_arg_mutates_field() {
+    let input = r#"
+struct Holder { slc: Slice<int> }
+
+fn run() -> int {
+  let mut h = Holder { slc: [10] }
+  let bump = || -> int { h.slc = [99]; 7 }
+  let ys = h.slc.append(bump())
+  ys[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn range_rhs_index_target_frozen() {
+    let input = r#"
+fn lo() -> int { 0 }
+
+fn run() -> int {
+  let mut rs = [0..0, 0..0]
+  let mut i = 0
+  let bump = || -> int { i = 1; 5 }
+  rs[i] = lo()..bump()
+  rs[0].end
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn identifier_native_receiver_arg_mutates_index() {
+    let input = r#"
+fn bump(i: Ref<int>) -> int { i.* = 1; 99 }
+
+fn run() -> int {
+  let xss = [[10], [20]]
+  let mut i = 0
+  let ys = Slice.append(xss[i], bump(&i))
+  ys[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_carrier_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_carrier_ref.snap
@@ -36,6 +36,7 @@ func main() {
 		h:  &h,
 		np: &b,
 	}
-	*h.p = retarget(c)
+	ref_1 := h.p
+	*ref_1 = retarget(c)
 	_ = a
 }

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_match_hidden_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_match_hidden_ref.snap
@@ -36,12 +36,13 @@ func main() {
 		h:  &h,
 		np: &b,
 	}
+	ref_2 := h.p
 	var tmp_1 int
 	if 0 == 0 {
 		tmp_1 = retarget(c)
 	} else {
 		tmp_1 = 0
 	}
-	*h.p = tmp_1
+	*ref_2 = tmp_1
 	_ = a
 }

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_prebound_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_prebound_ref.snap
@@ -25,6 +25,7 @@ func main() {
 	h := Holder{p: &a}
 	hp := &h
 	np := &b
-	*h.p = retarget(hp, np)
+	ref_1 := h.p
+	*ref_1 = retarget(hp, np)
 	_ = a
 }

--- a/tests/spec/emit/snapshots/call_callee_eval_order_propagate_arg.snap
+++ b/tests/spec/emit/snapshots/call_callee_eval_order_propagate_arg.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn make_f(i: Ref<int>) -> fn(int) -> int {\n  |x: int| -> int { x }\n}\n\nfn get(i: Ref<int>) -> Result<int, string> {\n  i.* = 1\n  Ok(7)\n}\n\nfn run() -> Result<int, string> {\n  let mut i = 0\n  let y = make_f(&i)(get(&i)?)\n  Ok(y)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func make_f(_ *int) func(int) int {
+	return func(x int) int {
+		return x
+	}
+}
+
+func get(i *int) lisette.Result[int, string] {
+	*i = 1
+	return lisette.MakeResultOk[int, string](7)
+}
+
+func run() lisette.Result[int, string] {
+	i := 0
+	callee_2 := make_f(&i)
+	check_1 := get(&i)
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
+	}
+	y := callee_2(check_1.OkVal)
+	return lisette.MakeResultOk[int, string](y)
+}

--- a/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
+++ b/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
@@ -23,7 +23,8 @@ func main() {
 	a := 1
 	b := 2
 	h := H{ptr: &a}
-	*h.ptr += h.repoint(&b)
+	ref_1 := h.ptr
+	*ref_1 += h.repoint(&b)
 	_ = a
 	_ = b
 }

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn run() -> int {\n  let mut xs = [10, 20]\n  let mut i = 0\n  let bump = || -> int { i = 1; 5 }\n  xs[i] += bump()\n  xs[0]\n}\n"
+---
+package main
+
+func run() int {
+	xs := []int{10, 20}
+	i := 0
+	bump := func() int {
+		i = 1
+		return 5
+	}
+	idx_1 := i
+	xs[idx_1] += bump()
+	return xs[0]
+}

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn run() -> Result<(), string> {\n  let mut xs = [10, 20]\n  let mut i = 0\n  let bump = || -> Result<int, string> {\n    i = 1\n    Ok(5)\n  }\n  xs[i] += bump()?\n  Ok(())\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func run() lisette.Result[struct{}, string] {
+	xs := []int{10, 20}
+	i := 0
+	bump := func() lisette.Result[int, string] {
+		i = 1
+		return lisette.MakeResultOk[int, string](5)
+	}
+	idx_2 := i
+	check_1 := bump()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
+	}
+	xs[idx_2] += check_1.OkVal
+	return lisette.MakeResultOk[struct{}, string](struct{}{})
+}

--- a/tests/spec/emit/snapshots/deref_assignment_target_captured_before_rhs.snap
+++ b/tests/spec/emit/snapshots/deref_assignment_target_captured_before_rhs.snap
@@ -23,7 +23,8 @@ func main() {
 	a := 1
 	b := 2
 	h := H{ptr: &a}
-	*h.ptr = h.repoint(&b)
+	ref_1 := h.ptr
+	*ref_1 = h.repoint(&b)
 	_ = a
 	_ = b
 }

--- a/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
+++ b/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Holder { slc: Slice<int> }\n\nfn run() -> int {\n  let mut h = Holder { slc: [10] }\n  let bump = || -> int { h.slc = [99]; 7 }\n  let ys = h.slc.append(bump())\n  ys[0]\n}\n"
+---
+package main
+
+import "fmt"
+
+type Holder struct {
+	slc []int
+}
+
+func (h Holder) String() string {
+	return fmt.Sprintf("Holder { slc: %v }", h.slc)
+}
+
+func run() int {
+	h := Holder{slc: []int{10}}
+	bump := func() int {
+		h.slc = []int{99}
+		return 7
+	}
+	recv_1 := h.slc
+	ys := append(recv_1, bump())
+	return ys[0]
+}

--- a/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn bump(i: Ref<int>) -> int { i.* = 1; 99 }\n\nfn run() -> int {\n  let xss = [[10], [20]]\n  let mut i = 0\n  let ys = Slice.append(xss[i], bump(&i))\n  ys[0]\n}\n"
+---
+package main
+
+func bump(i *int) int {
+	*i = 1
+	return 99
+}
+
+func run() int {
+	xss := [][]int{[]int{10}, []int{20}}
+	i := 0
+	recv_1 := xss[i]
+	ys := append(recv_1, bump(&i))
+	return ys[0]
+}

--- a/tests/spec/emit/snapshots/index_target_constructor_rhs_not_frozen.snap
+++ b/tests/spec/emit/snapshots/index_target_constructor_rhs_not_frozen.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Wrap(int)\n\nfn run() -> int {\n  let mut xs = [Wrap(0), Wrap(0)]\n  let i = 0\n  xs[i] = Wrap(5)\n  xs[0].0\n}\n"
+---
+package main
+
+import "fmt"
+
+type Wrap int
+
+func (w Wrap) String() string {
+	return fmt.Sprintf("Wrap(%v)", int(w))
+}
+
+func run() int {
+	xs := []Wrap{Wrap(0), Wrap(0)}
+	i := 0
+	xs[i] = Wrap(5)
+	return int(xs[0])
+}

--- a/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn bump(i: Ref<int>) -> int {\n  i.* = 1\n  99\n}\n\nfn test() -> int {\n  let xss = [[10], [20]]\n  let mut i = 0\n  let ys = xss[i].append(bump(&i))\n  ys[0]\n}\n"
+---
+package main
+
+func bump(i *int) int {
+	*i = 1
+	return 99
+}
+
+func test() int {
+	xss := [][]int{[]int{10}, []int{20}}
+	i := 0
+	recv_1 := xss[i]
+	ys := append(recv_1, bump(&i))
+	return ys[0]
+}

--- a/tests/spec/emit/snapshots/indexed_receiver_extend_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_extend_arg_mutates_index.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn bump_and_make(i: Ref<int>) -> Slice<int> {\n  i.* = 1\n  [99]\n}\n\nfn test() -> int {\n  let xss = [[10], [20]]\n  let mut i = 0\n  let ys = xss[i].extend(bump_and_make(&i))\n  ys[0]\n}\n"
+---
+package main
+
+func bump_and_make(i *int) []int {
+	*i = 1
+	return []int{99}
+}
+
+func test() int {
+	xss := [][]int{[]int{10}, []int{20}}
+	i := 0
+	recv_1 := xss[i]
+	ys := append(recv_1, bump_and_make(&i)...)
+	return ys[0]
+}

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -18,6 +18,7 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	*m["a"].items = append(*m["a"].items, 2)
+	ref_1 := m["a"].items
+	*ref_1 = append(*m["a"].items, 2)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -16,6 +16,7 @@ func main() {
 	w := Wrap([]int{1})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	*m["a"] = Wrap(append([]int(*m["a"]), 2))
+	ref_1 := m["a"]
+	*ref_1 = Wrap(append([]int(*m["a"]), 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/pointer_deref_field_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_deref_field_target_frozen_before_rhs.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Box { value: int }\n\nfn run() -> Result<(), string> {\n  let mut a = Box { value: 10 }\n  let mut b = Box { value: 20 }\n  let mut p = &a\n  let bump = || -> Result<int, string> {\n    p = &b\n    Ok(5)\n  }\n  p.*.value = bump()?\n  Ok(())\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Box struct {
+	value int
+}
+
+func (b Box) String() string {
+	return fmt.Sprintf("Box { value: %v }", b.value)
+}
+
+func run() lisette.Result[struct{}, string] {
+	a := Box{value: 10}
+	b := Box{value: 20}
+	p := &a
+	bump := func() lisette.Result[int, string] {
+		p = &b
+		return lisette.MakeResultOk[int, string](5)
+	}
+	ref_2 := p
+	check_1 := bump()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
+	}
+	ref_2.value = check_1.OkVal
+	return lisette.MakeResultOk[struct{}, string](struct{}{})
+}

--- a/tests/spec/emit/snapshots/pointer_deref_target_frozen_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_deref_target_frozen_before_call_rhs.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn run() -> int {\n  let mut a = 10\n  let mut b = 20\n  let mut p = &a\n  let repoint = || -> int { p = &b; 5 }\n  p.* = repoint()\n  a\n}\n"
+---
+package main
+
+func run() int {
+	a := 10
+	b := 20
+	p := &a
+	repoint := func() int {
+		p = &b
+		return 5
+	}
+	ref_1 := p
+	*ref_1 = repoint()
+	return a
+}

--- a/tests/spec/emit/snapshots/pointer_deref_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_deref_target_frozen_before_rhs.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn run() -> Result<(), string> {\n  let mut a = 10\n  let mut b = 20\n  let mut p = &a\n  let bump = || -> Result<int, string> {\n    p = &b\n    Ok(5)\n  }\n  p.* = bump()?\n  Ok(())\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func run() lisette.Result[struct{}, string] {
+	a := 10
+	b := 20
+	p := &a
+	bump := func() lisette.Result[int, string] {
+		p = &b
+		return lisette.MakeResultOk[int, string](5)
+	}
+	ref_2 := p
+	check_1 := bump()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
+	}
+	*ref_2 = check_1.OkVal
+	return lisette.MakeResultOk[struct{}, string](struct{}{})
+}

--- a/tests/spec/emit/snapshots/pointer_implicit_field_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_implicit_field_target_frozen_before_rhs.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Box { value: int }\n\nfn run() -> Result<(), string> {\n  let mut a = Box { value: 10 }\n  let mut b = Box { value: 20 }\n  let mut p = &a\n  let bump = || -> Result<int, string> {\n    p = &b\n    Ok(5)\n  }\n  p.value = bump()?\n  Ok(())\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Box struct {
+	value int
+}
+
+func (b Box) String() string {
+	return fmt.Sprintf("Box { value: %v }", b.value)
+}
+
+func run() lisette.Result[struct{}, string] {
+	a := Box{value: 10}
+	b := Box{value: 20}
+	p := &a
+	bump := func() lisette.Result[int, string] {
+		p = &b
+		return lisette.MakeResultOk[int, string](5)
+	}
+	ref_2 := p
+	check_1 := bump()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
+	}
+	ref_2.value = check_1.OkVal
+	return lisette.MakeResultOk[struct{}, string](struct{}{})
+}

--- a/tests/spec/emit/snapshots/range_rhs_index_target_frozen.snap
+++ b/tests/spec/emit/snapshots/range_rhs_index_target_frozen.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn lo() -> int { 0 }\n\nfn run() -> int {\n  let mut rs = [0..0, 0..0]\n  let mut i = 0\n  let bump = || -> int { i = 1; 5 }\n  rs[i] = lo()..bump()\n  rs[0].end\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func lo() int {
+	return 0
+}
+
+func run() int {
+	rs := []lisette.Range[int]{
+		lisette.Range[int]{
+			Start: 0,
+			End:   0,
+		},
+		lisette.Range[int]{
+			Start: 0,
+			End:   0,
+		},
+	}
+	i := 0
+	bump := func() int {
+		i = 1
+		return 5
+	}
+	idx_1 := i
+	rs[idx_1] = lisette.Range[int]{
+		Start: lo(),
+		End:   bump(),
+	}
+	return rs[0].End
+}

--- a/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
@@ -18,5 +18,6 @@ func arg() int {
 }
 
 func main() {
-	_ = append(*get(), arg())
+	recv_1 := *get()
+	_ = append(recv_1, arg())
 }

--- a/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
@@ -15,6 +15,7 @@ func (w Wrap) String() string {
 func main() {
 	w := Wrap([]int{1})
 	r := &w
-	*r = Wrap(append([]int(*r), 2))
+	ref_1 := r
+	*ref_1 = Wrap(append([]int(*r), 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/ref_slice_append_statement_rewrite.snap
+++ b/tests/spec/emit/snapshots/ref_slice_append_statement_rewrite.snap
@@ -7,6 +7,7 @@ package main
 func main() {
 	s := []int{1}
 	r := &s
-	*r = append(*r, 2)
+	ref_1 := r
+	*ref_1 = append(*r, 2)
 	_ = s
 }

--- a/tests/spec/emit/snapshots/regular_call_callee_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/regular_call_callee_eval_order_captured.snap
@@ -20,6 +20,7 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	fs := []func(int) int{f0, f1}
-	r := fs[i](bump(&i))
+	callee_1 := fs[i]
+	r := callee_1(bump(&i))
 	_ = r
 }

--- a/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn f0(x: int) -> int { x + 10 }\nfn f1(x: int) -> int { x + 20 }\nstruct Handler { f: fn(int) -> int }\n\nfn run() -> Result<int, string> {\n  let hs = [Handler { f: f0 }, Handler { f: f1 }]\n  let mut i = 0\n  let get = || -> Result<int, string> { i = 1; Ok(7) }\n  let y = hs[i].f(get()?)\n  Ok(y)\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func f0(x int) int {
+	return x + 10
+}
+
+func f1(x int) int {
+	return x + 20
+}
+
+type Handler struct {
+	f func(int) int
+}
+
+func (h Handler) String() string {
+	return fmt.Sprintf("Handler { f: %p }", h.f)
+}
+
+func run() lisette.Result[int, string] {
+	hs := []Handler{Handler{f: f0}, Handler{f: f1}}
+	i := 0
+	get := func() lisette.Result[int, string] {
+		i = 1
+		return lisette.MakeResultOk[int, string](7)
+	}
+	callee_2 := hs[i].f
+	check_1 := get()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
+	}
+	y := callee_2(check_1.OkVal)
+	return lisette.MakeResultOk[int, string](y)
+}

--- a/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Holder { slc: Slice<int> }\nfn bump(i: Ref<int>) -> int { i.* = 1; 99 }\n\nfn run() -> int {\n  let hs = [Holder { slc: [10] }, Holder { slc: [20] }]\n  let mut i = 0\n  let ys = hs[i].slc.append(bump(&i))\n  ys[0]\n}\n"
+---
+package main
+
+import "fmt"
+
+type Holder struct {
+	slc []int
+}
+
+func (h Holder) String() string {
+	return fmt.Sprintf("Holder { slc: %v }", h.slc)
+}
+
+func bump(i *int) int {
+	*i = 1
+	return 99
+}
+
+func run() int {
+	hs := []Holder{Holder{slc: []int{10}}, Holder{slc: []int{20}}}
+	i := 0
+	recv_1 := hs[i].slc
+	ys := append(recv_1, bump(&i))
+	return ys[0]
+}

--- a/tests/spec/emit/snapshots/slice_literal_rhs_index_target_frozen.snap
+++ b/tests/spec/emit/snapshots/slice_literal_rhs_index_target_frozen.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn run() -> int {\n  let mut xs = [[0], [0]]\n  let mut i = 0\n  let bump = || -> int { i = 1; 5 }\n  xs[i] = [bump()]\n  xs[0][0]\n}\n"
+---
+package main
+
+func run() int {
+	xs := [][]int{[]int{0}, []int{0}}
+	i := 0
+	bump := func() int {
+		i = 1
+		return 5
+	}
+	idx_1 := i
+	xs[idx_1] = []int{bump()}
+	return xs[0][0]
+}

--- a/tests/spec/emit/snapshots/slice_range_capped_callable_bounds_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_capped_callable_bounds_eval_order.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn start() -> int { 1 }\nfn end() -> int { 3 }\n\nfn test() -> int {\n  let xs = [10, 20, 30, 40]\n  let ys = xs[start()..end()]\n  ys.length()\n}\n"
+---
+package main
+
+func start() int {
+	return 1
+}
+
+func end() int {
+	return 3
+}
+
+func test() int {
+	xs := []int{10, 20, 30, 40}
+	start_1 := start()
+	end_2 := end()
+	ys := xs[start_1:end_2:end_2]
+	return len(ys)
+}

--- a/tests/spec/emit/snapshots/slice_range_capped_open_base_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/slice_range_capped_open_base_evaluated_once.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nfn make_items() -> Slice<int> { [10, 20, 30] }\n\nfn test() -> int {\n  let ys = make_items()[1..]\n  ys.length()\n}\n"
+---
+package main
+
+func make_items() []int {
+	return []int{10, 20, 30}
+}
+
+func test() int {
+	base_1 := make_items()
+	len_2 := len(base_1)
+	ys := base_1[1:len_2:len_2]
+	return len(ys)
+}

--- a/tests/spec/emit/snapshots/struct_literal_arg_callee_eval_order.snap
+++ b/tests/spec/emit/snapshots/struct_literal_arg_callee_eval_order.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "input: \nstruct Box { v: int }\nfn f0(b: Box) -> int { b.v }\nfn f1(b: Box) -> int { b.v }\n\nfn run() -> int {\n  let fs = [f0, f1]\n  let mut i = 0\n  let bump = || -> int { i = 1; 7 }\n  let y = fs[i](Box { v: bump() })\n  y\n}\n"
+---
+package main
+
+import "fmt"
+
+type Box struct {
+	v int
+}
+
+func (b Box) String() string {
+	return fmt.Sprintf("Box { v: %v }", b.v)
+}
+
+func f0(b Box) int {
+	return b.v
+}
+
+func f1(b Box) int {
+	return b.v
+}
+
+func run() int {
+	fs := []func(Box) int{f0, f1}
+	i := 0
+	bump := func() int {
+		i = 1
+		return 7
+	}
+	callee_1 := fs[i]
+	y := callee_1(Box{v: bump()})
+	return y
+}


### PR DESCRIPTION
Lis evaluates expressions left to right, but it was possible for the emitted Go to read an indexed receiver, computed callee, slice bound, or assignment target _after_ a sibling expession had already changed a value it depended on, leading to the wrong slot, fn or ptr being used at runtime. Hence this PR pins those operands into a temp before the sibling runs, so eval order matches the source order.

For example:

```rs
fn bump(i: Ref<int>) -> int {
  i.* = 1
  99
}

fn main() {
  let xss = [[10], [20]]
  let mut i = 0
  let ys = xss[i].append(bump(&i))  // i is 0 when xss[i] is chosen
  print(ys[0])                      // 10  (previously printed 20)
}
```

Source order says `xss[i]` is chosen while `i` is still `0`, so the append targets `xss[0]` and `ys[0]` is `10`. Previously the emitted Go ran `bump(&i)` first, bumping `i` to `1`, so it appended to `xss[1]` and printed `20`. The fix captures `xss[i]` into a temp before `bump` runs, so the receiver is locked in at the source-order moment.