### PR TITLE
refactor: route stringer synthesis through a single gate

### DIFF
--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -8,7 +8,7 @@ use crate::Planner;
 use crate::definitions::enum_layout::{
     ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, ENUM_TAG_FIELD,
 };
-use crate::definitions::structs::struct_field_go_name;
+use crate::definitions::structs::{should_synthesize_stringer, struct_field_go_name};
 use crate::names::go_name;
 
 type SpanMap = HashMap<String, Vec<Span>>;
@@ -121,7 +121,7 @@ impl Planner<'_> {
                         }
                     }
                 }
-                if let Some(stringer) = self.stringer_method_name(name) {
+                if let Some(stringer) = self.stringer_method_name(name, attributes) {
                     members
                         .entry(stringer.to_string())
                         .or_default()
@@ -182,14 +182,15 @@ impl Planner<'_> {
                     .entry(ENUM_TAG_FIELD.to_string())
                     .or_default()
                     .push(*name_span);
+                let synthesize = should_synthesize_stringer(attributes);
                 let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
-                if !has_user_string {
+                if synthesize && !has_user_string {
                     members
                         .entry(ENUM_STRINGER_METHOD.to_string())
                         .or_default()
                         .push(*name_span);
                 }
-                if !has_user_go_string {
+                if synthesize && !has_user_go_string {
                     members
                         .entry(ENUM_GO_STRINGER_METHOD.to_string())
                         .or_default()

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -1,6 +1,7 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
+use crate::definitions::structs::should_synthesize_stringer;
 use crate::names::generics::receiver_generics_string;
 use crate::names::go_name;
 use syntax::ast::{Attribute, Generic};
@@ -46,9 +47,10 @@ impl Planner<'_> {
         let has_json = attributes.iter().any(|a| a.name == "json");
         let has_iterable = attributes.iter().any(|a| a.name == "iterable");
 
+        let synthesize = should_synthesize_stringer(attributes);
         let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
-        let emit_string = !has_user_string;
-        let emit_go_string = !has_user_go_string;
+        let emit_string = synthesize && !has_user_string;
+        let emit_go_string = synthesize && !has_user_go_string;
         let needs_fmt = emit_string || emit_go_string;
         let layout = self.module.enum_layout(&enum_id).unwrap();
         let mut result = layout.emit_definition(&generics_string);

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -8,7 +8,7 @@ use crate::names::go_name;
 use crate::utils::receiver_name;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructKind};
 use syntax::program::DefinitionBody;
-use syntax::types::{SimpleKind, Type};
+use syntax::types::Type;
 
 impl Planner<'_> {
     pub(crate) fn emit_struct_definition(
@@ -24,7 +24,14 @@ impl Planner<'_> {
         let generics_string = self.generics_to_string_for_symbol(&symbol, generics, fx);
 
         if *kind == StructKind::Tuple {
-            return self.emit_tuple_struct(name, &generics_string, fields, generics, fx);
+            return self.emit_tuple_struct(
+                name,
+                &generics_string,
+                fields,
+                generics,
+                struct_attrs,
+                fx,
+            );
         }
 
         let mut field_strings: Vec<String> = Vec::with_capacity(fields.len());
@@ -49,7 +56,7 @@ impl Planner<'_> {
             )
         };
 
-        if let Some(stringer_name) = self.stringer_method_name(name) {
+        if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) {
             let string_method = emit_struct_stringer_method(
                 name,
                 &receiver_generics,
@@ -72,10 +79,11 @@ impl Planner<'_> {
         generics_string: &str,
         fields: &[StructFieldDefinition],
         generics: &[Generic],
+        struct_attrs: &[Attribute],
         fx: &mut EmitEffects,
     ) -> String {
         let definition = self.emit_tuple_struct_definition(name, generics_string, fields, fx);
-        let Some(stringer_name) = self.stringer_method_name(name) else {
+        let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) else {
             return definition;
         };
         let receiver_generics = receiver_generics_string(generics);
@@ -182,7 +190,7 @@ impl Planner<'_> {
             });
 
         let is_user_stringer = |method_name: &str| {
-            methods.is_some_and(|m| is_stringer_signature(m.get(method_name)))
+            methods.is_some_and(|m| m.get(method_name).is_some_and(Type::is_stringer_signature))
                 && !self.facts.is_ufcs_method(&qualified, method_name)
         };
 
@@ -196,13 +204,24 @@ impl Planner<'_> {
     /// `GoString` when the user already supplies `String`, none when both
     /// exist. Enums use [`Self::stringer_overrides`] directly, since they
     /// synthesize both a bare `String` and a qualified `GoString`.
-    pub(crate) fn stringer_method_name(&self, name: &str) -> Option<&'static str> {
+    pub(crate) fn stringer_method_name(
+        &self,
+        name: &str,
+        attributes: &[Attribute],
+    ) -> Option<&'static str> {
+        if !should_synthesize_stringer(attributes) {
+            return None;
+        }
         match self.stringer_overrides(name) {
             (true, true) => None,
             (true, false) => Some(ENUM_GO_STRINGER_METHOD),
             _ => Some(ENUM_STRINGER_METHOD),
         }
     }
+}
+
+pub(crate) fn should_synthesize_stringer(_attributes: &[Attribute]) -> bool {
+    true
 }
 
 pub(crate) fn struct_field_go_name(
@@ -234,20 +253,6 @@ pub(crate) fn is_raw_function_type(ty: &Type) -> bool {
 
 pub(crate) fn stringer_verb(is_function: bool) -> &'static str {
     if is_function { "%p" } else { "%v" }
-}
-
-fn is_stringer_signature(method_ty: Option<&Type>) -> bool {
-    let Some(ty) = method_ty else {
-        return false;
-    };
-    let func = match ty {
-        Type::Forall { body, .. } => body.as_ref(),
-        other => other,
-    };
-    let Type::Function(f) = func else {
-        return false;
-    };
-    f.params.len() == 1 && matches!(f.return_type.as_ref(), Type::Simple(SimpleKind::String))
 }
 
 fn is_option_type(ty: &Type) -> bool {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -753,6 +753,19 @@ impl Type {
         }
     }
 
+    pub fn is_stringer_signature(&self) -> bool {
+        let func = match self {
+            Type::Forall { body, .. } => body.as_ref(),
+            other => other,
+        };
+        matches!(
+            func,
+            Type::Function(f)
+                if f.params.len() == 1
+                    && matches!(f.return_type.as_ref(), Type::Simple(SimpleKind::String))
+        )
+    }
+
     pub fn has_name(&self, name: &str) -> bool {
         match self {
             Type::Nominal { id, .. } => id.last_segment() == name,

--- a/tests/spec/emit/snapshots/pointer_backed_newtype_emits_no_stringer.snap
+++ b/tests/spec/emit/snapshots/pointer_backed_newtype_emits_no_stringer.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Handle(Ref<int>)\n"
+---
+package main
+
+type Handle *int

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -894,6 +894,14 @@ struct UserId(int)
 }
 
 #[test]
+fn pointer_backed_newtype_emits_no_stringer() {
+    let input = r#"
+struct Handle(Ref<int>)
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_single_field_construction() {
     let input = r#"
 struct UserId(int)


### PR DESCRIPTION
Converges the five scattered stringer synthesis decision sites onto a single `should_synthesize_stringer` predicate, so synthesis of `String` and `GoString` can later be gated on the upcoming `#[displayable]` attribute.

Follow-up to #567