### PR TITLE
fix: make string value enums nominal

### DIFF
--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -44,6 +44,7 @@ fn needs_explicit_type_declaration(
         Expression::Literal { literal, .. } => match literal {
             Literal::Integer { .. } => !matches!(binding_ty.get_name(), Some("int") | None),
             Literal::Float { .. } => !matches!(binding_ty.get_name(), Some("float64") | None),
+            Literal::String { .. } => !matches!(binding_ty.get_name(), Some("string") | None),
             _ => false,
         },
         _ => false,

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -1,9 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
-use rustc_hash::FxHashSet;
 use syntax::ast::{Expression, FormatStringPart, Literal, Span};
-use syntax::program::DefinitionBody;
-use syntax::types::{SubstitutionMap, Symbol, Type, substitute};
+use syntax::types::{SimpleKind, Type};
 
 use super::super::TaskState;
 
@@ -84,12 +82,18 @@ impl TaskState<'_> {
             }
 
             Literal::String { value, raw } => {
-                let string_ty = self.type_string();
-                self.unify(store, expected_ty, &string_ty, &span);
+                let resolved = expected_ty.resolve_in(&self.env);
+                let ty = if adapts_to_string_value_enum(&resolved, store) {
+                    resolved.clone()
+                } else {
+                    let string_ty = self.type_string();
+                    self.unify(store, expected_ty, &string_ty, &span);
+                    string_ty
+                };
 
                 Expression::Literal {
                     literal: Literal::String { value, raw },
-                    ty: string_ty,
+                    ty,
                     span,
                 }
             }
@@ -195,31 +199,15 @@ impl TaskState<'_> {
     }
 }
 
-/// Walks the alias chain via the store so multi-hop aliases resolve, returning
-/// the underlying numeric type an untyped literal may adapt to (value enums and
-/// newtype structs included; a typed primitive still needs `as`).
 fn numeric_adapt_target(ty: &Type, store: &Store) -> Option<Type> {
-    let mut current = ty.clone();
-    let mut seen: FxHashSet<Symbol> = FxHashSet::default();
-    while let Type::Nominal { id, params, .. } = &current {
-        if !seen.insert(id.clone()) {
-            break;
-        }
-        let Some(def) = store.get_definition(id.as_str()) else {
-            break;
-        };
-        if !matches!(def.body, DefinitionBody::TypeAlias { .. }) {
-            break;
-        }
-        let def_ty = &def.ty;
-        let (vars, body) = match def_ty {
-            Type::Forall { vars, body } => (vars.clone(), body.as_ref().clone()),
-            other => (vec![], other.clone()),
-        };
-        let map: SubstitutionMap = vars.iter().cloned().zip(params.iter().cloned()).collect();
-        current = substitute(&body, &map);
-    }
-    current.literal_adaptation_target()
+    store.deep_resolve_alias(ty).literal_adaptation_target()
+}
+
+fn adapts_to_string_value_enum(ty: &Type, store: &Store) -> bool {
+    let peeled = store.deep_resolve_alias(ty);
+    matches!(&peeled, Type::Nominal { id, .. }
+        if store.is_nominal_value_enum(id.as_str())
+            && peeled.underlying_simple_kind() == Some(SimpleKind::String))
 }
 
 fn char_literal_codepoint(s: &str) -> Option<u64> {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -3,7 +3,7 @@ use crate::checker::TypeEnv;
 use crate::store::Store;
 use syntax::ast::{BinaryOperator, Expression, Literal, Span, UnaryOperator};
 use syntax::program::DefinitionBody;
-use syntax::types::{Type, substitute};
+use syntax::types::{SimpleKind, Type, substitute};
 
 use BinaryOperator::*;
 use UnaryOperator::*;
@@ -265,8 +265,8 @@ impl TaskState<'_> {
         let left_operand_ty = left_ty;
         let right_operand_ty = self.new_type_var();
 
-        let right_literal_kind = numeric_literal_kind(&right_operand);
-        let is_right_literal = !matches!(right_literal_kind, NumericLiteralKind::None);
+        let right_literal_kind = literal_kind(&right_operand);
+        let is_right_literal = !matches!(right_literal_kind, LiteralKind::None);
 
         let new_right_operand = self.with_value_context(|s| {
             if is_right_literal {
@@ -345,10 +345,10 @@ impl TaskState<'_> {
         //
         // Integer literals adapt when the target `is_numeric()` (int, float, etc.).
         // Float literals adapt only when the target `is_float()` (float32, float64).
-        let left_literal_kind = numeric_literal_kind(&left_operand);
-        let right_literal_kind = numeric_literal_kind(&right_operand);
-        let is_left_literal = !matches!(left_literal_kind, NumericLiteralKind::None);
-        let is_right_literal = !matches!(right_literal_kind, NumericLiteralKind::None);
+        let left_literal_kind = literal_kind(&left_operand);
+        let right_literal_kind = literal_kind(&right_operand);
+        let is_left_literal = !matches!(left_literal_kind, LiteralKind::None);
+        let is_right_literal = !matches!(right_literal_kind, LiteralKind::None);
 
         let (new_left_operand, new_right_operand) = self.with_value_context(|s| {
             if is_left_literal && !is_right_literal {
@@ -503,9 +503,18 @@ impl TaskState<'_> {
                     &span,
                 ) {
                     result_ty
+                } else if self.report_value_enum_boundary(
+                    &resolved_left_operand,
+                    &resolved_right_operand,
+                    store,
+                    span,
+                ) {
+                    left_operand_ty.clone()
                 } else {
-                    let numeric_ok = if !resolved_left_operand.is_string()
-                        && !resolved_right_operand.is_string()
+                    let is_string_like =
+                        |t: &Type| t.underlying_simple_kind() == Some(SimpleKind::String);
+                    let numeric_ok = if !is_string_like(&resolved_left_operand)
+                        && !is_string_like(&resolved_right_operand)
                     {
                         self.ensure_numeric_for_binary(operator, left_operand_ty, left_span)
                             & self.ensure_numeric_for_binary(operator, right_operand_ty, right_span)
@@ -675,7 +684,8 @@ impl TaskState<'_> {
             return;
         }
 
-        if !resolved_ty.is_ordered() && !resolved_ty.is_string() && !resolved_ty.is_boolean() {
+        let is_string_backed = resolved_ty.underlying_simple_kind() == Some(SimpleKind::String);
+        if !resolved_ty.is_ordered() && !is_string_backed && !resolved_ty.is_boolean() {
             self.sink
                 .push(diagnostics::infer::not_orderable(&resolved_ty, *span));
         }
@@ -721,8 +731,8 @@ impl TaskState<'_> {
         }
     }
 
-    /// Reports a comparison between a value enum and a typed primitive or a
-    /// different named numeric; returns whether a diagnostic was emitted.
+    /// Reports an operator boundary between a value enum and a typed primitive
+    /// of its backing, or two different value enums; returns whether it emitted.
     fn report_value_enum_boundary(
         &mut self,
         left: &Type,
@@ -733,12 +743,13 @@ impl TaskState<'_> {
         if left == right || store.deep_resolve_alias(left) == store.deep_resolve_alias(right) {
             return false;
         }
-        let left_is_value_enum = is_numeric_value_enum(left, store);
-        let right_is_value_enum = is_numeric_value_enum(right, store);
+        let left_is_value_enum = is_nominal_value_enum(left, store);
+        let right_is_value_enum = is_nominal_value_enum(right, store);
 
         if left_is_value_enum && right_is_value_enum {
             let underlying = left
-                .underlying_numeric_type()
+                .underlying_simple_kind()
+                .map(Type::Simple)
                 .unwrap_or_else(|| left.clone());
             self.sink
                 .push(diagnostics::infer::incompatible_named_numeric_types(
@@ -746,13 +757,13 @@ impl TaskState<'_> {
                     span,
                 ));
             true
-        } else if left_is_value_enum && is_plain_numeric_primitive(right) {
+        } else if left_is_value_enum && plain_primitive_of_backing(left, right) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     right, left, span,
                 ));
             true
-        } else if right_is_value_enum && is_plain_numeric_primitive(left) {
+        } else if right_is_value_enum && plain_primitive_of_backing(right, left) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     left, right, span,
@@ -809,7 +820,7 @@ impl TaskState<'_> {
             }
 
             (true, false) => {
-                if is_numeric_value_enum(left_ty, store) {
+                if is_nominal_value_enum(left_ty, store) {
                     self.sink
                         .push(diagnostics::infer::named_primitive_needs_cast(
                             right_ty, left_ty, *span,
@@ -818,7 +829,7 @@ impl TaskState<'_> {
                 Some(left_ty.clone())
             }
             (false, true) => {
-                if is_numeric_value_enum(right_ty, store) {
+                if is_nominal_value_enum(right_ty, store) {
                     self.sink
                         .push(diagnostics::infer::named_primitive_needs_cast(
                             left_ty, right_ty, *span,
@@ -1010,50 +1021,63 @@ fn is_numeric_literal(expression: &Expression) -> bool {
     }
 }
 
-/// Distinguishes integer vs float literals for type adaptation purposes.
-enum NumericLiteralKind {
-    /// Integer literal: adapts to any numeric type (is_numeric)
+/// Literal kinds for type adaptation purposes.
+enum LiteralKind {
     Integer,
-    /// Float literal: adapts only to float types (is_float)
     Float,
-    /// Not a numeric literal
+    String,
     None,
 }
 
-fn numeric_literal_kind(expression: &Expression) -> NumericLiteralKind {
+fn literal_kind(expression: &Expression) -> LiteralKind {
     match expression {
         Expression::Literal {
             literal: Literal::Integer { .. },
             ..
-        } => NumericLiteralKind::Integer,
+        } => LiteralKind::Integer,
         Expression::Literal {
             literal: Literal::Float { .. },
             ..
-        } => NumericLiteralKind::Float,
-        Expression::Paren { expression, .. } => numeric_literal_kind(expression),
+        } => LiteralKind::Float,
+        Expression::Literal {
+            literal: Literal::String { .. },
+            ..
+        } => LiteralKind::String,
+        Expression::Paren { expression, .. } => literal_kind(expression),
         Expression::Unary {
             operator: Negative | BitwiseNot,
             expression,
             ..
-        } => numeric_literal_kind(expression),
-        _ => NumericLiteralKind::None,
+        } => literal_kind(expression),
+        _ => LiteralKind::None,
     }
 }
 
-fn literal_can_adapt_to(kind: &NumericLiteralKind, target: &Type) -> bool {
+fn literal_can_adapt_to(kind: &LiteralKind, target: &Type) -> bool {
     match kind {
-        NumericLiteralKind::Integer => target.literal_adaptation_target().is_some(),
-        NumericLiteralKind::Float => target
+        LiteralKind::Integer => target.literal_adaptation_target().is_some(),
+        LiteralKind::Float => target
             .literal_adaptation_target()
             .is_some_and(|underlying| underlying.is_float()),
-        NumericLiteralKind::None => false,
+        LiteralKind::String => {
+            matches!(target, Type::Nominal { .. })
+                && target.underlying_simple_kind() == Some(SimpleKind::String)
+        }
+        LiteralKind::None => false,
     }
 }
 
-fn is_numeric_value_enum(ty: &Type, store: &Store) -> bool {
-    matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_numeric_value_enum(id.as_str()))
+fn is_nominal_value_enum(ty: &Type, store: &Store) -> bool {
+    matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_nominal_value_enum(id.as_str()))
 }
 
 fn is_plain_numeric_primitive(ty: &Type) -> bool {
     ty.is_numeric() && !ty.is_aliased_numeric_type()
+}
+
+fn plain_primitive_of_backing(value_enum: &Type, other: &Type) -> bool {
+    match value_enum.underlying_simple_kind() {
+        Some(SimpleKind::String) => other.is_string(),
+        _ => is_plain_numeric_primitive(other),
+    }
 }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -133,7 +133,7 @@ impl TaskState<'_> {
                 },
                 other @ (Type::Simple(_) | Type::Compound { .. }),
             ) => {
-                if matches!(other, Type::Simple(_)) && store.is_numeric_value_enum(id.as_str()) {
+                if matches!(other, Type::Simple(_)) && store.is_nominal_value_enum(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
                     let u = underlying.as_ref().clone();
@@ -149,7 +149,7 @@ impl TaskState<'_> {
                     ..
                 },
             ) => {
-                if matches!(other, Type::Simple(_)) && store.is_numeric_value_enum(id.as_str()) {
+                if matches!(other, Type::Simple(_)) && store.is_nominal_value_enum(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
                     let u = underlying.as_ref().clone();
@@ -377,7 +377,7 @@ impl TaskState<'_> {
                 ..
             } = t1
                 && store.get_interface(symbol2).is_none()
-                && !store.is_numeric_value_enum(symbol1.as_str())
+                && !store.is_nominal_value_enum(symbol1.as_str())
                 && self.try_unify(store, u, t2, span).is_ok()
             {
                 return Ok(());
@@ -387,7 +387,7 @@ impl TaskState<'_> {
                 ..
             } = t2
                 && store.get_interface(symbol1).is_none()
-                && !store.is_numeric_value_enum(symbol2.as_str())
+                && !store.is_nominal_value_enum(symbol2.as_str())
                 && self.try_unify(store, t1, u, span).is_ok()
             {
                 return Ok(());

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::types::{SimpleKind, Type};
+use syntax::types::{SimpleKind, Type, peel_alias};
 
 use crate::checker::TaskState;
 
@@ -58,6 +58,10 @@ impl TaskState<'_> {
         }
 
         if uintptr_scalar_conversion(&source_ty, &target_ty) {
+            return;
+        }
+
+        if peel_alias(&source_ty, |_| true) == peel_alias(&target_ty, |_| true) {
             return;
         }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -207,12 +207,15 @@ impl Store {
         }
     }
 
-    pub fn is_numeric_value_enum(&self, qualified_name: &str) -> bool {
+    pub fn is_nominal_value_enum(&self, qualified_name: &str) -> bool {
         matches!(
             self.get_definition(qualified_name).map(|definition| &definition.body),
             Some(DefinitionBody::ValueEnum { underlying_ty: Some(underlying), .. })
                 if underlying.has_underlying_numeric_type()
-                    || underlying.underlying_simple_kind() == Some(SimpleKind::Uintptr)
+                    || matches!(
+                        underlying.underlying_simple_kind(),
+                        Some(SimpleKind::Uintptr | SimpleKind::String)
+                    )
         )
     }
 

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -60,16 +60,18 @@ Compound types are different:
 
 Fixed-size arrays `[N]T` are not yet representable in Lisette. In return position they lower to `Slice<T>`. In any other position (e.g. parameters, struct fields, map keys, slice or map elements), the declaration is currently skipped.
 
-### Named numeric types
+### Named primitive types
 
-Go's named numeric types (`time.Duration`, `time.Weekday`, etc.) are nominal in Lisette just as in Go. This means that e.g. an `int` is not interchangeable with a named numeric type.
+Go's named primitive types (`time.Duration`, `time.Weekday`, etc.) are nominal in Lisette just as in Go. For example, this means that an `int` is not interchangeable with a named numeric type like `time.Weekday`.
 
-In both Lisette and Go, a literal adapts wherever the named type is expected; a typed value needs explicit conversion.
+In both languages, a literal adapts wherever the named type is expected; a typed value needs explicit conversion.
 
 ```rust
 time.Sleep(100 * time.Millisecond)    // literal adapts
 time.Sleep(elapsed as time.Duration)  // typed value needs `as`
 ```
+
+The same holds for string-backed named types such as `regexp/syntax.ErrorCode`, so a string literal adapts, while a typed `string` needs conversion.
 
 ### Variadic parameters
 

--- a/tests/e2e_smoke_project/src/main.lis
+++ b/tests/e2e_smoke_project/src/main.lis
@@ -4,6 +4,7 @@ import httpx "go:net/http"
 import "go:net/http/httptest"
 import "go:math"
 import "go:path"
+import "go:regexp/syntax"
 import "go:strconv"
 import "go:strings"
 import "go:sync"
@@ -2745,6 +2746,15 @@ fn test_duration_div_scalar() -> int {
   if half == 500000000 { 100 } else { 0 }
 }
 
+fn test_string_value_enum() -> int {
+  let code: syntax.ErrorCode = "invalid escape sequence"
+  let same = code == syntax.ErrInvalidEscape
+  let prefixed: syntax.ErrorCode = code + "!"
+  let raw = code as string
+  let ok = same && prefixed == "invalid escape sequence!" && raw == "invalid escape sequence"
+  if ok { 100 } else { 0 }
+}
+
 fn test_named_div_to_named_annotation() -> int {
   // Duration / Duration must stay Duration, not be cast to int64 in emit
   let d: time.Duration = time.Duration.Second / time.Duration.Millisecond
@@ -3941,6 +3951,7 @@ fn main() {
   report("duration_div_scalar", test_duration_div_scalar(), 100)
   report("named_div_to_named_annotation", test_named_div_to_named_annotation(), 100)
   report("named_div_literal_to_named_annotation", test_named_div_literal_to_named_annotation(), 100)
+  report("string_value_enum", test_string_value_enum(), 100)
   report("duration_add", test_duration_add(), 100)
   report("duration_sub", test_duration_sub(), 100)
   report("duration_comparison", test_duration_comparison(), 100)

--- a/tests/spec/emit/snapshots/e2e_smoke.snap
+++ b/tests/spec/emit/snapshots/e2e_smoke.snap
@@ -466,6 +466,7 @@ duration_div_duration: PASS
 duration_div_scalar: PASS
 named_div_to_named_annotation: PASS
 named_div_literal_to_named_annotation: PASS
+string_value_enum: PASS
 duration_add: PASS
 duration_sub: PASS
 duration_comparison: PASS

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -5153,3 +5153,118 @@ fn test() {
     )
     .assert_infer_code("type_mismatch");
 }
+
+fn code_typedef() -> &'static str {
+    r#"
+pub enum Code: string {
+  NotFound = "not found",
+  Timeout = "timeout",
+}
+pub fn needs(c: Code)
+"#
+}
+
+fn infer_code_main(body: &str) -> InferResult {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("status", "status.d.lis", code_typedef());
+    fs.add_file(
+        "main",
+        "main.lis",
+        &format!("import \"status\"\n\nfn test() {{\n{body}\n}}\n"),
+    );
+    infer_module("main", fs)
+}
+
+#[test]
+fn string_value_enum_adapts_string_literal() {
+    infer_code_main(
+        r#"
+  let _c: status.Code = "not found"
+  let _eq = status.Code.NotFound == "timeout"
+  status.needs("timeout")
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn string_value_enum_same_type_operators_ok() {
+    infer_code_main(
+        r#"
+  let _eq = status.Code.NotFound == status.Code.Timeout
+  let _lt = status.Code.NotFound < status.Code.Timeout
+  let _cat: status.Code = status.Code.NotFound + "!"
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn string_value_enum_rejects_typed_string_in_assignment() {
+    infer_code_main(
+        r#"
+  let s: string = "x"
+  let _c: status.Code = s
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn string_value_enum_rejects_named_to_string_assignment() {
+    infer_code_main(
+        r#"
+  let _s: string = status.Code.NotFound
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn string_value_enum_rejects_typed_string_in_comparison() {
+    infer_code_main(
+        r#"
+  let s: string = "x"
+  let _eq = status.Code.NotFound == s
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn string_value_enum_rejects_typed_string_in_concat() {
+    infer_code_main(
+        r#"
+  let s: string = "x"
+  let _cat = status.Code.NotFound + s
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn string_value_enum_cast_escape_hatch() {
+    infer_code_main(
+        r#"
+  let s: string = "x"
+  let _to: status.Code = s as status.Code
+  let _from: string = status.Code.NotFound as string
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn composite_newtype_identical_underlying_cast_ok() {
+    infer(
+        r#"
+struct Bytes(Slice<byte>)
+struct Mask(Slice<byte>)
+
+fn test(b: Bytes) {
+  let _m = b as Mask
+}
+"#,
+    )
+    .assert_no_errors();
+}


### PR DESCRIPTION
Go's named string types e.g. `regexp/syntax.ErrorCode` are now distinct from `string`, matching Go. A typed `string` no longer stands in for them; the user must convert explicitly with `as`. String literals still adapt, so common usage keeps working.

Previously Lisette treated these as interchangeable with `string`. That was unsound, so Lis accepted programs that emitted non-compiling Go (passing a typed `string` where an `ErrorCode` is expected, and the reverse), while also rejecting the explicit `ErrorCode as string` conversion that Go accepted.

```rs
let raw: string = "invalid escape sequence"

let e: syntax.ErrorCode = raw // accepted, but emitted Go that does not compile
let eq = syntax.ErrInvalidEscape == raw // accepted, but emitted Go that does not compile
let cast = syntax.ErrInvalidEscape as string // rejected, even though Go accepted it
```

Now, the first two require an explicit `as` (`raw as syntax.ErrorCode`), and the cast compiles. String literals still adapt, so `let code: syntax.ErrorCode = "invalid escape sequence"` and `syntax.ErrInvalidEscape == "invalid escape sequence"` keep working.

Follow-up to #572