### PR TITLE
fix: lsp autocomplete via non-generic type aliases

### DIFF
--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -2,6 +2,8 @@ use rustc_hash::FxHashSet;
 use tower_lsp::lsp_types::*;
 
 use syntax::ast::Expression;
+use syntax::program::DefinitionBody;
+use syntax::types::Type;
 
 use crate::definition::get_root_expression;
 use crate::snapshot::AnalysisSnapshot;
@@ -291,40 +293,20 @@ fn collect_interface_methods(
 pub(crate) fn get_type_completions(
     type_id: &str,
     snapshot: &AnalysisSnapshot,
-    same_module: bool,
+    current_module: &str,
 ) -> Vec<CompletionItem> {
-    use syntax::program::DefinitionBody;
+    let target = alias_target(type_id, snapshot);
+    let method_id = target.as_deref().unwrap_or(type_id);
 
-    let mut items = Vec::new();
+    let mut items = enum_variant_items(method_id, snapshot).unwrap_or_default();
 
-    match snapshot.definitions().get(type_id).map(|d| &d.body) {
-        Some(DefinitionBody::Enum { variants, .. }) => {
-            for variant in variants {
-                items.push(CompletionItem {
-                    label: variant.name.to_string(),
-                    kind: Some(CompletionItemKind::ENUM_MEMBER),
-                    ..Default::default()
-                });
-            }
-        }
-        Some(DefinitionBody::ValueEnum { variants, .. }) => {
-            for variant in variants {
-                items.push(CompletionItem {
-                    label: variant.name.to_string(),
-                    kind: Some(CompletionItemKind::ENUM_MEMBER),
-                    ..Default::default()
-                });
-            }
-        }
-        _ => {}
-    }
-
-    let method_prefix = format!("{type_id}.");
+    let same_module = id_is_in_module(method_id, current_module);
+    let method_prefix = format!("{method_id}.");
     for (qname, definition) in snapshot.definitions().iter() {
         if let Some(method_name) = qname.strip_prefix(method_prefix.as_str())
             && !method_name.contains('.')
             && matches!(definition.body, DefinitionBody::Value { .. })
-            && !is_instance_method(definition.ty(), type_id)
+            && !is_instance_method(definition.ty(), method_id)
             && (same_module || definition.visibility().is_public())
             && !items.iter().any(|i| i.label == method_name)
         {
@@ -338,6 +320,45 @@ pub(crate) fn get_type_completions(
     }
 
     items
+}
+
+fn id_is_in_module(qualified_id: &str, module: &str) -> bool {
+    qualified_id.starts_with(module) && qualified_id.as_bytes().get(module.len()) == Some(&b'.')
+}
+
+fn enum_variant_items(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<Vec<CompletionItem>> {
+    let to_item = |name: &str| CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::ENUM_MEMBER),
+        ..Default::default()
+    };
+    match &snapshot.definitions().get(type_id)?.body {
+        DefinitionBody::Enum { variants, .. } => {
+            Some(variants.iter().map(|v| to_item(&v.name)).collect())
+        }
+        DefinitionBody::ValueEnum { variants, .. } => {
+            Some(variants.iter().map(|v| to_item(&v.name)).collect())
+        }
+        _ => None,
+    }
+}
+
+/// Returns the target id of a non-generic alias.
+fn alias_target(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<String> {
+    let def = snapshot.definitions().get(type_id)?;
+    let DefinitionBody::TypeAlias { generics, .. } = &def.body else {
+        return None;
+    };
+    if !generics.is_empty() {
+        return None;
+    }
+    let target = match &def.ty {
+        Type::Nominal { id, .. } => id.to_string(),
+        Type::Simple(kind) => format!("prelude.{}", kind.leaf_name()),
+        Type::Compound { kind, .. } => format!("prelude.{}", kind.leaf_name()),
+        _ => return None,
+    };
+    (target != type_id).then_some(target)
 }
 
 fn is_instance_method(ty: &syntax::types::Type, type_id: &str) -> bool {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1124,9 +1124,7 @@ impl LanguageServer for Backend {
                     get_instance_completions(&type_id, &snapshot, same_module)
                 }
                 DotContext::TypeLevel(type_id) => {
-                    let same_module = type_id.starts_with(file.module_id.as_str())
-                        && type_id.as_bytes().get(file.module_id.len()) == Some(&b'.');
-                    get_type_completions(&type_id, &snapshot, same_module)
+                    get_type_completions(&type_id, &snapshot, &file.module_id)
                 }
             };
             return Ok(Some(CompletionResponse::Array(items)));
@@ -1145,8 +1143,7 @@ impl LanguageServer for Backend {
                     if let Some(definition) = snapshot.definitions().get(qualified.as_str())
                         && definition.is_type_definition()
                     {
-                        let same_module = module == file.module_id.as_str();
-                        let items = get_type_completions(&qualified, &snapshot, same_module);
+                        let items = get_type_completions(&qualified, &snapshot, &file.module_id);
                         return Ok(Some(CompletionResponse::Array(items)));
                     }
                 }
@@ -1157,7 +1154,7 @@ impl LanguageServer for Backend {
                         && definition.is_type_definition()
                         && definition.visibility().is_public()
                     {
-                        let items = get_type_completions(&qualified, &snapshot, false);
+                        let items = get_type_completions(&qualified, &snapshot, &file.module_id);
                         return Ok(Some(CompletionResponse::Array(items)));
                     }
                 }

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1024,6 +1024,86 @@ fn main() {
 }
 
 #[tokio::test]
+async fn completion_type_dot_via_alias_to_concrete_map_shows_methods() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+type M = Map<string, int>
+fn main() {
+  let _ = M.
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 12).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "new"),
+        "should include 'new' via alias to Map<string, int>, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_type_dot_via_alias_to_concrete_slice_shows_methods() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+type Buf = Slice<byte>
+fn main() {
+  let _ = Buf.
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 14).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "new"),
+        "should include 'new' via alias to Slice<byte>, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_enum_dot_via_type_alias_shows_variants() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+enum Kind { Int, String }
+type K = Kind
+fn main() {
+  let o = K.
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 3, 12).await;
+    assert!(
+        response.is_some(),
+        "should return completions for type-alias dot"
+    );
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "Int"),
+        "should include 'Int' variant via alias, got: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "String"),
+        "should include 'String' variant via alias, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_enum_dot_shows_tuple_variants() {
     let mut client = TestClient::new().await;
     client.initialize().await;
@@ -9632,6 +9712,130 @@ async fn completion_on_cross_module_enum_dot_access() {
         labels.contains(&"Green".to_string()),
         "should include variant 'Green', got: {:?}",
         labels
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_dot_on_alias_to_cross_module_enum_shows_variants() {
+    let mut client = TestClient::new().await;
+
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path();
+
+    std::fs::write(
+        root_path.join("lisette.toml"),
+        "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/utils")).unwrap();
+    std::fs::write(
+        root_path.join("src/utils/utils.lis"),
+        "pub enum Kind { Int, String }\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
+    std::fs::write(
+        root_path.join("src/main/main.lis"),
+        "import \"utils\"\ntype K = utils.Kind\nfn main() {\n  let o = K.\n}\n",
+    )
+    .unwrap();
+
+    client.initialize_with_root(root_path).await;
+
+    let utils_uri = format!("file://{}", root_path.join("src/utils/utils.lis").display());
+    let main_uri = format!("file://{}", root_path.join("src/main/main.lis").display());
+
+    client
+        .open(
+            &utils_uri,
+            &std::fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
+        )
+        .await;
+    client
+        .open(
+            &main_uri,
+            &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        )
+        .await;
+
+    let response = client.completion(&main_uri, 3, 12).await;
+    assert!(
+        response.is_some(),
+        "completion after alias dot should return results"
+    );
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.contains(&"Int".to_string()),
+        "should include 'Int' via alias to cross-module enum, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"String".to_string()),
+        "should include 'String' via alias to cross-module enum, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_dot_on_alias_to_cross_module_enum_hides_private_static_methods() {
+    let mut client = TestClient::new().await;
+
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path();
+
+    std::fs::write(
+        root_path.join("lisette.toml"),
+        "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/utils")).unwrap();
+    std::fs::write(
+        root_path.join("src/utils/utils.lis"),
+        "pub enum Kind { Int, String }\n\
+impl Kind {\n\
+  pub fn public_static() -> int { 1 }\n\
+  fn private_static() -> int { 2 }\n\
+}\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
+    std::fs::write(
+        root_path.join("src/main/main.lis"),
+        "import \"utils\"\ntype K = utils.Kind\nfn main() {\n  let _ = K.\n}\n",
+    )
+    .unwrap();
+
+    client.initialize_with_root(root_path).await;
+
+    let utils_uri = format!("file://{}", root_path.join("src/utils/utils.lis").display());
+    let main_uri = format!("file://{}", root_path.join("src/main/main.lis").display());
+
+    client
+        .open(
+            &utils_uri,
+            &std::fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
+        )
+        .await;
+    client
+        .open(
+            &main_uri,
+            &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        )
+        .await;
+
+    let response = client.completion(&main_uri, 3, 12).await;
+    assert!(response.is_some());
+
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.contains(&"public_static".to_string()),
+        "should include 'public_static' from cross-module aliased type, got: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"private_static".to_string()),
+        "should NOT include 'private_static' from cross-module aliased type, got: {labels:?}"
     );
 
     client.shutdown().await;


### PR DESCRIPTION
This change adds a few fixes to the lsp server autocomplete.

Example:

```rust
pub enum Kind { Int, String }

impl Kind {
  pub fn publ() -> int { 1 }
  fn priv() -> int { 2 } // private static fn
}
```
- The lsp now shows autocomplete for type aliases

```rust

import "utils"

type K = utils.Kind

fn main() {
  let _ = K.
//          ^ previously no autocomplete
}
```

- Hide (static) private methods from autocomplete


```rust
import "utils"

type K = utils.Kind

fn main() {
  let _ = K.
//          ^ Here the autocomplete should not show priv()
}
```

As a generic type alias (`type S<T> = Slice<T>`) is currently illegal syntax wise, its also not covered in this PR.