### PR TITLE
chore: release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.2.17](https://github.com/ivov/lisette/compare/lisette-v0.2.16...lisette-v0.2.17) - 2026-06-02
+
+- feat: add manual emptiness check lint [#577](https://github.com/ivov/lisette/pull/577) [`6dd1cb1`](https://github.com/ivov/lisette/commit/6dd1cb16c933e952f5eaec1aff1e5bb915cce389)
+- feat: add manual compound assignment lint [#576](https://github.com/ivov/lisette/pull/576) [`3e569d9`](https://github.com/ivov/lisette/commit/3e569d9a02b3cb8c3b9a53beac002acccc430acf)
+- fix: make newtype structs and bool-backed named types nominal [#575](https://github.com/ivov/lisette/pull/575) [`c3b2f75`](https://github.com/ivov/lisette/commit/c3b2f7586e67829cc02e4bdb384586923f893c01)
+- fix: lsp goto-def on type alias with same name as origin type name [#569](https://github.com/ivov/lisette/pull/569) [`801ce11`](https://github.com/ivov/lisette/commit/801ce118b5f3d58fe49391076bbe72197a164fa5)
+- feat: gate stringer synthesis on `#[displayable]` [#574](https://github.com/ivov/lisette/pull/574) [`a9333a9`](https://github.com/ivov/lisette/commit/a9333a90d2fa4b2804e2d64fa7890d5cc4a8657b)
+- fix: make string value enums nominal [#573](https://github.com/ivov/lisette/pull/573) [`6066322`](https://github.com/ivov/lisette/commit/6066322f6ad46d3ffa7656c092d1850aa31deb09)
+- fix: make numeric value enums nominal [#572](https://github.com/ivov/lisette/pull/572) [`081757a`](https://github.com/ivov/lisette/commit/081757aec41dd92d4181dfc789f095a3f6476d60)
+- feat: introduce `#[displayable]` attribute [#571](https://github.com/ivov/lisette/pull/571) [`d7acbed`](https://github.com/ivov/lisette/commit/d7acbedbe93a4466cd05404d1d78be4b20743d56)
+- refactor: suggest WaitGroup.Go in waitgroup warning [#570](https://github.com/ivov/lisette/pull/570) [`190180b`](https://github.com/ivov/lisette/commit/190180b880b40f9552417c9f4f957d0febd2fb86)
+- refactor: route stringer synthesis through a single gate [#568](https://github.com/ivov/lisette/pull/568) [`e60bde0`](https://github.com/ivov/lisette/commit/e60bde0d0731076688dda49366ed2983b1564679)
+- refactor: set up opt-in stringer capability [#567](https://github.com/ivov/lisette/pull/567) [`1557c7c`](https://github.com/ivov/lisette/commit/1557c7cd37bfcb41cbe43d0dead61632c81b744f)
+- fix: lsp autocomplete via non-generic type aliases [#563](https://github.com/ivov/lisette/pull/563) [`3ea55c0`](https://github.com/ivov/lisette/commit/3ea55c0d3bc9920d0a9fc352dda969e072294fac)
+- refactor: reclassify diagnostics [#566](https://github.com/ivov/lisette/pull/566) [`afc5027`](https://github.com/ivov/lisette/commit/afc50275bbf94ddbd98a7929b17febed2387237f)
+- feat: advisory `info` diagnostics [#565](https://github.com/ivov/lisette/pull/565) [`bb13b0a`](https://github.com/ivov/lisette/commit/bb13b0a1ab42dd48758df4a13c8e39b150e11024)
+- feat: warn on lost url query mutation [#564](https://github.com/ivov/lisette/pull/564) [`a5f94c6`](https://github.com/ivov/lisette/commit/a5f94c60d530ef9943a2d26c48db921ebdb5c34d)
+- feat: warn on match with identical arms [#562](https://github.com/ivov/lisette/pull/562) [`1a44853`](https://github.com/ivov/lisette/commit/1a448531a6b8f301a08538fc4a1d7c9c06a02e8a)
+- feat: warn on closures replaceable by the function itself [#561](https://github.com/ivov/lisette/pull/561) [`07fd58a`](https://github.com/ivov/lisette/commit/07fd58a508743bca410be434fed5bfa7dcce0f0b)
+- feat: add manual_map lint [#560](https://github.com/ivov/lisette/pull/560) [`4c0bcd3`](https://github.com/ivov/lisette/commit/4c0bcd32d6dbfb204d7c1709e1e7751cb7ff8069)
+- feat: add manual_unwrap_or lint [#558](https://github.com/ivov/lisette/pull/558) [`0c19819`](https://github.com/ivov/lisette/commit/0c198199910e2e1512b143e39c74c4c13431fd8a)
+
 ## [0.2.16](https://github.com/ivov/lisette/compare/lisette-v0.2.15...lisette-v0.2.16) - 2026-05-31
 
 - fix: reject value names in type annotations [#555](https://github.com/ivov/lisette/pull/555) [`c4dabbd`](https://github.com/ivov/lisette/commit/c4dabbd9d1a400cdcb08557b4874c5e193154696)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bincode",
  "ecow",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.16"
+version = "0.2.17"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.16", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.16", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.16", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.16", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.2.17", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.2.17", path = "../format" }
+emit = { package = "lisette-emit", version = "0.2.17", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.2.17", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.16", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.16", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.2.17", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
+format = { package = "lisette-format", version = "0.2.17", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.16", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.16", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.16", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.2.17 (upcoming)

- feat: add manual emptiness check lint [#577](https://github.com/ivov/lisette/pull/577) [`6dd1cb1`](https://github.com/ivov/lisette/commit/6dd1cb16c933e952f5eaec1aff1e5bb915cce389)
- feat: add manual compound assignment lint [#576](https://github.com/ivov/lisette/pull/576) [`3e569d9`](https://github.com/ivov/lisette/commit/3e569d9a02b3cb8c3b9a53beac002acccc430acf)
- fix: make newtype structs and bool-backed named types nominal [#575](https://github.com/ivov/lisette/pull/575) [`c3b2f75`](https://github.com/ivov/lisette/commit/c3b2f7586e67829cc02e4bdb384586923f893c01)
- fix: lsp goto-def on type alias with same name as origin type name [#569](https://github.com/ivov/lisette/pull/569) [`801ce11`](https://github.com/ivov/lisette/commit/801ce118b5f3d58fe49391076bbe72197a164fa5)
- feat: gate stringer synthesis on `#[displayable]` [#574](https://github.com/ivov/lisette/pull/574) [`a9333a9`](https://github.com/ivov/lisette/commit/a9333a90d2fa4b2804e2d64fa7890d5cc4a8657b)
- fix: make string value enums nominal [#573](https://github.com/ivov/lisette/pull/573) [`6066322`](https://github.com/ivov/lisette/commit/6066322f6ad46d3ffa7656c092d1850aa31deb09)
- fix: make numeric value enums nominal [#572](https://github.com/ivov/lisette/pull/572) [`081757a`](https://github.com/ivov/lisette/commit/081757aec41dd92d4181dfc789f095a3f6476d60)
- feat: introduce `#[displayable]` attribute [#571](https://github.com/ivov/lisette/pull/571) [`d7acbed`](https://github.com/ivov/lisette/commit/d7acbedbe93a4466cd05404d1d78be4b20743d56)
- refactor: suggest WaitGroup.Go in waitgroup warning [#570](https://github.com/ivov/lisette/pull/570) [`190180b`](https://github.com/ivov/lisette/commit/190180b880b40f9552417c9f4f957d0febd2fb86)
- refactor: route stringer synthesis through a single gate [#568](https://github.com/ivov/lisette/pull/568) [`e60bde0`](https://github.com/ivov/lisette/commit/e60bde0d0731076688dda49366ed2983b1564679)
- refactor: set up opt-in stringer capability [#567](https://github.com/ivov/lisette/pull/567) [`1557c7c`](https://github.com/ivov/lisette/commit/1557c7cd37bfcb41cbe43d0dead61632c81b744f)
- fix: lsp autocomplete via non-generic type aliases [#563](https://github.com/ivov/lisette/pull/563) [`3ea55c0`](https://github.com/ivov/lisette/commit/3ea55c0d3bc9920d0a9fc352dda969e072294fac)
- refactor: reclassify diagnostics [#566](https://github.com/ivov/lisette/pull/566) [`afc5027`](https://github.com/ivov/lisette/commit/afc50275bbf94ddbd98a7929b17febed2387237f)
- feat: advisory `info` diagnostics [#565](https://github.com/ivov/lisette/pull/565) [`bb13b0a`](https://github.com/ivov/lisette/commit/bb13b0a1ab42dd48758df4a13c8e39b150e11024)
- feat: warn on lost url query mutation [#564](https://github.com/ivov/lisette/pull/564) [`a5f94c6`](https://github.com/ivov/lisette/commit/a5f94c60d530ef9943a2d26c48db921ebdb5c34d)
- feat: warn on match with identical arms [#562](https://github.com/ivov/lisette/pull/562) [`1a44853`](https://github.com/ivov/lisette/commit/1a448531a6b8f301a08538fc4a1d7c9c06a02e8a)
- feat: warn on closures replaceable by the function itself [#561](https://github.com/ivov/lisette/pull/561) [`07fd58a`](https://github.com/ivov/lisette/commit/07fd58a508743bca410be434fed5bfa7dcce0f0b)
- feat: add manual_map lint [#560](https://github.com/ivov/lisette/pull/560) [`4c0bcd3`](https://github.com/ivov/lisette/commit/4c0bcd32d6dbfb204d7c1709e1e7751cb7ff8069)
- feat: add manual_unwrap_or lint [#558](https://github.com/ivov/lisette/pull/558) [`0c19819`](https://github.com/ivov/lisette/commit/0c198199910e2e1512b143e39c74c4c13431fd8a)
