### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.3.0](https://github.com/ivov/lisette/compare/lisette-v0.2.17...lisette-v0.3.0) - 2026-06-04
+
+- refactor: stop threading store through inference signatures [#597](https://github.com/ivov/lisette/pull/597) [`4890ad5`](https://github.com/ivov/lisette/commit/4890ad5be004222b4dfaf7f6ebe7ef8367e7874e)
+- feat: add out-of-domain value lint for closed named primitives [#596](https://github.com/ivov/lisette/pull/596) [`c434c3a`](https://github.com/ivov/lisette/commit/c434c3ab45e929a2e1e53b1a386f00fdf4ca1297)
+- refactor: share context and walk across checks and lints [#595](https://github.com/ivov/lisette/pull/595) [`40f5264`](https://github.com/ivov/lisette/commit/40f5264746c45021c1a54fd12bd9c230e56d0bd0)
+- feat: add non-negative length comparison lint [#593](https://github.com/ivov/lisette/pull/593) [`c268079`](https://github.com/ivov/lisette/commit/c2680798dfb5ddc02339a2f3da0fec9128f47913)
+- feat: catch x % 1 in redundant operation lint [#592](https://github.com/ivov/lisette/pull/592) [`7f26440`](https://github.com/ivov/lisette/commit/7f264408bfc85009116e1cb2afe15c4d00a3f3f4)
+- ci: flag breaking changes in github release notes [#591](https://github.com/ivov/lisette/pull/591) [`823ba05`](https://github.com/ivov/lisette/commit/823ba05269cddfd1e39e80ca7ef317f53a96287e)
+- refactor!: rename `--format` to `--output` in `lis check` [#590](https://github.com/ivov/lisette/pull/590) [`6b886fe`](https://github.com/ivov/lisette/commit/6b886fe9bae5d42939c9c9db999fd2f0c05a409d)
+- refactor!: remove value enums [#588](https://github.com/ivov/lisette/pull/588) [`260463c`](https://github.com/ivov/lisette/commit/260463cff8b0cd6cb6f4de675ff2694b8aba99ba)
+- feat: add redundant operation simplification lint [#589](https://github.com/ivov/lisette/pull/589) [`5b834b0`](https://github.com/ivov/lisette/commit/5b834b0b3c59e9e074e401946775d06da3a03989)
+- feat: add negated equality simplification lint [#586](https://github.com/ivov/lisette/pull/586) [`6edc4bf`](https://github.com/ivov/lisette/commit/6edc4bffaf48817b82bac2b4dc91fbcc7c6c99fc)
+- fix: lsp hover improvements [#583](https://github.com/ivov/lisette/pull/583) [`c536ba2`](https://github.com/ivov/lisette/commit/c536ba2d58d7d654e78ecd82570dbdd55a6e3c1b)
+- feat: add let-and-return simplification lint [#585](https://github.com/ivov/lisette/pull/585) [`fde3b5b`](https://github.com/ivov/lisette/commit/fde3b5bb304ef9b918f1fb10d2df45151eac3a96)
+- feat: lint match on bool that should be if/else [#584](https://github.com/ivov/lisette/pull/584) [`b08193d`](https://github.com/ivov/lisette/commit/b08193d3f80fd6b8fea54efb6b3f64a0dfc6d15f)
+- feat: add match-to-let simplification lint [#582](https://github.com/ivov/lisette/pull/582) [`e27c9b7`](https://github.com/ivov/lisette/commit/e27c9b70b9cbf5e9c4ea100b451d8e7ddc1a161b)
+- feat: add redundant assert_type lint [#580](https://github.com/ivov/lisette/pull/580) [`802bbfd`](https://github.com/ivov/lisette/commit/802bbfd03170e47679591d957081f235aaf567ba)
+- refactor!: rename attributes to `#[iterate]` and `#[display]` [#578](https://github.com/ivov/lisette/pull/578) [`ba0503e`](https://github.com/ivov/lisette/commit/ba0503e982bf21b76afa27f4f2d931600bd09afa)
+
 ## [0.2.17](https://github.com/ivov/lisette/compare/lisette-v0.2.16...lisette-v0.2.17) - 2026-06-02
 
 - feat: add manual emptiness check lint [#577](https://github.com/ivov/lisette/pull/577) [`6dd1cb1`](https://github.com/ivov/lisette/commit/6dd1cb16c933e952f5eaec1aff1e5bb915cce389)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.2.17"
+version = "0.3.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.17"
+version = "0.3.0"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.17"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.2.17", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.2.17", path = "../format" }
-emit = { package = "lisette-emit", version = "0.2.17", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.2.17", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.3.0", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.0", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.3.0", path = "../format" }
+emit = { package = "lisette-emit", version = "0.3.0", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.3.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.0", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.3.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.3.0", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.0", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.2.17", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
-format = { package = "lisette-format", version = "0.2.17", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.3.0", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.0", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.3.0", path = "../deps" }
+format = { package = "lisette-format", version = "0.3.0", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.2.17", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.2.17", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.2.17", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.2.17", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.3.0", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.0", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.3.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.0", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.3.0 (upcoming)

- refactor: stop threading store through inference signatures [#597](https://github.com/ivov/lisette/pull/597) [`4890ad5`](https://github.com/ivov/lisette/commit/4890ad5be004222b4dfaf7f6ebe7ef8367e7874e)
- feat: add out-of-domain value lint for closed named primitives [#596](https://github.com/ivov/lisette/pull/596) [`c434c3a`](https://github.com/ivov/lisette/commit/c434c3ab45e929a2e1e53b1a386f00fdf4ca1297)
- refactor: share context and walk across checks and lints [#595](https://github.com/ivov/lisette/pull/595) [`40f5264`](https://github.com/ivov/lisette/commit/40f5264746c45021c1a54fd12bd9c230e56d0bd0)
- feat: add non-negative length comparison lint [#593](https://github.com/ivov/lisette/pull/593) [`c268079`](https://github.com/ivov/lisette/commit/c2680798dfb5ddc02339a2f3da0fec9128f47913)
- feat: catch x % 1 in redundant operation lint [#592](https://github.com/ivov/lisette/pull/592) [`7f26440`](https://github.com/ivov/lisette/commit/7f264408bfc85009116e1cb2afe15c4d00a3f3f4)
- ci: flag breaking changes in github release notes [#591](https://github.com/ivov/lisette/pull/591) [`823ba05`](https://github.com/ivov/lisette/commit/823ba05269cddfd1e39e80ca7ef317f53a96287e)
- refactor!: rename `--format` to `--output` in `lis check` [#590](https://github.com/ivov/lisette/pull/590) [`6b886fe`](https://github.com/ivov/lisette/commit/6b886fe9bae5d42939c9c9db999fd2f0c05a409d)
- refactor!: remove value enums [#588](https://github.com/ivov/lisette/pull/588) [`260463c`](https://github.com/ivov/lisette/commit/260463cff8b0cd6cb6f4de675ff2694b8aba99ba)
- feat: add redundant operation simplification lint [#589](https://github.com/ivov/lisette/pull/589) [`5b834b0`](https://github.com/ivov/lisette/commit/5b834b0b3c59e9e074e401946775d06da3a03989)
- feat: add negated equality simplification lint [#586](https://github.com/ivov/lisette/pull/586) [`6edc4bf`](https://github.com/ivov/lisette/commit/6edc4bffaf48817b82bac2b4dc91fbcc7c6c99fc)
- fix: lsp hover improvements [#583](https://github.com/ivov/lisette/pull/583) [`c536ba2`](https://github.com/ivov/lisette/commit/c536ba2d58d7d654e78ecd82570dbdd55a6e3c1b)
- feat: add let-and-return simplification lint [#585](https://github.com/ivov/lisette/pull/585) [`fde3b5b`](https://github.com/ivov/lisette/commit/fde3b5bb304ef9b918f1fb10d2df45151eac3a96)
- feat: lint match on bool that should be if/else [#584](https://github.com/ivov/lisette/pull/584) [`b08193d`](https://github.com/ivov/lisette/commit/b08193d3f80fd6b8fea54efb6b3f64a0dfc6d15f)
- feat: add match-to-let simplification lint [#582](https://github.com/ivov/lisette/pull/582) [`e27c9b7`](https://github.com/ivov/lisette/commit/e27c9b70b9cbf5e9c4ea100b451d8e7ddc1a161b)
- feat: add redundant assert_type lint [#580](https://github.com/ivov/lisette/pull/580) [`802bbfd`](https://github.com/ivov/lisette/commit/802bbfd03170e47679591d957081f235aaf567ba)
- refactor!: rename attributes to `#[iterate]` and `#[display]` [#578](https://github.com/ivov/lisette/pull/578) [`ba0503e`](https://github.com/ivov/lisette/commit/ba0503e982bf21b76afa27f4f2d931600bd09afa)
