### PR TITLE
refactor: set up opt-in stringer capability

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -61,6 +61,39 @@ pub fn iterable_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
         .with_help("Only enums in `.lis` source can be marked `#[iterable]`")
 }
 
+pub fn displayable_not_a_struct_or_enum(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[displayable]` not on a struct or enum")
+        .with_attribute_code("displayable_not_a_struct_or_enum")
+        .with_span_label(attribute_span, "not on a struct or enum")
+        .with_help("Only a struct or enum can be marked `#[displayable]`")
+}
+
+pub fn displayable_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[displayable]` in a typedef")
+        .with_attribute_code("displayable_in_typedef")
+        .with_span_label(attribute_span, "disallowed in a `.d.lis` typedef")
+        .with_help("Only structs or enums in `.lis` source can be marked `#[displayable]`")
+}
+
+pub fn displayable_with_arguments(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[displayable]` takes no arguments")
+        .with_attribute_code("displayable_with_arguments")
+        .with_span_label(attribute_span, "remove the arguments")
+        .with_help("Write `#[displayable]` with no arguments")
+}
+
+pub fn displayable_on_pointer_newtype(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[displayable]` on a pointer-backed newtype")
+        .with_attribute_code("displayable_on_pointer_newtype")
+        .with_span_label(
+            attribute_span,
+            "a single-field tuple struct over `Ref<T>` cannot have a stringer",
+        )
+        .with_help(
+            "Go forbids methods on the named pointer type this lowers to. Format the value explicitly, or change the representation.",
+        )
+}
+
 pub fn iterable_variants_conflict(
     attribute_span: &Span,
     existing_span: Option<&Span>,

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -371,6 +371,7 @@ pub enum CachedDefinitionBody {
         generics: Vec<CachedGeneric>,
         variants: Vec<CachedEnumVariant>,
         methods: HashMap<String, Type>,
+        displayable: bool,
     },
     ValueEnum {
         variants: Vec<CachedValueEnumVariant>,
@@ -383,6 +384,7 @@ pub enum CachedDefinitionBody {
         kind: StructKind,
         methods: HashMap<String, Type>,
         constructor: Option<Type>,
+        displayable: bool,
     },
     Interface {
         definition: CachedInterface,
@@ -423,6 +425,7 @@ impl CachedDefinition {
                 generics,
                 variants,
                 methods,
+                displayable,
             } => CachedDefinitionBody::Enum {
                 generics: generics
                     .iter()
@@ -433,6 +436,7 @@ impl CachedDefinition {
                     .map(|v| CachedEnumVariant::from_variant(v, file_id_to_index))
                     .collect(),
                 methods: Self::convert_methods(methods),
+                displayable: *displayable,
             },
             DefinitionBody::ValueEnum {
                 variants,
@@ -452,6 +456,7 @@ impl CachedDefinition {
                 kind,
                 methods,
                 constructor,
+                displayable,
             } => CachedDefinitionBody::Struct {
                 generics: generics
                     .iter()
@@ -464,6 +469,7 @@ impl CachedDefinition {
                 kind: *kind,
                 methods: Self::convert_methods(methods),
                 constructor: constructor.clone(),
+                displayable: *displayable,
             },
             DefinitionBody::Interface { definition } => CachedDefinitionBody::Interface {
                 definition: CachedInterface::from_interface(definition, file_id_to_index),
@@ -522,10 +528,12 @@ impl CachedDefinition {
                 generics,
                 variants,
                 methods,
+                displayable,
             } => DefinitionBody::Enum {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 variants: variants.iter().map(|v| v.to_variant(file_ids)).collect(),
                 methods: Self::restore_methods(methods),
+                displayable: *displayable,
             },
             CachedDefinitionBody::ValueEnum {
                 variants,
@@ -542,12 +550,14 @@ impl CachedDefinition {
                 kind,
                 methods,
                 constructor,
+                displayable,
             } => DefinitionBody::Struct {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 fields: fields.iter().map(|f| f.to_field(file_ids)).collect(),
                 kind: *kind,
                 methods: Self::restore_methods(methods),
                 constructor: constructor.clone(),
+                displayable: *displayable,
             },
             CachedDefinitionBody::Interface { definition } => DefinitionBody::Interface {
                 definition: definition.to_interface(file_ids),

--- a/crates/semantics/src/checker/registration/displayable.rs
+++ b/crates/semantics/src/checker/registration/displayable.rs
@@ -1,0 +1,129 @@
+use syntax::ast::{Attribute, Expression};
+use syntax::program::{Definition, DefinitionBody};
+use syntax::types::Symbol;
+
+use super::TaskState;
+use crate::store::Store;
+
+impl TaskState<'_> {
+    pub(super) fn register_displayable(&mut self, store: &Store, items: &[Expression]) {
+        let module_id = self.cursor.module_id.clone();
+        let is_d_lis = self.is_d_lis(store);
+        for item in items {
+            self.check_displayable_item(store, &module_id, item, is_d_lis);
+        }
+    }
+
+    pub(super) fn register_module_displayable(&mut self, store: &Store, module_id: &str) {
+        let module = store.get_module(module_id).expect("module must exist");
+        for file in module.files.values() {
+            let is_d_lis = file.is_d_lis();
+            for item in &file.items {
+                self.check_displayable_item(store, module_id, item, is_d_lis);
+            }
+        }
+    }
+
+    fn check_displayable_item(
+        &mut self,
+        store: &Store,
+        module_id: &str,
+        item: &Expression,
+        is_d_lis: bool,
+    ) {
+        match item {
+            Expression::Struct {
+                attributes,
+                name,
+                fields,
+                ..
+            } => {
+                if let Some(attribute) = displayable_attribute(attributes) {
+                    self.validate_displayable(store, module_id, attribute, is_d_lis, Some(name));
+                }
+                for field in fields {
+                    self.reject_misplaced_displayable(&field.attributes);
+                }
+            }
+            Expression::Enum { attributes, .. } => {
+                if let Some(attribute) = displayable_attribute(attributes) {
+                    self.validate_displayable(store, module_id, attribute, is_d_lis, None);
+                }
+            }
+            Expression::Function { attributes, .. } => {
+                self.reject_misplaced_displayable(attributes);
+            }
+            Expression::ImplBlock { methods, .. } => {
+                self.reject_misplaced_displayable_methods(methods)
+            }
+            Expression::Interface {
+                method_signatures, ..
+            } => self.reject_misplaced_displayable_methods(method_signatures),
+            _ => {}
+        }
+    }
+
+    fn validate_displayable(
+        &mut self,
+        store: &Store,
+        module_id: &str,
+        attribute: &Attribute,
+        is_d_lis: bool,
+        struct_name: Option<&str>,
+    ) {
+        if !attribute.args.is_empty() {
+            self.sink
+                .push(diagnostics::attribute::displayable_with_arguments(
+                    &attribute.span,
+                ));
+            return;
+        }
+        if is_d_lis {
+            self.sink
+                .push(diagnostics::attribute::displayable_in_typedef(
+                    &attribute.span,
+                ));
+            return;
+        }
+        if let Some(name) = struct_name {
+            let qualified = Symbol::from_parts(module_id, name);
+            if let Some(definition) = store.get_definition(qualified.as_str())
+                && is_pointer_backed_newtype(definition)
+            {
+                self.sink
+                    .push(diagnostics::attribute::displayable_on_pointer_newtype(
+                        &attribute.span,
+                    ));
+            }
+        }
+    }
+
+    fn reject_misplaced_displayable(&mut self, attributes: &[Attribute]) {
+        if let Some(attribute) = displayable_attribute(attributes) {
+            self.sink
+                .push(diagnostics::attribute::displayable_not_a_struct_or_enum(
+                    &attribute.span,
+                ));
+        }
+    }
+
+    fn reject_misplaced_displayable_methods(&mut self, methods: &[Expression]) {
+        for method in methods {
+            if let Expression::Function { attributes, .. } = method {
+                self.reject_misplaced_displayable(attributes);
+            }
+        }
+    }
+}
+
+fn displayable_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
+    attributes.iter().find(|a| a.name == "displayable")
+}
+
+fn is_pointer_backed_newtype(definition: &Definition) -> bool {
+    definition.is_newtype()
+        && matches!(
+            &definition.body,
+            DefinitionBody::Struct { fields, .. } if fields[0].ty.is_ref()
+        )
+}

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod convert;
+mod displayable;
 mod iterables;
 mod methods;
 mod types;
@@ -47,6 +48,10 @@ pub(super) fn extract_go_name(attributes: &[Attribute]) -> Option<String> {
                 None
             }
         })
+}
+
+pub(super) fn has_displayable_attribute(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|a| a.name == "displayable")
 }
 
 pub(super) fn extract_attribute_flags(attributes: &[Attribute], name: &str) -> Vec<String> {
@@ -104,6 +109,7 @@ impl TaskState<'_> {
         }
 
         self.register_module_iterables(store, id);
+        self.register_module_displayable(store, id);
 
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = crate::call_classification::compute_module_ufcs(module, id);
@@ -343,6 +349,7 @@ impl TaskState<'_> {
         self.register_impl_blocks(store, items);
         self.register_values(store, items, visibility);
         self.register_iterables(store, items);
+        self.register_displayable(store, items);
     }
 
     pub fn register_type_names(
@@ -499,8 +506,18 @@ impl TaskState<'_> {
                     variants,
                     span,
                     doc,
+                    attributes,
                     ..
-                } => self.populate_enum(store, name, name_span, generics, variants, span, doc),
+                } => self.populate_enum(
+                    store,
+                    name,
+                    name_span,
+                    generics,
+                    variants,
+                    span,
+                    doc,
+                    has_displayable_attribute(attributes),
+                ),
                 Expression::ValueEnum {
                     name,
                     name_span,
@@ -524,10 +541,19 @@ impl TaskState<'_> {
                     kind,
                     span,
                     doc,
+                    attributes,
                     ..
-                } => {
-                    self.populate_struct(store, name, name_span, generics, fields, *kind, span, doc)
-                }
+                } => self.populate_struct(
+                    store,
+                    name,
+                    name_span,
+                    generics,
+                    fields,
+                    *kind,
+                    span,
+                    doc,
+                    has_displayable_attribute(attributes),
+                ),
                 Expression::Interface {
                     name,
                     name_span,

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -21,6 +21,7 @@ impl TaskState<'_> {
         variants: &[EnumVariant],
         span: &Span,
         doc: &Option<String>,
+        displayable: bool,
     ) {
         let qualified_name = self.qualify_name(name);
         let enum_ty = store
@@ -120,6 +121,7 @@ impl TaskState<'_> {
                     generics: generics.to_vec(),
                     variants: new_variants,
                     methods: MethodSignatures::default(),
+                    displayable,
                 },
             },
         );
@@ -387,6 +389,7 @@ impl TaskState<'_> {
         kind: StructKind,
         span: &Span,
         doc: &Option<String>,
+        displayable: bool,
     ) {
         let qualified_name = self.qualify_name(name);
         let struct_ty = store
@@ -455,6 +458,7 @@ impl TaskState<'_> {
                     kind,
                     methods: Default::default(),
                     constructor: None,
+                    displayable,
                 },
             },
         );

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -231,7 +231,7 @@ fn check_tag_with_alias(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiag
 }
 
 fn is_known_attribute(name: &str) -> bool {
-    is_serialization_key(name) || matches!(name, "tag" | "allow" | "iterable")
+    is_serialization_key(name) || matches!(name, "tag" | "allow" | "iterable" | "displayable")
 }
 
 fn is_serialization_key(key: &str) -> bool {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -28,6 +28,7 @@ pub enum DefinitionBody {
         generics: Vec<Generic>,
         variants: Vec<EnumVariant>,
         methods: MethodSignatures,
+        displayable: bool,
     },
     ValueEnum {
         variants: Vec<ValueEnumVariant>,
@@ -40,6 +41,7 @@ pub enum DefinitionBody {
         kind: StructKind,
         methods: MethodSignatures,
         constructor: Option<Type>,
+        displayable: bool,
     },
     Interface {
         definition: Interface,
@@ -113,6 +115,19 @@ impl Definition {
             DefinitionBody::ValueEnum { methods, .. } => Some(methods),
             _ => None,
         }
+    }
+
+    pub fn is_displayable(&self) -> bool {
+        matches!(
+            &self.body,
+            DefinitionBody::Struct {
+                displayable: true,
+                ..
+            } | DefinitionBody::Enum {
+                displayable: true,
+                ..
+            }
+        )
     }
 
     pub fn is_type_definition(&self) -> bool {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -323,6 +323,7 @@ fn store_get_definition_domain_style_go_module() {
                 kind: syntax::ast::StructKind::Record,
                 methods: Default::default(),
                 constructor: None,
+                displayable: false,
             },
         },
     );

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7431,6 +7431,72 @@ interface Service {
 }
 
 #[test]
+fn displayable_on_function() {
+    let input = r#"
+#[displayable]
+fn run() -> int {
+  0
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_on_struct_field() {
+    let input = r#"
+struct Config {
+  #[displayable]
+  value: int,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_on_impl_method() {
+    let input = r#"
+struct Widget {}
+
+impl Widget {
+  #[displayable]
+  fn build() -> int {
+    0
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_on_interface_method() {
+    let input = r#"
+interface Service {
+  #[displayable]
+  fn run() -> int
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_with_arguments() {
+    let input = r#"
+#[displayable(foo)]
+struct Point { x: int, y: int }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_on_pointer_newtype() {
+    let input = r#"
+#[displayable]
+struct Handle(Ref<int>)
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_type_alias_record_struct_as_value() {
     let input = r#"
 struct Coord { x: int, y: int }

--- a/tests/ui/errors/snapshots/displayable_on_function.snap
+++ b/tests/ui/errors/snapshots/displayable_on_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` not on a struct or enum
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[displayable]
+   · ───────┬──────
+   ·        ╰── not on a struct or enum
+ 3 │ fn run() -> int {
+   ╰────
+  help: Only a struct or enum can be marked `#[displayable]` · code: [attribute.displayable_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/displayable_on_impl_method.snap
+++ b/tests/ui/errors/snapshots/displayable_on_impl_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` not on a struct or enum
+   ╭─[test.lis:5:3]
+ 4 │ impl Widget {
+ 5 │   #[displayable]
+   ·   ───────┬──────
+   ·          ╰── not on a struct or enum
+ 6 │   fn build() -> int {
+   ╰────
+  help: Only a struct or enum can be marked `#[displayable]` · code: [attribute.displayable_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/displayable_on_interface_method.snap
+++ b/tests/ui/errors/snapshots/displayable_on_interface_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` not on a struct or enum
+   ╭─[test.lis:3:3]
+ 2 │ interface Service {
+ 3 │   #[displayable]
+   ·   ───────┬──────
+   ·          ╰── not on a struct or enum
+ 4 │   fn run() -> int
+   ╰────
+  help: Only a struct or enum can be marked `#[displayable]` · code: [attribute.displayable_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/displayable_on_pointer_newtype.snap
+++ b/tests/ui/errors/snapshots/displayable_on_pointer_newtype.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` on a pointer-backed newtype
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[displayable]
+   · ───────┬──────
+   ·        ╰── a single-field tuple struct over `Ref<T>` cannot have a stringer
+ 3 │ struct Handle(Ref<int>)
+   ╰────
+  help: Go forbids methods on the named pointer type this lowers to. Format the value explicitly, or change the representation · code: [attribute.displayable_on_pointer_newtype]

--- a/tests/ui/errors/snapshots/displayable_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/displayable_on_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` not on a struct or enum
+   ╭─[test.lis:3:3]
+ 2 │ struct Config {
+ 3 │   #[displayable]
+   ·   ───────┬──────
+   ·          ╰── not on a struct or enum
+ 4 │   value: int,
+   ╰────
+  help: Only a struct or enum can be marked `#[displayable]` · code: [attribute.displayable_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/displayable_with_arguments.snap
+++ b/tests/ui/errors/snapshots/displayable_with_arguments.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` takes no arguments
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[displayable(foo)]
+   · ─────────┬─────────
+   ·          ╰── remove the arguments
+ 3 │ struct Point { x: int, y: int }
+   ╰────
+  help: Write `#[displayable]` with no arguments · code: [attribute.displayable_with_arguments]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4484,6 +4484,31 @@ pub struct User {
 }
 
 #[test]
+fn displayable_attribute_is_known() {
+    assert_no_lint_warnings!(
+        r#"
+#[displayable]
+struct Point { x: int, y: int }
+
+#[displayable]
+enum Color {
+  Red,
+  Green,
+}
+
+fn main() {
+  let p = Point { x: 1, y: 2 }
+  let c = Color.Red
+  let _ = match c {
+    Red => p.x,
+    Green => p.y,
+  }
+}
+"#
+    );
+}
+
+#[test]
 fn duplicate_tag_key() {
     assert_lint_snapshot!(
         r#"


### PR DESCRIPTION
Groundwork for gating stringer synthesis behind an explicit opt-in in a follow-up.
