### PR TITLE
fix: make numeric value enums nominal

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1085,6 +1085,20 @@ pub fn incompatible_named_numeric_types(underlying_ty: &Type, span: Span) -> Lis
         ))
 }
 
+pub fn named_primitive_needs_cast(
+    primitive_ty: &Type,
+    named_ty: &Type,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type mismatch")
+        .with_infer_code("type_mismatch")
+        .with_span_label(
+            &span,
+            format!("cannot compute `{}` with `{}`", primitive_ty, named_ty),
+        )
+        .with_help(format!("Cast with `as`, e.g. `value as {}`", named_ty))
+}
+
 pub fn invalid_division_order(
     operator: &BinaryOperator,
     left_ty: &Type,

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -11,7 +11,6 @@ use syntax::types::Type;
 struct NumericBinaryEmitInfo {
     cast_left_to: Option<Type>,
     cast_right_to: Option<Type>,
-    cast_result_to: Option<Type>,
 }
 
 struct BinaryOperand<'a> {
@@ -246,11 +245,6 @@ impl Planner<'_> {
         };
 
         let result = format!("{} {} {}", left_string, operator, right_string);
-
-        let result = match &info.cast_result_to {
-            Some(ty) => format!("{}({})", self.go_type_string(ty, fx), result),
-            None => result,
-        };
         (setup, result)
     }
 }
@@ -335,19 +329,12 @@ fn is_casting_needed(
         return None;
     }
 
-    let left_underlying_ty = matching_underlying_numeric(&left.ty, &right.ty)?;
+    matching_underlying_numeric(&left.ty, &right.ty)?;
 
     let left_is_aliased = left.ty.is_aliased_numeric_type();
     let right_is_aliased = right.ty.is_aliased_numeric_type();
 
     if left.ty == right.ty {
-        if left_is_aliased && matches!(operator, BinaryOperator::Division) {
-            return Some(NumericBinaryEmitInfo {
-                cast_left_to: None,
-                cast_right_to: None,
-                cast_result_to: Some(left_underlying_ty),
-            });
-        }
         return None;
     }
 
@@ -358,12 +345,10 @@ fn is_casting_needed(
         (true, false) => Some(NumericBinaryEmitInfo {
             cast_left_to: None,
             cast_right_to: cast_unless_literal(right_is_literal, &left.ty),
-            cast_result_to: None,
         }),
         (false, true) => Some(NumericBinaryEmitInfo {
             cast_left_to: cast_unless_literal(left_is_literal, &right.ty),
             cast_right_to: None,
-            cast_result_to: None,
         }),
         _ => None,
     }

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -195,19 +195,15 @@ impl TaskState<'_> {
     }
 }
 
-/// Walks the alias chain through the store rather than the cached
-/// `underlying_ty` field so multi-hop aliases (with forward-declared
-/// intermediates) resolve. Rejects when any nominal in the chain is a value
-/// enum — those are a hard boundary requiring an explicit `as` cast.
+/// Walks the alias chain via the store so multi-hop aliases resolve, returning
+/// the underlying numeric type an untyped literal may adapt to (value enums and
+/// newtype structs included; a typed primitive still needs `as`).
 fn numeric_adapt_target(ty: &Type, store: &Store) -> Option<Type> {
     let mut current = ty.clone();
     let mut seen: FxHashSet<Symbol> = FxHashSet::default();
     while let Type::Nominal { id, params, .. } = &current {
         if !seen.insert(id.clone()) {
             break;
-        }
-        if store.value_variants_of(id).is_some() {
-            return None;
         }
         let Some(def) = store.get_definition(id.as_str()) else {
             break;
@@ -223,7 +219,7 @@ fn numeric_adapt_target(ty: &Type, store: &Store) -> Option<Type> {
         let map: SubstitutionMap = vars.iter().cloned().zip(params.iter().cloned()).collect();
         current = substitute(&body, &map);
     }
-    current.underlying_numeric_type()
+    current.literal_adaptation_target()
 }
 
 fn char_literal_codepoint(s: &str) -> Option<u64> {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -98,14 +98,15 @@ impl TaskState<'_> {
         expected_ty: &Type,
         span: Span,
     ) -> Expression {
-        // For negation with numeric expected type, propagate it to the operand
-        // so literals can adapt (e.g., `let x: int8 = -1` works)
-        let operand_expected_ty =
-            if operator == Negative && expected_ty.resolve_in(&self.env).is_numeric() {
-                expected_ty.clone()
-            } else {
-                self.new_type_var()
-            };
+        let propagate_to_operand = operator == Negative && {
+            let resolved = expected_ty.resolve_in(&self.env);
+            resolved.is_numeric() || resolved.has_underlying_numeric_type()
+        };
+        let operand_expected_ty = if propagate_to_operand {
+            expected_ty.clone()
+        } else {
+            self.new_type_var()
+        };
 
         if operator == Negative {
             self.scopes.increment_negation_depth();
@@ -421,20 +422,28 @@ impl TaskState<'_> {
                 let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
                 let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
 
-                let same_aliased_numeric = resolved_left_operand == resolved_right_operand
-                    && resolved_left_operand.is_aliased_numeric_type();
+                if !self.report_value_enum_boundary(
+                    &resolved_left_operand,
+                    &resolved_right_operand,
+                    store,
+                    span,
+                ) {
+                    let same_aliased_numeric = resolved_left_operand == resolved_right_operand
+                        && resolved_left_operand.is_aliased_numeric_type();
 
-                let different_but_compatible = resolved_left_operand != resolved_right_operand
-                    && resolved_left_operand.is_numeric_compatible_with(&resolved_right_operand);
+                    let different_but_compatible = resolved_left_operand != resolved_right_operand
+                        && resolved_left_operand
+                            .is_numeric_compatible_with(&resolved_right_operand);
 
-                if !same_aliased_numeric && !different_but_compatible {
-                    self.unify_binary_operands(
-                        store,
-                        operator,
-                        left_operand_ty,
-                        right_operand_ty,
-                        &span,
-                    );
+                    if !same_aliased_numeric && !different_but_compatible {
+                        self.unify_binary_operands(
+                            store,
+                            operator,
+                            left_operand_ty,
+                            right_operand_ty,
+                            &span,
+                        );
+                    }
                 }
                 self.ensure_comparable(store, left_operand_ty, left_span);
                 self.type_bool()
@@ -450,6 +459,15 @@ impl TaskState<'_> {
             LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => {
                 let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
                 let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
+
+                if self.report_value_enum_boundary(
+                    &resolved_left_operand,
+                    &resolved_right_operand,
+                    store,
+                    span,
+                ) {
+                    return self.type_bool();
+                }
 
                 let same_aliased_numeric = resolved_left_operand == resolved_right_operand
                     && resolved_left_operand.is_aliased_numeric_type();
@@ -478,6 +496,7 @@ impl TaskState<'_> {
                 let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
 
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
+                    store,
                     operator,
                     &resolved_left_operand,
                     &resolved_right_operand,
@@ -523,6 +542,7 @@ impl TaskState<'_> {
                 }
 
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
+                    store,
                     operator,
                     &left_resolved,
                     &right_resolved,
@@ -554,6 +574,7 @@ impl TaskState<'_> {
                 let right_resolved = right_operand_ty.resolve_in(&self.env);
 
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
+                    store,
                     operator,
                     &left_resolved,
                     &right_resolved,
@@ -700,8 +721,51 @@ impl TaskState<'_> {
         }
     }
 
+    /// Reports a comparison between a value enum and a typed primitive or a
+    /// different named numeric; returns whether a diagnostic was emitted.
+    fn report_value_enum_boundary(
+        &mut self,
+        left: &Type,
+        right: &Type,
+        store: &Store,
+        span: Span,
+    ) -> bool {
+        if left == right || store.deep_resolve_alias(left) == store.deep_resolve_alias(right) {
+            return false;
+        }
+        let left_is_value_enum = is_numeric_value_enum(left, store);
+        let right_is_value_enum = is_numeric_value_enum(right, store);
+
+        if left_is_value_enum && right_is_value_enum {
+            let underlying = left
+                .underlying_numeric_type()
+                .unwrap_or_else(|| left.clone());
+            self.sink
+                .push(diagnostics::infer::incompatible_named_numeric_types(
+                    &underlying,
+                    span,
+                ));
+            true
+        } else if left_is_value_enum && is_plain_numeric_primitive(right) {
+            self.sink
+                .push(diagnostics::infer::named_primitive_needs_cast(
+                    right, left, span,
+                ));
+            true
+        } else if right_is_value_enum && is_plain_numeric_primitive(left) {
+            self.sink
+                .push(diagnostics::infer::named_primitive_needs_cast(
+                    left, right, span,
+                ));
+            true
+        } else {
+            false
+        }
+    }
+
     fn try_operation_with_numeric_alias(
         &mut self,
+        store: &Store,
         operator: &BinaryOperator,
         left_ty: &Type,
         right_ty: &Type,
@@ -725,35 +789,47 @@ impl TaskState<'_> {
         let left_is_aliased = left_ty.is_aliased_numeric_type();
         let right_is_aliased = right_ty.is_aliased_numeric_type();
 
-        match (left_is_aliased, right_is_aliased, operator) {
-            (true, true, _) if left_ty == right_ty => {
-                if matches!(operator, Division) {
-                    // T / T → U (ratio yields underlying type)
-                    Some(left_underlying)
-                } else {
-                    Some(left_ty.clone())
-                }
+        match (left_is_aliased, right_is_aliased) {
+            (false, false) => None,
+
+            (true, true)
+                if left_ty == right_ty
+                    || store.deep_resolve_alias(left_ty) == store.deep_resolve_alias(right_ty) =>
+            {
+                Some(left_ty.clone())
             }
 
-            (true, false, _) => Some(left_ty.clone()),
-
-            (false, true, Division | Remainder) => {
-                self.sink.push(diagnostics::infer::invalid_division_order(
-                    operator, left_ty, right_ty, *span,
-                ));
-                None
-            }
-            (false, true, _) => Some(right_ty.clone()),
-
-            (false, false, _) => None,
-
-            (true, true, _) => {
+            (true, true) => {
                 self.sink
                     .push(diagnostics::infer::incompatible_named_numeric_types(
                         &left_underlying,
                         *span,
                     ));
-                None
+                Some(left_ty.clone())
+            }
+
+            (true, false) => {
+                if is_numeric_value_enum(left_ty, store) {
+                    self.sink
+                        .push(diagnostics::infer::named_primitive_needs_cast(
+                            right_ty, left_ty, *span,
+                        ));
+                }
+                Some(left_ty.clone())
+            }
+            (false, true) => {
+                if is_numeric_value_enum(right_ty, store) {
+                    self.sink
+                        .push(diagnostics::infer::named_primitive_needs_cast(
+                            left_ty, right_ty, *span,
+                        ));
+                } else if matches!(operator, Division | Remainder) {
+                    self.sink.push(diagnostics::infer::invalid_division_order(
+                        operator, left_ty, right_ty, *span,
+                    ));
+                    return None;
+                }
+                Some(right_ty.clone())
             }
         }
     }
@@ -955,15 +1031,29 @@ fn numeric_literal_kind(expression: &Expression) -> NumericLiteralKind {
             ..
         } => NumericLiteralKind::Float,
         Expression::Paren { expression, .. } => numeric_literal_kind(expression),
+        Expression::Unary {
+            operator: Negative | BitwiseNot,
+            expression,
+            ..
+        } => numeric_literal_kind(expression),
         _ => NumericLiteralKind::None,
     }
 }
 
-/// Checks whether a literal of the given kind can adapt to the target type.
 fn literal_can_adapt_to(kind: &NumericLiteralKind, target: &Type) -> bool {
     match kind {
-        NumericLiteralKind::Integer => target.is_numeric(),
-        NumericLiteralKind::Float => target.is_float(),
+        NumericLiteralKind::Integer => target.literal_adaptation_target().is_some(),
+        NumericLiteralKind::Float => target
+            .literal_adaptation_target()
+            .is_some_and(|underlying| underlying.is_float()),
         NumericLiteralKind::None => false,
     }
+}
+
+fn is_numeric_value_enum(ty: &Type, store: &Store) -> bool {
+    matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_numeric_value_enum(id.as_str()))
+}
+
+fn is_plain_numeric_primitive(ty: &Type) -> bool {
+    ty.is_numeric() && !ty.is_aliased_numeric_type()
 }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -127,24 +127,34 @@ impl TaskState<'_> {
             // Simple/Compound, follow the alias to the underlying type.
             (
                 Nominal {
+                    id,
                     underlying_ty: Some(underlying),
                     ..
                 },
-                Type::Simple(_) | Type::Compound { .. },
+                other @ (Type::Simple(_) | Type::Compound { .. }),
             ) => {
-                let u = underlying.as_ref().clone();
-                self.try_unify(store, &u, &r2, span)
+                if matches!(other, Type::Simple(_)) && store.is_numeric_value_enum(id.as_str()) {
+                    Err(UnifyError::TypeMismatch)
+                } else {
+                    let u = underlying.as_ref().clone();
+                    self.try_unify(store, &u, &r2, span)
+                }
             }
 
             (
-                Type::Simple(_) | Type::Compound { .. },
+                other @ (Type::Simple(_) | Type::Compound { .. }),
                 Nominal {
+                    id,
                     underlying_ty: Some(underlying),
                     ..
                 },
             ) => {
-                let u = underlying.as_ref().clone();
-                self.try_unify(store, &r1, &u, span)
+                if matches!(other, Type::Simple(_)) && store.is_numeric_value_enum(id.as_str()) {
+                    Err(UnifyError::TypeMismatch)
+                } else {
+                    let u = underlying.as_ref().clone();
+                    self.try_unify(store, &r1, &u, span)
+                }
             }
 
             // Simple/Compound vs Nominal interface: synthesise a nominal
@@ -367,6 +377,7 @@ impl TaskState<'_> {
                 ..
             } = t1
                 && store.get_interface(symbol2).is_none()
+                && !store.is_numeric_value_enum(symbol1.as_str())
                 && self.try_unify(store, u, t2, span).is_ok()
             {
                 return Ok(());
@@ -376,6 +387,7 @@ impl TaskState<'_> {
                 ..
             } = t2
                 && store.get_interface(symbol1).is_none()
+                && !store.is_numeric_value_enum(symbol2.as_str())
                 && self.try_unify(store, t1, u, span).is_ok()
             {
                 return Ok(());

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::types::Type;
+use syntax::types::{SimpleKind, Type};
 
 use crate::checker::TaskState;
 
@@ -54,6 +54,10 @@ impl TaskState<'_> {
         }
 
         if source_ty.has_underlying_numeric_type() && target_ty.has_underlying_numeric_type() {
+            return;
+        }
+
+        if uintptr_scalar_conversion(&source_ty, &target_ty) {
             return;
         }
 
@@ -153,6 +157,15 @@ impl TaskState<'_> {
             _ => {}
         }
     }
+}
+
+fn uintptr_scalar_conversion(source: &Type, target: &Type) -> bool {
+    let castable = |ty: &Type| {
+        ty.has_underlying_numeric_type() || ty.underlying_simple_kind() == Some(SimpleKind::Uintptr)
+    };
+    let either_uintptr = source.underlying_simple_kind() == Some(SimpleKind::Uintptr)
+        || target.underlying_simple_kind() == Some(SimpleKind::Uintptr);
+    either_uintptr && castable(source) && castable(target)
 }
 
 fn unwrap_parens_and_negation(expression: &Expression) -> &Expression {

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -7,7 +7,7 @@ use syntax::ast::{EnumVariant, Expression, StructFieldDefinition};
 use syntax::program::{
     Definition, DefinitionBody, File, Interface, MethodSignatures, Module, ModuleId,
 };
-use syntax::types::{SubstitutionMap, Symbol, Type, substitute};
+use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
 pub const ENTRY_MODULE_ID: &str = "_entry_";
 pub const ENTRY_FILE_ID: u32 = 0;
@@ -205,6 +205,15 @@ impl Store {
             DefinitionBody::ValueEnum { variants, .. } => Some(variants),
             _ => None,
         }
+    }
+
+    pub fn is_numeric_value_enum(&self, qualified_name: &str) -> bool {
+        matches!(
+            self.get_definition(qualified_name).map(|definition| &definition.body),
+            Some(DefinitionBody::ValueEnum { underlying_ty: Some(underlying), .. })
+                if underlying.has_underlying_numeric_type()
+                    || underlying.underlying_simple_kind() == Some(SimpleKind::Uintptr)
+        )
     }
 
     pub fn fields_of(&self, qualified_name: &str) -> Option<&[StructFieldDefinition]> {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1453,6 +1453,44 @@ impl Type {
         self.underlying_numeric_type().is_some()
     }
 
+    pub fn literal_adaptation_target(&self) -> Option<Type> {
+        if let Some(numeric) = self.underlying_numeric_type() {
+            return Some(numeric);
+        }
+        match self {
+            Type::Nominal { .. } if self.underlying_simple_kind() == Some(SimpleKind::Uintptr) => {
+                Some(Type::Simple(SimpleKind::Uintptr))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn underlying_simple_kind(&self) -> Option<SimpleKind> {
+        self.underlying_simple_kind_recursive(&mut HashSet::default())
+    }
+
+    fn underlying_simple_kind_recursive(
+        &self,
+        visited: &mut HashSet<Symbol>,
+    ) -> Option<SimpleKind> {
+        if let Some(kind) = self.as_simple() {
+            return Some(kind);
+        }
+        match self {
+            Type::Nominal {
+                id,
+                underlying_ty: Some(underlying),
+                ..
+            } => {
+                if !visited.insert(id.clone()) {
+                    return None;
+                }
+                underlying.underlying_simple_kind_recursive(visited)
+            }
+            _ => None,
+        }
+    }
+
     fn underlying_numeric_type_recursive(&self, visited: &mut HashSet<Symbol>) -> Option<Type> {
         match self {
             Type::Simple(_) if self.is_numeric() => Some(self.clone()),

--- a/docs/intro/coming-from-go.md
+++ b/docs/intro/coming-from-go.md
@@ -387,18 +387,16 @@ let result = "  Hello World  "
 
 ## Named numeric types
 
-In Go, named numeric types like `time.Duration` require explicit casts for arithmetic with their underlying type:
+Named numeric types like `time.Duration` work as in Go, with the conversion spelled `as T` rather than `T(x)`:
 
 ```go
 multiplier := 100
-delay := time.Millisecond * time.Duration(multiplier) // cast required
+delay := time.Millisecond * time.Duration(multiplier)
 ```
-
-Lisette inserts the cast automatically:
 
 ```rust
 let multiplier = 100
-let delay = time.Millisecond * multiplier  // works directly
+let delay = time.Millisecond * (multiplier as time.Duration)
 ```
 
 ## Unused code

--- a/docs/reference/03-operators.md
+++ b/docs/reference/03-operators.md
@@ -28,7 +28,7 @@ a + b |> f         // f(a + b)
 
 ## Arithmetic
 
-`+`, `-`, `*`, `/`, `%` require both operands to be the same numeric type. An exception is made for named numeric types from Go (like `time.Duration`), which can be used in arithmetic with their underlying type. See [`13-go-interop.md`](13-go-interop.md)
+`+`, `-`, `*`, `/`, `%` require both operands to be the same numeric type. An untyped numeric literal adapts to the other operand.
 
 Unary `-` negates a number. Disallowed for unsigned types:
 

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -62,21 +62,14 @@ Fixed-size arrays `[N]T` are not yet representable in Lisette. In return positio
 
 ### Named numeric types
 
-Go defines types like `time.Duration` as aliases for numeric primitives: `type Duration int64`. Go's nominal type system requires explicit casts for arithmetic between these types and their underlying type.
+Go's named numeric types (`time.Duration`, `time.Weekday`, etc.) are nominal in Lisette just as in Go. This means that e.g. an `int` is not interchangeable with a named numeric type.
 
-Lisette allows arithmetic between a named numeric type and compatible types from the same family (signed integers, unsigned integers, or floats). The compiler inserts the necessary casts in the generated Go code:
+In both Lisette and Go, a literal adapts wherever the named type is expected; a typed value needs explicit conversion.
 
 ```rust
-import "go:time"
-
-let multiplier = 100
-let delay = time.Millisecond * multiplier  // Duration * int → Duration
-let ratio = time.Minute / time.Second      // Duration / Duration → int64
+time.Sleep(100 * time.Millisecond)    // literal adapts
+time.Sleep(elapsed as time.Duration)  // typed value needs `as`
 ```
-
-The result type preserves the named type, with one exception: dividing two values of the same named type produces the underlying type (`T / T → U`), since a ratio is dimensionless.
-
-Cross-family arithmetic (e.g., `Duration * float64`) remains an error.
 
 ### Variadic parameters
 

--- a/tests/e2e_smoke_project/src/main.lis
+++ b/tests/e2e_smoke_project/src/main.lis
@@ -2727,15 +2727,15 @@ fn test_duration_times_literal() -> int {
 }
 
 fn test_duration_times_variable() -> int {
-  // Duration * variable - variable needs cast
+  // Duration * variable - a typed primitive needs an explicit cast
   let n: int = 3
-  let d = time.Duration.Second * n
+  let d = time.Duration.Second * (n as time.Duration)
   if d == 3000000000 { 100 } else { 0 }
 }
 
 fn test_duration_div_duration() -> int {
-  // Duration / Duration - yields underlying type (ratio)
-  let ratio: int64 = time.Duration.Second / time.Duration.Millisecond
+  // Duration / Duration - yields Duration (Go); cast for a raw ratio
+  let ratio: int64 = (time.Duration.Second / time.Duration.Millisecond) as int64
   if ratio == 1000 { 100 } else { 0 }
 }
 
@@ -2743,6 +2743,18 @@ fn test_duration_div_scalar() -> int {
   // Duration / scalar - yields Duration
   let half = time.Duration.Second / 2
   if half == 500000000 { 100 } else { 0 }
+}
+
+fn test_named_div_to_named_annotation() -> int {
+  // Duration / Duration must stay Duration, not be cast to int64 in emit
+  let d: time.Duration = time.Duration.Second / time.Duration.Millisecond
+  if d == 1000 { 100 } else { 0 }
+}
+
+fn test_named_div_literal_to_named_annotation() -> int {
+  // Duration / literal must stay Duration after the literal adapts
+  let d: time.Duration = time.Duration.Second / 2
+  if d == 500000000 { 100 } else { 0 }
 }
 
 fn test_duration_add() -> int {
@@ -2770,12 +2782,12 @@ fn test_duration_negation() -> int {
 
 fn test_eq_with_variable() -> int {
   let n: int = 1000000000
-  if time.Duration.Second == n { 100 } else { 0 }
+  if time.Duration.Second == (n as time.Duration) { 100 } else { 0 }
 }
 
 fn test_variable_not_variant() -> int {
   let n: int = 5
-  let result: time.Duration = time.Duration.Second * n
+  let result: time.Duration = time.Duration.Second * (n as time.Duration)
   if result == 5000000000 { 100 } else { 0 }
 }
 
@@ -2829,21 +2841,21 @@ fn get_duration_multiplier() -> int {
 }
 
 fn test_go_style_times_variable() -> int {
-  // Regression: time.Second * n should emit time.Duration(n), not go:time.Duration(n)
+  // Regression: time.Second * (n as Duration) should emit time.Duration(n), not go:time.Duration(n)
   let n = 5
-  let d = time.Second * n
+  let d = time.Second * (n as time.Duration)
   if d == 5000000000 { 100 } else { 0 }
 }
 
 fn test_go_style_times_function() -> int {
-  // Regression: time.Second * fn() should emit time.Duration(fn()), not go:time.Duration(fn())
-  let d = time.Second * get_duration_multiplier()
+  // Regression: time.Second * (fn() as Duration) emits time.Duration(fn()), not go:time.Duration(fn())
+  let d = time.Second * (get_duration_multiplier() as time.Duration)
   if d == 3000000000 { 100 } else { 0 }
 }
 
 fn test_lis_style_times_function() -> int {
   // Same for Lisette-style access
-  let d = time.Duration.Second * get_duration_multiplier()
+  let d = time.Duration.Second * (get_duration_multiplier() as time.Duration)
   if d == 3000000000 { 100 } else { 0 }
 }
 
@@ -3927,6 +3939,8 @@ fn main() {
   report("duration_times_variable", test_duration_times_variable(), 100)
   report("duration_div_duration", test_duration_div_duration(), 100)
   report("duration_div_scalar", test_duration_div_scalar(), 100)
+  report("named_div_to_named_annotation", test_named_div_to_named_annotation(), 100)
+  report("named_div_literal_to_named_annotation", test_named_div_literal_to_named_annotation(), 100)
   report("duration_add", test_duration_add(), 100)
   report("duration_sub", test_duration_sub(), 100)
   report("duration_comparison", test_duration_comparison(), 100)

--- a/tests/spec/emit/snapshots/e2e_smoke.snap
+++ b/tests/spec/emit/snapshots/e2e_smoke.snap
@@ -464,6 +464,8 @@ duration_times_literal: PASS
 duration_times_variable: PASS
 duration_div_duration: PASS
 duration_div_scalar: PASS
+named_div_to_named_annotation: PASS
+named_div_literal_to_named_annotation: PASS
 duration_add: PASS
 duration_sub: PASS
 duration_comparison: PASS

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -2432,7 +2432,7 @@ fn test() -> time.Duration {
 }
 
 #[test]
-fn numeric_alias_t_div_t_yields_underlying() {
+fn numeric_alias_t_div_t_yields_named() {
     let mut fs = MockFileSystem::new();
     fs.add_file("time", "time.d.lis", duration_typedef());
     fs.add_file(
@@ -2441,7 +2441,7 @@ fn numeric_alias_t_div_t_yields_underlying() {
         r#"
 import "time"
 
-fn test() -> int64 {
+fn test() -> time.Duration {
   time.Duration.Second / time.Duration.Millisecond
 }
 "#,
@@ -2612,7 +2612,43 @@ fn test() -> bool {
 }
 
 #[test]
-fn numeric_alias_u_div_t_error() {
+fn numeric_alias_u_div_t() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+fn test() -> time.Duration {
+  100 / time.Duration.Second
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn numeric_alias_u_rem_t() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+fn test() -> time.Duration {
+  100 % time.Duration.Second
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn numeric_alias_typed_primitive_divides_value_enum_rejected() {
     let mut fs = MockFileSystem::new();
     fs.add_file("time", "time.d.lis", duration_typedef());
     fs.add_file(
@@ -2622,33 +2658,16 @@ fn numeric_alias_u_div_t_error() {
 import "time"
 
 fn test() {
-  let x = 100 / time.Duration.Second;
+  let n: int = 100;
+  let x = n / time.Duration.Second;
 }
 "#,
     );
-    infer_module("main", fs).assert_infer_code("invalid_division_order");
+    infer_module("main", fs).assert_infer_code("type_mismatch");
 }
 
 #[test]
-fn numeric_alias_u_rem_t_error() {
-    let mut fs = MockFileSystem::new();
-    fs.add_file("time", "time.d.lis", duration_typedef());
-    fs.add_file(
-        "main",
-        "main.lis",
-        r#"
-import "time"
-
-fn test() {
-  let x = 100 % time.Duration.Second;
-}
-"#,
-    );
-    infer_module("main", fs).assert_infer_code("invalid_division_order");
-}
-
-#[test]
-fn numeric_alias_with_variable() {
+fn numeric_alias_with_variable_rejected() {
     let mut fs = MockFileSystem::new();
     fs.add_file("time", "time.d.lis", duration_typedef());
     fs.add_file(
@@ -2660,6 +2679,25 @@ import "time"
 fn test() -> time.Duration {
   let n: int = 5;
   time.Duration.Second * n
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn numeric_alias_with_variable_cast() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+fn test() -> time.Duration {
+  let n: int = 5;
+  time.Duration.Second * (n as time.Duration)
 }
 "#,
     );
@@ -2715,7 +2753,7 @@ fn numeric_alias_in_return() {
 import "time"
 
 fn get_delay(multiplier: int) -> time.Duration {
-  time.Duration.Millisecond * multiplier
+  time.Duration.Millisecond * (multiplier as time.Duration)
 }
 "#,
     );
@@ -2856,6 +2894,140 @@ fn test() {
 }
 
 #[test]
+fn numeric_alias_compare_different_named_types_error() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "time",
+        "time.d.lis",
+        r#"
+pub enum DurationA: int64 { Second = 1000000000 }
+pub enum DurationB: int64 { Second = 1000000000 }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+fn test() -> bool {
+  time.DurationA.Second == time.DurationB.Second
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("incompatible_named_numeric_types");
+}
+
+#[test]
+fn alias_backed_value_enum_rejects_typed_primitive() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "time",
+        "time.d.lis",
+        r#"
+type Base = int64
+pub enum Duration: Base {
+  Second = 1000000000,
+}
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+fn test() -> time.Duration {
+  let n: int64 = 5;
+  time.Duration.Second * n
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn uintptr_backed_value_enum_rejects_typed_primitive() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        r#"
+pub enum Errno: uintptr { EPERM = 1 }
+pub fn current() -> uintptr
+pub fn needs(e: Errno)
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() {
+  let n = sys.current()
+  sys.needs(n)
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn uintptr_backed_value_enum_cast_escape_hatch() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        r#"
+pub enum Errno: uintptr { EPERM = 1 }
+pub fn current() -> uintptr
+pub fn needs(e: Errno)
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() {
+  let n = sys.current()
+  sys.needs(n as sys.Errno)
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn uintptr_backed_value_enum_member_and_const_ok() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        r#"
+pub enum Errno: uintptr { EPERM = 1 }
+pub const ENOENT: Errno = 2
+pub fn needs(e: Errno)
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() {
+  sys.needs(sys.Errno.EPERM)
+  sys.needs(sys.ENOENT)
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
 fn numeric_alias_complex_chained() {
     let mut fs = MockFileSystem::new();
     fs.add_file("time", "time.d.lis", duration_typedef());
@@ -2886,8 +3058,8 @@ fn numeric_alias_parenthesized_ratio() {
 import "time"
 
 fn test() -> int64 {
-  // T / T yields int64, which is the underlying type
-  let ratio: int64 = time.Duration.Second / time.Duration.Millisecond;
+  // T / T yields the named type now; cast to the underlying for a raw ratio
+  let ratio: int64 = (time.Duration.Second / time.Duration.Millisecond) as int64;
   ratio
 }
 "#,
@@ -2907,7 +3079,7 @@ import "time"
 
 fn test() {
   let d: time.Duration = time.Duration.Second * 2;
-  let ratio: int64 = time.Duration.Second / time.Duration.Millisecond;
+  let ratio: int64 = (time.Duration.Second / time.Duration.Millisecond) as int64;
 }
 "#,
     );
@@ -4776,4 +4948,208 @@ fn main() { use_it(&MySource {}) }
 "#;
     infer_with_go_typedefs(input, &[("go:example.com/ui", typedef)])
         .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn transparent_newtype_division_order_still_errors() {
+    infer(
+        r#"
+struct Meters(int)
+fn test(m: Meters) {
+  let n: int = 100
+  let _x = n / m
+}
+"#,
+    )
+    .assert_infer_code("invalid_division_order");
+}
+
+#[test]
+fn alias_to_value_enum_rejects_typed_primitive_in_operator() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+type D = time.Duration
+
+fn test() {
+  let x: D = time.Duration.Second
+  let n: int64 = 2
+  let _y = x * n
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn alias_to_value_enum_rejects_typed_primitive_in_comparison() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+type D = time.Duration
+
+fn test() -> bool {
+  let x: D = time.Duration.Second
+  let n: int64 = 2
+  x == n
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn alias_to_value_enum_with_underlying_value_ok() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("time", "time.d.lis", duration_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "time"
+
+type D = time.Duration
+
+fn test() -> D {
+  let x: D = time.Duration.Second
+  let _ = x == time.Duration.Second
+  x * time.Duration.Second
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn alias_backed_uintptr_value_enum_rejects_typed_primitive() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        r#"
+type Base = uintptr
+pub enum Errno: Base { EPERM = 1 }
+pub fn current() -> uintptr
+pub fn needs(e: Errno)
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() {
+  let n = sys.current()
+  sys.needs(n)
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn uintptr_backed_value_enum_adapts_integer_literal() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        "pub enum Errno: uintptr { EPERM = 1 }\npub fn needs(e: Errno)\n",
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() {
+  let _e: sys.Errno = 1
+  let _ = sys.Errno.EPERM == 0
+  sys.needs(2)
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn uintptr_backed_value_enum_arithmetic_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        "pub enum Errno: uintptr { EPERM = 1 }\n",
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() -> sys.Errno {
+  sys.Errno.EPERM + 1
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn uintptr_backed_value_enum_ordering_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "sys",
+        "sys.d.lis",
+        "pub enum Errno: uintptr { EPERM = 1 }\n",
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "sys"
+
+fn test() -> bool {
+  sys.Errno.EPERM < 10
+}
+"#,
+    );
+    infer_module("main", fs).assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn bare_uintptr_arithmetic_rejected() {
+    infer(
+        r#"
+fn test() {
+  let a = 5 as uintptr
+  let b = 3 as uintptr
+  let _ = a + b
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn bare_uintptr_ordering_rejected() {
+    infer(
+        r#"
+fn test() {
+  let a = 5 as uintptr
+  let b = 3 as uintptr
+  let _ = a < b
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
 }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4862,7 +4862,8 @@ pub enum Duration: int64 {
 import "time"
 
 fn test() {
-  let x = 100 / time.Duration.Second;
+  let n: int = 100;
+  let x = n / time.Duration.Second;
 }
 "#;
     let mut fs = MockFileSystem::new();
@@ -4893,7 +4894,8 @@ pub enum Duration: int64 {
 import "time"
 
 fn test() {
-  let x = 100 % time.Duration.Second;
+  let n: int = 100;
+  let x = n % time.Duration.Second;
 }
 "#;
     let mut fs = MockFileSystem::new();
@@ -4992,7 +4994,8 @@ pub fn Sleep(d: Duration)
 import "time"
 
 fn test() {
-  time.Sleep(0);
+  let n: int64 = 0;
+  time.Sleep(n);
 }
 "#;
     let mut fs = MockFileSystem::new();

--- a/tests/ui/errors/snapshots/infer_invalid_division_by_numeric_alias.snap
+++ b/tests/ui/errors/snapshots/infer_invalid_division_by_numeric_alias.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Invalid operation
-   ╭─[main.lis:5:11]
- 4 │ fn test() {
- 5 │   let x = 100 / time.Duration.Second;
-   ·           ─────────────┬────────────
-   ·                        ╰── cannot compute `int` / `Duration`
- 6 │ }
+  [error] Type mismatch
+   ╭─[main.lis:6:11]
+ 5 │   let n: int = 100;
+ 6 │   let x = n / time.Duration.Second;
+   ·           ────────────┬───────────
+   ·                       ╰── cannot compute `int` with `Duration`
+ 7 │ }
    ╰────
-  help: To divide by `Duration`, the dividend (left operand) must also be `Duration` · code: [infer.invalid_division_order]
+  help: Cast with `as`, e.g. `value as Duration` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_invalid_remainder_by_numeric_alias.snap
+++ b/tests/ui/errors/snapshots/infer_invalid_remainder_by_numeric_alias.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Invalid operation
-   ╭─[main.lis:5:11]
- 4 │ fn test() {
- 5 │   let x = 100 % time.Duration.Second;
-   ·           ─────────────┬────────────
-   ·                        ╰── cannot compute `int` % `Duration`
- 6 │ }
+  [error] Type mismatch
+   ╭─[main.lis:6:11]
+ 5 │   let n: int = 100;
+ 6 │   let x = n % time.Duration.Second;
+   ·           ────────────┬───────────
+   ·                       ╰── cannot compute `int` with `Duration`
+ 7 │ }
    ╰────
-  help: To take the remainder by `Duration`, the dividend (left operand) must also be `Duration` · code: [infer.invalid_division_order]
+  help: Cast with `as`, e.g. `value as Duration` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_named_numeric_expected_suggests_as_cast.snap
+++ b/tests/ui/errors/snapshots/infer_named_numeric_expected_suggests_as_cast.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   [error] Type mismatch
-   ╭─[main.lis:5:14]
- 4 │ fn test() {
- 5 │   time.Sleep(0);
+   ╭─[main.lis:6:14]
+ 5 │   let n: int64 = 0;
+ 6 │   time.Sleep(n);
    ·              ┬
-   ·              ╰── expected `Duration`, found `int`
- 6 │ }
+   ·              ╰── expected `Duration`, found `int64`
+ 7 │ }
    ╰────
   help: Cast with `as`, e.g. `value as Duration` · code: [infer.type_mismatch]


### PR DESCRIPTION
Go's named numeric types e.g. `time.Duration`, `time.Weekday`, `syscall.Errno` are now distinct from their underlying integer, matching Go. A typed `int` or `int64` no longer stands in for them; users must convert explicitly with `as`. Untyped literals still adapt, so the common cases are unchanged.

Previously Lisette treated these types as interchangeable with their underlying primitive. That was unsound, i.e. Lis accepted programs that emitted non-compiling Go (passing a typed `int64` where a `time.Duration` is expected), and in arithmetic it silently inserted a conversion that Go itself rejected. 

Aligning Lis and Go in their treatment of named numeric types closes both gaps, so both now behave the same here.

```rust
let ms: int64 = 100

time.Sleep(ms) // was accepted but emitted invalid Go, now errors
time.Sleep(ms as time.Duration) // conversion, exactly as Go requires
time.Sleep(100 * time.Millisecond) // literals still adapt, no cast needed
```
