### PR TITLE
feat: warn on loop that runs at most once

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -298,6 +298,15 @@ pub fn bool_literal_comparison(span: &Span, replacement: &str) -> LisetteDiagnos
         .with_help(format!("Simplify to `{replacement}`"))
 }
 
+pub fn loop_runs_once(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Loop runs at most once")
+        .with_lint_code("loop_runs_once")
+        .with_span_label(span, "the body always exits before looping back")
+        .with_help(
+            "The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop.",
+        )
+}
+
 pub fn needless_return(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Needless `return`")
         .with_lint_code("needless_return")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/loop_runs_once.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/loop_runs_once.rs
@@ -1,0 +1,81 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::{Expression, Span};
+
+pub fn check_loop_runs_once(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let (body, span, keyword_len) = match expression {
+        Expression::Loop { body, span, .. } => (body.as_ref(), span, 4),
+        Expression::While { body, span, .. } | Expression::WhileLet { body, span, .. } => {
+            (body.as_ref(), span, 5)
+        }
+        Expression::For { body, span, .. } => (body.as_ref(), span, 3),
+        _ => return,
+    };
+
+    if always_exits(body) && !reenters_loop(body) {
+        let keyword = Span::new(span.file_id, span.byte_offset, keyword_len);
+        diagnostics.push(diagnostics::lint::loop_runs_once(&keyword));
+    }
+}
+
+/// True when every path through `expression` reaches a `break`, `return`, or
+/// diverging call. A reachable `continue` is vetoed separately by `reenters_loop`.
+fn always_exits(expression: &Expression) -> bool {
+    match expression {
+        Expression::Break { .. } | Expression::Return { .. } => true,
+        Expression::Continue { .. } => false,
+        Expression::Call { ty, .. } => ty.is_never(),
+        Expression::Paren { expression, .. } | Expression::Cast { expression, .. } => {
+            always_exits(expression)
+        }
+        Expression::If {
+            consequence,
+            alternative,
+            ..
+        }
+        | Expression::IfLet {
+            consequence,
+            alternative,
+            ..
+        } => always_exits(consequence) && always_exits(alternative),
+        Expression::Match { arms, .. } => {
+            !arms.is_empty() && arms.iter().all(|arm| always_exits(&arm.expression))
+        }
+        Expression::Block { items, .. }
+        | Expression::TryBlock { items, .. }
+        | Expression::RecoverBlock { items, .. } => block_exits(items),
+        Expression::Loop { .. }
+        | Expression::While { .. }
+        | Expression::WhileLet { .. }
+        | Expression::For { .. }
+        | Expression::Function { .. }
+        | Expression::Lambda { .. }
+        | Expression::Task { .. } => false,
+        _ => false,
+    }
+}
+
+/// A block reaches an exit when its first diverging statement is itself an exit.
+fn block_exits(items: &[Expression]) -> bool {
+    for item in items {
+        if item.diverges().is_some() {
+            return always_exits(item);
+        }
+    }
+    false
+}
+
+/// True when `expression` can reach a `continue` targeting this loop, including in
+/// a nested loop's header (iterable, condition, scrutinee) but not its body.
+fn reenters_loop(expression: &Expression) -> bool {
+    match expression {
+        Expression::Continue { .. } => true,
+        Expression::For { iterable, .. } => reenters_loop(iterable),
+        Expression::While { condition, .. } => reenters_loop(condition),
+        Expression::WhileLet { scrutinee, .. } => reenters_loop(scrutinee),
+        Expression::Loop { .. }
+        | Expression::Function { .. }
+        | Expression::Lambda { .. }
+        | Expression::Task { .. } => false,
+        _ => expression.children().into_iter().any(reenters_loop),
+    }
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -8,6 +8,7 @@ mod excess_parens_on_condition;
 mod helpers;
 mod identical_if_branches;
 mod invisible_in_string;
+mod loop_runs_once;
 mod match_literal_collection;
 mod naming;
 mod needless_bool;
@@ -34,6 +35,7 @@ pub use identical_if_branches::check_identical_if_branches;
 pub use invisible_in_string::{
     check_invisible_in_string_expression, check_invisible_in_string_pattern,
 };
+pub use loop_runs_once::check_loop_runs_once;
 pub use match_literal_collection::check_match_literal_collection;
 pub use naming::{check_expression_naming, check_pattern_naming};
 pub use needless_bool::check_needless_bool;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -73,12 +73,12 @@ use checks::{
     check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
     check_expression_naming, check_identical_if_branches, check_invisible_in_string_expression,
-    check_invisible_in_string_pattern, check_match_literal_collection, check_needless_bool,
-    check_needless_return, check_pattern_naming, check_replaceable_with_zero_fill,
-    check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
-    check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
-    check_unnecessary_raw_string_pattern, check_unsigned_comparison,
-    check_verbose_failure_propagation, check_waitgroup_add_in_task,
+    check_invisible_in_string_pattern, check_loop_runs_once, check_match_literal_collection,
+    check_needless_bool, check_needless_return, check_pattern_naming,
+    check_replaceable_with_zero_fill, check_rest_only_slice_pattern, check_self_assignment,
+    check_self_comparison, check_single_arm_match, check_uninterpolated_fstring,
+    check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
+    check_unsigned_comparison, check_verbose_failure_propagation, check_waitgroup_add_in_task,
 };
 use visitor::visit_ast;
 
@@ -92,6 +92,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_self_assignment,
     check_bool_literal_comparison,
     check_identical_if_branches,
+    check_loop_runs_once,
     check_empty_match_arm,
     check_excess_parens_on_condition,
     check_match_literal_collection,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1276,8 +1276,10 @@ fn unchanging_loop_condition_break_no_warning() {
 fn main() {
   let n = 5;
   while n < 10 {
+    if n > 7 {
+      break
+    }
     let _ = n
-    break
   }
 }
 "#
@@ -1291,7 +1293,10 @@ fn unchanging_loop_condition_return_no_warning() {
 fn main() {
   let n = 5;
   while n < 10 {
-    return
+    if n > 7 {
+      return
+    }
+    let _ = n
   }
 }
 "#
@@ -1410,6 +1415,206 @@ fn main() {
   let n = 5;
   while n < 10 {
     task { return }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_loop_break() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  loop {
+    let _ = 1
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_for_return() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  for _ in 0..10 {
+    return
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_while_return() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let flag = true
+  while flag {
+    return
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_if_else_both_exit() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let flag = true
+  loop {
+    if flag {
+      break
+    } else {
+      return
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_diverging_call() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  loop {
+    panic("stop")
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_conditional_break_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  for i in 0..10 {
+    if i > 5 {
+      break
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_continue_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  for i in 0..10 {
+    if i > 5 {
+      continue
+    }
+    let _ = i
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_continue_then_break_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut i = 0
+  loop {
+    i = i + 1
+    if i < 10 {
+      continue
+    }
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_continue_in_return_value_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn pick(n: int) -> int {
+  let mut i = 0
+  loop {
+    i = i + 1
+    return if i < n { continue } else { 42 }
+  }
+}
+
+fn main() {
+  let _ = pick(5)
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_continue_in_break_value_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut i = 0
+  let _x = loop {
+    i = i + 1
+    break if i < 10 { continue } else { 42 }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_continue_in_nested_for_iterable_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut i = 0
+  loop {
+    i = i + 1
+    for _ in if i < 10 { continue } else { 0..1 } {
+      let _ = i
+    }
+    break
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_normal_loop_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  for i in 0..10 {
+    let _ = i
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn loop_runs_once_return_in_lambda_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  for i in 0..10 {
+    let _f = || { return i }
+    let _ = i
   }
 }
 "#
@@ -2186,8 +2391,11 @@ fn no_dead_code_when_break_is_last() {
     assert_no_lint_warnings!(
         r#"
 fn main() {
+  let cond = true
   loop {
-    break
+    if cond {
+      break
+    }
   }
 }
 "#
@@ -2301,8 +2509,8 @@ pub fn foo() -> int {
 fn no_dead_code_after_loop_with_break() {
     assert_no_lint_warnings!(
         r#"
-pub fn foo() -> int {
-  loop { break };
+pub fn foo(cond: bool) -> int {
+  loop { if cond { break } };
   42
 }
 "#
@@ -2313,8 +2521,8 @@ pub fn foo() -> int {
 fn no_dead_code_after_while_with_break() {
     assert_no_lint_warnings!(
         r#"
-pub fn foo() -> int {
-  while true { break };
+pub fn foo(cond: bool) -> int {
+  while true { if cond { break } };
   42
 }
 "#
@@ -4545,7 +4753,12 @@ fn discarded_loop_break_value_silent_with_allow_attr() {
 #[allow(unused_value)]
 fn allowed() -> int { 42 }
 fn test() {
-  loop { break allowed() }
+  let cond = true
+  loop {
+    if cond {
+      break allowed()
+    }
+  }
 }
 fn main() {
   test()
@@ -5279,8 +5492,11 @@ fn empty_infinite_loop_with_break_no_warning() {
     assert_no_lint_warnings!(
         r#"
 fn main() {
+  let cond = true
   loop {
-    break
+    if cond {
+      break
+    }
   }
 }
 "#
@@ -5295,7 +5511,9 @@ fn main() {
   let mut i = 0
   loop {
     i = i + 1
-    break
+    if i > 5 {
+      break
+    }
   }
 }
 "#
@@ -5404,7 +5622,6 @@ fn main() {
         _ => {},
       }
     }
-    break
   }
 }
 "#
@@ -5445,7 +5662,6 @@ fn main() {
         _ => {},
       }
     }
-    break
   }
 }
 "#

--- a/tests/ui/lint/snapshots/loop_runs_once_diverging_call.snap
+++ b/tests/ui/lint/snapshots/loop_runs_once_diverging_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Loop runs at most once
+   ╭─[test.lis:3:3]
+ 2 │ fn main() {
+ 3 │   loop {
+   ·   ──┬─
+   ·     ╰── the body always exits before looping back
+ 4 │     panic("stop")
+   ╰────
+  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]

--- a/tests/ui/lint/snapshots/loop_runs_once_for_return.snap
+++ b/tests/ui/lint/snapshots/loop_runs_once_for_return.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Loop runs at most once
+   ╭─[test.lis:3:3]
+ 2 │ fn main() {
+ 3 │   for _ in 0..10 {
+   ·   ─┬─
+   ·    ╰── the body always exits before looping back
+ 4 │     return
+   ╰────
+  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]

--- a/tests/ui/lint/snapshots/loop_runs_once_if_else_both_exit.snap
+++ b/tests/ui/lint/snapshots/loop_runs_once_if_else_both_exit.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Loop runs at most once
+   ╭─[test.lis:4:3]
+ 3 │   let flag = true
+ 4 │   loop {
+   ·   ──┬─
+   ·     ╰── the body always exits before looping back
+ 5 │     if flag {
+   ╰────
+  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]

--- a/tests/ui/lint/snapshots/loop_runs_once_loop_break.snap
+++ b/tests/ui/lint/snapshots/loop_runs_once_loop_break.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Loop runs at most once
+   ╭─[test.lis:3:3]
+ 2 │ fn main() {
+ 3 │   loop {
+   ·   ──┬─
+   ·     ╰── the body always exits before looping back
+ 4 │     let _ = 1
+   ╰────
+  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]

--- a/tests/ui/lint/snapshots/loop_runs_once_while_return.snap
+++ b/tests/ui/lint/snapshots/loop_runs_once_while_return.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Loop runs at most once
+   ╭─[test.lis:4:3]
+ 3 │   let flag = true
+ 4 │   while flag {
+   ·   ──┬──
+   ·     ╰── the body always exits before looping back
+ 5 │     return
+   ╰────
+  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]


### PR DESCRIPTION
Adds a `loop_runs_once` warning for a loop whose body always exits on the first iteration, so the loop never repeats.

```
 [warning] Loop runs at most once
   ╭─[test.lis:4:3]
 3 │   let flag = true
 4 │   while flag {
   ·   ──┬──
   ·     ╰── the body always exits before looping back
 5 │     return
   ╰────
  help: The body always exits on the first iteration, so the loop never repeats. Make the exit conditional, or remove the loop · code: [lint.loop_runs_once]
```