### PR TITLE
feat: warn on lost url query mutation

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -599,6 +599,15 @@ pub fn duplicate_arguments(span: &Span, module: &str, function: &str) -> Lisette
         ))
 }
 
+pub fn lost_query_mutation(span: &Span, method: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Lost query mutation")
+        .with_lint_code("lost_query_mutation")
+        .with_span_label(span, "mutates a discarded copy")
+        .with_help(format!(
+            "`URL.Query` returns a fresh copy, so this `{method}` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field."
+        ))
+}
+
 pub fn waitgroup_add_in_task(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("`WaitGroup.Add` inside a `task`")
         .with_lint_code("waitgroup_add_in_task")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/lost_query_mutation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/lost_query_mutation.rs
@@ -1,0 +1,62 @@
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::Expression;
+
+use crate::store::Store;
+
+const MUTATING_METHODS: &[&str] = &["Set", "Add", "Del"];
+
+pub fn check_lost_query_mutation(
+    expression: &Expression,
+    store: &Store,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    let Expression::Call {
+        expression: callee,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    let Expression::DotAccess {
+        expression: receiver,
+        member,
+        ..
+    } = callee.unwrap_parens()
+    else {
+        return;
+    };
+
+    if !MUTATING_METHODS.contains(&member.as_str()) {
+        return;
+    }
+
+    let Expression::Call {
+        expression: query_callee,
+        ..
+    } = receiver.unwrap_parens()
+    else {
+        return;
+    };
+
+    let Expression::DotAccess {
+        expression: url,
+        member: query_member,
+        ..
+    } = query_callee.unwrap_parens()
+    else {
+        return;
+    };
+
+    if query_member != "Query" {
+        return;
+    }
+
+    let receiver_ty = store.peel_alias(&url.get_type().strip_refs());
+    if receiver_ty.strip_refs().get_qualified_id() != Some("go:net/url.URL") {
+        return;
+    }
+
+    diagnostics.push(diagnostics::lint::lost_query_mutation(span, member));
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -10,6 +10,7 @@ mod identical_if_branches;
 mod identical_match_arms;
 mod invisible_in_string;
 mod loop_runs_once;
+mod lost_query_mutation;
 mod manual_map;
 mod manual_unwrap_or;
 mod match_literal_collection;
@@ -43,6 +44,7 @@ pub use invisible_in_string::{
     check_invisible_in_string_expression, check_invisible_in_string_pattern,
 };
 pub use loop_runs_once::check_loop_runs_once;
+pub use lost_query_mutation::check_lost_query_mutation;
 pub use manual_map::check_manual_map;
 pub use manual_unwrap_or::check_manual_unwrap_or;
 pub use match_literal_collection::check_match_literal_collection;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -77,9 +77,10 @@ use checks::{
     check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
     check_expression_naming, check_identical_if_branches, check_identical_match_arms,
     check_invisible_in_string_expression, check_invisible_in_string_pattern, check_loop_runs_once,
-    check_manual_map, check_manual_unwrap_or, check_match_literal_collection, check_needless_bool,
-    check_needless_range_loop, check_needless_return, check_pattern_naming,
-    check_redundant_closure, check_redundant_pattern_matching, check_replaceable_with_zero_fill,
+    check_lost_query_mutation, check_manual_map, check_manual_unwrap_or,
+    check_match_literal_collection, check_needless_bool, check_needless_range_loop,
+    check_needless_return, check_pattern_naming, check_redundant_closure,
+    check_redundant_pattern_matching, check_replaceable_with_zero_fill,
     check_rest_only_slice_pattern, check_self_assignment, check_self_comparison,
     check_single_arm_match, check_uninterpolated_fstring, check_unnecessary_raw_string_expression,
     check_unnecessary_raw_string_pattern, check_unsigned_comparison,
@@ -149,6 +150,7 @@ impl AstLintGroup {
                 check_duplicate_logical_operand(expression, files, &mut sink);
                 check_expression_naming(expression, is_d_lis, &mut sink);
                 check_replaceable_with_zero_fill(expression, store, module_id, source, &mut sink);
+                check_lost_query_mutation(expression, store, &mut sink);
                 check_redundant_closure(expression, facts, &mut sink);
             },
             &mut |pattern| {

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -7444,3 +7444,129 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn lost_query_mutation_set() {
+    assert_lint_snapshot!(
+        r#"
+import "go:net/url"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  u.Query().Set("b", "2")
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_add() {
+    assert_lint_snapshot!(
+        r#"
+import "go:net/url"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  u.Query().Add("b", "2")
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_del() {
+    assert_lint_snapshot!(
+        r#"
+import "go:net/url"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  u.Query().Del("a")
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_alias_receiver() {
+    assert_lint_snapshot!(
+        r#"
+import "go:net/url"
+
+type MyURL = url.URL
+
+fn main() {
+  let mut u: MyURL = url.URL { Scheme: "https", Host: "example.com", .. }
+  u.Query().Set("b", "2")
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_bound_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:net/url"
+import "go:fmt"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  let q = u.Query()
+  q.Set("b", "2")
+  fmt.Println(q.Encode())
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_read_method_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:net/url"
+import "go:fmt"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  fmt.Println(u.Query().Get("a"))
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_encode_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:net/url"
+import "go:fmt"
+
+fn main() {
+  let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+  fmt.Println(u.Query().Encode())
+}
+"#
+    );
+}
+
+#[test]
+fn lost_query_mutation_user_type_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct Bag {
+  data: int,
+}
+
+impl Bag {
+  fn Query(self) -> Bag { self }
+  fn Set(self, k: string, v: string) -> int { self.data + k.length() + v.length() }
+}
+
+fn main() {
+  let b = Bag { data: 0 }
+  let _ = b.Query().Set("a", "b")
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/lost_query_mutation_add.snap
+++ b/tests/ui/lint/snapshots/lost_query_mutation_add.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Lost query mutation
+   ╭─[test.lis:6:3]
+ 5 │   let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+ 6 │   u.Query().Add("b", "2")
+   ·   ───────────┬───────────
+   ·              ╰── mutates a discarded copy
+ 7 │ }
+   ╰────
+  help: `URL.Query` returns a fresh copy, so this `Add` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field · code: [lint.lost_query_mutation]

--- a/tests/ui/lint/snapshots/lost_query_mutation_alias_receiver.snap
+++ b/tests/ui/lint/snapshots/lost_query_mutation_alias_receiver.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Lost query mutation
+   ╭─[test.lis:8:3]
+ 7 │   let mut u: MyURL = url.URL { Scheme: "https", Host: "example.com", .. }
+ 8 │   u.Query().Set("b", "2")
+   ·   ───────────┬───────────
+   ·              ╰── mutates a discarded copy
+ 9 │ }
+   ╰────
+  help: `URL.Query` returns a fresh copy, so this `Set` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field · code: [lint.lost_query_mutation]

--- a/tests/ui/lint/snapshots/lost_query_mutation_del.snap
+++ b/tests/ui/lint/snapshots/lost_query_mutation_del.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Lost query mutation
+   ╭─[test.lis:6:3]
+ 5 │   let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+ 6 │   u.Query().Del("a")
+   ·   ─────────┬────────
+   ·            ╰── mutates a discarded copy
+ 7 │ }
+   ╰────
+  help: `URL.Query` returns a fresh copy, so this `Del` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field · code: [lint.lost_query_mutation]

--- a/tests/ui/lint/snapshots/lost_query_mutation_set.snap
+++ b/tests/ui/lint/snapshots/lost_query_mutation_set.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Lost query mutation
+   ╭─[test.lis:6:3]
+ 5 │   let Ok(u) = url.Parse("http://example.com?a=1") else { return }
+ 6 │   u.Query().Set("b", "2")
+   ·   ───────────┬───────────
+   ·              ╰── mutates a discarded copy
+ 7 │ }
+   ╰────
+  help: `URL.Query` returns a fresh copy, so this `Set` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field · code: [lint.lost_query_mutation]


### PR DESCRIPTION
Adds a lint that flags mutating the `url.Values` returned by `net/url.URL.Query`, since `Query` returns a fresh copy and the mutation is silently lost.

```
  [warning] Lost query mutation
   ╭─[test.lis:6:3]
 5 │   let Ok(u) = url.Parse("http://example.com?a=1") else { return }
 6 │   u.Query().Set("b", "2")
   ·   ───────────┬───────────
   ·              ╰── mutates a discarded copy
 7 │ }
   ╰────
  help: `URL.Query` returns a fresh copy, so this `Set` has no effect. Bind the copy returned by `Query()` to an identifier, mutate it, then assign `values.Encode()` back to the URL's `RawQuery` field · code: [lint.lost_query_mutation]
```