### PR TITLE
fix: emit middle index for capped range-from slice

### DIFF
--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -208,11 +208,11 @@ fn emit_range_var_slice(base: &str, range: &str, range_kind: &str, needs_cap: bo
         return format!("{}[{}:{}]", base, start_str, end_str);
     }
 
-    let cap = if end_str.is_empty() {
+    let bound = if end_str.is_empty() {
         format!("len({})", base)
     } else {
         end_str.to_string()
     };
 
-    format!("{}[{}:{}:{}]", base, start_str, end_str, cap)
+    format!("{}[{}:{}:{}]", base, start_str, bound, bound)
 }

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -1008,6 +1008,17 @@ fn test(xs: Slice<int>, r: Prefix) -> Slice<int> {
 }
 
 #[test]
+fn slice_index_aliased_range_from() {
+    let input = r#"
+type Suffix = RangeFrom<int>
+fn test(xs: Slice<int>, r: Suffix) -> Slice<int> {
+  xs[r]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn mut_subslice_clones_for_aliased_range() {
     let input = r#"
 type Prefix = Range<int>

--- a/tests/spec/emit/snapshots/slice_index_aliased_range_from.snap
+++ b/tests/spec/emit/snapshots/slice_index_aliased_range_from.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "input: \ntype Suffix = RangeFrom<int>\nfn test(xs: Slice<int>, r: Suffix) -> Slice<int> {\n  xs[r]\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Suffix = lisette.RangeFrom[int]
+
+func test(xs []int, r Suffix) []int {
+	return xs[r.Start:len(xs):len(xs)]
+}


### PR DESCRIPTION
A stored `RangeFrom` used to index a slice now emits a three-index slice. Previously it produced `base[start::len(base)]` with an empty middle index, which failed to compile.

```rs
let xs = [10, 20, 30]
let r = 1..
let ys = xs[r]
```