### PR TITLE
fix: emit remaining pattern checks in switch case bodies

### DIFF
--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -494,7 +494,7 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
     validate_switch_arms(arms, &kind, &switch_path)?;
 
     let grouped = group_switch_branches(arms, &kind);
-    let branches = build_switch_branches(&kind, grouped.order, grouped.by_label, &grouped.fallback);
+    let branches = build_switch_branches(grouped.order, grouped.by_label, &grouped.fallback);
 
     let fallback = if grouped.fallback.is_empty() {
         None
@@ -632,11 +632,9 @@ fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches
     }
 }
 
-/// Splice the catchall into any type-switch case whose inner tree can still
-/// fail. Go type-switch cases do not fall through, so the fallback arms must
-/// be inlined into each fail-prone case body.
+/// Splice the catchall into any fail-prone case body: Go `switch` cases do not
+/// fall through to `default`, so a failed inner check has nowhere else to go.
 fn build_switch_branches(
-    kind: &SwitchKind,
     order: Vec<String>,
     mut by_label: HashMap<String, BranchGroup>,
     fallback_arms: &[ArmInfo],
@@ -651,7 +649,7 @@ fn build_switch_branches(
             let any_inner_can_fail = inner_arms
                 .iter()
                 .any(|a| a.has_guard || !a.checks.is_empty());
-            let decision = if matches!(kind, SwitchKind::TypeSwitch) && any_inner_can_fail {
+            let decision = if any_inner_can_fail {
                 let mut arms_with_fallback = inner_arms;
                 arms_with_fallback.extend(fallback_arms.iter().cloned());
                 build_tree(arms_with_fallback)

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -1369,3 +1369,55 @@ pub struct Rect { pub W: int, pub H: int }
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/shapes", typedef)]);
 }
+
+#[test]
+fn tuple_enum_match_checks_every_element() {
+    let input = r#"
+pub enum Hand {
+  Left,
+  Right,
+}
+
+impl Hand {
+  pub fn left_right(self, other: Hand) -> bool {
+    match (self, other) {
+      (Hand.Left, Hand.Right) => true,
+      _ => false,
+    }
+  }
+
+  pub fn left_left(self, other: Hand) -> bool {
+    match (self, other) {
+      (Hand.Left, Hand.Left) => true,
+      _ => false,
+    }
+  }
+
+  pub fn eq(self, other: Hand) -> bool {
+    match (self, other) {
+      (Hand.Left, Hand.Left) => true,
+      (Hand.Right, Hand.Right) => true,
+      _ => false,
+    }
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn switch_case_with_remaining_enum_check_routes_to_catchall() {
+    let input = r#"
+enum Side { Left, Right }
+struct Pair { a: Side, b: Side }
+
+fn classify(p: Pair) -> int {
+  match p {
+    Pair { a: Side.Left, b: Side.Left } => 1,
+    Pair { a: Side.Right, b: Side.Right } => 2,
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
+++ b/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
@@ -1,0 +1,74 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nenum Side { Left, Right }\nstruct Pair { a: Side, b: Side }\n\nfn classify(p: Pair) -> int {\n  match p {\n    Pair { a: Side.Left, b: Side.Left } => 1,\n    Pair { a: Side.Right, b: Side.Right } => 2,\n    _ => 0,\n  }\n}\n"
+---
+package main
+
+import "fmt"
+
+func MakeSideLeft() Side {
+	return Side{Tag: SideLeft}
+}
+
+func MakeSideRight() Side {
+	return Side{Tag: SideRight}
+}
+
+type SideTag int
+
+const (
+	SideLeft SideTag = iota
+	SideRight
+)
+
+type Side struct {
+	Tag SideTag
+}
+
+func (s Side) String() string {
+	switch s.Tag {
+	case SideLeft:
+		return "Left"
+	case SideRight:
+		return "Right"
+	default:
+		return fmt.Sprintf("Side(%d)", s.Tag)
+	}
+}
+
+func (s Side) GoString() string {
+	switch s.Tag {
+	case SideLeft:
+		return "Side.Left"
+	case SideRight:
+		return "Side.Right"
+	default:
+		return fmt.Sprintf("Side(%d)", s.Tag)
+	}
+}
+
+type Pair struct {
+	a Side
+	b Side
+}
+
+func (p Pair) String() string {
+	return fmt.Sprintf("Pair { a: %v, b: %v }", p.a, p.b)
+}
+
+func classify(p Pair) int {
+	switch p.a.Tag {
+	case SideLeft:
+		if p.b.Tag == SideLeft {
+			return 1
+		}
+		return 0
+	case SideRight:
+		if p.b.Tag == SideRight {
+			return 2
+		}
+		return 0
+	default:
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
+++ b/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
@@ -1,0 +1,91 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \npub enum Hand {\n  Left,\n  Right,\n}\n\nimpl Hand {\n  pub fn left_right(self, other: Hand) -> bool {\n    match (self, other) {\n      (Hand.Left, Hand.Right) => true,\n      _ => false,\n    }\n  }\n\n  pub fn left_left(self, other: Hand) -> bool {\n    match (self, other) {\n      (Hand.Left, Hand.Left) => true,\n      _ => false,\n    }\n  }\n\n  pub fn eq(self, other: Hand) -> bool {\n    match (self, other) {\n      (Hand.Left, Hand.Left) => true,\n      (Hand.Right, Hand.Right) => true,\n      _ => false,\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func MakeHandLeft() Hand {
+	return Hand{Tag: HandLeft}
+}
+
+func MakeHandRight() Hand {
+	return Hand{Tag: HandRight}
+}
+
+type HandTag int
+
+const (
+	HandLeft HandTag = iota
+	HandRight
+)
+
+type Hand struct {
+	Tag HandTag
+}
+
+func (h Hand) String() string {
+	switch h.Tag {
+	case HandLeft:
+		return "Left"
+	case HandRight:
+		return "Right"
+	default:
+		return fmt.Sprintf("Hand(%d)", h.Tag)
+	}
+}
+
+func (h Hand) GoString() string {
+	switch h.Tag {
+	case HandLeft:
+		return "Hand.Left"
+	case HandRight:
+		return "Hand.Right"
+	default:
+		return fmt.Sprintf("Hand(%d)", h.Tag)
+	}
+}
+
+func (h Hand) LeftRight(other Hand) bool {
+	subject_1 := lisette.MakeTuple2(h, other)
+	if subject_1.First.Tag == HandLeft {
+		if subject_1.Second.Tag == HandRight {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+func (h Hand) LeftLeft(other Hand) bool {
+	subject_1 := lisette.MakeTuple2(h, other)
+	if subject_1.First.Tag == HandLeft {
+		if subject_1.Second.Tag == HandLeft {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+func (h Hand) Eq(other Hand) bool {
+	subject_1 := lisette.MakeTuple2(h, other)
+	switch subject_1.First.Tag {
+	case HandLeft:
+		if subject_1.Second.Tag == HandLeft {
+			return true
+		}
+		return false
+	case HandRight:
+		if subject_1.Second.Tag == HandRight {
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
A `match` on a tuple or struct now checks every element of the pattern. Previously, once a Go `switch` was emitted on the first element, any remaining element checks in a case body were silently dropped, so an arm could match on its first element alone and run unconditionally.

Fix #553
