### PR TITLE
refactor!: rename `--format` to `--output` in `lis check`

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -71,9 +71,9 @@ fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
     match value {
         "unix" => Ok(OutputFormat::Unix),
         other => Err(ParseError::UnexpectedArgument {
-            message: format!("unexpected value `{}` for `--format`", other),
-            reason: "`--format` accepts `unix`".to_string(),
-            hint: "Use `lis check --format unix`".to_string(),
+            message: format!("unexpected value `{}` for `--output`", other),
+            reason: "`--output` accepts `unix`".to_string(),
+            hint: "Use `lis check --output unix`".to_string(),
         }),
     }
 }
@@ -170,16 +170,16 @@ impl Command {
                     match arg.as_str() {
                         "--errors-only" => errors_only = true,
                         "--warnings-only" => warnings_only = true,
-                        "--format" => {
+                        "--output" => {
                             let Some(value) = arguments.next() else {
                                 return Err(ParseError::MissingArgument {
                                     command: "check",
-                                    argument: "--format <value>",
+                                    argument: "--output <value>",
                                 });
                             };
                             format = parse_format(&value)?;
                         }
-                        s if s.starts_with("--format=") => {
+                        s if s.starts_with("--output=") => {
                             format = parse_format(s.split_once('=').unwrap().1)?;
                         }
                         s if s.starts_with('-') => {
@@ -354,36 +354,36 @@ mod tests {
     }
 
     #[test]
-    fn check_format_unix_space_form() {
-        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--format", "unix"]) else {
+    fn check_output_unix_space_form() {
+        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--output", "unix"]) else {
             panic!("expected Check command");
         };
         assert_eq!(format, OutputFormat::Unix);
     }
 
     #[test]
-    fn check_format_unix_equals_form() {
-        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--format=unix"]) else {
+    fn check_output_unix_equals_form() {
+        let Ok(Command::Check { format, .. }) = parse(&["lis", "check", "--output=unix"]) else {
             panic!("expected Check command");
         };
         assert_eq!(format, OutputFormat::Unix);
     }
 
     #[test]
-    fn check_format_missing_value() {
+    fn check_output_missing_value() {
         assert!(matches!(
-            parse(&["lis", "check", "--format"]),
+            parse(&["lis", "check", "--output"]),
             Err(ParseError::MissingArgument {
                 command: "check",
-                argument: "--format <value>",
+                argument: "--output <value>",
             })
         ));
     }
 
     #[test]
-    fn check_format_invalid_value() {
+    fn check_output_invalid_value() {
         assert!(matches!(
-            parse(&["lis", "check", "--format", "json"]),
+            parse(&["lis", "check", "--output", "json"]),
             Err(ParseError::UnexpectedArgument { .. })
         ));
     }
@@ -397,13 +397,13 @@ mod tests {
     }
 
     #[test]
-    fn check_format_composes_with_errors_only() {
+    fn check_output_composes_with_errors_only() {
         let Ok(Command::Check {
             format,
             errors_only,
             warnings_only,
             ..
-        }) = parse(&["lis", "check", "--format", "unix", "--errors-only"])
+        }) = parse(&["lis", "check", "--output", "unix", "--errors-only"])
         else {
             panic!("expected Check command");
         };

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -56,10 +56,10 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         check)
-            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --format" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --output" -- "$cur") )
             return 0
             ;;
-        --format)
+        --output)
             COMPREPLY=( $(compgen -W "unix" -- "$cur") )
             return 0
             ;;
@@ -125,7 +125,7 @@ _lis() {
                     _arguments \
                         '--errors-only[Show only errors]' \
                         '--warnings-only[Show only warnings]' \
-                        '--format[Machine-readable output]:format:(unix)'
+                        '--output[Machine-readable output]:output:(unix)'
                     ;;
                 doc)
                     _arguments {-s,--search}'[Search across prelude and Go stdlib]'
@@ -167,7 +167,7 @@ complete -c lis -n '__fish_seen_subcommand_from run' -l debug -d 'Include line d
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'
-complete -c lis -n '__fish_seen_subcommand_from check' -l format -r -a unix -d 'Machine-readable output'
+complete -c lis -n '__fish_seen_subcommand_from check' -l output -r -a unix -d 'Machine-readable output'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'
 complete -c lis -n '__fish_seen_subcommand_from complete' -a 'bash zsh fish' -d 'Shell type'
 complete -c lis -n '__fish_seen_subcommand_from help' -a 'new build run format check add sync learn doc help complete version' -d 'Command'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -131,13 +131,13 @@ Arguments:
 Options:
     `--errors-only`      Show only errors
     `--warnings-only`    Show only warnings
-    `--format` <unix>    Machine-readable output, one diagnostic per line
+    `--output` <unix>    Machine-readable output, one diagnostic per line
 
 Examples:
     `lis check`                          Check project in current dir
     `lis check` {path/to/project/dir:g}      Check project in specific dir
     `lis check` {script.lis:g}               Check single file
-    `lis check` {--format unix:g}            One diagnostic per line, for editors",
+    `lis check` {--output unix:g}            One diagnostic per line, for editors",
         ),
 
         "add" => print_help(

--- a/tests/e2e_learn.rs
+++ b/tests/e2e_learn.rs
@@ -38,7 +38,7 @@ fn e2e_learn() {
     );
 
     let check = Command::new(&lis)
-        .args(["check", "--format", "unix"])
+        .args(["check", "--output", "unix"])
         .arg(&project)
         .env("NO_COLOR", "1")
         .output()


### PR DESCRIPTION
`lis check --format` and `lis format --check` are confusingly similar, so let's rename `--format` to `--output`.