### PR TITLE
refactor: share ufcs methods across inference

### DIFF
--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -272,7 +272,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
             }
         } else {
             let allocator = binding_ids.clone();
-            let ufcs_snapshot = checker.ufcs_methods.clone();
+            let ufcs_shared = Arc::new(std::mem::take(&mut checker.ufcs_methods));
             let store_ref: &Store = &store;
 
             type WorkerOutput = (Vec<(String, File)>, Facts, LocalSink);
@@ -281,13 +281,16 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
                 .map(|(module_id, files)| {
                     let local_sink = LocalSink::new();
                     let mut worker = TaskState::new(&local_sink, allocator.clone());
-                    worker.ufcs_methods = ufcs_snapshot.clone();
+                    worker.ufcs_shared = Some(ufcs_shared.clone());
                     worker.infer_module(store_ref, &module_id, files);
                     let typed_files = std::mem::take(&mut worker.typed_files);
                     let facts = std::mem::replace(&mut worker.facts, Facts::new(allocator.clone()));
                     (typed_files, facts, local_sink)
                 })
                 .collect();
+
+            checker.ufcs_methods =
+                Arc::try_unwrap(ufcs_shared).unwrap_or_else(|arc| (*arc).clone());
 
             let mut worker_sinks: Vec<LocalSink> = Vec::with_capacity(outputs.len());
             for (typed_files, facts, sink_local) in outputs {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1105,7 +1105,7 @@ impl TaskState<'_> {
                 // UFCS method: receiver.method() where method is a free function
                 if let Type::Nominal { id, .. } = &receiver_ty
                     && self
-                        .ufcs_methods
+                        .effective_ufcs_methods()
                         .contains(&(id.to_string(), member.to_string()))
                 {
                     return CallKind::UfcsMethod;
@@ -1229,7 +1229,7 @@ impl TaskState<'_> {
 
         // If it's a UFCS-lowered method, skip — the emitter handles it differently
         if self
-            .ufcs_methods
+            .effective_ufcs_methods()
             .contains(&(qualified_name.to_string(), method.to_string()))
         {
             return None;

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -108,6 +108,8 @@ pub struct TaskState<'s> {
     pub satisfying_stack: rustc_hash::FxHashSet<(String, String)>,
     method_cache: RefCell<HashMap<EcoString, MethodSignatures>>,
     pub ufcs_methods: HashSet<(String, String)>,
+    /// When set, parallel workers read UFCS methods from here instead of cloning into `ufcs_methods`.
+    pub ufcs_shared: Option<Arc<HashSet<(String, String)>>>,
     /// Typed files produced by inference.
     pub typed_files: Vec<(String, File)>,
     /// Reentrancy counter: > 0 while resolving a generic bound annotation.
@@ -129,6 +131,7 @@ impl<'s> TaskState<'s> {
             satisfying_stack: rustc_hash::FxHashSet::default(),
             method_cache: RefCell::new(HashMap::default()),
             ufcs_methods: HashSet::default(),
+            ufcs_shared: None,
             typed_files: Vec::new(),
             bound_position_depth: 0,
         }
@@ -136,6 +139,10 @@ impl<'s> TaskState<'s> {
 
     pub fn with_fresh_allocator(sink: &'s LocalSink) -> Self {
         Self::new(sink, Arc::new(BindingIdAllocator::new()))
+    }
+
+    fn effective_ufcs_methods(&self) -> &HashSet<(String, String)> {
+        self.ufcs_shared.as_deref().unwrap_or(&self.ufcs_methods)
     }
 
     pub fn new_type_var(&mut self) -> Type {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6261,3 +6261,53 @@ fn main() {
 
     assert_build_snapshot!(fs, "github.com/user/myproject");
 }
+
+#[test]
+fn ufcs_method_resolves_across_modules_on_parallel_path() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "lib",
+        "box.lis",
+        r#"
+pub struct Box<T> { pub value: T }
+
+impl<T> Box<T> {
+  pub fn map<U>(self, f: fn(T) -> U) -> Box<U> {
+    Box { value: f(self.value) }
+  }
+}
+"#,
+    );
+    fs.add_file("filler_a", "a.lis", "pub fn ping() -> int { 1 }\n");
+    fs.add_file("filler_b", "b.lis", "pub fn ping() -> int { 2 }\n");
+    fs.add_file("filler_c", "c.lis", "pub fn ping() -> int { 3 }\n");
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "lib"
+import "filler_a"
+import "filler_b"
+import "filler_c"
+
+fn main() {
+  let _ = filler_a.ping();
+  let _ = filler_b.ping();
+  let _ = filler_c.ping();
+  let b: lib.Box<int> = lib.Box { value: 5 };
+  let mapped = b.map(|x| x + 1);
+  let _ = mapped.value;
+}
+"#,
+    );
+
+    let files = compile_project_files(fs, "github.com/user/myproject", false);
+    let go: String = files.iter().map(|f| f.to_go()).collect();
+    assert!(
+        go.contains("Box_Map("),
+        "UFCS method must lower to a free-function call (Box_Map) even on the \
+         parallel inference path; got:\n{go}"
+    );
+}


### PR DESCRIPTION
Parallel inference workers previously each cloned the full `ufcs_methods` set; they now read a single shared `Arc` instead, removing the per-worker clone.