### PR TITLE
fix: stop flattening tuple payloads of fallible calls

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -5,7 +5,7 @@ use crate::Planner;
 use crate::Renderer;
 use crate::ReturnContext;
 use crate::abi::{AbiShape, tuple_element_types};
-use crate::calls::go_interop::WrapperTarget;
+use crate::calls::go_interop::{TupleReturnLayout, WrapperTarget};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
@@ -234,14 +234,21 @@ pub(crate) fn emit_callee_abi_wrapping(
 ) -> String {
     match shape {
         AbiShape::PartialTuple => planner
-            .emit_partial_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot, fx)
+            .emit_partial_wrapping(
+                output,
+                call_str,
+                result_ty,
+                TupleReturnLayout::Packed,
+                WrapperTarget::FreshSlot,
+                fx,
+            )
             .expect("wrapper produced no slot"),
         AbiShape::CommaOk => planner
             .emit_comma_ok_wrapping(
                 output,
                 call_str,
                 result_ty,
-                false,
+                TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
                 fx,
             )
@@ -259,7 +266,14 @@ pub(crate) fn emit_callee_abi_wrapping(
                 .expect("wrapper produced no slot")
         }
         AbiShape::ResultTuple | AbiShape::BareError => planner
-            .emit_result_wrapping(output, call_str, result_ty, WrapperTarget::FreshSlot, fx)
+            .emit_result_wrapping(
+                output,
+                call_str,
+                result_ty,
+                TupleReturnLayout::Packed,
+                WrapperTarget::FreshSlot,
+                fx,
+            )
             .expect("wrapper produced no slot"),
         AbiShape::Tuple { arity } => {
             let temps = planner.create_temp_vars("ret", *arity);

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -1,7 +1,7 @@
 mod nullable;
 mod wrappers;
 
-pub(crate) use wrappers::WrapperTarget;
+pub(crate) use wrappers::{TupleReturnLayout, WrapperTarget};
 
 use crate::EmitEffects;
 use crate::Planner;
@@ -101,12 +101,26 @@ impl Planner<'_> {
                 let call_str =
                     self.emit_call(output, expression, None, ExpressionContext::value(), fx);
                 fx.require_stdlib();
-                Some(self.emit_result_wrapping(output, &call_str, result_ty, target, fx))
+                Some(self.emit_result_wrapping(
+                    output,
+                    &call_str,
+                    result_ty,
+                    TupleReturnLayout::Flattened,
+                    target,
+                    fx,
+                ))
             }
             GoCallStrategy::CommaOk => {
                 let call_str =
                     self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                Some(self.emit_comma_ok_wrapping(output, &call_str, result_ty, true, target, fx))
+                Some(self.emit_comma_ok_wrapping(
+                    output,
+                    &call_str,
+                    result_ty,
+                    TupleReturnLayout::Flattened,
+                    target,
+                    fx,
+                ))
             }
             GoCallStrategy::NullableReturn => {
                 let call_str =
@@ -118,7 +132,14 @@ impl Planner<'_> {
                 fx.require_stdlib();
                 let call_str =
                     self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                Some(self.emit_partial_wrapping(output, &call_str, result_ty, target, fx))
+                Some(self.emit_partial_wrapping(
+                    output,
+                    &call_str,
+                    result_ty,
+                    TupleReturnLayout::Flattened,
+                    target,
+                    fx,
+                ))
             }
             GoCallStrategy::Sentinel { value } => {
                 let call_str =

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -2,7 +2,9 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::calls::go_interop::build_tuple_literal;
-use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
+use crate::calls::go_interop::wrappers::{
+    TupleReturnLayout, WrapperOutcome, WrapperTarget, leaf_block,
+};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
@@ -20,8 +22,13 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String) {
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
-        let (wrap_setup, outcome) =
-            self.lower_comma_ok_wrapping(&call_str, option_ty, true, WrapperTarget::FreshSlot, fx);
+        let (wrap_setup, outcome) = self.lower_comma_ok_wrapping(
+            &call_str,
+            option_ty,
+            TupleReturnLayout::Flattened,
+            WrapperTarget::FreshSlot,
+            fx,
+        );
         setup.extend(wrap_setup);
         (setup, outcome.expect("wrapper produced no slot"))
     }
@@ -90,24 +97,24 @@ impl Planner<'_> {
         output: &mut String,
         call_str: &str,
         option_ty: &Type,
-        tuple_flattened: bool,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> WrapperOutcome {
         let (statements, outcome) =
-            self.lower_comma_ok_wrapping(call_str, option_ty, tuple_flattened, target, fx);
+            self.lower_comma_ok_wrapping(call_str, option_ty, layout, target, fx);
         output.push_str(&Renderer.render_setup(&statements));
         outcome
     }
 
-    /// Wrap a comma-ok-returning call into a tagged `Option`. `tuple_flattened`
-    /// distinguishes Go-imported `(T1, ..., Tn, bool)` from Lisette
-    /// `(Tuple_n[...], bool)`.
+    /// Wrap a comma-ok-returning call into a tagged `Option`. A `Flattened`
+    /// tuple inner type comes from a Go-imported `(T1, ..., Tn, bool)`; a
+    /// `Packed` one from a Lisette `(Tuple_n[...], bool)`.
     pub(crate) fn lower_comma_ok_wrapping(
         &mut self,
         call_str: &str,
         option_ty: &Type,
-        tuple_flattened: bool,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
@@ -119,7 +126,7 @@ impl Planner<'_> {
         let needs_nilable_validation = self.facts.is_nullable_option(option_ty);
 
         let needs_complex =
-            needs_nilable_validation || (tuple_flattened && inner_tuple_arity.is_some());
+            needs_nilable_validation || (layout.is_flattened() && inner_tuple_arity.is_some());
 
         if !needs_complex {
             let inner_ty_str = self.go_type_string(&inner_ty, fx);
@@ -131,7 +138,9 @@ impl Planner<'_> {
 
         let fallible = Fallible::from_type(option_ty).expect("Option type expected");
 
-        let val_vars = if tuple_flattened && let Some(arity) = inner_tuple_arity {
+        let val_vars = if layout.is_flattened()
+            && let Some(arity) = inner_tuple_arity
+        {
             self.create_temp_vars("ret", arity)
         } else {
             self.create_temp_vars("ret", 1)
@@ -150,7 +159,7 @@ impl Planner<'_> {
             call_str
         )));
 
-        let val_expression = if tuple_flattened && inner_tuple_arity.is_some() {
+        let val_expression = if layout.is_flattened() && inner_tuple_arity.is_some() {
             build_tuple_literal(&val_vars, &inner_ty, fx)
         } else {
             val_vars[0].clone()

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -27,6 +27,22 @@ pub(crate) enum WrapperTarget<'a> {
     Return,
 }
 
+/// How a fallible callee presents a tuple `Ok`/`Some` payload at the Go
+/// boundary: as separate return values (`Flattened`, e.g. a Go-imported
+/// `(A, B, error)`) or already bundled into one tuple value (`Packed`, the
+/// Lisette `(Tuple_n[...], error)` ABI).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TupleReturnLayout {
+    Packed,
+    Flattened,
+}
+
+impl TupleReturnLayout {
+    pub(crate) fn is_flattened(self) -> bool {
+        matches!(self, TupleReturnLayout::Flattened)
+    }
+}
+
 /// `Some(slot_name)` when the wrapper wrote into a fresh or named slot; `None`
 /// when it wrote a `return` statement and the caller should not emit its own.
 pub(crate) type WrapperOutcome = Option<String>;
@@ -90,10 +106,11 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         call_str: &str,
         ok_ty: &Type,
+        layout: TupleReturnLayout,
         fx: &mut EmitEffects,
     ) -> (String, String) {
         let mut buffer = String::new();
-        let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, fx);
+        let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, layout, fx);
         if !buffer.is_empty() {
             statements.push(LoweredStatement::RawGo(buffer));
         }
@@ -163,8 +180,13 @@ impl Planner<'_> {
         fx.require_stdlib();
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
-        let (wrap_setup, outcome) =
-            self.lower_partial_wrapping(&call_str, partial_ty, WrapperTarget::FreshSlot, fx);
+        let (wrap_setup, outcome) = self.lower_partial_wrapping(
+            &call_str,
+            partial_ty,
+            TupleReturnLayout::Flattened,
+            WrapperTarget::FreshSlot,
+            fx,
+        );
         setup.extend(wrap_setup);
         (setup, outcome.expect("wrapper produced no slot"))
     }
@@ -175,10 +197,12 @@ impl Planner<'_> {
         output: &mut String,
         call_str: &str,
         partial_ty: &Type,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> WrapperOutcome {
-        let (statements, outcome) = self.lower_partial_wrapping(call_str, partial_ty, target, fx);
+        let (statements, outcome) =
+            self.lower_partial_wrapping(call_str, partial_ty, layout, target, fx);
         output.push_str(&Renderer.render_setup(&statements));
         outcome
     }
@@ -188,6 +212,7 @@ impl Planner<'_> {
         &mut self,
         call_str: &str,
         partial_ty: &Type,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
@@ -198,7 +223,8 @@ impl Planner<'_> {
         let pkg = go_name::GO_STDLIB_PKG;
 
         let mut statements = Vec::new();
-        let (err_var, val_var) = self.push_go_returns(&mut statements, call_str, &ok_ty, fx);
+        let (err_var, val_var) =
+            self.push_go_returns(&mut statements, call_str, &ok_ty, layout, fx);
         let nil_check = self.partial_ok_nil_check(&ok_ty, &val_var, fx);
 
         let type_params = format!("{}, {}", ok_ty_str, err_ty_str);
@@ -275,8 +301,13 @@ impl Planner<'_> {
         fx.require_stdlib();
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
-        let (wrap_setup, outcome) =
-            self.lower_result_wrapping(&call_str, result_ty, WrapperTarget::FreshSlot, fx);
+        let (wrap_setup, outcome) = self.lower_result_wrapping(
+            &call_str,
+            result_ty,
+            TupleReturnLayout::Flattened,
+            WrapperTarget::FreshSlot,
+            fx,
+        );
         setup.extend(wrap_setup);
         (setup, outcome.expect("wrapper produced no slot"))
     }
@@ -287,10 +318,12 @@ impl Planner<'_> {
         output: &mut String,
         call_str: &str,
         result_ty: &Type,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> WrapperOutcome {
-        let (statements, outcome) = self.lower_result_wrapping(call_str, result_ty, target, fx);
+        let (statements, outcome) =
+            self.lower_result_wrapping(call_str, result_ty, layout, target, fx);
         output.push_str(&Renderer.render_setup(&statements));
         outcome
     }
@@ -300,6 +333,7 @@ impl Planner<'_> {
         &mut self,
         call_str: &str,
         result_ty: &Type,
+        layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
@@ -311,7 +345,7 @@ impl Planner<'_> {
 
         let mut statements = Vec::new();
         let ok_ty = fallible.ok_ty();
-        let (err_var, ok_val) = self.push_go_returns(&mut statements, call_str, ok_ty, fx);
+        let (err_var, ok_val) = self.push_go_returns(&mut statements, call_str, ok_ty, layout, fx);
 
         let result_ty_str = {
             let mut fe = FalliblePlanner::new(self, &fallible, fx);
@@ -427,16 +461,21 @@ impl Planner<'_> {
         (statements, outcome)
     }
 
-    /// Destructure a Go multi-return into error and value temps. Tuple ok
-    /// types get N+1 temps and a rebuilt Lisette tuple; others get 2 temps.
+    /// Destructure a Go multi-return into error and value temps. A `Flattened`
+    /// tuple ok type (Go-imported `(T1, ..., Tn, error)`) gets N+1 temps and a
+    /// rebuilt Lisette tuple; a `Packed` one (Lisette `(Tuple_n[...], error)`)
+    /// gets 2 temps like any other ok type.
     fn extract_go_returns(
         &mut self,
         output: &mut String,
         call_str: &str,
         ok_ty: &Type,
+        layout: TupleReturnLayout,
         fx: &mut EmitEffects,
     ) -> (String, String) {
-        if let Type::Tuple(elements) = ok_ty {
+        if layout.is_flattened()
+            && let Type::Tuple(elements) = ok_ty
+        {
             let tuple_arity = elements.len();
             let temp_vars = self.create_temp_vars("ret", tuple_arity + 1);
             write_line!(output, "{} := {}", temp_vars.join(", "), call_str);
@@ -617,6 +656,7 @@ impl Planner<'_> {
                 &mut body,
                 &call_str,
                 &return_type,
+                TupleReturnLayout::Flattened,
                 WrapperTarget::Return,
                 fx,
             ),
@@ -624,7 +664,7 @@ impl Planner<'_> {
                 &mut body,
                 &call_str,
                 &return_type,
-                true,
+                TupleReturnLayout::Flattened,
                 WrapperTarget::Return,
                 fx,
             ),
@@ -648,6 +688,7 @@ impl Planner<'_> {
                 &mut body,
                 &call_str,
                 &return_type,
+                TupleReturnLayout::Flattened,
                 WrapperTarget::Return,
                 fx,
             ),

--- a/tests/spec/emit/partial.rs
+++ b/tests/spec/emit/partial.rs
@@ -97,3 +97,30 @@ fn test(p: Partial<int, string>) -> bool {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn lisette_function_returning_partial_tuple_uses_packed_abi() {
+    let input = r#"
+fn pair<A, B>(a: A, b: B) -> Partial<(A, B), error> {
+  Partial.Ok((a, b))
+}
+
+fn test() {
+  match pair<int, string>(1, "x") {
+    Partial.Ok((first, second)) => {
+      let _ = first
+      let _ = second
+    },
+    Partial.Err(e) => {
+      let _ = e
+    },
+    Partial.Both((first, second), e) => {
+      let _ = first
+      let _ = second
+      let _ = e
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1002,6 +1002,28 @@ fn main() {
 }
 
 #[test]
+fn lisette_function_returning_result_tuple_uses_packed_abi() {
+    let input = r#"
+fn pair<A, B>(a: A, b: B) -> Result<(A, B), error> {
+  Ok((a, b))
+}
+
+fn test() {
+  match pair<int, string>(1, "x") {
+    Ok((first, second)) => {
+      let _ = first
+      let _ = second
+    },
+    Err(e) => {
+      let _ = e
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn complex_number_with_typed_float_multiplication() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/partial.rs
+description: "input: \nfn pair<A, B>(a: A, b: B) -> Partial<(A, B), error> {\n  Partial.Ok((a, b))\n}\n\nfn test() {\n  match pair<int, string>(1, \"x\") {\n    Partial.Ok((first, second)) => {\n      let _ = first\n      let _ = second\n    },\n    Partial.Err(e) => {\n      let _ = e\n    },\n    Partial.Both((first, second), e) => {\n      let _ = first\n      let _ = second\n      let _ = e\n    },\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
+	return lisette.MakeTuple2(a, b), nil
+}
+
+func test() {
+	ret_2, ret_3 := pair[int, string](1, "x")
+	var result_4 lisette.Partial[lisette.Tuple2[int, string], error]
+	if ret_3 != nil {
+		result_4 = lisette.MakePartialBoth[lisette.Tuple2[int, string], error](ret_2, ret_3)
+	} else {
+		result_4 = lisette.MakePartialOk[lisette.Tuple2[int, string], error](ret_2)
+	}
+	subject_1 := result_4
+	switch subject_1.Tag {
+	case lisette.PartialOk:
+		_ = subject_1.OkVal.First
+		_ = subject_1.OkVal.Second
+	case lisette.PartialErr:
+		_ = subject_1.ErrVal
+	default:
+		_ = subject_1.OkVal.First
+		_ = subject_1.OkVal.Second
+		_ = subject_1.ErrVal
+	}
+}

--- a/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nfn pair<A, B>(a: A, b: B) -> Result<(A, B), error> {\n  Ok((a, b))\n}\n\nfn test() {\n  match pair<int, string>(1, \"x\") {\n    Ok((first, second)) => {\n      let _ = first\n      let _ = second\n    },\n    Err(e) => {\n      let _ = e\n    },\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
+	return lisette.MakeTuple2(a, b), nil
+}
+
+func test() {
+	ret_2, ret_3 := pair[int, string](1, "x")
+	var result_4 lisette.Result[lisette.Tuple2[int, string], error]
+	if ret_3 != nil {
+		result_4 = lisette.MakeResultErr[lisette.Tuple2[int, string], error](ret_3)
+	} else {
+		result_4 = lisette.MakeResultOk[lisette.Tuple2[int, string], error](ret_2)
+	}
+	subject_1 := result_4
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal.First
+		_ = subject_1.OkVal.Second
+	} else {
+		_ = subject_1.ErrVal
+	}
+}


### PR DESCRIPTION
Calling a fn that returns a fallible type whose success value is a tuple now compiles.

```rs
fn pair<A, B>(a: A, b: B) -> Result<(A, B), error> {
  Ok((a, b))
}

fn main() {
  match pair<string, string>("Hello", "World") {
    Ok((hello, world)) => fmt.Println(f"{hello}, {world}!"),
    Err(e) => fmt.Println(f"{e}"),
  }
}
```

Fix #529
