### PR TITLE
fix: lsp hover improvements

### DIFF
--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -11,7 +11,7 @@ use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
 use crate::type_name;
 
-/// Hover for top-level type declarations and the annotation tree on a `TypeAlias`.
+/// Hover for top-level declarations and the annotation trees inside them.
 pub(crate) fn resolve_declaration_hover(
     expression: &Expression,
     offset: u32,
@@ -34,6 +34,18 @@ pub(crate) fn resolve_declaration_hover(
             annotation,
             ..
         } => resolve_annotation_hover(annotation, offset, file, snapshot)
+            .or_else(|| name_hover(name, *name_span)),
+        Expression::Function {
+            name,
+            name_span,
+            params,
+            return_annotation,
+            ..
+        } => params
+            .iter()
+            .filter_map(|p| p.annotation.as_ref())
+            .find_map(|a| resolve_annotation_hover(a, offset, file, snapshot))
+            .or_else(|| resolve_annotation_hover(return_annotation, offset, file, snapshot))
             .or_else(|| name_hover(name, *name_span)),
         Expression::Enum {
             name, name_span, ..

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, Pattern, Span, TypedPattern};
+use syntax::ast::{Annotation, Expression, Pattern, Span, TypedPattern};
 use syntax::program::{Definition, DefinitionBody};
 
 use crate::analysis::find_module_by_alias;
@@ -10,6 +10,124 @@ use crate::offset_in_span;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
 use crate::type_name;
+
+/// Hover for top-level type declarations and the annotation tree on a `TypeAlias`.
+pub(crate) fn resolve_declaration_hover(
+    expression: &Expression,
+    offset: u32,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<(syntax::types::Type, Span)> {
+    let name_hover = |name: &str, name_span: Span| -> Option<(syntax::types::Type, Span)> {
+        if !offset_in_span(offset, &name_span) {
+            return None;
+        }
+        let qualified = format!("{}.{}", file.module_id, name);
+        let definition = snapshot.definitions().get(qualified.as_str())?;
+        Some((definition.ty().clone(), name_span))
+    };
+
+    match expression {
+        Expression::TypeAlias {
+            name,
+            name_span,
+            annotation,
+            ..
+        } => resolve_annotation_hover(annotation, offset, file, snapshot)
+            .or_else(|| name_hover(name, *name_span)),
+        Expression::Enum {
+            name, name_span, ..
+        }
+        | Expression::Struct {
+            name, name_span, ..
+        }
+        | Expression::Interface {
+            name, name_span, ..
+        } => name_hover(name, *name_span),
+        _ => None,
+    }
+}
+
+fn resolve_annotation_hover(
+    annotation: &Annotation,
+    offset: u32,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<(syntax::types::Type, Span)> {
+    if !offset_in_span(offset, &annotation.get_span()) {
+        return None;
+    }
+    let recurse = |child| resolve_annotation_hover(child, offset, file, snapshot);
+    match annotation {
+        Annotation::Constructor { name, params, span } => params
+            .iter()
+            .find_map(recurse)
+            .or_else(|| resolve_constructor_name_hover(name, *span, offset, file, snapshot)),
+        Annotation::Function {
+            params,
+            return_type,
+            ..
+        } => params
+            .iter()
+            .find_map(recurse)
+            .or_else(|| recurse(return_type.as_ref())),
+        Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),
+        Annotation::Unknown | Annotation::Opaque { .. } => None,
+    }
+}
+
+fn resolve_constructor_name_hover(
+    name: &str,
+    span: Span,
+    offset: u32,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<(syntax::types::Type, Span)> {
+    let cursor_in_name = (offset - span.byte_offset) as usize;
+    let dot_pos = name.find('.').unwrap_or(name.len());
+
+    if cursor_in_name > dot_pos {
+        let (qualifier, simple) = name.split_once('.')?;
+        let module_name = find_module_by_alias(file, qualifier, &snapshot.result.go_package_names)?;
+        let qualified = format!("{}.{}", module_name, simple);
+        let definition = snapshot.definitions().get(qualified.as_str())?;
+        let simple_offset = span.byte_offset + dot_pos as u32 + 1;
+        let simple_span = Span::new(span.file_id, simple_offset, simple.len() as u32);
+        return Some((definition.ty().clone(), simple_span));
+    }
+
+    let first = &name[..dot_pos];
+    let first_span = Span::new(span.file_id, span.byte_offset, dot_pos as u32);
+    let ty = lookup_type_by_name(first, file, snapshot)?;
+    Some((ty, first_span))
+}
+
+fn lookup_type_by_name(
+    name: &str,
+    file: &syntax::program::File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<syntax::types::Type> {
+    let candidates = [
+        format!("{}.{}", file.module_id, name),
+        name.to_string(),
+        format!("prelude.{}", name),
+    ];
+    for qualified in &candidates {
+        if let Some(def) = snapshot.definitions().get(qualified.as_str()) {
+            return Some(def.ty().clone());
+        }
+    }
+    for import in file.imports() {
+        if import.name.starts_with("go:") {
+            continue;
+        }
+        let qualified = format!("{}.{}", import.name, name);
+        if let Some(def) = snapshot.definitions().get(qualified.as_str()) {
+            return Some(def.ty().clone());
+        }
+    }
+    None
+}
 
 /// Extract the type and span for hover display at the given offset within an expression.
 pub(crate) fn get_hover_type_and_span(

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -421,11 +421,13 @@ pub(crate) fn get_hover_type_and_span(
 /// the offset lands on a sub-item and returns that sub-item's doc instead.
 fn extract_doc_from_expression(expression: &Expression, offset: u32) -> Option<String> {
     match expression {
-        Expression::Function { doc, .. }
-        | Expression::Const { doc, .. }
-        | Expression::VariableDeclaration { doc, .. }
-        | Expression::TypeAlias { doc, .. }
-        | Expression::Interface { doc, .. } => doc.clone(),
+        Expression::Const { doc, .. } | Expression::VariableDeclaration { doc, .. } => doc.clone(),
+
+        Expression::Function { doc, name_span, .. }
+        | Expression::TypeAlias { doc, name_span, .. }
+        | Expression::Interface { doc, name_span, .. } => offset_in_span(offset, name_span)
+            .then(|| doc.clone())
+            .flatten(),
 
         Expression::Enum { doc, variants, .. } => variants
             .iter()

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -201,7 +201,8 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        let (ty, span) = hover::get_hover_type_and_span(expression, offset);
+        let (ty, span) = hover::resolve_declaration_hover(expression, offset, file, &snapshot)
+            .unwrap_or_else(|| hover::get_hover_type_and_span(expression, offset));
 
         if ty.is_type_var() || ty.is_error() {
             return Ok(None);

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -563,6 +563,169 @@ async fn hover_on_function_name_works() {
 }
 
 #[tokio::test]
+async fn hover_on_type_alias_name_shows_target() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "type K = int").await;
+
+    let hover = client.hover(TEST_URI, 0, 5).await;
+    let content = hover_content(&hover.expect("hover on K"));
+    assert!(content.contains("int"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_struct_name_shows_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "struct Point { x: int, y: int }")
+        .await;
+
+    let hover = client.hover(TEST_URI, 0, 9).await;
+    let content = hover_content(&hover.expect("hover on Point"));
+    assert!(content.contains("Point"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_enum_name_shows_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "enum Color { Red, Green, Blue }")
+        .await;
+
+    let hover = client.hover(TEST_URI, 0, 7).await;
+    let content = hover_content(&hover.expect("hover on Color"));
+    assert!(content.contains("Color"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_interface_name_shows_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "interface Foo { fn bar() -> int }")
+        .await;
+
+    let hover = client.hover(TEST_URI, 0, 12).await;
+    let content = hover_content(&hover.expect("hover on Foo"));
+    assert!(content.contains("Foo"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_primitive() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "type K = int").await;
+
+    let hover = client.hover(TEST_URI, 0, 10).await;
+    let content = hover_content(&hover.expect("hover on int"));
+    assert!(content.contains("int"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_qualified() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    let response_dir = src.join("response");
+    std::fs::create_dir_all(&response_dir).unwrap();
+    std::fs::write(
+        response_dir.join("response.lis"),
+        "pub enum Code { Ok, Err }",
+    )
+    .unwrap();
+    let main_content = "import \"response\"\n\ntype Code = response.Code\n";
+    std::fs::write(src.join("main.lis"), main_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+    let main_uri = Url::from_file_path(src.join("main.lis"))
+        .unwrap()
+        .to_string();
+    client.open(&main_uri, main_content).await;
+
+    // cursor on the member `Code` after the dot
+    let hover = client.hover(&main_uri, 2, 22).await;
+    let content = hover_content(&hover.expect("hover on response.Code"));
+    assert!(content.contains("Code"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_in_function_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "type Handler = fn(int) -> string")
+        .await;
+
+    // cursor on `int` inside the function annotation
+    let hover_param = client.hover(TEST_URI, 0, 19).await;
+    let content = hover_content(&hover_param.expect("hover on int"));
+    assert!(content.contains("int"), "got: {content}");
+
+    // cursor on `string` (return type)
+    let hover_ret = client.hover(TEST_URI, 0, 27).await;
+    let content = hover_content(&hover_ret.expect("hover on string"));
+    assert!(content.contains("string"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_in_tuple_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "type Pair = (int, string)").await;
+
+    let hover = client.hover(TEST_URI, 0, 19).await;
+    let content = hover_content(&hover.expect("hover on string in tuple"));
+    assert!(content.contains("string"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_generic_arg() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "type Ints = Slice<int>").await;
+
+    let hover = client.hover(TEST_URI, 0, 19).await;
+    let content = hover_content(&hover.expect("hover on int inside Slice<int>"));
+    assert!(content.contains("int"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_alias_target_generic_head() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "type Ints = Slice<int>").await;
+
+    let hover = client.hover(TEST_URI, 0, 13).await;
+    let content = hover_content(&hover.expect("hover on Slice head"));
+    assert!(content.contains("Slice"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_on_literal_returns_none() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -726,6 +726,81 @@ async fn hover_on_alias_target_generic_head() {
 }
 
 #[tokio::test]
+async fn hover_on_function_return_annotation() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "fn make() -> string { \"hi\" }")
+        .await;
+
+    let hover = client.hover(TEST_URI, 0, 14).await;
+    let content = hover_content(&hover.expect("hover on string return type"));
+    assert!(content.contains("string"), "got: {content}");
+    assert!(
+        !content.contains("->"),
+        "should be type only, got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_function_param_annotation() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "fn add(x: int) -> string { \"hi\" }")
+        .await;
+
+    let hover = client.hover(TEST_URI, 0, 11).await;
+    let content = hover_content(&hover.expect("hover on int param type"));
+    assert!(content.contains("int"), "got: {content}");
+    assert!(
+        !content.contains("string"),
+        "should not leak return type, got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_function_qualified_return_annotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    let http_dir = src.join("http");
+    std::fs::create_dir_all(&http_dir).unwrap();
+    std::fs::write(
+        http_dir.join("http.lis"),
+        "pub struct HandlerFunc { name: string }",
+    )
+    .unwrap();
+    let main_content =
+        "import \"http\"\n\nfn handle() -> http.HandlerFunc { http.HandlerFunc { name: \"\" } }\n";
+    std::fs::write(src.join("main.lis"), main_content).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize_with_root(root).await;
+    let main_uri = Url::from_file_path(src.join("main.lis"))
+        .unwrap()
+        .to_string();
+    client.open(&main_uri, main_content).await;
+
+    // cursor on `HandlerFunc` after the dot in the return annotation
+    let hover = client.hover(&main_uri, 2, 24).await;
+    let content = hover_content(&hover.expect("hover on http.HandlerFunc"));
+    assert!(content.contains("HandlerFunc"), "got: {content}");
+    assert!(
+        !content.contains("->"),
+        "should be type only, not full signature, got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_on_literal_returns_none() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -801,6 +801,46 @@ async fn hover_on_function_qualified_return_annotation() {
 }
 
 #[tokio::test]
+async fn hover_on_param_annotation_excludes_function_doc() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "/// Adds two ints\nfn add(x: int) -> string { \"hi\" }",
+        )
+        .await;
+
+    let hover = client.hover(TEST_URI, 1, 11).await;
+    let content = hover_content(&hover.expect("hover on int param type"));
+    assert!(content.contains("int"), "got: {content}");
+    assert!(
+        !content.contains("Adds two ints"),
+        "function doc leaked into param-type hover, got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_on_function_name_includes_doc() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "/// Adds two ints\nfn add(x: int) -> string { \"hi\" }",
+        )
+        .await;
+
+    let hover = client.hover(TEST_URI, 1, 3).await;
+    let content = hover_content(&hover.expect("hover on function name"));
+    assert!(content.contains("Adds two ints"), "got: {content}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_on_literal_returns_none() {
     let mut client = TestClient::new().await;
     client.initialize().await;


### PR DESCRIPTION
Back again for yet another small lsp DX improvement. 

For context; i built a small project in gleam a while back, and really got to like its lsp server. So im trying to bring things over to lisette when i notice something missing / not implemented.

Whats new:

lsp now shows hover on the name of top-level type declarations like`type`, `struct`, `enum`, `interface`

lsp now shows hover on the of a type alias, and origin type.

```rust
type Code = response.Code // Both the alias and origin now have a hover.
```

This also covers nested annotations, eg.

```rust
type Ints = Slice<int>
type Handler = fn(int) -> string
type Pair = (int, string)
```

lsp now shows hover on function param and return type annotations

```rust
fn handle_http() -> http.HandlerFunc {
//                       ^ show return type signature
}
```

```rust
fn add(x: int) -> string {
//        ^ allows to hover on individual types in arguments
}
```

Hovering on the function name itself now uses a narrower span (the name rather than the whole signature), a minor UX touch-up that seemed appropriate to include.

Modules / packages are not covered in this PR, as Go/Lis has a folder based package sytem so it does not work as easily as in languages with files as modules (eg. where would a lsp goto def jump to / what would a hover show?). I might revisit this at a later time.