### PR TITLE
refactor: consolidate context-free checks onto shared visitor

### DIFF
--- a/crates/semantics/src/passes/checks/const_naming.rs
+++ b/crates/semantics/src/passes/checks/const_naming.rs
@@ -2,28 +2,21 @@ use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
 use crate::passes::lints::ast_walk::casing::{is_screaming_snake_case, to_screaming_snake_case};
-use crate::passes::lints::ast_walk::visitor::visit_ast;
 
-pub(crate) fn run(items: &[Expression], sink: &LocalSink) {
-    visit_ast(
-        items,
-        &mut |expression| {
-            let Expression::Const {
-                identifier,
-                identifier_span,
-                ..
-            } = expression
-            else {
-                return;
-            };
-            if identifier.starts_with('_') || is_screaming_snake_case(identifier) {
-                return;
-            }
-            sink.push(diagnostics::lint::miscased_screaming_snake(
-                identifier_span,
-                &to_screaming_snake_case(identifier),
-            ));
-        },
-        &mut |_| {},
-    );
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+    let Expression::Const {
+        identifier,
+        identifier_span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+    if identifier.starts_with('_') || is_screaming_snake_case(identifier) {
+        return;
+    }
+    sink.push(diagnostics::lint::miscased_screaming_snake(
+        identifier_span,
+        &to_screaming_snake_case(identifier),
+    ));
 }

--- a/crates/semantics/src/passes/checks/decimal_file_mode.rs
+++ b/crates/semantics/src/passes/checks/decimal_file_mode.rs
@@ -4,13 +4,7 @@ use syntax::ast::{Expression, Literal};
 const FILE_MODE_ID: &str = "go:io/fs.FileMode";
 const PERM_MASK: u64 = 0o777;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::Literal {
         literal: Literal::Integer { value, text: None },
         ty,
@@ -20,9 +14,5 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         && ty.get_qualified_id() == Some(FILE_MODE_ID)
     {
         sink.push(diagnostics::infer::decimal_file_mode(span, *value));
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }

--- a/crates/semantics/src/passes/checks/duplicate_bindings.rs
+++ b/crates/semantics/src/passes/checks/duplicate_bindings.rs
@@ -10,19 +10,13 @@ use syntax::ast::{Binding, Expression, MatchArm, Pattern, SelectArm, SelectArmPa
 
 use crate::checker::infer::expressions::patterns::collect_pattern_bindings;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     match expression {
         Expression::Let { binding, .. } | Expression::For { binding, .. } => {
             visit_binding(binding, sink);
         }
         Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
-            check(pattern, sink);
+            check_pattern(pattern, sink);
         }
         Expression::Match { arms, .. } => {
             for arm in arms {
@@ -41,23 +35,19 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         }
         _ => {}
     }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
-    }
 }
 
 fn visit_binding(binding: &Binding, sink: &LocalSink) {
-    check(&binding.pattern, sink);
+    check_pattern(&binding.pattern, sink);
 }
 
 fn visit_match_arm(arm: &MatchArm, sink: &LocalSink) {
-    check(&arm.pattern, sink);
+    check_pattern(&arm.pattern, sink);
 }
 
 fn visit_select_arm(arm: &SelectArm, sink: &LocalSink) {
     if let SelectArmPattern::Receive { binding, .. } = &arm.pattern {
-        check(binding, sink);
+        check_pattern(binding, sink);
     } else if let SelectArmPattern::MatchReceive { arms, .. } = &arm.pattern {
         for arm in arms {
             visit_match_arm(arm, sink);
@@ -65,10 +55,10 @@ fn visit_select_arm(arm: &SelectArm, sink: &LocalSink) {
     }
 }
 
-fn check(pattern: &Pattern, sink: &LocalSink) {
+fn check_pattern(pattern: &Pattern, sink: &LocalSink) {
     if let Pattern::Or { patterns, .. } = pattern {
         for alternative in patterns {
-            check(alternative, sink);
+            check_pattern(alternative, sink);
         }
         return;
     }

--- a/crates/semantics/src/passes/checks/empty_infinite_loop.rs
+++ b/crates/semantics/src/passes/checks/empty_infinite_loop.rs
@@ -1,21 +1,11 @@
 use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::Loop { body, span, .. } = expression
         && let Expression::Block { items, .. } = body.as_ref()
         && items.is_empty()
     {
         sink.push(diagnostics::infer::empty_infinite_loop(span));
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }

--- a/crates/semantics/src/passes/checks/empty_range.rs
+++ b/crates/semantics/src/passes/checks/empty_range.rs
@@ -1,13 +1,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Literal, UnaryOperator};
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::Range {
         start: Some(start),
         end: Some(end),
@@ -19,10 +13,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         && start_value > end_value
     {
         sink.push(diagnostics::infer::empty_range(span));
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/enum_variant_value.rs
+++ b/crates/semantics/src/passes/checks/enum_variant_value.rs
@@ -4,13 +4,7 @@ use syntax::types::{Type, unqualified_name};
 
 use crate::store::Store;
 
-pub(crate) fn run(typed_ast: &[Expression], store: &Store, sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, store, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
     match expression {
         Expression::Identifier {
             qualified: Some(qualified),
@@ -19,7 +13,7 @@ fn visit_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
             ..
         } => {
             if let Some((enum_id, variant_name)) = qualified.rsplit_once('.') {
-                check(enum_id, variant_name, value, *span, store, sink);
+                check_variant(enum_id, variant_name, value, *span, store, sink);
             }
         }
         Expression::DotAccess {
@@ -30,18 +24,14 @@ fn visit_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
         } => {
             if let Type::Nominal { id, .. } = base.get_type().strip_refs() {
                 let display = format!("{}.{}", unqualified_name(&id), member);
-                check(&id, member, &display, *span, store, sink);
+                check_variant(&id, member, &display, *span, store, sink);
             }
         }
         _ => {}
     }
-
-    for child in expression.children() {
-        visit_expression(child, store, sink);
-    }
 }
 
-fn check(
+fn check_variant(
     enum_qualified: &str,
     variant_name: &str,
     display: &str,

--- a/crates/semantics/src/passes/checks/index_out_of_bounds.rs
+++ b/crates/semantics/src/passes/checks/index_out_of_bounds.rs
@@ -1,20 +1,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Literal};
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
-    check(expression, sink);
-    for child in expression.children() {
-        visit_expression(child, sink);
-    }
-}
-
-fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     let Expression::IndexedAccess {
         expression: receiver,
         index,

--- a/crates/semantics/src/passes/checks/irrefutable_patterns.rs
+++ b/crates/semantics/src/passes/checks/irrefutable_patterns.rs
@@ -17,13 +17,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Binding, Expression, Pattern, SelectArm, SelectArmPattern};
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     match expression {
         Expression::Let {
             binding,
@@ -52,10 +46,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
             }
         }
         _ => {}
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod json_serializable_fields;
 pub(crate) mod nan_comparison;
 pub(crate) mod native_value_usage;
 pub(crate) mod newtype;
+mod node_walk;
 pub(crate) mod oversized_shift;
 mod pattern_analysis;
 pub(crate) mod predeclared_shadowing;
@@ -95,30 +96,14 @@ fn run_file_checks(
     sink: &LocalSink,
     pattern_ctx: &pattern_analysis::Context,
 ) {
-    duplicate_bindings::run(&file.items, sink);
-    irrefutable_patterns::run(&file.items, sink);
-    receivers::run(&file.items, sink);
-    stringer_signature::run(&file.items, sink);
-    predeclared_shadowing::run(&file.items, sink);
+    node_walk::run(&file.items, store, file.is_d_lis(), sink);
+
     prelude_shadowing::run(&file.items, store, sink);
-    pub_type_export::run(&file.items, sink);
     generics::run(&file.items, &module.id, store, sink);
-    newtype::run(&file.items, store, sink);
     native_value_usage::run(&file.items, &module.id, store, sink);
-    enum_variant_value::run(&file.items, store, sink);
-    nan_comparison::run(&file.items, sink);
-    empty_infinite_loop::run(&file.items, sink);
-    empty_range::run(&file.items, sink);
-    empty_select_default::run(&file.items, sink);
-    decimal_file_mode::run(&file.items, sink);
-    index_out_of_bounds::run(&file.items, sink);
     json_serializable_fields::run(&file.items, sink);
-    oversized_shift::run(&file.items, sink);
-    repeated_if_condition::run(&file.items, sink);
-    temp_producing::run(&file.items, sink);
-    if !file.is_d_lis() {
-        const_naming::run(&file.items, sink);
-    }
+    empty_select_default::run(&file.items, sink);
+
     for expression in &file.items {
         pattern_analysis::check(expression, pattern_ctx, sink);
     }

--- a/crates/semantics/src/passes/checks/nan_comparison.rs
+++ b/crates/semantics/src/passes/checks/nan_comparison.rs
@@ -3,13 +3,7 @@ use syntax::ast::{BinaryOperator, Expression};
 
 use crate::call_target::resolve_call;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::Binary {
         operator,
         left,
@@ -27,10 +21,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
             let always_true = matches!(operator, NotEqual);
             sink.push(diagnostics::infer::nan_comparison(span, always_true));
         }
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/newtype.rs
+++ b/crates/semantics/src/passes/checks/newtype.rs
@@ -8,13 +8,7 @@ use syntax::types::{Type, unqualified_name};
 
 use crate::store::Store;
 
-pub(crate) fn run(typed_ast: &[Expression], store: &Store, sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, store, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
     match expression {
         Expression::Assignment { target, span, .. } => {
             check_newtype_field_assignment(target, *span, store, sink);
@@ -28,9 +22,6 @@ fn visit_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
             sink.push(diagnostics::infer::reference_through_newtype(*span));
         }
         _ => {}
-    }
-    for child in expression.children() {
-        visit_expression(child, store, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/node_walk.rs
+++ b/crates/semantics/src/passes/checks/node_walk.rs
@@ -1,0 +1,48 @@
+use diagnostics::LocalSink;
+use syntax::ast::Expression;
+
+use crate::passes::lints::ast_walk::visitor::visit_ast;
+use crate::store::Store;
+
+use super::{
+    const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop, empty_range,
+    enum_variant_value, index_out_of_bounds, irrefutable_patterns, nan_comparison, newtype,
+    oversized_shift, predeclared_shadowing, pub_type_export, receivers, repeated_if_condition,
+    stringer_signature, temp_producing,
+};
+
+type NodeCheck = fn(&Expression, &LocalSink);
+
+const NODE_CHECKS: &[NodeCheck] = &[
+    nan_comparison::check,
+    empty_range::check,
+    empty_infinite_loop::check,
+    oversized_shift::check,
+    repeated_if_condition::check,
+    index_out_of_bounds::check,
+    decimal_file_mode::check,
+    duplicate_bindings::check,
+    irrefutable_patterns::check,
+    receivers::check,
+    stringer_signature::check,
+    predeclared_shadowing::check,
+    pub_type_export::check,
+    temp_producing::check,
+];
+
+pub(crate) fn run(items: &[Expression], store: &Store, is_d_lis: bool, sink: &LocalSink) {
+    visit_ast(
+        items,
+        &mut |expression| {
+            for check in NODE_CHECKS {
+                check(expression, sink);
+            }
+            newtype::check(expression, store, sink);
+            enum_variant_value::check(expression, store, sink);
+            if !is_d_lis {
+                const_naming::check(expression, sink);
+            }
+        },
+        &mut |_| {},
+    );
+}

--- a/crates/semantics/src/passes/checks/oversized_shift.rs
+++ b/crates/semantics/src/passes/checks/oversized_shift.rs
@@ -2,13 +2,7 @@ use diagnostics::LocalSink;
 use syntax::ast::{BinaryOperator, Expression, Literal};
 use syntax::types::SimpleKind;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::Binary {
         operator,
         left,
@@ -34,10 +28,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
             bit_width,
             *value,
         ));
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/predeclared_shadowing.rs
+++ b/crates/semantics/src/passes/checks/predeclared_shadowing.rs
@@ -7,13 +7,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Generic};
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit(item, sink);
-    }
-}
-
-fn visit(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     check_type_name(expression, sink);
     for generic in generics_of(expression) {
         if is_reserved(&generic.name) {
@@ -22,9 +16,6 @@ fn visit(expression: &Expression, sink: &LocalSink) {
                 generic.span,
             ));
         }
-    }
-    for child in expression.children() {
-        visit(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/pub_type_export.rs
+++ b/crates/semantics/src/passes/checks/pub_type_export.rs
@@ -9,13 +9,7 @@ use syntax::ast::{Expression, Span, Visibility};
 
 use crate::passes::lints::ast_walk::casing::to_pascal_case;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit(item, sink);
-    }
-}
-
-fn visit(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Some((name, name_span, visibility)) = type_declaration(expression)
         && visibility.is_public()
         && !is_exportable(name)
@@ -25,9 +19,6 @@ fn visit(expression: &Expression, sink: &LocalSink) {
             &to_pascal_case(name),
             *name_span,
         ));
-    }
-    for child in expression.children() {
-        visit(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/receivers.rs
+++ b/crates/semantics/src/passes/checks/receivers.rs
@@ -7,13 +7,7 @@ use diagnostics::LocalSink;
 use syntax::ast::{Expression, Pattern};
 use syntax::types::Type;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::ImplBlock {
         ty: impl_ty,
         methods,
@@ -23,9 +17,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         for method in methods {
             check_method_receiver(method, impl_ty, sink);
         }
-    }
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/repeated_if_condition.rs
+++ b/crates/semantics/src/passes/checks/repeated_if_condition.rs
@@ -1,13 +1,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::If {
         condition,
         alternative,
@@ -24,10 +18,6 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         sink.push(diagnostics::infer::repeated_if_condition(
             &next_condition.get_span(),
         ));
-    }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
     }
 }
 

--- a/crates/semantics/src/passes/checks/stringer_signature.rs
+++ b/crates/semantics/src/passes/checks/stringer_signature.rs
@@ -8,24 +8,15 @@ use diagnostics::LocalSink;
 use syntax::ast::Expression;
 use syntax::types::{SimpleKind, Type};
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit(item, sink);
-    }
-}
-
-fn visit(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if let Expression::ImplBlock { methods, .. } = expression {
         for method in methods {
-            check(method, sink);
+            check_method(method, sink);
         }
-    }
-    for child in expression.children() {
-        visit(child, sink);
     }
 }
 
-fn check(method: &Expression, sink: &LocalSink) {
+fn check_method(method: &Expression, sink: &LocalSink) {
     let Expression::Function {
         name,
         name_span,

--- a/crates/semantics/src/passes/checks/temp_producing.rs
+++ b/crates/semantics/src/passes/checks/temp_producing.rs
@@ -2,64 +2,45 @@ use diagnostics::LocalSink;
 use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::program::ReceiverCoercion;
 
-pub(crate) fn run(typed_ast: &[Expression], sink: &LocalSink) {
-    for item in typed_ast {
-        visit_expression(item, sink);
-    }
-}
-
-fn visit_expression(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     match expression {
-        Expression::Call {
-            expression: callee,
-            args,
-            spread,
-            ..
-        } => {
+        Expression::Call { args, spread, .. } => {
             for arg in args {
-                check(arg, sink);
+                flag_sub_expression(arg, sink);
             }
             if let Some(s) = spread.as_ref() {
-                check(s, sink);
+                flag_sub_expression(s, sink);
             }
-            visit_expression(callee, sink);
-            for arg in args {
-                visit_expression(arg, sink);
-            }
-            if let Some(s) = spread.as_ref() {
-                visit_expression(s, sink);
-            }
-            return;
         }
         Expression::StructCall {
             field_assignments, ..
         } => {
             for f in field_assignments {
-                check(&f.value, sink);
+                flag_sub_expression(&f.value, sink);
             }
         }
         Expression::Binary { left, right, .. } => {
-            check(left, sink);
-            check(right, sink);
+            flag_sub_expression(left, sink);
+            flag_sub_expression(right, sink);
         }
         Expression::Unary { expression, .. } | Expression::Reference { expression, .. } => {
-            check(expression, sink);
+            flag_sub_expression(expression, sink);
         }
         Expression::Cast { expression, .. } => {
-            check(expression, sink);
+            flag_sub_expression(expression, sink);
         }
         Expression::If { condition, .. } | Expression::While { condition, .. } => {
-            check(condition, sink);
+            flag_sub_expression(condition, sink);
         }
         Expression::IndexedAccess { index, .. } => {
-            check(index, sink);
+            flag_sub_expression(index, sink);
         }
         Expression::Range { start, end, .. } => {
             if let Some(s) = start {
-                check(s, sink);
+                flag_sub_expression(s, sink);
             }
             if let Some(e) = end {
-                check(e, sink);
+                flag_sub_expression(e, sink);
             }
         }
         Expression::Literal {
@@ -67,7 +48,7 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
             ..
         } => {
             for e in elements {
-                check(e, sink);
+                flag_sub_expression(e, sink);
             }
         }
         Expression::Literal {
@@ -76,19 +57,15 @@ fn visit_expression(expression: &Expression, sink: &LocalSink) {
         } => {
             for p in parts {
                 if let FormatStringPart::Expression(e) = p {
-                    check(e, sink);
+                    flag_sub_expression(e, sink);
                 }
             }
         }
         _ => {}
     }
-
-    for child in expression.children() {
-        visit_expression(child, sink);
-    }
 }
 
-fn check(expression: &Expression, sink: &LocalSink) {
+fn flag_sub_expression(expression: &Expression, sink: &LocalSink) {
     if is_temp_producing(expression) || has_auto_address_on_call(expression) {
         sink.push(diagnostics::infer::complex_sub_expression(
             expression.get_span(),

--- a/crates/semantics/src/passes/lints/ast_walk/visitor.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/visitor.rs
@@ -1,4 +1,7 @@
-use syntax::ast::{Expression, MatchArm, Pattern, RestPattern, SelectArm, SelectArmPattern};
+use syntax::ast::{
+    Expression, FormatStringPart, Literal, MatchArm, Pattern, RestPattern, SelectArm,
+    SelectArmPattern,
+};
 
 pub fn visit_ast<E, P>(ast: &[Expression], expression_visitor: &mut E, pattern_visitor: &mut P)
 where
@@ -24,6 +27,34 @@ where
             visit_node(val, expression_visitor, pattern_visitor);
         }
 
+        Expression::Literal {
+            literal: Literal::Slice(elements),
+            ..
+        } => {
+            for element in elements {
+                visit_node(element, expression_visitor, pattern_visitor);
+            }
+        }
+
+        Expression::Literal {
+            literal: Literal::FormatString(parts),
+            ..
+        } => {
+            for part in parts {
+                if let FormatStringPart::Expression(expression) = part {
+                    visit_node(expression, expression_visitor, pattern_visitor);
+                }
+            }
+        }
+
+        Expression::Interface {
+            method_signatures, ..
+        } => {
+            for signature in method_signatures {
+                visit_node(signature, expression_visitor, pattern_visitor);
+            }
+        }
+
         Expression::Literal { .. }
         | Expression::Identifier { .. }
         | Expression::Unit { .. }
@@ -36,8 +67,7 @@ where
         | Expression::Struct { .. }
         | Expression::TypeAlias { .. }
         | Expression::VariableDeclaration { .. }
-        | Expression::ModuleImport { .. }
-        | Expression::Interface { .. } => {}
+        | Expression::ModuleImport { .. } => {}
 
         Expression::Function { params, body, .. } => {
             for param in params {


### PR DESCRIPTION
The checks layer walked the syntax tree once per check, with every check hand-rolling its own recursion. This consolidates the context-free checks onto a single shared traversal, so the tree is walked once and the logic for descending into it lives in one place rather than being duplicated across checks.