### PR TITLE
feat: advisory `info` diagnostics

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -189,6 +189,15 @@ impl Command {
                     }
                 }
 
+                if errors_only && warnings_only {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: "`--errors-only` and `--warnings-only` cannot be used together"
+                            .to_string(),
+                        reason: "they select mutually exclusive sets of diagnostics".to_string(),
+                        hint: "Use only one of `--errors-only` or `--warnings-only`".to_string(),
+                    });
+                }
+
                 Ok(Command::Check {
                     path,
                     errors_only,
@@ -375,6 +384,14 @@ mod tests {
     fn check_format_invalid_value() {
         assert!(matches!(
             parse(&["lis", "check", "--format", "json"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn check_rejects_both_filter_flags() {
+        assert!(matches!(
+            parse(&["lis", "check", "--errors-only", "--warnings-only"]),
             Err(ParseError::UnexpectedArgument { .. })
         ));
     }

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -171,6 +171,7 @@ fn check_single_file(
             start.elapsed(),
             counts.errors,
             counts.warnings,
+            counts.info,
         );
     }
     counts.errors
@@ -243,6 +244,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
 
     let mut total_errors = 0;
     let mut total_warnings = 0;
+    let mut total_info = 0;
     let mut total_files = 0;
     let mut read_failures = 0;
 
@@ -298,6 +300,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
         };
         total_errors += counts.errors;
         total_warnings += counts.warnings;
+        total_info += counts.info;
         total_files += result.user_file_count;
     }
 
@@ -305,7 +308,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
 
     let all_errors = total_errors + read_failures;
     if !unix {
-        render::print_summary(total_files, elapsed, all_errors, total_warnings);
+        render::print_summary(total_files, elapsed, all_errors, total_warnings, total_info);
     }
 
     all_errors

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -92,7 +92,11 @@ pub fn compile(
     let semantic_result = analyze_output.result;
     let emit_stamps = analyze_output.emit_stamps;
 
-    let user_file_count = semantic_result.files.len();
+    let user_file_count: usize = semantic_result
+        .modules
+        .values()
+        .map(|module| module.file_ids.len())
+        .sum();
 
     let sources: HashMap<u32, SourceInfo> = semantic_result
         .files

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -200,7 +200,7 @@ impl fmt::Display for LisetteDiagnostic {
                     format_with_backticks(&self.message, true, |s| format!("{}", s.yellow().bold()))
                 }
                 Severity::Advice => {
-                    format_with_backticks(&self.message, true, |s| format!("{}", s.cyan().bold()))
+                    format_with_backticks(&self.message, true, |s| format!("{}", s.blue().bold()))
                 }
             };
             write!(f, "{}", styled_message)?;
@@ -286,7 +286,7 @@ impl Diagnostic for LisetteDiagnostic {
                     let base_style = match severity {
                         Severity::Error => |s: &str| format!("{}", s.red()),
                         Severity::Warning => |s: &str| format!("{}", s.yellow()),
-                        Severity::Advice => |s: &str| format!("{}", s.cyan()),
+                        Severity::Advice => |s: &str| format!("{}", s.blue()),
                     };
                     format_with_backticks(label, true, base_style)
                 } else {
@@ -323,30 +323,29 @@ impl LisetteDiagnostic {
         self.note.as_deref()
     }
 
-    pub fn error(message: impl Into<String>) -> Self {
+    fn new(message: impl Into<String>, severity: Severity) -> Self {
         Self {
             message: message.into(),
             labels: Vec::new(),
             help: None,
             note: None,
-            severity: Severity::Error,
+            severity,
             code: None,
             file_id: None,
             use_color: false,
         }
     }
 
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::new(message, Severity::Error)
+    }
+
     pub fn warn(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            labels: Vec::new(),
-            help: None,
-            note: None,
-            severity: Severity::Warning,
-            code: None,
-            file_id: None,
-            use_color: false,
-        }
+        Self::new(message, Severity::Warning)
+    }
+
+    pub fn info(message: impl Into<String>) -> Self {
+        Self::new(message, Severity::Advice)
     }
 
     pub fn with_color(mut self, use_color: bool) -> Self {
@@ -407,8 +406,8 @@ impl LisetteDiagnostic {
 
     pub fn with_lint_code(mut self, code: &str) -> Self {
         debug_assert!(
-            matches!(self.severity, Severity::Warning),
-            "with_lint_code requires Warning severity (got {:?}); \
+            matches!(self.severity, Severity::Warning | Severity::Advice),
+            "with_lint_code requires Warning or Advice severity (got {:?}); \
              use a phase-specific code constructor for errors",
             self.severity,
         );
@@ -455,7 +454,7 @@ impl LisetteDiagnostic {
         match self.severity {
             Severity::Error => "error",
             Severity::Warning => "warning",
-            Severity::Advice => "note",
+            Severity::Advice => "info",
         }
     }
 
@@ -471,11 +470,29 @@ impl LisetteDiagnostic {
         self.severity == Severity::Warning
     }
 
+    pub fn is_info(&self) -> bool {
+        self.severity == Severity::Advice
+    }
+
     pub fn sort_key(a: &Self, b: &Self) -> std::cmp::Ordering {
         a.file_id()
             .cmp(&b.file_id())
             .then_with(|| a.primary_offset().cmp(&b.primary_offset()))
             .then_with(|| a.code_str().cmp(&b.code_str()))
             .then_with(|| a.plain_message().cmp(b.plain_message()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_constructor_is_advice_severity() {
+        let diagnostic = LisetteDiagnostic::info("advisory");
+        assert!(diagnostic.is_info());
+        assert!(!diagnostic.is_error());
+        assert!(!diagnostic.is_warning());
+        assert_eq!(diagnostic.severity_word(), "info");
     }
 }

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -363,7 +363,7 @@ pub fn manual_unwrap_or(span: &Span, default_has_effects: bool) -> LisetteDiagno
     } else {
         "unwrap_or"
     };
-    LisetteDiagnostic::warn("Manual unwrap_or")
+    LisetteDiagnostic::info("Manual `unwrap_or`")
         .with_lint_code("manual_unwrap_or")
         .with_span_label(span, "can be simpler")
         .with_help(format!("Replace this `match` with `.{method}(...)`"))

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -27,6 +27,10 @@ impl Filter {
     pub fn show_warnings(&self) -> bool {
         !self.errors_only
     }
+
+    pub fn show_info(&self) -> bool {
+        !self.errors_only && !self.warnings_only
+    }
 }
 
 fn format_time(elapsed: Duration) -> String {
@@ -39,7 +43,7 @@ fn format_time(elapsed: Duration) -> String {
     }
 }
 
-pub fn print_summary(file_count: usize, elapsed: Duration, errors: i32, warnings: i32) {
+pub fn print_summary(file_count: usize, elapsed: Duration, errors: i32, warnings: i32, info: i32) {
     let time_string = format_time(elapsed);
     let use_color = std::env::var("NO_COLOR").is_err();
     let time_display = if use_color {
@@ -53,7 +57,7 @@ pub fn print_summary(file_count: usize, elapsed: Duration, errors: i32, warnings
         &format!("{} files", file_count)
     };
 
-    if errors == 0 && warnings == 0 {
+    if errors == 0 && warnings == 0 && info == 0 {
         eprintln!("  ✓ No issues · {} {}", files_str, time_display);
     } else {
         let mut parts = Vec::new();
@@ -71,6 +75,9 @@ pub fn print_summary(file_count: usize, elapsed: Duration, errors: i32, warnings
                 format!("{} warnings", warnings)
             });
         }
+        if info > 0 {
+            parts.push(format!("{} info", info));
+        }
         let findings = format!("Found {}", parts.join(", "));
         let findings_display = if use_color {
             format!("{}", findings.bold())
@@ -86,11 +93,13 @@ fn color_handler(highlight: Style) -> GraphicalReportHandler {
         characters: ThemeCharacters {
             error: "🔴".into(),
             warning: "🟡".into(),
+            advice: "🔵".into(),
             ..ThemeCharacters::unicode()
         },
         styles: ThemeStyles {
             error: Style::new().red(),
             warning: Style::new().yellow(),
+            advice: Style::new().blue(),
             link: Style::new(),
             help: Style::new().dimmed(),
             highlights: vec![highlight],
@@ -105,6 +114,7 @@ fn nocolor_handler() -> GraphicalReportHandler {
         characters: ThemeCharacters {
             error: "[error]".into(),
             warning: "[warning]".into(),
+            advice: "[info]".into(),
             ..ThemeCharacters::unicode()
         },
         styles: ThemeStyles::none(),
@@ -129,10 +139,31 @@ fn render(
     }
 }
 
+fn render_group<F: Fn(u32) -> Option<(String, String)>>(
+    diagnostics: &[&LisetteDiagnostic],
+    highlight: Style,
+    use_color: bool,
+    sources: &mut SourceCache<F>,
+) {
+    if diagnostics.is_empty() {
+        return;
+    }
+    let handler = if use_color {
+        color_handler(highlight)
+    } else {
+        nocolor_handler()
+    };
+    for diagnostic in diagnostics {
+        let (src, name) = sources.get(diagnostic.file_id());
+        render(&handler, diagnostic, &src, &name, use_color);
+    }
+}
+
 pub struct Counts {
     pub files: usize,
     pub errors: i32,
     pub warnings: i32,
+    pub info: i32,
 }
 
 /// Resolves a `file_id` to its source, falling back to the entry file.
@@ -173,20 +204,30 @@ fn partition_diagnostics<'a>(
     errors: &'a [LisetteDiagnostic],
     lints: &'a [LisetteDiagnostic],
     filter: &Filter,
-) -> (Vec<&'a LisetteDiagnostic>, Vec<&'a LisetteDiagnostic>) {
-    let (errors, infer_warnings): (Vec<_>, Vec<_>) = if filter.show_errors() {
-        errors.iter().partition(|d| d.is_error())
-    } else {
-        (Vec::new(), Vec::new())
-    };
+) -> (
+    Vec<&'a LisetteDiagnostic>,
+    Vec<&'a LisetteDiagnostic>,
+    Vec<&'a LisetteDiagnostic>,
+) {
+    let mut error_bucket = Vec::new();
+    let mut warning_bucket = Vec::new();
+    let mut info_bucket = Vec::new();
 
-    let warnings: Vec<_> = if filter.show_warnings() {
-        infer_warnings.into_iter().chain(lints.iter()).collect()
-    } else {
-        Vec::new()
-    };
+    for diagnostic in errors.iter().chain(lints.iter()) {
+        if diagnostic.is_error() {
+            if filter.show_errors() {
+                error_bucket.push(diagnostic);
+            }
+        } else if diagnostic.is_info() {
+            if filter.show_info() {
+                info_bucket.push(diagnostic);
+            }
+        } else if filter.show_warnings() {
+            warning_bucket.push(diagnostic);
+        }
+    }
 
-    (errors, warnings)
+    (error_bucket, warning_bucket, info_bucket)
 }
 
 pub fn render_all(
@@ -198,9 +239,9 @@ pub fn render_all(
     default_source: &str,
     default_filename: &str,
 ) -> Counts {
-    let (errors, warnings) = partition_diagnostics(errors, lints, filter);
+    let (errors, warnings, info) = partition_diagnostics(errors, lints, filter);
 
-    let has_diagnostics = !errors.is_empty() || !warnings.is_empty();
+    let has_diagnostics = !errors.is_empty() || !warnings.is_empty() || !info.is_empty();
     if has_diagnostics {
         eprintln!(); // Blank line before first diagnostic
     }
@@ -208,34 +249,15 @@ pub fn render_all(
     let use_color = std::env::var("NO_COLOR").is_err();
     let mut sources = SourceCache::new(get_source, default_source, default_filename);
 
-    if !errors.is_empty() {
-        let handler = if use_color {
-            color_handler(Style::new().red())
-        } else {
-            nocolor_handler()
-        };
-        for error in &errors {
-            let (src, name) = sources.get(error.file_id());
-            render(&handler, error, &src, &name, use_color);
-        }
-    }
-
-    if !warnings.is_empty() {
-        let handler = if use_color {
-            color_handler(Style::new().yellow())
-        } else {
-            nocolor_handler()
-        };
-        for warning in &warnings {
-            let (src, name) = sources.get(warning.file_id());
-            render(&handler, warning, &src, &name, use_color);
-        }
-    }
+    render_group(&errors, Style::new().red(), use_color, &mut sources);
+    render_group(&warnings, Style::new().yellow(), use_color, &mut sources);
+    render_group(&info, Style::new().blue(), use_color, &mut sources);
 
     Counts {
         files: file_count.max(1),
         errors: errors.len() as i32,
         warnings: warnings.len() as i32,
+        info: info.len() as i32,
     }
 }
 
@@ -266,11 +288,11 @@ pub fn render_unix(
     default_source: &str,
     default_filename: &str,
 ) -> (String, Counts) {
-    let (errors, warnings) = partition_diagnostics(errors, lints, filter);
+    let (errors, warnings, info) = partition_diagnostics(errors, lints, filter);
 
     let mut sources = SourceCache::new(get_source, default_source, default_filename);
     let mut output = String::new();
-    for diagnostic in errors.iter().chain(warnings.iter()) {
+    for diagnostic in errors.iter().chain(warnings.iter()).chain(info.iter()) {
         let (src, name) = sources.get(diagnostic.file_id());
         output.push_str(&unix_line(diagnostic, &src, &name));
         output.push('\n');
@@ -280,6 +302,64 @@ pub fn render_unix(
         files: file_count.max(1),
         errors: errors.len() as i32,
         warnings: warnings.len() as i32,
+        info: info.len() as i32,
     };
     (output, counts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn show_all() -> Filter {
+        Filter {
+            errors_only: false,
+            warnings_only: false,
+        }
+    }
+
+    #[test]
+    fn each_severity_lands_in_its_own_bucket() {
+        let errors = vec![LisetteDiagnostic::error("e")];
+        let lints = vec![LisetteDiagnostic::warn("w"), LisetteDiagnostic::info("i")];
+        let (errors, warnings, info) = partition_diagnostics(&errors, &lints, &show_all());
+        assert_eq!(errors.len(), 1);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(info.len(), 1);
+    }
+
+    #[test]
+    fn info_hidden_under_errors_only() {
+        let empty: Vec<LisetteDiagnostic> = Vec::new();
+        let lints = vec![LisetteDiagnostic::info("i")];
+        let filter = Filter {
+            errors_only: true,
+            warnings_only: false,
+        };
+        let (_, _, info) = partition_diagnostics(&empty, &lints, &filter);
+        assert!(info.is_empty());
+    }
+
+    #[test]
+    fn info_hidden_under_warnings_only() {
+        let empty: Vec<LisetteDiagnostic> = Vec::new();
+        let lints = vec![LisetteDiagnostic::info("i")];
+        let filter = Filter {
+            errors_only: false,
+            warnings_only: true,
+        };
+        let (_, _, info) = partition_diagnostics(&empty, &lints, &filter);
+        assert!(info.is_empty());
+    }
+
+    #[test]
+    fn unix_counts_and_labels_info_separately() {
+        let empty: Vec<LisetteDiagnostic> = Vec::new();
+        let lints = vec![LisetteDiagnostic::info("advisory")];
+        let (output, counts) = render_unix(&empty, &lints, |_| None, 1, &show_all(), "", "f.lis");
+        assert_eq!(counts.errors, 0);
+        assert_eq!(counts.warnings, 0);
+        assert_eq!(counts.info, 1);
+        assert!(output.contains("info: advisory"));
+    }
 }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "0.2.16", path = "../syntax" }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -261,6 +261,8 @@ pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Di
         range,
         severity: Some(if d.is_error() {
             DiagnosticSeverity::ERROR
+        } else if d.is_info() {
+            DiagnosticSeverity::INFORMATION
         } else {
             DiagnosticSeverity::WARNING
         }),
@@ -279,5 +281,24 @@ pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Di
         source: Some("lisette".into()),
         code: d.code_str().map(|s| NumberOrString::String(s.to_string())),
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_maps_to_lsp_information() {
+        let index = LineIndex::new("");
+        let diagnostic = convert_diagnostic(&LisetteDiagnostic::info("advisory"), &index);
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::INFORMATION));
+    }
+
+    #[test]
+    fn warning_maps_to_lsp_warning() {
+        let index = LineIndex::new("");
+        let diagnostic = convert_diagnostic(&LisetteDiagnostic::warn("w"), &index);
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
     }
 }

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -378,12 +378,12 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
                     .map(|m| m.file_ids().collect())
                     .unwrap_or_default();
 
-                let has_module_warnings = lints.iter().any(|lint| {
+                let has_module_lints = lints.iter().any(|lint| {
                     lint.file_id()
                         .map(|fid| file_ids.contains(&fid))
                         .unwrap_or(true)
                 });
-                if !has_module_warnings
+                if !has_module_lints
                     && let Err(e) =
                         save_module_cache(&compiled, &store, project_root, &ufcs_methods)
                 {

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -87,7 +87,7 @@ tabBtns.forEach((btn) => {
 });
 
 // ─── Status helpers ───────────────────────────────────────────────────────────
-type StatusKind = "idle" | "running" | "ok" | "error" | "warning";
+type StatusKind = "idle" | "running" | "ok" | "error" | "warning" | "info";
 
 function setStatus(kind: StatusKind, label: string) {
   statusEl.className = `status-${kind}`;
@@ -236,8 +236,10 @@ async function main() {
 
     const errors = diags.filter((d) => d.severity === "error").length;
     const warnings = diags.filter((d) => d.severity === "warning").length;
+    const info = diags.filter((d) => d.severity === "info").length;
     if (errors > 0) setStatus("error", `${errors} error${errors > 1 ? "s" : ""}`);
     else if (warnings > 0) setStatus("warning", `${warnings} warning${warnings > 1 ? "s" : ""}`);
+    else if (info > 0) setStatus("info", `${info} info`);
     else setStatus("ok", "No issues");
     setButtons(false);
   });

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -180,6 +180,7 @@ html, body {
 .status-ok     { background: rgba(63,185,80,.15);   color: var(--success); }
 .status-error  { background: rgba(248,81,73,.15);   color: var(--error); }
 .status-warning{ background: rgba(210,153,34,.15);  color: var(--warning); }
+.status-info   { background: rgba(88,166,255,.15);  color: var(--info); }
 
 /* ─── Layout ──────────────────────────────── */
 #main-layout {

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -109,7 +109,14 @@ fn convert_lisette_diag(
     source: &str,
 ) -> JsDiagnostic {
     let message = diag.plain_message().to_string();
-    let severity = if diag.is_error() { "error" } else { "warning" }.to_string();
+    let severity = if diag.is_error() {
+        "error"
+    } else if diag.is_info() {
+        "info"
+    } else {
+        "warning"
+    }
+    .to_string();
 
     let offset = diag.primary_offset();
     let (line, col, end_line, end_col) = {
@@ -558,7 +565,7 @@ fn definition_to_completion_kind(def: &Definition) -> &'static str {
         DefinitionBody::Interface { .. } => "type",
         DefinitionBody::TypeAlias { .. } => "type",
         DefinitionBody::Value { .. } => {
-            if matches!(&def.ty, Type::Function { .. }) { "function" } else { "variable" }
+            if matches!(&def.ty, Type::Function(_)) { "function" } else { "variable" }
         }
     }
 }
@@ -647,7 +654,7 @@ fn build_dot_completions(
                     if !method.contains('.') {
                         items.push(JsCompletionItem {
                             label: method.to_string(),
-                            kind: if matches!(def.ty(), Type::Function { .. }) { "method" } else { "field" },
+                            kind: if matches!(def.ty(), Type::Function(_)) { "method" } else { "field" },
                             detail: Some(format!("{}", def.ty())),
                             insert_text: None,
                         });
@@ -884,11 +891,11 @@ pub fn signature_help(code: &str, offset: u32) -> String {
             Type::Forall { body, .. } => body.as_ref(),
             other => other,
         };
-        if let Type::Function { params, return_type, .. } = callee_ty_inner {
+        if let Type::Function(f) = callee_ty_inner {
             // Build the signature label
             let callee_name = callee.callee_name().unwrap_or_else(|| "fn".to_string());
-            let param_strs: Vec<String> = params.iter().map(|p| format!("{}", p)).collect();
-            let ret_str = format!("{}", return_type);
+            let param_strs: Vec<String> = f.params.iter().map(|p| format!("{}", p)).collect();
+            let ret_str = format!("{}", f.return_type);
             let ret_part = if ret_str == "()" { String::new() } else { format!(" -> {}", ret_str) };
             let label = format!("{}({}){}", callee_name, param_strs.join(", "), ret_part);
 
@@ -909,4 +916,21 @@ pub fn signature_help(code: &str, offset: u32) -> String {
     }
 
     String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_diagnostic_converts_to_info_severity() {
+        let diag = lisette_diagnostics::LisetteDiagnostic::info("advisory");
+        assert_eq!(convert_lisette_diag(&diag, "").severity, "info");
+    }
+
+    #[test]
+    fn warning_diagnostic_converts_to_warning_severity() {
+        let diag = lisette_diagnostics::LisetteDiagnostic::warn("w");
+        assert_eq!(convert_lisette_diag(&diag, "").severity, "warning");
+    }
 }

--- a/tests/_harness/formatting.rs
+++ b/tests/_harness/formatting.rs
@@ -7,6 +7,7 @@ fn snapshot_theme() -> GraphicalTheme {
         characters: ThemeCharacters {
             error: "[error]".into(),
             warning: "[warning]".into(),
+            advice: "[info]".into(),
             ..ThemeCharacters::unicode()
         },
         styles: ThemeStyles::none(),

--- a/tests/ui/lint/snapshots/manual_unwrap_or_else_effectful_default.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_else_effectful_default.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Manual unwrap_or
+  [info] Manual `unwrap_or`
    ╭─[test.lis:8:11]
  7 │   let o: Option<int> = Some(1)
  8 │   let _ = match o {

--- a/tests/ui/lint/snapshots/manual_unwrap_or_option.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_option.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Manual unwrap_or
+  [info] Manual `unwrap_or`
    ╭─[test.lis:4:11]
  3 │   let o: Option<int> = Some(1)
  4 │   let _ = match o {

--- a/tests/ui/lint/snapshots/manual_unwrap_or_result.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_result.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Manual unwrap_or
+  [info] Manual `unwrap_or`
    ╭─[test.lis:4:11]
  3 │   let r: Result<int, string> = Ok(1)
  4 │   let _ = match r {

--- a/tests/ui/lint/snapshots/manual_unwrap_or_reversed_arms.snap
+++ b/tests/ui/lint/snapshots/manual_unwrap_or_reversed_arms.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/lint/mod.rs
 ---
-  [warning] Manual unwrap_or
+  [info] Manual `unwrap_or`
    ╭─[test.lis:4:11]
  3 │   let o: Option<int> = Some(1)
  4 │   let _ = match o {


### PR DESCRIPTION
Adds an `info` diagnostic level for advisory suggestions that are neither errors or possible errors, typically simplifications or style notes. Info diagnostics render in blue, map to LSP `Information`, and do not affect the exit code.