### PR TITLE
fix: resolve enum variant access through a type alias

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -48,73 +48,10 @@ impl TaskState<'_> {
             }
         }
 
-        if let Some(root) = expression.root_identifier()
-            && let Some(qualified_root) = self.lookup_qualified_name(store, root)
-            && let Some(base) = expression.as_dotted_path()
+        if let Some(resolved) =
+            self.resolve_qualified_path(store, &expression, &member, span, expected_ty)
         {
-            let path = format!("{}.{}", base, member);
-            if self.lookup_type(store, &path).is_some() {
-                self.track_name_usage(store, &qualified_root, &span, root.len() as u32);
-                return self.infer_expression(
-                    store,
-                    Expression::Identifier {
-                        value: path.into(),
-                        ty: Type::uninferred(),
-                        span,
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    expected_ty,
-                );
-            }
-
-            let alias_target = store
-                .get_definition(&qualified_root)
-                .and_then(|definition| {
-                    if let DefinitionBody::TypeAlias { .. } = &definition.body {
-                        let underlying = definition.ty.unwrap_forall();
-                        match underlying {
-                            Type::Nominal { id, params, .. }
-                                if params.is_empty() && id.as_str() != qualified_root.as_str() =>
-                            {
-                                return Some(id.to_string());
-                            }
-                            Type::Simple(kind) => {
-                                return Some(format!("prelude.{}", kind.leaf_name()));
-                            }
-                            Type::Compound { kind, args } if args.is_empty() => {
-                                return Some(format!("prelude.{}", kind.leaf_name()));
-                            }
-                            _ => {}
-                        }
-                    }
-                    None
-                });
-
-            if let Some(resolved_id) = alias_target {
-                let mut paths = Vec::with_capacity(2);
-                let short_name = unqualified_name(&resolved_id);
-                if short_name != resolved_id {
-                    paths.push(format!("{}.{}", short_name, member));
-                }
-                paths.push(format!("{}.{}", resolved_id, member));
-
-                for path in paths {
-                    if self.lookup_type(store, &path).is_some() {
-                        return self.infer_expression(
-                            store,
-                            Expression::Identifier {
-                                value: path.into(),
-                                ty: Type::uninferred(),
-                                span,
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            expected_ty,
-                        );
-                    }
-                }
-            }
+            return resolved;
         }
 
         if let Some(root) = expression.root_identifier()
@@ -157,6 +94,84 @@ impl TaskState<'_> {
         }
 
         self.infer_dot_access(store, expression, member, span, expected_ty)
+    }
+
+    fn resolve_qualified_path(
+        &mut self,
+        store: &Store,
+        expression: &Expression,
+        member: &EcoString,
+        span: Span,
+        expected_ty: &Type,
+    ) -> Option<Expression> {
+        let root = expression.root_identifier()?;
+        let qualified_root = self.lookup_qualified_name(store, root)?;
+        let base = expression.as_dotted_path()?;
+
+        let direct = format!("{}.{}", base, member);
+        let path = if self.lookup_type(store, &direct).is_some() {
+            self.track_name_usage(store, &qualified_root, &span, root.len() as u32);
+            direct
+        } else {
+            let resolved_id = self.nongeneric_alias_target(store, &qualified_root)?;
+            if self.alias_member_is_enum_variant(store, &resolved_id, member) {
+                return None;
+            }
+            let short_name = unqualified_name(&resolved_id);
+            let mut candidates = Vec::with_capacity(2);
+            if short_name != resolved_id {
+                candidates.push(format!("{}.{}", short_name, member));
+            }
+            candidates.push(format!("{}.{}", resolved_id, member));
+            candidates
+                .into_iter()
+                .find(|candidate| self.lookup_type(store, candidate).is_some())?
+        };
+
+        Some(self.infer_expression(
+            store,
+            Expression::Identifier {
+                value: path.into(),
+                ty: Type::uninferred(),
+                span,
+                binding_id: None,
+                qualified: None,
+            },
+            expected_ty,
+        ))
+    }
+
+    fn nongeneric_alias_target(&self, store: &Store, qualified_root: &str) -> Option<String> {
+        let definition = store.get_definition(qualified_root)?;
+        let DefinitionBody::TypeAlias { .. } = &definition.body else {
+            return None;
+        };
+        match definition.ty.unwrap_forall() {
+            Type::Nominal { id, params, .. }
+                if params.is_empty() && id.as_str() != qualified_root =>
+            {
+                Some(id.to_string())
+            }
+            Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
+            Type::Compound { kind, args } if args.is_empty() => {
+                Some(format!("prelude.{}", kind.leaf_name()))
+            }
+            _ => None,
+        }
+    }
+
+    fn alias_member_is_enum_variant(&self, store: &Store, type_id: &str, member: &str) -> bool {
+        store
+            .get_definition(type_id)
+            .is_some_and(|definition| match &definition.body {
+                DefinitionBody::Enum { variants, .. } => {
+                    variants.iter().any(|variant| variant.name == member)
+                }
+                DefinitionBody::ValueEnum { variants, .. } => {
+                    variants.iter().any(|variant| variant.name == member)
+                }
+                _ => false,
+            })
     }
 }
 
@@ -895,15 +910,9 @@ impl TaskState<'_> {
 
         if let DefinitionBody::ValueEnum { methods, .. } = &definition.body
             && methods.contains_key(args.member_name)
+            && !self.is_type_level_receiver(store, args.expression)
         {
-            let is_type_access = matches!(
-                args.expression,
-                Expression::DotAccess { expression, .. }
-                    if expression.get_type().resolve_in(&self.env).as_import_namespace().is_some()
-            );
-            if !is_type_access {
-                return None;
-            }
+            return None;
         }
 
         let variant_qualified_name = id.with_segment(args.member_name);

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -1233,6 +1233,62 @@ fn main() {
 }
 
 #[test]
+fn entry_module_type_alias_cross_module_enum_variant() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "palette",
+        "mod.lis",
+        r#"
+pub enum Color {
+  RGB,
+  Named(string),
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "palette"
+
+type LocalColor = palette.Color
+
+fn main() {
+  let _ = LocalColor.RGB
+  let _ = LocalColor.Named("teal")
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn entry_module_type_alias_value_enum_variant_method_collision() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "go:reflect"
+
+type K = reflect.Kind
+
+fn main() {
+  fmt.Println(K.String)
+  fmt.Println(K.Int)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn multimodule_enum_static_method() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/entry_module_type_alias_cross_module_enum_variant.snap
+++ b/tests/spec/build/snapshots/entry_module_type_alias_cross_module_enum_variant.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "github.com/user/myproject/palette"
+
+type LocalColor = palette.Color
+
+func main() {
+	_ = palette.MakeColorRGB()
+	_ = palette.MakeColorNamed("teal")
+}
+
+
+// === palette/mod.go ===
+package palette
+
+import "fmt"
+
+func MakeColorRGB() Color {
+	return Color{Tag: ColorRGB}
+}
+
+func MakeColorNamed(arg0 string) Color {
+	return Color{Tag: ColorNamed, Named: arg0}
+}
+
+type ColorTag int
+
+const (
+	ColorRGB ColorTag = iota
+	ColorNamed
+)
+
+type Color struct {
+	Tag   ColorTag
+	Named string
+}
+
+func (c Color) String() string {
+	switch c.Tag {
+	case ColorRGB:
+		return "Color.RGB"
+	case ColorNamed:
+		return fmt.Sprintf("Color.Named(%v)", c.Named)
+	default:
+		return fmt.Sprintf("Color(%d)", c.Tag)
+	}
+}

--- a/tests/spec/build/snapshots/entry_module_type_alias_value_enum_variant_method_collision.snap
+++ b/tests/spec/build/snapshots/entry_module_type_alias_value_enum_variant_method_collision.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type K = reflect.Kind
+
+func main() {
+	fmt.Println(reflect.String)
+	fmt.Println(reflect.Int)
+}


### PR DESCRIPTION
Enum variant access through a non-generic type alias now resolves the same as direct access.

An ADT enum variant reached through an alias emitted an invalid Go name:

```rs
import "utils" // pub enum Color { RGB, Named(string) }
type C = utils.Color

fn main() {
  let _ = C.RGB // was utils.Color_RGB (undefined)
}
```

Discovered while reviewing #532