### PR TITLE
chore: release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.2.16](https://github.com/ivov/lisette/compare/lisette-v0.2.15...lisette-v0.2.16) - 2026-05-31
+
+- fix: reject value names in type annotations [#555](https://github.com/ivov/lisette/pull/555) [`c4dabbd`](https://github.com/ivov/lisette/commit/c4dabbd9d1a400cdcb08557b4874c5e193154696)
+- feat: add `#[iterable]` for enum iteration [#557](https://github.com/ivov/lisette/pull/557) [`6a0db29`](https://github.com/ivov/lisette/commit/6a0db29d8bed754e9125196a243121ed220850ea)
+- refactor: share ufcs methods across inference [#556](https://github.com/ivov/lisette/pull/556) [`f4a635b`](https://github.com/ivov/lisette/commit/f4a635b0648bc7f052ff4622730a0d857fa35244)
+- fix: emit remaining pattern checks in switch case bodies [#554](https://github.com/ivov/lisette/pull/554) [`0cd4e5f`](https://github.com/ivov/lisette/commit/0cd4e5fe834aaa5967293b2cd1ef3c6a5283ebdf)
+- feat: suggest is_some/is_ok over match-to-bool [#552](https://github.com/ivov/lisette/pull/552) [`0a34bf2`](https://github.com/ivov/lisette/commit/0a34bf29fddac6740e7c62fdb2bdf825ec447119)
+- fix: validate unknown attributes on enums [#551](https://github.com/ivov/lisette/pull/551) [`00fcbf4`](https://github.com/ivov/lisette/commit/00fcbf48de22d2acb1850f3b96fe389052616e5f)
+- refactor: render enums as bare variant names [#550](https://github.com/ivov/lisette/pull/550) [`4d817a4`](https://github.com/ivov/lisette/commit/4d817a4c308503169929fd80efca69c6034aacf5)
+- feat: warn on range loop that only indexes a slice [#549](https://github.com/ivov/lisette/pull/549) [`69e5f43`](https://github.com/ivov/lisette/commit/69e5f43d04974b9cc4343b960b3dc53423b9e8e2)
+- perf: box function variant to shrink type enum [#548](https://github.com/ivov/lisette/pull/548) [`9b679d9`](https://github.com/ivov/lisette/commit/9b679d94ce1011ba6c4b4721f8c1adf4a0a973f5)
+- fix: reject enum and module types used as runtime values [#532](https://github.com/ivov/lisette/pull/532) [`30a5e73`](https://github.com/ivov/lisette/commit/30a5e7303b39f19534c361937df2f3df00849f98)
+- feat: warn on loop that runs at most once [#545](https://github.com/ivov/lisette/pull/545) [`d3b1d9e`](https://github.com/ivov/lisette/commit/d3b1d9e923ac008a661a2dd654e39dee9ec59ac6)
+- perf: avoid per-node allocations in ast traversal [#544](https://github.com/ivov/lisette/pull/544) [`e6ca8c2`](https://github.com/ivov/lisette/commit/e6ca8c2f3d5f43db1c1b1eba2dadcc0a4510bb6d)
+- test: check lis learn project e2e [#543](https://github.com/ivov/lisette/pull/543) [`6dff023`](https://github.com/ivov/lisette/commit/6dff0239d9bdcdb0b0e7319855cf5adc00ec57e5)
+- refactor: consolidate context-free checks onto shared visitor [#542](https://github.com/ivov/lisette/pull/542) [`a116b4b`](https://github.com/ivov/lisette/commit/a116b4b7cde0cfc5a2abde8ff8ed5c59aef946f7)
+- test: build no-entry emit snapshots in e2e suite [#541](https://github.com/ivov/lisette/pull/541) [`b0bae23`](https://github.com/ivov/lisette/commit/b0bae2333efb5f324cd9d2ab22ec513a32295e8e)
+- feat: reject loop with unchanging condition [#540](https://github.com/ivov/lisette/pull/540) [`80a0f1e`](https://github.com/ivov/lisette/commit/80a0f1ea8f6fb1f784d3817d439b19e4a1ffa8b2)
+- test: check emitted Go with go vet [#539](https://github.com/ivov/lisette/pull/539) [`09d6c96`](https://github.com/ivov/lisette/commit/09d6c9638fffbdd933c97a5a58a26ae28b32d5fa)
+- refactor: unify unit enum variant emission via constructor [#538](https://github.com/ivov/lisette/pull/538) [`a694be0`](https://github.com/ivov/lisette/commit/a694be0236644142b95cd589ba3e52e0cd84dcb0)
+- fix: resolve enum variant access through a type alias [#537](https://github.com/ivov/lisette/pull/537) [`701d20b`](https://github.com/ivov/lisette/commit/701d20be7f10b3b3f7d609cbac0dfff117748bc9)
+- ci: run in-crate unit tests [#536](https://github.com/ivov/lisette/pull/536) [`bde0e25`](https://github.com/ivov/lisette/commit/bde0e254d35aa72830c17379893e0dc02f66c5c8)
+- feat: warn on WaitGroup.Add inside a task [#535](https://github.com/ivov/lisette/pull/535) [`186ed22`](https://github.com/ivov/lisette/commit/186ed221df9f9379c3438a6d52056c50cbe24142)
+- feat: warn on needless boolean if-else [#534](https://github.com/ivov/lisette/pull/534) [`36a2a2a`](https://github.com/ivov/lisette/commit/36a2a2ad158426cb512e782ee6ac67d5c11837a2)
+- fix: stop flattening tuple payloads of fallible calls [#533](https://github.com/ivov/lisette/pull/533) [`611906c`](https://github.com/ivov/lisette/commit/611906c179e6259f7b22b86ab0403ba014c82e0b)
+- feat: warn on needless return in tail position [#530](https://github.com/ivov/lisette/pull/530) [`2128a29`](https://github.com/ivov/lisette/commit/2128a296dfa4ef10af47c70ee0363b6e9b2b4b56)
+
 ## [0.2.15](https://github.com/ivov/lisette/compare/lisette-v0.2.14...lisette-v0.2.15) - 2026-05-28
 
 - fix: emit middle index for capped range-from slice [#527](https://github.com/ivov/lisette/pull/527) [`00f3b56`](https://github.com/ivov/lisette/commit/00f3b562a9e0887655766e7ebaf75828fe85da72)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bincode",
  "ecow",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.15"
+version = "0.2.16"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.15", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.15", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.15", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.15", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.16", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.16", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.16", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.16", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.15", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.15", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.16", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.16", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.15", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.15", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.15", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.15", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.16 (upcoming)

- fix: reject value names in type annotations [#555](https://github.com/ivov/lisette/pull/555) [`c4dabbd`](https://github.com/ivov/lisette/commit/c4dabbd9d1a400cdcb08557b4874c5e193154696)
- feat: add `#[iterable]` for enum iteration [#557](https://github.com/ivov/lisette/pull/557) [`6a0db29`](https://github.com/ivov/lisette/commit/6a0db29d8bed754e9125196a243121ed220850ea)
- refactor: share ufcs methods across inference [#556](https://github.com/ivov/lisette/pull/556) [`f4a635b`](https://github.com/ivov/lisette/commit/f4a635b0648bc7f052ff4622730a0d857fa35244)
- fix: emit remaining pattern checks in switch case bodies [#554](https://github.com/ivov/lisette/pull/554) [`0cd4e5f`](https://github.com/ivov/lisette/commit/0cd4e5fe834aaa5967293b2cd1ef3c6a5283ebdf)
- feat: suggest is_some/is_ok over match-to-bool [#552](https://github.com/ivov/lisette/pull/552) [`0a34bf2`](https://github.com/ivov/lisette/commit/0a34bf29fddac6740e7c62fdb2bdf825ec447119)
- fix: validate unknown attributes on enums [#551](https://github.com/ivov/lisette/pull/551) [`00fcbf4`](https://github.com/ivov/lisette/commit/00fcbf48de22d2acb1850f3b96fe389052616e5f)
- refactor: render enums as bare variant names [#550](https://github.com/ivov/lisette/pull/550) [`4d817a4`](https://github.com/ivov/lisette/commit/4d817a4c308503169929fd80efca69c6034aacf5)
- feat: warn on range loop that only indexes a slice [#549](https://github.com/ivov/lisette/pull/549) [`69e5f43`](https://github.com/ivov/lisette/commit/69e5f43d04974b9cc4343b960b3dc53423b9e8e2)
- perf: box function variant to shrink type enum [#548](https://github.com/ivov/lisette/pull/548) [`9b679d9`](https://github.com/ivov/lisette/commit/9b679d94ce1011ba6c4b4721f8c1adf4a0a973f5)
- fix: reject enum and module types used as runtime values [#532](https://github.com/ivov/lisette/pull/532) [`30a5e73`](https://github.com/ivov/lisette/commit/30a5e7303b39f19534c361937df2f3df00849f98)
- feat: warn on loop that runs at most once [#545](https://github.com/ivov/lisette/pull/545) [`d3b1d9e`](https://github.com/ivov/lisette/commit/d3b1d9e923ac008a661a2dd654e39dee9ec59ac6)
- perf: avoid per-node allocations in ast traversal [#544](https://github.com/ivov/lisette/pull/544) [`e6ca8c2`](https://github.com/ivov/lisette/commit/e6ca8c2f3d5f43db1c1b1eba2dadcc0a4510bb6d)
- test: check lis learn project e2e [#543](https://github.com/ivov/lisette/pull/543) [`6dff023`](https://github.com/ivov/lisette/commit/6dff0239d9bdcdb0b0e7319855cf5adc00ec57e5)
- refactor: consolidate context-free checks onto shared visitor [#542](https://github.com/ivov/lisette/pull/542) [`a116b4b`](https://github.com/ivov/lisette/commit/a116b4b7cde0cfc5a2abde8ff8ed5c59aef946f7)
- test: build no-entry emit snapshots in e2e suite [#541](https://github.com/ivov/lisette/pull/541) [`b0bae23`](https://github.com/ivov/lisette/commit/b0bae2333efb5f324cd9d2ab22ec513a32295e8e)
- feat: reject loop with unchanging condition [#540](https://github.com/ivov/lisette/pull/540) [`80a0f1e`](https://github.com/ivov/lisette/commit/80a0f1ea8f6fb1f784d3817d439b19e4a1ffa8b2)
- test: check emitted Go with go vet [#539](https://github.com/ivov/lisette/pull/539) [`09d6c96`](https://github.com/ivov/lisette/commit/09d6c9638fffbdd933c97a5a58a26ae28b32d5fa)
- refactor: unify unit enum variant emission via constructor [#538](https://github.com/ivov/lisette/pull/538) [`a694be0`](https://github.com/ivov/lisette/commit/a694be0236644142b95cd589ba3e52e0cd84dcb0)
- fix: resolve enum variant access through a type alias [#537](https://github.com/ivov/lisette/pull/537) [`701d20b`](https://github.com/ivov/lisette/commit/701d20be7f10b3b3f7d609cbac0dfff117748bc9)
- ci: run in-crate unit tests [#536](https://github.com/ivov/lisette/pull/536) [`bde0e25`](https://github.com/ivov/lisette/commit/bde0e254d35aa72830c17379893e0dc02f66c5c8)
- feat: warn on WaitGroup.Add inside a task [#535](https://github.com/ivov/lisette/pull/535) [`186ed22`](https://github.com/ivov/lisette/commit/186ed221df9f9379c3438a6d52056c50cbe24142)
- feat: warn on needless boolean if-else [#534](https://github.com/ivov/lisette/pull/534) [`36a2a2a`](https://github.com/ivov/lisette/commit/36a2a2ad158426cb512e782ee6ac67d5c11837a2)
- fix: stop flattening tuple payloads of fallible calls [#533](https://github.com/ivov/lisette/pull/533) [`611906c`](https://github.com/ivov/lisette/commit/611906c179e6259f7b22b86ab0403ba014c82e0b)
- feat: warn on needless return in tail position [#530](https://github.com/ivov/lisette/pull/530) [`2128a29`](https://github.com/ivov/lisette/commit/2128a296dfa4ef10af47c70ee0363b6e9b2b4b56)
