### PR TITLE
test: check lis learn project e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
           go: 'true'
       - run: cargo build -p lisette --locked
       - run: cargo test -p tests --test e2e_smoke --locked -- --format terse
+      - run: cargo test -p tests --test e2e_learn --locked -- --format terse
 
   stdlib-check:
     name: Stdlib check

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,5 +27,9 @@ name = "e2e_smoke"
 path = "e2e_smoke.rs"
 
 [[test]]
+name = "e2e_learn"
+path = "e2e_learn.rs"
+
+[[test]]
 name = "e2e_suite"
 path = "e2e_suite.rs"

--- a/tests/e2e_learn.rs
+++ b/tests/e2e_learn.rs
@@ -1,0 +1,66 @@
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn e2e_learn() {
+    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap();
+
+    let build = Command::new("cargo")
+        .args(["build", "-p", "lisette", "--quiet"])
+        .current_dir(repo)
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("failed to build lisette");
+    assert!(build.success(), "cargo build -p lisette failed");
+
+    let lis = repo.join("target/debug/lis");
+    let temp = TempDir::new().expect("failed to create temp dir");
+
+    let learn = Command::new(&lis)
+        .arg("learn")
+        .current_dir(temp.path())
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run lis learn");
+    assert!(
+        learn.status.success(),
+        "lis learn failed:\n{}",
+        String::from_utf8_lossy(&learn.stderr)
+    );
+
+    let project = temp.path().join("learn-lisette");
+    assert!(
+        project.join("lisette.toml").exists() && project.join("src/main.lis").exists(),
+        "lis learn did not scaffold the expected src/ layout"
+    );
+
+    let check = Command::new(&lis)
+        .args(["check", "--format", "unix"])
+        .arg(&project)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run lis check");
+    let check_stdout = String::from_utf8_lossy(&check.stdout);
+    assert!(
+        check.status.success() && check_stdout.trim().is_empty(),
+        "lis check reported issues on the scaffolded learn project:\n{}{}",
+        check_stdout,
+        String::from_utf8_lossy(&check.stderr)
+    );
+
+    let format = Command::new(&lis)
+        .args(["format", "--check"])
+        .arg(&project)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run lis format --check");
+    assert!(
+        format.status.success(),
+        "lis format --check reported unformatted files in the scaffolded learn project:\n{}{}",
+        String::from_utf8_lossy(&format.stdout),
+        String::from_utf8_lossy(&format.stderr)
+    );
+}


### PR DESCRIPTION
Add check to ensure the `lis learn` starter project works end to end.