### PR TITLE
feat: add manual_unwrap_or lint

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -341,6 +341,18 @@ pub fn redundant_pattern_matching(span: &Span, predicate: &str) -> LisetteDiagno
         .with_help(format!("Replace this `match` with `.{predicate}()`"))
 }
 
+pub fn manual_unwrap_or(span: &Span, default_has_effects: bool) -> LisetteDiagnostic {
+    let method = if default_has_effects {
+        "unwrap_or_else"
+    } else {
+        "unwrap_or"
+    };
+    LisetteDiagnostic::warn("Manual unwrap_or")
+        .with_lint_code("manual_unwrap_or")
+        .with_span_label(span, "can be simpler")
+        .with_help(format!("Replace this `match` with `.{method}(...)`"))
+}
+
 pub fn empty_match_arm(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Empty match arm")
         .with_lint_code("empty_match_arm")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/manual_unwrap_or.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/manual_unwrap_or.rs
@@ -1,0 +1,128 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
+use syntax::types::unqualified_name;
+
+use super::super::visitor::visit_ast;
+use super::helpers::is_side_effect_free;
+
+pub fn check_manual_unwrap_or(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+    let Expression::Match {
+        subject,
+        arms,
+        origin,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if matches!(origin, MatchOrigin::IfLet { .. }) {
+        return;
+    }
+
+    if arms.len() != 2 {
+        return;
+    }
+
+    let subject_ty = subject.get_type();
+    let (success_variant, failure_variant) = if subject_ty.is_option() {
+        ("Some", "None")
+    } else if subject_ty.is_result() {
+        ("Ok", "Err")
+    } else {
+        return;
+    };
+
+    let default = if is_success_arm(&arms[0], success_variant) {
+        failure_default(&arms[1], failure_variant)
+    } else if is_success_arm(&arms[1], success_variant) {
+        failure_default(&arms[0], failure_variant)
+    } else {
+        return;
+    };
+
+    let Some(default) = default else {
+        return;
+    };
+
+    if default.diverges().is_some() {
+        return;
+    }
+
+    let default_has_effects = !is_side_effect_free(default);
+    if default_has_effects && has_escaping_control_flow(default) {
+        return;
+    }
+
+    let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
+    diagnostics.push(diagnostics::lint::manual_unwrap_or(
+        &match_keyword_span,
+        default_has_effects,
+    ));
+}
+
+// `?`, `return`, `break`, and `continue` target a scope outside the synthesized
+// `unwrap_or_else` closure, so a default containing them cannot be moved into one.
+fn has_escaping_control_flow(default: &Expression) -> bool {
+    let mut found = false;
+    visit_ast(
+        std::slice::from_ref(default),
+        &mut |node| {
+            found |= matches!(
+                node,
+                Expression::Return { .. }
+                    | Expression::Propagate { .. }
+                    | Expression::Break { .. }
+                    | Expression::Continue { .. }
+            );
+        },
+        &mut |_| {},
+    );
+    found
+}
+
+fn enum_variant_fields<'a>(arm: &'a MatchArm, variant: &str) -> Option<&'a [Pattern]> {
+    if arm.has_guard() {
+        return None;
+    }
+    let Pattern::EnumVariant {
+        identifier, fields, ..
+    } = &arm.pattern
+    else {
+        return None;
+    };
+    if unqualified_name(identifier) != variant {
+        return None;
+    }
+    Some(fields)
+}
+
+fn is_success_arm(arm: &MatchArm, success_variant: &str) -> bool {
+    let Some(fields) = enum_variant_fields(arm, success_variant) else {
+        return false;
+    };
+    let [
+        Pattern::Identifier {
+            identifier: bound, ..
+        },
+    ] = fields
+    else {
+        return false;
+    };
+    let Expression::Identifier { value, .. } = arm.expression.unwrap_parens() else {
+        return false;
+    };
+    value == bound
+}
+
+fn failure_default<'a>(arm: &'a MatchArm, failure_variant: &str) -> Option<&'a Expression> {
+    let fields = enum_variant_fields(arm, failure_variant)?;
+    if !fields
+        .iter()
+        .all(|field| matches!(field, Pattern::WildCard { .. }))
+    {
+        return None;
+    }
+    Some(arm.expression.unwrap_parens())
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -9,6 +9,7 @@ mod helpers;
 mod identical_if_branches;
 mod invisible_in_string;
 mod loop_runs_once;
+mod manual_unwrap_or;
 mod match_literal_collection;
 mod naming;
 mod needless_bool;
@@ -38,6 +39,7 @@ pub use invisible_in_string::{
     check_invisible_in_string_expression, check_invisible_in_string_pattern,
 };
 pub use loop_runs_once::check_loop_runs_once;
+pub use manual_unwrap_or::check_manual_unwrap_or;
 pub use match_literal_collection::check_match_literal_collection;
 pub use naming::{check_expression_naming, check_pattern_naming};
 pub use needless_bool::check_needless_bool;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -73,13 +73,13 @@ use checks::{
     check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
     check_expression_naming, check_identical_if_branches, check_invisible_in_string_expression,
-    check_invisible_in_string_pattern, check_loop_runs_once, check_match_literal_collection,
-    check_needless_bool, check_needless_range_loop, check_needless_return, check_pattern_naming,
-    check_redundant_pattern_matching, check_replaceable_with_zero_fill,
-    check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
-    check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
-    check_unnecessary_raw_string_pattern, check_unsigned_comparison,
-    check_verbose_failure_propagation, check_waitgroup_add_in_task,
+    check_invisible_in_string_pattern, check_loop_runs_once, check_manual_unwrap_or,
+    check_match_literal_collection, check_needless_bool, check_needless_range_loop,
+    check_needless_return, check_pattern_naming, check_redundant_pattern_matching,
+    check_replaceable_with_zero_fill, check_rest_only_slice_pattern, check_self_assignment,
+    check_self_comparison, check_single_arm_match, check_uninterpolated_fstring,
+    check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
+    check_unsigned_comparison, check_verbose_failure_propagation, check_waitgroup_add_in_task,
 };
 use visitor::visit_ast;
 
@@ -102,6 +102,7 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_needless_return,
     check_single_arm_match,
     check_redundant_pattern_matching,
+    check_manual_unwrap_or,
     check_uninterpolated_fstring,
     check_unnecessary_raw_string_expression,
     check_invisible_in_string_expression,

--- a/tests/e2e_smoke_project/src/main.lis
+++ b/tests/e2e_smoke_project/src/main.lis
@@ -569,18 +569,12 @@ fn test_struct_let_destructure() -> int {
 
 fn test_option_some() -> int {
   let x = Some(42)
-  match x {
-    Some(n) => n,
-    None => 0,
-  }
+  x.unwrap_or(0)
 }
 
 fn test_option_none() -> int {
   let x: Option<int> = None
-  match x {
-    Some(n) => n,
-    None => -1,
-  }
+  x.unwrap_or(-1)
 }
 
 fn test_option_chain() -> int {
@@ -598,10 +592,7 @@ fn get_option() -> Option<int> {
 
 fn test_option_passthrough() -> int {
   let x = get_option()
-  match x {
-    Some(n) => n,
-    None => 0,
-  }
+  x.unwrap_or(0)
 }
 
 fn maybe_double(x: int) -> Option<int> {
@@ -609,17 +600,11 @@ fn maybe_double(x: int) -> Option<int> {
 }
 
 fn test_option_conditional() -> int {
-  match maybe_double(5) {
-    Some(n) => n,
-    None => 0,
-  }
+  maybe_double(5).unwrap_or(0)
 }
 
 fn test_option_conditional_none() -> int {
-  match maybe_double(-1) {
-    Some(n) => n,
-    None => -1,
-  }
+  maybe_double(-1).unwrap_or(-1)
 }
 
 fn test_option_nested() -> int {
@@ -635,10 +620,7 @@ struct Container { value: Option<int> }
 
 fn test_option_in_struct() -> int {
   let c = Container { value: Some(99) }
-  match c.value {
-    Some(n) => n,
-    None => 0,
-  }
+  c.value.unwrap_or(0)
 }
 
 fn get_some() -> Option<int> {
@@ -646,10 +628,7 @@ fn get_some() -> Option<int> {
 }
 
 fn test_option_return_some() -> int {
-  match get_some() {
-    Some(n) => n,
-    None => 0,
-  }
+  get_some().unwrap_or(0)
 }
 
 fn get_none() -> Option<int> {
@@ -657,10 +636,7 @@ fn get_none() -> Option<int> {
 }
 
 fn test_option_return_none() -> int {
-  match get_none() {
-    Some(n) => n,
-    None => -1,
-  }
+  get_none().unwrap_or(-1)
 }
 
 // if let
@@ -850,18 +826,12 @@ fn test_while_let_result() -> int {
 
 fn test_result_ok() -> int {
   let x = Ok(42)
-  match x {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  x.unwrap_or(-1)
 }
 
 fn test_result_err() -> int {
   let x: Result<int, string> = Err("failed")
-  match x {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  x.unwrap_or(-1)
 }
 
 fn fallible() -> Result<int, string> {
@@ -874,10 +844,7 @@ fn fallible_propagate() -> Result<int, string> {
 }
 
 fn test_result_propagation() -> int {
-  match fallible_propagate() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  fallible_propagate().unwrap_or(-1)
 }
 
 fn test_result_chain() -> int {
@@ -910,10 +877,7 @@ fn fallible_propagate_err() -> Result<int, string> {
 }
 
 fn test_result_propagation_err() -> int {
-  match fallible_propagate_err() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  fallible_propagate_err().unwrap_or(-1)
 }
 
 fn multi_fallible() -> Result<int, string> {
@@ -923,10 +887,7 @@ fn multi_fallible() -> Result<int, string> {
 }
 
 fn test_result_multi_propagation() -> int {
-  match multi_fallible() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  multi_fallible().unwrap_or(-1)
 }
 
 fn check_error(e: string) -> int {
@@ -963,10 +924,7 @@ fn test_try_block_basic() -> int {
   let result = try {
     try_risky_ok()?
   }
-  match result {
-    Ok(x) => x,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 fn test_try_block_multiple() -> int {
@@ -975,10 +933,7 @@ fn test_try_block_multiple() -> int {
     let b = try_risky_ok()?
     a + b
   }
-  match result {
-    Ok(x) => x,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 fn test_try_block_early_err() -> int {
@@ -997,10 +952,7 @@ fn test_try_block_option() -> int {
     let x = try_maybe_some()?
     x + 5
   }
-  match opt {
-    Some(v) => v,
-    None => 0,
-  }
+  opt.unwrap_or(0)
 }
 
 fn test_try_block_option_none() -> int {
@@ -1019,16 +971,10 @@ fn test_try_block_nested() -> int {
     let inner: Result<int, string> = try {
       try_risky_ok()?
     }
-    let inner_val = match inner {
-      Ok(x) => x,
-      Err(_) => 0,
-    }
+    let inner_val = inner.unwrap_or(0)
     inner_val + try_risky_ok()?
   }
-  match outer {
-    Ok(x) => x,
-    Err(_) => 0,
-  }
+  outer.unwrap_or(0)
 }
 
 fn test_try_block_with_loop() -> int {
@@ -1040,20 +986,14 @@ fn test_try_block_with_loop() -> int {
     }
     sum + try_risky_ok()?
   }
-  match result {
-    Ok(x) => x,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 fn test_try_block_conditional() -> int {
   let result = try {
     if true { try_risky_ok()? } else { 0 }
   }
-  match result {
-    Ok(x) => x,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 // Control flow tests
@@ -1357,14 +1297,8 @@ fn test_buffered_channel() -> int {
   ch.send(10)
   ch.send(20)
   // Receive the values
-  let v1 = match ch.receive() {
-    Some(v) => v,
-    None => 0,
-  }
-  let v2 = match ch.receive() {
-    Some(v) => v,
-    None => 0,
-  }
+  let v1 = ch.receive().unwrap_or(0)
+  let v2 = ch.receive().unwrap_or(0)
   v1 + v2
 }
 
@@ -1374,10 +1308,7 @@ fn test_blocking_send_receive() -> int {
     ch.send(42)
   }
   // Blocking receive waits for the send
-  match ch.receive() {
-    Some(v) => v,
-    None => 0,
-  }
+  ch.receive().unwrap_or(0)
 }
 
 fn test_channel_iteration() -> int {
@@ -1399,10 +1330,7 @@ fn test_channel_split() -> int {
   task {
     tx.send(99)
   }
-  match rx.receive() {
-    Some(v) => v,
-    None => 0,
-  }
+  rx.receive().unwrap_or(0)
 }
 
 fn test_select_match_receive_value() -> int {
@@ -1486,10 +1414,7 @@ fn try_in_arg_helper() -> Result<int, string> {
 }
 
 fn test_try_in_argument() -> int {
-  match try_in_arg_helper() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  try_in_arg_helper().unwrap_or(-1)
 }
 
 struct Fallible { value: int }
@@ -1503,10 +1428,7 @@ impl Fallible {
 fn test_try_then_chain() -> int {
   // Can't easily chain after try, test try on method call
   let f = Fallible { value: 25 }
-  match f.get() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  f.get().unwrap_or(-1)
 }
 
 fn try_return_helper() -> Result<int, string> {
@@ -1515,10 +1437,7 @@ fn try_return_helper() -> Result<int, string> {
 }
 
 fn test_try_in_return() -> int {
-  match try_return_helper() {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  try_return_helper().unwrap_or(-1)
 }
 
 fn test_try_in_lambda() -> int {
@@ -1526,10 +1445,7 @@ fn test_try_in_lambda() -> int {
     let v = fallible()?
     Ok(v + x)
   }
-  match f(5) {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  f(5).unwrap_or(-1)
 }
 
 // Lambda edge cases tests
@@ -2655,10 +2571,7 @@ fn maybe_int_for_test(b: bool) -> Option<int> {
 }
 
 fn unwrap_or_for_test(o: Option<int>, fallback: int) -> int {
-  match o {
-    Some(v) => v,
-    None => fallback,
-  }
+  o.unwrap_or(fallback)
 }
 
 fn test_result_direct_arg_ok() -> int {
@@ -2715,10 +2628,7 @@ fn parse_digit(s: string) -> Result<int, string> {
 
 fn test_result_if_else_chain_ok() -> int {
   let res = parse_digit("1")
-  match res {
-    Ok(n) => n,
-    Err(_) => -1,
-  }
+  res.unwrap_or(-1)
 }
 
 fn test_result_if_else_chain_err() -> int {
@@ -2735,10 +2645,7 @@ fn get_optional(flag: bool) -> Option<int> {
 
 fn test_option_if_else_chain_some() -> int {
   let opt = get_optional(true)
-  match opt {
-    Some(n) => n,
-    None => -1,
-  }
+  opt.unwrap_or(-1)
 }
 
 fn test_option_if_else_chain_none() -> int {
@@ -3036,19 +2943,13 @@ fn test_option_zip() -> int {
 fn test_option_flatten() -> int {
   let nested: Option<Option<int>> = Some(Some(100))
   let flat = nested.flatten()
-  match flat {
-    Some(v) => v,
-    None => 0,
-  }
+  flat.unwrap_or(0)
 }
 
 fn test_result_map() -> int {
   let res = Ok(50)
   let result = res.map(|x| x * 2)
-  match result {
-    Ok(v) => v,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 fn test_result_and_then() -> int {
@@ -3058,10 +2959,7 @@ fn test_result_and_then() -> int {
   } else {
     Err("too small")
   })
-  match result {
-    Ok(v) => v,
-    Err(_) => 0,
-  }
+  result.unwrap_or(0)
 }
 
 fn test_result_map_or() -> int {

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2117,7 +2117,7 @@ struct Container {
 fn main() {
   let c = Container { value: Some(42) };
   let _ = match c.value {
-    Some(n) => n,
+    Some(n) => n + 1,
     None => 0,
   }
 }
@@ -3768,6 +3768,190 @@ fn main() {
 }
 
 #[test]
+fn manual_unwrap_or_option() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = match o {
+    Some(v) => v,
+    None => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_result() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let r: Result<int, string> = Ok(1)
+  let _ = match r {
+    Ok(v) => v,
+    Err(_) => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_reversed_arms() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = match o {
+    None => 0,
+    Some(v) => v,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_else_effectful_default() {
+    assert_lint_snapshot!(
+        r#"
+fn fallback() -> int {
+  0
+}
+
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = match o {
+    Some(v) => v,
+    None => fallback(),
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_transformed_body_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = match o {
+    Some(v) => v + 1,
+    None => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_bound_error_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let r: Result<int, string> = Ok(1)
+  let _ = match r {
+    Ok(v) => v,
+    Err(e) => e.length(),
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_propagating_default_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn fallback() -> Result<int, string> {
+  Ok(0)
+}
+
+fn run(r: Result<int, string>) -> Result<int, string> {
+  let v = match r {
+    Ok(v) => v,
+    Err(_) => fallback()?,
+  }
+  Ok(v)
+}
+
+fn main() {
+  let _ = run(Ok(1))
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_conditional_return_default_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn run(o: Option<int>, flag: bool) -> int {
+  let v = match o {
+    Some(v) => v,
+    None => if flag { return 0 } else { 5 },
+  }
+  v + 1
+}
+
+fn main() {
+  let _ = run(Some(1), true)
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_diverging_default_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = match o {
+    Some(v) => v,
+    None => return (),
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_custom_enum_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+enum Maybe { Yes(int), Nope }
+
+fn main() {
+  let m = Maybe.Yes(1)
+  let _ = match m {
+    Maybe.Yes(v) => v,
+    Maybe.Nope => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn manual_unwrap_or_mismatched_binding_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let other = 5
+  let _ = match o {
+    Some(v) => other,
+    None => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
 fn redundant_if_let_else() {
     assert_lint_snapshot!(
         r#"
@@ -5188,13 +5372,13 @@ fn main() {
 }
 
 #[test]
-fn verbose_failure_propagation_option_unwrap_or_no_warning() {
+fn verbose_failure_propagation_option_value_default_no_warning() {
     assert_no_lint_warnings!(
         r#"
 fn main() {
   let x: Option<int> = Some(1)
   let _ = match x {
-    Some(v) => v,
+    Some(v) => v + 1,
     None => 0,
   }
 }

--- a/tests/ui/lint/snapshots/manual_unwrap_or_else_effectful_default.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_else_effectful_default.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Manual unwrap_or
+   ╭─[test.lis:8:11]
+ 7 │   let o: Option<int> = Some(1)
+ 8 │   let _ = match o {
+   ·           ──┬──
+   ·             ╰── can be simpler
+ 9 │     Some(v) => v,
+   ╰────
+  help: Replace this `match` with `.unwrap_or_else(...)` · code: [lint.manual_unwrap_or]

--- a/tests/ui/lint/snapshots/manual_unwrap_or_option.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Manual unwrap_or
+   ╭─[test.lis:4:11]
+ 3 │   let o: Option<int> = Some(1)
+ 4 │   let _ = match o {
+   ·           ──┬──
+   ·             ╰── can be simpler
+ 5 │     Some(v) => v,
+   ╰────
+  help: Replace this `match` with `.unwrap_or(...)` · code: [lint.manual_unwrap_or]

--- a/tests/ui/lint/snapshots/manual_unwrap_or_result.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_result.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Manual unwrap_or
+   ╭─[test.lis:4:11]
+ 3 │   let r: Result<int, string> = Ok(1)
+ 4 │   let _ = match r {
+   ·           ──┬──
+   ·             ╰── can be simpler
+ 5 │     Ok(v) => v,
+   ╰────
+  help: Replace this `match` with `.unwrap_or(...)` · code: [lint.manual_unwrap_or]

--- a/tests/ui/lint/snapshots/manual_unwrap_or_reversed_arms.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_reversed_arms.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Manual unwrap_or
+   ╭─[test.lis:4:11]
+ 3 │   let o: Option<int> = Some(1)
+ 4 │   let _ = match o {
+   ·           ──┬──
+   ·             ╰── can be simpler
+ 5 │     None => 0,
+   ╰────
+  help: Replace this `match` with `.unwrap_or(...)` · code: [lint.manual_unwrap_or]


### PR DESCRIPTION
Adds a `manual_unwrap_or` lint that flags a two-arm `match` on `Option` or `Result` which only extracts the payload or return a default, and suggests `.unwrap_or(...)` instead.

```
  [warning] Manual unwrap_or
   ╭─[test.lis:4:11]
 3 │   let o: Option<int> = Some(1)
 4 │   let _ = match o {
   ·           ──┬──
   ·             ╰── can be simpler
 5 │     None => 0,
   ╰────
  help: Replace this `match` with `.unwrap_or(...)` · code: [lint.manual_unwrap_or]
```