### PR TITLE
test: build no-entry emit snapshots in e2e suite

### DIFF
--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -473,7 +473,7 @@ impl Planner<'_> {
                     if let Some(go_name) = self.go_name_for_binding(&param.pattern) {
                         self.declare_param(identifier, go_name)
                     } else {
-                        "_".to_string()
+                        self.scope.bind(identifier.as_str(), "_")
                     }
                 }
                 Pattern::WildCard { .. } => "_".to_string(),

--- a/tests/e2e_suite.rs
+++ b/tests/e2e_suite.rs
@@ -41,7 +41,7 @@ fn e2e_suite() {
     let mut emit_failures = Vec::new();
     let mut skipped_imports = Vec::new();
     let mut skipped_denylist = Vec::new();
-    let mut skipped_no_entry = Vec::new();
+    let mut build_only = Vec::new();
     let mut included = Vec::new();
 
     for HarvestedTest {
@@ -67,21 +67,21 @@ fn e2e_suite() {
         };
         let EmittedTest { go_code, entry } = result;
 
-        let Some(entry) = entry else {
-            skipped_no_entry.push(name.clone());
-            continue;
-        };
         write_subpackage(&target, name, &go_code, entry).expect("write subpackage");
-        included.push(name.clone());
+        if entry.is_some() {
+            included.push(name.clone());
+        } else {
+            build_only.push(name.clone());
+        }
     }
 
     eprintln!(
-        "harvested {}, included {}, skipped {} (imports), {} (deny-list), {} (no entry), {} re-emit failures",
+        "harvested {}, included {} (run), {} (build-only), skipped {} (imports), {} (deny-list), {} re-emit failures",
         harvested.len(),
         included.len(),
+        build_only.len(),
         skipped_imports.len(),
         skipped_denylist.len(),
-        skipped_no_entry.len(),
         emit_failures.len(),
     );
 

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -232,17 +232,19 @@ pub fn write_subpackage(
     target_dir: &Path,
     name: &str,
     go_code: &str,
-    entry: EntryPoint,
+    entry: Option<EntryPoint>,
 ) -> std::io::Result<()> {
     let pkg_dir = target_dir.join(format!("test_{name}"));
     fs::create_dir_all(&pkg_dir)?;
     fs::write(pkg_dir.join("test.go"), go_code)?;
 
-    let entry_name = entry.as_go_name();
-    let runner = format!(
-        "package test_{name}\n\nimport \"testing\"\n\nfunc TestRun(t *testing.T) {{\n\tdefer func() {{\n\t\tif r := recover(); r != nil {{\n\t\t\tt.Fatalf(\"panic: %v\", r)\n\t\t}}\n\t}}()\n\t{entry_name}()\n}}\n"
-    );
-    fs::write(pkg_dir.join("test_test.go"), runner)?;
+    if let Some(entry) = entry {
+        let entry_name = entry.as_go_name();
+        let runner = format!(
+            "package test_{name}\n\nimport \"testing\"\n\nfunc TestRun(t *testing.T) {{\n\tdefer func() {{\n\t\tif r := recover(); r != nil {{\n\t\t\tt.Fatalf(\"panic: %v\", r)\n\t\t}}\n\t}}()\n\t{entry_name}()\n}}\n"
+        );
+        fs::write(pkg_dir.join("test_test.go"), runner)?;
+    }
     Ok(())
 }
 

--- a/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
+++ b/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/types.rs
-description: "input: \nenum Status {\n  Ready,\n}\n\nimpl Status {\n  fn MarshalJSON(self) -> int {\n    1\n  }\n}\n"
+description: "input: \nenum Status {\n  Ready,\n}\n\nimpl Status {\n  fn MarshalJSON(self) -> Result<Slice<byte>, error> {\n    Ok([])\n  }\n}\n"
 ---
 package main
 
@@ -29,6 +29,6 @@ func (s Status) String() string {
 	}
 }
 
-func (s Status) MarshalJSON() int {
-	return 1
+func (s Status) MarshalJSON() ([]byte, error) {
+	return ([]byte)(nil), nil
 }

--- a/tests/spec/emit/snapshots/function_with_mut_parameter.snap
+++ b/tests/spec/emit/snapshots/function_with_mut_parameter.snap
@@ -5,5 +5,5 @@ description: "input: \nfn process(mut items: Slice<int>) {\n  items = [1, 2, 3]\
 package main
 
 func process(_ []int) {
-	items = []int{1, 2, 3}
+	_ = []int{1, 2, 3}
 }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2146,8 +2146,8 @@ enum Status {
 }
 
 impl Status {
-  fn MarshalJSON(self) -> int {
-    1
+  fn MarshalJSON(self) -> Result<Slice<byte>, error> {
+    Ok([])
   }
 }
 "#;


### PR DESCRIPTION
The e2e suite now compiles the 401 emit snapshots that lack an entrypoint, as build-only packages. This allows them to be now checked by `go build` and `go vet` and brings compiled coverage to 1.3k snapshots.