### PR TITLE
feat: warn on WaitGroup.Add inside a task

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -547,3 +547,12 @@ pub fn duplicate_arguments(span: &Span, module: &str, function: &str) -> Lisette
             "Passing the same value twice to `{display_module}.{function}` makes this call a no-op. Did you mean to pass different values?"
         ))
 }
+
+pub fn waitgroup_add_in_task(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("`WaitGroup.Add` inside a `task`")
+        .with_lint_code("waitgroup_add_in_task")
+        .with_span_label(span, "may run after `Wait`")
+        .with_help(
+            "If `Wait` runs before this `Add`, it sees a zero counter and returns immediately. Call `Add` before the `task`",
+        )
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -21,6 +21,7 @@ mod uninterpolated_fstring;
 mod unnecessary_raw_string;
 mod unsigned_comparison;
 mod verbose_failure_propagation;
+mod waitgroup_add_in_task;
 
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use double_negation::check_double_negation;
@@ -48,3 +49,4 @@ pub use unnecessary_raw_string::{
 };
 pub use unsigned_comparison::check_unsigned_comparison;
 pub use verbose_failure_propagation::check_verbose_failure_propagation;
+pub use waitgroup_add_in_task::check_waitgroup_add_in_task;

--- a/crates/semantics/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
@@ -1,0 +1,116 @@
+use diagnostics::LisetteDiagnostic;
+use rustc_hash::FxHashSet;
+use syntax::ast::{BindingId, Expression, Literal, Span, UnaryOperator};
+use syntax::types::Type;
+
+pub fn check_waitgroup_add_in_task(
+    expression: &Expression,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let body = match expression {
+        Expression::Function { body, .. } | Expression::Lambda { body, .. } => body,
+        _ => return,
+    };
+
+    let mut waited: FxHashSet<BindingId> = FxHashSet::default();
+    let mut adds: Vec<(BindingId, Span)> = Vec::new();
+    collect(body, false, &mut waited, &mut adds);
+
+    for (binding, span) in adds {
+        if waited.contains(&binding) {
+            diagnostics.push(diagnostics::lint::waitgroup_add_in_task(&span));
+        }
+    }
+}
+
+/// Gather every `WaitGroup` `Wait` reached outside a `task`, and every positive
+/// `Add` reached inside one. Nested functions and lambdas are their own roots,
+/// so descent stops at their boundary.
+fn collect(
+    expression: &Expression,
+    in_task: bool,
+    waited: &mut FxHashSet<BindingId>,
+    adds: &mut Vec<(BindingId, Span)>,
+) {
+    match expression {
+        Expression::Function { .. } | Expression::Lambda { .. } => return,
+        Expression::Task { expression, .. } => {
+            collect(expression, true, waited, adds);
+            return;
+        }
+        Expression::Call {
+            expression: callee,
+            args,
+            span,
+            ..
+        } => {
+            if let Some((member, binding)) = waitgroup_method(callee) {
+                match member {
+                    "Wait" if !in_task => {
+                        waited.insert(binding);
+                    }
+                    "Add" if in_task => {
+                        if args
+                            .first()
+                            .is_some_and(|delta| !is_nonpositive_literal(delta))
+                        {
+                            adds.push((binding, *span));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+
+    for child in expression.children() {
+        collect(child, in_task, waited, adds);
+    }
+}
+
+fn waitgroup_method(callee: &Expression) -> Option<(&str, BindingId)> {
+    let Expression::DotAccess {
+        expression: receiver,
+        member,
+        ..
+    } = callee.unwrap_parens()
+    else {
+        return None;
+    };
+    let Expression::Identifier {
+        binding_id: Some(binding),
+        ..
+    } = receiver.unwrap_parens()
+    else {
+        return None;
+    };
+    if !is_waitgroup(&receiver.get_type()) {
+        return None;
+    }
+    Some((member.as_str(), *binding))
+}
+
+fn is_waitgroup(ty: &Type) -> bool {
+    ty.strip_refs().get_qualified_id() == Some("go:sync.WaitGroup")
+}
+
+/// A zero or negative delta is the `Done` equivalent and is legitimate inside a
+/// `task`; only a positive (or unknown) delta must precede `Wait`.
+fn is_nonpositive_literal(delta: &Expression) -> bool {
+    match delta.unwrap_parens() {
+        Expression::Literal {
+            literal: Literal::Integer { value, .. },
+            ..
+        } => *value == 0,
+        Expression::Unary {
+            operator: UnaryOperator::Negative,
+            expression,
+            ..
+        } => matches!(
+            expression.unwrap_parens(),
+            Expression::Literal { literal: Literal::Integer { value, .. }, .. } if *value != 0
+        ),
+        _ => false,
+    }
+}

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -78,7 +78,7 @@ use checks::{
     check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
     check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
     check_unnecessary_raw_string_pattern, check_unsigned_comparison,
-    check_verbose_failure_propagation,
+    check_verbose_failure_propagation, check_waitgroup_add_in_task,
 };
 use visitor::visit_ast;
 
@@ -104,6 +104,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_verbose_failure_propagation,
     check_dup_arg,
     check_duplicate_cutset,
+    check_waitgroup_add_in_task,
     check_struct_attributes,
     check_attributes,
 ];

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -5776,3 +5776,92 @@ pub struct Job {
 "#
     );
 }
+
+#[test]
+fn waitgroup_add_in_task() {
+    assert_lint_snapshot!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  task {
+    wg.Add(1)
+    wg.Done()
+  }
+  wg.Wait()
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_add_before_task_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  wg.Add(1)
+  task {
+    wg.Done()
+  }
+  wg.Wait()
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_add_in_task_not_waited_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  task {
+    wg.Add(1)
+    wg.Done()
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_negative_add_in_task_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  wg.Add(1)
+  task {
+    wg.Add(-1)
+  }
+  wg.Wait()
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_distinct_groups_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg1 = sync.WaitGroup {}
+  let mut wg2 = sync.WaitGroup {}
+  task {
+    wg1.Add(1)
+  }
+  wg2.Wait()
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/waitgroup_add_in_task.snap
+++ b/tests/ui/lint/snapshots/waitgroup_add_in_task.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] `WaitGroup.Add` inside a `task`
+   ╭─[test.lis:7:5]
+ 6 │   task {
+ 7 │     wg.Add(1)
+   ·     ────┬────
+   ·         ╰── may run after `Wait`
+ 8 │     wg.Done()
+   ╰────
+  help: If `Wait` runs before this `Add`, it sees a zero counter and returns immediately. Call `Add` before the `task` · code: [lint.waitgroup_add_in_task]


### PR DESCRIPTION
Adds a warning when `WaitGroup.Add` is called inside a `task` while the same `WaitGroup` is awaited outside it. This is a race where `Wait` can return before the counter is incremented and silently skip the synchronization.

```
  [warning] `WaitGroup.Add` inside a `task`
   ╭─[test.lis:7:5]
 6 │   task {
 7 │     wg.Add(1)
   ·     ────┬────
   ·         ╰── may run after `Wait`
 8 │     wg.Done()
   ╰────
  help: If `Wait` runs before this `Add`, it sees a zero counter and returns immediately. Call `Add` before the `task` · code: [lint.waitgroup_add_in_task]
```