### PR TITLE
fix: reject value names in type annotations

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -169,7 +169,7 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
         .with_help("Define or import this type")
 }
 
-pub fn not_a_type(
+pub fn value_in_type_position(
     name: &str,
     kind: &str,
     annotation_span: Span,
@@ -181,9 +181,9 @@ pub fn not_a_type(
         name.len() as u32,
     );
 
-    let mut diag = LisetteDiagnostic::error(format!("`{}` is not a type", name))
-        .with_resolve_code("not_a_type")
-        .with_span_label(&name_span, format!("{} used in type position", kind));
+    let mut diag = LisetteDiagnostic::error("Value in type position")
+        .with_resolve_code("value_in_type_position")
+        .with_span_label(&name_span, format!("expected type, found {}", kind));
 
     if let Some(help) = help {
         diag = diag.with_help(help);

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -169,6 +169,29 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
         .with_help("Define or import this type")
 }
 
+pub fn not_a_type(
+    name: &str,
+    kind: &str,
+    annotation_span: Span,
+    help: Option<String>,
+) -> LisetteDiagnostic {
+    let name_span = Span::new(
+        annotation_span.file_id,
+        annotation_span.byte_offset,
+        name.len() as u32,
+    );
+
+    let mut diag = LisetteDiagnostic::error(format!("`{}` is not a type", name))
+        .with_resolve_code("not_a_type")
+        .with_span_label(&name_span, format!("{} used in type position", kind));
+
+    if let Some(help) = help {
+        diag = diag.with_help(help);
+    }
+
+    diag
+}
+
 pub fn undeclared_impl_type_param(
     type_name: &str,
     annotation_span: Span,

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -478,9 +478,12 @@ impl<'s> TaskState<'s> {
         }
 
         let qualified_name = self.lookup_qualified_name(store, type_name)?;
-        let ty = store.get_type(&qualified_name)?.clone();
+        let definition = store.get_definition(&qualified_name)?;
+        if !definition_names_a_type(definition, &qualified_name) {
+            return None;
+        }
 
-        Some((qualified_name, ty))
+        Some((qualified_name, definition.ty.clone()))
     }
 
     pub(crate) fn resolve_type_from_prelude(
@@ -489,8 +492,11 @@ impl<'s> TaskState<'s> {
         type_name: &str,
     ) -> Option<(String, Type)> {
         let qualified_name = format!("prelude.{}", type_name);
-        let ty = store.get_type(&qualified_name)?.clone();
-        Some((qualified_name, ty))
+        let definition = store.get_definition(&qualified_name)?;
+        if !definition_names_a_type(definition, &qualified_name) {
+            return None;
+        }
+        Some((qualified_name, definition.ty.clone()))
     }
 
     pub(crate) fn get_all_methods(&self, store: &Store, ty: &Type) -> MethodSignatures {
@@ -770,6 +776,24 @@ impl<'s> TaskState<'s> {
 ///
 /// Reserved names include Go keywords, Go predeclared identifiers, Go builtins,
 /// Go type constraint names, and Lisette prelude symbols.
+/// Whether `definition` introduces a type with name `qualified_name`.
+/// Type declarations (struct/enum/interface/typedef/value-enum) qualify, plus
+/// the placeholder `Value` entries that `collect_type_name_entries` writes
+/// during pre-registration — those carry a self-referential `Type::Nominal`
+/// id, distinguishing them from real values (functions, consts, enum variant
+/// constructors whose `ty` points at the parent enum).
+fn definition_names_a_type(definition: &Definition, qualified_name: &str) -> bool {
+    if !matches!(definition.body, DefinitionBody::Value { .. }) {
+        return true;
+    }
+
+    definition
+        .ty
+        .unwrap_forall()
+        .get_qualified_id()
+        .is_some_and(|id| id == qualified_name)
+}
+
 fn is_reserved_import_alias(name: &str) -> bool {
     matches!(
         name,

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -478,12 +478,9 @@ impl<'s> TaskState<'s> {
         }
 
         let qualified_name = self.lookup_qualified_name(store, type_name)?;
-        let definition = store.get_definition(&qualified_name)?;
-        if !definition_names_a_type(definition, &qualified_name) {
-            return None;
-        }
+        let ty = store.get_type(&qualified_name)?.clone();
 
-        Some((qualified_name, definition.ty.clone()))
+        Some((qualified_name, ty))
     }
 
     pub(crate) fn resolve_type_from_prelude(
@@ -492,11 +489,8 @@ impl<'s> TaskState<'s> {
         type_name: &str,
     ) -> Option<(String, Type)> {
         let qualified_name = format!("prelude.{}", type_name);
-        let definition = store.get_definition(&qualified_name)?;
-        if !definition_names_a_type(definition, &qualified_name) {
-            return None;
-        }
-        Some((qualified_name, definition.ty.clone()))
+        let ty = store.get_type(&qualified_name)?.clone();
+        Some((qualified_name, ty))
     }
 
     pub(crate) fn get_all_methods(&self, store: &Store, ty: &Type) -> MethodSignatures {
@@ -776,24 +770,6 @@ impl<'s> TaskState<'s> {
 ///
 /// Reserved names include Go keywords, Go predeclared identifiers, Go builtins,
 /// Go type constraint names, and Lisette prelude symbols.
-/// Whether `definition` introduces a type with name `qualified_name`.
-/// Type declarations (struct/enum/interface/typedef/value-enum) qualify, plus
-/// the placeholder `Value` entries that `collect_type_name_entries` writes
-/// during pre-registration — those carry a self-referential `Type::Nominal`
-/// id, distinguishing them from real values (functions, consts, enum variant
-/// constructors whose `ty` points at the parent enum).
-fn definition_names_a_type(definition: &Definition, qualified_name: &str) -> bool {
-    if !matches!(definition.body, DefinitionBody::Value { .. }) {
-        return true;
-    }
-
-    definition
-        .ty
-        .unwrap_forall()
-        .get_qualified_id()
-        .is_some_and(|id| id == qualified_name)
-}
-
 fn is_reserved_import_alias(name: &str) -> bool {
     matches!(
         name,

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -4,7 +4,7 @@ use crate::checker::EnvResolve;
 use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span};
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{SubstitutionMap, Type, substitute};
+use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
 use crate::checker::TaskState;
 use crate::store::Store;
@@ -89,14 +89,6 @@ impl TaskState<'_> {
                             *annotation_span,
                             receiver.as_deref(),
                         ));
-                    } else if let Some((kind, help)) = self.classify_non_type_name(store, type_name)
-                    {
-                        self.sink.push(diagnostics::infer::not_a_type(
-                            type_name,
-                            kind,
-                            *annotation_span,
-                            help,
-                        ));
                     } else {
                         self.sink.push(diagnostics::infer::type_not_found(
                             type_name,
@@ -105,6 +97,18 @@ impl TaskState<'_> {
                     }
                     return Type::Error;
                 };
+
+                if let Some((kind, help)) =
+                    self.classify_non_type_name(store, &qualified_name, type_name)
+                {
+                    self.sink.push(diagnostics::infer::value_in_type_position(
+                        type_name,
+                        kind,
+                        *annotation_span,
+                        help,
+                    ));
+                    return Type::Error;
+                }
 
                 self.track_name_usage(
                     store,
@@ -224,66 +228,64 @@ impl TaskState<'_> {
         }
     }
 
-    /// Returns `Some((kind, help))` if `type_name` resolves to a value
-    /// (constant, function, or enum variant) rather than a type — used to
-    /// produce a more targeted diagnostic than the generic "type not found".
     pub(super) fn classify_non_type_name(
         &self,
         store: &Store,
+        qualified_name: &str,
         type_name: &str,
     ) -> Option<(&'static str, Option<String>)> {
-        let qualified_name = self.lookup_qualified_name(store, type_name)?;
-        let definition = store.get_definition(&qualified_name)?;
+        let definition = store.get_definition(qualified_name)?;
         if !matches!(definition.body, DefinitionBody::Value { .. }) {
             return None;
         }
-        // Pre-registration placeholders share `DefinitionBody::Value` but
-        // point at themselves — those are real type names, not values.
         let body = definition.ty.unwrap_forall();
-        let resolves_to_self = body
+
+        if body
             .get_qualified_id()
-            .is_some_and(|id| id == qualified_name);
-        if resolves_to_self {
+            .is_some_and(|id| id == qualified_name)
+        {
             return None;
         }
 
-        // Tuple/struct variants are registered as constructor functions
-        // returning the parent enum; unit variants are registered with the
-        // parent enum as their `ty`. Inspect both shapes.
-        let constructor_return_id = if let Type::Function(f) = body {
-            f.return_type.get_qualified_id()
-        } else {
-            None
+        let is_function = matches!(body, Type::Function(_));
+        let enum_id = match body {
+            Type::Function(f) => f.return_type.get_qualified_id(),
+            other => other.get_qualified_id(),
         };
-        let parent_enum_id = constructor_return_id
-            .or_else(|| body.get_qualified_id())
-            .filter(|id| {
-                store.get_definition(id).is_some_and(|d| {
-                    matches!(
-                        d.body,
-                        DefinitionBody::Enum { .. } | DefinitionBody::ValueEnum { .. }
-                    )
-                })
-            });
+        let variant_name = unqualified_name(qualified_name);
+        let parent_enum = enum_id.filter(|id| {
+            store.get_definition(id).is_some_and(|d| match &d.body {
+                DefinitionBody::Enum { variants, .. } => {
+                    variants.iter().any(|v| v.name == variant_name)
+                }
+                DefinitionBody::ValueEnum { variants, .. } => {
+                    variants.iter().any(|v| v.name == variant_name)
+                }
+                _ => false,
+            })
+        });
 
-        if let Some(enum_id) = parent_enum_id {
-            let enum_name = enum_id.rsplit_once('.').map(|(_, n)| n).unwrap_or(enum_id);
-            let help = if constructor_return_id.is_some() {
+        if let Some(enum_id) = parent_enum {
+            let enum_name = unqualified_name(enum_id);
+            let help = if is_function {
                 format!(
-                    "Use `{}` for the enum type, or call `{}(...)` to construct a value.",
+                    "Use `{}` for the enum type, or call `{}(...)` to construct a value",
                     enum_name, type_name
                 )
             } else {
-                format!("Use `{}` for the enum type.", enum_name)
+                format!("Use `{}` for the enum type", enum_name)
             };
             return Some(("enum variant", Some(help)));
         }
 
-        if matches!(body, Type::Function(_)) {
-            return Some(("function", None));
+        if is_function {
+            return Some((
+                "function",
+                Some("Use a function type alias or write the function type directly".to_string()),
+            ));
         }
 
-        Some(("value", None))
+        Some(("value", Some("Only a type is allowed here".to_string())))
     }
 
     pub(super) fn resolve_type_with_arity(

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -89,6 +89,14 @@ impl TaskState<'_> {
                             *annotation_span,
                             receiver.as_deref(),
                         ));
+                    } else if let Some((kind, help)) = self.classify_non_type_name(store, type_name)
+                    {
+                        self.sink.push(diagnostics::infer::not_a_type(
+                            type_name,
+                            kind,
+                            *annotation_span,
+                            help,
+                        ));
                     } else {
                         self.sink.push(diagnostics::infer::type_not_found(
                             type_name,
@@ -214,6 +222,68 @@ impl TaskState<'_> {
                 unreachable!("Annotation::Opaque should not be converted to a type")
             }
         }
+    }
+
+    /// Returns `Some((kind, help))` if `type_name` resolves to a value
+    /// (constant, function, or enum variant) rather than a type — used to
+    /// produce a more targeted diagnostic than the generic "type not found".
+    pub(super) fn classify_non_type_name(
+        &self,
+        store: &Store,
+        type_name: &str,
+    ) -> Option<(&'static str, Option<String>)> {
+        let qualified_name = self.lookup_qualified_name(store, type_name)?;
+        let definition = store.get_definition(&qualified_name)?;
+        if !matches!(definition.body, DefinitionBody::Value { .. }) {
+            return None;
+        }
+        // Pre-registration placeholders share `DefinitionBody::Value` but
+        // point at themselves — those are real type names, not values.
+        let body = definition.ty.unwrap_forall();
+        let resolves_to_self = body
+            .get_qualified_id()
+            .is_some_and(|id| id == qualified_name);
+        if resolves_to_self {
+            return None;
+        }
+
+        // Tuple/struct variants are registered as constructor functions
+        // returning the parent enum; unit variants are registered with the
+        // parent enum as their `ty`. Inspect both shapes.
+        let constructor_return_id = if let Type::Function(f) = body {
+            f.return_type.get_qualified_id()
+        } else {
+            None
+        };
+        let parent_enum_id = constructor_return_id
+            .or_else(|| body.get_qualified_id())
+            .filter(|id| {
+                store.get_definition(id).is_some_and(|d| {
+                    matches!(
+                        d.body,
+                        DefinitionBody::Enum { .. } | DefinitionBody::ValueEnum { .. }
+                    )
+                })
+            });
+
+        if let Some(enum_id) = parent_enum_id {
+            let enum_name = enum_id.rsplit_once('.').map(|(_, n)| n).unwrap_or(enum_id);
+            let help = if constructor_return_id.is_some() {
+                format!(
+                    "Use `{}` for the enum type, or call `{}(...)` to construct a value.",
+                    enum_name, type_name
+                )
+            } else {
+                format!("Use `{}` for the enum type.", enum_name)
+            };
+            return Some(("enum variant", Some(help)));
+        }
+
+        if matches!(body, Type::Function(_)) {
+            return Some(("function", None));
+        }
+
+        Some(("value", None))
     }
 
     pub(super) fn resolve_type_with_arity(

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -261,38 +261,39 @@ impl TaskState<'_> {
                 } else {
                     variant.name_span
                 };
-                if let Some(&(v_a, f_a, is_struct_a, ty_a, _)) = seen.get(&go_name) {
-                    let ty_a_resolved = ty_a.resolve_in(&self.env);
-                    // Skip the conflict check if either side already errored — the
-                    // primary diagnostic on the bad annotation is enough.
-                    if !matches!(ty_a_resolved, Type::Error)
-                        && !matches!(resolved, Type::Error)
-                        && ty_a_resolved != resolved
-                    {
-                        let loc_a = if is_struct_a {
-                            format!("{}.{}.{}", name, v_a, f_a)
-                        } else {
-                            format!("{}.{}", name, v_a)
-                        };
-                        let loc_b = if is_struct {
-                            format!("{}.{}.{}", name, variant.name, field.name)
-                        } else {
-                            format!("{}.{}", name, variant.name)
-                        };
-                        self.sink.push(diagnostics::infer::enum_field_type_conflict(
-                            &loc_a,
-                            &ty_a.resolve_in(&self.env).to_string(),
-                            &loc_b,
-                            &resolved.to_string(),
-                            span,
-                        ));
-                    }
-                } else {
+                let Some(&(v_a, f_a, is_struct_a, ty_a, _)) = seen.get(&go_name) else {
                     seen.insert(
                         go_name,
                         (&variant.name, &field.name, is_struct, &field.ty, span),
                     );
+                    continue;
+                };
+
+                let ty_a_resolved = ty_a.resolve_in(&self.env);
+                if matches!(ty_a_resolved, Type::Error)
+                    || matches!(resolved, Type::Error)
+                    || ty_a_resolved == resolved
+                {
+                    continue;
                 }
+
+                let loc_a = if is_struct_a {
+                    format!("{}.{}.{}", name, v_a, f_a)
+                } else {
+                    format!("{}.{}", name, v_a)
+                };
+                let loc_b = if is_struct {
+                    format!("{}.{}.{}", name, variant.name, field.name)
+                } else {
+                    format!("{}.{}", name, variant.name)
+                };
+                self.sink.push(diagnostics::infer::enum_field_type_conflict(
+                    &loc_a,
+                    &ty_a_resolved.to_string(),
+                    &loc_b,
+                    &resolved.to_string(),
+                    span,
+                ));
             }
         }
     }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -262,7 +262,13 @@ impl TaskState<'_> {
                     variant.name_span
                 };
                 if let Some(&(v_a, f_a, is_struct_a, ty_a, _)) = seen.get(&go_name) {
-                    if ty_a.resolve_in(&self.env) != resolved {
+                    let ty_a_resolved = ty_a.resolve_in(&self.env);
+                    // Skip the conflict check if either side already errored — the
+                    // primary diagnostic on the bad annotation is enough.
+                    if !matches!(ty_a_resolved, Type::Error)
+                        && !matches!(resolved, Type::Error)
+                        && ty_a_resolved != resolved
+                    {
                         let loc_a = if is_struct_a {
                             format!("{}.{}.{}", name, v_a, f_a)
                         } else {

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4734,13 +4734,6 @@ fn main() {
 
 #[test]
 fn value_placeholder_for_forward_reference_resolves() {
-    // Pins the self-referential placeholder branch in
-    // `definition_names_a_type`. `collect_type_name_entries` pre-registers
-    // every type name with a `DefinitionBody::Value` placeholder before
-    // `populate_X` fills in the real body; while that placeholder is in
-    // place, other items in the same module must still resolve it as a
-    // type. Forward references trigger the window: when `Holder`'s field
-    // annotation is resolved, `Later`'s body is still the placeholder.
     infer(
         r#"{
         struct Holder {

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4733,6 +4733,31 @@ fn main() {
 }
 
 #[test]
+fn value_placeholder_for_forward_reference_resolves() {
+    // Pins the self-referential placeholder branch in
+    // `definition_names_a_type`. `collect_type_name_entries` pre-registers
+    // every type name with a `DefinitionBody::Value` placeholder before
+    // `populate_X` fills in the real body; while that placeholder is in
+    // place, other items in the same module must still resolve it as a
+    // type. Forward references trigger the window: when `Holder`'s field
+    // annotation is resolved, `Later`'s body is still the placeholder.
+    infer(
+        r#"{
+        struct Holder {
+          inner: Later,
+        }
+
+        struct Later {
+          n: int,
+        }
+
+        Holder { inner: Later { n: 1 } }
+        }"#,
+    )
+    .assert_type_struct("Holder");
+}
+
+#[test]
 fn interface_covariance_rejects_reverse_direction() {
     let typedef = r#"
 pub interface Stringer {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1856,6 +1856,25 @@ fn run(f: helper) -> int {
 }
 
 #[test]
+fn infer_not_a_type_function_returning_enum() {
+    let input = r#"
+enum Kind {
+  Int,
+  String,
+}
+
+fn make() -> Kind {
+  Kind.Int
+}
+
+fn run(f: make) -> int {
+  return f(0)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_variable_not_found_no_suggestion() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1806,6 +1806,56 @@ type Foo<T: Undefined> = T
 }
 
 #[test]
+fn infer_not_a_type_unit_variant_local() {
+    let input = r#"
+enum Kind {
+  Int,
+  String,
+}
+
+enum Column {
+  PrimaryKey { name: string, kind: Kind },
+  String { name: string, kind: Kind.String },
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_a_type_unit_variant_prelude() {
+    let input = r#"
+fn nothing() -> None {
+  return None
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_a_type_constructor_variant() {
+    let input = r#"
+fn test() {
+  let x: Some = Some(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_a_type_function_name() {
+    let input = r#"
+fn helper(x: int) -> int {
+  return x * 2
+}
+
+fn run(f: helper) -> int {
+  return f(21)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_variable_not_found_no_suggestion() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_not_a_type_constructor_variant.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_constructor_variant.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 1841
+---
+  [error] `Some` is not a type
+   ╭─[test.lis:3:10]
+ 2 │ fn test() {
+ 3 │   let x: Some = Some(1)
+   ·          ──┬─
+   ·            ╰── enum variant used in type position
+ 4 │ }
+   ╰────
+  help: Use `Option` for the enum type, or call `Some(...)` to construct a value · code: [resolve.not_a_type]

--- a/tests/ui/errors/snapshots/infer_not_a_type_constructor_variant.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_constructor_variant.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
-assertion_line: 1841
 ---
-  [error] `Some` is not a type
+  [error] Value in type position
    ╭─[test.lis:3:10]
  2 │ fn test() {
  3 │   let x: Some = Some(1)
    ·          ──┬─
-   ·            ╰── enum variant used in type position
+   ·            ╰── expected type, found enum variant
  4 │ }
    ╰────
-  help: Use `Option` for the enum type, or call `Some(...)` to construct a value · code: [resolve.not_a_type]
+  help: Use `Option` for the enum type, or call `Some(...)` to construct a value · code: [resolve.value_in_type_position]

--- a/tests/ui/errors/snapshots/infer_not_a_type_function_name.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_function_name.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 1855
+---
+  [error] `helper` is not a type
+   ╭─[test.lis:6:11]
+ 5 │ 
+ 6 │ fn run(f: helper) -> int {
+   ·           ───┬──
+   ·              ╰── function used in type position
+ 7 │   return f(21)
+   ╰────
+  help:  · code: [resolve.not_a_type]

--- a/tests/ui/errors/snapshots/infer_not_a_type_function_name.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_function_name.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
-assertion_line: 1855
 ---
-  [error] `helper` is not a type
+  [error] Value in type position
    ╭─[test.lis:6:11]
  5 │ 
  6 │ fn run(f: helper) -> int {
    ·           ───┬──
-   ·              ╰── function used in type position
+   ·              ╰── expected type, found function
  7 │   return f(21)
    ╰────
-  help:  · code: [resolve.not_a_type]
+  help: Use a function type alias or write the function type directly · code: [resolve.value_in_type_position]

--- a/tests/ui/errors/snapshots/infer_not_a_type_function_returning_enum.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_function_returning_enum.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Value in type position
+    ╭─[test.lis:11:11]
+ 10 │ 
+ 11 │ fn run(f: make) -> int {
+    ·           ──┬─
+    ·             ╰── expected type, found function
+ 12 │   return f(0)
+    ╰────
+  help: Use a function type alias or write the function type directly · code: [resolve.value_in_type_position]

--- a/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_local.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_local.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 1821
+---
+  [error] `Kind.String` is not a type
+    ╭─[test.lis:9:32]
+  8 │   PrimaryKey { name: string, kind: Kind },
+  9 │   String { name: string, kind: Kind.String },
+    ·                                ─────┬─────
+    ·                                     ╰── enum variant used in type position
+ 10 │ }
+    ╰────
+  help: Use `Kind` for the enum type · code: [resolve.not_a_type]

--- a/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_local.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_local.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
-assertion_line: 1821
 ---
-  [error] `Kind.String` is not a type
+  [error] Value in type position
     ╭─[test.lis:9:32]
   8 │   PrimaryKey { name: string, kind: Kind },
   9 │   String { name: string, kind: Kind.String },
     ·                                ─────┬─────
-    ·                                     ╰── enum variant used in type position
+    ·                                     ╰── expected type, found enum variant
  10 │ }
     ╰────
-  help: Use `Kind` for the enum type · code: [resolve.not_a_type]
+  help: Use `Kind` for the enum type · code: [resolve.value_in_type_position]

--- a/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_prelude.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_prelude.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
-assertion_line: 1831
 ---
-  [error] `None` is not a type
+  [error] Value in type position
    ╭─[test.lis:2:17]
  1 │ 
  2 │ fn nothing() -> None {
    ·                 ──┬─
-   ·                   ╰── enum variant used in type position
+   ·                   ╰── expected type, found enum variant
  3 │   return None
    ╰────
-  help: Use `Option` for the enum type · code: [resolve.not_a_type]
+  help: Use `Option` for the enum type · code: [resolve.value_in_type_position]

--- a/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_prelude.snap
+++ b/tests/ui/errors/snapshots/infer_not_a_type_unit_variant_prelude.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+assertion_line: 1831
+---
+  [error] `None` is not a type
+   ╭─[test.lis:2:17]
+ 1 │ 
+ 2 │ fn nothing() -> None {
+   ·                 ──┬─
+   ·                   ╰── enum variant used in type position
+ 3 │   return None
+   ╰────
+  help: Use `Option` for the enum type · code: [resolve.not_a_type]


### PR DESCRIPTION
First i noticed that the compiler did allow for enum variants in type position,
and silently narrowed down the root type without compile errors. 
After some digging i noticed a few other, related edge cases.

Example 1: Enum variant used as a field type

```rust
pub enum Kind {
  Int,
  String,
}

pub enum Column {
  String { name: string, kind: Kind.String },
}

fn main() {
  let _ = Column.String { name: "id", kind: Kind.Int }
}

```

**Before:** `No issues` the `Kind.String` annotation silently
degrades to `Kind`, so `kind: Kind.Int` is accepted and emitted as
the variant's payload.

**After:**

```text
🔴 `Kind.String` is not a type
   │   String { name: string, kind: Kind.String },
   │                                ─────┬─────
   ·                                     ╰── enum variant used in type position
   help: Use `Kind` for the enum type
```

Example 2: Enum variant used as a let-binding type

```rust
fn main() {
  let x: Some = Some(1)
  let _ = x
}
```

**Before:**

```text
🔴 Wrong type argument count
   │   let x: Some = Some(1)
   │   ──────────┬──────────
   ·             ╰── expected `<T>`, found `<>`
   help: This type expects 1 type parameter but received 0 type parameters

🔴 Type mismatch
   │   let x: Some = Some(1)
   │                 ───┬───
   ·                    ╰── expected `fn (T) -> Option<T>`, found `Option<int>`
```

The resolver treats `Some` as a single-arity type constructor producing two cascading errors.

**After:**

```text
🔴 `Some` is not a type
   │   let x: Some = Some(1)
   │          ──┬─
   ·            ╰── enum variant used in type position
   help: Use `Option` for the enum type, or call `Some(...)` to construct a value
```


Example 3: Enum variant used as a return type


```rust
fn nothing() -> None {
  return None
}
```

**Before:**

```text
🔴 Wrong type argument count
   │ fn nothing() -> None {
   │     return None
   │ }
   · expected `<T>`, found `<>`
```

The error wraps the entire function body and is confusing to the user as in what is actually wrong.

**After:**

```text
🔴 `None` is not a type
   │ fn nothing() -> None {
   │                 ──┬─
   ·                   ╰── enum variant used in type position
   help: Use `Option` for the enum type
```

Example 4: Function name used as a type

```rust
fn double(x: int) -> int {
  return x * 2
}

fn run(f: double) -> int {
  return f(21)
}

fn main() {
  let _ = run(double)
}
```

**Before:** No type error at all, just unrelated linter warnings. The
`f: double` annotation pulls the function's `ty` (`fn(int) -> int`)
and silently uses it as `f`'s type, so the call site happens to
type-check.

**After:**

```text
🔴 `double` is not a type
   │ fn run(f: double) -> int {
   │           ───┬──
   ·              ╰── function used in type position
```

This forces the user the either make a type alias: `type Double = fn(int) -> int` or change the function type
signature to `fn(int) -> int)`
