### PR TITLE
feat: introduce `#[displayable]` attribute

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -94,6 +94,15 @@ pub fn displayable_on_pointer_newtype(attribute_span: &Span) -> LisetteDiagnosti
         )
 }
 
+pub fn displayable_specialized_to_string(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[displayable]` conflicts with your `to_string`")
+        .with_attribute_code("displayable_specialized_to_string")
+        .with_span_label(attribute_span, "adds a `to_string` of its own")
+        .with_help(
+            "`#[displayable]` needs a plain `fn to_string(self) -> string` on the type. Write `to_string` in that form, or remove `#[displayable]`.",
+        )
+}
+
 pub fn iterable_variants_conflict(
     attribute_span: &Span,
     existing_span: Option<&Span>,

--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -39,6 +39,32 @@ impl Planner<'_> {
         }
     }
 
+    pub(crate) fn collect_user_to_string_types(&mut self, files: &[&File]) {
+        for file in files {
+            for item in &file.items {
+                let Expression::ImplBlock {
+                    receiver_name,
+                    methods,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                for method in methods {
+                    if !is_display_to_string(method) {
+                        continue;
+                    }
+                    let qualified = self.facts.qualified_current(receiver_name);
+                    if self.facts.is_ufcs_method(qualified.as_str(), "to_string") {
+                        continue;
+                    }
+                    self.module
+                        .record_user_to_string_type(receiver_name.to_string());
+                }
+            }
+        }
+    }
+
     /// Detect free top-level private Lisette names (free functions and
     /// constants) whose natural Go form would collide after `escape_reserved`
     /// — e.g. `len` escapes to `len_` and clashes with a sibling `len_`. The
@@ -169,4 +195,21 @@ impl Planner<'_> {
 
         code
     }
+}
+
+fn is_display_to_string(method: &Expression) -> bool {
+    if !matches!(method, Expression::Function { .. }) {
+        return false;
+    }
+    let func = method.to_function_definition();
+    func.name.as_str() == "to_string"
+        && func.params.len() == 1
+        && matches!(
+            &func.params[0].pattern,
+            syntax::ast::Pattern::Identifier { identifier, .. } if identifier == "self"
+        )
+        && matches!(
+            func.return_type,
+            syntax::types::Type::Simple(syntax::types::SimpleKind::String)
+        )
 }

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -127,6 +127,12 @@ impl Planner<'_> {
                         .or_default()
                         .push(*name_span);
                 }
+                if self.should_synthesize_to_string(name, attributes) {
+                    members
+                        .entry(self.to_string_method_go_name())
+                        .or_default()
+                        .push(*name_span);
+                }
             }
             Expression::Enum {
                 name,
@@ -193,6 +199,12 @@ impl Planner<'_> {
                 if synthesize && !has_user_go_string {
                     members
                         .entry(ENUM_GO_STRINGER_METHOD.to_string())
+                        .or_default()
+                        .push(*name_span);
+                }
+                if self.should_synthesize_to_string(name, attributes) {
+                    members
+                        .entry(self.to_string_method_go_name())
                         .or_default()
                         .push(*name_span);
                 }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -83,6 +83,7 @@ impl Planner<'_> {
             result.push_str("\n\n");
             result.push_str(&layout.emit_variants_function(&fn_name));
         }
+        self.append_to_string_method(&mut result, name, &receiver_generics, attributes);
         if needs_fmt {
             fx.require_fmt();
         }

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -56,7 +56,8 @@ impl Planner<'_> {
             )
         };
 
-        if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) {
+        let mut result = if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs)
+        {
             let string_method = emit_struct_stringer_method(
                 name,
                 &receiver_generics,
@@ -69,7 +70,9 @@ impl Planner<'_> {
             format!("{definition}\n\n{string_method}")
         } else {
             definition
-        }
+        };
+        self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
+        result
     }
 
     /// Emit a tuple struct and its optional Stringer.
@@ -83,26 +86,28 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> String {
         let definition = self.emit_tuple_struct_definition(name, generics_string, fields, fx);
-        let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) else {
-            return definition;
-        };
         let receiver_generics = receiver_generics_string(generics);
-        let is_type_alias = fields.len() == 1 && generics_string.is_empty();
-        let underlying_go_type = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
-        let string_method = emit_tuple_struct_stringer_method(
-            name,
-            &receiver_generics,
-            fields.len(),
-            underlying_go_type.as_deref(),
-            stringer_name,
-        );
-        if string_method.is_empty() {
-            return definition;
+        let mut result = definition;
+        if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) {
+            let is_type_alias = fields.len() == 1 && generics_string.is_empty();
+            let underlying_go_type = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
+            let string_method = emit_tuple_struct_stringer_method(
+                name,
+                &receiver_generics,
+                fields.len(),
+                underlying_go_type.as_deref(),
+                stringer_name,
+            );
+            if !string_method.is_empty() {
+                if string_method.contains("fmt.") {
+                    fx.require_fmt();
+                }
+                result.push_str("\n\n");
+                result.push_str(&string_method);
+            }
         }
-        if string_method.contains("fmt.") {
-            fx.require_fmt();
-        }
-        format!("{definition}\n\n{string_method}")
+        self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
+        result
     }
 
     /// Emit one Go struct field with its stringer metadata.
@@ -200,6 +205,32 @@ impl Planner<'_> {
         (has_stringer, has_go_stringer)
     }
 
+    pub(crate) fn should_synthesize_to_string(&self, name: &str, attributes: &[Attribute]) -> bool {
+        attributes.iter().any(|a| a.name == "displayable") && !self.module.has_user_to_string(name)
+    }
+
+    pub(crate) fn to_string_method_go_name(&self) -> String {
+        if self.method_needs_export("to_string") {
+            go_name::snake_to_camel("to_string")
+        } else {
+            go_name::escape_keyword("to_string").into_owned()
+        }
+    }
+
+    pub(crate) fn append_to_string_method(
+        &self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        attributes: &[Attribute],
+    ) {
+        if self.should_synthesize_to_string(name, attributes) {
+            let go_method = self.to_string_method_go_name();
+            out.push_str("\n\n");
+            out.push_str(&emit_to_string_method(name, receiver_generics, &go_method));
+        }
+    }
+
     /// Single stringer to synthesize for structs: `String` by default,
     /// `GoString` when the user already supplies `String`, none when both
     /// exist. Enums use [`Self::stringer_overrides`] directly, since they
@@ -267,6 +298,15 @@ fn is_option_type(ty: &Type) -> bool {
         }
         _ => false,
     }
+}
+
+fn emit_to_string_method(name: &str, receiver_generics: &str, method_name: &str) -> String {
+    let receiver = receiver_name(name);
+    let go_type_name = go_name::escape_keyword(name);
+    let receiver_type = format!("{go_type_name}{receiver_generics}");
+    format!(
+        "func ({receiver} {receiver_type}) {method_name}() string {{\nreturn {receiver}.String()\n}}"
+    )
 }
 
 fn emit_struct_stringer_method(

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -110,6 +110,12 @@ impl GlobalEmitData {
                 _ => {}
             }
 
+            if definition.visibility.is_public() && definition.is_displayable() {
+                globals
+                    .exported_method_names
+                    .insert("to_string".to_string());
+            }
+
             if let Definition {
                 name: Some(name),
                 body: DefinitionBody::Enum { variants, .. },

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -40,6 +40,7 @@ impl Planner<'_> {
         let mut collection_effects = EmitEffects::default();
         self.collect_module_aliases(files);
         self.collect_local_exported_method_names(files);
+        self.collect_user_to_string_types(files);
         self.collect_generic_constraints(files, &mut collection_effects);
         self.collect_enum_layouts();
         self.collect_escape_remap(files);

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -9,6 +9,7 @@ pub(crate) struct ModuleState {
     enum_layouts: HashMap<String, EnumLayout>,
     tag_exported_fields: HashSet<String>,
     exported_method_names: HashSet<String>,
+    user_to_string_types: HashSet<String>,
     module_aliases: HashMap<String, String>,
     reverse_module_aliases: HashMap<String, String>,
     escape_remap: HashMap<String, String>,
@@ -42,6 +43,14 @@ impl ModuleState {
 
     pub(crate) fn has_local_exported_method_name(&self, name: &str) -> bool {
         self.exported_method_names.contains(name)
+    }
+
+    pub(crate) fn record_user_to_string_type(&mut self, type_name: impl Into<String>) {
+        self.user_to_string_types.insert(type_name.into());
+    }
+
+    pub(crate) fn has_user_to_string(&self, type_name: &str) -> bool {
+        self.user_to_string_types.contains(type_name)
     }
 
     pub(crate) fn record_module_alias(

--- a/crates/semantics/src/checker/registration/displayable.rs
+++ b/crates/semantics/src/checker/registration/displayable.rs
@@ -1,123 +1,256 @@
-use syntax::ast::{Attribute, Expression};
+use syntax::ast::{Attribute, Expression, Span};
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::Symbol;
+use syntax::types::{Symbol, Type};
 
-use super::TaskState;
+use super::{TaskState, wrap_with_impl_generics};
+use crate::call_classification::is_ufcs_method_type;
 use crate::store::Store;
 
 impl TaskState<'_> {
-    pub(super) fn register_displayable(&mut self, store: &Store, items: &[Expression]) {
+    pub(super) fn register_displayable(&mut self, store: &mut Store, items: &[Expression]) {
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(store);
+        let mut candidates = Vec::new();
         for item in items {
-            self.check_displayable_item(store, &module_id, item, is_d_lis);
+            collect_displayable_candidates(item, is_d_lis, &mut candidates);
+        }
+        for candidate in candidates {
+            self.process_displayable_candidate(store, &module_id, candidate);
         }
     }
 
-    pub(super) fn register_module_displayable(&mut self, store: &Store, module_id: &str) {
-        let module = store.get_module(module_id).expect("module must exist");
-        for file in module.files.values() {
-            let is_d_lis = file.is_d_lis();
-            for item in &file.items {
-                self.check_displayable_item(store, module_id, item, is_d_lis);
+    pub(super) fn register_module_displayable(&mut self, store: &mut Store, module_id: &str) {
+        let candidates = {
+            let module = store.get_module(module_id).expect("module must exist");
+            let mut candidates = Vec::new();
+            for file in module.files.values() {
+                let is_d_lis = file.is_d_lis();
+                for item in &file.items {
+                    collect_displayable_candidates(item, is_d_lis, &mut candidates);
+                }
             }
+            candidates
+        };
+
+        for candidate in candidates {
+            self.process_displayable_candidate(store, module_id, candidate);
         }
     }
 
-    fn check_displayable_item(
+    fn process_displayable_candidate(
         &mut self,
-        store: &Store,
+        store: &mut Store,
         module_id: &str,
-        item: &Expression,
-        is_d_lis: bool,
+        candidate: DisplayableCandidate,
     ) {
-        match item {
-            Expression::Struct {
-                attributes,
-                name,
-                fields,
-                ..
-            } => {
-                if let Some(attribute) = displayable_attribute(attributes) {
-                    self.validate_displayable(store, module_id, attribute, is_d_lis, Some(name));
-                }
-                for field in fields {
-                    self.reject_misplaced_displayable(&field.attributes);
-                }
+        let DisplayableCandidate {
+            attribute_span,
+            kind,
+        } = candidate;
+        let TypeCandidate {
+            name,
+            is_struct,
+            is_d_lis,
+            has_args,
+        } = match kind {
+            CandidateKind::Misplaced => {
+                self.sink
+                    .push(diagnostics::attribute::displayable_not_a_struct_or_enum(
+                        &attribute_span,
+                    ));
+                return;
             }
-            Expression::Enum { attributes, .. } => {
-                if let Some(attribute) = displayable_attribute(attributes) {
-                    self.validate_displayable(store, module_id, attribute, is_d_lis, None);
-                }
-            }
-            Expression::Function { attributes, .. } => {
-                self.reject_misplaced_displayable(attributes);
-            }
-            Expression::ImplBlock { methods, .. } => {
-                self.reject_misplaced_displayable_methods(methods)
-            }
-            Expression::Interface {
-                method_signatures, ..
-            } => self.reject_misplaced_displayable_methods(method_signatures),
-            _ => {}
-        }
-    }
+            CandidateKind::Type(type_candidate) => type_candidate,
+        };
 
-    fn validate_displayable(
-        &mut self,
-        store: &Store,
-        module_id: &str,
-        attribute: &Attribute,
-        is_d_lis: bool,
-        struct_name: Option<&str>,
-    ) {
-        if !attribute.args.is_empty() {
+        if has_args {
             self.sink
                 .push(diagnostics::attribute::displayable_with_arguments(
-                    &attribute.span,
+                    &attribute_span,
                 ));
             return;
         }
         if is_d_lis {
             self.sink
                 .push(diagnostics::attribute::displayable_in_typedef(
-                    &attribute.span,
+                    &attribute_span,
                 ));
             return;
         }
-        if let Some(name) = struct_name {
-            let qualified = Symbol::from_parts(module_id, name);
-            if let Some(definition) = store.get_definition(qualified.as_str())
-                && is_pointer_backed_newtype(definition)
-            {
-                self.sink
-                    .push(diagnostics::attribute::displayable_on_pointer_newtype(
-                        &attribute.span,
-                    ));
-            }
-        }
-    }
 
-    fn reject_misplaced_displayable(&mut self, attributes: &[Attribute]) {
-        if let Some(attribute) = displayable_attribute(attributes) {
+        let qualified = Symbol::from_parts(module_id, &name);
+        if is_struct
+            && let Some(definition) = store.get_definition(qualified.as_str())
+            && is_pointer_backed_newtype(definition)
+        {
             self.sink
-                .push(diagnostics::attribute::displayable_not_a_struct_or_enum(
-                    &attribute.span,
+                .push(diagnostics::attribute::displayable_on_pointer_newtype(
+                    &attribute_span,
                 ));
+            return;
         }
+
+        self.synthesize_to_string(store, module_id, &attribute_span, &qualified);
     }
 
-    fn reject_misplaced_displayable_methods(&mut self, methods: &[Expression]) {
-        for method in methods {
-            if let Expression::Function { attributes, .. } = method {
-                self.reject_misplaced_displayable(attributes);
+    fn synthesize_to_string(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        attribute_span: &Span,
+        qualified: &Symbol,
+    ) {
+        let Some(scheme) = store.get_type(qualified.as_str()).cloned() else {
+            return;
+        };
+        let Some(generics) = store
+            .get_definition(qualified.as_str())
+            .and_then(type_generics)
+        else {
+            return;
+        };
+
+        if let Some(user_ty) = user_to_string_type(store, qualified) {
+            if is_ufcs_method_type(&user_ty, generics.len()) {
+                self.sink
+                    .push(diagnostics::attribute::displayable_specialized_to_string(
+                        attribute_span,
+                    ));
+                return;
             }
+            if user_ty.is_stringer_signature() {
+                return;
+            }
+        }
+
+        let receiver_ty = match scheme {
+            Type::Forall { body, .. } => *body,
+            other => other,
+        };
+        let fn_ty = Type::function(
+            vec![receiver_ty],
+            vec![false],
+            Default::default(),
+            Box::new(Type::string()),
+        );
+        let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &[]);
+
+        let module = store.get_module_mut(module_id).expect("module must exist");
+        if let Some(methods) = module
+            .definitions
+            .get_mut(qualified.as_str())
+            .and_then(Definition::methods_mut)
+        {
+            methods.insert("to_string".into(), method_ty);
         }
     }
 }
 
+fn user_to_string_type(store: &Store, qualified: &Symbol) -> Option<Type> {
+    match &store.get_definition(qualified.as_str())?.body {
+        DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. } => {
+            methods.get("to_string").cloned()
+        }
+        _ => None,
+    }
+}
+
+fn type_generics(definition: &Definition) -> Option<Vec<syntax::ast::Generic>> {
+    match &definition.body {
+        DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
+            Some(generics.clone())
+        }
+        _ => None,
+    }
+}
+
+struct DisplayableCandidate {
+    attribute_span: Span,
+    kind: CandidateKind,
+}
+
+enum CandidateKind {
+    Type(TypeCandidate),
+    Misplaced,
+}
+
+struct TypeCandidate {
+    name: String,
+    is_struct: bool,
+    is_d_lis: bool,
+    has_args: bool,
+}
+
 fn displayable_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
     attributes.iter().find(|a| a.name == "displayable")
+}
+
+fn misplaced_candidate(attribute: &Attribute) -> DisplayableCandidate {
+    DisplayableCandidate {
+        attribute_span: attribute.span,
+        kind: CandidateKind::Misplaced,
+    }
+}
+
+fn collect_method_attributes(methods: &[Expression], out: &mut Vec<DisplayableCandidate>) {
+    for method in methods {
+        if let Expression::Function { attributes, .. } = method {
+            out.extend(displayable_attribute(attributes).map(misplaced_candidate));
+        }
+    }
+}
+
+fn collect_displayable_candidates(
+    item: &Expression,
+    is_d_lis: bool,
+    out: &mut Vec<DisplayableCandidate>,
+) {
+    match item {
+        Expression::Struct {
+            attributes,
+            name,
+            fields,
+            ..
+        } => {
+            if let Some(attribute) = displayable_attribute(attributes) {
+                out.push(DisplayableCandidate {
+                    attribute_span: attribute.span,
+                    kind: CandidateKind::Type(TypeCandidate {
+                        name: name.to_string(),
+                        is_struct: true,
+                        is_d_lis,
+                        has_args: !attribute.args.is_empty(),
+                    }),
+                });
+            }
+            for field in fields {
+                out.extend(displayable_attribute(&field.attributes).map(misplaced_candidate));
+            }
+        }
+        Expression::Enum {
+            attributes, name, ..
+        } => {
+            if let Some(attribute) = displayable_attribute(attributes) {
+                out.push(DisplayableCandidate {
+                    attribute_span: attribute.span,
+                    kind: CandidateKind::Type(TypeCandidate {
+                        name: name.to_string(),
+                        is_struct: false,
+                        is_d_lis,
+                        has_args: !attribute.args.is_empty(),
+                    }),
+                });
+            }
+        }
+        Expression::Function { attributes, .. } => {
+            out.extend(displayable_attribute(attributes).map(misplaced_candidate));
+        }
+        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
+        Expression::Interface {
+            method_signatures, ..
+        } => collect_method_attributes(method_signatures, out),
+        _ => {}
+    }
 }
 
 fn is_pointer_backed_newtype(definition: &Definition) -> bool {

--- a/docs/reference/11-interfaces.md
+++ b/docs/reference/11-interfaces.md
@@ -3,8 +3,8 @@
 An interface is a set of method signatures that a type can implement.
 
 ```rust
-interface Display {
-  fn to_string(self) -> string
+interface Shape {
+  fn area(self) -> int
 }
 ```
 
@@ -13,18 +13,18 @@ interface Display {
 Lisette uses structural typing for interfaces, so a type automatically implements an interface by having all its methods:
 
 ```rust
-struct Point {
-  x: int,
-  y: int,
+struct Rectangle {
+  width: int,
+  height: int,
 }
 
-impl Point {
-  fn to_string(self) -> string {
-    f"({self.x}, {self.y})"
-  }  
+impl Rectangle {
+  fn area(self) -> int {
+    self.width * self.height
+  }
 }
 
-// `Point` automatically implements `Display`
+// `Rectangle` automatically implements `Shape`
 ```
 
 📚 See [`05-functions.md`](05-functions.md)

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -1,10 +1,6 @@
 # Attributes
 
-Attributes attach metadata or behavior to declarations:
-
-- structs and fields for serialization,
-- enums for iteration, and
-- functions for lint suppression.
+Attributes attach metadata or behavior to declarations.
 
 ## Serialization
 
@@ -167,6 +163,28 @@ for direction in Direction.variants() {
 ```
 
 `Direction.variants()` returns a `Slice<Direction>`. Only enums whose variants have no payloads can be `#[iterable]`.
+
+## Display
+
+Add `#[displayable]` to a struct or enum to synthesize a `to_string(self) -> string` method.
+
+```rs
+interface Display {
+  fn to_string(self) -> string
+}
+
+#[displayable]
+struct Point {
+  x: int,
+  y: int,
+}
+
+fn render(value: Display) -> string {
+  value.to_string()
+}
+
+render(Point { x: 1, y: 2 }) // `Point` satisfies `Display`
+```
 
 <br>
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -45,6 +45,112 @@ fn main() {
 }
 
 #[test]
+fn displayable_cross_module_to_string_exported() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "point.lis",
+        r#"
+#[displayable]
+pub struct Point {
+  pub x: int,
+  pub y: int,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "util"
+
+fn main() {
+  let p = util.Point { x: 1, y: 2 }
+  fmt.Print(p.to_string())
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn displayable_cross_module_satisfies_local_interface() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "point.lis",
+        r#"
+#[displayable]
+pub struct Point {
+  pub x: int,
+  pub y: int,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "util"
+
+interface Display {
+  fn to_string(self) -> string
+}
+
+fn render(value: Display) -> string {
+  value.to_string()
+}
+
+fn main() {
+  let p = util.Point { x: 1, y: 2 }
+  fmt.Print(render(p))
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn go_name_collision_user_to_string_wrong_signature() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[displayable]
+struct A {
+  x: int,
+}
+
+impl A {
+  fn to_string(self) -> int {
+    0
+  }
+}
+
+fn main() {
+  let a = A { x: 1 }
+  let _ = a.to_string()
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes.iter().any(|code| code == "emit.go_name_collision"),
+        "a wrong-signature user to_string does not suppress synthesis, so the synthesized to_string collides with it; got: {codes:?}"
+    );
+}
+
+#[test]
 fn user_function_returning_result_no_type_args() {
     let mut fs = MockFileSystem::new();
 
@@ -6176,6 +6282,32 @@ fn main() {
     assert!(
         codes.iter().any(|code| code == "emit.go_name_collision"),
         "field string exports to String, colliding with the generated String() method; got: {codes:?}"
+    );
+}
+
+#[test]
+fn go_name_collision_member_vs_synthesized_to_string() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[displayable]
+struct Point {
+  to_string: int,
+}
+
+fn main() {
+  let p = Point { to_string: 1 }
+  let _ = p.to_string
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes.iter().any(|code| code == "emit.go_name_collision"),
+        "field to_string collides with the synthesized #[displayable] to_string() method; got: {codes:?}"
     );
 }
 

--- a/tests/spec/build/snapshots/displayable_cross_module_satisfies_local_interface.snap
+++ b/tests/spec/build/snapshots/displayable_cross_module_satisfies_local_interface.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/util"
+)
+
+type Display interface {
+	ToString() string
+}
+
+func render(value Display) string {
+	return value.ToString()
+}
+
+func main() {
+	p := util.Point{
+		X: 1,
+		Y: 2,
+	}
+	fmt.Print(render(p))
+}
+
+
+// === util/point.go ===
+package util
+
+import "fmt"
+
+type Point struct {
+	X int
+	Y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
+}
+
+func (p Point) ToString() string {
+	return p.String()
+}

--- a/tests/spec/build/snapshots/displayable_cross_module_to_string_exported.snap
+++ b/tests/spec/build/snapshots/displayable_cross_module_to_string_exported.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/util"
+)
+
+func main() {
+	p := util.Point{
+		X: 1,
+		Y: 2,
+	}
+	fmt.Print(p.ToString())
+}
+
+
+// === util/point.go ===
+package util
+
+import "fmt"
+
+type Point struct {
+	X int
+	Y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
+}
+
+func (p Point) ToString() string {
+	return p.String()
+}

--- a/tests/spec/emit/snapshots/displayable_enum_synthesizes_to_string.snap
+++ b/tests/spec/emit/snapshots/displayable_enum_synthesizes_to_string.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nenum Color { Red, Green }\n"
+---
+package main
+
+import "fmt"
+
+func MakeColorRed() Color {
+	return Color{Tag: ColorRed}
+}
+
+func MakeColorGreen() Color {
+	return Color{Tag: ColorGreen}
+}
+
+type ColorTag int
+
+const (
+	ColorRed ColorTag = iota
+	ColorGreen
+)
+
+type Color struct {
+	Tag ColorTag
+}
+
+func (c Color) String() string {
+	switch c.Tag {
+	case ColorRed:
+		return "Red"
+	case ColorGreen:
+		return "Green"
+	default:
+		return fmt.Sprintf("Color(%d)", c.Tag)
+	}
+}
+
+func (c Color) GoString() string {
+	switch c.Tag {
+	case ColorRed:
+		return "Color.Red"
+	case ColorGreen:
+		return "Color.Green"
+	default:
+		return fmt.Sprintf("Color(%d)", c.Tag)
+	}
+}
+
+func (c Color) to_string() string {
+	return c.String()
+}

--- a/tests/spec/emit/snapshots/displayable_generic_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/displayable_generic_struct_to_string.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct Box<T> { value: T }\n"
+---
+package main
+
+import "fmt"
+
+type Box[T any] struct {
+	value T
+}
+
+func (b Box[T]) String() string {
+	return fmt.Sprintf("Box { value: %v }", b.value)
+}
+
+func (b Box[T]) to_string() string {
+	return b.String()
+}

--- a/tests/spec/emit/snapshots/displayable_satisfies_display_interface.snap
+++ b/tests/spec/emit/snapshots/displayable_satisfies_display_interface.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \ninterface Display {\n  fn to_string(self) -> string\n}\n\n#[displayable]\nstruct Point { x: int, y: int }\n\nfn render(d: Display) -> string {\n  d.to_string()\n}\n\nfn use_it() -> string {\n  render(Point { x: 1, y: 2 })\n}\n"
+---
+package main
+
+import "fmt"
+
+type Display interface {
+	to_string() string
+}
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
+}
+
+func (p Point) to_string() string {
+	return p.String()
+}
+
+func render(d Display) string {
+	return d.to_string()
+}
+
+func use_it() string {
+	return render(Point{
+		x: 1,
+		y: 2,
+	})
+}

--- a/tests/spec/emit/snapshots/displayable_struct_synthesizes_to_string.snap
+++ b/tests/spec/emit/snapshots/displayable_struct_synthesizes_to_string.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct Point { x: int, y: int }\n"
+---
+package main
+
+import "fmt"
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
+}
+
+func (p Point) to_string() string {
+	return p.String()
+}

--- a/tests/spec/emit/snapshots/displayable_to_string_delegates_to_user_stringer.snap
+++ b/tests/spec/emit/snapshots/displayable_to_string_delegates_to_user_stringer.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn string(self) -> string {\n    \"p\"\n  }\n}\n"
+---
+package main
+
+import "fmt"
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) GoString() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
+}
+
+func (p Point) to_string() string {
+	return p.String()
+}
+
+func (p Point) String() string {
+	return "p"
+}

--- a/tests/spec/emit/snapshots/displayable_user_to_string_suppresses_synthesis.snap
+++ b/tests/spec/emit/snapshots/displayable_user_to_string_suppresses_synthesis.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn to_string(self) -> string {\n    \"p\"\n  }\n}\n"
+---
+package main
+
+import "fmt"
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
+}
+
+func (p Point) to_string() string {
+	return "p"
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -31,6 +31,84 @@ fn count() -> int {
 }
 
 #[test]
+fn displayable_struct_synthesizes_to_string() {
+    let input = r#"
+#[displayable]
+struct Point { x: int, y: int }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_enum_synthesizes_to_string() {
+    let input = r#"
+#[displayable]
+enum Color { Red, Green }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_generic_struct_to_string() {
+    let input = r#"
+#[displayable]
+struct Box<T> { value: T }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_user_to_string_suppresses_synthesis() {
+    let input = r#"
+#[displayable]
+struct Point { x: int, y: int }
+
+impl Point {
+  fn to_string(self) -> string {
+    "p"
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_to_string_delegates_to_user_stringer() {
+    let input = r#"
+#[displayable]
+struct Point { x: int, y: int }
+
+impl Point {
+  fn string(self) -> string {
+    "p"
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_satisfies_display_interface() {
+    let input = r#"
+interface Display {
+  fn to_string(self) -> string
+}
+
+#[displayable]
+struct Point { x: int, y: int }
+
+fn render(d: Display) -> string {
+  d.to_string()
+}
+
+fn use_it() -> string {
+  render(Point { x: 1, y: 2 })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn struct_instantiation() {
     let input = r#"
 struct Point { x: int, y: int }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7497,6 +7497,23 @@ struct Handle(Ref<int>)
 }
 
 #[test]
+fn displayable_with_specialized_to_string() {
+    let input = r#"
+#[displayable]
+struct Box<T> {
+  value: T,
+}
+
+impl Box<int> {
+  fn to_string(self) -> string {
+    "boxed-int"
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_type_alias_record_struct_as_value() {
     let input = r#"
 struct Coord { x: int, y: int }

--- a/tests/ui/errors/snapshots/displayable_with_specialized_to_string.snap
+++ b/tests/ui/errors/snapshots/displayable_with_specialized_to_string.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` conflicts with your `to_string`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[displayable]
+   · ───────┬──────
+   ·        ╰── adds a `to_string` of its own
+ 3 │ struct Box<T> {
+   ╰────
+  help: `#[displayable]` needs a plain `fn to_string(self) -> string` on the type. Write `to_string` in that form, or remove `#[displayable]` · code: [attribute.displayable_specialized_to_string]


### PR DESCRIPTION
Adds a `#[displayable]` attribute that synthesizes a `to_string(self) -> string` method for any marked struct or enum.

```rs
interface Display {
  fn to_string(self) -> string
}

#[displayable]
struct Point {
  x: int,
  y: int,
}

fn render(value: Display) -> string {
  value.to_string()
}

render(Point { x: 1, y: 2 }) // `Point` satisfies `Display`
```

Follow-up to #567 and #568. The upcoming fourth PR in this series will make the attribute opt-in for rendering.