### PR TITLE
feat: gate stringer synthesis on `#[displayable]`

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -85,13 +85,8 @@ pub fn displayable_with_arguments(attribute_span: &Span) -> LisetteDiagnostic {
 pub fn displayable_on_pointer_newtype(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[displayable]` on a pointer-backed newtype")
         .with_attribute_code("displayable_on_pointer_newtype")
-        .with_span_label(
-            attribute_span,
-            "a single-field tuple struct over `Ref<T>` cannot have a stringer",
-        )
-        .with_help(
-            "Go forbids methods on the named pointer type this lowers to. Format the value explicitly, or change the representation.",
-        )
+        .with_span_label(attribute_span, "a `Ref` has no display form")
+        .with_help("Give the type named fields, or drop `#[displayable]`")
 }
 
 pub fn displayable_specialized_to_string(attribute_span: &Span) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2101,6 +2101,22 @@ pub fn newtype_field_assignment(type_name: &str, span: Span) -> LisetteDiagnosti
         ))
 }
 
+pub fn interpolation_without_stringer(
+    type_name: &str,
+    span: Span,
+    pointer_newtype: bool,
+) -> LisetteDiagnostic {
+    let help = if pointer_newtype {
+        "Interpolate the inner value directly, or change the representation".to_string()
+    } else {
+        format!("Mark `{type_name}` with `#[displayable]`, or interpolate its fields directly.")
+    };
+    LisetteDiagnostic::error(format!("`{type_name}` cannot be interpolated"))
+        .with_infer_code("interpolation_without_stringer")
+        .with_span_label(&span, "has no display form")
+        .with_help(help)
+}
+
 pub fn complex_select_expression(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Complex expression in `select` arm")
         .with_infer_code("complex_select_expression")

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -51,7 +51,7 @@ impl Planner<'_> {
         let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
         let emit_string = synthesize && !has_user_string;
         let emit_go_string = synthesize && !has_user_go_string;
-        let needs_fmt = emit_string || emit_go_string;
+        let needs_fmt = emit_string || emit_go_string || has_json;
         let layout = self.module.enum_layout(&enum_id).unwrap();
         let mut result = layout.emit_definition(&generics_string);
         if emit_string {

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -7,7 +7,7 @@ use crate::names::generics::receiver_generics_string;
 use crate::names::go_name;
 use crate::utils::receiver_name;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructKind};
-use syntax::program::DefinitionBody;
+use syntax::program::{Definition, DefinitionBody};
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -88,6 +88,9 @@ impl Planner<'_> {
         let definition = self.emit_tuple_struct_definition(name, generics_string, fields, fx);
         let receiver_generics = receiver_generics_string(generics);
         let mut result = definition;
+        if self.is_pointer_backed_newtype(name) {
+            return result;
+        }
         if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) {
             let is_type_alias = fields.len() == 1 && generics_string.is_empty();
             let underlying_go_type = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
@@ -209,6 +212,19 @@ impl Planner<'_> {
         attributes.iter().any(|a| a.name == "displayable") && !self.module.has_user_to_string(name)
     }
 
+    pub(crate) fn is_pointer_backed_newtype(&self, name: &str) -> bool {
+        let qualified = self.facts.qualified_current(name);
+        self.facts
+            .definition(qualified.as_str())
+            .is_some_and(|definition| {
+                definition.is_pointer_backed_newtype(|id| {
+                    self.facts
+                        .definition(id)
+                        .is_some_and(Definition::is_type_alias)
+                })
+            })
+    }
+
     pub(crate) fn to_string_method_go_name(&self) -> String {
         if self.method_needs_export("to_string") {
             go_name::snake_to_camel("to_string")
@@ -251,8 +267,8 @@ impl Planner<'_> {
     }
 }
 
-pub(crate) fn should_synthesize_stringer(_attributes: &[Attribute]) -> bool {
-    true
+pub(crate) fn should_synthesize_stringer(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|a| a.name == "displayable")
 }
 
 pub(crate) fn struct_field_go_name(
@@ -354,9 +370,6 @@ fn emit_tuple_struct_stringer_method(
         );
     }
     if let Some(underlying) = underlying_go_type {
-        if underlying.starts_with('*') {
-            return String::new();
-        }
         return format!(
             "func ({receiver} {receiver_type}) {method_name}() string {{\nreturn fmt.Sprintf(\"{name}(%v)\", {underlying}({receiver}))\n}}"
         );

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -244,6 +244,27 @@ async fn completion_includes_prelude_types() {
 }
 
 #[tokio::test]
+async fn completion_includes_synthesized_to_string() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "#[displayable]\nstruct Point { x: int, y: int }\n\nfn main() {\n  let p = Point { x: 1, y: 2 }\n  p.\n}",
+        )
+        .await;
+
+    let response = client.completion(TEST_URI, 5, 4).await;
+    let labels = completion_labels(&response.unwrap());
+    assert!(
+        labels.iter().any(|l| l == "to_string"),
+        "expected synthesized `to_string` in instance completions; got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_includes_local_bindings() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/semantics/src/checker/registration/displayable.rs
+++ b/crates/semantics/src/checker/registration/displayable.rs
@@ -81,7 +81,11 @@ impl TaskState<'_> {
         let qualified = Symbol::from_parts(module_id, &name);
         if is_struct
             && let Some(definition) = store.get_definition(qualified.as_str())
-            && is_pointer_backed_newtype(definition)
+            && definition.is_pointer_backed_newtype(|id| {
+                store
+                    .get_definition(id)
+                    .is_some_and(Definition::is_type_alias)
+            })
         {
             self.sink
                 .push(diagnostics::attribute::displayable_on_pointer_newtype(
@@ -103,12 +107,14 @@ impl TaskState<'_> {
         let Some(scheme) = store.get_type(qualified.as_str()).cloned() else {
             return;
         };
-        let Some(generics) = store
-            .get_definition(qualified.as_str())
-            .and_then(type_generics)
-        else {
+        let Some(definition) = store.get_definition(qualified.as_str()) else {
             return;
         };
+        let Some(generics) = type_generics(definition) else {
+            return;
+        };
+        let visibility = definition.visibility().clone();
+        let name_span = definition.name_span();
 
         if let Some(user_ty) = user_to_string_type(store, qualified) {
             if is_ufcs_method_type(&user_ty, generics.len()) {
@@ -135,14 +141,30 @@ impl TaskState<'_> {
         );
         let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &[]);
 
+        let to_string_key = qualified.with_segment("to_string");
         let module = store.get_module_mut(module_id).expect("module must exist");
         if let Some(methods) = module
             .definitions
             .get_mut(qualified.as_str())
             .and_then(Definition::methods_mut)
         {
-            methods.insert("to_string".into(), method_ty);
+            methods.insert("to_string".into(), method_ty.clone());
         }
+        module
+            .definitions
+            .entry(to_string_key)
+            .or_insert_with(|| Definition {
+                visibility,
+                ty: method_ty,
+                name: None,
+                name_span,
+                doc: None,
+                body: DefinitionBody::Value {
+                    allowed_lints: vec![],
+                    go_hints: vec![],
+                    go_name: None,
+                },
+            });
     }
 }
 
@@ -251,12 +273,4 @@ fn collect_displayable_candidates(
         } => collect_method_attributes(method_signatures, out),
         _ => {}
     }
-}
-
-fn is_pointer_backed_newtype(definition: &Definition) -> bool {
-    definition.is_newtype()
-        && matches!(
-            &definition.body,
-            DefinitionBody::Struct { fields, .. } if fields[0].ty.is_ref()
-        )
 }

--- a/crates/semantics/src/passes/checks/interpolation_stringer.rs
+++ b/crates/semantics/src/passes/checks/interpolation_stringer.rs
@@ -1,0 +1,114 @@
+//! Flags f-string interpolation of a first-party struct or enum that has no stringer.
+
+use diagnostics::LocalSink;
+use rustc_hash::FxHashSet as HashSet;
+use syntax::ast::{Expression, FormatStringPart, Literal};
+use syntax::program::{Definition, DefinitionBody, File};
+use syntax::types::Type;
+
+use crate::passes::lints::ast_walk::visitor::visit_ast;
+use crate::store::Store;
+
+pub(crate) fn run(
+    items: &[Expression],
+    store: &Store,
+    ufcs_methods: &HashSet<(String, String)>,
+    sink: &LocalSink,
+) {
+    visit_ast(
+        items,
+        &mut |expression| check_expression(expression, store, ufcs_methods, sink),
+        &mut |_| {},
+    );
+}
+
+fn check_expression(
+    expression: &Expression,
+    store: &Store,
+    ufcs_methods: &HashSet<(String, String)>,
+    sink: &LocalSink,
+) {
+    if let Expression::Literal {
+        literal: Literal::FormatString(parts),
+        ..
+    } = expression
+    {
+        for part in parts {
+            if let FormatStringPart::Expression(inner) = part {
+                check_interpolation(inner, store, ufcs_methods, sink);
+            }
+        }
+    }
+}
+
+fn check_interpolation(
+    inner: &Expression,
+    store: &Store,
+    ufcs_methods: &HashSet<(String, String)>,
+    sink: &LocalSink,
+) {
+    let peeled = store.peel_alias(&inner.get_type());
+    let Type::Nominal { id, .. } = &peeled else {
+        return;
+    };
+    let Some(definition) = store.get_definition(id.as_str()) else {
+        return;
+    };
+    if !matches!(
+        definition.body,
+        DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. }
+    ) {
+        return;
+    }
+    if is_foreign(definition, id.as_str(), store)
+        || has_stringer(definition, id.as_str(), store, ufcs_methods)
+    {
+        return;
+    }
+    sink.push(diagnostics::infer::interpolation_without_stringer(
+        id.last_segment(),
+        inner.get_span(),
+        is_pointer_newtype(definition, store),
+    ));
+}
+
+fn is_foreign(definition: &Definition, id: &str, store: &Store) -> bool {
+    if let Some(module) = store.module_for_qualified_name(id)
+        && (module == "prelude" || module.starts_with("go:"))
+    {
+        return true;
+    }
+    definition
+        .name_span()
+        .and_then(|span| store.get_file(span.file_id))
+        .is_some_and(File::is_d_lis)
+}
+
+fn has_stringer(
+    definition: &Definition,
+    id: &str,
+    store: &Store,
+    ufcs_methods: &HashSet<(String, String)>,
+) -> bool {
+    if is_pointer_newtype(definition, store) {
+        return false;
+    }
+    if definition.is_displayable() {
+        return true;
+    }
+    let Some(methods) = store.get_own_methods(id) else {
+        return false;
+    };
+    ["string", "String"].iter().any(|name| {
+        methods.get(*name).is_some_and(Type::is_stringer_signature)
+            && !ufcs_methods.contains(&(id.to_string(), (*name).to_string()))
+    })
+}
+
+fn is_pointer_newtype(definition: &Definition, store: &Store) -> bool {
+    definition.is_pointer_backed_newtype(|id| {
+        store
+            .get_definition(id)
+            .is_some_and(Definition::is_type_alias)
+    })
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod empty_select_default;
 pub(crate) mod enum_variant_value;
 pub(crate) mod generics;
 pub(crate) mod index_out_of_bounds;
+pub(crate) mod interpolation_stringer;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
 pub(crate) mod json_serializable_fields;
@@ -28,7 +29,7 @@ pub(crate) mod visibility;
 
 use diagnostics::{LocalSink, PatternIssue};
 use rayon::prelude::*;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use syntax::ast::BindingId;
 use syntax::program::{File, Module};
 
@@ -63,10 +64,20 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
     let or_spans = &facts.or_pattern_error_spans;
     let bindings = &facts.bindings;
 
+    let ufcs_methods = analysis.ufcs_methods;
+
     if work.len() < PARALLEL_THRESHOLD {
         let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
         for (module, file) in &work {
-            run_file_checks(module, file, store, bindings, sink, &pattern_ctx);
+            run_file_checks(
+                module,
+                file,
+                store,
+                bindings,
+                ufcs_methods,
+                sink,
+                &pattern_ctx,
+            );
         }
         facts.pattern_issues = pattern_ctx.take_issues();
         return;
@@ -78,7 +89,15 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
         .map(|(module, file)| {
             let local_sink = LocalSink::new();
             let pattern_ctx = pattern_analysis::Context::new(analysis, or_spans);
-            run_file_checks(module, file, store, bindings, &local_sink, &pattern_ctx);
+            run_file_checks(
+                module,
+                file,
+                store,
+                bindings,
+                ufcs_methods,
+                &local_sink,
+                &pattern_ctx,
+            );
             (local_sink, pattern_ctx.take_issues())
         })
         .collect();
@@ -98,10 +117,12 @@ fn run_file_checks(
     file: &File,
     store: &Store,
     bindings: &HashMap<BindingId, BindingFact>,
+    ufcs_methods: &HashSet<(String, String)>,
     sink: &LocalSink,
     pattern_ctx: &pattern_analysis::Context,
 ) {
     node_walk::run(&file.items, store, bindings, file.is_d_lis(), sink);
+    interpolation_stringer::run(&file.items, store, ufcs_methods, sink);
 
     prelude_shadowing::run(&file.items, store, sink);
     generics::run(&file.items, &module.id, store, sink);

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -86,6 +86,18 @@ impl Definition {
         )
     }
 
+    pub fn is_pointer_backed_newtype<F>(&self, is_alias: F) -> bool
+    where
+        F: Fn(&str) -> bool,
+    {
+        self.is_newtype()
+            && matches!(
+                &self.body,
+                DefinitionBody::Struct { fields, .. }
+                    if crate::types::peel_alias(&fields[0].ty, is_alias).is_ref()
+            )
+    }
+
     pub fn allowed_lints(&self) -> &[String] {
         match &self.body {
             DefinitionBody::Value { allowed_lints, .. } => allowed_lints,

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -166,17 +166,32 @@ for direction in Direction.variants() {
 
 ## Display
 
-Add `#[displayable]` to a struct or enum to synthesize a `to_string(self) -> string` method.
+Add `#[displayable]` to a struct or enum to render it as a readable string when displayed.
+
 
 ```rs
-interface Display {
-  fn to_string(self) -> string
-}
-
 #[displayable]
 struct Point {
   x: int,
   y: int,
+}
+
+let p = Point { x: 1, y: 2 }
+
+fmt.Println(p) // `Point { x: 1, y: 2 }`
+```
+
+Without `#[displayable]`, a struct or enum cannot be interpolated in an f-string, and displays using Go's `%v` default formatting.
+
+```rs
+fmt.Println(p) // `{1 2}` if Point is not `#[displayable]`
+```
+
+`#[displayable]` also gives the enum or struct a `to_string(self) -> string` method.
+
+```rs
+interface Display {
+  fn to_string(self) -> string
 }
 
 fn render(value: Display) -> string {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6267,6 +6267,7 @@ fn go_name_collision_field_vs_generated_stringer() {
         ENTRY_MODULE_ID,
         "main.lis",
         r#"
+#[displayable]
 pub struct Thing {
   pub string: int,
 }

--- a/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
@@ -4,10 +4,7 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Face interface {
 }
@@ -18,10 +15,6 @@ func Fallible(arg int) (int, Face) {
 
 type Holder[T any] struct {
 	Val T
-}
-
-func (h Holder[T]) String() string {
-	return fmt.Sprintf("Holder { val: %v }", h.Val)
 }
 
 func Holder_Resolve[T any, R any, E any](self Holder[T], f func(T) lisette.Partial[R, E]) lisette.Partial[R, E] {

--- a/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
@@ -4,10 +4,7 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Face interface {
 }
@@ -18,10 +15,6 @@ func Resultant(arg int) (int, Face) {
 
 type Holder struct {
 	N int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { n: %v }", h.N)
 }
 
 func Holder_Resolve[R any, E any](self Holder, f func(int) lisette.Result[R, E]) lisette.Result[R, E] {

--- a/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
+++ b/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
@@ -4,17 +4,10 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Holder struct {
 	N int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { n: %v }", h.N)
 }
 
 func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {

--- a/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
+++ b/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
@@ -8,10 +8,6 @@ import "crypto/tls"
 
 type MyCache struct{}
 
-func (m MyCache) String() string {
-	return "MyCache"
-}
-
 func (m MyCache) Get(_ string) *tls.ClientSessionState {
 	return nil
 }

--- a/tests/spec/build/snapshots/cross_module_bounded_impl_tracks_imports.snap
+++ b/tests/spec/build/snapshots/cross_module_bounded_impl_tracks_imports.snap
@@ -13,10 +13,6 @@ type Box[T ifaces.Showable] struct {
 	Value T
 }
 
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
-}
-
 func (b Box[T]) Display() string {
 	return fmt.Sprintf("Box(%s)", b.Value.Show())
 }
@@ -40,10 +36,6 @@ import (
 
 type Item struct {
 	name string
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v }", i.name)
 }
 
 func (i Item) Show() string {

--- a/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_and_namespace_alias.snap
@@ -17,8 +17,6 @@ func main() {
 // === utils/color.go ===
 package utils
 
-import "fmt"
-
 func MakeColorRGB() Color {
 	return Color{Tag: ColorRGB}
 }
@@ -31,22 +29,4 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRGB:
-		return "RGB"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRGB:
-		return "Color.RGB"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }

--- a/tests/spec/build/snapshots/cross_module_enum_construction_uses_import_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_construction_uses_import_alias.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === lib/colors.go ===
 package lib
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -23,28 +21,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/cross_module_enum_variant_non_t_payload.snap
+++ b/tests/spec/build/snapshots/cross_module_enum_variant_non_t_payload.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === data/data.go ===
 package data
 
-import "fmt"
-
 func MakeResult2Success[T any](arg0 T) Result2[T] {
 	return Result2[T]{Tag: Result2Success, Success: arg0}
 }
@@ -25,28 +23,6 @@ type Result2[T any] struct {
 	Tag     Result2Tag
 	Success T
 	Failure string
-}
-
-func (r Result2[T]) String() string {
-	switch r.Tag {
-	case Result2Success:
-		return fmt.Sprintf("Success(%v)", r.Success)
-	case Result2Failure:
-		return fmt.Sprintf("Failure(%v)", r.Failure)
-	default:
-		return fmt.Sprintf("Result2(%d)", r.Tag)
-	}
-}
-
-func (r Result2[T]) GoString() string {
-	switch r.Tag {
-	case Result2Success:
-		return fmt.Sprintf("Result2.Success(%v)", r.Success)
-	case Result2Failure:
-		return fmt.Sprintf("Result2.Failure(%v)", r.Failure)
-	default:
-		return fmt.Sprintf("Result2(%d)", r.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
@@ -18,14 +18,8 @@ func main() {
 // === util/box.go ===
 package util
 
-import "fmt"
-
 type Box[T any] struct {
 	Items []T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { items: %v }", b.Items)
 }
 
 func Box_New[T any]() Box[T] {

--- a/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_free_function_turbofish.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === lib/mod.go ===
 package lib
 
-import "fmt"
-
 func MakeResult2Ok2[T any, E any](arg0 T) Result2[T, E] {
 	return Result2[T, E]{Tag: Result2Ok2, Ok2: arg0}
 }
@@ -25,28 +23,6 @@ type Result2[T any, E any] struct {
 	Tag  Result2Tag
 	Ok2  T
 	Err2 E
-}
-
-func (r Result2[T, E]) String() string {
-	switch r.Tag {
-	case Result2Ok2:
-		return fmt.Sprintf("Ok2(%v)", r.Ok2)
-	case Result2Err2:
-		return fmt.Sprintf("Err2(%v)", r.Err2)
-	default:
-		return fmt.Sprintf("Result2(%d)", r.Tag)
-	}
-}
-
-func (r Result2[T, E]) GoString() string {
-	switch r.Tag {
-	case Result2Ok2:
-		return fmt.Sprintf("Result2.Ok2(%v)", r.Ok2)
-	case Result2Err2:
-		return fmt.Sprintf("Result2.Err2(%v)", r.Err2)
-	default:
-		return fmt.Sprintf("Result2(%d)", r.Tag)
-	}
 }
 
 func Ok2[T any, E any](value T) Result2[T, E] {

--- a/tests/spec/build/snapshots/cross_module_generic_instance_method_value.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_instance_method_value.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Box[T any] struct {
 	Value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
 }
 
 func (b Box[T]) Get() T {

--- a/tests/spec/build/snapshots/cross_module_generic_return_only_string_vs_int.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_return_only_string_vs_int.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === lib/mod.go ===
 package lib
 
-import "fmt"
-
 func MakeValidatedValid[T any](arg0 T) Validated[T] {
 	return Validated[T]{Tag: ValidatedValid, Valid: arg0}
 }
@@ -27,35 +25,9 @@ type Validated[T any] struct {
 	Invalid string
 }
 
-func (v Validated[T]) String() string {
-	switch v.Tag {
-	case ValidatedValid:
-		return fmt.Sprintf("Valid(%v)", v.Valid)
-	case ValidatedInvalid:
-		return fmt.Sprintf("Invalid(%v)", v.Invalid)
-	default:
-		return fmt.Sprintf("Validated(%d)", v.Tag)
-	}
-}
-
-func (v Validated[T]) GoString() string {
-	switch v.Tag {
-	case ValidatedValid:
-		return fmt.Sprintf("Validated.Valid(%v)", v.Valid)
-	case ValidatedInvalid:
-		return fmt.Sprintf("Validated.Invalid(%v)", v.Invalid)
-	default:
-		return fmt.Sprintf("Validated(%d)", v.Tag)
-	}
-}
-
 type ValidationResult[T any] struct {
 	Value     Validated[T]
 	FieldName string
-}
-
-func (v ValidationResult[T]) String() string {
-	return fmt.Sprintf("ValidationResult { value: %v, field_name: %v }", v.Value, v.FieldName)
 }
 
 func ValidationResult_NewInvalid[T any](field, msg string) ValidationResult[T] {

--- a/tests/spec/build/snapshots/cross_module_generic_static_method_turbofish.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_static_method_turbofish.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/mod.go ===
 package lib
 
-import "fmt"
-
 type Box[T any] struct {
 	Val T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { val: %v }", b.Val)
 }
 
 func Box_New[T any](v T) Box[T] {

--- a/tests/spec/build/snapshots/cross_module_generic_static_method_value_instantiated.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_static_method_value_instantiated.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Box[T any] struct {
 	Value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
 }
 
 func Box_New[T any](x T) Box[T] {

--- a/tests/spec/build/snapshots/cross_module_instance_method_value.snap
+++ b/tests/spec/build/snapshots/cross_module_instance_method_value.snap
@@ -4,15 +4,9 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func (p Point) Sum() int {

--- a/tests/spec/build/snapshots/cross_module_instance_method_value_as_callback.snap
+++ b/tests/spec/build/snapshots/cross_module_instance_method_value_as_callback.snap
@@ -4,15 +4,9 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func (p Point) Sum() int {

--- a/tests/spec/build/snapshots/cross_module_interface_impl_in_main.snap
+++ b/tests/spec/build/snapshots/cross_module_interface_impl_in_main.snap
@@ -25,10 +25,6 @@ type Name struct {
 	value string
 }
 
-func (n Name) String() string {
-	return fmt.Sprintf("Name { value: %v }", n.value)
-}
-
 func (n Name) Display() string {
 	return n.value
 }

--- a/tests/spec/build/snapshots/cross_module_interface_method_call.snap
+++ b/tests/spec/build/snapshots/cross_module_interface_method_call.snap
@@ -10,18 +10,12 @@ func main() {}
 // === models/models.go ===
 package models
 
-import "fmt"
-
 type Showable interface {
 	Show() string
 }
 
 type Item struct {
 	Name string
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v }", i.Name)
 }
 
 func (i Item) Show() string {

--- a/tests/spec/build/snapshots/cross_module_interface_method_casing.snap
+++ b/tests/spec/build/snapshots/cross_module_interface_method_casing.snap
@@ -26,14 +26,8 @@ func main() {
 // === models/mod.go ===
 package models
 
-import "fmt"
-
 type User struct {
 	Name string
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }
 
 func (u User) Describe() string {

--- a/tests/spec/build/snapshots/cross_module_nested_generic_static_method.snap
+++ b/tests/spec/build/snapshots/cross_module_nested_generic_static_method.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === container/container.go ===
 package container
 
-import "fmt"
-
 type Box[T any] struct {
 	Item T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { item: %v }", b.Item)
 }
 
 func Box_New[T any](item T) Box[T] {

--- a/tests/spec/build/snapshots/cross_module_pointer_receiver_method_value.snap
+++ b/tests/spec/build/snapshots/cross_module_pointer_receiver_method_value.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Counter struct {
 	Count int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { count: %v }", c.Count)
 }
 
 func (c *Counter) Increment() {

--- a/tests/spec/build/snapshots/cross_module_static_method_call.snap
+++ b/tests/spec/build/snapshots/cross_module_static_method_call.snap
@@ -4,15 +4,9 @@ source: tests/spec/build/mod.rs
 // === geometry/lib.go ===
 package geometry
 
-import "fmt"
-
 type Point struct {
 	X float64
 	Y float64
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func Point_New(x, y float64) Point {

--- a/tests/spec/build/snapshots/cross_module_type_alias_remote_static_method.snap
+++ b/tests/spec/build/snapshots/cross_module_type_alias_remote_static_method.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/mod.go ===
 package lib
 
-import "fmt"
-
 type Box struct {
 	X int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.X)
 }
 
 func Box_New(x int) Box {

--- a/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
+++ b/tests/spec/build/snapshots/cross_module_type_in_function_signature.snap
@@ -44,13 +44,7 @@ func main() {
 // === models/mod.go ===
 package models
 
-import "fmt"
-
 type Item struct {
 	Name  string
 	Value int
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v, value: %v }", i.Name, i.Value)
 }

--- a/tests/spec/build/snapshots/cross_module_ufcs_uses_import_alias.snap
+++ b/tests/spec/build/snapshots/cross_module_ufcs_uses_import_alias.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === lib/box.go ===
 package lib
 
-import "fmt"
-
 type Box[T any] struct {
 	Value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
 }
 
 func Box_Map[T any, U any](self Box[T], f func(T) U) Box[U] {

--- a/tests/spec/build/snapshots/entry_module_type_alias_cross_module_enum_variant.snap
+++ b/tests/spec/build/snapshots/entry_module_type_alias_cross_module_enum_variant.snap
@@ -17,8 +17,6 @@ func main() {
 // === palette/mod.go ===
 package palette
 
-import "fmt"
-
 func MakeColorRGB() Color {
 	return Color{Tag: ColorRGB}
 }
@@ -37,26 +35,4 @@ const (
 type Color struct {
 	Tag   ColorTag
 	Named string
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRGB:
-		return "RGB"
-	case ColorNamed:
-		return fmt.Sprintf("Named(%v)", c.Named)
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRGB:
-		return "Color.RGB"
-	case ColorNamed:
-		return fmt.Sprintf("Color.Named(%v)", c.Named)
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }

--- a/tests/spec/build/snapshots/enum_type_alias_with_import_alias.snap
+++ b/tests/spec/build/snapshots/enum_type_alias_with_import_alias.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 func MakeEventClick(arg0 int) Event {
 	return Event{Tag: EventClick, X: arg0}
 }
@@ -19,24 +17,6 @@ const (
 type Event struct {
 	Tag EventTag
 	X   int
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
+++ b/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
@@ -24,10 +24,6 @@ type Score struct {
 	val  int
 }
 
-func (s Score) String() string {
-	return fmt.Sprintf("Score { name: %v, val: %v }", s.name, s.val)
-}
-
 func (s Score) MapVal() string {
 	return s.name
 }

--- a/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
+++ b/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Entry[T any] struct {
 	value T
-}
-
-func (e Entry[T]) String() string {
-	return fmt.Sprintf("Entry { value: %v }", e.value)
 }
 
 type Cache[T any] interface {
@@ -20,10 +14,6 @@ type Cache[T any] interface {
 
 type MyCache[T any] struct {
 	entry Entry[T]
-}
-
-func (m MyCache[T]) String() string {
-	return fmt.Sprintf("MyCache { entry: %v }", m.entry)
 }
 
 func (m MyCache[T]) Get(_ string) *Entry[T] {

--- a/tests/spec/build/snapshots/go_exported_impl_method_kept_even_when_never_called.snap
+++ b/tests/spec/build/snapshots/go_exported_impl_method_kept_even_when_never_called.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Widget struct {
 	name string
-}
-
-func (w Widget) String() string {
-	return fmt.Sprintf("Widget { name: %v }", w.name)
 }
 
 func (w Widget) MarshalJSON() string {

--- a/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_error_interface.snap
+++ b/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_error_interface.snap
@@ -15,10 +15,6 @@ type MyErr struct {
 	msg string
 }
 
-func (m MyErr) String() string {
-	return fmt.Sprintf("MyErr { msg: %v }", m.msg)
-}
-
 func (m MyErr) Error() string {
 	return "ERR: " + m.msg
 }

--- a/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_fmt_stringer.snap
+++ b/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_fmt_stringer.snap
@@ -15,10 +15,6 @@ type A struct {
 	a string
 }
 
-func (a A) GoString() string {
-	return fmt.Sprintf("A { a: %v }", a.a)
-}
-
 func (a A) String() string {
 	return a.a + "asdf"
 }

--- a/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_go_stringer.snap
+++ b/tests/spec/build/snapshots/go_exported_impl_method_kept_when_only_reached_via_go_stringer.snap
@@ -15,10 +15,6 @@ type A struct {
 	a string
 }
 
-func (a A) String() string {
-	return fmt.Sprintf("A { a: %v }", a.a)
-}
-
 func (a A) GoString() string {
 	return a.a + "asdf"
 }

--- a/tests/spec/build/snapshots/impl_bounds_with_module_alias_import_path.snap
+++ b/tests/spec/build/snapshots/impl_bounds_with_module_alias_import_path.snap
@@ -12,17 +12,10 @@ type Printable interface {
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	I "github.com/user/myproject/ifaces"
-)
+import I "github.com/user/myproject/ifaces"
 
 type Box[T I.Printable] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func (b Box[T]) show() string {
@@ -31,10 +24,6 @@ func (b Box[T]) show() string {
 
 type Name struct {
 	name string
-}
-
-func (n Name) String() string {
-	return fmt.Sprintf("Name { name: %v }", n.name)
 }
 
 func (n Name) Print() string {

--- a/tests/spec/build/snapshots/import_alias_static_method_call.snap
+++ b/tests/spec/build/snapshots/import_alias_static_method_call.snap
@@ -4,15 +4,9 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func Point_New(x, y int) Point {

--- a/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
+++ b/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Entry struct {
 	name string
-}
-
-func (e Entry) String() string {
-	return fmt.Sprintf("Entry { name: %v }", e.name)
 }
 
 type BaseCache interface {
@@ -24,10 +18,6 @@ type ExtendedCache interface {
 }
 
 type MyCache struct{}
-
-func (m MyCache) String() string {
-	return "MyCache"
-}
 
 func (m MyCache) Get(_ string) *Entry {
 	return nil

--- a/tests/spec/build/snapshots/iterable_enum_export_name_consistency.snap
+++ b/tests/spec/build/snapshots/iterable_enum_export_name_consistency.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 func MakePublicPhaseBuild() PublicPhase {
 	return PublicPhase{Tag: PublicPhaseBuild}
 }
@@ -24,24 +22,6 @@ type PublicPhase struct {
 	Tag PublicPhaseTag
 }
 
-func (p PublicPhase) String() string {
-	switch p.Tag {
-	case PublicPhaseBuild:
-		return "Build"
-	default:
-		return fmt.Sprintf("PublicPhase(%d)", p.Tag)
-	}
-}
-
-func (p PublicPhase) GoString() string {
-	switch p.Tag {
-	case PublicPhaseBuild:
-		return "PublicPhase.Build"
-	default:
-		return fmt.Sprintf("PublicPhase(%d)", p.Tag)
-	}
-}
-
 func PublicPhase_Variants() []PublicPhase {
 	return []PublicPhase{
 		{Tag: PublicPhaseBuild},
@@ -56,24 +36,6 @@ const (
 
 type LocalPhase struct {
 	Tag LocalPhaseTag
-}
-
-func (l LocalPhase) String() string {
-	switch l.Tag {
-	case LocalPhaseCheck:
-		return "Check"
-	default:
-		return fmt.Sprintf("LocalPhase(%d)", l.Tag)
-	}
-}
-
-func (l LocalPhase) GoString() string {
-	switch l.Tag {
-	case LocalPhaseCheck:
-		return "LocalPhase.Check"
-	default:
-		return fmt.Sprintf("LocalPhase(%d)", l.Tag)
-	}
 }
 
 func LocalPhase_Variants() []LocalPhase {

--- a/tests/spec/build/snapshots/iterable_enum_named_go_keyword.snap
+++ b/tests/spec/build/snapshots/iterable_enum_named_go_keyword.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 func Makemap_A() map_ {
 	return map_{Tag: mapA}
 }
@@ -23,28 +21,6 @@ const (
 
 type map_ struct {
 	Tag mapTag
-}
-
-func (m map_) String() string {
-	switch m.Tag {
-	case mapA:
-		return "A"
-	case mapB:
-		return "B"
-	default:
-		return fmt.Sprintf("map(%d)", m.Tag)
-	}
-}
-
-func (m map_) GoString() string {
-	switch m.Tag {
-	case mapA:
-		return "map.A"
-	case mapB:
-		return "map.B"
-	default:
-		return fmt.Sprintf("map(%d)", m.Tag)
-	}
 }
 
 func map_variants() []map_ {

--- a/tests/spec/build/snapshots/lisette_cased_error_method_promotes_to_go_exported.snap
+++ b/tests/spec/build/snapshots/lisette_cased_error_method_promotes_to_go_exported.snap
@@ -10,10 +10,6 @@ type MyErr struct {
 	msg string
 }
 
-func (m MyErr) String() string {
-	return fmt.Sprintf("MyErr { msg: %v }", m.msg)
-}
-
 func (m MyErr) Error() string {
 	return "ERR: " + m.msg
 }

--- a/tests/spec/build/snapshots/lisette_cased_go_stringer_method_promotes_to_go_exported.snap
+++ b/tests/spec/build/snapshots/lisette_cased_go_stringer_method_promotes_to_go_exported.snap
@@ -10,10 +10,6 @@ type A struct {
 	a string
 }
 
-func (a A) String() string {
-	return fmt.Sprintf("A { a: %v }", a.a)
-}
-
 func (a A) GoString() string {
 	return "dbg_" + a.a
 }

--- a/tests/spec/build/snapshots/lisette_cased_stringer_method_promotes_to_go_exported.snap
+++ b/tests/spec/build/snapshots/lisette_cased_stringer_method_promotes_to_go_exported.snap
@@ -10,10 +10,6 @@ type A struct {
 	a string
 }
 
-func (a A) GoString() string {
-	return fmt.Sprintf("A { a: %v }", a.a)
-}
-
 func (a A) String() string {
 	return "lis_" + a.a
 }

--- a/tests/spec/build/snapshots/local_alias_cross_module_enum_struct_variant_tag.snap
+++ b/tests/spec/build/snapshots/local_alias_cross_module_enum_struct_variant_tag.snap
@@ -4,8 +4,6 @@ source: tests/spec/build/mod.rs
 // === lib/lib.go ===
 package lib
 
-import "fmt"
-
 func MakeEventClick(arg0 int) Event {
 	return Event{Tag: EventClick, X: arg0}
 }
@@ -19,24 +17,6 @@ const (
 type Event struct {
 	Tag EventTag
 	X   int
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
+++ b/tests/spec/build/snapshots/mixed_constrained_unconstrained_impl_blocks.snap
@@ -14,10 +14,6 @@ type Box[T any] struct {
 	value T
 }
 
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
-}
-
 func Box_print[T Printable](self Box[T]) {
 	fmt.Println(self.value.ToString())
 }
@@ -28,10 +24,6 @@ func (b Box[T]) get() T {
 
 type Name struct {
 	name string
-}
-
-func (n Name) String() string {
-	return fmt.Sprintf("Name { name: %v }", n.name)
 }
 
 func (n Name) ToString() string {

--- a/tests/spec/build/snapshots/module_alias_used_in_type_references.snap
+++ b/tests/spec/build/snapshots/module_alias_used_in_type_references.snap
@@ -19,14 +19,8 @@ func main() {
 // === models/user/user.go ===
 package user
 
-import "fmt"
-
 type User struct {
 	Name string
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }
 
 func New(name string) User {

--- a/tests/spec/build/snapshots/multi_file_module_bootstrap_imports.snap
+++ b/tests/spec/build/snapshots/multi_file_module_bootstrap_imports.snap
@@ -4,28 +4,16 @@ source: tests/spec/build/mod.rs
 // === bar/bar.go ===
 package bar
 
-import "fmt"
-
 type Bar struct {
 	Name string
-}
-
-func (b Bar) String() string {
-	return fmt.Sprintf("Bar { name: %v }", b.Name)
 }
 
 
 // === foo/foo.go ===
 package foo
 
-import "fmt"
-
 type Foo struct {
 	Value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.Value)
 }
 
 func Foo_New(v int) Foo {
@@ -36,14 +24,8 @@ func Foo_New(v int) Foo {
 // === gizmo/gizmo.go ===
 package gizmo
 
-import "fmt"
-
 type Widget struct {
 	Name string
-}
-
-func (w Widget) String() string {
-	return fmt.Sprintf("Widget { name: %v }", w.Name)
 }
 
 
@@ -67,7 +49,6 @@ func main() {
 package types
 
 import (
-	"fmt"
 	"github.com/user/myproject/bar"
 	"github.com/user/myproject/foo"
 	g "github.com/user/myproject/gizmo"
@@ -105,36 +86,6 @@ type MyEnum struct {
 	Multi1         bar.Bar
 	ContainerSlice []foo.Foo
 	Aliased        g.Widget
-}
-
-func (m MyEnum) String() string {
-	switch m.Tag {
-	case MyEnumSingle:
-		return fmt.Sprintf("Single(%v)", m.Single)
-	case MyEnumMulti:
-		return fmt.Sprintf("Multi(%v, %v)", m.Multi0, m.Multi1)
-	case MyEnumContainerSlice:
-		return fmt.Sprintf("ContainerSlice(%v)", m.ContainerSlice)
-	case MyEnumAliased:
-		return fmt.Sprintf("Aliased(%v)", m.Aliased)
-	default:
-		return fmt.Sprintf("MyEnum(%d)", m.Tag)
-	}
-}
-
-func (m MyEnum) GoString() string {
-	switch m.Tag {
-	case MyEnumSingle:
-		return fmt.Sprintf("MyEnum.Single(%v)", m.Single)
-	case MyEnumMulti:
-		return fmt.Sprintf("MyEnum.Multi(%v, %v)", m.Multi0, m.Multi1)
-	case MyEnumContainerSlice:
-		return fmt.Sprintf("MyEnum.ContainerSlice(%v)", m.ContainerSlice)
-	case MyEnumAliased:
-		return fmt.Sprintf("MyEnum.Aliased(%v)", m.Aliased)
-	default:
-		return fmt.Sprintf("MyEnum(%d)", m.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/multi_file_module_bootstrap_imports_stdlib.snap
+++ b/tests/spec/build/snapshots/multi_file_module_bootstrap_imports_stdlib.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === foo/foo.go ===
 package foo
 
-import "fmt"
-
 type Foo struct {
 	Value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.Value)
 }
 
 func Foo_New(v int) Foo {
@@ -40,7 +34,6 @@ func main() {
 package types
 
 import (
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 	"github.com/user/myproject/foo"
 )
@@ -58,24 +51,6 @@ const (
 type MyEnum struct {
 	Tag   MyEnumTag
 	Maybe lisette.Option[foo.Foo]
-}
-
-func (m MyEnum) String() string {
-	switch m.Tag {
-	case MyEnumMaybe:
-		return fmt.Sprintf("Maybe(%v)", m.Maybe)
-	default:
-		return fmt.Sprintf("MyEnum(%d)", m.Tag)
-	}
-}
-
-func (m MyEnum) GoString() string {
-	switch m.Tag {
-	case MyEnumMaybe:
-		return fmt.Sprintf("MyEnum.Maybe(%v)", m.Maybe)
-	default:
-		return fmt.Sprintf("MyEnum(%d)", m.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/multi_file_module_sibling_visibility.snap
+++ b/tests/spec/build/snapshots/multi_file_module_sibling_visibility.snap
@@ -13,15 +13,9 @@ func main() {
 // === point.go ===
 package main
 
-import "fmt"
-
 type Point struct {
 	x float64
 	y float64
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func Point_new(x, y float64) Point {

--- a/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
+++ b/tests/spec/build/snapshots/multimodule_cross_module_enum_usage.snap
@@ -23,8 +23,6 @@ func main() {
 // === shapes/lib.go ===
 package shapes
 
-import "fmt"
-
 func MakeShapeKindCircleKind(arg0 Circle) ShapeKind {
 	return ShapeKind{Tag: ShapeKindCircleKind, CircleKind: arg0}
 }
@@ -35,10 +33,6 @@ func MakeShapeKindRectKind(arg0 float64, arg1 float64) ShapeKind {
 
 type Circle struct {
 	Radius float64
-}
-
-func (c Circle) String() string {
-	return fmt.Sprintf("Circle { radius: %v }", c.Radius)
 }
 
 type ShapeKindTag int
@@ -53,26 +47,4 @@ type ShapeKind struct {
 	CircleKind Circle
 	Width      float64
 	Height     float64
-}
-
-func (s ShapeKind) String() string {
-	switch s.Tag {
-	case ShapeKindCircleKind:
-		return fmt.Sprintf("CircleKind(%v)", s.CircleKind)
-	case ShapeKindRectKind:
-		return fmt.Sprintf("RectKind { width: %v, height: %v }", s.Width, s.Height)
-	default:
-		return fmt.Sprintf("ShapeKind(%d)", s.Tag)
-	}
-}
-
-func (s ShapeKind) GoString() string {
-	switch s.Tag {
-	case ShapeKindCircleKind:
-		return fmt.Sprintf("ShapeKind.CircleKind(%v)", s.CircleKind)
-	case ShapeKindRectKind:
-		return fmt.Sprintf("ShapeKind.RectKind { width: %v, height: %v }", s.Width, s.Height)
-	default:
-		return fmt.Sprintf("ShapeKind(%d)", s.Tag)
-	}
 }

--- a/tests/spec/build/snapshots/multimodule_enum_constructors_not_leaked.snap
+++ b/tests/spec/build/snapshots/multimodule_enum_constructors_not_leaked.snap
@@ -4,10 +4,7 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	"github.com/user/myproject/utils"
-)
+import "github.com/user/myproject/utils"
 
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
@@ -26,28 +23,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/build/snapshots/multimodule_enum_static_method.snap
+++ b/tests/spec/build/snapshots/multimodule_enum_static_method.snap
@@ -15,8 +15,6 @@ func main() {
 // === shapes/mod.go ===
 package shapes
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -39,32 +37,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func Color_Default() Color {

--- a/tests/spec/build/snapshots/multimodule_generic_tuple_struct_method.snap
+++ b/tests/spec/build/snapshots/multimodule_generic_tuple_struct_method.snap
@@ -15,14 +15,8 @@ func main() {
 // === types/lib.go ===
 package types
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 func (w Wrapper[T]) Unwrap() T {

--- a/tests/spec/build/snapshots/multimodule_generic_type_alias.snap
+++ b/tests/spec/build/snapshots/multimodule_generic_type_alias.snap
@@ -15,14 +15,8 @@ func main() {
 // === types/mod.go ===
 package types
 
-import "fmt"
-
 type Box[T any] struct {
 	Value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
 }
 
 

--- a/tests/spec/build/snapshots/multimodule_import_between_local_modules.snap
+++ b/tests/spec/build/snapshots/multimodule_import_between_local_modules.snap
@@ -33,18 +33,11 @@ func Abs(n int) int {
 // === shapes/lib.go ===
 package shapes
 
-import (
-	"fmt"
-	"github.com/user/myproject/mymath"
-)
+import "github.com/user/myproject/mymath"
 
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func (p Point) ManhattanDistance(other Point) int {

--- a/tests/spec/build/snapshots/multimodule_iterable_enum.snap
+++ b/tests/spec/build/snapshots/multimodule_iterable_enum.snap
@@ -18,8 +18,6 @@ func main() {
 // === phases/mod.go ===
 package phases
 
-import "fmt"
-
 func MakeBuildPhaseValidate() BuildPhase {
 	return BuildPhase{Tag: BuildPhaseValidate}
 }
@@ -42,32 +40,6 @@ const (
 
 type BuildPhase struct {
 	Tag BuildPhaseTag
-}
-
-func (b BuildPhase) String() string {
-	switch b.Tag {
-	case BuildPhaseValidate:
-		return "Validate"
-	case BuildPhaseParse:
-		return "Parse"
-	case BuildPhaseCodegen:
-		return "Codegen"
-	default:
-		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
-	}
-}
-
-func (b BuildPhase) GoString() string {
-	switch b.Tag {
-	case BuildPhaseValidate:
-		return "BuildPhase.Validate"
-	case BuildPhaseParse:
-		return "BuildPhase.Parse"
-	case BuildPhaseCodegen:
-		return "BuildPhase.Codegen"
-	default:
-		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
-	}
 }
 
 func BuildPhase_Variants() []BuildPhase {

--- a/tests/spec/build/snapshots/multimodule_nested_path_enum_construction.snap
+++ b/tests/spec/build/snapshots/multimodule_nested_path_enum_construction.snap
@@ -18,8 +18,6 @@ func main() {
 // === types/events/mod.go ===
 package events
 
-import "fmt"
-
 func MakeEventClick(arg0 int, arg1 int) Event {
 	return Event{Tag: EventClick, X: arg0, Y: arg1}
 }
@@ -39,26 +37,4 @@ type Event struct {
 	Tag EventTag
 	X   int
 	Y   int
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click { x: %v, y: %v }", e.X, e.Y)
-	case EventReset:
-		return "Reset"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click { x: %v, y: %v }", e.X, e.Y)
-	case EventReset:
-		return "Event.Reset"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }

--- a/tests/spec/build/snapshots/multimodule_static_method_call.snap
+++ b/tests/spec/build/snapshots/multimodule_static_method_call.snap
@@ -15,15 +15,9 @@ func main() {
 // === shapes/lib.go ===
 package shapes
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func Point_New(x, y int) Point {

--- a/tests/spec/build/snapshots/multimodule_tuple_struct_field_access.snap
+++ b/tests/spec/build/snapshots/multimodule_tuple_struct_field_access.snap
@@ -31,28 +31,14 @@ func main() {
 // === types/lib.go ===
 package types
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 type Point struct {
 	F0 int
 	F1 int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
-}
-
 type Pair[A any, B any] struct {
 	F0 A
 	F1 B
-}
-
-func (p Pair[A, B]) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }

--- a/tests/spec/build/snapshots/multimodule_type_alias_enum_all_variants.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_enum_all_variants.snap
@@ -12,8 +12,6 @@ type UIEvent = events.Event
 // === events/mod.go ===
 package events
 
-import "fmt"
-
 func MakeEventClick(arg0 int, arg1 int) Event {
 	return Event{Tag: EventClick, X: arg0, Y: arg1}
 }
@@ -39,32 +37,6 @@ type Event struct {
 	X        int
 	Y        int
 	KeyPress string
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click { x: %v, y: %v }", e.X, e.Y)
-	case EventKeyPress:
-		return fmt.Sprintf("KeyPress(%v)", e.KeyPress)
-	case EventClose:
-		return "Close"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click { x: %v, y: %v }", e.X, e.Y)
-	case EventKeyPress:
-		return fmt.Sprintf("Event.KeyPress(%v)", e.KeyPress)
-	case EventClose:
-		return "Event.Close"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_enum_pattern_matching.snap
@@ -12,8 +12,6 @@ type UIEvent = events.Event
 // === events/mod.go ===
 package events
 
-import "fmt"
-
 func MakeEventClick(arg0 int, arg1 int) Event {
 	return Event{Tag: EventClick, X: arg0, Y: arg1}
 }
@@ -39,32 +37,6 @@ type Event struct {
 	X        int
 	Y        int
 	KeyPress string
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click { x: %v, y: %v }", e.X, e.Y)
-	case EventKeyPress:
-		return fmt.Sprintf("KeyPress(%v)", e.KeyPress)
-	case EventClose:
-		return "Close"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click { x: %v, y: %v }", e.X, e.Y)
-	case EventKeyPress:
-		return fmt.Sprintf("Event.KeyPress(%v)", e.KeyPress)
-	case EventClose:
-		return "Event.Close"
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }
 
 

--- a/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
@@ -4,15 +4,9 @@ source: tests/spec/build/mod.rs
 // === geo/lib.go ===
 package geo
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 type Coordinate = Point

--- a/tests/spec/build/snapshots/multimodule_type_alias_struct_literal.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_struct_literal.snap
@@ -12,14 +12,8 @@ type PublicSecret = internal.Secret
 // === internal/mod.go ===
 package internal
 
-import "fmt"
-
 type Secret struct {
 	Value int
-}
-
-func (s Secret) String() string {
-	return fmt.Sprintf("Secret { value: %v }", s.Value)
 }
 
 

--- a/tests/spec/build/snapshots/multimodule_ufcs_method.snap
+++ b/tests/spec/build/snapshots/multimodule_ufcs_method.snap
@@ -18,14 +18,8 @@ func main() {
 // === types/lib.go ===
 package types
 
-import "fmt"
-
 type Box[T any] struct {
 	Value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.Value)
 }
 
 func Box_Map[T any, U any](self Box[T], f func(T) U) Box[U] {

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
@@ -19,10 +19,6 @@ type Container[T any] struct {
 	label string
 }
 
-func (c Container[T]) String() string {
-	return fmt.Sprintf("Container { value: %v, label: %v }", c.value, c.label)
-}
-
 func Container_display[T Printable](self Container[T]) string {
 	return fmt.Sprintf("[%s] %s", self.label, self.value.PrintVal())
 }
@@ -34,10 +30,6 @@ func Container_total[T Summable](self Container[T]) int {
 type Item struct {
 	name  string
 	count int
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v, count: %v }", i.name, i.count)
 }
 
 func (i Item) PrintVal() string {

--- a/tests/spec/build/snapshots/multiple_json_attributes_merge.snap
+++ b/tests/spec/build/snapshots/multiple_json_attributes_merge.snap
@@ -4,18 +4,11 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "encoding/json"
 
 type User struct {
 	FirstName  string `json:"firstName,omitempty"`
 	MiddleName string `json:"middleName,omitempty"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { first_name: %v, middle_name: %v }", u.FirstName, u.MiddleName)
 }
 
 func main() {

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -14,10 +14,6 @@ type Label struct {
 	text string
 }
 
-func (l Label) String() string {
-	return fmt.Sprintf("Label { text: %v }", l.text)
-}
-
 func (l Label) Show() string {
 	return l.text
 }
@@ -72,10 +68,6 @@ type Pair[A traits.Showable, B traits.Showable] struct {
 	Second B
 }
 
-func (p Pair[A, B]) String() string {
-	return fmt.Sprintf("Pair { first: %v, second: %v }", p.First, p.Second)
-}
-
 func (p Pair[A, B]) Show() string {
 	return fmt.Sprintf("(%s, %s)", p.First.Show(), p.Second.Show())
 }
@@ -87,10 +79,6 @@ func (p Pair[A, B]) Display() string {
 type Tagged[T traits.Showable] struct {
 	Value T
 	Label string
-}
-
-func (t Tagged[T]) String() string {
-	return fmt.Sprintf("Tagged { value: %v, label: %v }", t.Value, t.Label)
 }
 
 func (t Tagged[T]) Show() string {

--- a/tests/spec/build/snapshots/nested_module_static_method_call.snap
+++ b/tests/spec/build/snapshots/nested_module_static_method_call.snap
@@ -14,15 +14,9 @@ func main() {
 // === models/user/user.go ===
 package user
 
-import "fmt"
-
 type User struct {
 	Name  string
 	Email string
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, email: %v }", u.Name, u.Email)
 }
 
 func User_New(name, email string) User {

--- a/tests/spec/build/snapshots/nested_module_type_qualifier.snap
+++ b/tests/spec/build/snapshots/nested_module_type_qualifier.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === core/types/types.go ===
 package types
 
-import "fmt"
-
 type Item struct {
 	Name string
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v }", i.Name)
 }
 
 

--- a/tests/spec/build/snapshots/nested_submodule_type_reference.snap
+++ b/tests/spec/build/snapshots/nested_submodule_type_reference.snap
@@ -4,17 +4,10 @@ source: tests/spec/build/mod.rs
 // === lib/mod.go ===
 package lib
 
-import (
-	"fmt"
-	"github.com/user/myproject/lib/sub"
-)
+import "github.com/user/myproject/lib/sub"
 
 type Container struct {
 	Items []sub.Item
-}
-
-func (c Container) String() string {
-	return fmt.Sprintf("Container { items: %v }", c.Items)
 }
 
 func FirstItem(c Container) sub.Item {
@@ -25,15 +18,9 @@ func FirstItem(c Container) sub.Item {
 // === lib/sub/mod.go ===
 package sub
 
-import "fmt"
-
 type Item struct {
 	Name  string
 	Score int
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { name: %v, score: %v }", i.Name, i.Score)
 }
 
 

--- a/tests/spec/build/snapshots/non_error_err_slot_stays_tagged.snap
+++ b/tests/spec/build/snapshots/non_error_err_slot_stays_tagged.snap
@@ -4,17 +4,10 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type MyError struct {
 	msg string
-}
-
-func (m MyError) String() string {
-	return fmt.Sprintf("MyError { msg: %v }", m.msg)
 }
 
 func parse(s string) lisette.Result[int, MyError] {

--- a/tests/spec/build/snapshots/non_go_err_result_keeps_tagged_form.snap
+++ b/tests/spec/build/snapshots/non_go_err_result_keeps_tagged_form.snap
@@ -4,24 +4,13 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type LoadError struct {
 	msg string
 }
 
-func (l LoadError) String() string {
-	return fmt.Sprintf("LoadError { msg: %v }", l.msg)
-}
-
 type Loader struct{}
-
-func (l Loader) String() string {
-	return "Loader"
-}
 
 func (l Loader) Load(_ string) lisette.Result[int, LoadError] {
 	return lisette.MakeResultOk[int, LoadError](0)

--- a/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
+++ b/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
@@ -11,15 +11,7 @@ import (
 
 type Reader1 struct{}
 
-func (r Reader1) String() string {
-	return "Reader1"
-}
-
 type Reader2 struct{}
-
-func (r Reader2) String() string {
-	return "Reader2"
-}
 
 func (r Reader1) Read(_ []uint8) (int, error) {
 	return 0, nil

--- a/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
+++ b/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
@@ -4,10 +4,7 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Face interface {
 }
@@ -18,10 +15,6 @@ func Lookup(_ int) Face {
 
 type Holder struct {
 	N int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { n: %v }", h.N)
 }
 
 func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {

--- a/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
+++ b/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
@@ -29,10 +29,6 @@ type Person struct {
 	Name string
 }
 
-func (p Person) String() string {
-	return fmt.Sprintf("Person { name: %v }", p.Name)
-}
-
 func (p Person) Greet() string {
 	return fmt.Sprintf("Hello, I'm %s", p.Name)
 }

--- a/tests/spec/build/snapshots/receiver_name_collision_with_parameter.snap
+++ b/tests/spec/build/snapshots/receiver_name_collision_with_parameter.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === builder/mod.go ===
 package builder
 
-import "fmt"
-
 type StringBuilder struct {
 	Content string
-}
-
-func (s StringBuilder) String() string {
-	return fmt.Sprintf("StringBuilder { content: %v }", s.Content)
 }
 
 func (ss StringBuilder) Append(s string) StringBuilder {

--- a/tests/spec/build/snapshots/same_module_cross_file_method_casing.snap
+++ b/tests/spec/build/snapshots/same_module_cross_file_method_casing.snap
@@ -14,15 +14,9 @@ func main() {
 // === shapes/types.go ===
 package shapes
 
-import "fmt"
-
 type Point struct {
 	X float64
 	Y float64
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func Point_New(x, y float64) Point {
@@ -35,10 +29,6 @@ func Point_New(x, y float64) Point {
 type Builder struct {
 	X float64
 	Y float64
-}
-
-func (b Builder) String() string {
-	return fmt.Sprintf("Builder { x: %v, y: %v }", b.X, b.Y)
 }
 
 func Builder_New() Builder {

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
@@ -15,10 +15,6 @@ func Resultant(arg int) (int, Face) {
 
 type Holder struct{}
 
-func (h Holder) String() string {
-	return "Holder"
-}
-
 func Holder_Resolve[R any, E any](_ Holder, default_ R, _ ...func(int) lisette.Result[R, E]) lisette.Result[R, E] {
 	return lisette.MakeResultOk[R, E](default_)
 }

--- a/tests/spec/build/snapshots/static_method_name_casing_consistency.snap
+++ b/tests/spec/build/snapshots/static_method_name_casing_consistency.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === api/lib.go ===
 package api
 
-import "fmt"
-
 type Service struct {
 	Name string
-}
-
-func (s Service) String() string {
-	return fmt.Sprintf("Service { name: %v }", s.Name)
 }
 
 func Service_New(name string) Service {
@@ -22,17 +16,10 @@ func Service_New(name string) Service {
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	"github.com/user/myproject/api"
-)
+import "github.com/user/myproject/api"
 
 type Helper struct {
 	value int
-}
-
-func (h Helper) String() string {
-	return fmt.Sprintf("Helper { value: %v }", h.value)
 }
 
 func Helper_New(v int) Helper {

--- a/tests/spec/build/snapshots/struct_satisfies_inherited_methods_via_lowering.snap
+++ b/tests/spec/build/snapshots/struct_satisfies_inherited_methods_via_lowering.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Dev struct{}
 
-func (d Dev) String() string {
-	return "Dev"
-}
-
 func (d Dev) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/build/snapshots/unused_method_with_go_import_not_emitted.snap
+++ b/tests/spec/build/snapshots/unused_method_with_go_import_not_emitted.snap
@@ -11,10 +11,6 @@ type Name struct {
 	last  string
 }
 
-func (n Name) String() string {
-	return fmt.Sprintf("Name { first: %v, last: %v }", n.first, n.last)
-}
-
 func main() {
 	n := Name{
 		first: "A",

--- a/tests/spec/build/snapshots/user_close_lowers_to_bare_error.snap
+++ b/tests/spec/build/snapshots/user_close_lowers_to_bare_error.snap
@@ -6,10 +6,6 @@ package main
 
 type Resource struct{}
 
-func (r Resource) String() string {
-	return "Resource"
-}
-
 func (r Resource) Close() error {
 	return nil
 }

--- a/tests/spec/build/snapshots/user_file_named_bootstrap_does_not_collide.snap
+++ b/tests/spec/build/snapshots/user_file_named_bootstrap_does_not_collide.snap
@@ -8,8 +8,6 @@ package main
 // === main.go ===
 package main
 
-import "fmt"
-
 func MakeAA() A {
 	return A{Tag: AA}
 }
@@ -26,22 +24,4 @@ const (
 
 type A struct {
 	Tag ATag
-}
-
-func (a A) String() string {
-	switch a.Tag {
-	case AA:
-		return "A"
-	default:
-		return fmt.Sprintf("A(%d)", a.Tag)
-	}
-}
-
-func (a A) GoString() string {
-	switch a.Tag {
-	case AA:
-		return "A.A"
-	default:
-		return fmt.Sprintf("A(%d)", a.Tag)
-	}
 }

--- a/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
+++ b/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Entry struct {
 	name string
-}
-
-func (e Entry) String() string {
-	return fmt.Sprintf("Entry { name: %v }", e.name)
 }
 
 type Cache interface {
@@ -19,10 +13,6 @@ type Cache interface {
 }
 
 type MyCache struct{}
-
-func (m MyCache) String() string {
-	return "MyCache"
-}
 
 func (m MyCache) GetSession(_ string) *Entry {
 	return nil

--- a/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
+++ b/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Entry struct {
 	name string
-}
-
-func (e Entry) String() string {
-	return fmt.Sprintf("Entry { name: %v }", e.name)
 }
 
 type Cache interface {
@@ -19,10 +13,6 @@ type Cache interface {
 }
 
 type MyCache struct{}
-
-func (m MyCache) String() string {
-	return "MyCache"
-}
 
 func (m MyCache) Get(_ string) *Entry {
 	return nil

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -14,10 +14,6 @@ type Widget struct {
 	id int
 }
 
-func (w Widget) String() string {
-	return fmt.Sprintf("Widget { id: %v }", w.id)
-}
-
 func (w Widget) MarshalJSON() ([]uint8, error) {
 	return []uint8("\"custom\""), nil
 }

--- a/tests/spec/build/snapshots/user_read_lowers_partial_to_io_reader.snap
+++ b/tests/spec/build/snapshots/user_read_lowers_partial_to_io_reader.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Reader struct{}
 
-func (r Reader) String() string {
-	return "Reader"
-}
-
 func (r Reader) Read(_ []uint8) (int, error) {
 	return 0, io.EOF
 }

--- a/tests/spec/build/snapshots/user_text_marshaler_skips_adapter.snap
+++ b/tests/spec/build/snapshots/user_text_marshaler_skips_adapter.snap
@@ -4,14 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "fmt"
-
 type Widget struct {
 	id int
-}
-
-func (w Widget) String() string {
-	return fmt.Sprintf("Widget { id: %v }", w.id)
 }
 
 func (w Widget) MarshalText() ([]byte, error) {

--- a/tests/spec/emit/snapshots/address_of_enum_variant.snap
+++ b/tests/spec/emit/snapshots/address_of_enum_variant.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List {\n  Cons(int, Ref<List>),\n  Nil,\n}\n\nfn tes
 ---
 package main
 
-import "fmt"
-
 func MakeListCons(arg0 int, arg1 *List) List {
 	return List{Tag: ListCons, Cons0: arg0, Cons1: arg1}
 }
@@ -25,28 +23,6 @@ type List struct {
 	Tag   ListTag
 	Cons0 int
 	Cons1 *List
-}
-
-func (l List) String() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List) GoString() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "List.Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func test() List {

--- a/tests/spec/emit/snapshots/address_of_function_call.snap
+++ b/tests/spec/emit/snapshots/address_of_function_call.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { value: int }\n\nfn make_foo() -> Foo {\n  Fo
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.value)
 }
 
 func make_foo() Foo {

--- a/tests/spec/emit/snapshots/alias_chain_propagates_comparable_through_two_steps.snap
+++ b/tests/spec/emit/snapshots/alias_chain_propagates_comparable_through_two_steps.snap
@@ -4,18 +4,12 @@ description: "input: \ntype B<T> = Map<T, int>\ntype A<T> = B<T>\n\nstruct Box<T
 ---
 package main
 
-import "fmt"
-
 type B[T comparable] = map[T]int
 
 type A[T comparable] = B[T]
 
 type Box[T comparable] struct {
 	table A[T]
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { table: %v }", b.table)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/aliased_go_import_preserved_for_unused_type.snap
+++ b/tests/spec/emit/snapshots/aliased_go_import_preserved_for_unused_type.snap
@@ -4,17 +4,10 @@ description: "input: \nimport s \"go:sync\"\n\nstruct Wrapper {\n  mu: s.Mutex,\
 ---
 package main
 
-import (
-	"fmt"
-	s "sync"
-)
+import s "sync"
 
 type Wrapper struct {
 	mu s.Mutex
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { mu: %v }", w.mu)
 }
 
 func main() {}

--- a/tests/spec/emit/snapshots/append_non_lvalue_receiver_discards.snap
+++ b/tests/spec/emit/snapshots/append_non_lvalue_receiver_discards.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Items { items: Slice<int> }\n\nfn get() -> Items {
 ---
 package main
 
-import "fmt"
-
 type Items struct {
 	items []int
-}
-
-func (i Items) String() string {
-	return fmt.Sprintf("Items { items: %v }", i.items)
 }
 
 func get() Items {

--- a/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_concrete_struct.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> i
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Status { Good(int), Bad(string) }\n\nfn test(s: Stat
 ---
 package main
 
-import "fmt"
-
 func MakeStatusGood(arg0 int) Status {
 	return Status{Tag: StatusGood, Good: arg0}
 }
@@ -25,28 +23,6 @@ type Status struct {
 	Tag  StatusTag
 	Good int
 	Bad  string
-}
-
-func (s Status) String() string {
-	switch s.Tag {
-	case StatusGood:
-		return fmt.Sprintf("Good(%v)", s.Good)
-	case StatusBad:
-		return fmt.Sprintf("Bad(%v)", s.Bad)
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
-func (s Status) GoString() string {
-	switch s.Tag {
-	case StatusGood:
-		return fmt.Sprintf("Status.Good(%v)", s.Good)
-	case StatusBad:
-		return fmt.Sprintf("Status.Bad(%v)", s.Bad)
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
 }
 
 func test(s Status) int {

--- a/tests/spec/emit/snapshots/as_binding_on_slice_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_slice_element.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(pts: Slice<Poi
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(pts []Point) int {

--- a/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_tuple_element.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(pair: (Point, 
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(pair lisette.Tuple2[Point, int]) int {

--- a/tests/spec/emit/snapshots/as_binding_unused_elided.snap
+++ b/tests/spec/emit/snapshots/as_binding_unused_elided.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> i
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_carrier_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_carrier_ref.snap
@@ -4,23 +4,13 @@ description: "input: \nstruct Holder { p: Ref<int> }\nstruct Carrier { h: Ref<Ho
 ---
 package main
 
-import "fmt"
-
 type Holder struct {
 	p *int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { p: %v }", h.p)
 }
 
 type Carrier struct {
 	h  *Holder
 	np *int
-}
-
-func (c Carrier) String() string {
-	return fmt.Sprintf("Carrier { h: %v, np: %v }", c.h, c.np)
 }
 
 func retarget(c Carrier) int {

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_match_hidden_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_match_hidden_ref.snap
@@ -4,23 +4,13 @@ description: "input: \nstruct Holder { p: Ref<int> }\nstruct Carrier { h: Ref<Ho
 ---
 package main
 
-import "fmt"
-
 type Holder struct {
 	p *int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { p: %v }", h.p)
 }
 
 type Carrier struct {
 	h  *Holder
 	np *int
-}
-
-func (c Carrier) String() string {
-	return fmt.Sprintf("Carrier { h: %v, np: %v }", c.h, c.np)
 }
 
 func retarget(c Carrier) int {

--- a/tests/spec/emit/snapshots/assignment_deref_target_frozen_prebound_ref.snap
+++ b/tests/spec/emit/snapshots/assignment_deref_target_frozen_prebound_ref.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Holder { p: Ref<int> }\n\nfn retarget(h: Ref<Holde
 ---
 package main
 
-import "fmt"
-
 type Holder struct {
 	p *int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { p: %v }", h.p)
 }
 
 func retarget(h *Holder, np *int) int {

--- a/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
+++ b/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Thing {\n  name: string,\n}\n\nimpl Thing {\n  fn 
 ---
 package main
 
-import "fmt"
-
 type Thing struct {
 	name string
-}
-
-func (t Thing) String() string {
-	return fmt.Sprintf("Thing { name: %v }", t.name)
 }
 
 func Thing_maybe_create(name string) (Thing, bool) {

--- a/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
@@ -6,10 +6,6 @@ package main
 
 type Foo struct{}
 
-func (f Foo) String() string {
-	return "Foo"
-}
-
 func (f *Foo) need_ref() {}
 
 func test() {

--- a/tests/spec/emit/snapshots/auto_address_function_call_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_function_call_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(s
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.value)
 }
 
 func (f *Foo) increment() {

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(s
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.value)
 }
 
 func (f *Foo) increment() {

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(s
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.value)
 }
 
 func (f *Foo) increment() {

--- a/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  fn inc(self: Ref<B
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func (b *Box) inc() int {

--- a/tests/spec/emit/snapshots/auto_address_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_struct_literal_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { value: int }\n\nimpl Foo {\n  fn increment(s
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	value int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { value: %v }", f.value)
 }
 
 func (f *Foo) increment() {

--- a/tests/spec/emit/snapshots/block_expr_append_map_entry_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_map_entry_no_double_eval.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Outer { items: Slice<int> }\n\nfn key() -> string 
 ---
 package main
 
-import "fmt"
-
 type Outer struct {
 	items []int
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { items: %v }", o.items)
 }
 
 func key() string {

--- a/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn get() -> Ref<Wrap> {\n  let
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func get() *Wrap {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/block_vs_struct_disambiguation.snap
+++ b/tests/spec/emit/snapshots/block_vs_struct_disambiguation.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Point { x: int }\n\nfn test_if() -> int {\n  let x
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v }", p.x)
 }
 
 func test_if() int {

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Carrier {\n  C { p: Ref<int> },\n}\n\nfn bump(c: Car
 ---
 package main
 
-import "fmt"
-
 func MakeCarrierC(arg0 *int) Carrier {
 	return Carrier{Tag: CarrierC, P: arg0}
 }
@@ -19,24 +17,6 @@ const (
 type Carrier struct {
 	Tag CarrierTag
 	P   *int
-}
-
-func (c Carrier) String() string {
-	switch c.Tag {
-	case CarrierC:
-		return fmt.Sprintf("C { p: %v }", c.P)
-	default:
-		return fmt.Sprintf("Carrier(%d)", c.Tag)
-	}
-}
-
-func (c Carrier) GoString() string {
-	switch c.Tag {
-	case CarrierC:
-		return fmt.Sprintf("Carrier.C { p: %v }", c.P)
-	default:
-		return fmt.Sprintf("Carrier(%d)", c.Tag)
-	}
 }
 
 func bump(c Carrier) int {

--- a/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Carrier { p: Ref<int> }\n\nfn bump(c: Carrier) -> 
 ---
 package main
 
-import "fmt"
-
 type Carrier struct {
 	p *int
-}
-
-func (c Carrier) String() string {
-	return fmt.Sprintf("Carrier { p: %v }", c.p)
 }
 
 func bump(c Carrier) int {

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -11,10 +11,6 @@ import (
 
 type Loader struct{}
 
-func (l Loader) String() string {
-	return "Loader"
-}
-
 func (l Loader) Load(_ string) (int, error) {
 	return 1, nil
 }

--- a/tests/spec/emit/snapshots/cast_tuple_struct_to_underlying.snap
+++ b/tests/spec/emit/snapshots/cast_tuple_struct_to_underlying.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrapper(int)\n\nfn test() -> int {\n  let w = Wrap
 ---
 package main
 
-import "fmt"
-
 type Wrapper int
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper(%v)", int(w))
-}
 
 func test() int {
 	w := Wrapper(42)

--- a/tests/spec/emit/snapshots/cast_underlying_to_tuple_struct.snap
+++ b/tests/spec/emit/snapshots/cast_underlying_to_tuple_struct.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrapper(int)\n\nfn test() -> Wrapper {\n  let n = 
 ---
 package main
 
-import "fmt"
-
 type Wrapper int
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper(%v)", int(w))
-}
 
 func test() Wrapper {
 	n := 42

--- a/tests/spec/emit/snapshots/coercion_in_map_value_via_indexed_assignment.snap
+++ b/tests/spec/emit/snapshots/coercion_in_map_value_via_indexed_assignment.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/coercion_in_match_arm_value.snap
+++ b/tests/spec/emit/snapshots/coercion_in_match_arm_value.snap
@@ -8,15 +8,7 @@ import "io"
 
 type A struct{}
 
-func (a A) String() string {
-	return "A"
-}
-
 type B struct{}
-
-func (b B) String() string {
-	return "B"
-}
 
 func (a A) Read(_ []uint8) (int, error) {
 	return 0, nil

--- a/tests/spec/emit/snapshots/coercion_in_match_arm_via_typed_let.snap
+++ b/tests/spec/emit/snapshots/coercion_in_match_arm_via_typed_let.snap
@@ -8,15 +8,7 @@ import "io"
 
 type A struct{}
 
-func (a A) String() string {
-	return "A"
-}
-
 type B struct{}
-
-func (b B) String() string {
-	return "B"
-}
 
 func (a A) Read(_ []uint8) (int, error) {
 	return 0, nil

--- a/tests/spec/emit/snapshots/coercion_in_struct_literal_field.snap
+++ b/tests/spec/emit/snapshots/coercion_in_struct_literal_field.snap
@@ -4,16 +4,9 @@ description: "input: \nimport \"go:io\"\n\nstruct Doubler {}\n\nimpl Doubler {\n
 ---
 package main
 
-import (
-	"fmt"
-	"io"
-)
+import "io"
 
 type Doubler struct{}
-
-func (d Doubler) String() string {
-	return "Doubler"
-}
 
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
@@ -21,10 +14,6 @@ func (d Doubler) Read(_ []uint8) (int, error) {
 
 type Wrapper struct {
 	reader io.Reader
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { reader: %v }", w.reader)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/coercion_in_tail_return_position.snap
+++ b/tests/spec/emit/snapshots/coercion_in_tail_return_position.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/coercion_in_typed_let_binding.snap
+++ b/tests/spec/emit/snapshots/coercion_in_typed_let_binding.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
+++ b/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct H { ptr: Ref<int> }\n\nimpl H {\n  fn repoint(self
 ---
 package main
 
-import "fmt"
-
 type H struct {
 	ptr *int
-}
-
-func (h H) String() string {
-	return fmt.Sprintf("H { ptr: %v }", h.ptr)
 }
 
 func (h *H) repoint(q *int) int {

--- a/tests/spec/emit/snapshots/constrained_impl_block_emits_bound.snap
+++ b/tests/spec/emit/snapshots/constrained_impl_block_emits_bound.snap
@@ -4,8 +4,6 @@ description: "input: \ninterface Displayable {\n  fn display(self) -> string\n}\
 ---
 package main
 
-import "fmt"
-
 type Displayable interface {
 	display() string
 }
@@ -13,10 +11,6 @@ type Displayable interface {
 type Labeled[T Displayable] struct {
 	label string
 	value T
-}
-
-func (l Labeled[T]) String() string {
-	return fmt.Sprintf("Labeled { label: %v, value: %v }", l.label, l.value)
 }
 
 func (l Labeled[T]) show() string {

--- a/tests/spec/emit/snapshots/defer_with_method_call.snap
+++ b/tests/spec/emit/snapshots/defer_with_method_call.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type Resource struct{}
 
-func (r Resource) String() string {
-	return "Resource"
-}
-
 func (r Resource) close() {
 	fmt.Print("closed")
 }

--- a/tests/spec/emit/snapshots/deref_assignment_target_captured_before_rhs.snap
+++ b/tests/spec/emit/snapshots/deref_assignment_target_captured_before_rhs.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct H { ptr: Ref<int> }\n\nimpl H {\n  fn repoint(self
 ---
 package main
 
-import "fmt"
-
 type H struct {
 	ptr *int
-}
-
-func (h H) String() string {
-	return fmt.Sprintf("H { ptr: %v }", h.ptr)
 }
 
 func (h *H) repoint(q *int) int {

--- a/tests/spec/emit/snapshots/deref_dot_assignment_on_call_result.snap
+++ b/tests/spec/emit/snapshots/deref_dot_assignment_on_call_result.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nfn main() {\n  let mut b = Box {
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/deref_field_access.snap
+++ b/tests/spec/emit/snapshots/deref_field_access.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { value: int }\n\nimpl Counter {\n  fn inc
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	value int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { value: %v }", c.value)
 }
 
 func (c *Counter) increment() {

--- a/tests/spec/emit/snapshots/deref_field_assignment_parens.snap
+++ b/tests/spec/emit/snapshots/deref_field_assignment_parens.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Item { x: int }\n\nfn main() {\n  let mut v = Item
 ---
 package main
 
-import "fmt"
-
 type Item struct {
 	x int
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { x: %v }", i.x)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/deref_map_value_method_call.snap
+++ b/tests/spec/emit/snapshots/deref_map_value_method_call.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { count: int }\n\nimpl Counter {\n  fn inc
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	count int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { count: %v }", c.count)
 }
 
 func (c *Counter) increment() {

--- a/tests/spec/emit/snapshots/deref_self_in_ref_receiver.snap
+++ b/tests/spec/emit/snapshots/deref_self_in_ref_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { x: int }\n\nimpl Foo {\n  fn copy_out(self: 
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	x int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { x: %v }", f.x)
 }
 
 func (f *Foo) copy_out() Foo {

--- a/tests/spec/emit/snapshots/displayable_empty_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/displayable_empty_struct_to_string.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct Blank {}\n"
+---
+package main
+
+type Blank struct{}
+
+func (b Blank) String() string {
+	return "Blank"
+}
+
+func (b Blank) to_string() string {
+	return b.String()
+}

--- a/tests/spec/emit/snapshots/displayable_tuple_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/displayable_tuple_struct_to_string.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \n#[displayable]\nstruct UserId(int)\n"
+---
+package main
+
+import "fmt"
+
+type UserId int
+
+func (u UserId) String() string {
+	return fmt.Sprintf("UserId(%v)", int(u))
+}
+
+func (u UserId) to_string() string {
+	return u.String()
+}

--- a/tests/spec/emit/snapshots/doc_comment_on_enum.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_enum.snap
@@ -4,8 +4,6 @@ description: "input: \n/// Represents the status of a task.\nenum Status { Pendi
 ---
 package main
 
-import "fmt"
-
 func MakeStatusPending() Status {
 	return Status{Tag: StatusPending}
 }
@@ -29,30 +27,4 @@ const (
 
 type Status struct {
 	Tag StatusTag
-}
-
-func (s Status) String() string {
-	switch s.Tag {
-	case StatusPending:
-		return "Pending"
-	case StatusRunning:
-		return "Running"
-	case StatusComplete:
-		return "Complete"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
-func (s Status) GoString() string {
-	switch s.Tag {
-	case StatusPending:
-		return "Status.Pending"
-	case StatusRunning:
-		return "Status.Running"
-	case StatusComplete:
-		return "Status.Complete"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_enum_variants.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_enum_variants.snap
@@ -4,8 +4,6 @@ description: "input: \n/// Result of a network operation.\nenum NetworkResult {\
 ---
 package main
 
-import "fmt"
-
 func MakeNetworkResultSuccess() NetworkResult {
 	return NetworkResult{Tag: NetworkResultSuccess}
 }
@@ -33,30 +31,4 @@ const (
 type NetworkResult struct {
 	Tag   NetworkResultTag
 	Error int
-}
-
-func (n NetworkResult) String() string {
-	switch n.Tag {
-	case NetworkResultSuccess:
-		return "Success"
-	case NetworkResultTimeout:
-		return "Timeout"
-	case NetworkResultError:
-		return fmt.Sprintf("Error(%v)", n.Error)
-	default:
-		return fmt.Sprintf("NetworkResult(%d)", n.Tag)
-	}
-}
-
-func (n NetworkResult) GoString() string {
-	switch n.Tag {
-	case NetworkResultSuccess:
-		return "NetworkResult.Success"
-	case NetworkResultTimeout:
-		return "NetworkResult.Timeout"
-	case NetworkResultError:
-		return fmt.Sprintf("NetworkResult.Error(%v)", n.Error)
-	default:
-		return fmt.Sprintf("NetworkResult(%d)", n.Tag)
-	}
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_impl_method.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_impl_method.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { count: int }\n\nimpl Counter {\n  /// Cr
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	count int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { count: %v }", c.count)
 }
 
 // Creates a new counter starting at zero.

--- a/tests/spec/emit/snapshots/doc_comment_on_struct.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_struct.snap
@@ -4,14 +4,8 @@ description: "input: \n/// A 2D point with x and y coordinates.\nstruct Point { 
 ---
 package main
 
-import "fmt"
-
 // A 2D point with x and y coordinates.
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_struct_fields.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_struct_fields.snap
@@ -4,16 +4,10 @@ description: "input: \n/// A user in the system.\nstruct User {\n  /// The user'
 ---
 package main
 
-import "fmt"
-
 // A user in the system.
 type User struct {
 	// The user's display name.
 	Name string
 	// The user's age in years.
 	age int
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, age: %v }", u.Name, u.age)
 }

--- a/tests/spec/emit/snapshots/dot_field_through_ref_assignment_captured.snap
+++ b/tests/spec/emit/snapshots/dot_field_through_ref_assignment_captured.snap
@@ -4,22 +4,12 @@ description: "input: \nstruct P { x: int }\nstruct H { ptr: Ref<P> }\n\nimpl H {
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	x int
 }
 
-func (p P) String() string {
-	return fmt.Sprintf("P { x: %v }", p.x)
-}
-
 type H struct {
 	ptr *P
-}
-
-func (h H) String() string {
-	return fmt.Sprintf("H { ptr: %v }", h.ptr)
 }
 
 func (h *H) repoint(q *P) int {

--- a/tests/spec/emit/snapshots/double_newtype_direct_assignment.snap
+++ b/tests/spec/emit/snapshots/double_newtype_direct_assignment.snap
@@ -4,19 +4,9 @@ description: "input: \nstruct A(int)\nstruct B(A)\n\nfn main() {\n  let mut w = 
 ---
 package main
 
-import "fmt"
-
 type A int
 
-func (a A) String() string {
-	return fmt.Sprintf("A(%v)", int(a))
-}
-
 type B A
-
-func (b B) String() string {
-	return fmt.Sprintf("B(%v)", A(b))
-}
 
 func main() {
 	_ = B(A(1))

--- a/tests/spec/emit/snapshots/double_newtype_nested_field_assignment.snap
+++ b/tests/spec/emit/snapshots/double_newtype_nested_field_assignment.snap
@@ -4,27 +4,13 @@ description: "input: \nstruct Inner { x: int }\nstruct A(Inner)\nstruct B(A)\n\n
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type A Inner
 
-func (a A) String() string {
-	return fmt.Sprintf("A(%v)", Inner(a))
-}
-
 type B A
-
-func (b B) String() string {
-	return fmt.Sprintf("B(%v)", A(b))
-}
 
 func main() {
 	w := B(A(Inner{x: 1}))

--- a/tests/spec/emit/snapshots/double_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/double_newtype_slice_append.snap
@@ -4,19 +4,9 @@ description: "input: \nstruct A(Slice<int>)\nstruct B(A)\n\nfn main() {\n  let m
 ---
 package main
 
-import "fmt"
-
 type A []int
 
-func (a A) String() string {
-	return fmt.Sprintf("A(%v)", []int(a))
-}
-
 type B A
-
-func (b B) String() string {
-	return fmt.Sprintf("B(%v)", A(b))
-}
 
 func main() {
 	w := B(A(([]int)(nil)))

--- a/tests/spec/emit/snapshots/empty_struct.snap
+++ b/tests/spec/emit/snapshots/empty_struct.snap
@@ -5,7 +5,3 @@ description: "input: \nstruct Blank {}\n"
 package main
 
 type Blank struct{}
-
-func (b Blank) String() string {
-	return "Blank"
-}

--- a/tests/spec/emit/snapshots/empty_struct_literal.snap
+++ b/tests/spec/emit/snapshots/empty_struct_literal.snap
@@ -6,10 +6,6 @@ package main
 
 type Empty struct{}
 
-func (e Empty) String() string {
-	return "Empty"
-}
-
 func test() Empty {
 	return Empty{}
 }

--- a/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
+++ b/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Status {\n  Ready,\n}\n\nimpl Status {\n  fn Marshal
 ---
 package main
 
-import "fmt"
-
 func MakeStatusReady() Status {
 	return Status{Tag: StatusReady}
 }
@@ -18,24 +16,6 @@ const (
 
 type Status struct {
 	Tag StatusTag
-}
-
-func (s Status) String() string {
-	switch s.Tag {
-	case StatusReady:
-		return "Ready"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
-func (s Status) GoString() string {
-	switch s.Tag {
-	case StatusReady:
-		return "Status.Ready"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
 }
 
 func (s Status) MarshalJSON() ([]byte, error) {

--- a/tests/spec/emit/snapshots/enum_struct_variant_named_tag.snap
+++ b/tests/spec/emit/snapshots/enum_struct_variant_named_tag.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E {\n  Tag { x: int },\n  Other { x: int },\n}\n\nfn
 ---
 package main
 
-import "fmt"
-
 func MakeETag(arg0 int) E {
 	return E{Tag: ETag_, X: arg0}
 }
@@ -24,28 +22,6 @@ const (
 type E struct {
 	Tag ETag
 	X   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case ETag_:
-		return fmt.Sprintf("Tag { x: %v }", e.X)
-	case EOther:
-		return fmt.Sprintf("Other { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case ETag_:
-		return fmt.Sprintf("E.Tag { x: %v }", e.X)
-	case EOther:
-		return fmt.Sprintf("E.Other { x: %v }", e.X)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/enum_struct_variant_with_ref_field.snap
+++ b/tests/spec/emit/snapshots/enum_struct_variant_with_ref_field.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Tree {\n  Leaf(int),\n  Node { value: int, left: Ref
 ---
 package main
 
-import "fmt"
-
 func MakeTreeLeaf(arg0 int) Tree {
 	return Tree{Tag: TreeLeaf, Leaf: arg0}
 }
@@ -27,28 +25,6 @@ type Tree struct {
 	Value int
 	Left  *Tree
 	Right *Tree
-}
-
-func (t Tree) String() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Node { value: %v, left: %v, right: %v }", t.Value, t.Left, t.Right)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
-}
-
-func (t Tree) GoString() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Tree.Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Tree.Node { value: %v, left: %v, right: %v }", t.Value, t.Left, t.Right)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
 }
 
 func test() Tree {

--- a/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
+++ b/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Transform<T> {\n  Identity,\n  Apply(fn(T) -> T),\n}
 ---
 package main
 
-import "fmt"
-
 func MakeTransformIdentity[T any]() Transform[T] {
 	return Transform[T]{Tag: TransformIdentity}
 }
@@ -24,28 +22,6 @@ const (
 type Transform[T any] struct {
 	Tag   TransformTag
 	Apply func(T) T
-}
-
-func (t Transform[T]) String() string {
-	switch t.Tag {
-	case TransformIdentity:
-		return "Identity"
-	case TransformApply:
-		return fmt.Sprintf("Apply(%p)", t.Apply)
-	default:
-		return fmt.Sprintf("Transform(%d)", t.Tag)
-	}
-}
-
-func (t Transform[T]) GoString() string {
-	switch t.Tag {
-	case TransformIdentity:
-		return "Transform.Identity"
-	case TransformApply:
-		return fmt.Sprintf("Transform.Apply(%p)", t.Apply)
-	default:
-		return fmt.Sprintf("Transform(%d)", t.Tag)
-	}
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color {\n  Red,\n  Blue,\n}\n\nimpl Color {\n  fn St
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -23,17 +21,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func (c Color) String() string {

--- a/tests/spec/emit/snapshots/enum_user_string_method_emits_go_string.snap
+++ b/tests/spec/emit/snapshots/enum_user_string_method_emits_go_string.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color {\n  Red,\n  Blue,\n}\n\nimpl Color {\n  pub f
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -23,17 +21,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func (c Color) String() string {

--- a/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
+++ b/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn test() -> Color {\n
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func test() Color {

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -32,32 +32,6 @@ type ASTNode struct {
 	ASTNodeString_ string
 }
 
-func (a ASTNode) String() string {
-	switch a.Tag {
-	case ASTNodeNumber:
-		return fmt.Sprintf("Number(%v)", a.Number)
-	case ASTNodeString:
-		return fmt.Sprintf("String(%v)", a.ASTNodeString_)
-	case ASTNodeNull:
-		return "Null"
-	default:
-		return fmt.Sprintf("ASTNode(%d)", a.Tag)
-	}
-}
-
-func (a ASTNode) GoString() string {
-	switch a.Tag {
-	case ASTNodeNumber:
-		return fmt.Sprintf("ASTNode.Number(%v)", a.Number)
-	case ASTNodeString:
-		return fmt.Sprintf("ASTNode.String(%v)", a.ASTNodeString_)
-	case ASTNodeNull:
-		return "ASTNode.Null"
-	default:
-		return fmt.Sprintf("ASTNode(%d)", a.Tag)
-	}
-}
-
 func visit(node ASTNode) string {
 	switch node.Tag {
 	case ASTNodeNumber:

--- a/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
+++ b/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Pair<A, B> { Both(A, B), Neither }\n\nfn test(p: Pai
 ---
 package main
 
-import "fmt"
-
 func MakePairBoth[A any, B any](arg0 A, arg1 B) Pair[A, B] {
 	return Pair[A, B]{Tag: PairBoth, Both0: arg0, Both1: arg1}
 }
@@ -25,28 +23,6 @@ type Pair[A any, B any] struct {
 	Tag   PairTag
 	Both0 A
 	Both1 B
-}
-
-func (p Pair[A, B]) String() string {
-	switch p.Tag {
-	case PairBoth:
-		return fmt.Sprintf("Both(%v, %v)", p.Both0, p.Both1)
-	case PairNeither:
-		return "Neither"
-	default:
-		return fmt.Sprintf("Pair(%d)", p.Tag)
-	}
-}
-
-func (p Pair[A, B]) GoString() string {
-	switch p.Tag {
-	case PairBoth:
-		return fmt.Sprintf("Pair.Both(%v, %v)", p.Both0, p.Both1)
-	case PairNeither:
-		return "Pair.Neither"
-	default:
-		return fmt.Sprintf("Pair(%d)", p.Tag)
-	}
 }
 
 func test(p Pair[int, string]) int {

--- a/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_function.snap
+++ b/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_function.snap
@@ -4,18 +4,12 @@ description: "input: \ninterface Named {\n  fn name(self) -> string\n}\n\nstruct
 ---
 package main
 
-import "fmt"
-
 type Named interface {
 	name() string
 }
 
 type Person struct {
 	value string
-}
-
-func (p Person) String() string {
-	return fmt.Sprintf("Person { value: %v }", p.value)
 }
 
 func (p Person) name() string {

--- a/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_struct.snap
+++ b/tests/spec/emit/snapshots/explicit_named_bound_merges_with_inferred_comparable_on_struct.snap
@@ -4,18 +4,12 @@ description: "input: \ninterface Named {\n  fn name(self) -> string\n}\n\nstruct
 ---
 package main
 
-import "fmt"
-
 type Named interface {
 	name() string
 }
 
 type Person struct {
 	value string
-}
-
-func (p Person) String() string {
-	return fmt.Sprintf("Person { value: %v }", p.value)
 }
 
 func (p Person) name() string {
@@ -27,10 +21,6 @@ type Box[T interface {
 	comparable
 }] struct {
 	table map[T]int
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { table: %v }", b.table)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
+++ b/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List<T> {\n  Cons(T, Ref<List<T>>),\n  Nil,\n}\n\nfn
 ---
 package main
 
-import "fmt"
-
 func MakeListCons[T any](arg0 T, arg1 *List[T]) List[T] {
 	return List[T]{Tag: ListCons, Cons0: arg0, Cons1: arg1}
 }
@@ -25,28 +23,6 @@ type List[T any] struct {
 	Tag   ListTag
 	Cons0 T
 	Cons1 *List[T]
-}
-
-func (l List[T]) String() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List[T]) GoString() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "List.Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func list_len[T any](list List[T]) int {

--- a/tests/spec/emit/snapshots/field_access_assignment.snap
+++ b/tests/spec/emit/snapshots/field_access_assignment.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> int {\n  
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
+++ b/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Holder { slc: Slice<int> }\n\nfn run() -> int {\n 
 ---
 package main
 
-import "fmt"
-
 type Holder struct {
 	slc []int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { slc: %v }", h.slc)
 }
 
 func run() int {

--- a/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
+++ b/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { x: int }\n\nfn main() {\n  let items = [Foo 
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	x int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { x: %v }", f.x)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/for_complex_pattern_unused_item.snap
+++ b/tests/spec/emit/snapshots/for_complex_pattern_unused_item.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  for P { v } in [P { v
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/for_in_loop_receiver_collision.snap
+++ b/tests/spec/emit/snapshots/for_in_loop_receiver_collision.snap
@@ -10,10 +10,6 @@ type IntList struct {
 	items []int
 }
 
-func (i IntList) String() string {
-	return fmt.Sprintf("IntList { items: %v }", i.items)
-}
-
 func (i IntList) display() string {
 	s := "["
 	for _, i_1 := range i.items {

--- a/tests/spec/emit/snapshots/for_loop_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/for_loop_struct_pattern.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(points: Slice<
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(points []Point) int {

--- a/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
@@ -4,8 +4,6 @@ description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int
 ---
 package main
 
-import "fmt"
-
 type Handler func(int) int
 
 func double(x int) int {
@@ -16,16 +14,8 @@ type Box[T any] struct {
 	V T
 }
 
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.V)
-}
-
 type Wrap struct {
 	B Box[Handler]
-}
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap { b: %v }", w.B)
 }
 
 func make_box[T any](x T) Box[T] {

--- a/tests/spec/emit/snapshots/generic_constructor_value_type_args.snap
+++ b/tests/spec/emit/snapshots/generic_constructor_value_type_args.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Wrap<T> { W(T) }\n\nfn main() {\n  let f = Wrap.W\n 
 ---
 package main
 
-import "fmt"
-
 func MakeWrapW[T any](arg0 T) Wrap[T] {
 	return Wrap[T]{Tag: WrapW, W: arg0}
 }
@@ -19,24 +17,6 @@ const (
 type Wrap[T any] struct {
 	Tag WrapTag
 	W   T
-}
-
-func (w Wrap[T]) String() string {
-	switch w.Tag {
-	case WrapW:
-		return fmt.Sprintf("W(%v)", w.W)
-	default:
-		return fmt.Sprintf("Wrap(%d)", w.Tag)
-	}
-}
-
-func (w Wrap[T]) GoString() string {
-	switch w.Tag {
-	case WrapW:
-		return fmt.Sprintf("Wrap.W(%v)", w.W)
-	default:
-		return fmt.Sprintf("Wrap(%d)", w.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/generic_enum_variant_non_t_data_needs_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_enum_variant_non_t_data_needs_type_arg.snap
@@ -4,8 +4,6 @@ description: "input: \nenum MyResult<T> {\n  Ok(T),\n  Fail(string),\n}\n\nfn ma
 ---
 package main
 
-import "fmt"
-
 func MakeMyResultOk[T any](arg0 T) MyResult[T] {
 	return MyResult[T]{Tag: MyResultOk, Ok: arg0}
 }
@@ -25,28 +23,6 @@ type MyResult[T any] struct {
 	Tag  MyResultTag
 	Ok   T
 	Fail string
-}
-
-func (m MyResult[T]) String() string {
-	switch m.Tag {
-	case MyResultOk:
-		return fmt.Sprintf("Ok(%v)", m.Ok)
-	case MyResultFail:
-		return fmt.Sprintf("Fail(%v)", m.Fail)
-	default:
-		return fmt.Sprintf("MyResult(%d)", m.Tag)
-	}
-}
-
-func (m MyResult[T]) GoString() string {
-	switch m.Tag {
-	case MyResultOk:
-		return fmt.Sprintf("MyResult.Ok(%v)", m.Ok)
-	case MyResultFail:
-		return fmt.Sprintf("MyResult.Fail(%v)", m.Fail)
-	default:
-		return fmt.Sprintf("MyResult(%d)", m.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -31,28 +31,6 @@ type Either[L Displayable, R Displayable] struct {
 	Right R
 }
 
-func (e Either[L, R]) String() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
-func (e Either[L, R]) GoString() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Either.Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Either.Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
 func (e Either[L, R]) display() string {
 	if e.Tag == EitherLeft {
 		s := e.Left.display()
@@ -64,10 +42,6 @@ func (e Either[L, R]) display() string {
 
 type Name struct {
 	value string
-}
-
-func (n Name) String() string {
-	return fmt.Sprintf("Name { value: %v }", n.value)
 }
 
 func (n Name) display() string {

--- a/tests/spec/emit/snapshots/generic_enum_with_map_key_type_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_map_key_type_parameter.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Container<K, V> {\n  Empty,\n  Indexed(Map<K, V>),\n
 ---
 package main
 
-import "fmt"
-
 func MakeContainerEmpty[K comparable, V any]() Container[K, V] {
 	return Container[K, V]{Tag: ContainerEmpty}
 }
@@ -24,28 +22,6 @@ const (
 type Container[K comparable, V any] struct {
 	Tag     ContainerTag
 	Indexed map[K]V
-}
-
-func (c Container[K, V]) String() string {
-	switch c.Tag {
-	case ContainerEmpty:
-		return "Empty"
-	case ContainerIndexed:
-		return fmt.Sprintf("Indexed(%v)", c.Indexed)
-	default:
-		return fmt.Sprintf("Container(%d)", c.Tag)
-	}
-}
-
-func (c Container[K, V]) GoString() string {
-	switch c.Tag {
-	case ContainerEmpty:
-		return "Container.Empty"
-	case ContainerIndexed:
-		return fmt.Sprintf("Container.Indexed(%v)", c.Indexed)
-	default:
-		return fmt.Sprintf("Container(%d)", c.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Either<L, R> { Left(L), Right(R) }\n\nfn test() -> E
 ---
 package main
 
-import "fmt"
-
 func MakeEitherLeft[L any, R any](arg0 L) Either[L, R] {
 	return Either[L, R]{Tag: EitherLeft, Left: arg0}
 }
@@ -25,28 +23,6 @@ type Either[L any, R any] struct {
 	Tag   EitherTag
 	Left  L
 	Right R
-}
-
-func (e Either[L, R]) String() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
-func (e Either[L, R]) GoString() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Either.Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Either.Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
 }
 
 func test() Either[int, string] {

--- a/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
@@ -4,8 +4,6 @@ description: "input: \nenum MyResult<T> { Success(T), Failure }\n\nfn test() -> 
 ---
 package main
 
-import "fmt"
-
 func MakeMyResultSuccess[T any](arg0 T) MyResult[T] {
 	return MyResult[T]{Tag: MyResultSuccess, Success: arg0}
 }
@@ -24,28 +22,6 @@ const (
 type MyResult[T any] struct {
 	Tag     MyResultTag
 	Success T
-}
-
-func (m MyResult[T]) String() string {
-	switch m.Tag {
-	case MyResultSuccess:
-		return fmt.Sprintf("Success(%v)", m.Success)
-	case MyResultFailure:
-		return "Failure"
-	default:
-		return fmt.Sprintf("MyResult(%d)", m.Tag)
-	}
-}
-
-func (m MyResult[T]) GoString() string {
-	switch m.Tag {
-	case MyResultSuccess:
-		return fmt.Sprintf("MyResult.Success(%v)", m.Success)
-	case MyResultFailure:
-		return "MyResult.Failure"
-	default:
-		return fmt.Sprintf("MyResult(%d)", m.Tag)
-	}
 }
 
 func test() MyResult[int] {

--- a/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Entry { name: string }\n\npub interface Cache {\n 
 ---
 package main
 
-import "fmt"
-
 type Entry struct {
 	name string
-}
-
-func (e Entry) String() string {
-	return fmt.Sprintf("Entry { name: %v }", e.name)
 }
 
 type Cache interface {
@@ -20,20 +14,12 @@ type Cache interface {
 
 type MyCache struct{}
 
-func (m MyCache) String() string {
-	return "MyCache"
-}
-
 func (m MyCache) Get(_ string) *Entry {
 	return nil
 }
 
 type Wrapper[T any] struct {
 	cache T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper { cache: %v }", w.cache)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
+++ b/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Validated<T> { Valid(T), Invalid(string) }\n\nstruct
 ---
 package main
 
-import "fmt"
-
 func MakeValidatedValid[T any](arg0 T) Validated[T] {
 	return Validated[T]{Tag: ValidatedValid, Valid: arg0}
 }
@@ -27,35 +25,9 @@ type Validated[T any] struct {
 	Invalid string
 }
 
-func (v Validated[T]) String() string {
-	switch v.Tag {
-	case ValidatedValid:
-		return fmt.Sprintf("Valid(%v)", v.Valid)
-	case ValidatedInvalid:
-		return fmt.Sprintf("Invalid(%v)", v.Invalid)
-	default:
-		return fmt.Sprintf("Validated(%d)", v.Tag)
-	}
-}
-
-func (v Validated[T]) GoString() string {
-	switch v.Tag {
-	case ValidatedValid:
-		return fmt.Sprintf("Validated.Valid(%v)", v.Valid)
-	case ValidatedInvalid:
-		return fmt.Sprintf("Validated.Invalid(%v)", v.Invalid)
-	default:
-		return fmt.Sprintf("Validated(%d)", v.Tag)
-	}
-}
-
 type ValidationResult[T any] struct {
 	value      Validated[T]
 	field_name string
-}
-
-func (v ValidationResult[T]) String() string {
-	return fmt.Sprintf("ValidationResult { value: %v, field_name: %v }", v.value, v.field_name)
 }
 
 func ValidationResult_new_invalid[T any](field, msg string) ValidationResult[T] {

--- a/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Stack<T> { items: Slice<T> }\n\nimpl<T> Stack<T> {
 ---
 package main
 
-import "fmt"
-
 type Stack[T any] struct {
 	items []T
-}
-
-func (s Stack[T]) String() string {
-	return fmt.Sprintf("Stack { items: %v }", s.items)
 }
 
 func Stack_new[T any]() Stack[T] {

--- a/tests/spec/emit/snapshots/generic_static_method_explicit_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_explicit_type_arg.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nimpl<T> Box<T> {\n  fn new(
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func Box_new[T any](value T) Box[T] {

--- a/tests/spec/emit/snapshots/generic_static_method_inferred.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_inferred.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nimpl<T> Box<T> {\n  fn new(
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func Box_new[T any](value T) Box[T] {

--- a/tests/spec/emit/snapshots/generic_static_method_non_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_non_inferred_type_arg.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Container<T> {\n  items: Slice<T>,\n  label: strin
 ---
 package main
 
-import "fmt"
-
 type Container[T any] struct {
 	items []T
 	label string
-}
-
-func (c Container[T]) String() string {
-	return fmt.Sprintf("Container { items: %v, label: %v }", c.items, c.label)
 }
 
 func Container_new[T any](label string) Container[T] {

--- a/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Container<T> {\n  items: Slice<T>,\n  name: string
 ---
 package main
 
-import "fmt"
-
 type Container[T any] struct {
 	items []T
 	name  string
-}
-
-func (c Container[T]) String() string {
-	return fmt.Sprintf("Container { items: %v, name: %v }", c.items, c.name)
 }
 
 func Container_new[T any](name string) Container[T] {

--- a/tests/spec/emit/snapshots/generic_struct.snap
+++ b/tests/spec/emit/snapshots/generic_struct.snap
@@ -4,12 +4,6 @@ description: "input: \nstruct Box<T> { value: T }\n"
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }

--- a/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
@@ -4,8 +4,6 @@ description: "input: \nstruct Handler<T> { callback: fn(T) -> int }\nenum E { A(
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 Handler[string]) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -16,10 +14,6 @@ func MakeEB(arg0 Handler[string]) E {
 
 type Handler[T any] struct {
 	callback func(T) int
-}
-
-func (h Handler[T]) String() string {
-	return fmt.Sprintf("Handler { callback: %p }", h.callback)
 }
 
 type ETag int
@@ -33,28 +27,6 @@ type E struct {
 	Tag ETag
 	A   Handler[string]
 	B   Handler[string]
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/generic_struct_instantiation.snap
+++ b/tests/spec/emit/snapshots/generic_struct_instantiation.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nfn test() -> Box<int> {\n  
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func test() Box[int] {

--- a/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
@@ -4,10 +4,7 @@ description: "input: \nstruct Pair<T> { coords: (T, T) }\nenum E { A(Pair<int>),
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func MakeEA(arg0 Pair[int]) E {
 	return E{Tag: EA, A: arg0}
@@ -21,10 +18,6 @@ type Pair[T any] struct {
 	coords lisette.Tuple2[T, T]
 }
 
-func (p Pair[T]) String() string {
-	return fmt.Sprintf("Pair { coords: %v }", p.coords)
-}
-
 type ETag int
 
 const (
@@ -36,28 +29,6 @@ type E struct {
 	Tag ETag
 	A   Pair[int]
 	B   Pair[int]
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/generic_struct_with_map_field_comparable_constraint.snap
+++ b/tests/spec/emit/snapshots/generic_struct_with_map_field_comparable_constraint.snap
@@ -4,12 +4,6 @@ description: "input: \nstruct Cache<K, V> {\n  data: Map<K, V>,\n}\n"
 ---
 package main
 
-import "fmt"
-
 type Cache[K comparable, V any] struct {
 	data map[K]V
-}
-
-func (c Cache[K, V]) String() string {
-	return fmt.Sprintf("Cache { data: %v }", c.data)
 }

--- a/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Entry { name: string }\n\npub interface Cache {\n 
 ---
 package main
 
-import "fmt"
-
 type Entry struct {
 	name string
-}
-
-func (e Entry) String() string {
-	return fmt.Sprintf("Entry { name: %v }", e.name)
 }
 
 type Cache interface {
@@ -20,20 +14,12 @@ type Cache interface {
 
 type MyCache struct{}
 
-func (m MyCache) String() string {
-	return "MyCache"
-}
-
 func (m MyCache) Get(_ string) *Entry {
 	return nil
 }
 
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/generic_tuple_struct_constructor_type_args.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_constructor_type_args.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Wrapper<T>(T)\n\nfn main() {\n  let w = Wrapper<in
 ---
 package main
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_pattern.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T>(T)\n\nfn test(b: Box<int>) -> int {\n  matc
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	F0 T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box(%v)", b.F0)
 }
 
 func test(b Box[int]) int {

--- a/tests/spec/emit/snapshots/go_keyword_method_name_map.snap
+++ b/tests/spec/emit/snapshots/go_keyword_method_name_map.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nimpl<T> Box<T> {\n  fn map(
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func (b Box[T]) map_(f func(T) T) Box[T] {

--- a/tests/spec/emit/snapshots/go_keyword_struct_field_assignment.snap
+++ b/tests/spec/emit/snapshots/go_keyword_struct_field_assignment.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Config {\n  range: int,\n  default: string,\n}\n\n
 ---
 package main
 
-import "fmt"
-
 type Config struct {
 	range_   int
 	default_ string
-}
-
-func (c Config) String() string {
-	return fmt.Sprintf("Config { range: %v, default: %v }", c.range_, c.default_)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/go_named_function_alias_preserved_through_option_tuple_return.snap
+++ b/tests/spec/emit/snapshots/go_named_function_alias_preserved_through_option_tuple_return.snap
@@ -8,10 +8,6 @@ import "example.com/tea"
 
 type Model struct{}
 
-func (m Model) String() string {
-	return "Model"
-}
-
 func (m Model) Init() tea.Cmd {
 	return nil
 }

--- a/tests/spec/emit/snapshots/if_generic_struct_literal_in_condition.snap
+++ b/tests/spec/emit/snapshots/if_generic_struct_literal_in_condition.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { v: T }\n\nfn test() -> int {\n  let b = B
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	v T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/if_generic_struct_literal_method_callee_in_condition.snap
+++ b/tests/spec/emit/snapshots/if_generic_struct_literal_method_callee_in_condition.snap
@@ -1,18 +1,11 @@
 ---
 source: tests/spec/emit/control_flow.rs
-assertion_line: 2327
 description: "input: \nstruct Box<T> { v: T }\n\nimpl<T> Box<T> {\n  fn ok(self) -> bool { true }\n}\n\nfn test() {\n  if Box { v: 1 }.ok() {\n    let _ = 1\n  }\n}\n"
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	v T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func (b Box[T]) ok() bool {

--- a/tests/spec/emit/snapshots/if_generic_struct_literal_selector.snap
+++ b/tests/spec/emit/snapshots/if_generic_struct_literal_selector.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { v: T }\n\nfn test() -> int {\n  if Box { 
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	v T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/if_generic_tuple_struct_comparison.snap
+++ b/tests/spec/emit/snapshots/if_generic_tuple_struct_comparison.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct W<T>(T)\n\nfn test() -> int {\n  let w = W(1)\n  i
 ---
 package main
 
-import "fmt"
-
 type W[T any] struct {
 	F0 T
-}
-
-func (w W[T]) String() string {
-	return fmt.Sprintf("W(%v)", w.F0)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/if_let_irrefutable_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_ident_subject_unused.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let p = P { v: 1 }\n 
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/if_let_irrefutable_unused_subject.snap
+++ b/tests/spec/emit/snapshots/if_let_irrefutable_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn mk() -> P { P { v: 1 } }\n\nfn te
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func mk() P {

--- a/tests/spec/emit/snapshots/if_let_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/if_let_or_pattern_unused_branch_binding.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\nfn test() {\n  let x = 5\n 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/if_struct_literal_in_condition.snap
+++ b/tests/spec/emit/snapshots/if_struct_literal_in_condition.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn sum
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func (p Point) sum() int {

--- a/tests/spec/emit/snapshots/impl_block_bare_self.snap
+++ b/tests/spec/emit/snapshots/impl_block_bare_self.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn sum
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func (p Point) sum() int {

--- a/tests/spec/emit/snapshots/impl_block_bare_self_generic.snap
+++ b/tests/spec/emit/snapshots/impl_block_bare_self_generic.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Container<T> { value: T }\n\nimpl<T> Container<T> 
 ---
 package main
 
-import "fmt"
-
 type Container[T any] struct {
 	value T
-}
-
-func (c Container[T]) String() string {
-	return fmt.Sprintf("Container { value: %v }", c.value)
 }
 
 func (c Container[T]) get() T {

--- a/tests/spec/emit/snapshots/impl_block_generic.snap
+++ b/tests/spec/emit/snapshots/impl_block_generic.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nimpl<T> Box<T> {\n  fn new(
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func Box_new[T any](value T) Box[T] {

--- a/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
@@ -31,28 +31,6 @@ type Either[L any, R any] struct {
 	Right R
 }
 
-func (e Either[L, R]) String() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
-func (e Either[L, R]) GoString() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Either.Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Either.Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
 		return fmt.Sprintf("int(%d)", self.Left)

--- a/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
@@ -31,28 +31,6 @@ type Either[L any, R any] struct {
 	Right R
 }
 
-func (e Either[L, R]) String() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
-func (e Either[L, R]) GoString() string {
-	switch e.Tag {
-	case EitherLeft:
-		return fmt.Sprintf("Either.Left(%v)", e.Left)
-	case EitherRight:
-		return fmt.Sprintf("Either.Right(%v)", e.Right)
-	default:
-		return fmt.Sprintf("Either(%d)", e.Tag)
-	}
-}
-
 func Either_describe(self Either[MyInt, MyString]) MyString {
 	if self.Tag == EitherLeft {
 		return fmt.Sprintf("int(%d)", self.Left)

--- a/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_enum_receiver_and_make_function.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_enum_receiver_and_make_function.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Holder<T> {\n  Empty,\n}\n\nimpl<T> Holder<T> {\n  f
 ---
 package main
 
-import "fmt"
-
 func MakeHolderEmpty[T comparable]() Holder[T] {
 	return Holder[T]{Tag: HolderEmpty}
 }
@@ -18,24 +16,6 @@ const (
 
 type Holder[T comparable] struct {
 	Tag HolderTag
-}
-
-func (h Holder[T]) String() string {
-	switch h.Tag {
-	case HolderEmpty:
-		return "Empty"
-	default:
-		return fmt.Sprintf("Holder(%d)", h.Tag)
-	}
-}
-
-func (h Holder[T]) GoString() string {
-	switch h.Tag {
-	case HolderEmpty:
-		return "Holder.Empty"
-	default:
-		return fmt.Sprintf("Holder(%d)", h.Tag)
-	}
 }
 
 func (h Holder[T]) count() int {

--- a/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_struct_receiver.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_body_constrains_struct_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> {\n  value: T,\n}\n\nimpl<T> Box<T> {\n  fn
 ---
 package main
 
-import "fmt"
-
 type Box[T comparable] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func (b Box[T]) count() int {

--- a/tests/spec/emit/snapshots/impl_method_map_key_return_constrains_struct_receiver.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_return_constrains_struct_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> {\n  value: T,\n}\n\nimpl<T> Box<T> {\n  fn
 ---
 package main
 
-import "fmt"
-
 type Box[T comparable] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func (b Box[T]) make_map() map[T]int {

--- a/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
+++ b/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Node {\n  pub value: int,\n  pub next: Option<int>
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Node struct {
 	Value int
 	Next  lisette.Option[int]
-}
-
-func (n Node) String() string {
-	return fmt.Sprintf("Node { value: %v, next: %v }", n.Value, n.Next)
 }
 
 func (n Node) sum() int {

--- a/tests/spec/emit/snapshots/impl_methods_share_local_variable_name.snap
+++ b/tests/spec/emit/snapshots/impl_methods_share_local_variable_name.snap
@@ -6,10 +6,6 @@ package main
 
 type Calc struct{}
 
-func (c Calc) String() string {
-	return "Calc"
-}
-
 func (c Calc) Wider() uint64 {
 	var total uint64 = 0
 	total++

--- a/tests/spec/emit/snapshots/implicit_coercion_in_function_argument.snap
+++ b/tests/spec/emit/snapshots/implicit_coercion_in_function_argument.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/index_target_constructor_rhs_not_frozen.snap
+++ b/tests/spec/emit/snapshots/index_target_constructor_rhs_not_frozen.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(int)\n\nfn run() -> int {\n  let mut xs = [Wr
 ---
 package main
 
-import "fmt"
-
 type Wrap int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", int(w))
-}
 
 func run() int {
 	xs := []Wrap{Wrap(0), Wrap(0)}

--- a/tests/spec/emit/snapshots/interface_private_method_keyword_escape.snap
+++ b/tests/spec/emit/snapshots/interface_private_method_keyword_escape.snap
@@ -14,10 +14,6 @@ type S struct {
 	value int
 }
 
-func (s S) String() string {
-	return fmt.Sprintf("S { value: %v }", s.value)
-}
-
 func (s S) range_() int {
 	return s.value
 }

--- a/tests/spec/emit/snapshots/interface_self_referential_fbound_erased.snap
+++ b/tests/spec/emit/snapshots/interface_self_referential_fbound_erased.snap
@@ -10,10 +10,6 @@ type Cloner[T any] interface {
 
 type Foo struct{}
 
-func (f Foo) String() string {
-	return "Foo"
-}
-
 func (f Foo) Clone() Foo {
 	return Foo{}
 }

--- a/tests/spec/emit/snapshots/interop_address_of_method_value.snap
+++ b/tests/spec/emit/snapshots/interop_address_of_method_value.snap
@@ -6,10 +6,6 @@ package main
 
 type S struct{}
 
-func (s S) String() string {
-	return "S"
-}
-
 func (s S) inc() int {
 	return 1
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -5,17 +5,12 @@ description: "input: \nimport \"go:strconv\"\n\nstruct Holder { f: fn(string) ->
 package main
 
 import (
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 	"strconv"
 )
 
 type Holder struct {
 	f func(string) (int, error)
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { f: %p }", h.f)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_result_struct_field.snap
+++ b/tests/spec/emit/snapshots/interop_result_struct_field.snap
@@ -5,17 +5,12 @@ description: "input: \nimport \"go:strconv\"\n\nstruct Parser { parse: fn(string
 package main
 
 import (
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 	"strconv"
 )
 
 type Parser struct {
 	parse func(string) (int, error)
-}
-
-func (p Parser) String() string {
-	return fmt.Sprintf("Parser { parse: %p }", p.parse)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -5,7 +5,6 @@ description: "input: \nimport \"go:strconv\"\n\ntype F = fn(string) -> Result<in
 package main
 
 import (
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 	"strconv"
 )
@@ -15,10 +14,6 @@ type F func(string) (int, error)
 type Pair struct {
 	F0 F
 	F1 int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
@@ -11,10 +11,6 @@ import (
 
 type Box struct{}
 
-func (b Box) String() string {
-	return "Box"
-}
-
 func (b Box) apply(f func(string) (int, error)) (int, error) {
 	return f("1")
 }

--- a/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
@@ -10,10 +10,6 @@ type Counter struct {
 	count int
 }
 
-func (c Counter) GoString() string {
-	return fmt.Sprintf("Counter { count: %v }", c.count)
-}
-
 func (c Counter) String() string {
 	return fmt.Sprint(c.count)
 }

--- a/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
@@ -10,10 +10,6 @@ type Counter struct {
 	count int
 }
 
-func (c Counter) GoString() string {
-	return fmt.Sprintf("Counter { count: %v }", c.count)
-}
-
 func (c Counter) String() string {
 	return fmt.Sprint(c.count)
 }

--- a/tests/spec/emit/snapshots/iterable_enum_variants.snap
+++ b/tests/spec/emit/snapshots/iterable_enum_variants.snap
@@ -4,8 +4,6 @@ description: "input: \n#[iterable]\npub enum BuildPhase {\n  Validate,\n  Parse,
 ---
 package main
 
-import "fmt"
-
 func MakeBuildPhaseValidate() BuildPhase {
 	return BuildPhase{Tag: BuildPhaseValidate}
 }
@@ -28,32 +26,6 @@ const (
 
 type BuildPhase struct {
 	Tag BuildPhaseTag
-}
-
-func (b BuildPhase) String() string {
-	switch b.Tag {
-	case BuildPhaseValidate:
-		return "Validate"
-	case BuildPhaseParse:
-		return "Parse"
-	case BuildPhaseCodegen:
-		return "Codegen"
-	default:
-		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
-	}
-}
-
-func (b BuildPhase) GoString() string {
-	switch b.Tag {
-	case BuildPhaseValidate:
-		return "BuildPhase.Validate"
-	case BuildPhaseParse:
-		return "BuildPhase.Parse"
-	case BuildPhaseCodegen:
-		return "BuildPhase.Codegen"
-	default:
-		return fmt.Sprintf("BuildPhase(%d)", b.Tag)
-	}
 }
 
 func BuildPhase_variants() []BuildPhase {

--- a/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
@@ -33,32 +33,6 @@ type Status struct {
 	Tag StatusTag
 }
 
-func (s Status) String() string {
-	switch s.Tag {
-	case StatusActive:
-		return "Active"
-	case StatusInactive:
-		return "Inactive"
-	case StatusSuspended:
-		return "Suspended"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
-func (s Status) GoString() string {
-	switch s.Tag {
-	case StatusActive:
-		return "Status.Active"
-	case StatusInactive:
-		return "Status.Inactive"
-	case StatusSuspended:
-		return "Status.Suspended"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
 func (s Status) MarshalJSON() ([]byte, error) {
 	switch s.Tag {
 	case StatusActive:

--- a/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
@@ -30,28 +30,6 @@ type Shape struct {
 	Rectangle1 float64
 }
 
-func (s Shape) String() string {
-	switch s.Tag {
-	case ShapeRectangle:
-		return fmt.Sprintf("Rectangle(%v, %v)", s.Rectangle0, s.Rectangle1)
-	case ShapePoint:
-		return "Point"
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
-func (s Shape) GoString() string {
-	switch s.Tag {
-	case ShapeRectangle:
-		return fmt.Sprintf("Shape.Rectangle(%v, %v)", s.Rectangle0, s.Rectangle1)
-	case ShapePoint:
-		return "Shape.Point"
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
 func (s Shape) MarshalJSON() ([]byte, error) {
 	switch s.Tag {
 	case ShapeRectangle:

--- a/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
@@ -35,32 +35,6 @@ type Shape struct {
 	Square float64
 }
 
-func (s Shape) String() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Circle(%v)", s.Circle)
-	case ShapeSquare:
-		return fmt.Sprintf("Square(%v)", s.Square)
-	case ShapeUnknown:
-		return "Unknown"
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
-func (s Shape) GoString() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Shape.Circle(%v)", s.Circle)
-	case ShapeSquare:
-		return fmt.Sprintf("Shape.Square(%v)", s.Square)
-	case ShapeUnknown:
-		return "Shape.Unknown"
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
 func (s Shape) MarshalJSON() ([]byte, error) {
 	switch s.Tag {
 	case ShapeCircle:

--- a/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
@@ -30,28 +30,6 @@ type Message struct {
 	Y   int
 }
 
-func (m Message) String() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Move { x: %v, y: %v }", m.X, m.Y)
-	case MessageQuit:
-		return "Quit"
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
-}
-
-func (m Message) GoString() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Message.Move { x: %v, y: %v }", m.X, m.Y)
-	case MessageQuit:
-		return "Message.Quit"
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
-}
-
 func (m Message) MarshalJSON() ([]byte, error) {
 	switch m.Tag {
 	case MessageMove:

--- a/tests/spec/emit/snapshots/json_tagged_struct_field_access.snap
+++ b/tests/spec/emit/snapshots/json_tagged_struct_field_access.snap
@@ -4,15 +4,9 @@ description: "input: \n#[json]\nstruct User {\n  name: string,\n  age: int,\n}\n
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"name"`
 	Age  int    `json:"age"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, age: %v }", u.Name, u.Age)
 }
 
 func test() string {

--- a/tests/spec/emit/snapshots/let_complex_pattern_unused_temp.snap
+++ b/tests/spec/emit/snapshots/let_complex_pattern_unused_temp.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn mk() -> P { P { v: 1 } }\nfn test
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func mk() P {

--- a/tests/spec/emit/snapshots/let_discard_shadowed_unit_struct.snap
+++ b/tests/spec/emit/snapshots/let_discard_shadowed_unit_struct.snap
@@ -6,10 +6,6 @@ package main
 
 type Blank struct{}
 
-func (b Blank) String() string {
-	return "Blank"
-}
-
 func test() {
 	_ = Blank{}
 }

--- a/tests/spec/emit/snapshots/let_else_irrefutable_unused_subject.snap
+++ b/tests/spec/emit/snapshots/let_else_irrefutable_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn mk() -> P { P { v: 1 } }\n\nfn te
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func mk() P {

--- a/tests/spec/emit/snapshots/let_else_or_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\n\nfn test(e: E) -> int {\n 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/let_else_or_pattern_dropped_binding_else_leak.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_dropped_binding_else_leak.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E {\n  A(int),\n  B(int),\n  C,\n}\nfn test() {\n  l
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/let_else_or_pattern_else_scope_shadow.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_else_scope_shadow.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E {\n  A(int),\n  B(int),\n  C,\n}\nfn test() {\n  l
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/let_else_or_pattern_no_loop_wrapper.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_no_loop_wrapper.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Val { A(int), B(int), C }\n\nfn test(items: Slice<Va
 ---
 package main
 
-import "fmt"
-
 func MakeValA(arg0 int) Val {
 	return Val{Tag: ValA, A: arg0}
 }
@@ -30,32 +28,6 @@ type Val struct {
 	Tag ValTag
 	A   int
 	B   int
-}
-
-func (v Val) String() string {
-	switch v.Tag {
-	case ValA:
-		return fmt.Sprintf("A(%v)", v.A)
-	case ValB:
-		return fmt.Sprintf("B(%v)", v.B)
-	case ValC:
-		return "C"
-	default:
-		return fmt.Sprintf("Val(%d)", v.Tag)
-	}
-}
-
-func (v Val) GoString() string {
-	switch v.Tag {
-	case ValA:
-		return fmt.Sprintf("Val.A(%v)", v.A)
-	case ValB:
-		return fmt.Sprintf("Val.B(%v)", v.B)
-	case ValC:
-		return "Val.C"
-	default:
-		return fmt.Sprintf("Val(%d)", v.Tag)
-	}
 }
 
 func test(items []Val) int {

--- a/tests/spec/emit/snapshots/let_else_or_pattern_outer_preserved_when_pattern_uses_different_name.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_outer_preserved_when_pattern_uses_different_name.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E {\n  A(int),\n  B(int),\n  C,\n}\nfn test() {\n  l
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/let_else_struct_or_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_struct_or_pattern.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Point { x: Option<int>, y: Option<int> }\n\nfn tes
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Point struct {
 	x lisette.Option[int]
 	y lisette.Option[int]
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/let_else_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_struct_pattern.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(opt: Option<Po
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(opt lisette.Option[Point]) int {

--- a/tests/spec/emit/snapshots/let_struct_destructure.snap
+++ b/tests/spec/emit/snapshots/let_struct_destructure.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> int {\n  
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/let_struct_destructure_partial.snap
+++ b/tests/spec/emit/snapshots/let_struct_destructure_partial.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> int {\n  
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/lisette_struct_with_go_imported_field_zero_fills.snap
+++ b/tests/spec/emit/snapshots/lisette_struct_with_go_imported_field_zero_fills.snap
@@ -4,17 +4,10 @@ description: "input: \nimport \"go:net/http\"\n\nstruct Wrapper { srv: http.Serv
 ---
 package main
 
-import (
-	"fmt"
-	"net/http"
-)
+import "net/http"
 
 type Wrapper struct {
 	srv http.Server
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { srv: %v }", w.srv)
 }
 
 func test() Wrapper {

--- a/tests/spec/emit/snapshots/lisette_struct_with_go_interface_zero_fills.snap
+++ b/tests/spec/emit/snapshots/lisette_struct_with_go_interface_zero_fills.snap
@@ -4,17 +4,10 @@ description: "input: \nimport \"go:context\"\n\nstruct Wrapper { ctx: context.Co
 ---
 package main
 
-import (
-	"context"
-	"fmt"
-)
+import "context"
 
 type Wrapper struct {
 	ctx context.Context
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { ctx: %v }", w.ctx)
 }
 
 func test() Wrapper {

--- a/tests/spec/emit/snapshots/lisette_struct_with_go_named_scalar_zero_fills.snap
+++ b/tests/spec/emit/snapshots/lisette_struct_with_go_named_scalar_zero_fills.snap
@@ -4,17 +4,10 @@ description: "input: \nimport \"go:time\"\n\nstruct Wrapper { d: time.Duration }
 ---
 package main
 
-import (
-	"fmt"
-	"time"
-)
+import "time"
 
 type Wrapper struct {
 	d time.Duration
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { d: %v }", w.d)
 }
 
 func test() Wrapper {

--- a/tests/spec/emit/snapshots/local_enum_definition_in_function_body.snap
+++ b/tests/spec/emit/snapshots/local_enum_definition_in_function_body.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn main() {\n  let c =
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_enum_variant.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_enum_variant.snap
@@ -4,8 +4,6 @@ description: "input: \ntype Table<T> = Map<T, int>\n\nenum Holder<T> {\n  Some(T
 ---
 package main
 
-import "fmt"
-
 func MakeHolderSome[T comparable](arg0 Table[T]) Holder[T] {
 	return Holder[T]{Tag: HolderSome, Some: arg0}
 }
@@ -21,24 +19,6 @@ const (
 type Holder[T comparable] struct {
 	Tag  HolderTag
 	Some Table[T]
-}
-
-func (h Holder[T]) String() string {
-	switch h.Tag {
-	case HolderSome:
-		return fmt.Sprintf("Some(%v)", h.Some)
-	default:
-		return fmt.Sprintf("Holder(%d)", h.Tag)
-	}
-}
-
-func (h Holder[T]) GoString() string {
-	switch h.Tag {
-	case HolderSome:
-		return fmt.Sprintf("Holder.Some(%v)", h.Some)
-	default:
-		return fmt.Sprintf("Holder(%d)", h.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_struct_field_use.snap
+++ b/tests/spec/emit/snapshots/map_alias_propagates_comparable_to_struct_field_use.snap
@@ -4,16 +4,10 @@ description: "input: \ntype Table<T> = Map<T, int>\n\nstruct Box<T> {\n  table: 
 ---
 package main
 
-import "fmt"
-
 type Table[T comparable] = map[T]int
 
 type Box[T comparable] struct {
 	table Table[T]
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { table: %v }", b.table)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_entry_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box {\n  items: Slice<int>,\n}\n\nfn main() {\n  l
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	items []int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { items: %v }", b.items)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box {\n  items: Slice<int>,\n}\n\nfn main() {\n  l
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	items []int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { items: %v }", b.items)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box {\n  items: Slice<int>,\n}\n\nfn get_map(m: Ma
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	items []int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { items: %v }", b.items)
 }
 
 func get_map(m map[string]Box) map[string]Box {

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut m = Map
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	m := make(map[string]Wrap)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner {\n  items: Slice<int>,\n}\nstruct Wrap(Inne
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	items []int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { items: %v }", i.items)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	m := make(map[string]Wrap)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Wrap(Slice<int>, int)\n\nfn main() {\n  let mut m 
 ---
 package main
 
-import "fmt"
-
 type Wrap struct {
 	F0 []int
 	F1 int
-}
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v, %v)", w.F0, w.F1)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_field_assign_captures_key.snap
+++ b/tests/spec/emit/snapshots/map_field_assign_captures_key.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Pair { x: int }\n\nfn set_key(k: Ref<string>) -> i
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	x int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair { x: %v }", p.x)
 }
 
 func set_key(k *string) int {

--- a/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
@@ -13,16 +13,8 @@ type Key struct {
 	k string
 }
 
-func (k Key) String() string {
-	return fmt.Sprintf("Key { k: %v }", k.k)
-}
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func make_key(counter *int) Key {

--- a/tests/spec/emit/snapshots/map_field_assignment_double_newtype.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_double_newtype.snap
@@ -4,27 +4,13 @@ description: "input: \nstruct Inner { x: int }\nstruct A(Inner)\nstruct B(A)\n\n
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type A Inner
 
-func (a A) String() string {
-	return fmt.Sprintf("A(%v)", Inner(a))
-}
-
 type B A
-
-func (b B) String() string {
-	return fmt.Sprintf("B(%v)", A(b))
-}
 
 func main() {
 	m := make(map[string]B)

--- a/tests/spec/emit/snapshots/map_field_assignment_expression_position.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_expression_position.snap
@@ -10,10 +10,6 @@ type Config struct {
 	value int
 }
 
-func (c Config) String() string {
-	return fmt.Sprintf("Config { value: %v }", c.value)
-}
-
 func main() {
 	m := make(map[string]Config)
 	m["a"] = Config{value: 1}

--- a/tests/spec/emit/snapshots/map_field_assignment_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_key_evaluated_once.snap
@@ -10,10 +10,6 @@ type C struct {
 	value int
 }
 
-func (c C) String() string {
-	return fmt.Sprintf("C { value: %v }", c.value)
-}
-
 func make_key() string {
 	fmt.Println("key")
 	return "a"

--- a/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
@@ -10,10 +10,6 @@ type Box struct {
 	x int
 }
 
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
-}
-
 func make_i() int {
 	fmt.Println("i")
 	return 0

--- a/tests/spec/emit/snapshots/map_field_assignment_newtype.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_newtype.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct New(int)\n\nfn main() {\n  let mut m: Map<string, 
 ---
 package main
 
-import "fmt"
-
 type New int
-
-func (n New) String() string {
-	return fmt.Sprintf("New(%v)", int(n))
-}
 
 func main() {
 	m := make(map[string]New)

--- a/tests/spec/emit/snapshots/map_field_assignment_newtype_inner_field.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_newtype_inner_field.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn main() 
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	m := make(map[string]Wrap)

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Box { x: int }\n\nfn main() {\n  let mut m = Map.f
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Box { x: int }\n\nfn main() {\n  let mut m = Map.f
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
@@ -13,10 +13,6 @@ type Box struct {
 	x int
 }
 
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
-}
-
 func main() {
 	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("a", Box{x: 1})})
 	entry := m["a"]

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Outer { items: Ref<Slice<int>> }\n\nfn main() {\n 
 ---
 package main
 
-import "fmt"
-
 type Outer struct {
 	items *[]int
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { items: %v }", o.items)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Outer { items: Ref<Slice<int>> }\n\nfn main() {\n 
 ---
 package main
 
-import "fmt"
-
 type Outer struct {
 	items *[]int
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { items: %v }", o.items)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(int)\n\nfn main() {\n  let mut w = Wrap(1)\n 
 ---
 package main
 
-import "fmt"
-
 type Wrap int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", int(w))
-}
 
 func main() {
 	w := Wrap(1)

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
@@ -4,28 +4,14 @@ description: "input: \nstruct Inner { items: Slice<int> }\nstruct Wrap(Inner)\ns
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	items []int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { items: %v }", i.items)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 type Outer struct {
 	w *Wrap
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { w: %v }", o.w)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
@@ -4,28 +4,14 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\nstruct Outer
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 type Outer struct {
 	w *Wrap
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { w: %v }", o.w)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { items: Slice<int> }\nstruct Wrap(Inner)\n\
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	items []int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { items: %v }", i.items)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	w := Wrap(Inner{items: []int{1}})

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn main() 
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	w := Wrap(Inner{x: 0})

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut w = Wra
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/map_struct_field_assignment.snap
+++ b/tests/spec/emit/snapshots/map_struct_field_assignment.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Player {\n  name: string,\n  score: int,\n}\n\nfn 
 ---
 package main
 
-import "fmt"
-
 type Player struct {
 	name  string
 	score int
-}
-
-func (p Player) String() string {
-	return fmt.Sprintf("Player { name: %v, score: %v }", p.name, p.score)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/map_struct_field_assignment_go_keyword.snap
+++ b/tests/spec/emit/snapshots/map_struct_field_assignment_go_keyword.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Config {\n  range: int,\n  name: string,\n}\n\nfn 
 ---
 package main
 
-import "fmt"
-
 type Config struct {
 	range_ int
 	name   string
-}
-
-func (c Config) String() string {
-	return fmt.Sprintf("Config { range: %v, name: %v }", c.range_, c.name)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
+++ b/tests/spec/emit/snapshots/match_arm_binding_shadows_outer_name.snap
@@ -11,10 +11,6 @@ type Point struct {
 	y int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
-}
-
 func test(p Point) int {
 	var result int
 	result = p.x + p.x

--- a/tests/spec/emit/snapshots/match_call_subject_catchall.snap
+++ b/tests/spec/emit/snapshots/match_call_subject_catchall.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn make_point() -> Poi
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func make_point() Point {

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct W<T>(T)\n\nfn test() -> int {\n  let w = W(1)\n  m
 ---
 package main
 
-import "fmt"
-
 type W[T any] struct {
 	F0 T
-}
-
-func (w W[T]) String() string {
-	return fmt.Sprintf("W(%v)", w.F0)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_selector.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_selector.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct W<T>(T)\n\nfn test() -> int {\n  match 1 {\n    n 
 ---
 package main
 
-import "fmt"
-
 type W[T any] struct {
 	F0 T
-}
-
-func (w W[T]) String() string {
-	return fmt.Sprintf("W(%v)", w.F0)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/match_guard_on_struct.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_struct.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> s
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) string {

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn main() {\n  let p =
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
+++ b/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Dir { North, South }\n\nfn check(d: Dir, urgent: boo
 ---
 package main
 
-import "fmt"
-
 func MakeDirNorth() Dir {
 	return Dir{Tag: DirNorth}
 }
@@ -23,28 +21,6 @@ const (
 
 type Dir struct {
 	Tag DirTag
-}
-
-func (d Dir) String() string {
-	switch d.Tag {
-	case DirNorth:
-		return "North"
-	case DirSouth:
-		return "South"
-	default:
-		return fmt.Sprintf("Dir(%d)", d.Tag)
-	}
-}
-
-func (d Dir) GoString() string {
-	switch d.Tag {
-	case DirNorth:
-		return "Dir.North"
-	case DirSouth:
-		return "Dir.South"
-	default:
-		return fmt.Sprintf("Dir(%d)", d.Tag)
-	}
 }
 
 func check(d Dir, urgent bool) string {

--- a/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C(int) }\n\nfn test(e: E) -> int
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -31,32 +29,6 @@ type E struct {
 	A   int
 	B   int
 	C   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return fmt.Sprintf("C(%v)", e.C)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return fmt.Sprintf("E.C(%v)", e.C)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn mk() -> P { P { v: 1 } }\n\nfn te
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func mk() P {

--- a/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let p = P { v: 1 }\n 
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_in_defer_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_defer_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  defer {\n    let p = 
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_in_lambda_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_lambda_unused_subject.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct P { v: int }\nfn test() -> int {\n  let opt = Some
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/match_in_recover_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_recover_unused_subject.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let out = recover {\n
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_in_task_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_task_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  task {\n    let p = P
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_on_aliased_lisette_enum_emits_enum_tag_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_aliased_lisette_enum_emits_enum_tag_switch.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\ntype Palette = Color\n
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 type Palette = Color

--- a/tests/spec/emit/snapshots/match_on_deref_enum.snap
+++ b/tests/spec/emit/snapshots/match_on_deref_enum.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn test(c: Ref<Color>)
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func test(c *Color) int {

--- a/tests/spec/emit/snapshots/match_on_enum.snap
+++ b/tests/spec/emit/snapshots/match_on_enum.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn test(color: Color) 
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func test(color Color) int {

--- a/tests/spec/emit/snapshots/match_on_enum_variant_as_subject.snap
+++ b/tests/spec/emit/snapshots/match_on_enum_variant_as_subject.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Dir { North, South, East }\n\nfn test() -> string {\
 ---
 package main
 
-import "fmt"
-
 func MakeDirNorth() Dir {
 	return Dir{Tag: DirNorth}
 }
@@ -28,32 +26,6 @@ const (
 
 type Dir struct {
 	Tag DirTag
-}
-
-func (d Dir) String() string {
-	switch d.Tag {
-	case DirNorth:
-		return "North"
-	case DirSouth:
-		return "South"
-	case DirEast:
-		return "East"
-	default:
-		return fmt.Sprintf("Dir(%d)", d.Tag)
-	}
-}
-
-func (d Dir) GoString() string {
-	switch d.Tag {
-	case DirNorth:
-		return "Dir.North"
-	case DirSouth:
-		return "Dir.South"
-	case DirEast:
-		return "Dir.East"
-	default:
-		return fmt.Sprintf("Dir(%d)", d.Tag)
-	}
 }
 
 func test() string {

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Pair(int, int)\n\nfn test() -> int {\n  let a = 10
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 int
 	F1 int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
@@ -4,22 +4,12 @@ description: "input: \nstruct Pair(int, int)\nstruct Name(string)\n\nfn test() -
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 int
 	F1 int
 }
 
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
-}
-
 type Name string
-
-func (n Name) String() string {
-	return fmt.Sprintf("Name(%v)", string(n))
-}
 
 func test() string {
 	p := Pair{

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
@@ -4,10 +4,7 @@ description: "input: \nenum E { A((int, int)), B((int, int)), C }\nfn eval(e: E)
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func MakeEA(arg0 lisette.Tuple2[int, int]) E {
 	return E{Tag: EA, A: arg0}
@@ -33,32 +30,6 @@ type E struct {
 	Tag ETag
 	A   lisette.Tuple2[int, int]
 	B   lisette.Tuple2[int, int]
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func eval(e E) int {

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\nfn test() {\n  let e = E.C\
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
@@ -4,10 +4,7 @@ description: "input: \nenum E { A((int, int)), B((int, int)), C }\nfn eval(e: E)
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func MakeEA(arg0 lisette.Tuple2[int, int]) E {
 	return E{Tag: EA, A: arg0}
@@ -33,32 +30,6 @@ type E struct {
 	Tag ETag
 	A   lisette.Tuple2[int, int]
 	B   lisette.Tuple2[int, int]
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func eval(e E) int {

--- a/tests/spec/emit/snapshots/match_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_unused_branch_binding.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\nfn test() {\n  let x = 5\n 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Event {\n  Click(int, int),\n  KeyPress(string),\n}\
 ---
 package main
 
-import "fmt"
-
 func MakeEventClick(arg0 int, arg1 int) Event {
 	return Event{Tag: EventClick, Click0: arg0, Click1: arg1}
 }
@@ -26,28 +24,6 @@ type Event struct {
 	Click0   int
 	Click1   int
 	KeyPress string
-}
-
-func (e Event) String() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Click(%v, %v)", e.Click0, e.Click1)
-	case EventKeyPress:
-		return fmt.Sprintf("KeyPress(%v)", e.KeyPress)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
-}
-
-func (e Event) GoString() string {
-	switch e.Tag {
-	case EventClick:
-		return fmt.Sprintf("Event.Click(%v, %v)", e.Click0, e.Click1)
-	case EventKeyPress:
-		return fmt.Sprintf("Event.KeyPress(%v)", e.KeyPress)
-	default:
-		return fmt.Sprintf("Event(%d)", e.Tag)
-	}
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
+++ b/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Shape {\n  Circle(int),\n  Rectangle { width: int, h
 ---
 package main
 
-import "fmt"
-
 func MakeShapeCircle(arg0 int) Shape {
 	return Shape{Tag: ShapeCircle, Circle: arg0}
 }
@@ -26,28 +24,6 @@ type Shape struct {
 	Circle int
 	Width  int
 	Height int
-}
-
-func (s Shape) String() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Circle(%v)", s.Circle)
-	case ShapeRectangle:
-		return fmt.Sprintf("Rectangle { width: %v, height: %v }", s.Width, s.Height)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
-func (s Shape) GoString() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Shape.Circle(%v)", s.Circle)
-	case ShapeRectangle:
-		return fmt.Sprintf("Shape.Rectangle { width: %v, height: %v }", s.Width, s.Height)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
 }
 
 func (s Shape) area() int {

--- a/tests/spec/emit/snapshots/match_self_struct_field_pattern_uses_receiver_name.snap
+++ b/tests/spec/emit/snapshots/match_self_struct_field_pattern_uses_receiver_name.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn des
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func (p Point) describe() string {

--- a/tests/spec/emit/snapshots/match_single_arm_struct_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_single_arm_struct_ident_subject_unused.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let p = P { v: 1 }\n 
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/match_single_arm_struct_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_single_arm_struct_unused_subject.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct P { v: int }\nfn mk() -> P { P { v: 1 } }\nfn test
 ---
 package main
 
-import "fmt"
-
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func mk() P {

--- a/tests/spec/emit/snapshots/match_struct_literal_subject_parenthesized.snap
+++ b/tests/spec/emit/snapshots/match_struct_literal_subject_parenthesized.snap
@@ -10,10 +10,6 @@ type Point struct {
 	x int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v }", p.x)
-}
-
 func main() {
 	var result int
 	subject_1 := Point{x: 1}.x

--- a/tests/spec/emit/snapshots/match_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> i
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_struct_pattern_with_binding.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> i
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/match_struct_rest_catchall.snap
+++ b/tests/spec/emit/snapshots/match_struct_rest_catchall.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) -> i
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/match_subject_var_discard_ignores_string_literal_lookalike.snap
+++ b/tests/spec/emit/snapshots/match_subject_var_discard_ignores_string_literal_lookalike.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Point { x: int }\n\nfn make() -> Point {\n  Point 
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v }", p.x)
 }
 
 func make_() Point {

--- a/tests/spec/emit/snapshots/match_with_wildcard.snap
+++ b/tests/spec/emit/snapshots/match_with_wildcard.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn test(color: Color) 
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func test(color Color) int {

--- a/tests/spec/emit/snapshots/method_call.snap
+++ b/tests/spec/emit/snapshots/method_call.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn get
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func (p Point) get_x() int {

--- a/tests/spec/emit/snapshots/method_call_on_enum_variant.snap
+++ b/tests/spec/emit/snapshots/method_call_on_enum_variant.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nimpl Color {\n  fn nam
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func (c Color) name() string {

--- a/tests/spec/emit/snapshots/method_expression_as_value_public.snap
+++ b/tests/spec/emit/snapshots/method_expression_as_value_public.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  pub fn add(self, y
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func (b Box) Add(y int) int {

--- a/tests/spec/emit/snapshots/method_with_reference_self.snap
+++ b/tests/spec/emit/snapshots/method_with_reference_self.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { count: int }\n\nimpl Counter {\n  fn get
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	count int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { count: %v }", c.count)
 }
 
 func (c *Counter) get_count() int {

--- a/tests/spec/emit/snapshots/mixed_lowering_and_bare_methods_satisfy_go_interface.snap
+++ b/tests/spec/emit/snapshots/mixed_lowering_and_bare_methods_satisfy_go_interface.snap
@@ -8,10 +8,6 @@ import "example.com/mixed"
 
 type Svc struct{}
 
-func (s Svc) String() string {
-	return "Svc"
-}
-
 func (s Svc) Load(_ string) (int, error) {
 	return 1, nil
 }

--- a/tests/spec/emit/snapshots/multiple_methods.snap
+++ b/tests/spec/emit/snapshots/multiple_methods.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn new
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func Point_new(x, y int) Point {

--- a/tests/spec/emit/snapshots/mutable_interface_var_uses_var_declaration.snap
+++ b/tests/spec/emit/snapshots/mutable_interface_var_uses_var_declaration.snap
@@ -4,18 +4,12 @@ description: "input: \ninterface Printable {\n  fn to_string(self) -> string\n}\
 ---
 package main
 
-import "fmt"
-
 type Printable interface {
 	ToString() string
 }
 
 type Box struct {
 	label string
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { label: %v }", b.label)
 }
 
 func (b Box) ToString() string {

--- a/tests/spec/emit/snapshots/nested_block_return_in_struct_spread.snap
+++ b/tests/spec/emit/snapshots/nested_block_return_in_struct_spread.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct S { a: int }\nfn test() -> int {\n  let _ = S { a:
 ---
 package main
 
-import "fmt"
-
 type S struct {
 	a int
-}
-
-func (s S) String() string {
-	return fmt.Sprintf("S { a: %v }", s.a)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/nested_generic_struct.snap
+++ b/tests/spec/emit/snapshots/nested_generic_struct.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nfn test() -> Box<Box<int>> 
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func test() Box[Box[int]] {

--- a/tests/spec/emit/snapshots/nested_map_struct_field_assignment.snap
+++ b/tests/spec/emit/snapshots/nested_map_struct_field_assignment.snap
@@ -4,23 +4,13 @@ description: "input: \nstruct Inner {\n  value: int,\n}\n\nstruct Outer {\n  inn
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	value int
-}
-
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { value: %v }", i.value)
 }
 
 type Outer struct {
 	inner Inner
 	name  string
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { inner: %v, name: %v }", o.inner, o.name)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u:
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func raw() int {
 	return 1

--- a/tests/spec/emit/snapshots/newtype_field_assign_ref_expr_position.snap
+++ b/tests/spec/emit/snapshots/newtype_field_assign_ref_expr_position.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(int)\n\nfn main() {\n  let mut w = Wrap(0)\n 
 ---
 package main
 
-import "fmt"
-
 type Wrap int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", int(w))
-}
 
 func main() {
 	w := Wrap(0)

--- a/tests/spec/emit/snapshots/newtype_field_assignment.snap
+++ b/tests/spec/emit/snapshots/newtype_field_assignment.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type New int
 
-func (n New) String() string {
-	return fmt.Sprintf("New(%v)", int(n))
-}
-
 func main() {
 	n := New(1)
 	n = New(2)

--- a/tests/spec/emit/snapshots/newtype_field_assignment_expression_position.snap
+++ b/tests/spec/emit/snapshots/newtype_field_assignment_expression_position.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type New int
 
-func (n New) String() string {
-	return fmt.Sprintf("New(%v)", int(n))
-}
-
 func main() {
 	n := New(1)
 	n = New(2)

--- a/tests/spec/emit/snapshots/newtype_nested_field_assign_eval_order.snap
+++ b/tests/spec/emit/snapshots/newtype_nested_field_assign_eval_order.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn bump(i:
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func bump(i *int) int {
 	*i++

--- a/tests/spec/emit/snapshots/newtype_nested_field_assign_expr_position.snap
+++ b/tests/spec/emit/snapshots/newtype_nested_field_assign_expr_position.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn main() 
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	w := Wrap(Inner{x: 0})

--- a/tests/spec/emit/snapshots/newtype_nested_field_assignment.snap
+++ b/tests/spec/emit/snapshots/newtype_nested_field_assignment.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn main() 
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	w := Wrap(Inner{x: 1})

--- a/tests/spec/emit/snapshots/newtype_nested_field_ref.snap
+++ b/tests/spec/emit/snapshots/newtype_nested_field_ref.snap
@@ -4,21 +4,11 @@ description: "input: \nstruct Inner { x: int }\nstruct Wrap(Inner)\n\nfn main() 
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func main() {
 	w := Wrap(Inner{x: 1})

--- a/tests/spec/emit/snapshots/newtype_nested_tuple_field_assignment.snap
+++ b/tests/spec/emit/snapshots/newtype_nested_tuple_field_assignment.snap
@@ -4,22 +4,12 @@ description: "input: \nstruct Pair(int, int)\nstruct Wrap(Pair)\n\nfn main() {\n
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 int
 	F1 int
 }
 
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
-}
-
 type Wrap Pair
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Pair(w))
-}
 
 func main() {
 	w := Wrap(Pair{

--- a/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn make(i: int) -> UserId {\n  i\n}
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func make_(i int) UserId {
 	return UserId(i)

--- a/tests/spec/emit/snapshots/newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/newtype_slice_append.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut w = Wra
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
@@ -4,20 +4,10 @@ description: "input: \nstruct UserId(int)\nstruct Box { v: UserId }\n\nfn test(i
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 type Box struct {
 	v UserId
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func test(i int) Box {

--- a/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_pattern_match.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn test(uid: UserId) -> int {\n  ma
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func test(uid UserId) int {
 	return int(uid)

--- a/tests/spec/emit/snapshots/newtype_tuple_field_append.snap
+++ b/tests/spec/emit/snapshots/newtype_tuple_field_append.snap
@@ -4,22 +4,12 @@ description: "input: \nstruct Pair(Slice<int>, int)\nstruct Wrap(Pair)\n\nfn mai
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 []int
 	F1 int
 }
 
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
-}
-
 type Wrap Pair
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Pair(w))
-}
 
 func main() {
 	w := Wrap(Pair{

--- a/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u:
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func raw() int {
 	return 1

--- a/tests/spec/emit/snapshots/nilable_option_in_tuple_slot_lowers_directly_satisfying_go_interface.snap
+++ b/tests/spec/emit/snapshots/nilable_option_in_tuple_slot_lowers_directly_satisfying_go_interface.snap
@@ -8,10 +8,6 @@ import "example.com/tea"
 
 type Model struct{}
 
-func (m Model) String() string {
-	return "Model"
-}
-
 func (m Model) Update(_ tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }

--- a/tests/spec/emit/snapshots/non_generic_alias_pins_unconstrained_type_param.snap
+++ b/tests/spec/emit/snapshots/non_generic_alias_pins_unconstrained_type_param.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Phantom<T, P> { pub value: T }\n\ntype IntPhantom 
 ---
 package main
 
-import "fmt"
-
 type Phantom[T any, P any] struct {
 	Value T
-}
-
-func (p Phantom[T, P]) String() string {
-	return fmt.Sprintf("Phantom { value: %v }", p.Value)
 }
 
 type IntPhantom = Phantom[int, string]

--- a/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
+++ b/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
@@ -4,8 +4,6 @@ description: "input: \ninterface Printable {\n  fn to_string(self) -> string\n}\
 ---
 package main
 
-import "fmt"
-
 type Printable interface {
 	ToString() string
 }
@@ -14,20 +12,12 @@ type Box struct {
 	label string
 }
 
-func (b Box) String() string {
-	return fmt.Sprintf("Box { label: %v }", b.label)
-}
-
 func (b Box) ToString() string {
 	return b.label
 }
 
 type Circle struct {
 	radius int
-}
-
-func (c Circle) String() string {
-	return fmt.Sprintf("Circle { radius: %v }", c.radius)
 }
 
 func (c Circle) ToString() string {

--- a/tests/spec/emit/snapshots/option_ref_lowers_to_bare_nilable_pointer_in_interface_impl.snap
+++ b/tests/spec/emit/snapshots/option_ref_lowers_to_bare_nilable_pointer_in_interface_impl.snap
@@ -8,10 +8,6 @@ import "example.com/store"
 
 type Store struct{}
 
-func (s Store) String() string {
-	return "Store"
-}
-
 func (s Store) Find(_ string) *store.Entry {
 	return nil
 }

--- a/tests/spec/emit/snapshots/option_with_interface_type_param.snap
+++ b/tests/spec/emit/snapshots/option_with_interface_type_param.snap
@@ -4,10 +4,7 @@ description: "input: \ninterface Printable {\n  fn to_string(self) -> string\n}\
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Printable interface {
 	to_string() string
@@ -15,10 +12,6 @@ type Printable interface {
 
 type Text struct {
 	content string
-}
-
-func (t Text) String() string {
-	return fmt.Sprintf("Text { content: %v }", t.content)
 }
 
 func (t Text) to_string() string {

--- a/tests/spec/emit/snapshots/or_pattern_enum_variants.snap
+++ b/tests/spec/emit/snapshots/or_pattern_enum_variants.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n\nfn test(c: Color) -> s
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 func test(c Color) string {

--- a/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Shape {\n  Circle(int),\n  Square(int),\n  Triangle(
 ---
 package main
 
-import "fmt"
-
 func MakeShapeCircle(arg0 int) Shape {
 	return Shape{Tag: ShapeCircle, Circle: arg0}
 }
@@ -31,32 +29,6 @@ type Shape struct {
 	Circle   int
 	Square   int
 	Triangle int
-}
-
-func (s Shape) String() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Circle(%v)", s.Circle)
-	case ShapeSquare:
-		return fmt.Sprintf("Square(%v)", s.Square)
-	case ShapeTriangle:
-		return fmt.Sprintf("Triangle(%v)", s.Triangle)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
-func (s Shape) GoString() string {
-	switch s.Tag {
-	case ShapeCircle:
-		return fmt.Sprintf("Shape.Circle(%v)", s.Circle)
-	case ShapeSquare:
-		return fmt.Sprintf("Shape.Square(%v)", s.Square)
-	case ShapeTriangle:
-		return fmt.Sprintf("Shape.Triangle(%v)", s.Triangle)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
 }
 
 func shape_size(s Shape) int {

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Res { Ok(int), Err(int) }\n\nfn test(r: Res, thresho
 ---
 package main
 
-import "fmt"
-
 func MakeResOk(arg0 int) Res {
 	return Res{Tag: ResOk, Ok: arg0}
 }
@@ -25,28 +23,6 @@ type Res struct {
 	Tag ResTag
 	Ok  int
 	Err int
-}
-
-func (r Res) String() string {
-	switch r.Tag {
-	case ResOk:
-		return fmt.Sprintf("Ok(%v)", r.Ok)
-	case ResErr:
-		return fmt.Sprintf("Err(%v)", r.Err)
-	default:
-		return fmt.Sprintf("Res(%d)", r.Tag)
-	}
-}
-
-func (r Res) GoString() string {
-	switch r.Tag {
-	case ResOk:
-		return fmt.Sprintf("Res.Ok(%v)", r.Ok)
-	case ResErr:
-		return fmt.Sprintf("Res.Err(%v)", r.Err)
-	default:
-		return fmt.Sprintf("Res(%d)", r.Tag)
-	}
 }
 
 func test(r Res, threshold int) int {

--- a/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
@@ -4,10 +4,7 @@ description: "input: \nenum E { A(int), B(int) }\n\nfn test() -> int {\n  let mu
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
@@ -28,28 +25,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\n\nfn test(e: E) -> int {\n 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/or_pattern_no_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_no_bindings.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Status { Pending, Running, Complete, Failed }\n\nfn 
 ---
 package main
 
-import "fmt"
-
 func MakeStatusPending() Status {
 	return Status{Tag: StatusPending}
 }
@@ -33,36 +31,6 @@ const (
 
 type Status struct {
 	Tag StatusTag
-}
-
-func (s Status) String() string {
-	switch s.Tag {
-	case StatusPending:
-		return "Pending"
-	case StatusRunning:
-		return "Running"
-	case StatusComplete:
-		return "Complete"
-	case StatusFailed:
-		return "Failed"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
-}
-
-func (s Status) GoString() string {
-	switch s.Tag {
-	case StatusPending:
-		return "Status.Pending"
-	case StatusRunning:
-		return "Status.Running"
-	case StatusComplete:
-		return "Status.Complete"
-	case StatusFailed:
-		return "Status.Failed"
-	default:
-		return fmt.Sprintf("Status(%d)", s.Tag)
-	}
 }
 
 func test(s Status) string {

--- a/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int) }\n\nfn test(e: E) -> int {\n  ma
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -25,28 +23,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/parenthesized_call_base_field_assignment.snap
+++ b/tests/spec/emit/snapshots/parenthesized_call_base_field_assignment.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct S { x: int }\n\nfn get(r: Ref<S>) -> Ref<S> { r }\
 ---
 package main
 
-import "fmt"
-
 type S struct {
 	x int
-}
-
-func (s S) String() string {
-	return fmt.Sprintf("S { x: %v }", s.x)
 }
 
 func get(r *S) *S {

--- a/tests/spec/emit/snapshots/parenthesized_static_generic_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/parenthesized_static_generic_return_only_type_args.snap
@@ -6,10 +6,6 @@ package main
 
 type Factory struct{}
 
-func (f Factory) String() string {
-	return "Factory"
-}
-
 func Factory_Make[T any]() []T {
 	return []T{}
 }

--- a/tests/spec/emit/snapshots/parenthesized_tuple_struct_call.snap
+++ b/tests/spec/emit/snapshots/parenthesized_tuple_struct_call.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nfn test() -> Point {\n  (Point)
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/parenthesized_ufcs_generic_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/parenthesized_ufcs_generic_return_only_type_args.snap
@@ -6,10 +6,6 @@ package main
 
 type Factory struct{}
 
-func (f Factory) String() string {
-	return "Factory"
-}
-
 func Factory_make[T any](_ Factory) []T {
 	return []T{}
 }

--- a/tests/spec/emit/snapshots/partial_return_lowers_to_satisfy_go_interface.snap
+++ b/tests/spec/emit/snapshots/partial_return_lowers_to_satisfy_go_interface.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/pointer_deref_field_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_deref_field_target_frozen_before_rhs.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Box { value: int }\n\nfn run() -> Result<(), strin
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Box struct {
 	value int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func run() lisette.Result[struct{}, string] {

--- a/tests/spec/emit/snapshots/pointer_implicit_field_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/pointer_implicit_field_target_frozen_before_rhs.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Box { value: int }\n\nfn run() -> Result<(), strin
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Box struct {
 	value int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func run() lisette.Result[struct{}, string] {

--- a/tests/spec/emit/snapshots/prelude_type_shadowing_struct_and_methods.snap
+++ b/tests/spec/emit/snapshots/prelude_type_shadowing_struct_and_methods.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Span {\n  start: int,\n  end: int,\n}\n\nimpl Span
 ---
 package main
 
-import "fmt"
-
 type Span struct {
 	start int
 	end   int
-}
-
-func (s Span) String() string {
-	return fmt.Sprintf("Span { start: %v, end: %v }", s.start, s.end)
 }
 
 func Span_new(start, end int) Span {

--- a/tests/spec/emit/snapshots/private_field_not_capitalized_by_method_export.snap
+++ b/tests/spec/emit/snapshots/private_field_not_capitalized_by_method_export.snap
@@ -4,18 +4,12 @@ description: "input: \npub interface IFoo {\n  fn foo(self) -> int\n}\n\nstruct 
 ---
 package main
 
-import "fmt"
-
 type IFoo interface {
 	Foo() int
 }
 
 type S struct {
 	foo int
-}
-
-func (s S) String() string {
-	return fmt.Sprintf("S { foo: %v }", s.foo)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct User {\n  id: int,\n  name: string,\n}\n\nfn get_i
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type User struct {
 	id   int
 	name string
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { id: %v, name: %v }", u.id, u.name)
 }
 
 func get_id() lisette.Result[int, string] {

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct User {\n  id: int,\n  name: string,\n}\n\nfn get_b
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type User struct {
 	id   int
 	name string
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { id: %v, name: %v }", u.id, u.name)
 }
 
 func get_base() lisette.Result[User, string] {

--- a/tests/spec/emit/snapshots/pub_field_assignment_capitalizes.snap
+++ b/tests/spec/emit/snapshots/pub_field_assignment_capitalizes.snap
@@ -4,14 +4,8 @@ description: "input: \npub struct Counter {\n  pub value: int,\n}\n\nfn test() {
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	Value int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { value: %v }", c.Value)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/pub_interface_impl_method_capitalized.snap
+++ b/tests/spec/emit/snapshots/pub_interface_impl_method_capitalized.snap
@@ -4,18 +4,12 @@ description: "input: \npub interface Printable {\n  fn display(self) -> string\n
 ---
 package main
 
-import "fmt"
-
 type Printable interface {
 	Display() string
 }
 
 type Box struct {
 	value string
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func (b Box) Display() string {

--- a/tests/spec/emit/snapshots/pure_signature_interface_skips_adapter.snap
+++ b/tests/spec/emit/snapshots/pure_signature_interface_skips_adapter.snap
@@ -8,10 +8,6 @@ import "example.com/simple"
 
 type Greeter struct{}
 
-func (g Greeter) String() string {
-	return "Greeter"
-}
-
 func (g Greeter) Greet(name string) string {
 	return name
 }

--- a/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
+++ b/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
@@ -10,10 +10,6 @@ type IntList struct {
 	items []int
 }
 
-func (i IntList) String() string {
-	return fmt.Sprintf("IntList { items: %v }", i.items)
-}
-
 func (i IntList) display() string {
 	s := "["
 	_bound_1 := len(i.items)

--- a/tests/spec/emit/snapshots/receiver_type_in_struct.snap
+++ b/tests/spec/emit/snapshots/receiver_type_in_struct.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Consumer { input: Receiver<int> }\n\nfn test(c: Co
 ---
 package main
 
-import "fmt"
-
 type Consumer struct {
 	input <-chan int
-}
-
-func (c Consumer) String() string {
-	return fmt.Sprintf("Consumer { input: %v }", c.input)
 }
 
 func test(c Consumer) <-chan int {

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List {\n  Cons(int, List),\n  Nil,\n}\n\nfn list_sum
 ---
 package main
 
-import "fmt"
-
 func MakeListCons(arg0 int, arg1 *List) List {
 	return List{Tag: ListCons, Cons0: arg0, Cons1: arg1}
 }
@@ -25,28 +23,6 @@ type List struct {
 	Tag   ListTag
 	Cons0 int
 	Cons1 *List
-}
-
-func (l List) String() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List) GoString() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "List.Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func list_sum(l List) int {

--- a/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
@@ -28,28 +28,6 @@ type Node struct {
 	Right *Node
 }
 
-func (n Node) String() string {
-	switch n.Tag {
-	case NodeLeaf:
-		return fmt.Sprintf("Leaf { value: %v }", n.Value)
-	case NodeBranch:
-		return fmt.Sprintf("Branch { left: %v, right: %v }", n.Left, n.Right)
-	default:
-		return fmt.Sprintf("Node(%d)", n.Tag)
-	}
-}
-
-func (n Node) GoString() string {
-	switch n.Tag {
-	case NodeLeaf:
-		return fmt.Sprintf("Node.Leaf { value: %v }", n.Value)
-	case NodeBranch:
-		return fmt.Sprintf("Node.Branch { left: %v, right: %v }", n.Left, n.Right)
-	default:
-		return fmt.Sprintf("Node(%d)", n.Tag)
-	}
-}
-
 func main() {
 	ptr_1 := Node{
 		Tag:   NodeLeaf,

--- a/tests/spec/emit/snapshots/recursive_enum_ref_argument_no_double_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ref_argument_no_double_pointer.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List {\n  Cons(int, Ref<List>),\n  Nil,\n}\n\nfn tes
 ---
 package main
 
-import "fmt"
-
 func MakeListCons(arg0 int, arg1 *List) List {
 	return List{Tag: ListCons, Cons0: arg0, Cons1: arg1}
 }
@@ -25,28 +23,6 @@ type List struct {
 	Tag   ListTag
 	Cons0 int
 	Cons1 *List
-}
-
-func (l List) String() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List) GoString() string {
-	switch l.Tag {
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	case ListNil:
-		return "List.Nil"
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func test() List {

--- a/tests/spec/emit/snapshots/recursive_enum_ref_value_no_double_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ref_value_no_double_pointer.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Tree {\n  Leaf(int),\n  Node(Ref<Tree>, Ref<Tree>),\
 ---
 package main
 
-import "fmt"
-
 func MakeTreeLeaf(arg0 int) Tree {
 	return Tree{Tag: TreeLeaf, Leaf: arg0}
 }
@@ -26,28 +24,6 @@ type Tree struct {
 	Leaf  int
 	Node0 *Tree
 	Node1 *Tree
-}
-
-func (t Tree) String() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Node(%v, %v)", t.Node0, t.Node1)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
-}
-
-func (t Tree) GoString() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Tree.Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Tree.Node(%v, %v)", t.Node0, t.Node1)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
 }
 
 func leaf(n int) *Tree {

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Tree<T> {\n  Leaf(T),\n  Node { left: Tree<T>, right
 ---
 package main
 
-import "fmt"
-
 func MakeTreeLeaf[T any](arg0 T) Tree[T] {
 	return Tree[T]{Tag: TreeLeaf, Leaf: arg0}
 }
@@ -26,28 +24,6 @@ type Tree[T any] struct {
 	Leaf  T
 	Left  *Tree[T]
 	Right *Tree[T]
-}
-
-func (t Tree[T]) String() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Node { left: %v, right: %v }", t.Left, t.Right)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
-}
-
-func (t Tree[T]) GoString() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Tree.Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Tree.Node { left: %v, right: %v }", t.Left, t.Right)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
 }
 
 func count_leaves[T any](tree Tree[T]) int {

--- a/tests/spec/emit/snapshots/recursive_enum_tree.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tree.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Tree {\n  Leaf(int),\n  Node(Tree, Tree),\n}\n\nfn t
 ---
 package main
 
-import "fmt"
-
 func MakeTreeLeaf(arg0 int) Tree {
 	return Tree{Tag: TreeLeaf, Leaf: arg0}
 }
@@ -26,28 +24,6 @@ type Tree struct {
 	Leaf  int
 	Node0 *Tree
 	Node1 *Tree
-}
-
-func (t Tree) String() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Node(%v, %v)", t.Node0, t.Node1)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
-}
-
-func (t Tree) GoString() string {
-	switch t.Tag {
-	case TreeLeaf:
-		return fmt.Sprintf("Tree.Leaf(%v)", t.Leaf)
-	case TreeNode:
-		return fmt.Sprintf("Tree.Node(%v, %v)", t.Node0, t.Node1)
-	default:
-		return fmt.Sprintf("Tree(%d)", t.Tag)
-	}
 }
 
 func test() Tree {

--- a/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
@@ -28,28 +28,6 @@ type Node struct {
 	Branch1 *Node
 }
 
-func (n Node) String() string {
-	switch n.Tag {
-	case NodeLeaf:
-		return fmt.Sprintf("Leaf(%v)", n.Leaf)
-	case NodeBranch:
-		return fmt.Sprintf("Branch(%v, %v)", n.Branch0, n.Branch1)
-	default:
-		return fmt.Sprintf("Node(%d)", n.Tag)
-	}
-}
-
-func (n Node) GoString() string {
-	switch n.Tag {
-	case NodeLeaf:
-		return fmt.Sprintf("Node.Leaf(%v)", n.Leaf)
-	case NodeBranch:
-		return fmt.Sprintf("Node.Branch(%v, %v)", n.Branch0, n.Branch1)
-	default:
-		return fmt.Sprintf("Node(%d)", n.Tag)
-	}
-}
-
 func main() {
 	ptr_1 := MakeNodeLeaf(1)
 	ptr_2 := MakeNodeLeaf(2)

--- a/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List {\n  Nil,\n  Cons(int, List),\n}\n\nfn main() {
 ---
 package main
 
-import "fmt"
-
 func MakeListNil() List {
 	return List{Tag: ListNil}
 }
@@ -25,28 +23,6 @@ type List struct {
 	Tag   ListTag
 	Cons0 int
 	Cons1 *List
-}
-
-func (l List) String() string {
-	switch l.Tag {
-	case ListNil:
-		return "Nil"
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List) GoString() string {
-	switch l.Tag {
-	case ListNil:
-		return "List.Nil"
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
@@ -4,8 +4,6 @@ description: "input: \nenum List<T> {\n  Nil,\n  Cons(T, List<T>)\n}\n\nfn test(
 ---
 package main
 
-import "fmt"
-
 func MakeListNil[T any]() List[T] {
 	return List[T]{Tag: ListNil}
 }
@@ -25,28 +23,6 @@ type List[T any] struct {
 	Tag   ListTag
 	Cons0 T
 	Cons1 *List[T]
-}
-
-func (l List[T]) String() string {
-	switch l.Tag {
-	case ListNil:
-		return "Nil"
-	case ListCons:
-		return fmt.Sprintf("Cons(%v, %v)", l.Cons0, l.Cons1)
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
-}
-
-func (l List[T]) GoString() string {
-	switch l.Tag {
-	case ListNil:
-		return "List.Nil"
-	case ListCons:
-		return fmt.Sprintf("List.Cons(%v, %v)", l.Cons0, l.Cons1)
-	default:
-		return fmt.Sprintf("List(%d)", l.Tag)
-	}
 }
 
 func test() List[int] {

--- a/tests/spec/emit/snapshots/ref_bounded_generic_absorbs_ref_into_type_param.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_absorbs_ref_into_type_param.snap
@@ -4,18 +4,12 @@ description: "input: \ninterface Mutable {\n  fn mutate(self, val: string)\n}\n\
 ---
 package main
 
-import "fmt"
-
 type Mutable interface {
 	mutate(string)
 }
 
 type Box struct {
 	content string
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { content: %v }", b.content)
 }
 
 func (b *Box) mutate(val string) {

--- a/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
@@ -14,10 +14,6 @@ type Person struct {
 	name string
 }
 
-func (p Person) String() string {
-	return fmt.Sprintf("Person { name: %v }", p.name)
-}
-
 func (p Person) greet() string {
 	return fmt.Sprintf("Hello, %s", p.name)
 }

--- a/tests/spec/emit/snapshots/ref_call_field_assign_eval_order.snap
+++ b/tests/spec/emit/snapshots/ref_call_field_assign_eval_order.snap
@@ -10,10 +10,6 @@ type S struct {
 	x int
 }
 
-func (s S) String() string {
-	return fmt.Sprintf("S { x: %v }", s.x)
-}
-
 func get() *S {
 	fmt.Println("get")
 	s := S{x: 1}

--- a/tests/spec/emit/snapshots/ref_call_field_assignment.snap
+++ b/tests/spec/emit/snapshots/ref_call_field_assignment.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Item { x: int }\n\nfn get() -> Ref<Item> { &Item {
 ---
 package main
 
-import "fmt"
-
 type Item struct {
 	x int
-}
-
-func (i Item) String() string {
-	return fmt.Sprintf("Item { x: %v }", i.x)
 }
 
 func get() *Item {

--- a/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type Wrap []int
 
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
-
 func get() *Wrap {
 	fmt.Println("get")
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/ref_call_newtype_nested_assign_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_newtype_nested_assign_no_double_eval.snap
@@ -10,15 +10,7 @@ type Inner struct {
 	x int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { x: %v }", i.x)
-}
-
 type Wrap Inner
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", Inner(w))
-}
 
 func get() *Wrap {
 	fmt.Println("get")

--- a/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut w = Wra
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/ref_newtype_dot0_assignment_auto_deref.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_dot0_assignment_auto_deref.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn main() {\n  let mut id = UserId(
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func main() {
 	id := UserId(1)

--- a/tests/spec/emit/snapshots/ref_newtype_dot0_auto_deref.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_dot0_auto_deref.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn main() {\n  let id = UserId(5)\n
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func main() {
 	id := UserId(5)

--- a/tests/spec/emit/snapshots/ref_newtype_extend_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_extend_expr_position.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut w = Wra
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrap(Slice<int>)\n\nfn main() {\n  let mut w = Wra
 ---
 package main
 
-import "fmt"
-
 type Wrap []int
-
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", []int(w))
-}
 
 func main() {
 	w := Wrap([]int{1})

--- a/tests/spec/emit/snapshots/ref_of_call_nested_enum_constructors.snap
+++ b/tests/spec/emit/snapshots/ref_of_call_nested_enum_constructors.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Expr {\n  Num(int),\n  Add(Ref<Expr>, Ref<Expr>),\n}
 ---
 package main
 
-import "fmt"
-
 func MakeExprNum(arg0 int) Expr {
 	return Expr{Tag: ExprNum, Num: arg0}
 }
@@ -26,28 +24,6 @@ type Expr struct {
 	Num  int
 	Add0 *Expr
 	Add1 *Expr
-}
-
-func (e Expr) String() string {
-	switch e.Tag {
-	case ExprNum:
-		return fmt.Sprintf("Num(%v)", e.Num)
-	case ExprAdd:
-		return fmt.Sprintf("Add(%v, %v)", e.Add0, e.Add1)
-	default:
-		return fmt.Sprintf("Expr(%d)", e.Tag)
-	}
-}
-
-func (e Expr) GoString() string {
-	switch e.Tag {
-	case ExprNum:
-		return fmt.Sprintf("Expr.Num(%v)", e.Num)
-	case ExprAdd:
-		return fmt.Sprintf("Expr.Add(%v, %v)", e.Add0, e.Add1)
-	default:
-		return fmt.Sprintf("Expr(%d)", e.Tag)
-	}
 }
 
 func test() Expr {

--- a/tests/spec/emit/snapshots/ref_receiver_camel_cases_public_snake_case_field.snap
+++ b/tests/spec/emit/snapshots/ref_receiver_camel_cases_public_snake_case_field.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo {\n  pub bar_baz: string,\n}\n\nimpl Foo {\n  
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	BarBaz string
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { bar_baz: %v }", f.BarBaz)
 }
 
 func (f *Foo) show() string {

--- a/tests/spec/emit/snapshots/ref_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/ref_temp_var_no_collision.snap
@@ -10,10 +10,6 @@ type Box struct {
 	x int
 }
 
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
-}
-
 func make_box() Box {
 	return Box{x: 1}
 }

--- a/tests/spec/emit/snapshots/reference_nested_parens_no_hoist.snap
+++ b/tests/spec/emit/snapshots/reference_nested_parens_no_hoist.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct S { x: int }\n\nimpl S {\n  fn inc(self: Ref<S>) {
 ---
 package main
 
-import "fmt"
-
 type S struct {
 	x int
-}
-
-func (s S) String() string {
-	return fmt.Sprintf("S { x: %v }", s.x)
 }
 
 func (s *S) inc() {

--- a/tests/spec/emit/snapshots/reference_to_newtype_field.snap
+++ b/tests/spec/emit/snapshots/reference_to_newtype_field.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type Wrap int
 
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", int(w))
-}
-
 func main() {
 	w := Wrap(1)
 	inner := int(w)

--- a/tests/spec/emit/snapshots/repeated_cast_to_go_interface_uses_lowered_struct_directly.snap
+++ b/tests/spec/emit/snapshots/repeated_cast_to_go_interface_uses_lowered_struct_directly.snap
@@ -8,10 +8,6 @@ import "io"
 
 type Doubler struct{}
 
-func (d Doubler) String() string {
-	return "Doubler"
-}
-
 func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
+++ b/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct MyError { msg: string }\n\nimpl MyError {\n  fn Er
 ---
 package main
 
-import "fmt"
-
 type MyError struct {
 	msg string
-}
-
-func (m MyError) String() string {
-	return fmt.Sprintf("MyError { msg: %v }", m.msg)
 }
 
 func (m MyError) Error() string {

--- a/tests/spec/emit/snapshots/result_with_struct.snap
+++ b/tests/spec/emit/snapshots/result_with_struct.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> Result<Po
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() lisette.Result[Point, string] {

--- a/tests/spec/emit/snapshots/select_match_receive_complex_unused_recv.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_complex_unused_recv.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let ch = Channel.buff
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/select_pattern_bindings_do_not_leak.snap
+++ b/tests/spec/emit/snapshots/select_pattern_bindings_do_not_leak.snap
@@ -10,10 +10,6 @@ type Point struct {
 	x int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v }", p.x)
-}
-
 func main() {
 	ch1 := make(chan Point, 1)
 	x := 99

--- a/tests/spec/emit/snapshots/select_shorthand_receive_complex_unused_recv.snap
+++ b/tests/spec/emit/snapshots/select_shorthand_receive_complex_unused_recv.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct P { v: int }\nfn test() {\n  let ch = Channel.buff
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type P struct {
 	v int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P { v: %v }", p.v)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/select_struct_pattern.snap
+++ b/tests/spec/emit/snapshots/select_struct_pattern.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Message { id: int, data: int }\n\nfn test(ch: Rece
 ---
 package main
 
-import "fmt"
-
 type Message struct {
 	id   int
 	data int
-}
-
-func (m Message) String() string {
-	return fmt.Sprintf("Message { id: %v, data: %v }", m.id, m.data)
 }
 
 func test(ch <-chan Message) int {

--- a/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
@@ -4,10 +4,7 @@ description: "input: \nfn f0(x: int) -> int { x + 10 }\nfn f1(x: int) -> int { x
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func f0(x int) int {
 	return x + 10
@@ -19,10 +16,6 @@ func f1(x int) int {
 
 type Handler struct {
 	f func(int) int
-}
-
-func (h Handler) String() string {
-	return fmt.Sprintf("Handler { f: %p }", h.f)
 }
 
 func run() lisette.Result[int, string] {

--- a/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Holder { slc: Slice<int> }\nfn bump(i: Ref<int>) -
 ---
 package main
 
-import "fmt"
-
 type Holder struct {
 	slc []int
-}
-
-func (h Holder) String() string {
-	return fmt.Sprintf("Holder { slc: %v }", h.slc)
 }
 
 func bump(i *int) int {

--- a/tests/spec/emit/snapshots/sender_type_in_struct.snap
+++ b/tests/spec/emit/snapshots/sender_type_in_struct.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Producer { output: Sender<int> }\n\nfn test(p: Pro
 ---
 package main
 
-import "fmt"
-
 type Producer struct {
 	output chan<- int
-}
-
-func (p Producer) String() string {
-	return fmt.Sprintf("Producer { output: %v }", p.output)
 }
 
 func test(p Producer) chan<- int {

--- a/tests/spec/emit/snapshots/simple_enum.snap
+++ b/tests/spec/emit/snapshots/simple_enum.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color { Red, Green, Blue }\n"
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,30 +26,4 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }

--- a/tests/spec/emit/snapshots/simple_struct_definition.snap
+++ b/tests/spec/emit/snapshots/simple_struct_definition.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Point { x: int, y: int }\n"
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }

--- a/tests/spec/emit/snapshots/single_field_tuple_struct_destructure.snap
+++ b/tests/spec/emit/snapshots/single_field_tuple_struct_destructure.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Wrapper(int)\n\nfn test() -> int {\n  let w = Wrap
 ---
 package main
 
-import "fmt"
-
 type Wrapper int
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper(%v)", int(w))
-}
 
 func test() int {
 	w := Wrapper(42)

--- a/tests/spec/emit/snapshots/single_variant_unit_enum.snap
+++ b/tests/spec/emit/snapshots/single_variant_unit_enum.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Marker {\n  Value,\n}\n\nfn test() -> Marker {\n  Ma
 ---
 package main
 
-import "fmt"
-
 func MakeMarkerValue() Marker {
 	return Marker{Tag: MarkerValue}
 }
@@ -18,24 +16,6 @@ const (
 
 type Marker struct {
 	Tag MarkerTag
-}
-
-func (m Marker) String() string {
-	switch m.Tag {
-	case MarkerValue:
-		return "Value"
-	default:
-		return fmt.Sprintf("Marker(%d)", m.Tag)
-	}
-}
-
-func (m Marker) GoString() string {
-	switch m.Tag {
-	case MarkerValue:
-		return "Marker.Value"
-	default:
-		return fmt.Sprintf("Marker(%d)", m.Tag)
-	}
 }
 
 func test() Marker {

--- a/tests/spec/emit/snapshots/slice_of_option_interface.snap
+++ b/tests/spec/emit/snapshots/slice_of_option_interface.snap
@@ -4,10 +4,7 @@ description: "input: \ninterface Printable {\n  fn to_string(self) -> string\n}\
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Printable interface {
 	to_string() string
@@ -17,16 +14,8 @@ type Text struct {
 	content string
 }
 
-func (t Text) String() string {
-	return fmt.Sprintf("Text { content: %v }", t.content)
-}
-
 type Number struct {
 	value int
-}
-
-func (n Number) String() string {
-	return fmt.Sprintf("Number { value: %v }", n.value)
 }
 
 func (t Text) to_string() string {

--- a/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(Slice<int>), B(Slice<int>) }\n\nfn test(e: E) 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 []int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -25,28 +23,6 @@ type E struct {
 	Tag ETag
 	A   []int
 	B   []int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test(e E) int {

--- a/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/some_with_named_function_alias_arg.snap
@@ -4,10 +4,7 @@ description: "input: \ntype Handler = fn(int) -> int\n\nfn double(x: int) -> int
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Handler func(int) int
 
@@ -17,10 +14,6 @@ func double(x int) int {
 
 type Wrapper struct {
 	F lisette.Option[Handler]
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { f: %v }", w.F)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/specialized_impl_builtin_type_int.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_builtin_type_int.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> {\n  item: T,\n}\n\nimpl Box<int> {\n  fn u
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	item T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { item: %v }", b.item)
 }
 
 func Box_unwrap(self Box[int]) int {

--- a/tests/spec/emit/snapshots/specialized_impl_builtin_type_string.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_builtin_type_string.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Wrapper<T> {\n  value: T,\n}\n\nimpl Wrapper<strin
 ---
 package main
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	value T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper { value: %v }", w.value)
 }
 
 func Wrapper_greet(_ Wrapper[string]) string {

--- a/tests/spec/emit/snapshots/specialized_impl_uses_ufcs.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_uses_ufcs.snap
@@ -4,16 +4,10 @@ description: "input: \ntype MyInt = int\n\nstruct Box<T> { val: T }\n\nimpl Box<
 ---
 package main
 
-import "fmt"
-
 type MyInt = int
 
 type Box[T any] struct {
 	val T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { val: %v }", b.val)
 }
 
 func Box_doubled(self Box[MyInt]) MyInt {

--- a/tests/spec/emit/snapshots/spread_arg_into_receiver_method_ufcs.snap
+++ b/tests/spec/emit/snapshots/spread_arg_into_receiver_method_ufcs.snap
@@ -6,10 +6,6 @@ package main
 
 type Logger struct{}
 
-func (l Logger) String() string {
-	return "Logger"
-}
-
 func (l Logger) Push(_ ...string) {}
 
 func test(l Logger, parts []string) {

--- a/tests/spec/emit/snapshots/spread_arg_into_ufcs_method.snap
+++ b/tests/spec/emit/snapshots/spread_arg_into_ufcs_method.snap
@@ -6,10 +6,6 @@ package main
 
 type Logger struct{}
 
-func (l Logger) String() string {
-	return "Logger"
-}
-
 func (l Logger) push(_ ...string) {}
 
 func test(l Logger, parts []string) {

--- a/tests/spec/emit/snapshots/static_method_as_value.snap
+++ b/tests/spec/emit/snapshots/static_method_as_value.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  fn new(x: int) -> 
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func Box_new(x int) Box {

--- a/tests/spec/emit/snapshots/static_method_call.snap
+++ b/tests/spec/emit/snapshots/static_method_call.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  fn new
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func Point_new(x, y int) Point {

--- a/tests/spec/emit/snapshots/static_method_returning_channel_not_hijacked.snap
+++ b/tests/spec/emit/snapshots/static_method_returning_channel_not_hijacked.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Foo { ch: Channel<int> }\n\nimpl Foo {\n  fn new()
 ---
 package main
 
-import "fmt"
-
 type Foo struct {
 	ch chan int
-}
-
-func (f Foo) String() string {
-	return fmt.Sprintf("Foo { ch: %v }", f.ch)
 }
 
 func Foo_new() chan int {

--- a/tests/spec/emit/snapshots/struct_field_access.snap
+++ b/tests/spec/emit/snapshots/struct_field_access.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test(p: Point) {\n 
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test(p Point) {

--- a/tests/spec/emit/snapshots/struct_field_go_interface_pattern_emits_type_switch.snap
+++ b/tests/spec/emit/snapshots/struct_field_go_interface_pattern_emits_type_switch.snap
@@ -4,17 +4,10 @@ description: "input: \nimport \"go:example.com/events\"\n\nstruct Box {\n  e: ev
 ---
 package main
 
-import (
-	"example.com/events"
-	"fmt"
-)
+import "example.com/events"
 
 type Box struct {
 	e events.Event
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { e: %v }", b.e)
 }
 
 func describe(b Box) int {

--- a/tests/spec/emit/snapshots/struct_field_init_option_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_option_function.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Wrapper {\n  opt: Option<int>,\n}\n\nfn get_opt(b:
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Wrapper struct {
 	opt lisette.Option[int]
-}
-
-func (w Wrapper) String() string {
-	return fmt.Sprintf("Wrapper { opt: %v }", w.opt)
 }
 
 func get_opt(b bool) (int, bool) {

--- a/tests/spec/emit/snapshots/struct_field_init_result_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_result_function.snap
@@ -4,17 +4,10 @@ description: "input: \nstruct Container {\n  res: Result<int, string>,\n}\n\nfn 
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Container struct {
 	res lisette.Result[int, string]
-}
-
-func (c Container) String() string {
-	return fmt.Sprintf("Container { res: %v }", c.res)
 }
 
 func get_res(b bool) lisette.Result[int, string] {

--- a/tests/spec/emit/snapshots/struct_go_keyword_type_name.snap
+++ b/tests/spec/emit/snapshots/struct_go_keyword_type_name.snap
@@ -10,10 +10,6 @@ type default_ struct {
 	value int
 }
 
-func (d default_) String() string {
-	return fmt.Sprintf("default { value: %v }", d.value)
-}
-
 func main() {
 	x := default_{value: 42}
 	fmt.Println(x)

--- a/tests/spec/emit/snapshots/struct_instantiation.snap
+++ b/tests/spec/emit/snapshots/struct_instantiation.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> Point {\n
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/struct_literal_arg_callee_eval_order.snap
+++ b/tests/spec/emit/snapshots/struct_literal_arg_callee_eval_order.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { v: int }\nfn f0(b: Box) -> int { b.v }\nfn f
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	v int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func f0(b Box) int {

--- a/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Pair { a: int, b: int }\n\nfn bump(i: Ref<int>) ->
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	a int
 	b int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair { a: %v, b: %v }", p.a, p.b)
 }
 
 func bump(i *int) int {

--- a/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
+++ b/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct MultiWrapper {\n  first: Option<int>,\n  second: O
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type MultiWrapper struct {
 	first  lisette.Option[int]
 	second lisette.Option[string]
-}
-
-func (m MultiWrapper) String() string {
-	return fmt.Sprintf("MultiWrapper { first: %v, second: %v }", m.first, m.second)
 }
 
 func get_int(x int) (int, bool) {

--- a/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
@@ -4,17 +4,11 @@ description: "input: \nstruct Big { a: int, b: int, c: int, d: int }\n\nfn test(
 ---
 package main
 
-import "fmt"
-
 type Big struct {
 	a int
 	b int
 	c int
 	d int
-}
-
-func (b Big) String() string {
-	return fmt.Sprintf("Big { a: %v, b: %v, c: %v, d: %v }", b.a, b.b, b.c, b.d)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/struct_pattern_param_public_field.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_param_public_field.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { pub x: int, pub y: int }\n\nfn get_x(Point
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func get_x(arg_1 Point) int {

--- a/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_aliased_parent.snap
+++ b/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_aliased_parent.snap
@@ -8,10 +8,6 @@ import "example.com/shapes"
 
 type Square struct{}
 
-func (s Square) String() string {
-	return "Square"
-}
-
 func (s Square) Area() (int, error) {
 	return 4, nil
 }

--- a/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_inherited_methods.snap
+++ b/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_inherited_methods.snap
@@ -8,10 +8,6 @@ import "example.com/rw"
 
 type Dev struct{}
 
-func (d Dev) String() string {
-	return "Dev"
-}
-
 func (d Dev) Read(_ []uint8) (int, error) {
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/struct_spread_field_before_base_eval_order.snap
+++ b/tests/spec/emit/snapshots/struct_spread_field_before_base_eval_order.snap
@@ -11,10 +11,6 @@ type Point struct {
 	y int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
-}
-
 func make_x() int {
 	fmt.Println("x")
 	return 1

--- a/tests/spec/emit/snapshots/struct_spread_only.snap
+++ b/tests/spec/emit/snapshots/struct_spread_only.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> Point {\n
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/struct_spread_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/struct_spread_temp_var_no_collision.snap
@@ -11,10 +11,6 @@ type Point struct {
 	y int
 }
 
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
-}
-
 func main() {
 	p1 := Point{
 		x: 1,

--- a/tests/spec/emit/snapshots/struct_spread_update.snap
+++ b/tests/spec/emit/snapshots/struct_spread_update.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() -> Point {\n
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/struct_spread_update_multiple_fields.snap
+++ b/tests/spec/emit/snapshots/struct_spread_update_multiple_fields.snap
@@ -4,16 +4,10 @@ description: "input: \nstruct Config { host: string, port: int, timeout: int }\n
 ---
 package main
 
-import "fmt"
-
 type Config struct {
 	host    string
 	port    int
 	timeout int
-}
-
-func (c Config) String() string {
-	return fmt.Sprintf("Config { host: %v, port: %v, timeout: %v }", c.host, c.port, c.timeout)
 }
 
 func test() Config {

--- a/tests/spec/emit/snapshots/struct_spread_update_public_fields.snap
+++ b/tests/spec/emit/snapshots/struct_spread_update_public_fields.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { pub x: int, pub y: int }\n\nfn test() -> P
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/struct_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/struct_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct A { a: string }\n\nimpl A {\n  fn String(self) -> 
 ---
 package main
 
-import "fmt"
-
 type A struct {
 	a string
-}
-
-func (a A) GoString() string {
-	return fmt.Sprintf("A { a: %v }", a.a)
 }
 
 func (a A) String() string {

--- a/tests/spec/emit/snapshots/struct_user_string_method_emits_go_string.snap
+++ b/tests/spec/emit/snapshots/struct_user_string_method_emits_go_string.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nimpl Point {\n  pub fn
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) GoString() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func (p Point) String() string {

--- a/tests/spec/emit/snapshots/struct_variant_construction.snap
+++ b/tests/spec/emit/snapshots/struct_variant_construction.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Message {\n  Move { x: int, y: int },\n}\n\nfn make_
 ---
 package main
 
-import "fmt"
-
 func MakeMessageMove(arg0 int, arg1 int) Message {
 	return Message{Tag: MessageMove, X: arg0, Y: arg1}
 }
@@ -20,24 +18,6 @@ type Message struct {
 	Tag MessageTag
 	X   int
 	Y   int
-}
-
-func (m Message) String() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Move { x: %v, y: %v }", m.X, m.Y)
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
-}
-
-func (m Message) GoString() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Message.Move { x: %v, y: %v }", m.X, m.Y)
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
 }
 
 func make_move() Message {

--- a/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Message {\n  Move { x: int, y: int },\n  Quit,\n}\n\
 ---
 package main
 
-import "fmt"
-
 func MakeMessageMove(arg0 int, arg1 int) Message {
 	return Message{Tag: MessageMove, X: arg0, Y: arg1}
 }
@@ -25,28 +23,6 @@ type Message struct {
 	Tag MessageTag
 	X   int
 	Y   int
-}
-
-func (m Message) String() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Move { x: %v, y: %v }", m.X, m.Y)
-	case MessageQuit:
-		return "Quit"
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
-}
-
-func (m Message) GoString() string {
-	switch m.Tag {
-	case MessageMove:
-		return fmt.Sprintf("Message.Move { x: %v, y: %v }", m.X, m.Y)
-	case MessageQuit:
-		return "Message.Quit"
-	default:
-		return fmt.Sprintf("Message(%d)", m.Tag)
-	}
 }
 
 func handle(m Message) int {

--- a/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Shape {\n  Rectangle { x: int, y: int, width: int, h
 ---
 package main
 
-import "fmt"
-
 func MakeShapeRectangle(arg0 int, arg1 int, arg2 int, arg3 int) Shape {
 	return Shape{Tag: ShapeRectangle, X: arg0, Y: arg1, Width: arg2, Height: arg3}
 }
@@ -22,24 +20,6 @@ type Shape struct {
 	Y      int
 	Width  int
 	Height int
-}
-
-func (s Shape) String() string {
-	switch s.Tag {
-	case ShapeRectangle:
-		return fmt.Sprintf("Rectangle { x: %v, y: %v, width: %v, height: %v }", s.X, s.Y, s.Width, s.Height)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
-}
-
-func (s Shape) GoString() string {
-	switch s.Tag {
-	case ShapeRectangle:
-		return fmt.Sprintf("Shape.Rectangle { x: %v, y: %v, width: %v, height: %v }", s.X, s.Y, s.Width, s.Height)
-	default:
-		return fmt.Sprintf("Shape(%d)", s.Tag)
-	}
 }
 
 func area(s Shape) int {

--- a/tests/spec/emit/snapshots/struct_with_different_types.snap
+++ b/tests/spec/emit/snapshots/struct_with_different_types.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct User { name: string, age: int, active: bool }\n"
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	name   string
 	age    int
 	active bool
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, age: %v, active: %v }", u.name, u.age, u.active)
 }

--- a/tests/spec/emit/snapshots/struct_with_json_name_override.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_name_override.snap
@@ -4,12 +4,6 @@ description: "input: \n#[json]\nstruct User {\n  #[json(\"userName\")]\n  name: 
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"userName"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_json_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_omitempty.snap
@@ -4,12 +4,6 @@ description: "input: \n#[json]\nstruct User {\n  #[json(omitempty)]\n  name: str
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"name,omitempty"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_json_skip.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_skip.snap
@@ -4,12 +4,6 @@ description: "input: \n#[json]\nstruct User {\n  #[json(skip)]\n  password: stri
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Password string `json:"-"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { password: %v }", u.Password)
 }

--- a/tests/spec/emit/snapshots/struct_with_json_snake_case.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_snake_case.snap
@@ -4,13 +4,7 @@ description: "input: \n#[json(snake_case)]\nstruct User {\n  first_name: string,
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { first_name: %v, last_name: %v }", u.FirstName, u.LastName)
 }

--- a/tests/spec/emit/snapshots/struct_with_json_tag.snap
+++ b/tests/spec/emit/snapshots/struct_with_json_tag.snap
@@ -4,13 +4,7 @@ description: "input: \n#[json]\nstruct User {\n  name: string,\n  age: int,\n}\n
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"name"`
 	Age  int    `json:"age"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, age: %v }", u.Name, u.Age)
 }

--- a/tests/spec/emit/snapshots/struct_with_multiple_raw_tags.snap
+++ b/tests/spec/emit/snapshots/struct_with_multiple_raw_tags.snap
@@ -4,12 +4,6 @@ description: "input: \n#[tag(\"validate\")]\n#[tag(\"custom\")]\nstruct User {\n
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `custom:"foo" validate:"required"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_multiple_tags.snap
+++ b/tests/spec/emit/snapshots/struct_with_multiple_tags.snap
@@ -4,12 +4,6 @@ description: "input: \n#[json]\n#[db]\nstruct User {\n  #[json(omitempty)]\n  #[
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"name,omitempty" db:"user_name"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_negated_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_negated_omitempty.snap
@@ -4,13 +4,7 @@ description: "input: \n#[json(omitempty)]\nstruct User {\n  #[json(!omitempty)]\
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Id   int    `json:"id"`
 	Name string `json:"name,omitempty"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { id: %v, name: %v }", u.Id, u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
@@ -4,18 +4,11 @@ description: "input: \ntype Maybe<T> = Option<T>\n\n#[json(omitempty)]\nstruct U
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Maybe[T any] = lisette.Option[T]
 
 type User struct {
 	Name  Maybe[string]          `json:"name,omitempty,omitzero"`
 	Email lisette.Option[string] `json:"email,omitempty,omitzero"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, email: %v }", u.Name, u.Email)
 }

--- a/tests/spec/emit/snapshots/struct_with_option_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_option_omitempty.snap
@@ -4,16 +4,9 @@ description: "input: \n#[json(omitempty)]\nstruct User {\n  name: string,\n  ema
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type User struct {
 	Name  string                 `json:"name,omitempty"`
 	Email lisette.Option[string] `json:"email,omitempty,omitzero"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v, email: %v }", u.Name, u.Email)
 }

--- a/tests/spec/emit/snapshots/struct_with_snake_case_oauth.snap
+++ b/tests/spec/emit/snapshots/struct_with_snake_case_oauth.snap
@@ -4,12 +4,6 @@ description: "input: \n#[json(snake_case)]\nstruct Auth {\n  OAuth2Token: string
 ---
 package main
 
-import "fmt"
-
 type Auth struct {
 	OAuth2Token string `json:"oauth2_token"`
-}
-
-func (a Auth) String() string {
-	return fmt.Sprintf("Auth { OAuth2Token: %v }", a.OAuth2Token)
 }

--- a/tests/spec/emit/snapshots/struct_with_tag_ordering.snap
+++ b/tests/spec/emit/snapshots/struct_with_tag_ordering.snap
@@ -4,12 +4,6 @@ description: "input: \n#[yaml]\n#[json]\n#[xml]\n#[db]\nstruct User {\n  #[yaml(
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"user" db:"user" xml:"user" yaml:"user"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_tag_raw_mode.snap
+++ b/tests/spec/emit/snapshots/struct_with_tag_raw_mode.snap
@@ -4,12 +4,6 @@ description: "input: \n#[tag]\nstruct User {\n  #[tag(`json:\"name,omitempty\" v
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	Name string `json:"name,omitempty" validate:"required"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { name: %v }", u.Name)
 }

--- a/tests/spec/emit/snapshots/struct_with_tag_structured_defaults.snap
+++ b/tests/spec/emit/snapshots/struct_with_tag_structured_defaults.snap
@@ -4,12 +4,6 @@ description: "input: \n#[tag(\"bson\", snake_case)]\nstruct User {\n  userName: 
 ---
 package main
 
-import "fmt"
-
 type User struct {
 	UserName string `bson:"user_name"`
-}
-
-func (u User) String() string {
-	return fmt.Sprintf("User { userName: %v }", u.UserName)
 }

--- a/tests/spec/emit/snapshots/struct_zero_fill_enum_struct_variant.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_enum_struct_variant.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Action {\n  Move { x: int, y: int, dist: int },\n  S
 ---
 package main
 
-import "fmt"
-
 func MakeActionMove(arg0 int, arg1 int, arg2 int) Action {
 	return Action{Tag: ActionMove, X: arg0, Y: arg1, Dist: arg2}
 }
@@ -26,28 +24,6 @@ type Action struct {
 	X    int
 	Y    int
 	Dist int
-}
-
-func (a Action) String() string {
-	switch a.Tag {
-	case ActionMove:
-		return fmt.Sprintf("Move { x: %v, y: %v, dist: %v }", a.X, a.Y, a.Dist)
-	case ActionStop:
-		return "Stop"
-	default:
-		return fmt.Sprintf("Action(%d)", a.Tag)
-	}
-}
-
-func (a Action) GoString() string {
-	switch a.Tag {
-	case ActionMove:
-		return fmt.Sprintf("Action.Move { x: %v, y: %v, dist: %v }", a.X, a.Y, a.Dist)
-	case ActionStop:
-		return "Action.Stop"
-	default:
-		return fmt.Sprintf("Action(%d)", a.Tag)
-	}
 }
 
 func test() Action {

--- a/tests/spec/emit/snapshots/struct_zero_fill_lisette_option_emits_none.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_lisette_option_emits_none.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Conf { name: string, opt: Option<int> }\n\nfn test
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Conf struct {
 	name string
 	opt  lisette.Option[int]
-}
-
-func (c Conf) String() string {
-	return fmt.Sprintf("Conf { name: %v, opt: %v }", c.name, c.opt)
 }
 
 func test() Conf {

--- a/tests/spec/emit/snapshots/struct_zero_fill_lisette_primitives.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_lisette_primitives.snap
@@ -4,16 +4,10 @@ description: "input: \nstruct Conf { name: string, count: int, on: bool }\n\nfn 
 ---
 package main
 
-import "fmt"
-
 type Conf struct {
 	name  string
 	count int
 	on    bool
-}
-
-func (c Conf) String() string {
-	return fmt.Sprintf("Conf { name: %v, count: %v, on: %v }", c.name, c.count, c.on)
 }
 
 func test() Conf {

--- a/tests/spec/emit/snapshots/struct_zero_fill_lisette_slice_omitted_map_non_nil.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_lisette_slice_omitted_map_non_nil.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Conf { items: Slice<int>, lookup: Map<string, int>
 ---
 package main
 
-import "fmt"
-
 type Conf struct {
 	items  []int
 	lookup map[string]int
-}
-
-func (c Conf) String() string {
-	return fmt.Sprintf("Conf { items: %v, lookup: %v }", c.items, c.lookup)
 }
 
 func test() Conf {

--- a/tests/spec/emit/snapshots/struct_zero_fill_nested_user_struct_recurses.snap
+++ b/tests/spec/emit/snapshots/struct_zero_fill_nested_user_struct_recurses.snap
@@ -4,26 +4,15 @@ description: "input: \nstruct Inner { opt: Option<int>, items: Slice<int> }\nstr
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Inner struct {
 	opt   lisette.Option[int]
 	items []int
 }
 
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { opt: %v, items: %v }", i.opt, i.items)
-}
-
 type Outer struct {
 	inner Inner
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { inner: %v }", o.inner)
 }
 
 func test() Outer {

--- a/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
+++ b/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Side { Left, Right }\nstruct Pair { a: Side, b: Side
 ---
 package main
 
-import "fmt"
-
 func MakeSideLeft() Side {
 	return Side{Tag: SideLeft}
 }
@@ -25,35 +23,9 @@ type Side struct {
 	Tag SideTag
 }
 
-func (s Side) String() string {
-	switch s.Tag {
-	case SideLeft:
-		return "Left"
-	case SideRight:
-		return "Right"
-	default:
-		return fmt.Sprintf("Side(%d)", s.Tag)
-	}
-}
-
-func (s Side) GoString() string {
-	switch s.Tag {
-	case SideLeft:
-		return "Side.Left"
-	case SideRight:
-		return "Side.Right"
-	default:
-		return fmt.Sprintf("Side(%d)", s.Tag)
-	}
-}
-
 type Pair struct {
 	a Side
 	b Side
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair { a: %v, b: %v }", p.a, p.b)
 }
 
 func classify(p Pair) int {

--- a/tests/spec/emit/snapshots/transitive_go_import_uses_declared_package_name.snap
+++ b/tests/spec/emit/snapshots/transitive_go_import_uses_declared_package_name.snap
@@ -11,10 +11,6 @@ import (
 
 type Model struct{}
 
-func (m Model) String() string {
-	return "Model"
-}
-
 func (m Model) Init() tea.Cmd {
 	return func() uv.Event {
 		return nil

--- a/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
+++ b/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
@@ -4,10 +4,7 @@ description: "input: \npub enum Hand {\n  Left,\n  Right,\n}\n\nimpl Hand {\n  p
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func MakeHandLeft() Hand {
 	return Hand{Tag: HandLeft}
@@ -26,28 +23,6 @@ const (
 
 type Hand struct {
 	Tag HandTag
-}
-
-func (h Hand) String() string {
-	switch h.Tag {
-	case HandLeft:
-		return "Left"
-	case HandRight:
-		return "Right"
-	default:
-		return fmt.Sprintf("Hand(%d)", h.Tag)
-	}
-}
-
-func (h Hand) GoString() string {
-	switch h.Tag {
-	case HandLeft:
-		return "Hand.Left"
-	case HandRight:
-		return "Hand.Right"
-	default:
-		return fmt.Sprintf("Hand(%d)", h.Tag)
-	}
 }
 
 func (h Hand) LeftRight(other Hand) bool {

--- a/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
+++ b/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
@@ -11,10 +11,6 @@ import (
 
 type Model struct{}
 
-func (m Model) String() string {
-	return "Model"
-}
-
 func (m Model) Init() tea.Cmd {
 	return nil
 }

--- a/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_tail_position.snap
+++ b/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_tail_position.snap
@@ -8,10 +8,6 @@ import "example.com/tea"
 
 type Model struct{}
 
-func (m Model) String() string {
-	return "Model"
-}
-
 func (m Model) Init() tea.Cmd {
 	return nil
 }

--- a/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Pair(int, int)\n\nfn bump(i: Ref<int>) -> int {\n 
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 int
 	F1 int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }
 
 func bump(i *int) int {

--- a/tests/spec/emit/snapshots/tuple_struct_function_vs_constructor.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_function_vs_constructor.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nfn add_points(a: Point, b: Poin
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func add_points(a, b Point) Point {

--- a/tests/spec/emit/snapshots/tuple_struct_generic_method.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_generic_method.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Wrapper<T>(T)\n\nimpl<T> Wrapper<T> {\n  fn unwrap
 ---
 package main
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 func (w Wrapper[T]) unwrap() T {

--- a/tests/spec/emit/snapshots/tuple_struct_generic_multi_field.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_generic_multi_field.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Pair<A, B>(A, B)\n\nfn test() -> Pair<int, string>
 ---
 package main
 
-import "fmt"
-
 type Pair[A any, B any] struct {
 	F0 A
 	F1 B
-}
-
-func (p Pair[A, B]) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }
 
 func test() Pair[int, string] {

--- a/tests/spec/emit/snapshots/tuple_struct_generic_single_field.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_generic_single_field.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Wrapper<T>(T)\n\nfn test() -> Wrapper<int> {\n  Wr
 ---
 package main
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 func test() Wrapper[int] {

--- a/tests/spec/emit/snapshots/tuple_struct_if_let.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_if_let.snap
@@ -4,18 +4,11 @@ description: "input: \nstruct Point(int, int)\n\nfn test(p: Option<Point>) -> in
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func test(p lisette.Option[Point]) int {

--- a/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nfn test(p: Point) -> int {\n  m
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/tuple_struct_method_self_access.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_method_self_access.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nimpl Point {\n  fn x(self: Poin
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func (p Point) x() int {

--- a/tests/spec/emit/snapshots/tuple_struct_multi_field_access.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_multi_field_access.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nfn test(p: Point) -> int {\n  p
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func test(p Point) int {

--- a/tests/spec/emit/snapshots/tuple_struct_multi_field_construction.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_multi_field_construction.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point(int, int)\n\nfn test() -> Point {\n  Point(1
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }
 
 func test() Point {

--- a/tests/spec/emit/snapshots/tuple_struct_multi_field_def.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_multi_field_def.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct Point(int, int)\n"
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	F0 int
 	F1 int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point(%v, %v)", p.F0, p.F1)
 }

--- a/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_pattern_in_match.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Pair(int, int)\n\nfn test(p: Pair) -> int {\n  mat
 ---
 package main
 
-import "fmt"
-
 type Pair struct {
 	F0 int
 	F1 int
-}
-
-func (p Pair) String() string {
-	return fmt.Sprintf("Pair(%v, %v)", p.F0, p.F1)
 }
 
 func test(p Pair) int {

--- a/tests/spec/emit/snapshots/tuple_struct_single_field_access.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_single_field_access.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn test(id: UserId) -> int {\n  id.
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func test(id UserId) int {
 	return int(id)

--- a/tests/spec/emit/snapshots/tuple_struct_single_field_construction.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_single_field_construction.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nfn test() -> UserId {\n  UserId(42)
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func test() UserId {
 	return UserId(42)

--- a/tests/spec/emit/snapshots/tuple_struct_single_field_def.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_single_field_def.snap
@@ -4,10 +4,4 @@ description: "input: \nstruct UserId(int)\n"
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) String() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}

--- a/tests/spec/emit/snapshots/tuple_struct_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nimpl UserId {\n  fn String(self) ->
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) GoString() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func (u UserId) String() string {
 	return "custom"

--- a/tests/spec/emit/snapshots/tuple_struct_user_string_method_emits_go_string.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_user_string_method_emits_go_string.snap
@@ -4,13 +4,7 @@ description: "input: \nstruct UserId(int)\n\nimpl UserId {\n  pub fn string(self
 ---
 package main
 
-import "fmt"
-
 type UserId int
-
-func (u UserId) GoString() string {
-	return fmt.Sprintf("UserId(%v)", int(u))
-}
 
 func (u UserId) String() string {
 	return "custom"

--- a/tests/spec/emit/snapshots/tuple_struct_zero_field.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_zero_field.snap
@@ -6,10 +6,6 @@ package main
 
 type Marker struct{}
 
-func (m Marker) String() string {
-	return "Marker"
-}
-
 func test() Marker {
 	return Marker{}
 }

--- a/tests/spec/emit/snapshots/type_alias_chained.snap
+++ b/tests/spec/emit/snapshots/type_alias_chained.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location 
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 type Location = Point

--- a/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
+++ b/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Color {\n  Red,\n  Green,\n  Blue,\n}\n\ntype MyColo
 ---
 package main
 
-import "fmt"
-
 func MakeColorRed() Color {
 	return Color{Tag: ColorRed}
 }
@@ -28,32 +26,6 @@ const (
 
 type Color struct {
 	Tag ColorTag
-}
-
-func (c Color) String() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Red"
-	case ColorGreen:
-		return "Green"
-	case ColorBlue:
-		return "Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
-}
-
-func (c Color) GoString() string {
-	switch c.Tag {
-	case ColorRed:
-		return "Color.Red"
-	case ColorGreen:
-		return "Color.Green"
-	case ColorBlue:
-		return "Color.Blue"
-	default:
-		return fmt.Sprintf("Color(%d)", c.Tag)
-	}
 }
 
 type MyColor = Color

--- a/tests/spec/emit/snapshots/type_alias_field_access.snap
+++ b/tests/spec/emit/snapshots/type_alias_field_access.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location 
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 type Location = Point

--- a/tests/spec/emit/snapshots/type_alias_generic_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/type_alias_generic_tuple_struct_constructor.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Wrapper<T>(T)\ntype W<T> = Wrapper<T>\n\nfn test()
 ---
 package main
 
-import "fmt"
-
 type Wrapper[T any] struct {
 	F0 T
-}
-
-func (w Wrapper[T]) String() string {
-	return fmt.Sprintf("Wrapper(%v)", w.F0)
 }
 
 type W[T any] = Wrapper[T]

--- a/tests/spec/emit/snapshots/type_alias_in_return_type.snap
+++ b/tests/spec/emit/snapshots/type_alias_in_return_type.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { pub x: int, pub y: int }\n\ntype Location 
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	X int
 	Y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.X, p.Y)
 }
 
 type Location = Point

--- a/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
@@ -4,24 +4,14 @@ description: "input: \nstruct Inner { pub val: int }\n\ntype Wrapper = Inner\n\n
 ---
 package main
 
-import "fmt"
-
 type Inner struct {
 	Val int
-}
-
-func (i Inner) String() string {
-	return fmt.Sprintf("Inner { val: %v }", i.Val)
 }
 
 type Wrapper = Inner
 
 type Outer struct {
 	Item Wrapper
-}
-
-func (o Outer) String() string {
-	return fmt.Sprintf("Outer { item: %v }", o.Item)
 }
 
 func get_val(o Outer) int {

--- a/tests/spec/emit/snapshots/type_alias_multi_field_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/type_alias_multi_field_tuple_struct_constructor.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point2D(int, int)\ntype P = Point2D\n\nfn test() -
 ---
 package main
 
-import "fmt"
-
 type Point2D struct {
 	F0 int
 	F1 int
-}
-
-func (p Point2D) String() string {
-	return fmt.Sprintf("Point2D(%v, %v)", p.F0, p.F1)
 }
 
 type P = Point2D

--- a/tests/spec/emit/snapshots/type_alias_struct_static_method.snap
+++ b/tests/spec/emit/snapshots/type_alias_struct_static_method.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { v: int }\n\nimpl Box {\n  fn new(v: int) -> 
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	v int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func Box_new(v int) Box {

--- a/tests/spec/emit/snapshots/type_alias_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/type_alias_tuple_struct_constructor.snap
@@ -8,10 +8,6 @@ import "fmt"
 
 type Wrap int
 
-func (w Wrap) String() string {
-	return fmt.Sprintf("Wrap(%v)", int(w))
-}
-
 type Alias = Wrap
 
 func main() {

--- a/tests/spec/emit/snapshots/type_alias_with_generic.snap
+++ b/tests/spec/emit/snapshots/type_alias_with_generic.snap
@@ -4,14 +4,8 @@ description: "input: \ntype IntBox = Box<int>\n\nstruct Box<T> { value: T }\n"
 ---
 package main
 
-import "fmt"
-
 type IntBox = Box[int]
 
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }

--- a/tests/spec/emit/snapshots/typed_let_loop_interface_declares_annotated_type.snap
+++ b/tests/spec/emit/snapshots/typed_let_loop_interface_declares_annotated_type.snap
@@ -10,15 +10,7 @@ type Printable interface {
 
 type A struct{}
 
-func (a A) String() string {
-	return "A"
-}
-
 type B struct{}
-
-func (b B) String() string {
-	return "B"
-}
 
 func (a A) text() string {
 	return "a"

--- a/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
+++ b/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
@@ -12,15 +12,7 @@ type Printable interface {
 
 type A struct{}
 
-func (a A) String() string {
-	return "A"
-}
-
 type B struct{}
-
-func (b B) String() string {
-	return "B"
-}
 
 func (a A) text() string {
 	return "a"

--- a/tests/spec/emit/snapshots/ufcs_address_of_receiver_parens.snap
+++ b/tests/spec/emit/snapshots/ufcs_address_of_receiver_parens.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { x: int }\n\nimpl Counter {\n  fn inc(sel
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	x int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { x: %v }", c.x)
 }
 
 func (c *Counter) inc() int {

--- a/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/ufcs_address_of_struct_literal_receiver.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { x: int }\n\nimpl Counter {\n  fn inc(sel
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	x int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { x: %v }", c.x)
 }
 
 func (c *Counter) inc() int {

--- a/tests/spec/emit/snapshots/ufcs_call_private_keyword_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_private_keyword_method.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  fn range(self) -> 
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func (b Box) range_() int {

--- a/tests/spec/emit/snapshots/ufcs_call_receiver_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_receiver_eval_order_captured.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Counter { n: int }\n\nimpl Counter {\n  fn get(sel
 ---
 package main
 
-import "fmt"
-
 type Counter struct {
 	n int
-}
-
-func (c Counter) String() string {
-	return fmt.Sprintf("Counter { n: %v }", c.n)
 }
 
 func (c Counter) get() int {

--- a/tests/spec/emit/snapshots/ufcs_call_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_return_only_type_args.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { value: T }\n\nimpl<T> Box<T> {\n  fn make
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	value T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
 func Box_make[T any, U any](_ Box[T]) U {

--- a/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_to_public_snake_case_receiver_method.snap
@@ -6,10 +6,6 @@ package main
 
 type Service struct{}
 
-func (s Service) String() string {
-	return "Service"
-}
-
 func (s Service) GetSession() int {
 	return 42
 }

--- a/tests/spec/emit/snapshots/ufcs_call_to_receiver_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_to_receiver_method.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  fn add(self, y: in
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func (b Box) add(y int) int {

--- a/tests/spec/emit/snapshots/ufcs_receiver_method_deref_parenthesized.snap
+++ b/tests/spec/emit/snapshots/ufcs_receiver_method_deref_parenthesized.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box { x: int }\n\nimpl Box {\n  fn add(self, y: in
 ---
 package main
 
-import "fmt"
-
 type Box struct {
 	x int
-}
-
-func (b Box) String() string {
-	return fmt.Sprintf("Box { x: %v }", b.x)
 }
 
 func (b Box) add(y int) int {

--- a/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Adder { base: int }\n\nimpl Adder {\n  fn add(self
 ---
 package main
 
-import "fmt"
-
 type Adder struct {
 	base int
-}
-
-func (a Adder) String() string {
-	return fmt.Sprintf("Adder { base: %v }", a.base)
 }
 
 func (aa Adder) add(a, b int) int {

--- a/tests/spec/emit/snapshots/ufcs_stringer_on_specialized_impl_does_not_suppress_auto.snap
+++ b/tests/spec/emit/snapshots/ufcs_stringer_on_specialized_impl_does_not_suppress_auto.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct Box<T> { v: T }\n\nimpl Box<int> {\n  fn String(se
 ---
 package main
 
-import "fmt"
-
 type Box[T any] struct {
 	v T
-}
-
-func (b Box[T]) String() string {
-	return fmt.Sprintf("Box { v: %v }", b.v)
 }
 
 func Box_String(_ Box[int]) string {

--- a/tests/spec/emit/snapshots/unit_call_in_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_tuple_struct_constructor.snap
@@ -4,17 +4,11 @@ description: "input: \nfn noop() {}\nstruct P((), int)\n\nfn test() -> P {\n  P(
 ---
 package main
 
-import "fmt"
-
 func noop() {}
 
 type P struct {
 	F0 struct{}
 	F1 int
-}
-
-func (p P) String() string {
-	return fmt.Sprintf("P(%v, %v)", p.F0, p.F1)
 }
 
 func test() P {

--- a/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
@@ -8,10 +8,6 @@ func noop() {}
 
 type Box struct{}
 
-func (b Box) String() string {
-	return "Box"
-}
-
 func (b Box) ping(_ struct{}) {}
 
 func test() {

--- a/tests/spec/emit/snapshots/unknown_return_in_struct_field_emits_any.snap
+++ b/tests/spec/emit/snapshots/unknown_return_in_struct_field_emits_any.snap
@@ -4,12 +4,6 @@ description: "input: \nstruct Bag {\n  pub callback: fn() -> Unknown,\n}\n"
 ---
 package main
 
-import "fmt"
-
 type Bag struct {
 	Callback func() any
-}
-
-func (b Bag) String() string {
-	return fmt.Sprintf("Bag { callback: %p }", b.Callback)
 }

--- a/tests/spec/emit/snapshots/user_defined_unit_enum.snap
+++ b/tests/spec/emit/snapshots/user_defined_unit_enum.snap
@@ -4,8 +4,6 @@ description: "input: \nenum Tag { A, B, C }\n\nfn test() -> bool {\n  let u1 = T
 ---
 package main
 
-import "fmt"
-
 func MakeTagA() Tag {
 	return Tag{Tag: TagA}
 }
@@ -28,32 +26,6 @@ const (
 
 type Tag struct {
 	Tag TagTag
-}
-
-func (t Tag) String() string {
-	switch t.Tag {
-	case TagA:
-		return "A"
-	case TagB:
-		return "B"
-	case TagC:
-		return "C"
-	default:
-		return fmt.Sprintf("Tag(%d)", t.Tag)
-	}
-}
-
-func (t Tag) GoString() string {
-	switch t.Tag {
-	case TagA:
-		return "Tag.A"
-	case TagB:
-		return "Tag.B"
-	case TagC:
-		return "Tag.C"
-	default:
-		return fmt.Sprintf("Tag(%d)", t.Tag)
-	}
 }
 
 func test() bool {

--- a/tests/spec/emit/snapshots/while_generic_tuple_selector.snap
+++ b/tests/spec/emit/snapshots/while_generic_tuple_selector.snap
@@ -4,14 +4,8 @@ description: "input: \nstruct W<T>(T)\n\nfn test() {\n  let mut i = 0\n  while W
 ---
 package main
 
-import "fmt"
-
 type W[T any] struct {
 	F0 T
-}
-
-func (w W[T]) String() string {
-	return fmt.Sprintf("W(%v)", w.F0)
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/while_let_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/while_let_or_pattern_unused_branch_binding.snap
@@ -4,8 +4,6 @@ description: "input: \nenum E { A(int), B(int), C }\nfn test() {\n  let x = 5\n 
 ---
 package main
 
-import "fmt"
-
 func MakeEA(arg0 int) E {
 	return E{Tag: EA, A: arg0}
 }
@@ -30,32 +28,6 @@ type E struct {
 	Tag ETag
 	A   int
 	B   int
-}
-
-func (e E) String() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("B(%v)", e.B)
-	case EC:
-		return "C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
-}
-
-func (e E) GoString() string {
-	switch e.Tag {
-	case EA:
-		return fmt.Sprintf("E.A(%v)", e.A)
-	case EB:
-		return fmt.Sprintf("E.B(%v)", e.B)
-	case EC:
-		return "E.C"
-	default:
-		return fmt.Sprintf("E(%d)", e.Tag)
-	}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/while_struct_literal_condition_parenthesized.snap
+++ b/tests/spec/emit/snapshots/while_struct_literal_condition_parenthesized.snap
@@ -4,15 +4,9 @@ description: "input: \nstruct Point { x: int, y: int }\n\nfn test() {\n  while P
 ---
 package main
 
-import "fmt"
-
 type Point struct {
 	x int
 	y int
-}
-
-func (p Point) String() string {
-	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
 func test() {

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -49,6 +49,24 @@ enum Color { Red, Green }
 }
 
 #[test]
+fn displayable_empty_struct_to_string() {
+    let input = r#"
+#[displayable]
+struct Blank {}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn displayable_tuple_struct_to_string() {
+    let input = r#"
+#[displayable]
+struct UserId(int)
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn displayable_generic_struct_to_string() {
     let input = r#"
 #[displayable]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7514,6 +7514,56 @@ impl Box<int> {
 }
 
 #[test]
+fn interpolate_struct_without_stringer() {
+    let input = r#"
+struct Point { x: int, y: int }
+
+fn show() -> string {
+  let p = Point { x: 1, y: 2 }
+  f"{p}"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn interpolate_pointer_newtype() {
+    let input = r#"
+struct Handle(Ref<int>)
+
+fn show(h: Handle) -> string {
+  f"{h}"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn displayable_on_alias_pointer_newtype() {
+    let input = r#"
+type R = Ref<int>
+
+#[displayable]
+struct Handle(R)
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn interpolate_alias_pointer_newtype() {
+    let input = r#"
+type R = Ref<int>
+
+struct Handle(R)
+
+fn show(h: Handle) -> string {
+  f"{h}"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_type_alias_record_struct_as_value() {
     let input = r#"
 struct Coord { x: int, y: int }

--- a/tests/ui/errors/snapshots/displayable_on_alias_pointer_newtype.snap
+++ b/tests/ui/errors/snapshots/displayable_on_alias_pointer_newtype.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[displayable]` on a pointer-backed newtype
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ #[displayable]
+   · ───────┬──────
+   ·        ╰── a `Ref` has no display form
+ 5 │ struct Handle(R)
+   ╰────
+  help: Give the type named fields, or drop `#[displayable]` · code: [attribute.displayable_on_pointer_newtype]

--- a/tests/ui/errors/snapshots/displayable_on_pointer_newtype.snap
+++ b/tests/ui/errors/snapshots/displayable_on_pointer_newtype.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[displayable]
    · ───────┬──────
-   ·        ╰── a single-field tuple struct over `Ref<T>` cannot have a stringer
+   ·        ╰── a `Ref` has no display form
  3 │ struct Handle(Ref<int>)
    ╰────
-  help: Go forbids methods on the named pointer type this lowers to. Format the value explicitly, or change the representation · code: [attribute.displayable_on_pointer_newtype]
+  help: Give the type named fields, or drop `#[displayable]` · code: [attribute.displayable_on_pointer_newtype]

--- a/tests/ui/errors/snapshots/interpolate_alias_pointer_newtype.snap
+++ b/tests/ui/errors/snapshots/interpolate_alias_pointer_newtype.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `Handle` cannot be interpolated
+   ╭─[test.lis:7:6]
+ 6 │ fn show(h: Handle) -> string {
+ 7 │   f"{h}"
+   ·      ┬
+   ·      ╰── has no display form
+ 8 │ }
+   ╰────
+  help: Interpolate the inner value directly, or change the representation · code: [infer.interpolation_without_stringer]

--- a/tests/ui/errors/snapshots/interpolate_pointer_newtype.snap
+++ b/tests/ui/errors/snapshots/interpolate_pointer_newtype.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `Handle` cannot be interpolated
+   ╭─[test.lis:5:6]
+ 4 │ fn show(h: Handle) -> string {
+ 5 │   f"{h}"
+   ·      ┬
+   ·      ╰── has no display form
+ 6 │ }
+   ╰────
+  help: Interpolate the inner value directly, or change the representation · code: [infer.interpolation_without_stringer]

--- a/tests/ui/errors/snapshots/interpolate_struct_without_stringer.snap
+++ b/tests/ui/errors/snapshots/interpolate_struct_without_stringer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `Point` cannot be interpolated
+   ╭─[test.lis:6:6]
+ 5 │   let p = Point { x: 1, y: 2 }
+ 6 │   f"{p}"
+   ·      ┬
+   ·      ╰── has no display form
+ 7 │ }
+   ╰────
+  help: Mark `Point` with `#[displayable]`, or interpolate its fields directly · code: [infer.interpolation_without_stringer]


### PR DESCRIPTION
Rendering a struct or enum as a readable string is now opt-in via the `#[displayable]` attribute. 

```rs
#[displayable]
struct Point { x: int, y: int }

let p = Point { x: 1, y: 2 }
fmt.Println(p) // Point { x: 1, y: 2 }
```

Without the attribute, the type still prints but in Go's default form:

```rs
struct Point { x: int, y: int }

fmt.Println(Point { x: 1, y: 2 }) // {1 2}
```

Motivation:
- Whether the type has a stable display representation is now an explicit user decision. Intent is now visible at the type.
- Every other attribute-based synthesized capability is already something the user explicitly asks for: `#[iterable]`, `#[json]`. Auto-rendering was the only remaining default-on exception. 
- We remove an ever-present `fmt` dependency from emitted modules that never need it. 
- We trim down unused emitted output and speed up codegen.
- `#[displayable]` now controls both counterparts: `to_string()` in Lisette and `String()` in Go.

The tradeoff is a bit of annotation pressure.

Completes the `#[displayable]` series: #567 + #568 + #571