### PR TITLE
test: check emitted Go with go vet

### DIFF
--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -69,7 +69,9 @@ impl Planner<'_> {
         let has_default = arms
             .iter()
             .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
-        let exhaustive = if needs_retry_loop { false } else { has_default };
+        let all_arms_diverge =
+            !arm_plans.is_empty() && arm_plans.iter().all(|arm| arm.body().ends_with_diverge());
+        let exhaustive = all_arms_diverge || if needs_retry_loop { false } else { has_default };
         let mut postlude: Vec<LoweredStatement> = Vec::new();
         let mut panic_buffer = String::new();
         emit_unreachable_panic_if_needed(&mut panic_buffer, place, exhaustive);

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -372,6 +372,11 @@ impl SelectStatementPlan {
         self.postlude
             .last()
             .is_some_and(LoweredStatement::ends_with_diverge)
+            || self.all_arms_diverge()
+    }
+
+    pub(crate) fn all_arms_diverge(&self) -> bool {
+        !self.arms.is_empty() && self.arms.iter().all(|arm| arm.body().ends_with_diverge())
     }
 }
 
@@ -498,6 +503,10 @@ impl LoweredStatement {
         }
     }
 
+    pub(crate) fn blocks_fallthrough(&self) -> bool {
+        !matches!(self, LoweredStatement::WhileLet(_)) && self.ends_with_diverge()
+    }
+
     pub(crate) fn references_var(&self, var: &str) -> bool {
         match self {
             LoweredStatement::If(plan) => plan.references_var(var),
@@ -606,12 +615,14 @@ impl LoweredStatement {
 
 impl IfPlan {
     fn ends_with_diverge(&self) -> bool {
+        if !self.then_body.ends_with_diverge() {
+            return false;
+        }
         match &self.else_arm {
             ElseArm::None => false,
             ElseArm::ElseIf(inner) if inner.condition_setup.is_empty() => inner.ends_with_diverge(),
             ElseArm::ElseIf(_) => false,
-            ElseArm::Else { body, inline: true } => body.ends_with_diverge(),
-            ElseArm::Else { inline: false, .. } => false,
+            ElseArm::Else { body, .. } => body.ends_with_diverge(),
         }
     }
 

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -133,10 +133,26 @@ impl Planner<'_> {
         (vec![declaration, LoweredStatement::Loop(plan)], result_var)
     }
 
-    /// Lower a function/lambda body to a `LoweredBlock`. Non-value bodies map
-    /// each item through `lower_statement`; value bodies lower the tail through
-    /// the shared `lower_return_tail`. Unlike branch-arm return lowering, a
-    /// function body does not elide a tail `let` into the return place.
+    fn lower_body_until_diverge(
+        &mut self,
+        rest: &[Expression],
+        last: &Expression,
+        return_ctx: &ReturnContext,
+        fx: &mut EmitEffects,
+    ) -> (Vec<LoweredStatement>, bool) {
+        let mut statements: Vec<LoweredStatement> = Vec::with_capacity(rest.len() + 1);
+        for item in rest {
+            let statement = self.lower_statement(item, return_ctx, fx);
+            let diverged = statement.blocks_fallthrough();
+            statements.push(statement);
+            if diverged {
+                return (statements, true);
+            }
+        }
+        statements.extend(self.lower_return_tail(last, return_ctx, fx));
+        (statements, false)
+    }
+
     pub(crate) fn lower_function_body(
         &mut self,
         body: &Expression,
@@ -160,11 +176,10 @@ impl Planner<'_> {
             };
         };
 
-        let mut statements: Vec<LoweredStatement> = rest
-            .iter()
-            .map(|item| self.lower_statement(item, return_ctx, fx))
-            .collect();
-        statements.extend(self.lower_return_tail(last, return_ctx, fx));
+        let (mut statements, diverged) = self.lower_body_until_diverge(rest, last, return_ctx, fx);
+        if diverged {
+            return LoweredBlock { statements };
+        }
 
         // A unit/statement-only body under a non-unit signature has no value to
         // return, so `lower_return_tail` emits it as a bare statement. A
@@ -653,11 +668,7 @@ impl Planner<'_> {
             };
         };
 
-        let mut statements: Vec<LoweredStatement> = rest
-            .iter()
-            .map(|item| self.lower_statement(item, return_ctx, fx))
-            .collect();
-        statements.extend(self.lower_return_tail(last, return_ctx, fx));
+        let (statements, _) = self.lower_body_until_diverge(rest, last, return_ctx, fx);
         LoweredBlock { statements }
     }
 

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -61,7 +61,11 @@ impl Renderer {
         }
         output.push_str("}\n");
         if plan.retry_loop {
-            output.push_str("break\n}\n");
+            if plan.all_arms_diverge() {
+                output.push_str("}\n");
+            } else {
+                output.push_str("break\n}\n");
+            }
         }
         for statement in &plan.postlude {
             self.render_statement(output, statement);

--- a/tests/e2e_suite.rs
+++ b/tests/e2e_suite.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 
 use harness::{
     EmittedTest, HarvestedTest, compile_e2e_suite_test, harvest_snapshots, prelude_dir,
-    read_go_version, read_skip_list, run_go_test, skip_reason_for_imports, snapshots_dir,
-    target_dir, write_go_mod, write_subpackage,
+    read_go_version, read_skip_list, run_go_test, run_go_vet, skip_reason_for_imports,
+    snapshots_dir, target_dir, write_go_mod, write_subpackage,
 };
 
 #[test]
@@ -108,5 +108,11 @@ fn e2e_suite() {
             eprintln!("{out}");
             panic!("go test failed");
         }
+    }
+
+    eprintln!("running `go vet ./...` in {}", target.display());
+    if let Err(out) = run_go_vet(&target) {
+        eprintln!("{out}");
+        panic!("go vet failed");
     }
 }

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -276,6 +276,23 @@ pub fn run_go_test(target_dir: &Path, timeout_per_pkg: &str) -> Result<String, S
     }
 }
 
+pub fn run_go_vet(target_dir: &Path) -> Result<String, String> {
+    let output = Command::new("go")
+        .args(["vet", "-unreachable=false", "-copylocks=false", "./..."])
+        .current_dir(target_dir)
+        .env("NO_COLOR", "1")
+        .output()
+        .map_err(|e| format!("failed to spawn go vet: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}{stderr}");
+    if output.status.success() {
+        Ok(combined)
+    } else {
+        Err(combined)
+    }
+}
+
 pub fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1170,10 +1170,9 @@ fn test() -> Option<()> {
 fn wrapped_return_temp_no_collision() {
     let input = r#"
 fn foo() -> Option<int> {
-  return if true { Some(1) } else { None };
   let tmp_1 = 7;
   let _ = tmp_1;
-  None
+  return if true { Some(1) } else { None };
 }
 
 fn main() {

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
@@ -8,7 +8,6 @@ import "errors"
 
 func fail_unit() error {
 	return errors.New("boom")
-	return nil
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
@@ -8,7 +8,6 @@ import "errors"
 
 func fail() (int, error) {
 	return *new(int), errors.New("boom")
-	return 1, nil
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
@@ -6,7 +6,6 @@ package main
 
 func missing() (int, bool) {
 	return *new(int), false
-	return 1, true
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
@@ -28,7 +28,6 @@ loop_1:
 			default:
 				break loop_1
 			}
-			break
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/select_closed_shorthand_receive_does_not_steal.snap
+++ b/tests/spec/emit/snapshots/select_closed_shorthand_receive_does_not_steal.snap
@@ -25,7 +25,5 @@ func test() int {
 		default:
 			return 30
 		}
-		break
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/select_match_receive_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_on_go_interface_uses_comma_ok.snap
@@ -20,5 +20,4 @@ func drain(ch <-chan shapes.Shape) int {
 			return -1
 		}
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/select_send_and_receive.snap
+++ b/tests/spec/emit/snapshots/select_send_and_receive.snap
@@ -22,7 +22,5 @@ func test() int {
 		default:
 			return 0
 		}
-		break
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/select_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern.snap
@@ -29,7 +29,5 @@ func test(ch <-chan Message) int {
 		default:
 			return 0
 		}
-		break
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/select_struct_pattern_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern_on_go_interface_uses_comma_ok.snap
@@ -25,7 +25,5 @@ func drain(ch <-chan shapes.Shape) int {
 		default:
 			return 0
 		}
-		break
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/select_with_default.snap
+++ b/tests/spec/emit/snapshots/select_with_default.snap
@@ -19,7 +19,5 @@ func test() int {
 		default:
 			return 0
 		}
-		break
 	}
-	panic("unreachable")
 }

--- a/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
@@ -1,16 +1,15 @@
 ---
 source: tests/spec/emit/result_option_patterns.rs
-description: "input: \nfn foo() -> Option<int> {\n  return if true { Some(1) } else { None };\n  let tmp_1 = 7;\n  let _ = tmp_1;\n  None\n}\n\nfn main() {\n  let _ = foo();\n}\n"
+description: "input: \nfn foo() -> Option<int> {\n  let tmp_1 = 7;\n  let _ = tmp_1;\n  return if true { Some(1) } else { None };\n}\n\nfn main() {\n  let _ = foo();\n}\n"
 ---
 package main
 
 func foo() (int, bool) {
+	tmp_1 := 7
+	_ = tmp_1
 	if true {
 		return 1, true
 	}
-	return *new(int), false
-	tmp_1 := 7
-	_ = tmp_1
 	return *new(int), false
 }
 


### PR DESCRIPTION
The e2e suite now runs `go vet` over every built package, and the emitter no longer produces the unreachable Go that previously passed `gofmt` and `go test` unnoticed. Two `go vet` settings `unreachable` and `copylocks` remain disabled and will be tackled in future.
