### PR TITLE
feat: add `#[iterable]` for enum iteration

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -31,3 +31,46 @@ pub fn conflicting_case_transforms(span: &Span) -> LisetteDiagnostic {
         .with_span_label(span, "conflicting")
         .with_help("Choose either `snake_case` or `camel_case`, not both")
 }
+
+pub fn iterable_non_unit_variant(attribute_span: &Span, variant_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[iterable]` on enum with payload variant")
+        .with_attribute_code("iterable_non_unit_variant")
+        .with_span_label(attribute_span, "disallowed if a variant has a payload")
+        .with_span_label(variant_span, "this variant has a payload")
+        .with_help("Remove the payload, or drop `#[iterable]`")
+}
+
+pub fn iterable_generic_enum(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[iterable]` on generic enum")
+        .with_attribute_code("iterable_generic_enum")
+        .with_span_label(attribute_span, "disallowed if enum has generics")
+        .with_help("Remove the generic type parameters, or drop `#[iterable]`")
+}
+
+pub fn iterable_not_an_enum(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[iterable]` not on enum")
+        .with_attribute_code("iterable_not_an_enum")
+        .with_span_label(attribute_span, "not on an enum")
+        .with_help("Only an enum can be marked `#[iterable]`")
+}
+
+pub fn iterable_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[iterable]` in a typedef")
+        .with_attribute_code("iterable_in_typedef")
+        .with_span_label(attribute_span, "disallowed in a `.d.lis` typedef")
+        .with_help("Only enums in `.lis` source can be marked `#[iterable]`")
+}
+
+pub fn iterable_variants_conflict(
+    attribute_span: &Span,
+    existing_span: Option<&Span>,
+) -> LisetteDiagnostic {
+    let mut diagnostic =
+        LisetteDiagnostic::error("`#[iterable]` conflicts with existing `variants`")
+            .with_attribute_code("iterable_variants_conflict")
+            .with_span_label(attribute_span, "would synthesize `variants`");
+    if let Some(span) = existing_span {
+        diagnostic = diagnostic.with_span_label(span, "`variants` already defined here");
+    }
+    diagnostic.with_help("Rename the existing `variants`, or drop `#[iterable]`")
+}

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -133,10 +133,24 @@ impl Planner<'_> {
                 name_span,
                 variants,
                 attributes,
+                visibility,
                 ..
             } => {
                 let type_go = go_name::escape_keyword(name).into_owned();
                 self.check_reserved_prefix(&type_go, name_span, diagnostics);
+
+                if attributes
+                    .iter()
+                    .any(|attribute| attribute.name == "iterable")
+                {
+                    let variants_fn =
+                        self.variants_go_name(name, matches!(visibility, Visibility::Public));
+                    package_block
+                        .entry(variants_fn)
+                        .or_default()
+                        .push(*name_span);
+                }
+
                 package_block
                     .entry(type_go.clone())
                     .or_default()

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -309,6 +309,21 @@ impl EnumLayout {
         )
     }
 
+    pub(crate) fn emit_variants_function(&self, fn_name: &str) -> String {
+        let go_type_name = go_name::escape_keyword(&self.enum_name);
+
+        let mut lines = Vec::new();
+        lines.push(format!("func {fn_name}() []{go_type_name} {{"));
+        lines.push(format!("return []{go_type_name}{{"));
+        for variant in &self.variants {
+            lines.push(format!("{{Tag: {}}},", variant.tag_constant));
+        }
+        lines.push("}".to_string());
+        lines.push("}".to_string());
+
+        lines.join("\n")
+    }
+
     pub(crate) fn emit_json_methods(&self, receiver_generics: &str) -> String {
         let receiver = receiver_name(&self.enum_name);
         let go_type_name = go_name::escape_keyword(&self.enum_name);

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -44,6 +44,7 @@ impl Planner<'_> {
         let generics_string = self.generics_to_string_for_symbol(&enum_id, generics, fx);
         let receiver_generics = receiver_generics_string(generics);
         let has_json = attributes.iter().any(|a| a.name == "json");
+        let has_iterable = attributes.iter().any(|a| a.name == "iterable");
 
         let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
         let emit_string = !has_user_string;
@@ -71,6 +72,15 @@ impl Planner<'_> {
             result.push_str("\n\n");
             result.push_str(&layout.emit_json_methods(&receiver_generics));
         }
+        if has_iterable {
+            let is_public = self
+                .facts
+                .definition(enum_id.as_str())
+                .is_some_and(|definition| definition.visibility().is_public());
+            let fn_name = self.variants_go_name(name, is_public);
+            result.push_str("\n\n");
+            result.push_str(&layout.emit_variants_function(&fn_name));
+        }
         if needs_fmt {
             fx.require_fmt();
         }
@@ -79,6 +89,16 @@ impl Planner<'_> {
         }
 
         Some(result)
+    }
+
+    /// Export-aware Go name for an `#[iterable]` enum's synthesized `variants`
+    /// function. Matches the static-method call-site naming so the definition
+    /// and its calls agree.
+    pub(crate) fn variants_go_name(&self, enum_name: &str, is_public: bool) -> String {
+        go_name::iterable_variants_fn_name(
+            enum_name,
+            is_public || self.method_needs_export("variants"),
+        )
     }
 
     pub(crate) fn create_make_function_code(

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -42,6 +42,15 @@ pub(crate) fn snake_to_camel(s: &str) -> String {
     s.split('_').map(capitalize_first).collect()
 }
 
+pub(crate) fn iterable_variants_fn_name(enum_name: &str, exported: bool) -> String {
+    let method_segment = if exported {
+        snake_to_camel("variants")
+    } else {
+        "variants".to_string()
+    };
+    format!("{}_{}", enum_name, method_segment)
+}
+
 pub(crate) fn go_package_name(module: &str) -> &str {
     module.rsplit('/').next().unwrap_or(module)
 }

--- a/crates/semantics/src/checker/registration/iterables.rs
+++ b/crates/semantics/src/checker/registration/iterables.rs
@@ -1,0 +1,235 @@
+use syntax::ast::{Attribute, Expression, Span, VariantFields};
+use syntax::program::{Definition, DefinitionBody, Visibility};
+use syntax::types::{CompoundKind, Symbol, Type};
+
+use super::TaskState;
+use crate::store::Store;
+
+impl TaskState<'_> {
+    /// Register iterables from a single items list (the `register_types_and_values` path).
+    pub(super) fn register_iterables(&mut self, store: &mut Store, items: &[Expression]) {
+        let module_id = self.cursor.module_id.clone();
+        let is_d_lis = self.is_d_lis(store);
+        let mut candidates = Vec::new();
+        for item in items {
+            collect_iterable_candidates(item, is_d_lis, &mut candidates);
+        }
+        for candidate in candidates {
+            self.process_iterable_candidate(store, &module_id, candidate);
+        }
+    }
+
+    /// Register iterables across all of the module's files (the `register_module`
+    /// path), after every file is registered so cross-file collisions are visible.
+    pub(super) fn register_module_iterables(&mut self, store: &mut Store, module_id: &str) {
+        let candidates = {
+            let module = store.get_module(module_id).expect("module must exist");
+            let mut candidates = Vec::new();
+            for file in module.files.values() {
+                let is_d_lis = file.is_d_lis();
+                for item in &file.items {
+                    collect_iterable_candidates(item, is_d_lis, &mut candidates);
+                }
+            }
+            candidates
+        };
+
+        for candidate in candidates {
+            self.process_iterable_candidate(store, module_id, candidate);
+        }
+    }
+
+    fn process_iterable_candidate(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        candidate: IterableCandidate,
+    ) {
+        let IterableCandidate {
+            attribute_span,
+            kind,
+        } = candidate;
+        let EnumCandidate {
+            name,
+            name_span,
+            is_generic,
+            is_d_lis,
+            payload_variant_span,
+        } = match kind {
+            CandidateKind::NotAnEnum => {
+                self.sink.push(diagnostics::attribute::iterable_not_an_enum(
+                    &attribute_span,
+                ));
+                return;
+            }
+            CandidateKind::Enum(enum_candidate) => enum_candidate,
+        };
+
+        if is_d_lis {
+            self.sink
+                .push(diagnostics::attribute::iterable_in_typedef(&attribute_span));
+            return;
+        }
+        if is_generic {
+            self.sink
+                .push(diagnostics::attribute::iterable_generic_enum(
+                    &attribute_span,
+                ));
+            return;
+        }
+        if let Some(variant_span) = payload_variant_span {
+            self.sink
+                .push(diagnostics::attribute::iterable_non_unit_variant(
+                    &attribute_span,
+                    &variant_span,
+                ));
+            return;
+        }
+
+        let qualified = Symbol::from_parts(module_id, &name);
+        let variants_key = qualified.with_segment("variants");
+
+        // A static method or a variant literally named `variants` both register
+        // a `Value` at `Enum.variants`; an instance method lands in the enum's
+        // method map. Any of the three collides.
+        let existing_span = store
+            .get_definition(variants_key.as_str())
+            .and_then(|definition| definition.name_span);
+        let (has_instance_variants, visibility) = match store.get_definition(qualified.as_str()) {
+            Some(definition) => (
+                matches!(&definition.body, DefinitionBody::Enum { methods, .. } if methods.contains_key("variants")),
+                definition.visibility().clone(),
+            ),
+            None => (false, Visibility::Private),
+        };
+        if existing_span.is_some() || has_instance_variants {
+            self.sink
+                .push(diagnostics::attribute::iterable_variants_conflict(
+                    &attribute_span,
+                    existing_span.as_ref(),
+                ));
+            return;
+        }
+
+        let Some(enum_ty) = store.get_type(qualified.as_str()).cloned() else {
+            return;
+        };
+
+        let slice_ty = Type::Compound {
+            kind: CompoundKind::Slice,
+            args: vec![enum_ty],
+        };
+        let fn_ty = Type::function(vec![], vec![], Default::default(), Box::new(slice_ty));
+
+        let module = store.get_module_mut(module_id).expect("module must exist");
+        module.definitions.insert(
+            variants_key,
+            Definition {
+                visibility,
+                ty: fn_ty,
+                name: None,
+                name_span: Some(name_span),
+                doc: None,
+                body: DefinitionBody::Value {
+                    allowed_lints: vec![],
+                    go_hints: vec![],
+                    go_name: None,
+                },
+            },
+        );
+    }
+}
+
+struct IterableCandidate {
+    attribute_span: Span,
+    kind: CandidateKind,
+}
+
+enum CandidateKind {
+    Enum(EnumCandidate),
+    NotAnEnum,
+}
+
+struct EnumCandidate {
+    name: String,
+    name_span: Span,
+    is_generic: bool,
+    is_d_lis: bool,
+    payload_variant_span: Option<Span>,
+}
+
+fn iterable_attribute_span(attributes: &[Attribute]) -> Option<Span> {
+    attributes
+        .iter()
+        .find(|a| a.name == "iterable")
+        .map(|a| a.span)
+}
+
+fn misplaced_candidate(span: Span) -> IterableCandidate {
+    IterableCandidate {
+        attribute_span: span,
+        kind: CandidateKind::NotAnEnum,
+    }
+}
+
+/// Record any `#[iterable]` on a method (impl or interface) as misplaced.
+fn collect_method_attributes(methods: &[Expression], out: &mut Vec<IterableCandidate>) {
+    for method in methods {
+        if let Expression::Function { attributes, .. } = method {
+            out.extend(iterable_attribute_span(attributes).map(misplaced_candidate));
+        }
+    }
+}
+
+/// Collect every `#[iterable]` occurrence on a top-level item: an enum to
+/// validate and synthesize, anything else (including fields and methods)
+/// recorded as misplaced so the attribute is never silently accepted off an enum.
+fn collect_iterable_candidates(
+    item: &Expression,
+    is_d_lis: bool,
+    out: &mut Vec<IterableCandidate>,
+) {
+    match item {
+        Expression::Enum {
+            attributes,
+            name,
+            name_span,
+            generics,
+            variants,
+            ..
+        } => {
+            if let Some(attribute_span) = iterable_attribute_span(attributes) {
+                let payload_variant_span = variants
+                    .iter()
+                    .find(|v| !matches!(v.fields, VariantFields::Unit))
+                    .map(|v| v.name_span);
+                out.push(IterableCandidate {
+                    attribute_span,
+                    kind: CandidateKind::Enum(EnumCandidate {
+                        name: name.to_string(),
+                        name_span: *name_span,
+                        is_generic: !generics.is_empty(),
+                        is_d_lis,
+                        payload_variant_span,
+                    }),
+                });
+            }
+        }
+        Expression::Struct {
+            attributes, fields, ..
+        } => {
+            out.extend(iterable_attribute_span(attributes).map(misplaced_candidate));
+            for field in fields {
+                out.extend(iterable_attribute_span(&field.attributes).map(misplaced_candidate));
+            }
+        }
+        Expression::Function { attributes, .. } => {
+            out.extend(iterable_attribute_span(attributes).map(misplaced_candidate));
+        }
+        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
+        Expression::Interface {
+            method_signatures, ..
+        } => collect_method_attributes(method_signatures, out),
+        _ => {}
+    }
+}

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod convert;
+mod iterables;
 mod methods;
 mod types;
 
@@ -101,6 +102,8 @@ impl TaskState<'_> {
         for (file_id, imports) in &file_data {
             self.register_file_values(store, id, *file_id, imports);
         }
+
+        self.register_module_iterables(store, id);
 
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = crate::call_classification::compute_module_ufcs(module, id);
@@ -339,6 +342,7 @@ impl TaskState<'_> {
         self.register_type_definitions(store, items);
         self.register_impl_blocks(store, items);
         self.register_values(store, items, visibility);
+        self.register_iterables(store, items);
     }
 
     pub fn register_type_names(

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -231,7 +231,7 @@ fn check_tag_with_alias(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiag
 }
 
 fn is_known_attribute(name: &str) -> bool {
-    is_serialization_key(name) || name == "tag" || name == "allow"
+    is_serialization_key(name) || matches!(name, "tag" | "allow" | "iterable")
 }
 
 fn is_serialization_key(key: &str) -> bool {

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -851,6 +851,11 @@ impl<'source> Parser<'source> {
 
             let item_doc = self.collect_doc_comments();
             let method_attrs = self.parse_attributes();
+            if !self.is(Function)
+                && let Some(attribute) = method_attrs.first()
+            {
+                self.error_misplaced_attribute(attribute.span);
+            }
             match self.current_token().kind {
                 Function => {
                     let method =

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -152,6 +152,12 @@ impl<'source> Parser<'source> {
 
         let doc = doc_with_span.map(|(text, _)| text);
 
+        if !matches!(self.current_token().kind, Enum | Struct | Function)
+            && let Some(attribute) = attributes.first()
+        {
+            self.error_misplaced_attribute(attribute.span);
+        }
+
         let expression = match self.current_token().kind {
             Enum => self.parse_enum_definition(doc, attributes),
             Struct => self.parse_struct_definition(doc, attributes),
@@ -831,6 +837,18 @@ impl<'source> Parser<'source> {
         let error = ParseError::new("Unattached doc comment", span, "is detached")
             .with_parse_code("detached_doc_comment")
             .with_help("Place the doc comment on the line immediately above a symbol definition");
+
+        self.errors.push(error);
+    }
+
+    fn error_misplaced_attribute(&mut self, span: Span) {
+        let error = ParseError::new(
+            "Attribute not supported on target",
+            span,
+            "not supported on target",
+        )
+        .with_parse_code("misplaced_attribute")
+        .with_help("Remove the attribute, or move it onto an enum, struct, or function");
 
         self.errors.push(error);
     }

--- a/docs/reference/06-structs-and-enums.md
+++ b/docs/reference/06-structs-and-enums.md
@@ -195,6 +195,12 @@ let err = Err("oh no")
 
 📚 See [`09-error-handling.md`](09-error-handling.md)
 
+### Iterating on enum variants
+
+To iterate on enum variants in declaration order, mark an enum with the `#[iterable]` attribute.
+
+📚 See [`15-attributes.md`](15-attributes.md)
+
 <br>
 
 <table><tr>

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -1,6 +1,10 @@
 # Attributes
 
-Attributes attach metadata to structs and fields, typically for serialization.
+Attributes attach metadata or behavior to declarations:
+
+- structs and fields for serialization,
+- enums for iteration, and
+- functions for lint suppression.
 
 ## Serialization
 
@@ -143,6 +147,26 @@ fn warm_cache(path: string) {
   os.ReadFile(path)  // preload file, ignore contents
 }
 ```
+
+## Iteration
+
+Add `#[iterable]` to an enum to synthesize a `variants()` associated function returning every variant, in declaration order:
+
+```rs
+#[iterable]
+enum Direction {
+  North,
+  East,
+  West,
+  South,
+}
+
+for direction in Direction.variants() {
+  fmt.Println(direction)
+}
+```
+
+`Direction.variants()` returns a `Slice<Direction>`. Only enums whose variants have no payloads can be `#[iterable]`.
 
 <br>
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -1327,6 +1327,93 @@ fn main() {
 }
 
 #[test]
+fn iterable_enum_named_go_keyword() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[iterable]
+enum map {
+  A,
+  B,
+}
+
+fn main() {
+  let _ = map.variants()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn iterable_enum_export_name_consistency() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[iterable]
+pub enum PublicPhase {
+  Build,
+}
+
+#[iterable]
+enum LocalPhase {
+  Check,
+}
+
+fn main() {
+  let _ = LocalPhase.variants()
+  let _ = PublicPhase.variants()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn multimodule_iterable_enum() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "phases",
+        "mod.lis",
+        r#"
+#[iterable]
+pub enum BuildPhase {
+  Validate,
+  Parse,
+  Codegen,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "phases"
+
+fn main() {
+  let mut total = 0
+  for _phase in phases.BuildPhase.variants() {
+    total = total + 1
+  }
+  let _ = total
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn receiver_name_collision_with_parameter() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/iterable_enum_export_name_consistency.snap
+++ b/tests/spec/build/snapshots/iterable_enum_export_name_consistency.snap
@@ -1,0 +1,88 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+func MakePublicPhaseBuild() PublicPhase {
+	return PublicPhase{Tag: PublicPhaseBuild}
+}
+
+func MakeLocalPhaseCheck() LocalPhase {
+	return LocalPhase{Tag: LocalPhaseCheck}
+}
+
+type PublicPhaseTag int
+
+const (
+	PublicPhaseBuild PublicPhaseTag = iota
+)
+
+type PublicPhase struct {
+	Tag PublicPhaseTag
+}
+
+func (p PublicPhase) String() string {
+	switch p.Tag {
+	case PublicPhaseBuild:
+		return "Build"
+	default:
+		return fmt.Sprintf("PublicPhase(%d)", p.Tag)
+	}
+}
+
+func (p PublicPhase) GoString() string {
+	switch p.Tag {
+	case PublicPhaseBuild:
+		return "PublicPhase.Build"
+	default:
+		return fmt.Sprintf("PublicPhase(%d)", p.Tag)
+	}
+}
+
+func PublicPhase_Variants() []PublicPhase {
+	return []PublicPhase{
+		{Tag: PublicPhaseBuild},
+	}
+}
+
+type LocalPhaseTag int
+
+const (
+	LocalPhaseCheck LocalPhaseTag = iota
+)
+
+type LocalPhase struct {
+	Tag LocalPhaseTag
+}
+
+func (l LocalPhase) String() string {
+	switch l.Tag {
+	case LocalPhaseCheck:
+		return "Check"
+	default:
+		return fmt.Sprintf("LocalPhase(%d)", l.Tag)
+	}
+}
+
+func (l LocalPhase) GoString() string {
+	switch l.Tag {
+	case LocalPhaseCheck:
+		return "LocalPhase.Check"
+	default:
+		return fmt.Sprintf("LocalPhase(%d)", l.Tag)
+	}
+}
+
+func LocalPhase_Variants() []LocalPhase {
+	return []LocalPhase{
+		{Tag: LocalPhaseCheck},
+	}
+}
+
+func main() {
+	_ = LocalPhase_Variants()
+	_ = PublicPhase_Variants()
+}

--- a/tests/spec/build/snapshots/iterable_enum_named_go_keyword.snap
+++ b/tests/spec/build/snapshots/iterable_enum_named_go_keyword.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+func Makemap_A() map_ {
+	return map_{Tag: mapA}
+}
+
+func Makemap_B() map_ {
+	return map_{Tag: mapB}
+}
+
+type mapTag int
+
+const (
+	mapA mapTag = iota
+	mapB
+)
+
+type map_ struct {
+	Tag mapTag
+}
+
+func (m map_) String() string {
+	switch m.Tag {
+	case mapA:
+		return "A"
+	case mapB:
+		return "B"
+	default:
+		return fmt.Sprintf("map(%d)", m.Tag)
+	}
+}
+
+func (m map_) GoString() string {
+	switch m.Tag {
+	case mapA:
+		return "map.A"
+	case mapB:
+		return "map.B"
+	default:
+		return fmt.Sprintf("map(%d)", m.Tag)
+	}
+}
+
+func map_variants() []map_ {
+	return []map_{
+		{Tag: mapA},
+		{Tag: mapB},
+	}
+}
+
+func main() {
+	_ = map_variants()
+}

--- a/tests/spec/build/snapshots/multimodule_iterable_enum.snap
+++ b/tests/spec/build/snapshots/multimodule_iterable_enum.snap
@@ -1,0 +1,79 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "github.com/user/myproject/phases"
+
+func main() {
+	total := 0
+	for range phases.BuildPhase_Variants() {
+		total++
+	}
+	_ = total
+}
+
+
+// === phases/mod.go ===
+package phases
+
+import "fmt"
+
+func MakeBuildPhaseValidate() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseValidate}
+}
+
+func MakeBuildPhaseParse() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseParse}
+}
+
+func MakeBuildPhaseCodegen() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseCodegen}
+}
+
+type BuildPhaseTag int
+
+const (
+	BuildPhaseValidate BuildPhaseTag = iota
+	BuildPhaseParse
+	BuildPhaseCodegen
+)
+
+type BuildPhase struct {
+	Tag BuildPhaseTag
+}
+
+func (b BuildPhase) String() string {
+	switch b.Tag {
+	case BuildPhaseValidate:
+		return "Validate"
+	case BuildPhaseParse:
+		return "Parse"
+	case BuildPhaseCodegen:
+		return "Codegen"
+	default:
+		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
+	}
+}
+
+func (b BuildPhase) GoString() string {
+	switch b.Tag {
+	case BuildPhaseValidate:
+		return "BuildPhase.Validate"
+	case BuildPhaseParse:
+		return "BuildPhase.Parse"
+	case BuildPhaseCodegen:
+		return "BuildPhase.Codegen"
+	default:
+		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
+	}
+}
+
+func BuildPhase_Variants() []BuildPhase {
+	return []BuildPhase{
+		{Tag: BuildPhaseValidate},
+		{Tag: BuildPhaseParse},
+		{Tag: BuildPhaseCodegen},
+	}
+}

--- a/tests/spec/emit/snapshots/iterable_enum_variants.snap
+++ b/tests/spec/emit/snapshots/iterable_enum_variants.snap
@@ -1,0 +1,73 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[iterable]\npub enum BuildPhase {\n  Validate,\n  Parse,\n  Codegen,\n}\n\nfn count() -> int {\n  let mut total = 0\n  for _phase in BuildPhase.variants() {\n    total = total + 1\n  }\n  total\n}\n"
+---
+package main
+
+import "fmt"
+
+func MakeBuildPhaseValidate() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseValidate}
+}
+
+func MakeBuildPhaseParse() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseParse}
+}
+
+func MakeBuildPhaseCodegen() BuildPhase {
+	return BuildPhase{Tag: BuildPhaseCodegen}
+}
+
+type BuildPhaseTag int
+
+const (
+	BuildPhaseValidate BuildPhaseTag = iota
+	BuildPhaseParse
+	BuildPhaseCodegen
+)
+
+type BuildPhase struct {
+	Tag BuildPhaseTag
+}
+
+func (b BuildPhase) String() string {
+	switch b.Tag {
+	case BuildPhaseValidate:
+		return "Validate"
+	case BuildPhaseParse:
+		return "Parse"
+	case BuildPhaseCodegen:
+		return "Codegen"
+	default:
+		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
+	}
+}
+
+func (b BuildPhase) GoString() string {
+	switch b.Tag {
+	case BuildPhaseValidate:
+		return "BuildPhase.Validate"
+	case BuildPhaseParse:
+		return "BuildPhase.Parse"
+	case BuildPhaseCodegen:
+		return "BuildPhase.Codegen"
+	default:
+		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
+	}
+}
+
+func BuildPhase_variants() []BuildPhase {
+	return []BuildPhase{
+		{Tag: BuildPhaseValidate},
+		{Tag: BuildPhaseParse},
+		{Tag: BuildPhaseCodegen},
+	}
+}
+
+func count() int {
+	total := 0
+	for range BuildPhase_variants() {
+		total++
+	}
+	return total
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -10,6 +10,27 @@ struct Point { x: int, y: int }
 }
 
 #[test]
+fn iterable_enum_variants() {
+    let input = r#"
+#[iterable]
+pub enum BuildPhase {
+  Validate,
+  Parse,
+  Codegen,
+}
+
+fn count() -> int {
+  let mut total = 0
+  for _phase in BuildPhase.variants() {
+    total = total + 1
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn struct_instantiation() {
     let input = r#"
 struct Point { x: int, y: int }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -519,6 +519,32 @@ fn main() {
 }
 
 #[test]
+fn parse_attribute_on_unsupported_declaration() {
+    let input = r#"
+#[iterable]
+interface Service {
+  fn run(self) -> int
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_attribute_on_interface_parent() {
+    let input = r#"
+interface Parent {
+  fn base(self) -> int
+}
+
+interface Child {
+  #[iterable]
+  impl Parent
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_missing_closing_brace() {
     let input = r#"
 fn main() {
@@ -7230,6 +7256,106 @@ struct Coord { x: int, y: int }
 fn main() {
   let c = Coord
   let _ = c
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_payload_variant() {
+    let input = r#"
+#[iterable]
+enum Token {
+  Eof,
+  Ident(string),
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_generic_enum() {
+    let input = r#"
+#[iterable]
+enum Cached<T> {
+  Hit,
+  Miss,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_struct() {
+    let input = r#"
+#[iterable]
+struct Point { x: int, y: int }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_variants_method_collision() {
+    let input = r#"
+#[iterable]
+enum Color {
+  Red,
+  Green,
+}
+
+impl Color {
+  fn variants() -> int {
+    0
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_variant_named_variants() {
+    let input = r#"
+#[iterable]
+enum Color {
+  Red,
+  variants,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_struct_field() {
+    let input = r#"
+struct Config {
+  #[iterable]
+  value: int,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_impl_method() {
+    let input = r#"
+struct Widget {}
+
+impl Widget {
+  #[iterable]
+  fn build() -> int {
+    0
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn iterable_on_interface_method() {
+    let input = r#"
+interface Service {
+  #[iterable]
+  fn run() -> int
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/iterable_on_generic_enum.snap
+++ b/tests/ui/errors/snapshots/iterable_on_generic_enum.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` on generic enum
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── disallowed if enum has generics
+ 3 │ enum Cached<T> {
+   ╰────
+  help: Remove the generic type parameters, or drop `#[iterable]` · code: [attribute.iterable_generic_enum]

--- a/tests/ui/errors/snapshots/iterable_on_impl_method.snap
+++ b/tests/ui/errors/snapshots/iterable_on_impl_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` not on enum
+   ╭─[test.lis:5:3]
+ 4 │ impl Widget {
+ 5 │   #[iterable]
+   ·   ─────┬─────
+   ·        ╰── not on an enum
+ 6 │   fn build() -> int {
+   ╰────
+  help: Only an enum can be marked `#[iterable]` · code: [attribute.iterable_not_an_enum]

--- a/tests/ui/errors/snapshots/iterable_on_interface_method.snap
+++ b/tests/ui/errors/snapshots/iterable_on_interface_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` not on enum
+   ╭─[test.lis:3:3]
+ 2 │ interface Service {
+ 3 │   #[iterable]
+   ·   ─────┬─────
+   ·        ╰── not on an enum
+ 4 │   fn run() -> int
+   ╰────
+  help: Only an enum can be marked `#[iterable]` · code: [attribute.iterable_not_an_enum]

--- a/tests/ui/errors/snapshots/iterable_on_payload_variant.snap
+++ b/tests/ui/errors/snapshots/iterable_on_payload_variant.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` on enum with payload variant
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── disallowed if a variant has a payload
+ 3 │ enum Token {
+ 4 │   Eof,
+ 5 │   Ident(string),
+   ·   ──┬──
+   ·     ╰── this variant has a payload
+ 6 │ }
+   ╰────
+  help: Remove the payload, or drop `#[iterable]` · code: [attribute.iterable_non_unit_variant]

--- a/tests/ui/errors/snapshots/iterable_on_struct.snap
+++ b/tests/ui/errors/snapshots/iterable_on_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` not on enum
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── not on an enum
+ 3 │ struct Point { x: int, y: int }
+   ╰────
+  help: Only an enum can be marked `#[iterable]` · code: [attribute.iterable_not_an_enum]

--- a/tests/ui/errors/snapshots/iterable_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/iterable_on_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` not on enum
+   ╭─[test.lis:3:3]
+ 2 │ struct Config {
+ 3 │   #[iterable]
+   ·   ─────┬─────
+   ·        ╰── not on an enum
+ 4 │   value: int,
+   ╰────
+  help: Only an enum can be marked `#[iterable]` · code: [attribute.iterable_not_an_enum]

--- a/tests/ui/errors/snapshots/iterable_variant_named_variants.snap
+++ b/tests/ui/errors/snapshots/iterable_variant_named_variants.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` conflicts with existing `variants`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── would synthesize `variants`
+ 3 │ enum Color {
+ 4 │   Red,
+ 5 │   variants,
+   ·   ────┬───
+   ·       ╰── `variants` already defined here
+ 6 │ }
+   ╰────
+  help: Rename the existing `variants`, or drop `#[iterable]` · code: [attribute.iterable_variants_conflict]

--- a/tests/ui/errors/snapshots/iterable_variants_method_collision.snap
+++ b/tests/ui/errors/snapshots/iterable_variants_method_collision.snap
@@ -1,0 +1,19 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[iterable]` conflicts with existing `variants`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── would synthesize `variants`
+ 3 │ enum Color {
+   ╰────
+    ╭─[test.lis:9:6]
+  8 │ impl Color {
+  9 │   fn variants() -> int {
+    ·      ────┬───
+    ·          ╰── `variants` already defined here
+ 10 │     0
+    ╰────
+  help: Rename the existing `variants`, or drop `#[iterable]` · code: [attribute.iterable_variants_conflict]

--- a/tests/ui/errors/snapshots/parse_attribute_on_interface_parent.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_on_interface_parent.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Attribute not supported on target
+   ╭─[test.lis:7:3]
+ 6 │ interface Child {
+ 7 │   #[iterable]
+   ·   ─────┬─────
+   ·        ╰── not supported on target
+ 8 │   impl Parent
+   ╰────
+  help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]

--- a/tests/ui/errors/snapshots/parse_attribute_on_unsupported_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_on_unsupported_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Attribute not supported on target
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[iterable]
+   · ─────┬─────
+   ·      ╰── not supported on target
+ 3 │ interface Service {
+   ╰────
+  help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]


### PR DESCRIPTION
Adds an `#[iterable]` attribute for enum iteration. For marked enums, the compiler now synthesizes a `variants()` associated fn that returns every enum variant in declaration order as an ordinary `Slice`.

```rs
#[iterable]
enum Direction {
  North,
  East,
  West,
  South,
}

for direction in Direction.variants() {
  fmt.Println(direction)
}
```

`#[iterable]` is allowed only on enums whose variants carry no payload and on non-generic enums.