### PR TITLE
feat: add redundant assert_type lint

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2386,6 +2386,16 @@ pub fn redundant_cast(ty: &Type, span: Span) -> LisetteDiagnostic {
         .with_help("Remove the unnecessary cast")
 }
 
+pub fn redundant_assert_type(ty: &Type, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::info("Redundant type assertion")
+        .with_infer_code("redundant_assert_type")
+        .with_span_label(&span, format!("already of type `{}`", ty))
+        .with_help(format!(
+            "`assert_type` narrows an `Unknown` value, but this value is already `{}`, so the assertion always succeeds",
+            ty
+        ))
+}
+
 pub fn integer_literal_overflow(
     target_ty: &str,
     min: i128,

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -468,6 +468,10 @@ impl TaskState<'_> {
             return_ty.clone()
         };
 
+        if call_kind == CallKind::AssertType {
+            self.check_redundant_assert_type(&return_ty, &new_args, span);
+        }
+
         Expression::Call {
             expression: callee_expression.into(),
             args: new_args,
@@ -898,6 +902,29 @@ impl TaskState<'_> {
                 self.with_value_context(|s| s.infer_expression(store, arg, &expected_ty))
             })
             .collect()
+    }
+
+    fn check_redundant_assert_type(&mut self, return_ty: &Type, args: &[Expression], span: Span) {
+        let resolved_return = return_ty.resolve_in(&self.env);
+        let Some(asserted_ty) = resolved_return.inner() else {
+            return;
+        };
+        let asserted_ty = asserted_ty.resolve_in(&self.env);
+
+        let Some(arg) = args.first() else {
+            return;
+        };
+        let value_ty = arg.get_type().resolve_in(&self.env);
+        if value_ty.is_unknown() {
+            return;
+        }
+
+        if value_ty == asserted_ty {
+            self.sink.push(diagnostics::infer::redundant_assert_type(
+                &asserted_ty,
+                span,
+            ));
+        }
     }
 
     /// Suggests postfix `f(xs...)` when a `..xs` range arg lands against a variadic callee.

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -3693,7 +3693,7 @@ fn unit_call_in_assert_type() {
 fn noop() {}
 
 fn main() {
-  let x = assert_type<()>(noop())
+  let x = assert_type<int>(noop())
   let _ = x
 }
 "#;

--- a/tests/spec/emit/snapshots/unit_call_in_assert_type.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_assert_type.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "input: \nfn noop() {}\n\nfn main() {\n  let x = assert_type<()>(noop())\n  let _ = x\n}\n"
+description: "input: \nfn noop() {}\n\nfn main() {\n  let x = assert_type<int>(noop())\n  let _ = x\n}\n"
 ---
 package main
 
@@ -10,6 +10,6 @@ func noop() {}
 
 func main() {
 	noop()
-	x := lisette.AssertType[struct{}](struct{}{})
+	x := lisette.AssertType[int](struct{}{})
 	_ = x
 }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5527,6 +5527,40 @@ fn test() -> int {
 }
 
 #[test]
+fn assert_type_interface_narrowing_not_redundant() {
+    let input = r#"
+interface Animal {
+  fn sound(self) -> string
+}
+
+struct Dog {}
+
+impl Dog {
+  fn sound(self) -> string { "woof" }
+}
+
+fn pick(a: Animal) -> Option<Animal> {
+  assert_type<Dog>(a)
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.type_mismatch")),
+        "expected the coercion scenario to produce a type mismatch"
+    );
+    assert!(
+        !result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.redundant_assert_type")),
+        "narrowing an interface to a concrete type must not be flagged redundant"
+    );
+}
+
+#[test]
 fn infer_integer_literal_overflow_int8() {
     let input = r#"
 fn test() {

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -7749,6 +7749,56 @@ fn main() {
 }
 
 #[test]
+fn redundant_assert_type_primitive() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = assert_type<int>(x)
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_assert_type_named() {
+    assert_lint_snapshot!(
+        r#"
+struct Point { x: int }
+
+fn main() {
+  let p = Point { x: 1 }
+  let _ = assert_type<Point>(p)
+}
+"#
+    );
+}
+
+#[test]
+fn assert_type_on_unknown_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let value: Unknown = 7
+  let _ = assert_type<int>(value)
+}
+"#
+    );
+}
+
+#[test]
+fn assert_type_different_type_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = assert_type<int64>(x)
+}
+"#
+    );
+}
+
+#[test]
 fn lost_query_mutation_set() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/redundant_assert_type_named.snap
+++ b/tests/ui/lint/snapshots/redundant_assert_type_named.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Redundant type assertion
+   ╭─[test.lis:6:11]
+ 5 │   let p = Point { x: 1 }
+ 6 │   let _ = assert_type<Point>(p)
+   ·           ──────────┬──────────
+   ·                     ╰── already of type `Point`
+ 7 │ }
+   ╰────
+  help: `assert_type` narrows an `Unknown` value, but this value is already `Point`, so the assertion always succeeds · code: [infer.redundant_assert_type]

--- a/tests/ui/lint/snapshots/redundant_assert_type_primitive.snap
+++ b/tests/ui/lint/snapshots/redundant_assert_type_primitive.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Redundant type assertion
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = assert_type<int>(x)
+   ·           ─────────┬─────────
+   ·                    ╰── already of type `int`
+ 5 │ }
+   ╰────
+  help: `assert_type` narrows an `Unknown` value, but this value is already `int`, so the assertion always succeeds · code: [infer.redundant_assert_type]


### PR DESCRIPTION
Adds a lint that flags `assert_type<T>(x)` when `x` is already statically `T`, making the runtime assertion a no-op.

```
  [info] Redundant type assertion
   ╭─[test.lis:4:11]
 3 │   let x = 5
 4 │   let _ = assert_type<int>(x)
   ·           ─────────┬─────────
   ·                    ╰── already of type `int`
 5 │ }
   ╰────
  help: `assert_type` narrows an `Unknown` value, but this value is already `int`, so the assertion always succeeds · code: [infer.redundant_assert_type]
```