### PR TITLE
fix: lsp goto-def on type alias with same name as origin type name

### DIFF
--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -1,5 +1,7 @@
 use rustc_hash::FxHashMap;
-use syntax::ast::{Expression, MatchArm, Pattern, Span, StructFieldPattern, TypedPattern};
+use syntax::ast::{
+    Annotation, Expression, MatchArm, Pattern, Span, StructFieldPattern, TypedPattern,
+};
 use syntax::types::unqualified_name;
 
 use crate::analysis::find_module_by_alias;
@@ -182,6 +184,66 @@ pub(crate) fn resolve_import_span(
             None
         }
     })
+}
+
+/// Goto-def target for a cursor inside a type annotation tree.
+pub(crate) fn resolve_annotation_definition(
+    annotation: &Annotation,
+    offset: u32,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<Span> {
+    if !offset_in_span(offset, &annotation.get_span()) {
+        return None;
+    }
+
+    let recurse = |child| resolve_annotation_definition(child, offset, file, snapshot);
+
+    match annotation {
+        Annotation::Constructor { name, span, params } => params
+            .iter()
+            .find_map(recurse)
+            .or_else(|| resolve_constructor_name(name, *span, offset, file, snapshot)),
+        Annotation::Function {
+            params,
+            return_type,
+            ..
+        } => params
+            .iter()
+            .find_map(recurse)
+            .or_else(|| recurse(return_type.as_ref())),
+        Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),
+        Annotation::Unknown | Annotation::Opaque { .. } => None,
+    }
+}
+
+/// Resolve a `Constructor` name's goto target. Routes the simple side through
+/// the qualifier's module so a same-named local can't shadow it.
+fn resolve_constructor_name(
+    name: &str,
+    span: Span,
+    offset: u32,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<Span> {
+    let cursor_in_name = (offset - span.byte_offset) as usize;
+    let dot_pos = name.find('.').unwrap_or(name.len());
+
+    if cursor_in_name <= dot_pos {
+        let first = &name[..dot_pos];
+        return resolve_import_span(first, file, &snapshot.result.go_package_names)
+            .or_else(|| lookup_definition_span(first, file, snapshot));
+    }
+
+    let (qualifier, simple) = name.split_once('.')?;
+    let module_name = find_module_by_alias(file, qualifier, &snapshot.result.go_package_names)?;
+
+    let qualified = format!("{}.{}", module_name, simple);
+
+    snapshot
+        .definitions()
+        .get(qualified.as_str())
+        .and_then(|d| d.name_span())
 }
 
 pub(crate) fn lookup_definition_span(

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -23,10 +23,10 @@ use crate::completion::{
     get_module_prefix, get_type_completions, resolve_variable_type,
 };
 use crate::definition::{
-    find_struct_field_span, is_go_typedef_span, lookup_definition_span, resolve_definition_span,
-    resolve_dot_access_definition, resolve_enum_in_pattern, resolve_import_span,
-    resolve_match_pattern_definition, resolve_struct_call_field, resolve_word_at_offset,
-    word_at_offset,
+    find_struct_field_span, is_go_typedef_span, lookup_definition_span,
+    resolve_annotation_definition, resolve_definition_span, resolve_dot_access_definition,
+    resolve_enum_in_pattern, resolve_import_span, resolve_match_pattern_definition,
+    resolve_struct_call_field, resolve_word_at_offset, word_at_offset,
 };
 use crate::paths::uri_to_module_file;
 use crate::project::find_project_root;
@@ -321,6 +321,18 @@ impl LanguageServer for Backend {
                 if offset_in_span(offset, name_span) =>
             {
                 Some(*name_span)
+            }
+
+            syntax::ast::Expression::TypeAlias {
+                name_span,
+                annotation,
+                ..
+            } => {
+                if offset_in_span(offset, name_span) {
+                    Some(*name_span)
+                } else {
+                    resolve_annotation_definition(annotation, offset, file, &snapshot)
+                }
             }
 
             syntax::ast::Expression::Struct {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -10523,6 +10523,197 @@ async fn goto_definition_struct_field_in_definition() {
 }
 
 #[tokio::test]
+async fn goto_definition_type_alias_rhs_with_shadowing_lhs_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+
+    let src = root.join("src");
+    let server_dir = src.join("server");
+    let response_dir = server_dir.join("response");
+    std::fs::create_dir_all(&response_dir).unwrap();
+
+    let response_content = "pub enum Code { Ok, NotFound }\n";
+    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+
+    let routes_content = "import \"server/response\"\n\ntype Code = response.Code\n";
+    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let response_uri = Url::from_file_path(response_dir.join("response.lis"))
+        .unwrap()
+        .to_string();
+    let routes_uri = Url::from_file_path(server_dir.join("routes.lis"))
+        .unwrap()
+        .to_string();
+
+    client.open(&response_uri, response_content).await;
+    client.open(&routes_uri, routes_content).await;
+
+    let lhs =
+        definition_location(&client.goto_definition(&routes_uri, 2, 6).await.unwrap()).unwrap();
+    assert_eq!(lhs.uri.as_str(), routes_uri);
+    assert_eq!(lhs.range.start.line, 2);
+
+    let qualifier =
+        definition_location(&client.goto_definition(&routes_uri, 2, 14).await.unwrap()).unwrap();
+    assert_eq!(qualifier.uri.as_str(), routes_uri);
+    assert_eq!(qualifier.range.start.line, 0);
+
+    let rhs =
+        definition_location(&client.goto_definition(&routes_uri, 2, 23).await.unwrap()).unwrap();
+    assert_eq!(rhs.uri.as_str(), response_uri);
+    assert_eq!(rhs.range.start.line, 0);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_type_alias_inside_generic_param() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+
+    let src = root.join("src");
+    let server_dir = src.join("server");
+    let response_dir = server_dir.join("response");
+    std::fs::create_dir_all(&response_dir).unwrap();
+
+    let response_content = "pub enum Code { Ok, NotFound }\n";
+    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+
+    let routes_content = "import \"server/response\"\n\ntype Codes = Slice<response.Code>\n";
+    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let response_uri = Url::from_file_path(response_dir.join("response.lis"))
+        .unwrap()
+        .to_string();
+    let routes_uri = Url::from_file_path(server_dir.join("routes.lis"))
+        .unwrap()
+        .to_string();
+
+    client.open(&response_uri, response_content).await;
+    client.open(&routes_uri, routes_content).await;
+
+    let qualifier =
+        definition_location(&client.goto_definition(&routes_uri, 2, 22).await.unwrap()).unwrap();
+    assert_eq!(qualifier.uri.as_str(), routes_uri);
+
+    let inner =
+        definition_location(&client.goto_definition(&routes_uri, 2, 30).await.unwrap()).unwrap();
+    assert_eq!(inner.uri.as_str(), response_uri);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_type_alias_inside_function_annotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+
+    let src = root.join("src");
+    let server_dir = src.join("server");
+    let response_dir = server_dir.join("response");
+    std::fs::create_dir_all(&response_dir).unwrap();
+
+    let response_content = "pub enum Code { Ok, NotFound }\n";
+    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+
+    let routes_content =
+        "import \"server/response\"\n\ntype Handler = fn(response.Code) -> response.Code\n";
+    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let response_uri = Url::from_file_path(response_dir.join("response.lis"))
+        .unwrap()
+        .to_string();
+    let routes_uri = Url::from_file_path(server_dir.join("routes.lis"))
+        .unwrap()
+        .to_string();
+
+    client.open(&response_uri, response_content).await;
+    client.open(&routes_uri, routes_content).await;
+
+    let param =
+        definition_location(&client.goto_definition(&routes_uri, 2, 28).await.unwrap()).unwrap();
+    assert_eq!(param.uri.as_str(), response_uri);
+
+    let ret =
+        definition_location(&client.goto_definition(&routes_uri, 2, 46).await.unwrap()).unwrap();
+    assert_eq!(ret.uri.as_str(), response_uri);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_type_alias_inside_tuple_annotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+
+    let src = root.join("src");
+    let server_dir = src.join("server");
+    let response_dir = server_dir.join("response");
+    std::fs::create_dir_all(&response_dir).unwrap();
+
+    let response_content = "pub enum Code { Ok, NotFound }\n";
+    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+
+    let routes_content = "import \"server/response\"\n\ntype Pair = (response.Code, int)\n";
+    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+
+    let response_uri = Url::from_file_path(response_dir.join("response.lis"))
+        .unwrap()
+        .to_string();
+    let routes_uri = Url::from_file_path(server_dir.join("routes.lis"))
+        .unwrap()
+        .to_string();
+
+    client.open(&response_uri, response_content).await;
+    client.open(&routes_uri, routes_content).await;
+
+    let qualifier =
+        definition_location(&client.goto_definition(&routes_uri, 2, 15).await.unwrap()).unwrap();
+    assert_eq!(qualifier.uri.as_str(), routes_uri);
+
+    let inner =
+        definition_location(&client.goto_definition(&routes_uri, 2, 23).await.unwrap()).unwrap();
+    assert_eq!(inner.uri.as_str(), response_uri);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_type_alias_rhs_same_module() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "struct Bar { x: int }\ntype Foo = Bar\n";
+    client.open(TEST_URI, source).await;
+
+    let rhs = definition_location(&client.goto_definition(TEST_URI, 1, 12).await.unwrap()).unwrap();
+    assert_eq!(rhs.uri.as_str(), TEST_URI);
+    assert_eq!(rhs.range.start.line, 0);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn hover_struct_field_in_definition() {
     let mut client = TestClient::new().await;
     client.initialize().await;


### PR DESCRIPTION
This change fixes lsp goto definition for type aliases where the name matches the origin name eg:

`type Code = response.Code`

```rust
import "server/response"

type Code = response.Code
//                   ^ goto def not working because alias name is same as origin
```

This change also handles goto for nested annotations eg.

```rust
type Code = Slice<response.Code>
type Handler = fn(response.Code) -> response.Code
type Pair = (response.Code, int)
```