### PR TITLE
feat: reject loop with unchanging condition

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2201,6 +2201,15 @@ pub fn repeated_if_condition(span: &Span) -> LisetteDiagnostic {
         )
 }
 
+pub fn unchanging_loop_condition(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Loop condition never changes")
+        .with_infer_code("unchanging_loop_condition")
+        .with_span_label(span, "never changes")
+        .with_help(
+            "Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop?",
+        )
+}
+
 pub fn index_out_of_bounds(span: &Span, index_text: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Index out of bounds")
         .with_infer_code("index_out_of_bounds")

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -22,14 +22,17 @@ pub(crate) mod receivers;
 pub(crate) mod repeated_if_condition;
 pub(crate) mod stringer_signature;
 pub(crate) mod temp_producing;
+pub(crate) mod unchanging_loop_condition;
 pub(crate) mod visibility;
 
 use diagnostics::{LocalSink, PatternIssue};
 use rayon::prelude::*;
+use rustc_hash::FxHashMap as HashMap;
+use syntax::ast::BindingId;
 use syntax::program::{File, Module};
 
 use crate::context::AnalysisContext;
-use crate::facts::Facts;
+use crate::facts::{BindingFact, Facts};
 use crate::store::Store;
 
 use super::PARALLEL_THRESHOLD;
@@ -57,11 +60,12 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
     });
 
     let or_spans = &facts.or_pattern_error_spans;
+    let bindings = &facts.bindings;
 
     if work.len() < PARALLEL_THRESHOLD {
         let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
         for (module, file) in &work {
-            run_file_checks(module, file, store, sink, &pattern_ctx);
+            run_file_checks(module, file, store, bindings, sink, &pattern_ctx);
         }
         facts.pattern_issues = pattern_ctx.take_issues();
         return;
@@ -73,7 +77,7 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
         .map(|(module, file)| {
             let local_sink = LocalSink::new();
             let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
-            run_file_checks(module, file, store, &local_sink, &pattern_ctx);
+            run_file_checks(module, file, store, bindings, &local_sink, &pattern_ctx);
             (local_sink, pattern_ctx.take_issues())
         })
         .collect();
@@ -92,6 +96,7 @@ fn run_file_checks(
     module: &Module,
     file: &File,
     store: &Store,
+    bindings: &HashMap<BindingId, BindingFact>,
     sink: &LocalSink,
     pattern_ctx: &pattern_analysis::Context,
 ) {
@@ -115,6 +120,7 @@ fn run_file_checks(
     json_serializable_fields::run(&file.items, sink);
     oversized_shift::run(&file.items, sink);
     repeated_if_condition::run(&file.items, sink);
+    unchanging_loop_condition::run(&file.items, bindings, sink);
     temp_producing::run(&file.items, sink);
     if !file.is_d_lis() {
         const_naming::run(&file.items, sink);

--- a/crates/semantics/src/passes/checks/unchanging_loop_condition.rs
+++ b/crates/semantics/src/passes/checks/unchanging_loop_condition.rs
@@ -1,0 +1,112 @@
+use diagnostics::LocalSink;
+use rustc_hash::FxHashMap as HashMap;
+use syntax::ast::{BindingId, Expression, UnaryOperator};
+
+use crate::facts::BindingFact;
+
+pub(crate) fn run(
+    typed_ast: &[Expression],
+    bindings: &HashMap<BindingId, BindingFact>,
+    sink: &LocalSink,
+) {
+    for item in typed_ast {
+        visit_expression(item, bindings, sink);
+    }
+}
+
+fn visit_expression(
+    expression: &Expression,
+    bindings: &HashMap<BindingId, BindingFact>,
+    sink: &LocalSink,
+) {
+    if let Expression::While {
+        condition, body, ..
+    } = expression
+        && condition_is_unchanging(condition, bindings)
+        && !body_has_exit(body)
+    {
+        sink.push(diagnostics::infer::unchanging_loop_condition(
+            &condition.get_span(),
+        ));
+    }
+
+    for child in expression.children() {
+        visit_expression(child, bindings, sink);
+    }
+}
+
+/// True when the condition references a binding and is built only from
+/// never-mutated bindings, literals, and pure operators. Member, index, and
+/// pointer-deref access are rejected: they read through aliases that the
+/// per-binding mutation facts do not track.
+///
+/// `mutated` is whole-program, not loop-scoped: a binding assigned outside the
+/// loop also suppresses the check. That is a deliberate sound under-approximation
+/// (loop-scoped invariance cannot be decided from this fact without false
+/// positives), so the check misses loops whose variable is changed only outside
+/// the body but never wrongly flags a loop that can terminate.
+fn condition_is_unchanging(
+    condition: &Expression,
+    bindings: &HashMap<BindingId, BindingFact>,
+) -> bool {
+    let mut references_binding = false;
+    is_invariant(condition, bindings, &mut references_binding) && references_binding
+}
+
+fn is_invariant(
+    expression: &Expression,
+    bindings: &HashMap<BindingId, BindingFact>,
+    references_binding: &mut bool,
+) -> bool {
+    match expression {
+        Expression::Identifier {
+            binding_id: Some(id),
+            ..
+        } => match bindings.get(id) {
+            Some(fact) if !fact.mutated => {
+                *references_binding = true;
+                true
+            }
+            _ => false,
+        },
+        Expression::Identifier { .. } => false,
+        Expression::Literal { .. } => expression
+            .children()
+            .into_iter()
+            .all(|child| is_invariant(child, bindings, references_binding)),
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            ..
+        } => false,
+        Expression::Paren { expression, .. } | Expression::Unary { expression, .. } => {
+            is_invariant(expression, bindings, references_binding)
+        }
+        Expression::Binary { left, right, .. } => {
+            is_invariant(left, bindings, references_binding)
+                && is_invariant(right, bindings, references_binding)
+        }
+        _ => false,
+    }
+}
+
+fn body_has_exit(body: &Expression) -> bool {
+    body.contains_break() || contains_function_exit(body, false)
+}
+
+fn contains_function_exit(expression: &Expression, inside_try: bool) -> bool {
+    match expression {
+        Expression::Return { .. } => true,
+        Expression::Propagate {
+            expression: inner, ..
+        } => !inside_try || contains_function_exit(inner, inside_try),
+        Expression::Call { ty, .. } if ty.is_never() => true,
+        Expression::Function { .. } | Expression::Lambda { .. } | Expression::Task { .. } => false,
+        Expression::TryBlock { items, .. } => {
+            items.iter().any(|item| contains_function_exit(item, true))
+        }
+        _ => expression
+            .children()
+            .into_iter()
+            .any(|child| contains_function_exit(child, inside_try)),
+    }
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1213,6 +1213,210 @@ fn main() {
 }
 
 #[test]
+fn unchanging_loop_condition_comparison() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n = 5;
+  while n < 10 {
+    let _ = n
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_negated_flag() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let done = false;
+  while !done {
+    let _ = done
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_mutated_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut i = 0;
+  while i < 10 {
+    i = i + 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_partial_mutation_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = 0;
+  let b = 5;
+  while a < b {
+    a = a + 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_break_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n = 5;
+  while n < 10 {
+    let _ = n
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_return_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let n = 5;
+  while n < 10 {
+    return
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_call_in_condition_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn check() -> bool { true }
+
+fn main() {
+  while check() {
+    let _ = 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_literal_condition_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  while true {
+    let _ = 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_try_scoped_propagate() {
+    assert_lint_snapshot!(
+        r#"
+fn may_fail() -> Result<int, string> { Ok(1) }
+
+fn main() {
+  let n = 5;
+  while n < 10 {
+    let _ = try { may_fail()? }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_function_propagate_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn may_fail() -> Result<int, string> { Ok(1) }
+
+fn run() -> Result<int, string> {
+  let n = 5;
+  while n < 10 {
+    let _ = may_fail()?
+  }
+  Ok(0)
+}
+
+fn main() {
+  let _ = run()
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_diverging_call_in_try_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn may_fail() -> Result<int, string> { Ok(1) }
+fn diverge() -> Never { panic("x") }
+
+fn run() {
+  let n = 5;
+  while n < 10 {
+    let _ = try {
+      let _ = may_fail()?
+      diverge()
+    }
+  }
+}
+
+fn main() {
+  run()
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_deref_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut x = 0;
+  let r = &x;
+  while r.* < 10 {
+    x = x + 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unchanging_loop_condition_task_return() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let n = 5;
+  while n < 10 {
+    task { return }
+  }
+}
+"#
+    );
+}
+
+#[test]
 fn unused_function() {
     assert_lint_snapshot!(
         r#"
@@ -5136,10 +5340,10 @@ import "go:fmt"
 
 fn main() {
   let ch = Channel.new<int>()
-  let done = false
+  let mut done = false
   while !done {
     select {
-      let Some(v) = ch.receive() => fmt.Println(v),
+      let Some(v) = ch.receive() => { fmt.Println(v); done = true },
       _ => {},
     }
   }

--- a/tests/ui/lint/snapshots/empty_select_default_fires_in_while.snap
+++ b/tests/ui/lint/snapshots/empty_select_default_fires_in_while.snap
@@ -3,7 +3,7 @@ source: tests/ui/lint/mod.rs
 ---
   [error] Empty `select` default arm in a loop
     ╭─[test.lis:10:12]
-  9 │       let Some(v) = ch.receive() => fmt.Println(v),
+  9 │       let Some(v) = ch.receive() => { fmt.Println(v); done = true },
  10 │       _ => {},
     ·            ─┬
     ·             ╰── busy-spins

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_comparison.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_comparison.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Loop condition never changes
+   ╭─[test.lis:4:9]
+ 3 │   let n = 5;
+ 4 │   while n < 10 {
+   ·         ───┬──
+   ·            ╰── never changes
+ 5 │     let _ = n
+   ╰────
+  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_negated_flag.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_negated_flag.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Loop condition never changes
+   ╭─[test.lis:4:9]
+ 3 │   let done = false;
+ 4 │   while !done {
+   ·         ──┬──
+   ·           ╰── never changes
+ 5 │     let _ = done
+   ╰────
+  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_task_return.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_task_return.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Loop condition never changes
+   ╭─[test.lis:4:9]
+ 3 │   let n = 5;
+ 4 │   while n < 10 {
+   ·         ───┬──
+   ·            ╰── never changes
+ 5 │     task { return }
+   ╰────
+  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_try_scoped_propagate.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_try_scoped_propagate.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Loop condition never changes
+   ╭─[test.lis:6:9]
+ 5 │   let n = 5;
+ 6 │   while n < 10 {
+   ·         ───┬──
+   ·            ╰── never changes
+ 7 │     let _ = try { may_fail()? }
+   ╰────
+  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]


### PR DESCRIPTION
Adds a compile error for a `while` loop whose condition can never change, i.e. the loop is infinite or never runs.

```
  [error] Loop condition never changes
   ╭─[test.lis:6:9]
 5 │   let n = 5;
 6 │   while n < 10 {
   ·         ───┬──
   ·            ╰── never changes
 7 │     let _ = try { may_fail()? }
   ╰────
  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]
```