### PR TITLE
feat: warn on needless return in tail position

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -298,6 +298,13 @@ pub fn bool_literal_comparison(span: &Span, replacement: &str) -> LisetteDiagnos
         .with_help(format!("Simplify to `{replacement}`"))
 }
 
+pub fn needless_return(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Needless `return`")
+        .with_lint_code("needless_return")
+        .with_span_label(span, "redundant in tail position")
+        .with_help("The final expression of a function is its return value. Drop `return` and keep the value")
+}
+
 pub fn identical_if_branches(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Identical if-else branches")
         .with_lint_code("identical_if_branches")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -10,6 +10,7 @@ mod identical_if_branches;
 mod invisible_in_string;
 mod match_literal_collection;
 mod naming;
+mod needless_return;
 mod replaceable_with_zero_fill;
 mod rest_only_slice_pattern;
 mod self_assignment;
@@ -33,6 +34,7 @@ pub use invisible_in_string::{
 };
 pub use match_literal_collection::check_match_literal_collection;
 pub use naming::{check_expression_naming, check_pattern_naming};
+pub use needless_return::check_needless_return;
 pub use replaceable_with_zero_fill::check_replaceable_with_zero_fill;
 pub use rest_only_slice_pattern::check_rest_only_slice_pattern;
 pub use self_assignment::check_self_assignment;

--- a/crates/semantics/src/passes/lints/ast_walk/checks/needless_return.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/needless_return.rs
@@ -1,0 +1,52 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::Expression;
+
+pub fn check_needless_return(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let Expression::Function { body, .. } = expression else {
+        return;
+    };
+
+    flag_tail_returns(body, diagnostics);
+}
+
+/// Flag a `return <value>` sitting in tail position, where the value is what
+/// the surrounding block yields anyway.
+fn flag_tail_returns(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    match expression {
+        Expression::Return {
+            expression: value,
+            span,
+            ..
+        } => {
+            // Bare `return` is excluded: dropping it can change the block's
+            // type when a preceding statement is non-unit.
+            if !matches!(value.as_ref(), Expression::Unit { .. }) {
+                diagnostics.push(diagnostics::lint::needless_return(span));
+            }
+        }
+        Expression::Block { items, .. } => {
+            if let Some(last) = items.last() {
+                flag_tail_returns(last, diagnostics);
+            }
+        }
+        Expression::If {
+            consequence,
+            alternative,
+            ..
+        }
+        | Expression::IfLet {
+            consequence,
+            alternative,
+            ..
+        } => {
+            flag_tail_returns(consequence, diagnostics);
+            flag_tail_returns(alternative, diagnostics);
+        }
+        Expression::Match { arms, .. } => {
+            for arm in arms {
+                flag_tail_returns(&arm.expression, diagnostics);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -73,11 +73,12 @@ use checks::{
     check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
     check_expression_naming, check_identical_if_branches, check_invisible_in_string_expression,
-    check_invisible_in_string_pattern, check_match_literal_collection, check_pattern_naming,
-    check_replaceable_with_zero_fill, check_rest_only_slice_pattern, check_self_assignment,
-    check_self_comparison, check_single_arm_match, check_uninterpolated_fstring,
-    check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
-    check_unsigned_comparison, check_verbose_failure_propagation,
+    check_invisible_in_string_pattern, check_match_literal_collection, check_needless_return,
+    check_pattern_naming, check_replaceable_with_zero_fill, check_rest_only_slice_pattern,
+    check_self_assignment, check_self_comparison, check_single_arm_match,
+    check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
+    check_unnecessary_raw_string_pattern, check_unsigned_comparison,
+    check_verbose_failure_propagation,
 };
 use visitor::visit_ast;
 
@@ -94,6 +95,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_empty_match_arm,
     check_excess_parens_on_condition,
     check_match_literal_collection,
+    check_needless_return,
     check_single_arm_match,
     check_uninterpolated_fstring,
     check_unnecessary_raw_string_expression,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -667,6 +667,163 @@ fn main() {
 }
 
 #[test]
+fn needless_return_simple() {
+    assert_lint_snapshot!(
+        r#"
+fn five() -> int {
+  return 5
+}
+
+fn main() {
+  let _ = five()
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_after_statements() {
+    assert_lint_snapshot!(
+        r#"
+fn doubled(n: int) -> int {
+  let x = n * 2
+  return x
+}
+
+fn main() {
+  let _ = doubled(3)
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_if_else_branches() {
+    assert_lint_snapshot!(
+        r#"
+fn sign(n: int) -> int {
+  if n > 0 {
+    return 1
+  } else {
+    return 2
+  }
+}
+
+fn main() {
+  let _ = sign(3)
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_match_arms() {
+    assert_lint_snapshot!(
+        r#"
+fn label(n: int) -> string {
+  match n {
+    0 => return "zero",
+    _ => return "other",
+  }
+}
+
+fn main() {
+  let _ = label(0)
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_early_return_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn clamp(n: int) -> int {
+  if n > 0 {
+    return 1
+  }
+  n + 1
+}
+
+fn main() {
+  let _ = clamp(1)
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_in_loop_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn first_positive(xs: Slice<int>) -> int {
+  for x in xs {
+    if x > 0 {
+      return x
+    }
+  }
+  0
+}
+
+fn main() {
+  let _ = first_positive([1])
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_bare_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn greet() {
+  return
+}
+
+fn main() {
+  greet()
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_let_else_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn unwrap_or_zero(x: Option<int>) -> int {
+  let Some(v) = x else {
+    return 0
+  }
+  v
+}
+
+fn main() {
+  let _ = unwrap_or_zero(Some(3))
+}
+"#
+    );
+}
+
+#[test]
+fn needless_return_in_lambda_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn apply() -> int {
+  let f = || {
+    return 1
+  }
+  f()
+}
+
+fn main() {
+  let _ = apply()
+}
+"#
+    );
+}
+
+#[test]
 fn nan_comparison_equal() {
     assert_lint_snapshot!(
         r#"
@@ -1742,8 +1899,8 @@ pub fn foo() -> int {
 fn no_dead_code_when_return_is_last() {
     assert_no_lint_warnings!(
         r#"
-pub fn foo() -> int {
-  return 42
+pub fn foo() {
+  return
 }
 "#
     );
@@ -1826,11 +1983,11 @@ pub fn foo() -> int {
 fn no_dead_code_when_only_one_branch_returns() {
     assert_no_lint_warnings!(
         r#"
-pub fn foo() -> int {
+pub fn foo() {
   if true {
-    return 1
+    return
   } else {
-    2
+    ()
   }
 }
 "#
@@ -1857,10 +2014,10 @@ pub fn foo(x: int) -> int {
 fn no_dead_code_when_not_all_match_arms_diverge() {
     assert_no_lint_warnings!(
         r#"
-pub fn foo(x: int) -> int {
+pub fn foo(x: int) {
   match x {
-    0 => return 0,
-    _ => 1,
+    0 => { return },
+    _ => (),
   }
 }
 "#
@@ -5315,7 +5472,7 @@ fn dup_arg_calls_with_side_effects_no_warning() {
 import "go:math"
 
 fn next() -> float64 {
-  return 1.0
+  1.0
 }
 
 fn main() {

--- a/tests/ui/lint/snapshots/needless_return_after_statements.snap
+++ b/tests/ui/lint/snapshots/needless_return_after_statements.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Needless `return`
+   ╭─[test.lis:4:3]
+ 3 │   let x = n * 2
+ 4 │   return x
+   ·   ────┬───
+   ·       ╰── redundant in tail position
+ 5 │ }
+   ╰────
+  help: The final expression of a function is its return value. Drop `return` and keep the value · code: [lint.needless_return]

--- a/tests/ui/lint/snapshots/needless_return_if_else_branches.snap
+++ b/tests/ui/lint/snapshots/needless_return_if_else_branches.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Needless `return`
+   ╭─[test.lis:4:5]
+ 3 │   if n > 0 {
+ 4 │     return 1
+   ·     ────┬───
+   ·         ╰── redundant in tail position
+ 5 │   } else {
+   ╰────
+  help: The final expression of a function is its return value. Drop `return` and keep the value · code: [lint.needless_return]

--- a/tests/ui/lint/snapshots/needless_return_match_arms.snap
+++ b/tests/ui/lint/snapshots/needless_return_match_arms.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Needless `return`
+   ╭─[test.lis:4:10]
+ 3 │   match n {
+ 4 │     0 => return "zero",
+   ·          ──────┬──────
+   ·                ╰── redundant in tail position
+ 5 │     _ => return "other",
+   ╰────
+  help: The final expression of a function is its return value. Drop `return` and keep the value · code: [lint.needless_return]

--- a/tests/ui/lint/snapshots/needless_return_simple.snap
+++ b/tests/ui/lint/snapshots/needless_return_simple.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Needless `return`
+   ╭─[test.lis:3:3]
+ 2 │ fn five() -> int {
+ 3 │   return 5
+   ·   ────┬───
+   ·       ╰── redundant in tail position
+ 4 │ }
+   ╰────
+  help: The final expression of a function is its return value. Drop `return` and keep the value · code: [lint.needless_return]


### PR DESCRIPTION
Adds a `needless_return` warning that flags a `return` whose value is already the function body's implicit return value, so the `return` keyword can be dropped.

```
  [warning] Needless `return`
   ╭─[test.lis:4:3]
 3 │   let x = n * 2
 4 │   return x
   ·   ────┬───
   ·       ╰── redundant in tail position
 5 │ }
   ╰────
  help: The final expression of a function is its return value. Drop `return` and keep the value · code: [lint.needless_return]
```
