### PR TITLE
fix: validate unknown attributes on enums

### DIFF
--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -156,9 +156,9 @@ impl<'a> Formatter<'a> {
         let doc_comments_doc = self.comments.take_doc_comments_before(start);
 
         let attrs = match expression {
-            Expression::Function { attributes, .. } | Expression::Struct { attributes, .. } => {
-                self.attributes(attributes)
-            }
+            Expression::Function { attributes, .. }
+            | Expression::Struct { attributes, .. }
+            | Expression::Enum { attributes, .. } => self.attributes(attributes),
             _ => Document::Sequence(vec![]),
         };
         let between_attrs_and_keyword = self.comments.take_comments_before(start);
@@ -317,9 +317,9 @@ impl<'a> Formatter<'a> {
 
     fn item_leading_edge(item: &'a Expression) -> u32 {
         let attrs: &[Attribute] = match item {
-            Expression::Function { attributes, .. } | Expression::Struct { attributes, .. } => {
-                attributes
-            }
+            Expression::Function { attributes, .. }
+            | Expression::Struct { attributes, .. }
+            | Expression::Enum { attributes, .. } => attributes,
             _ => &[],
         };
         attrs

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -24,6 +24,16 @@ pub fn check_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDi
     }
 }
 
+pub fn check_enum_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let Expression::Enum { attributes, .. } = expression else {
+        return;
+    };
+
+    for attribute in attributes {
+        check_unknown_attribute(attribute, diagnostics);
+    }
+}
+
 pub fn check_struct_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
     let Expression::Struct {
         attributes: struct_attributes,

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -68,7 +68,7 @@ fn run_module(module: &Module, store: &Store, sink: &LocalSink) {
     }
 }
 
-use attributes::{check_attributes, check_struct_attributes};
+use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
     check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
@@ -109,6 +109,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_waitgroup_add_in_task,
     check_struct_attributes,
     check_attributes,
+    check_enum_attributes,
 ];
 
 const PATTERN_CHECKS: &[PatternCheck] = &[

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -969,6 +969,11 @@ fn attribute_multiple_on_struct() {
 }
 
 #[test]
+fn attribute_on_enum() {
+    assert_format_snapshot!("#[json]\nenum Shape { Circle, Square }");
+}
+
+#[test]
 fn attribute_on_field() {
     assert_format_snapshot!(
         r#"struct Person {

--- a/tests/spec/format/snapshots/attribute_on_enum.snap
+++ b/tests/spec/format/snapshots/attribute_on_enum.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: #[json]\nenum Shape { Circle, Square }"
+---
+#[json]
+enum Shape {
+  Circle,
+  Square,
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3848,6 +3848,19 @@ pub struct User {
 }
 
 #[test]
+fn unknown_attribute_on_enum() {
+    assert_lint_snapshot!(
+        r#"
+#[foo]
+enum Color {
+  Red,
+  Green,
+}
+"#
+    );
+}
+
+#[test]
 fn field_attribute_without_struct_attribute() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Unknown attribute
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[foo]
+   · ───┬──
+   ·    ╰── not recognized
+ 3 │ enum Color {
+   ╰────
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[msgpack]`, `#[mapstructure]`, `#[tag]` · code: [lint.unknown_attribute]


### PR DESCRIPTION
Unknown attributes on an enum now produce a warning, matching the existing behavior for structs.