### PR TITLE
fix: make newtype structs and bool-backed named types nominal

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1075,9 +1075,9 @@ pub fn division_by_zero(span: Span) -> LisetteDiagnostic {
         .with_help("This operation will panic at runtime")
 }
 
-pub fn incompatible_named_numeric_types(underlying_ty: &Type, span: Span) -> LisetteDiagnostic {
+pub fn incompatible_named_types(underlying_ty: &Type, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Type mismatch")
-        .with_infer_code("incompatible_named_numeric_types")
+        .with_infer_code("incompatible_named_types")
         .with_span_label(&span, "cannot compute")
         .with_help(format!(
             "Cast one to the other's type, or convert both to `{}`",

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -45,6 +45,7 @@ fn needs_explicit_type_declaration(
             Literal::Integer { .. } => !matches!(binding_ty.get_name(), Some("int") | None),
             Literal::Float { .. } => !matches!(binding_ty.get_name(), Some("float64") | None),
             Literal::String { .. } => !matches!(binding_ty.get_name(), Some("string") | None),
+            Literal::Boolean(_) => !matches!(binding_ty.get_name(), Some("bool") | None),
             _ => false,
         },
         _ => false,

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -2,7 +2,7 @@ use crate::checker::EnvResolve;
 use crate::store::Store;
 use syntax::ast::BindingKind;
 use syntax::ast::{Binding, BindingId, Expression, MatchArm, MatchOrigin, Pattern, Span};
-use syntax::types::Type;
+use syntax::types::{SimpleKind, Type};
 
 use super::super::TaskState;
 
@@ -140,6 +140,16 @@ impl TaskState<'_> {
         result
     }
 
+    fn infer_condition(&mut self, store: &Store, condition: Expression, span: &Span) -> Expression {
+        let cond_ty = self.new_type_var();
+        let inferred = self.infer_expression(store, condition, &cond_ty);
+        if cond_ty.resolve_in(&self.env).underlying_simple_kind() != Some(SimpleKind::Bool) {
+            let bool_ty = self.type_bool();
+            self.unify(store, &bool_ty, &cond_ty, span);
+        }
+        inferred
+    }
+
     pub(super) fn infer_if(
         &mut self,
         store: &Store,
@@ -219,8 +229,7 @@ impl TaskState<'_> {
             consequence_ty
         };
 
-        let bool_ty = self.type_bool();
-        let new_condition = self.infer_expression(store, *condition, &bool_ty);
+        let new_condition = self.infer_condition(store, *condition, &span);
         if let Some(span) = Self::find_propagate(&new_condition) {
             self.sink
                 .push(diagnostics::infer::propagate_in_condition(span));
@@ -283,11 +292,9 @@ impl TaskState<'_> {
                 let (new_pattern, typed_pattern) =
                     self.infer_pattern(store, a.pattern, pattern_ty, arm_kind);
 
-                let bool_ty = self.type_bool();
-                let new_guard = a.guard.map(|guard| {
-                    let guard_expression = self.infer_expression(store, *guard, &bool_ty);
-                    Box::new(guard_expression)
-                });
+                let new_guard = a
+                    .guard
+                    .map(|guard| Box::new(self.infer_condition(store, *guard, &span)));
 
                 let independent_ty;
                 let arm_expected = if arms_independent || needs_reconciliation {
@@ -389,8 +396,7 @@ impl TaskState<'_> {
         let unit_ty = self.type_unit();
         self.unify(store, expected_ty, &unit_ty, &span);
 
-        let bool_ty = self.type_bool();
-        let new_condition = self.infer_expression(store, *condition, &bool_ty);
+        let new_condition = self.infer_condition(store, *condition, &span);
         if let Some(span) = Self::find_propagate(&new_condition) {
             self.sink
                 .push(diagnostics::infer::propagate_in_condition(span));

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -15,12 +15,18 @@ impl TaskState<'_> {
     ) -> Expression {
         match literal {
             Literal::Boolean(boolean) => {
-                let bool_ty = self.type_bool();
-                self.unify(store, expected_ty, &bool_ty, &span);
+                let resolved = expected_ty.resolve_in(&self.env);
+                let ty = if adapts_to_named_type(&resolved, store, SimpleKind::Bool) {
+                    resolved.clone()
+                } else {
+                    let bool_ty = self.type_bool();
+                    self.unify(store, expected_ty, &bool_ty, &span);
+                    bool_ty
+                };
 
                 Expression::Literal {
                     literal: Literal::Boolean(boolean),
-                    ty: bool_ty,
+                    ty,
                     span,
                 }
             }
@@ -83,7 +89,7 @@ impl TaskState<'_> {
 
             Literal::String { value, raw } => {
                 let resolved = expected_ty.resolve_in(&self.env);
-                let ty = if adapts_to_string_value_enum(&resolved, store) {
+                let ty = if adapts_to_named_type(&resolved, store, SimpleKind::String) {
                     resolved.clone()
                 } else {
                     let string_ty = self.type_string();
@@ -203,11 +209,11 @@ fn numeric_adapt_target(ty: &Type, store: &Store) -> Option<Type> {
     store.deep_resolve_alias(ty).literal_adaptation_target()
 }
 
-fn adapts_to_string_value_enum(ty: &Type, store: &Store) -> bool {
+fn adapts_to_named_type(ty: &Type, store: &Store, kind: SimpleKind) -> bool {
     let peeled = store.deep_resolve_alias(ty);
     matches!(&peeled, Type::Nominal { id, .. }
-        if store.is_nominal_value_enum(id.as_str())
-            && peeled.underlying_simple_kind() == Some(SimpleKind::String))
+        if store.is_nominal_defined_type(id.as_str())
+            && peeled.underlying_simple_kind() == Some(kind))
 }
 
 fn char_literal_codepoint(s: &str) -> Option<u64> {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -98,9 +98,13 @@ impl TaskState<'_> {
         expected_ty: &Type,
         span: Span,
     ) -> Expression {
-        let propagate_to_operand = operator == Negative && {
+        let propagate_to_operand = {
             let resolved = expected_ty.resolve_in(&self.env);
-            resolved.is_numeric() || resolved.has_underlying_numeric_type()
+            match operator {
+                Negative => resolved.is_numeric() || resolved.has_underlying_numeric_type(),
+                Not => resolved.underlying_simple_kind() == Some(SimpleKind::Bool),
+                _ => false,
+            }
         };
         let operand_expected_ty = if propagate_to_operand {
             expected_ty.clone()
@@ -141,9 +145,16 @@ impl TaskState<'_> {
                 }
             }
             Not => {
-                let bool_ty = self.type_bool();
-                self.unify(store, &bool_ty, &operand_expected_ty, &span);
-                bool_ty
+                let resolved = operand_expected_ty.resolve_in(&self.env);
+                if !resolved.is_boolean()
+                    && resolved.underlying_simple_kind() == Some(SimpleKind::Bool)
+                {
+                    operand_expected_ty.clone()
+                } else {
+                    let bool_ty = self.type_bool();
+                    self.unify(store, &bool_ty, &operand_expected_ty, &span);
+                    bool_ty
+                }
             }
             BitwiseNot => {
                 let resolved = operand_expected_ty.resolve_in(&self.env);
@@ -422,7 +433,7 @@ impl TaskState<'_> {
                 let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
                 let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
 
-                if !self.report_value_enum_boundary(
+                if !self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
                     store,
@@ -450,17 +461,40 @@ impl TaskState<'_> {
             }
 
             And | Or => {
-                let bool_ty = self.type_bool();
-                self.unify(store, left_operand_ty, &bool_ty, &span);
-                self.unify(store, right_operand_ty, &bool_ty, &span);
-                bool_ty
+                let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
+                let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
+
+                if self.report_named_type_boundary(
+                    &resolved_left_operand,
+                    &resolved_right_operand,
+                    store,
+                    span,
+                ) {
+                    left_operand_ty.clone()
+                } else if resolved_left_operand.underlying_simple_kind() == Some(SimpleKind::Bool)
+                    || resolved_right_operand.underlying_simple_kind() == Some(SimpleKind::Bool)
+                {
+                    self.unify_binary_operands(
+                        store,
+                        operator,
+                        left_operand_ty,
+                        right_operand_ty,
+                        &span,
+                    );
+                    left_operand_ty.clone()
+                } else {
+                    let bool_ty = self.type_bool();
+                    self.unify(store, left_operand_ty, &bool_ty, &span);
+                    self.unify(store, right_operand_ty, &bool_ty, &span);
+                    bool_ty
+                }
             }
 
             LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => {
                 let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
                 let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
 
-                if self.report_value_enum_boundary(
+                if self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
                     store,
@@ -503,7 +537,7 @@ impl TaskState<'_> {
                     &span,
                 ) {
                     result_ty
-                } else if self.report_value_enum_boundary(
+                } else if self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
                     store,
@@ -733,7 +767,7 @@ impl TaskState<'_> {
 
     /// Reports an operator boundary between a value enum and a typed primitive
     /// of its backing, or two different value enums; returns whether it emitted.
-    fn report_value_enum_boundary(
+    fn report_named_type_boundary(
         &mut self,
         left: &Type,
         right: &Type,
@@ -743,27 +777,26 @@ impl TaskState<'_> {
         if left == right || store.deep_resolve_alias(left) == store.deep_resolve_alias(right) {
             return false;
         }
-        let left_is_value_enum = is_nominal_value_enum(left, store);
-        let right_is_value_enum = is_nominal_value_enum(right, store);
+        let left_is_defined_type = is_nominal_defined_type(left, store);
+        let right_is_defined_type = is_nominal_defined_type(right, store);
 
-        if left_is_value_enum && right_is_value_enum {
+        if left_is_defined_type && right_is_defined_type {
             let underlying = left
                 .underlying_simple_kind()
                 .map(Type::Simple)
                 .unwrap_or_else(|| left.clone());
-            self.sink
-                .push(diagnostics::infer::incompatible_named_numeric_types(
-                    &underlying,
-                    span,
-                ));
+            self.sink.push(diagnostics::infer::incompatible_named_types(
+                &underlying,
+                span,
+            ));
             true
-        } else if left_is_value_enum && plain_primitive_of_backing(left, right) {
+        } else if left_is_defined_type && plain_primitive_of_backing(left, right) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     right, left, span,
                 ));
             true
-        } else if right_is_value_enum && plain_primitive_of_backing(right, left) {
+        } else if right_is_defined_type && plain_primitive_of_backing(right, left) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     left, right, span,
@@ -811,16 +844,15 @@ impl TaskState<'_> {
             }
 
             (true, true) => {
-                self.sink
-                    .push(diagnostics::infer::incompatible_named_numeric_types(
-                        &left_underlying,
-                        *span,
-                    ));
+                self.sink.push(diagnostics::infer::incompatible_named_types(
+                    &left_underlying,
+                    *span,
+                ));
                 Some(left_ty.clone())
             }
 
             (true, false) => {
-                if is_nominal_value_enum(left_ty, store) {
+                if is_nominal_defined_type(left_ty, store) {
                     self.sink
                         .push(diagnostics::infer::named_primitive_needs_cast(
                             right_ty, left_ty, *span,
@@ -829,7 +861,7 @@ impl TaskState<'_> {
                 Some(left_ty.clone())
             }
             (false, true) => {
-                if is_nominal_value_enum(right_ty, store) {
+                if is_nominal_defined_type(right_ty, store) {
                     self.sink
                         .push(diagnostics::infer::named_primitive_needs_cast(
                             left_ty, right_ty, *span,
@@ -1026,6 +1058,7 @@ enum LiteralKind {
     Integer,
     Float,
     String,
+    Boolean,
     None,
 }
 
@@ -1043,9 +1076,13 @@ fn literal_kind(expression: &Expression) -> LiteralKind {
             literal: Literal::String { .. },
             ..
         } => LiteralKind::String,
+        Expression::Literal {
+            literal: Literal::Boolean(_),
+            ..
+        } => LiteralKind::Boolean,
         Expression::Paren { expression, .. } => literal_kind(expression),
         Expression::Unary {
-            operator: Negative | BitwiseNot,
+            operator: Negative | BitwiseNot | Not,
             expression,
             ..
         } => literal_kind(expression),
@@ -1054,30 +1091,32 @@ fn literal_kind(expression: &Expression) -> LiteralKind {
 }
 
 fn literal_can_adapt_to(kind: &LiteralKind, target: &Type) -> bool {
+    let named_backed_by = |k: SimpleKind| {
+        matches!(target, Type::Nominal { .. }) && target.underlying_simple_kind() == Some(k)
+    };
     match kind {
         LiteralKind::Integer => target.literal_adaptation_target().is_some(),
         LiteralKind::Float => target
             .literal_adaptation_target()
             .is_some_and(|underlying| underlying.is_float()),
-        LiteralKind::String => {
-            matches!(target, Type::Nominal { .. })
-                && target.underlying_simple_kind() == Some(SimpleKind::String)
-        }
+        LiteralKind::String => named_backed_by(SimpleKind::String),
+        LiteralKind::Boolean => named_backed_by(SimpleKind::Bool),
         LiteralKind::None => false,
     }
 }
 
-fn is_nominal_value_enum(ty: &Type, store: &Store) -> bool {
-    matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_nominal_value_enum(id.as_str()))
+fn is_nominal_defined_type(ty: &Type, store: &Store) -> bool {
+    matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_nominal_defined_type(id.as_str()))
 }
 
 fn is_plain_numeric_primitive(ty: &Type) -> bool {
     ty.is_numeric() && !ty.is_aliased_numeric_type()
 }
 
-fn plain_primitive_of_backing(value_enum: &Type, other: &Type) -> bool {
-    match value_enum.underlying_simple_kind() {
+fn plain_primitive_of_backing(defined_ty: &Type, other: &Type) -> bool {
+    match defined_ty.underlying_simple_kind() {
         Some(SimpleKind::String) => other.is_string(),
+        Some(SimpleKind::Bool) => other.is_boolean(),
         _ => is_plain_numeric_primitive(other),
     }
 }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -133,7 +133,7 @@ impl TaskState<'_> {
                 },
                 other @ (Type::Simple(_) | Type::Compound { .. }),
             ) => {
-                if matches!(other, Type::Simple(_)) && store.is_nominal_value_enum(id.as_str()) {
+                if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
                     let u = underlying.as_ref().clone();
@@ -149,7 +149,7 @@ impl TaskState<'_> {
                     ..
                 },
             ) => {
-                if matches!(other, Type::Simple(_)) && store.is_nominal_value_enum(id.as_str()) {
+                if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
                     let u = underlying.as_ref().clone();
@@ -377,7 +377,7 @@ impl TaskState<'_> {
                 ..
             } = t1
                 && store.get_interface(symbol2).is_none()
-                && !store.is_nominal_value_enum(symbol1.as_str())
+                && !store.is_nominal_defined_type(symbol1.as_str())
                 && self.try_unify(store, u, t2, span).is_ok()
             {
                 return Ok(());
@@ -387,7 +387,7 @@ impl TaskState<'_> {
                 ..
             } = t2
                 && store.get_interface(symbol1).is_none()
-                && !store.is_nominal_value_enum(symbol2.as_str())
+                && !store.is_nominal_defined_type(symbol2.as_str())
                 && self.try_unify(store, t1, u, span).is_ok()
             {
                 return Ok(());

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -7,7 +7,7 @@ use syntax::ast::{EnumVariant, Expression, StructFieldDefinition};
 use syntax::program::{
     Definition, DefinitionBody, File, Interface, MethodSignatures, Module, ModuleId,
 };
-use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
+use syntax::types::{SubstitutionMap, Symbol, Type, substitute};
 
 pub const ENTRY_MODULE_ID: &str = "_entry_";
 pub const ENTRY_FILE_ID: u32 = 0;
@@ -207,16 +207,11 @@ impl Store {
         }
     }
 
-    pub fn is_nominal_value_enum(&self, qualified_name: &str) -> bool {
-        matches!(
-            self.get_definition(qualified_name).map(|definition| &definition.body),
-            Some(DefinitionBody::ValueEnum { underlying_ty: Some(underlying), .. })
-                if underlying.has_underlying_numeric_type()
-                    || matches!(
-                        underlying.underlying_simple_kind(),
-                        Some(SimpleKind::Uintptr | SimpleKind::String)
-                    )
-        )
+    pub fn is_nominal_defined_type(&self, qualified_name: &str) -> bool {
+        match self.get_definition(qualified_name) {
+            Some(def) => matches!(def.body, DefinitionBody::ValueEnum { .. }) || def.is_newtype(),
+            None => false,
+        }
     }
 
     pub fn fields_of(&self, qualified_name: &str) -> Option<&[StructFieldDefinition]> {

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -71,7 +71,7 @@ time.Sleep(100 * time.Millisecond)    // literal adapts
 time.Sleep(elapsed as time.Duration)  // typed value needs `as`
 ```
 
-The same holds for string-backed named types such as `regexp/syntax.ErrorCode`, so a string literal adapts, while a typed `string` needs conversion.
+Composite-backed structs like `net.IP` (over `[]byte`) are the exception: they stay assignable to their underlying type, as in Go.
 
 ### Variadic parameters
 

--- a/tests/e2e_smoke_project/src/main.lis
+++ b/tests/e2e_smoke_project/src/main.lis
@@ -2755,6 +2755,25 @@ fn test_string_value_enum() -> int {
   if ok { 100 } else { 0 }
 }
 
+struct Ticket(int)
+
+fn test_newtype_struct_nominal() -> int {
+  let id: Ticket = 7
+  let n: int = 3
+  let summed = id + (n as Ticket)
+  let raw = id as int
+  if summed == 10 && raw == 7 { 100 } else { 0 }
+}
+
+struct Toggle(bool)
+
+fn test_bool_newtype_nominal() -> int {
+  let on: Toggle = true
+  let off = !on
+  let combined = on && off
+  if on && !combined { 100 } else { 0 }
+}
+
 fn test_named_div_to_named_annotation() -> int {
   // Duration / Duration must stay Duration, not be cast to int64 in emit
   let d: time.Duration = time.Duration.Second / time.Duration.Millisecond
@@ -3952,6 +3971,8 @@ fn main() {
   report("named_div_to_named_annotation", test_named_div_to_named_annotation(), 100)
   report("named_div_literal_to_named_annotation", test_named_div_literal_to_named_annotation(), 100)
   report("string_value_enum", test_string_value_enum(), 100)
+  report("newtype_struct_nominal", test_newtype_struct_nominal(), 100)
+  report("bool_newtype_nominal", test_bool_newtype_nominal(), 100)
   report("duration_add", test_duration_add(), 100)
   report("duration_sub", test_duration_sub(), 100)
   report("duration_comparison", test_duration_comparison(), 100)

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4056,7 +4056,7 @@ fn newtype_return_from_underlying_variable_casts() {
 struct UserId(int)
 
 fn make(i: int) -> UserId {
-  i
+  i as UserId
 }
 "#;
     assert_emit_snapshot!(input);
@@ -4074,7 +4074,7 @@ fn take(u: UserId) {
 }
 
 fn test() {
-  let id: UserId = raw()
+  let id: UserId = raw() as UserId
   take(id)
 }
 "#;
@@ -4094,7 +4094,7 @@ fn take(u: UserId) {
 
 fn test() {
   let mut id = UserId(0)
-  id = raw()
+  id = raw() as UserId
   take(id)
 }
 "#;
@@ -4108,7 +4108,7 @@ struct UserId(int)
 struct Box { v: UserId }
 
 fn test(i: int) -> Box {
-  Box { v: i }
+  Box { v: i as UserId }
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/e2e_smoke.snap
+++ b/tests/spec/emit/snapshots/e2e_smoke.snap
@@ -467,6 +467,8 @@ duration_div_scalar: PASS
 named_div_to_named_annotation: PASS
 named_div_literal_to_named_annotation: PASS
 string_value_enum: PASS
+newtype_struct_nominal: PASS
+bool_newtype_nominal: PASS
 duration_add: PASS
 duration_sub: PASS
 duration_comparison: PASS

--- a/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_assignment_from_underlying_value_casts.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let mut id = UserId(0)\n  id = raw()\n  take(id)\n}\n"
+description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let mut id = UserId(0)\n  id = raw() as UserId\n  take(id)\n}\n"
 ---
 package main
 

--- a/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_return_from_underlying_variable_casts.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "input: \nstruct UserId(int)\n\nfn make(i: int) -> UserId {\n  i\n}\n"
+description: "input: \nstruct UserId(int)\n\nfn make(i: int) -> UserId {\n  i as UserId\n}\n"
 ---
 package main
 

--- a/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_struct_field_from_underlying_value_casts.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "input: \nstruct UserId(int)\nstruct Box { v: UserId }\n\nfn test(i: int) -> Box {\n  Box { v: i }\n}\n"
+description: "input: \nstruct UserId(int)\nstruct Box { v: UserId }\n\nfn test(i: int) -> Box {\n  Box { v: i as UserId }\n}\n"
 ---
 package main
 

--- a/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_typed_let_from_underlying_call_casts.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let id: UserId = raw()\n  take(id)\n}\n"
+description: "input: \nstruct UserId(int)\n\nfn raw() -> int { 1 }\n\nfn take(u: UserId) {\n  let _ = u\n}\n\nfn test() {\n  let id: UserId = raw() as UserId\n  take(id)\n}\n"
 ---
 package main
 

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -2890,7 +2890,7 @@ fn test() {
 }
 "#,
     );
-    infer_module("main", fs).assert_infer_code("incompatible_named_numeric_types");
+    infer_module("main", fs).assert_infer_code("incompatible_named_types");
 }
 
 #[test]
@@ -2915,7 +2915,7 @@ fn test() -> bool {
 }
 "#,
     );
-    infer_module("main", fs).assert_infer_code("incompatible_named_numeric_types");
+    infer_module("main", fs).assert_infer_code("incompatible_named_types");
 }
 
 #[test]
@@ -4951,7 +4951,7 @@ fn main() { use_it(&MySource {}) }
 }
 
 #[test]
-fn transparent_newtype_division_order_still_errors() {
+fn newtype_division_with_typed_primitive_rejected() {
     infer(
         r#"
 struct Meters(int)
@@ -4961,7 +4961,7 @@ fn test(m: Meters) {
 }
 "#,
     )
-    .assert_infer_code("invalid_division_order");
+    .assert_infer_code("type_mismatch");
 }
 
 #[test]
@@ -5263,6 +5263,136 @@ struct Mask(Slice<byte>)
 
 fn test(b: Bytes) {
   let _m = b as Mask
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn newtype_struct_rejects_typed_primitive() {
+    infer(
+        r#"
+struct Meters(int)
+fn need(_m: Meters) {}
+fn test() {
+  let n: int = 5
+  need(n)
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn newtype_struct_adapts_literal_and_casts() {
+    infer(
+        r#"
+struct Meters(int)
+fn need(_m: Meters) {}
+fn test() {
+  let _m: Meters = 5
+  let n: int = 5
+  need(n as Meters)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn composite_newtype_transparent_to_unnamed_underlying() {
+    infer(
+        r#"
+struct Bytes(Slice<byte>)
+fn test(raw: Slice<byte>) {
+  let b: Bytes = raw
+  let _back: Slice<byte> = b
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn distinct_composite_newtypes_not_assignable() {
+    infer(
+        r#"
+struct Bytes(Slice<byte>)
+struct Mask(Slice<byte>)
+fn test(b: Bytes) {
+  let _m: Mask = b
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn bool_newtype_adapts_literal_and_logical_ops() {
+    infer(
+        r#"
+struct Flag(bool)
+fn test(f: Flag) -> Flag {
+  let _g: Flag = true
+  let _neg: Flag = !true
+  let _eq = f == true
+  let _and = f && true
+  let _and_neg = f && !true
+  !f
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn bool_newtype_rejects_typed_bool() {
+    infer(
+        r#"
+struct Flag(bool)
+fn test(f: Flag) -> bool {
+  let b: bool = true
+  f == b
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn bool_newtype_ordering_rejected() {
+    infer(
+        r#"
+struct Flag(bool)
+fn test(f: Flag, g: Flag) -> bool {
+  f < g
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn bool_newtype_in_conditions() {
+    infer(
+        r#"
+struct Flag(bool)
+fn pick(f: Flag) -> int {
+  if f { 1 } else { 0 }
+}
+fn negated(f: Flag) -> int {
+  if !f { 1 } else { 0 }
+}
+fn loops(start: Flag) {
+  let mut f = start
+  while f { f = !f }
+}
+fn guarded(f: Flag, x: int) -> int {
+  match x {
+    _ if f => 1,
+    _ => 0,
+  }
 }
 "#,
     )

--- a/tests/ui/errors/snapshots/infer_different_numeric_aliases.snap
+++ b/tests/ui/errors/snapshots/infer_different_numeric_aliases.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                                 ╰── cannot compute
  6 │ }
    ╰────
-  help: Cast one to the other's type, or convert both to `int64` · code: [infer.incompatible_named_numeric_types]
+  help: Cast one to the other's type, or convert both to `int64` · code: [infer.incompatible_named_types]


### PR DESCRIPTION
Single-field struct types are now nominal, so `struct UserId(int)` and `fs.FileMode` no longer freely stand in for their underlying type. As in prior PRs, literals adapt, whereas typed values needs an explicit cast. This closes the last gap where Lis accepted a scenario of this kind (and its reverse) and emitted Go that did not compile.

```rs
struct UserId(int)

let n: int = 42
let id: UserId = n      // was accepted, emitted invalid Go; now errors
let id = n as UserId    // explicit conversion
let id: UserId = 42     // literal adapts, no cast
```

Composite-backed structs are an exception: `net.IP` (over `[]byte`) stays assignable to its unnamed underlying, because Go allows it.

Bool-backed types like `asn1.Flag` follow the same rule, and now support the operators Go defines on `bool`: `==`, `!=`, `&&`, `||`, `!`, and use as an `if`/`while`/guard condition. Ordering (`<`, `>`) stays rejected, since Go does not define it on `bool` either.

Closes the nominalization series: #573 + #572