### PR TITLE
fix: skip go variable emission for module and enum alias

### DIFF
--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -278,6 +278,33 @@ impl Planner<'_> {
         Some(go_name)
     }
 
+    /// Returns true when `expression` is a module-enum type access used as a
+    /// namespace alias (e.g. `utils.Color`). Such expressions resolve to Go
+    /// type names, not values, so they cannot be emitted as Go variables.
+    pub(crate) fn is_enum_type_namespace_alias(&self, expression: &Expression) -> bool {
+        let Expression::DotAccess {
+            expression: inner,
+            member,
+            ..
+        } = expression
+        else {
+            return false;
+        };
+
+        let inner_ty = inner.get_type();
+
+        let Some(module) = inner_ty.as_import_namespace() else {
+            return false;
+        };
+
+        let qualified = format!("{}.{}", module, member);
+
+        matches!(
+            self.facts.definition(qualified.as_str()),
+            Some(def) if matches!(def.body, DefinitionBody::Enum { .. } | DefinitionBody::ValueEnum { .. })
+        )
+    }
+
     /// Instance method used as a value (e.g. `lib.Point.area` callback →
     /// `lib.Point.Area` Go method expression).
     pub(crate) fn emit_instance_method_value_dot(

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -152,7 +152,18 @@ impl Planner<'_> {
         let is_prelude = enum_module == go_name::PRELUDE_MODULE;
         let is_cross_module = !self.facts.is_current_module(enum_module) && !is_prelude;
 
-        if is_cross_module && !matches!(expression, Expression::Identifier { .. }) {
+        let is_direct_enum_access = matches!(expression, Expression::Identifier { .. })
+            || matches!(
+                expression,
+                Expression::DotAccess {
+                    expression: inner,
+                    member: type_name,
+                    ..
+                } if inner.get_type().as_import_namespace().is_some()
+                    && unqualified_name(enum_id) == type_name.as_str()
+            );
+
+        if is_cross_module && !is_direct_enum_access {
             return None;
         }
 

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -199,6 +199,12 @@ impl Planner<'_> {
             return;
         }
 
+        if value.get_type().as_import_namespace().is_some()
+            || self.is_enum_type_namespace_alias(value)
+        {
+            return;
+        }
+
         if let Expression::Propagate { expression, .. } = unwrapped {
             self.emit_propagate(output, expression, Some("_"), return_ctx, fx);
             return;

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -305,6 +305,16 @@ impl Planner<'_> {
             return;
         }
 
+        // Module namespace and enum type-namespace aliases (eg. `let e = utils` or `let e = utils.Color`)
+        // have no runtime value in Go. Bind the Lisette name so downstream dot-accesses
+        // resolve via result-type  information, but emit no Go variable.
+        if value.get_type().as_import_namespace().is_some()
+            || self.is_enum_type_namespace_alias(value)
+        {
+            self.scope.bind(identifier, raw_go_name);
+            return;
+        }
+
         let value_expression = self.emit_value(
             output,
             value,

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6175,3 +6175,36 @@ fn main() {
         "a single-field tuple is a newtype with no F0 field; got: {codes:?}"
     );
 }
+
+#[test]
+fn cross_module_enum_and_namespace_alias() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "utils",
+        "color.lis",
+        r#"
+pub enum Color {
+  RGB,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "utils"
+
+fn function() {
+  let u = utils
+  let c = utils.Color
+  fmt.Println("rgb via namespace", u.Color.RGB)
+  fmt.Println("rgb via type alias", c.RGB)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6197,7 +6197,7 @@ pub enum Color {
 import "go:fmt"
 import "utils"
 
-fn function() {
+fn main() {
   let u = utils
   let c = utils.Color
   fmt.Println("rgb via namespace", u.Color.RGB)

--- a/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/build/mod.rs
+assertion_line: 6209
+---
+// === main.go ===
+package main
+
+
+// === utils/color.go ===
+package utils
+
+import "fmt"
+
+func MakeColorRGB() Color {
+	return Color{Tag: ColorRGB}
+}
+
+type ColorTag int
+
+const (
+	ColorRGB ColorTag = iota
+)
+
+type Color struct {
+	Tag ColorTag
+}
+
+func (c Color) String() string {
+	switch c.Tag {
+	case ColorRGB:
+		return "Color.RGB"
+	default:
+		return fmt.Sprintf("Color(%d)", c.Tag)
+	}
+}

--- a/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
@@ -1,9 +1,18 @@
 ---
 source: tests/spec/build/mod.rs
-assertion_line: 6209
 ---
 // === main.go ===
 package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/utils"
+)
+
+func main() {
+	fmt.Println("rgb via namespace", utils.MakeColorRGB())
+	fmt.Println("rgb via type alias", utils.MakeColorRGB())
+}
 
 
 // === utils/color.go ===

--- a/tests/spec/build/snapshots/cross_module_enum_construction_uses_import_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_construction_uses_import_alias.snap
@@ -46,6 +46,6 @@ import (
 )
 
 func main() {
-	c := L.Color{Tag: L.ColorRed}
+	c := L.MakeColorRed()
 	fmt.Println(c)
 }

--- a/tests/spec/build/snapshots/multimodule_nested_path_enum_struct_literal.snap
+++ b/tests/spec/build/snapshots/multimodule_nested_path_enum_struct_literal.snap
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	reset := events.Event{Tag: events.EventReset}
+	reset := events.MakeEventReset()
 	fmt.Println(reset)
 }
 

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -822,6 +822,7 @@ import "go:fmt"
 
 fn function() {
   let m = time.Month
+  let _ = time.Month
   fmt.Println("march", m.March)
 }
 "#;

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -815,6 +815,20 @@ fn main() {
 }
 
 #[test]
+fn interop_go_value_enum_type_alias() {
+    let input = r#"
+import "go:time"
+import "go:fmt"
+
+fn function() {
+  let m = time.Month
+  fmt.Println("march", m.March)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_value_enum_nested_module() {
     let input = r#"
 import "go:debug/dwarf"

--- a/tests/spec/emit/snapshots/interop_go_value_enum_type_alias.snap
+++ b/tests/spec/emit/snapshots/interop_go_value_enum_type_alias.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+assertion_line: 828
+description: "input: \nimport \"go:time\"\nimport \"go:fmt\"\n\nfn function() {\n  let m = time.Month\n  fmt.Println(\"march\", m.March)\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func function() {
+	fmt.Println("march", time.March)
+}


### PR DESCRIPTION
Assigning a module or enum type to a let binding produces invalid Go code. This change makes the emitter drop the intermediate variable, and fixes an previous inconsistency in enum constructor usage (see the note below)

Example:

```rust
// src/utils/utils.lis

pub enum Color {
  RGB,
}
```

```rust 
// src/main.lis

import "go:fmt"
import "go:time"

import "utils"

fn main() {
  let _ = time.Month
  let _ = utils
  let _ = utils.Color

  let m = time.Month
  let u = utils
  let c = utils.Color

  fmt.Println("march", m.March)
  fmt.Println("u.Color.RGB", u.Color.RGB)
  fmt.Println("c.RGB", c.RGB)
}
```

The above currently compiles to:

```go
package main

import (
	"demo/utils"
	"fmt"
	"time"
)

func main() {
	_ = time.Month
	_ = utils
	_ = utils.Color
	m := time.Month
	u := utils
	c := utils.Color
	fmt.Println("march", time.March)
	fmt.Println("u.Color.RGB", utils.Color{Tag: utils.ColorRGB})
	fmt.Println("c.RGB", utils.MakeColorRGB())
}
```

The above results in errors:

```
./main.go:10:6: time.Month (type) is not an expression
./main.go:11:6: use of package utils not in selector
./main.go:12:6: utils.Color (type) is not an expression
./main.go:13:2: declared and not used: m
./main.go:13:7: time.Month (type) is not an expression
./main.go:14:2: declared and not used: u
./main.go:14:7: use of package utils not in selector
./main.go:15:2: declared and not used: c
./main.go:15:7: utils.Color (type) is not an expression
```

After this change:

```go
package main

import (
	"demo/utils"
	"fmt"
	"time"
)

func main() {
	fmt.Println("march", time.March)
	fmt.Println("u.Color.RGB", utils.MakeColorRGB())
	fmt.Println("c.RGB", utils.MakeColorRGB())
}
```

**Note** 

The current version of lis also compiles an enum alias directly to a struct, no as an constructor.

Lis:

```rust
import "utils"

fn main() {
  let u = utils
  let c = utils.Color

  let _ = u.Color.RGB
  let _ = c.RGB
}
```

Go:
```
package main

import "demo/utils"

func main() {
	u := utils
	c := utils.Color
	_ = utils.Color{Tag: utils.ColorRGB} // <--- Not using the constructor
	_ = utils.MakeColorRGB()
}
```

After this change both of the above use the constructor `utils.MakeColorRGB()`, and not the direct struct.

**Finally** 

It _might_ be surprising to the user that a discarded let binding (one that cannot be represented in go) is just dropped. Im not sure if that will be a problem or not. Meaning that this:

```rust
import "go:time"

fn main() {
  let _ = time.Month
}
```

Will compile to nothing:

```go
package main

func main() {}
```




