### PR TITLE
feat: catch x % 1 in redundant operation lint

### DIFF
--- a/crates/semantics/src/passes/lints/ast_walk/checks/redundant_operation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/redundant_operation.rs
@@ -91,6 +91,13 @@ fn classify<'a>(
                 return None;
             }
         }
+        Remainder => {
+            if int_one(right) {
+                (left, Outcome::Constant("0"))
+            } else {
+                return None;
+            }
+        }
         BitwiseOr | BitwiseXor => {
             if int_zero(right) {
                 (left, Outcome::Identity)

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1214,6 +1214,30 @@ fn main() {
 }
 
 #[test]
+fn redundant_operation_modulo_one() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x % 1
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_operation_modulo_reversed_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = 1 % x
+}
+"#
+    );
+}
+
+#[test]
 fn negated_equality_equal() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/redundant_operation_modulo_one.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_modulo_one.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Operation always evaluates to `0`
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x % 1
+   ·           ──┬──
+   ·             ╰── always `0`
+ 5 │ }
+   ╰────
+  help: Simplify this operation to `0` · code: [lint.redundant_operation]


### PR DESCRIPTION
Adds `x % 1` to the redundant operation lint.

```
  [info] Operation always evaluates to `0`
   ╭─[test.lis:4:11]
 3 │   let x = 5
 4 │   let _ = x % 1
   ·           ──┬──
   ·             ╰── always `0`
 5 │ }
   ╰────
  help: Simplify this operation to `0` · code: [lint.redundant_operation]
```