### PR TITLE
refactor: share context and walk across checks and lints

### DIFF
--- a/crates/semantics/src/passes/checks/const_naming.rs
+++ b/crates/semantics/src/passes/checks/const_naming.rs
@@ -1,9 +1,12 @@
-use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
 use crate::passes::lints::ast_walk::casing::{is_screaming_snake_case, to_screaming_snake_case};
+use crate::passes::walk::NodeCtx;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    if ctx.is_d_lis {
+        return;
+    }
     let Expression::Const {
         identifier,
         identifier_span,
@@ -15,7 +18,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     if identifier.starts_with('_') || is_screaming_snake_case(identifier) {
         return;
     }
-    sink.push(diagnostics::lint::miscased_screaming_snake(
+    ctx.sink.push(diagnostics::lint::miscased_screaming_snake(
         identifier_span,
         &to_screaming_snake_case(identifier),
     ));

--- a/crates/semantics/src/passes/checks/decimal_file_mode.rs
+++ b/crates/semantics/src/passes/checks/decimal_file_mode.rs
@@ -1,10 +1,10 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Literal};
 
 const FILE_MODE_ID: &str = "go:io/fs.FileMode";
 const PERM_MASK: u64 = 0o777;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::Literal {
         literal: Literal::Integer { value, text: None },
         ty,
@@ -13,6 +13,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && *value > PERM_MASK
         && ty.get_qualified_id() == Some(FILE_MODE_ID)
     {
-        sink.push(diagnostics::infer::decimal_file_mode(span, *value));
+        ctx.sink
+            .push(diagnostics::infer::decimal_file_mode(span, *value));
     }
 }

--- a/crates/semantics/src/passes/checks/duplicate_bindings.rs
+++ b/crates/semantics/src/passes/checks/duplicate_bindings.rs
@@ -4,13 +4,15 @@
 //! Walks every `Pattern` site in the typed AST. Mirrors the behaviour of the
 //! previous inline check in `checker/infer/checks.rs::check_duplicate_bindings`.
 
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{Binding, Expression, MatchArm, Pattern, SelectArm, SelectArmPattern, Span};
 
 use crate::checker::infer::expressions::patterns::collect_pattern_bindings;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
     match expression {
         Expression::Let { binding, .. } | Expression::For { binding, .. } => {
             visit_binding(binding, sink);

--- a/crates/semantics/src/passes/checks/empty_infinite_loop.rs
+++ b/crates/semantics/src/passes/checks/empty_infinite_loop.rs
@@ -1,11 +1,11 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::Loop { body, span, .. } = expression
         && let Expression::Block { items, .. } = body.as_ref()
         && items.is_empty()
     {
-        sink.push(diagnostics::infer::empty_infinite_loop(span));
+        ctx.sink.push(diagnostics::infer::empty_infinite_loop(span));
     }
 }

--- a/crates/semantics/src/passes/checks/empty_range.rs
+++ b/crates/semantics/src/passes/checks/empty_range.rs
@@ -1,7 +1,7 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, UnaryOperator};
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::Range {
         start: Some(start),
         end: Some(end),
@@ -12,7 +12,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && let Some(end_value) = signed_integer_literal(end.unwrap_parens())
         && start_value > end_value
     {
-        sink.push(diagnostics::infer::empty_range(span));
+        ctx.sink.push(diagnostics::infer::empty_range(span));
     }
 }
 

--- a/crates/semantics/src/passes/checks/enum_variant_value.rs
+++ b/crates/semantics/src/passes/checks/enum_variant_value.rs
@@ -2,9 +2,10 @@ use diagnostics::LocalSink;
 use syntax::ast::{Expression, Span};
 use syntax::types::{Type, unqualified_name};
 
+use crate::passes::walk::NodeCtx;
 use crate::store::Store;
 
-pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     match expression {
         Expression::Identifier {
             qualified: Some(qualified),
@@ -13,7 +14,7 @@ pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
             ..
         } => {
             if let Some((enum_id, variant_name)) = qualified.rsplit_once('.') {
-                check_variant(enum_id, variant_name, value, *span, store, sink);
+                check_variant(enum_id, variant_name, value, *span, ctx.store, ctx.sink);
             }
         }
         Expression::DotAccess {
@@ -24,7 +25,7 @@ pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
         } => {
             if let Type::Nominal { id, .. } = base.get_type().strip_refs() {
                 let display = format!("{}.{}", unqualified_name(&id), member);
-                check_variant(&id, member, &display, *span, store, sink);
+                check_variant(&id, member, &display, *span, ctx.store, ctx.sink);
             }
         }
         _ => {}

--- a/crates/semantics/src/passes/checks/index_out_of_bounds.rs
+++ b/crates/semantics/src/passes/checks/index_out_of_bounds.rs
@@ -1,7 +1,7 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Literal};
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     let Expression::IndexedAccess {
         expression: receiver,
         index,
@@ -28,7 +28,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && let Some(value) = index.as_integer()
         && value >= elements.len() as u64
     {
-        sink.push(diagnostics::infer::index_out_of_bounds(
+        ctx.sink.push(diagnostics::infer::index_out_of_bounds(
             span,
             &value.to_string(),
         ));
@@ -50,7 +50,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && expressions_equivalent(receiver, call_receiver)
     {
         let receiver_text = receiver.root_identifier().unwrap_or("xs");
-        sink.push(diagnostics::infer::index_out_of_bounds(
+        ctx.sink.push(diagnostics::infer::index_out_of_bounds(
             span,
             &format!("{receiver_text}.length()"),
         ));

--- a/crates/semantics/src/passes/checks/interpolation_stringer.rs
+++ b/crates/semantics/src/passes/checks/interpolation_stringer.rs
@@ -6,7 +6,7 @@ use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::program::{Definition, DefinitionBody, File};
 use syntax::types::Type;
 
-use crate::passes::lints::ast_walk::visitor::visit_ast;
+use crate::passes::walk::visit_ast;
 use crate::store::Store;
 
 pub(crate) fn run(

--- a/crates/semantics/src/passes/checks/irrefutable_patterns.rs
+++ b/crates/semantics/src/passes/checks/irrefutable_patterns.rs
@@ -14,10 +14,12 @@
 //! `let pat else { ... }` relaxes the or-pattern rule (the `else` arm handles
 //! the refutable case) but still rejects bare literal patterns.
 
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use syntax::ast::{Binding, Expression, Pattern, SelectArm, SelectArmPattern};
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
     match expression {
         Expression::Let {
             binding,

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -29,12 +29,12 @@ pub(crate) mod visibility;
 
 use diagnostics::{LocalSink, PatternIssue};
 use rayon::prelude::*;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use syntax::ast::BindingId;
+use rustc_hash::FxHashSet as HashSet;
 use syntax::program::{File, Module};
 
 use crate::context::AnalysisContext;
-use crate::facts::{BindingFact, Facts};
+use crate::facts::Facts;
+use crate::passes::walk::NodeCtx;
 use crate::store::Store;
 
 use super::PARALLEL_THRESHOLD;
@@ -61,8 +61,8 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
             .then_with(|| a.1.id.cmp(&b.1.id))
     });
 
-    let or_spans = &facts.or_pattern_error_spans;
-    let bindings = &facts.bindings;
+    let facts_ref: &Facts = &*facts;
+    let or_spans = &facts_ref.or_pattern_error_spans;
 
     let ufcs_methods = analysis.ufcs_methods;
 
@@ -73,7 +73,7 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
                 module,
                 file,
                 store,
-                bindings,
+                facts_ref,
                 ufcs_methods,
                 sink,
                 &pattern_ctx,
@@ -93,7 +93,7 @@ pub(crate) fn run_all(analysis: &AnalysisContext, facts: &mut Facts, sink: &Loca
                 module,
                 file,
                 store,
-                bindings,
+                facts_ref,
                 ufcs_methods,
                 &local_sink,
                 &pattern_ctx,
@@ -116,12 +116,21 @@ fn run_file_checks(
     module: &Module,
     file: &File,
     store: &Store,
-    bindings: &HashMap<BindingId, BindingFact>,
+    facts: &Facts,
     ufcs_methods: &HashSet<(String, String)>,
     sink: &LocalSink,
     pattern_ctx: &pattern_analysis::Context,
 ) {
-    node_walk::run(&file.items, store, bindings, file.is_d_lis(), sink);
+    let ctx = NodeCtx {
+        store,
+        facts,
+        files: &module.files,
+        module_id: &module.id,
+        source: &file.source,
+        is_d_lis: file.is_d_lis(),
+        sink,
+    };
+    node_walk::run(&file.items, &ctx);
     interpolation_stringer::run(&file.items, store, ufcs_methods, sink);
 
     prelude_shadowing::run(&file.items, store, sink);

--- a/crates/semantics/src/passes/checks/nan_comparison.rs
+++ b/crates/semantics/src/passes/checks/nan_comparison.rs
@@ -1,9 +1,9 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression};
 
 use crate::call_target::resolve_call;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::Binary {
         operator,
         left,
@@ -19,7 +19,8 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         ) && (is_math_nan_call(left.unwrap_parens()) || is_math_nan_call(right.unwrap_parens()))
         {
             let always_true = matches!(operator, NotEqual);
-            sink.push(diagnostics::infer::nan_comparison(span, always_true));
+            ctx.sink
+                .push(diagnostics::infer::nan_comparison(span, always_true));
         }
     }
 }

--- a/crates/semantics/src/passes/checks/newtype.rs
+++ b/crates/semantics/src/passes/checks/newtype.rs
@@ -6,19 +6,21 @@ use diagnostics::LocalSink;
 use syntax::ast::{Expression, Span, UnaryOperator};
 use syntax::types::{Type, unqualified_name};
 
+use crate::passes::walk::NodeCtx;
 use crate::store::Store;
 
-pub(crate) fn check(expression: &Expression, store: &Store, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
     match expression {
         Expression::Assignment { target, span, .. } => {
-            check_newtype_field_assignment(target, *span, store, sink);
+            check_newtype_field_assignment(target, *span, ctx.store, sink);
             if has_map_field_in_chain(target) {
                 sink.push(diagnostics::infer::map_field_chain_assignment(*span));
             }
         }
         Expression::Reference {
             expression, span, ..
-        } if targets_newtype_field(expression, store) => {
+        } if targets_newtype_field(expression, ctx.store) => {
             sink.push(diagnostics::infer::reference_through_newtype(*span));
         }
         _ => {}

--- a/crates/semantics/src/passes/checks/node_walk.rs
+++ b/crates/semantics/src/passes/checks/node_walk.rs
@@ -1,10 +1,6 @@
-use diagnostics::LocalSink;
-use rustc_hash::FxHashMap as HashMap;
-use syntax::ast::{BindingId, Expression};
+use syntax::ast::Expression;
 
-use crate::facts::BindingFact;
-use crate::passes::lints::ast_walk::visitor::visit_ast;
-use crate::store::Store;
+use crate::passes::walk::{NodeCheck, NodeCtx, walk_nodes};
 
 use super::{
     const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop, empty_range,
@@ -12,8 +8,6 @@ use super::{
     oversized_shift, predeclared_shadowing, pub_type_export, receivers, repeated_if_condition,
     stringer_signature, temp_producing, unchanging_loop_condition,
 };
-
-type NodeCheck = fn(&Expression, &LocalSink);
 
 const NODE_CHECKS: &[NodeCheck] = &[
     nan_comparison::check,
@@ -30,28 +24,12 @@ const NODE_CHECKS: &[NodeCheck] = &[
     predeclared_shadowing::check,
     pub_type_export::check,
     temp_producing::check,
+    newtype::check,
+    enum_variant_value::check,
+    unchanging_loop_condition::check,
+    const_naming::check,
 ];
 
-pub(crate) fn run(
-    items: &[Expression],
-    store: &Store,
-    bindings: &HashMap<BindingId, BindingFact>,
-    is_d_lis: bool,
-    sink: &LocalSink,
-) {
-    visit_ast(
-        items,
-        &mut |expression| {
-            for check in NODE_CHECKS {
-                check(expression, sink);
-            }
-            newtype::check(expression, store, sink);
-            enum_variant_value::check(expression, store, sink);
-            unchanging_loop_condition::check(expression, bindings, sink);
-            if !is_d_lis {
-                const_naming::check(expression, sink);
-            }
-        },
-        &mut |_| {},
-    );
+pub(crate) fn run(items: &[Expression], ctx: &NodeCtx) {
+    walk_nodes(items, ctx, NODE_CHECKS, &[]);
 }

--- a/crates/semantics/src/passes/checks/oversized_shift.rs
+++ b/crates/semantics/src/passes/checks/oversized_shift.rs
@@ -1,8 +1,8 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression};
 use syntax::types::SimpleKind;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::Binary {
         operator,
         left,
@@ -19,7 +19,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && let Some(value) = right.as_integer()
         && value >= u64::from(bit_width)
     {
-        sink.push(diagnostics::infer::oversized_shift(
+        ctx.sink.push(diagnostics::infer::oversized_shift(
             span,
             kind.leaf_name(),
             bit_width,

--- a/crates/semantics/src/passes/checks/predeclared_shadowing.rs
+++ b/crates/semantics/src/passes/checks/predeclared_shadowing.rs
@@ -4,14 +4,15 @@
 //! constraints, so a user declaration of the same name shadows the builtin and
 //! the generated Go fails to compile.
 
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Generic};
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
-    check_type_name(expression, sink);
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    check_type_name(expression, ctx.sink);
     for generic in generics_of(expression) {
         if is_reserved(&generic.name) {
-            sink.push(diagnostics::infer::predeclared_type_shadowed(
+            ctx.sink.push(diagnostics::infer::predeclared_type_shadowed(
                 &generic.name,
                 generic.span,
             ));

--- a/crates/semantics/src/passes/checks/pub_type_export.rs
+++ b/crates/semantics/src/passes/checks/pub_type_export.rs
@@ -4,17 +4,17 @@
 //! unexported Go definition while cross-module references reach for the
 //! exported spelling, so downstream packages fail to compile.
 
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Span, Visibility};
 
 use crate::passes::lints::ast_walk::casing::to_pascal_case;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Some((name, name_span, visibility)) = type_declaration(expression)
         && visibility.is_public()
         && !is_exportable(name)
     {
-        sink.push(diagnostics::infer::pub_type_not_exportable(
+        ctx.sink.push(diagnostics::infer::pub_type_not_exportable(
             name,
             &to_pascal_case(name),
             *name_span,

--- a/crates/semantics/src/passes/checks/receivers.rs
+++ b/crates/semantics/src/passes/checks/receivers.rs
@@ -3,11 +3,12 @@
 //! named `self` has the right type. Methods with an unrelated first parameter
 //! are treated as static methods and skipped.
 
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Pattern};
 use syntax::types::Type;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::ImplBlock {
         ty: impl_ty,
         methods,
@@ -15,7 +16,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
     } = expression
     {
         for method in methods {
-            check_method_receiver(method, impl_ty, sink);
+            check_method_receiver(method, impl_ty, ctx.sink);
         }
     }
 }

--- a/crates/semantics/src/passes/checks/repeated_if_condition.rs
+++ b/crates/semantics/src/passes/checks/repeated_if_condition.rs
@@ -1,7 +1,7 @@
-use diagnostics::LocalSink;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::If {
         condition,
         alternative,
@@ -15,7 +15,7 @@ pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
         && is_side_effect_free(next_condition)
         && expressions_equivalent(condition, next_condition)
     {
-        sink.push(diagnostics::infer::repeated_if_condition(
+        ctx.sink.push(diagnostics::infer::repeated_if_condition(
             &next_condition.get_span(),
         ));
     }

--- a/crates/semantics/src/passes/checks/stringer_signature.rs
+++ b/crates/semantics/src/passes/checks/stringer_signature.rs
@@ -4,14 +4,15 @@
 //! emitted Go would have two methods named `String` (or `GoString`) and fail
 //! to compile with "method redeclared".
 
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use syntax::ast::Expression;
 use syntax::types::{SimpleKind, Type};
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::ImplBlock { methods, .. } = expression {
         for method in methods {
-            check_method(method, sink);
+            check_method(method, ctx.sink);
         }
     }
 }

--- a/crates/semantics/src/passes/checks/temp_producing.rs
+++ b/crates/semantics/src/passes/checks/temp_producing.rs
@@ -1,8 +1,10 @@
+use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::program::ReceiverCoercion;
 
-pub(crate) fn check(expression: &Expression, sink: &LocalSink) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
     match expression {
         Expression::Call { args, spread, .. } => {
             for arg in args {

--- a/crates/semantics/src/passes/checks/unchanging_loop_condition.rs
+++ b/crates/semantics/src/passes/checks/unchanging_loop_condition.rs
@@ -1,21 +1,17 @@
-use diagnostics::LocalSink;
 use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{BindingId, Expression, UnaryOperator};
 
 use crate::facts::BindingFact;
+use crate::passes::walk::NodeCtx;
 
-pub(crate) fn check(
-    expression: &Expression,
-    bindings: &HashMap<BindingId, BindingFact>,
-    sink: &LocalSink,
-) {
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     if let Expression::While {
         condition, body, ..
     } = expression
-        && condition_is_unchanging(condition, bindings)
+        && condition_is_unchanging(condition, &ctx.facts.bindings)
         && !body_has_exit(body)
     {
-        sink.push(diagnostics::infer::unchanging_loop_condition(
+        ctx.sink.push(diagnostics::infer::unchanging_loop_condition(
             &condition.get_span(),
         ));
     }

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -1,4 +1,5 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
+use diagnostics::LocalSink;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Attribute, AttributeArg, Expression, StructFieldDefinition};
 
@@ -16,28 +17,29 @@ pub(crate) const SERIALIZATION_KEYS: &[&str] = &[
 /// Recognized attributes that are not serialization keys.
 const OTHER_ATTRIBUTES: &[&str] = &["tag", "allow", "iterate", "display"];
 
-pub fn check_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
     let attributes = match expression {
         Expression::Function { attributes, .. } => attributes,
         _ => return,
     };
 
     for attribute in attributes {
-        check_unknown_attribute(attribute, diagnostics);
+        check_unknown_attribute(attribute, ctx.sink);
     }
 }
 
-pub fn check_enum_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_enum_attributes(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Enum { attributes, .. } = expression else {
         return;
     };
 
     for attribute in attributes {
-        check_unknown_attribute(attribute, diagnostics);
+        check_unknown_attribute(attribute, ctx.sink);
     }
 }
 
-pub fn check_struct_attributes(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_struct_attributes(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
     let Expression::Struct {
         attributes: struct_attributes,
         fields,
@@ -48,9 +50,9 @@ pub fn check_struct_attributes(expression: &Expression, diagnostics: &mut Vec<Li
     };
 
     for attribute in struct_attributes {
-        check_unknown_attribute(attribute, diagnostics);
-        check_unknown_tag_options(attribute, diagnostics);
-        check_conflicting_case_transforms(attribute, diagnostics);
+        check_unknown_attribute(attribute, sink);
+        check_unknown_tag_options(attribute, sink);
+        check_conflicting_case_transforms(attribute, sink);
     }
 
     let struct_keys: HashSet<&str> = struct_attributes
@@ -60,15 +62,15 @@ pub fn check_struct_attributes(expression: &Expression, diagnostics: &mut Vec<Li
         .collect();
 
     for field in fields {
-        check_field_attributes(field, &struct_keys, diagnostics);
+        check_field_attributes(field, &struct_keys, sink);
     }
 }
 
-fn check_unknown_attribute(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn check_unknown_attribute(attribute: &Attribute, sink: &LocalSink) {
     let name = &attribute.name;
 
     if !is_known_attribute(name) {
-        diagnostics.push(diagnostics::lint::unknown_attribute(
+        sink.push(diagnostics::lint::unknown_attribute(
             &attribute.span,
             name,
             &known_attributes(),
@@ -79,21 +81,21 @@ fn check_unknown_attribute(attribute: &Attribute, diagnostics: &mut Vec<LisetteD
 fn check_field_attributes(
     field: &StructFieldDefinition,
     struct_keys: &HashSet<&str>,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
+    sink: &LocalSink,
 ) {
     let mut seen_keys: Vec<(&str, &Attribute)> = Vec::new();
 
     for attribute in &field.attributes {
         let attribute_key = get_attribute_key(attribute);
 
-        check_unknown_attribute(attribute, diagnostics);
-        check_unknown_tag_options(attribute, diagnostics);
+        check_unknown_attribute(attribute, sink);
+        check_unknown_tag_options(attribute, sink);
 
         if let Some(key) = attribute_key
             && is_serialization_key(key)
             && !struct_keys.contains(key)
         {
-            diagnostics.push(
+            sink.push(
                 diagnostics::attribute::field_attribute_without_struct_attribute(
                     &attribute.span,
                     key,
@@ -103,7 +105,7 @@ fn check_field_attributes(
 
         if let Some(key) = attribute_key {
             if let Some((_, first_attribute)) = seen_keys.iter().find(|(k, _)| *k == key) {
-                diagnostics.push(diagnostics::attribute::duplicate_tag_key(
+                sink.push(diagnostics::attribute::duplicate_tag_key(
                     &attribute.span,
                     key,
                     &first_attribute.span,
@@ -114,10 +116,10 @@ fn check_field_attributes(
         }
 
         // Check for conflicting case transforms
-        check_conflicting_case_transforms(attribute, diagnostics);
+        check_conflicting_case_transforms(attribute, sink);
 
         // Check for raw tags that should use predefined aliases
-        check_tag_with_alias(attribute, diagnostics);
+        check_tag_with_alias(attribute, sink);
     }
 }
 
@@ -147,7 +149,7 @@ fn extract_key_from_raw(raw: &str) -> Option<&str> {
 /// Known tag options.
 const KNOWN_TAG_OPTIONS: &[&str] = &["snake_case", "camel_case", "omitempty", "skip", "string"];
 
-fn check_unknown_tag_options(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn check_unknown_tag_options(attribute: &Attribute, sink: &LocalSink) {
     // Only check serialization attributes (json, db, etc.) and structured #[tag("key", ...)]
     let is_serialization = is_serialization_key(&attribute.name);
     let is_structured_tag = attribute.name == "tag"
@@ -173,13 +175,13 @@ fn check_unknown_tag_options(attribute: &Attribute, diagnostics: &mut Vec<Lisett
         match arg {
             AttributeArg::Flag(flag) => {
                 if !KNOWN_TAG_OPTIONS.contains(&flag.as_str()) {
-                    diagnostics.push(diagnostics::lint::unknown_tag_option(&attribute.span, flag));
+                    sink.push(diagnostics::lint::unknown_tag_option(&attribute.span, flag));
                 }
             }
             AttributeArg::NegatedFlag(flag) => {
                 // Only omitempty can be negated
                 if flag != "omitempty" {
-                    diagnostics.push(diagnostics::lint::unknown_tag_option(
+                    sink.push(diagnostics::lint::unknown_tag_option(
                         &attribute.span,
                         &format!("!{}", flag),
                     ));
@@ -191,10 +193,7 @@ fn check_unknown_tag_options(attribute: &Attribute, diagnostics: &mut Vec<Lisett
     }
 }
 
-fn check_conflicting_case_transforms(
-    attribute: &Attribute,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+fn check_conflicting_case_transforms(attribute: &Attribute, sink: &LocalSink) {
     let mut has_snake_case = false;
     let mut has_camel_case = false;
 
@@ -209,14 +208,14 @@ fn check_conflicting_case_transforms(
     }
 
     if has_snake_case && has_camel_case {
-        diagnostics.push(diagnostics::attribute::conflicting_case_transforms(
+        sink.push(diagnostics::attribute::conflicting_case_transforms(
             &attribute.span,
         ));
     }
 }
 
 /// Checks if a #[tag(...)] uses a key that has a predefined alias.
-fn check_tag_with_alias(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn check_tag_with_alias(attribute: &Attribute, sink: &LocalSink) {
     // Only check #[tag(...)] attributes
     if attribute.name != "tag" {
         return;
@@ -233,7 +232,7 @@ fn check_tag_with_alias(attribute: &Attribute, diagnostics: &mut Vec<LisetteDiag
     if let Some(key) = key
         && is_serialization_key(key)
     {
-        diagnostics.push(diagnostics::lint::tag_has_alias(&attribute.span, key));
+        sink.push(diagnostics::lint::tag_has_alias(&attribute.span, key));
     }
 }
 

--- a/crates/semantics/src/passes/lints/ast_walk/checks/bool_literal_comparison.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/bool_literal_comparison.rs
@@ -1,12 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression};
 
 use super::helpers::bool_literal;
 
-pub fn check_bool_literal_comparison(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_bool_literal_comparison(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -49,7 +46,7 @@ pub fn check_bool_literal_comparison(
         other_text
     };
 
-    diagnostics.push(diagnostics::lint::bool_literal_comparison(
+    ctx.sink.push(diagnostics::lint::bool_literal_comparison(
         span,
         &replacement,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/double_negation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/double_negation.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Span, UnaryOperator};
 
-pub fn check_double_negation(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_double_negation(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Unary {
         operator,
         expression: operand,
@@ -36,5 +36,6 @@ pub fn check_double_negation(expression: &Expression, diagnostics: &mut Vec<Lise
     );
 
     let is_bool = *operator == UnaryOperator::Not;
-    diagnostics.push(diagnostics::lint::double_negation(&operators_span, is_bool));
+    ctx.sink
+        .push(diagnostics::lint::double_negation(&operators_span, is_bool));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/dup_arg.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/dup_arg.rs
@@ -1,4 +1,4 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
 use super::helpers::{expressions_equivalent, is_side_effect_free};
@@ -17,7 +17,7 @@ const DUP_ARG_TARGETS: &[(&str, &str, usize, usize)] = &[
     ("go:strings", "ReplaceAll", 1, 2),
 ];
 
-pub fn check_dup_arg(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_dup_arg(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
         expression: callee,
         args,
@@ -55,7 +55,7 @@ pub fn check_dup_arg(expression: &Expression, diagnostics: &mut Vec<LisetteDiagn
         if !expressions_equivalent(arg_a, arg_b) {
             return;
         }
-        diagnostics.push(diagnostics::lint::duplicate_arguments(
+        ctx.sink.push(diagnostics::lint::duplicate_arguments(
             span,
             target_module,
             target_function,

--- a/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_cutset.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_cutset.rs
@@ -1,10 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Literal};
 
 const CUTSET_FUNCTIONS: &[&str] = &["Trim", "TrimLeft", "TrimRight"];
 
-pub fn check_duplicate_cutset(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_duplicate_cutset(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
         expression: callee,
         args,
@@ -41,7 +41,8 @@ pub fn check_duplicate_cutset(expression: &Expression, diagnostics: &mut Vec<Lis
     };
 
     if has_duplicate_char(value) {
-        diagnostics.push(diagnostics::lint::trim_charset_misuse(span, member));
+        ctx.sink
+            .push(diagnostics::lint::trim_charset_misuse(span, member));
     }
 }
 

--- a/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_logical_operand.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/duplicate_logical_operand.rs
@@ -1,15 +1,11 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{BinaryOperator, Expression, Span};
 use syntax::program::File;
 
 use super::helpers::{expressions_equivalent, is_side_effect_free};
 
-pub fn check_duplicate_logical_operand(
-    expression: &Expression,
-    files: &HashMap<u32, File>,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_duplicate_logical_operand(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -38,11 +34,11 @@ pub fn check_duplicate_logical_operand(
         return;
     }
 
-    let Some(operand_text) = source_text(left.get_span(), files) else {
+    let Some(operand_text) = source_text(left.get_span(), ctx.files) else {
         return;
     };
 
-    diagnostics.push(diagnostics::lint::duplicate_logical_operand(
+    ctx.sink.push(diagnostics::lint::duplicate_logical_operand(
         span,
         operand_text,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/empty_match_arm.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/empty_match_arm.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-pub fn check_empty_match_arm(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_empty_match_arm(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match { arms, .. } = expression else {
         return;
     };
@@ -10,7 +10,7 @@ pub fn check_empty_match_arm(expression: &Expression, diagnostics: &mut Vec<Lise
         if let Expression::Block { items, span, .. } = &*arm.expression
             && items.is_empty()
         {
-            diagnostics.push(diagnostics::lint::empty_match_arm(span));
+            ctx.sink.push(diagnostics::lint::empty_match_arm(span));
         }
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-pub fn check_excess_parens_on_condition(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_excess_parens_on_condition(expression: &Expression, ctx: &NodeCtx) {
     let (condition, keyword) = match expression {
         Expression::If { condition, .. } => (condition.as_ref(), "if"),
         Expression::While { condition, .. } => (condition.as_ref(), "while"),
@@ -13,6 +10,7 @@ pub fn check_excess_parens_on_condition(
     };
 
     if let Expression::Paren { span, .. } = condition {
-        diagnostics.push(diagnostics::lint::unnecessary_parens(span, keyword));
+        ctx.sink
+            .push(diagnostics::lint::unnecessary_parens(span, keyword));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/helpers.rs
@@ -1,7 +1,38 @@
-use syntax::ast::{Expression, Literal, Pattern};
+use syntax::ast::{BinaryOperator, Expression, Literal, Pattern};
 use syntax::types::unqualified_name;
 
-use super::super::visitor::visit_ast;
+use crate::passes::walk::visit_ast;
+
+pub(super) fn is_zero_literal(expression: &Expression) -> bool {
+    matches!(
+        expression,
+        Expression::Literal {
+            literal: Literal::Integer { value: 0, .. },
+            ..
+        }
+    )
+}
+
+pub(super) fn is_one_literal(expression: &Expression) -> bool {
+    matches!(
+        expression,
+        Expression::Literal {
+            literal: Literal::Integer { value: 1, .. },
+            ..
+        }
+    )
+}
+
+pub(super) fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
+    use BinaryOperator::*;
+    match operator {
+        LessThan => GreaterThan,
+        GreaterThan => LessThan,
+        LessThanOrEqual => GreaterThanOrEqual,
+        GreaterThanOrEqual => LessThanOrEqual,
+        other => other,
+    }
+}
 
 pub(super) fn bool_literal(expression: &Expression) -> Option<bool> {
     if let Expression::Literal {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/identical_if_branches.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/identical_if_branches.rs
@@ -1,12 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
 use super::helpers::{expressions_equivalent, is_empty_block};
 
-pub fn check_identical_if_branches(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_identical_if_branches(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
         consequence,
         alternative,
@@ -36,5 +33,6 @@ pub fn check_identical_if_branches(
         return;
     }
 
-    diagnostics.push(diagnostics::lint::identical_if_branches(span));
+    ctx.sink
+        .push(diagnostics::lint::identical_if_branches(span));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/identical_match_arms.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/identical_match_arms.rs
@@ -1,14 +1,11 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression, MatchOrigin, Span};
 
 use crate::checker::infer::expressions::patterns::collect_pattern_bindings;
 
 use super::helpers::{expressions_equivalent, is_empty_block};
 
-pub fn check_identical_match_arms(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_identical_match_arms(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         subject,
         arms,
@@ -55,7 +52,8 @@ pub fn check_identical_match_arms(
     }
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::identical_match_arms(&match_keyword_span));
+    ctx.sink
+        .push(diagnostics::lint::identical_match_arms(&match_keyword_span));
 }
 
 fn is_safe_to_drop(expression: &Expression) -> bool {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/invisible_in_string.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/invisible_in_string.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, FormatStringPart, Literal, Pattern};
 
-pub fn check_invisible_in_string_expression(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_invisible_in_string_expression(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Literal { literal, span, .. } = expression else {
         return;
     };
@@ -17,16 +14,13 @@ pub fn check_invisible_in_string_expression(
         _ => None,
     };
     if let Some((codepoint, name, is_bidi)) = found {
-        diagnostics.push(diagnostics::lint::invisible_in_string(
+        ctx.sink.push(diagnostics::lint::invisible_in_string(
             span, codepoint, name, is_bidi,
         ));
     }
 }
 
-pub fn check_invisible_in_string_pattern(
-    pattern: &Pattern,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_invisible_in_string_pattern(pattern: &Pattern, ctx: &NodeCtx) {
     let Pattern::Literal {
         literal: Literal::String { value, .. },
         span,
@@ -36,7 +30,7 @@ pub fn check_invisible_in_string_pattern(
         return;
     };
     if let Some((codepoint, name, is_bidi)) = first_invisible(value) {
-        diagnostics.push(diagnostics::lint::invisible_in_string(
+        ctx.sink.push(diagnostics::lint::invisible_in_string(
             span, codepoint, name, is_bidi,
         ));
     }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/let_and_return.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/let_and_return.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Pattern};
 
-pub fn check_let_and_return(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Block { items, .. } = expression else {
         return;
     };
@@ -39,5 +39,5 @@ pub fn check_let_and_return(expression: &Expression, diagnostics: &mut Vec<Liset
         return;
     }
 
-    diagnostics.push(diagnostics::lint::let_and_return(span));
+    ctx.sink.push(diagnostics::lint::let_and_return(span));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/loop_runs_once.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/loop_runs_once.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Span};
 
-pub fn check_loop_runs_once(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_loop_runs_once(expression: &Expression, ctx: &NodeCtx) {
     let (body, span, keyword_len) = match expression {
         Expression::Loop { body, span, .. } => (body.as_ref(), span, 4),
         Expression::While { body, span, .. } | Expression::WhileLet { body, span, .. } => {
@@ -13,7 +13,7 @@ pub fn check_loop_runs_once(expression: &Expression, diagnostics: &mut Vec<Liset
 
     if always_exits(body) && !reenters_loop(body) {
         let keyword = Span::new(span.file_id, span.byte_offset, keyword_len);
-        diagnostics.push(diagnostics::lint::loop_runs_once(&keyword));
+        ctx.sink.push(diagnostics::lint::loop_runs_once(&keyword));
     }
 }
 

--- a/crates/semantics/src/passes/lints/ast_walk/checks/lost_query_mutation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/lost_query_mutation.rs
@@ -1,15 +1,10 @@
-use diagnostics::LisetteDiagnostic;
 use syntax::ast::Expression;
 
-use crate::store::Store;
+use crate::passes::walk::NodeCtx;
 
 const MUTATING_METHODS: &[&str] = &["Set", "Add", "Del"];
 
-pub fn check_lost_query_mutation(
-    expression: &Expression,
-    store: &Store,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_lost_query_mutation(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
         expression: callee,
         span,
@@ -53,10 +48,11 @@ pub fn check_lost_query_mutation(
         return;
     }
 
-    let receiver_ty = store.peel_alias(&url.get_type().strip_refs());
+    let receiver_ty = ctx.store.peel_alias(&url.get_type().strip_refs());
     if receiver_ty.strip_refs().get_qualified_id() != Some("go:net/url.URL") {
         return;
     }
 
-    diagnostics.push(diagnostics::lint::lost_query_mutation(span, member));
+    ctx.sink
+        .push(diagnostics::lint::lost_query_mutation(span, member));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
@@ -1,12 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
 use super::helpers::{expressions_equivalent, is_side_effect_free};
 
-pub fn check_manual_compound_assignment(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_manual_compound_assignment(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Assignment {
         target,
         value,
@@ -29,5 +26,6 @@ pub fn check_manual_compound_assignment(
         return;
     }
 
-    diagnostics.push(diagnostics::lint::manual_compound_assignment(span, symbol));
+    ctx.sink
+        .push(diagnostics::lint::manual_compound_assignment(span, symbol));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/manual_is_empty.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/manual_is_empty.rs
@@ -1,8 +1,10 @@
-use diagnostics::LisetteDiagnostic;
-use syntax::ast::{BinaryOperator, Expression, Literal};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
 use syntax::types::{CompoundKind, Type};
 
-pub fn check_manual_is_empty(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+use super::helpers::{flip_comparison, is_zero_literal};
+
+pub fn check_manual_is_empty(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -53,7 +55,8 @@ pub fn check_manual_is_empty(expression: &Expression, diagnostics: &mut Vec<Lise
         format!("{receiver_text}.is_empty()")
     };
 
-    diagnostics.push(diagnostics::lint::manual_is_empty(span, &replacement));
+    ctx.sink
+        .push(diagnostics::lint::manual_is_empty(span, &replacement));
 }
 
 fn length_call_receiver(expression: &Expression) -> Option<&Expression> {
@@ -89,25 +92,4 @@ fn type_has_is_empty(ty: &Type) -> bool {
         || ty.is_channel()
         || ty.is_native(CompoundKind::Sender)
         || ty.is_receiver()
-}
-
-fn is_zero_literal(expression: &Expression) -> bool {
-    matches!(
-        expression,
-        Expression::Literal {
-            literal: Literal::Integer { value: 0, .. },
-            ..
-        }
-    )
-}
-
-fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
-    use BinaryOperator::*;
-    match operator {
-        LessThan => GreaterThan,
-        GreaterThan => LessThan,
-        LessThanOrEqual => GreaterThanOrEqual,
-        GreaterThanOrEqual => LessThanOrEqual,
-        other => other,
-    }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/manual_map.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/manual_map.rs
@@ -1,10 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
 use syntax::types::unqualified_name;
 
 use super::helpers::{enum_variant_binding, has_escaping_control_flow};
 
-pub fn check_manual_map(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_manual_map(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         subject,
         arms,
@@ -42,7 +42,8 @@ pub fn check_manual_map(expression: &Expression, diagnostics: &mut Vec<LisetteDi
     }
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::manual_map(&match_keyword_span));
+    ctx.sink
+        .push(diagnostics::lint::manual_map(&match_keyword_span));
 }
 
 fn check_option_map(arm_a: &MatchArm, arm_b: &MatchArm) -> bool {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/manual_unwrap_or.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/manual_unwrap_or.rs
@@ -1,10 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
 use syntax::types::unqualified_name;
 
 use super::helpers::{has_escaping_control_flow, is_side_effect_free};
 
-pub fn check_manual_unwrap_or(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_manual_unwrap_or(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         subject,
         arms,
@@ -55,7 +55,7 @@ pub fn check_manual_unwrap_or(expression: &Expression, diagnostics: &mut Vec<Lis
     }
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::manual_unwrap_or(
+    ctx.sink.push(diagnostics::lint::manual_unwrap_or(
         &match_keyword_span,
         default_has_effects,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/match_literal_collection.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/match_literal_collection.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Literal};
 
-pub fn check_match_literal_collection(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_match_literal_collection(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match { subject, .. } = expression else {
         return;
     };
@@ -26,6 +23,6 @@ pub fn check_match_literal_collection(
     };
 
     if let Some(span) = span {
-        diagnostics.push(diagnostics::lint::match_on_literal(span));
+        ctx.sink.push(diagnostics::lint::match_on_literal(span));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/match_on_bool.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/match_on_bool.rs
@@ -1,9 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Literal, MatchOrigin, Pattern, Span};
 
 use super::helpers::expressions_equivalent;
 
-pub fn check_match_on_bool(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_match_on_bool(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         arms,
         origin: MatchOrigin::Explicit,
@@ -37,7 +37,8 @@ pub fn check_match_on_bool(expression: &Expression, diagnostics: &mut Vec<Lisett
     }
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::match_on_bool(&match_keyword_span));
+    ctx.sink
+        .push(diagnostics::lint::match_on_bool(&match_keyword_span));
 }
 
 fn bool_pattern(pattern: &Pattern) -> Option<bool> {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/match_single_binding.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/match_single_binding.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchOrigin, Pattern, Span};
 
-pub fn check_match_single_binding(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_match_single_binding(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         arms,
         origin: MatchOrigin::Explicit,
@@ -28,7 +25,7 @@ pub fn check_match_single_binding(
     };
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::match_single_binding(
+    ctx.sink.push(diagnostics::lint::match_single_binding(
         &match_keyword_span,
         identifier,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/naming.rs
@@ -1,13 +1,12 @@
-use diagnostics::LisetteDiagnostic;
+use diagnostics::LocalSink;
 use syntax::ast::{Expression, Generic, Pattern, Span};
 
 use crate::passes::lints::ast_walk::casing::{is_snake_case, to_pascal_case, to_snake_case};
+use crate::passes::walk::NodeCtx;
 
-pub fn check_expression_naming(
-    expression: &Expression,
-    is_d_lis: bool,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
+    let sink = ctx.sink;
+    let is_d_lis = ctx.is_d_lis;
     match expression {
         Expression::Struct {
             name,
@@ -18,11 +17,11 @@ pub fn check_expression_naming(
             ..
         } => {
             if !visibility.is_public() {
-                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+                check_pascal_case(name, name_span, "non_pascal_case_type", sink);
             }
 
             for generic in generics {
-                check_type_parameter(generic, diagnostics);
+                check_type_parameter(generic, sink);
             }
 
             if !is_d_lis {
@@ -31,7 +30,7 @@ pub fn check_expression_naming(
                         &field.name,
                         &field.name_span,
                         "non_snake_case_struct_field",
-                        diagnostics,
+                        sink,
                     );
                 }
             }
@@ -46,11 +45,11 @@ pub fn check_expression_naming(
             ..
         } => {
             if !visibility.is_public() {
-                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+                check_pascal_case(name, name_span, "non_pascal_case_type", sink);
             }
 
             for generic in generics {
-                check_type_parameter(generic, diagnostics);
+                check_type_parameter(generic, sink);
             }
 
             for variant in variants {
@@ -58,7 +57,7 @@ pub fn check_expression_naming(
                     &variant.name,
                     &variant.name_span,
                     "non_pascal_case_enum_variant",
-                    diagnostics,
+                    sink,
                 );
             }
         }
@@ -71,11 +70,11 @@ pub fn check_expression_naming(
             ..
         } => {
             if !visibility.is_public() {
-                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+                check_pascal_case(name, name_span, "non_pascal_case_type", sink);
             }
 
             for generic in generics {
-                check_type_parameter(generic, diagnostics);
+                check_type_parameter(generic, sink);
             }
         }
 
@@ -87,11 +86,11 @@ pub fn check_expression_naming(
             ..
         } => {
             if !visibility.is_public() {
-                check_pascal_case(name, name_span, "non_pascal_case_type", diagnostics);
+                check_pascal_case(name, name_span, "non_pascal_case_type", sink);
             }
 
             for generic in generics {
-                check_type_parameter(generic, diagnostics);
+                check_type_parameter(generic, sink);
             }
         }
 
@@ -107,18 +106,18 @@ pub fn check_expression_naming(
                     matches!(&p.pattern, Pattern::Identifier { identifier, .. } if identifier == "self")
                 });
                 if !is_method {
-                    check_snake_case(name, name_span, "non_snake_case_function", diagnostics);
+                    check_snake_case(name, name_span, "non_snake_case_function", sink);
                 }
             }
 
             for generic in generics {
-                check_type_parameter(generic, diagnostics);
+                check_type_parameter(generic, sink);
             }
 
             if !is_d_lis {
                 for param in params {
                     if let Pattern::Identifier { identifier, span } = &param.pattern {
-                        check_snake_case(identifier, span, "non_snake_case_parameter", diagnostics);
+                        check_snake_case(identifier, span, "non_snake_case_parameter", sink);
                     }
                 }
             }
@@ -128,41 +127,32 @@ pub fn check_expression_naming(
     }
 }
 
-pub fn check_pattern_naming(
-    pattern: &Pattern,
-    is_d_lis: bool,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
-    if is_d_lis {
+pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
+    if ctx.is_d_lis {
         return;
     }
     if let Pattern::Identifier { identifier, span } = pattern {
-        check_snake_case(identifier, span, "non_snake_case_variable", diagnostics);
+        check_snake_case(identifier, span, "non_snake_case_variable", ctx.sink);
     }
 }
 
-fn check_type_parameter(generic: &Generic, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn check_type_parameter(generic: &Generic, sink: &LocalSink) {
     check_pascal_case(
         &generic.name,
         &generic.span,
         "non_pascal_case_type_parameter",
-        diagnostics,
+        sink,
     );
 }
 
-fn check_pascal_case(
-    name: &str,
-    span: &Span,
-    code: &str,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+fn check_pascal_case(name: &str, span: &Span, code: &str, sink: &LocalSink) {
     if name.starts_with('_') {
         return;
     }
 
     let first_char = name.chars().next().unwrap_or('A');
     if !first_char.is_uppercase() {
-        diagnostics.push(diagnostics::lint::miscased_pascal(
+        sink.push(diagnostics::lint::miscased_pascal(
             span,
             code,
             &to_pascal_case(name),
@@ -170,12 +160,12 @@ fn check_pascal_case(
     }
 }
 
-fn check_snake_case(name: &str, span: &Span, code: &str, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn check_snake_case(name: &str, span: &Span, code: &str, sink: &LocalSink) {
     if name.starts_with('_') || is_snake_case(name) {
         return;
     }
 
-    diagnostics.push(diagnostics::lint::miscased_snake(
+    sink.push(diagnostics::lint::miscased_snake(
         span,
         code,
         &to_snake_case(name),

--- a/crates/semantics/src/passes/lints/ast_walk/checks/negated_equality.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/negated_equality.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
 
-pub fn check_negated_equality(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_negated_equality(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Unary {
         operator: UnaryOperator::Not,
         expression: operand,
@@ -22,5 +22,6 @@ pub fn check_negated_equality(expression: &Expression, diagnostics: &mut Vec<Lis
         _ => return,
     };
 
-    diagnostics.push(diagnostics::lint::negated_equality(span, is_equal));
+    ctx.sink
+        .push(diagnostics::lint::negated_equality(span, is_equal));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/non_negative_comparison.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/non_negative_comparison.rs
@@ -1,11 +1,11 @@
-use diagnostics::LisetteDiagnostic;
-use syntax::ast::{BinaryOperator, Expression, Literal};
+use syntax::ast::{BinaryOperator, Expression};
 use syntax::program::CallKind;
 
-pub fn check_non_negative_comparison(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+use crate::passes::walk::NodeCtx;
+
+use super::helpers::{flip_comparison, is_zero_literal};
+
+pub fn check_non_negative_comparison(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -40,7 +40,7 @@ pub fn check_non_negative_comparison(
         _ => return,
     };
 
-    diagnostics.push(diagnostics::lint::non_negative_comparison(
+    ctx.sink.push(diagnostics::lint::non_negative_comparison(
         span,
         always_true,
     ));
@@ -73,26 +73,5 @@ fn native_method_name(callee: &Expression) -> Option<&str> {
             Some(value.split_once('.').map_or(value, |(_, m)| m))
         }
         _ => None,
-    }
-}
-
-fn is_zero_literal(expression: &Expression) -> bool {
-    matches!(
-        expression,
-        Expression::Literal {
-            literal: Literal::Integer { value: 0, .. },
-            ..
-        }
-    )
-}
-
-fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
-    use BinaryOperator::*;
-    match operator {
-        LessThan => GreaterThan,
-        GreaterThan => LessThan,
-        LessThanOrEqual => GreaterThanOrEqual,
-        GreaterThanOrEqual => LessThanOrEqual,
-        other => other,
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/redundant_closure.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/redundant_closure.rs
@@ -1,14 +1,10 @@
-use diagnostics::LisetteDiagnostic;
 use syntax::ast::{Expression, Pattern};
 use syntax::program::{CallKind, DotAccessKind};
 
 use crate::facts::Facts;
+use crate::passes::walk::NodeCtx;
 
-pub fn check_redundant_closure(
-    expression: &Expression,
-    facts: &Facts,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Lambda {
         params, body, span, ..
     } = expression
@@ -50,11 +46,13 @@ pub fn check_redundant_closure(
         param_names.push(identifier.as_str());
     }
 
-    let Some(callee_name) = hoistable_callee(callee.unwrap_parens(), &param_names, facts) else {
+    let Some(callee_name) = hoistable_callee(callee.unwrap_parens(), &param_names, ctx.facts)
+    else {
         return;
     };
 
-    diagnostics.push(diagnostics::lint::redundant_closure(span, &callee_name));
+    ctx.sink
+        .push(diagnostics::lint::redundant_closure(span, &callee_name));
 }
 
 fn lambda_body(body: &Expression) -> &Expression {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/redundant_operation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/redundant_operation.rs
@@ -1,8 +1,8 @@
-use diagnostics::LisetteDiagnostic;
-use syntax::ast::{BinaryOperator, Expression, Literal};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
 use syntax::types::Type;
 
-use super::helpers::{bool_literal, is_side_effect_free};
+use super::helpers::{bool_literal, is_one_literal, is_side_effect_free, is_zero_literal};
 
 enum Outcome {
     /// The operation returns its other operand unchanged (`x + 0`, `x && true`).
@@ -11,10 +11,7 @@ enum Outcome {
     Constant(&'static str),
 }
 
-pub fn check_redundant_operation(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_redundant_operation(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -37,9 +34,11 @@ pub fn check_redundant_operation(
         if !is_side_effect_free(other) {
             return;
         }
-        diagnostics.push(diagnostics::lint::redundant_operation(span, Some(value)));
+        ctx.sink
+            .push(diagnostics::lint::redundant_operation(span, Some(value)));
     } else {
-        diagnostics.push(diagnostics::lint::redundant_operation(span, None));
+        ctx.sink
+            .push(diagnostics::lint::redundant_operation(span, None));
     }
 }
 
@@ -56,70 +55,70 @@ fn classify<'a>(
 
     let (other, outcome) = match operator {
         Addition => {
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Identity)
-            } else if int_zero(left) {
+            } else if is_zero_literal(left) {
                 (right, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Subtraction => {
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Multiplication => {
-            if int_one(right) {
+            if is_one_literal(right) {
                 (left, Outcome::Identity)
-            } else if int_one(left) {
+            } else if is_one_literal(left) {
                 (right, Outcome::Identity)
-            } else if int_zero(right) {
+            } else if is_zero_literal(right) {
                 (left, Outcome::Constant("0"))
-            } else if int_zero(left) {
+            } else if is_zero_literal(left) {
                 (right, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         Division => {
-            if int_one(right) {
+            if is_one_literal(right) {
                 (left, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Remainder => {
-            if int_one(right) {
+            if is_one_literal(right) {
                 (left, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         BitwiseOr | BitwiseXor => {
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Identity)
-            } else if int_zero(left) {
+            } else if is_zero_literal(left) {
                 (right, Outcome::Identity)
             } else {
                 return None;
             }
         }
         BitwiseAnd => {
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Constant("0"))
-            } else if int_zero(left) {
+            } else if is_zero_literal(left) {
                 (right, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         BitwiseAndNot => {
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Identity)
-            } else if int_zero(left) {
+            } else if is_zero_literal(left) {
                 (right, Outcome::Constant("0"))
             } else {
                 return None;
@@ -128,7 +127,7 @@ fn classify<'a>(
         ShiftLeft | ShiftRight => {
             // `0 << n` is not folded to `0`: a negative `n` panics at runtime,
             // so the result is not unconditionally `0`.
-            if int_zero(right) {
+            if is_zero_literal(right) {
                 (left, Outcome::Identity)
             } else {
                 return None;
@@ -175,24 +174,4 @@ fn boolean_outcome(other: &Expression, literal: bool, is_and: bool) -> (&Express
 fn is_integer(ty: &Type) -> bool {
     ty.as_simple()
         .is_some_and(|kind| kind.is_signed_int() || kind.is_unsigned_int())
-}
-
-fn int_zero(expression: &Expression) -> bool {
-    matches!(
-        expression,
-        Expression::Literal {
-            literal: Literal::Integer { value: 0, .. },
-            ..
-        }
-    )
-}
-
-fn int_one(expression: &Expression) -> bool {
-    matches!(
-        expression,
-        Expression::Literal {
-            literal: Literal::Integer { value: 1, .. },
-            ..
-        }
-    )
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
@@ -1,13 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
 use syntax::types::unqualified_name;
 
 use super::helpers::bool_literal;
 
-pub fn check_redundant_pattern_matching(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_redundant_pattern_matching(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         subject,
         arms,
@@ -59,7 +56,7 @@ pub fn check_redundant_pattern_matching(
     };
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    diagnostics.push(diagnostics::lint::redundant_pattern_matching(
+    ctx.sink.push(diagnostics::lint::redundant_pattern_matching(
         &match_keyword_span,
         predicate,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/replaceable_with_zero_fill.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/replaceable_with_zero_fill.rs
@@ -1,21 +1,15 @@
-use diagnostics::LisetteDiagnostic;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Literal, Span, StructFieldAssignment, StructSpread};
 use syntax::program::DefinitionBody;
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
 use crate::checker::infer::expressions::struct_call::has_zero;
+use crate::passes::walk::NodeCtx;
 use crate::store::Store;
 
 const ZERO_FIELD_THRESHOLD: usize = 3;
 
-pub fn check_replaceable_with_zero_fill(
-    expression: &Expression,
-    store: &Store,
-    module_id: &str,
-    source: &str,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_replaceable_with_zero_fill(expression: &Expression, ctx: &NodeCtx) {
     let Expression::StructCall {
         name,
         field_assignments,
@@ -39,19 +33,19 @@ pub fn check_replaceable_with_zero_fill(
         return;
     }
 
-    let Some(unspecified) = unspecified_fields(store, ty, name, field_assignments) else {
+    let Some(unspecified) = unspecified_fields(ctx.store, ty, name, field_assignments) else {
         return;
     };
     if !unspecified.is_empty() {
         return;
     }
-    if !rewrite_would_typecheck(store, ty, name, field_assignments, module_id) {
+    if !rewrite_would_typecheck(ctx.store, ty, name, field_assignments, ctx.module_id) {
         return;
     }
 
-    let kept = render_kept_fields(source, field_assignments);
+    let kept = render_kept_fields(ctx.source, field_assignments);
     let owner_span = Span::new(span.file_id, span.byte_offset, name.len() as u32);
-    diagnostics.push(diagnostics::lint::replaceable_with_zero_fill(
+    ctx.sink.push(diagnostics::lint::replaceable_with_zero_fill(
         &owner_span,
         &kept,
         name,

--- a/crates/semantics/src/passes/lints/ast_walk/checks/rest_only_slice_pattern.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/rest_only_slice_pattern.rs
@@ -1,10 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Pattern, RestPattern};
 
-pub fn check_rest_only_slice_pattern(pattern: &Pattern, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_rest_only_slice_pattern(pattern: &Pattern, ctx: &NodeCtx) {
     if let Pattern::Or { patterns, .. } = pattern {
         for p in patterns {
-            check_rest_only_slice_pattern(p, diagnostics);
+            check_rest_only_slice_pattern(p, ctx);
         }
         return;
     }
@@ -22,6 +22,7 @@ pub fn check_rest_only_slice_pattern(pattern: &Pattern, diagnostics: &mut Vec<Li
             _ => "Use `let _` instead".to_string(),
         };
 
-        diagnostics.push(diagnostics::lint::rest_only_slice_pattern(span, help));
+        ctx.sink
+            .push(diagnostics::lint::rest_only_slice_pattern(span, help));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/self_assignment.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/self_assignment.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-pub fn check_self_assignment(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_self_assignment(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Assignment {
         target,
         value,
@@ -28,5 +28,5 @@ pub fn check_self_assignment(expression: &Expression, diagnostics: &mut Vec<Lise
         return;
     }
 
-    diagnostics.push(diagnostics::lint::self_assignment(span));
+    ctx.sink.push(diagnostics::lint::self_assignment(span));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/self_comparison.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/self_comparison.rs
@@ -1,7 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression};
 
-pub fn check_self_comparison(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_self_comparison(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -43,7 +43,7 @@ pub fn check_self_comparison(expression: &Expression, diagnostics: &mut Vec<Lise
     }
 
     let always_true = matches!(operator, Equal | LessThanOrEqual | GreaterThanOrEqual);
-    diagnostics.push(diagnostics::lint::tautological_comparison(
+    ctx.sink.push(diagnostics::lint::tautological_comparison(
         span,
         always_true,
     ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/single_arm_match.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/single_arm_match.rs
@@ -1,10 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchOrigin, Pattern, Span};
 use syntax::types::unqualified_name;
 
 use crate::is_trivial_expression;
 
-pub fn check_single_arm_match(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_single_arm_match(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         arms, origin, span, ..
     } = expression
@@ -40,7 +40,7 @@ pub fn check_single_arm_match(expression: &Expression, diagnostics: &mut Vec<Lis
         let pattern_string = pattern_to_suggestion(&first.pattern);
         let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
 
-        diagnostics.push(diagnostics::lint::single_arm_match(
+        ctx.sink.push(diagnostics::lint::single_arm_match(
             &match_keyword_span,
             &pattern_string,
         ));

--- a/crates/semantics/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, FormatStringPart, Literal};
 
-pub fn check_uninterpolated_fstring(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_uninterpolated_fstring(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Literal {
         literal: Literal::FormatString(parts),
         span,
@@ -19,6 +16,7 @@ pub fn check_uninterpolated_fstring(
         .any(|p| matches!(p, FormatStringPart::Expression(_)));
 
     if !has_interpolation {
-        diagnostics.push(diagnostics::lint::uninterpolated_fstring(span));
+        ctx.sink
+            .push(diagnostics::lint::uninterpolated_fstring(span));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
@@ -1,9 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
 use super::helpers::bool_literal;
 
-pub fn check_unnecessary_bool(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
         consequence,
         alternative,
@@ -26,7 +26,8 @@ pub fn check_unnecessary_bool(expression: &Expression, diagnostics: &mut Vec<Lis
         return;
     }
 
-    diagnostics.push(diagnostics::lint::unnecessary_bool(span, then_value));
+    ctx.sink
+        .push(diagnostics::lint::unnecessary_bool(span, then_value));
 }
 
 fn block_single_bool(expression: &Expression) -> Option<bool> {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_range_loop.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_range_loop.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{BindingId, Expression};
 
-pub fn check_unnecessary_range_loop(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_unnecessary_range_loop(expression: &Expression, ctx: &NodeCtx) {
     let Expression::For {
         iterable,
         body,
@@ -40,7 +37,8 @@ pub fn check_unnecessary_range_loop(
     walk.visit(body);
 
     if walk.found && !walk.blocked {
-        diagnostics.push(diagnostics::lint::unnecessary_range_loop(span, collection));
+        ctx.sink
+            .push(diagnostics::lint::unnecessary_range_loop(span, collection));
     }
 }
 

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_raw_string.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_raw_string.rs
@@ -1,10 +1,7 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, Literal, Pattern};
 
-pub fn check_unnecessary_raw_string_expression(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_unnecessary_raw_string_expression(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Literal {
         literal: Literal::String { value, raw: true },
         span,
@@ -14,14 +11,12 @@ pub fn check_unnecessary_raw_string_expression(
         return;
     };
     if !value.contains('\\') {
-        diagnostics.push(diagnostics::lint::unnecessary_raw_string(span));
+        ctx.sink
+            .push(diagnostics::lint::unnecessary_raw_string(span));
     }
 }
 
-pub fn check_unnecessary_raw_string_pattern(
-    pattern: &Pattern,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_unnecessary_raw_string_pattern(pattern: &Pattern, ctx: &NodeCtx) {
     let Pattern::Literal {
         literal: Literal::String { value, raw: true },
         span,
@@ -31,6 +26,7 @@ pub fn check_unnecessary_raw_string_pattern(
         return;
     };
     if !value.contains('\\') {
-        diagnostics.push(diagnostics::lint::unnecessary_raw_string(span));
+        ctx.sink
+            .push(diagnostics::lint::unnecessary_raw_string(span));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_return.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_return.rs
@@ -1,17 +1,18 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
+use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
-pub fn check_unnecessary_return(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+pub fn check_unnecessary_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Function { body, .. } = expression else {
         return;
     };
 
-    flag_tail_returns(body, diagnostics);
+    flag_tail_returns(body, ctx.sink);
 }
 
 /// Flag a `return <value>` sitting in tail position, where the value is what
 /// the surrounding block yields anyway.
-fn flag_tail_returns(expression: &Expression, diagnostics: &mut Vec<LisetteDiagnostic>) {
+fn flag_tail_returns(expression: &Expression, sink: &LocalSink) {
     match expression {
         Expression::Return {
             expression: value,
@@ -21,12 +22,12 @@ fn flag_tail_returns(expression: &Expression, diagnostics: &mut Vec<LisetteDiagn
             // Bare `return` is excluded: dropping it can change the block's
             // type when a preceding statement is non-unit.
             if !matches!(value.as_ref(), Expression::Unit { .. }) {
-                diagnostics.push(diagnostics::lint::unnecessary_return(span));
+                sink.push(diagnostics::lint::unnecessary_return(span));
             }
         }
         Expression::Block { items, .. } => {
             if let Some(last) = items.last() {
-                flag_tail_returns(last, diagnostics);
+                flag_tail_returns(last, sink);
             }
         }
         Expression::If {
@@ -39,12 +40,12 @@ fn flag_tail_returns(expression: &Expression, diagnostics: &mut Vec<LisetteDiagn
             alternative,
             ..
         } => {
-            flag_tail_returns(consequence, diagnostics);
-            flag_tail_returns(alternative, diagnostics);
+            flag_tail_returns(consequence, sink);
+            flag_tail_returns(alternative, sink);
         }
         Expression::Match { arms, .. } => {
             for arm in arms {
-                flag_tail_returns(&arm.expression, diagnostics);
+                flag_tail_returns(&arm.expression, sink);
             }
         }
         _ => {}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unsigned_comparison.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unsigned_comparison.rs
@@ -1,10 +1,9 @@
-use diagnostics::LisetteDiagnostic;
-use syntax::ast::{BinaryOperator, Expression, Literal};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
 
-pub fn check_unsigned_comparison(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+use super::helpers::{flip_comparison, is_zero_literal};
+
+pub fn check_unsigned_comparison(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
         operator,
         left,
@@ -39,26 +38,6 @@ pub fn check_unsigned_comparison(
         _ => return,
     };
 
-    diagnostics.push(diagnostics::lint::unsigned_comparison(span, always_true));
-}
-
-fn is_zero_literal(expression: &Expression) -> bool {
-    matches!(
-        expression,
-        Expression::Literal {
-            literal: Literal::Integer { value: 0, .. },
-            ..
-        }
-    )
-}
-
-fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
-    use BinaryOperator::*;
-    match operator {
-        LessThan => GreaterThan,
-        LessThanOrEqual => GreaterThanOrEqual,
-        GreaterThan => LessThan,
-        GreaterThanOrEqual => LessThanOrEqual,
-        other => other,
-    }
+    ctx.sink
+        .push(diagnostics::lint::unsigned_comparison(span, always_true));
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/verbose_failure_propagation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/verbose_failure_propagation.rs
@@ -1,13 +1,10 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use syntax::ast::{Expression, MatchArm, MatchOrigin, Pattern, Span};
 use syntax::types::unqualified_name;
 
 use super::helpers::enum_variant_binding;
 
-pub fn check_verbose_failure_propagation(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_verbose_failure_propagation(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
         subject,
         arms,
@@ -38,9 +35,10 @@ pub fn check_verbose_failure_propagation(
             MatchOrigin::IfLet { .. } => 2,
         };
         let keyword_span = Span::new(span.file_id, span.byte_offset, keyword_len);
-        diagnostics.push(diagnostics::lint::verbose_failure_propagation(
-            &keyword_span,
-        ));
+        ctx.sink
+            .push(diagnostics::lint::verbose_failure_propagation(
+                &keyword_span,
+            ));
     }
 }
 

--- a/crates/semantics/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
@@ -1,12 +1,9 @@
-use diagnostics::LisetteDiagnostic;
+use crate::passes::walk::NodeCtx;
 use rustc_hash::FxHashSet;
 use syntax::ast::{BindingId, Expression, Literal, Span, UnaryOperator};
 use syntax::types::Type;
 
-pub fn check_waitgroup_add_in_task(
-    expression: &Expression,
-    diagnostics: &mut Vec<LisetteDiagnostic>,
-) {
+pub fn check_waitgroup_add_in_task(expression: &Expression, ctx: &NodeCtx) {
     let body = match expression {
         Expression::Function { body, .. } | Expression::Lambda { body, .. } => body,
         _ => return,
@@ -18,7 +15,8 @@ pub fn check_waitgroup_add_in_task(
 
     for (binding, span) in adds {
         if waited.contains(&binding) {
-            diagnostics.push(diagnostics::lint::waitgroup_add_in_task(&span));
+            ctx.sink
+                .push(diagnostics::lint::waitgroup_add_in_task(&span));
         }
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -1,75 +1,15 @@
 pub(crate) mod attributes;
 pub(crate) mod casing;
 mod checks;
-pub(crate) mod visitor;
-
-use std::cell::RefCell;
 
 use crate::context::AnalysisContext;
 use crate::facts::Facts;
 use crate::passes::PARALLEL_THRESHOLD;
+use crate::passes::walk::{NodeCheck, NodeCtx, PatternCheck, walk_nodes};
 use crate::store::Store;
-use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use rayon::prelude::*;
-use rustc_hash::FxHashMap as HashMap;
-use syntax::ast::{Expression, Pattern};
-use syntax::program::{File, Module};
-
-pub struct LintContext<'a> {
-    pub ast: &'a [Expression],
-    pub source: &'a str,
-    pub is_d_lis: bool,
-    pub files: &'a HashMap<u32, File>,
-    pub module_id: &'a str,
-    pub store: &'a Store,
-    pub facts: &'a Facts,
-}
-
-pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts, sink: &LocalSink) {
-    let store = analysis.store;
-
-    let mut modules: Vec<&Module> = store
-        .modules
-        .values()
-        .filter(|m| !m.is_internal())
-        .collect();
-    modules.sort_unstable_by(|a, b| a.id.cmp(&b.id));
-
-    if modules.len() < PARALLEL_THRESHOLD {
-        for module in &modules {
-            run_module(module, store, facts, sink);
-        }
-        return;
-    }
-
-    let worker_sinks: Vec<LocalSink> = modules
-        .par_iter()
-        .map(|module| {
-            let local_sink = LocalSink::new();
-            run_module(module, store, facts, &local_sink);
-            local_sink
-        })
-        .collect();
-    sink.extend(LocalSink::merge(worker_sinks));
-}
-
-fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
-    for file in module.files.values() {
-        let ctx = LintContext {
-            ast: &file.items,
-            source: &file.source,
-            is_d_lis: file.is_d_lis(),
-            files: &module.files,
-            module_id: &module.id,
-            store,
-            facts,
-        };
-        let mut diagnostics = AstLintGroup.check(&ctx);
-        diagnostics.sort_by(LisetteDiagnostic::sort_key);
-        sink.extend(diagnostics);
-    }
-}
+use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
@@ -88,12 +28,8 @@ use checks::{
     check_unnecessary_raw_string_pattern, check_unnecessary_return, check_unsigned_comparison,
     check_verbose_failure_propagation, check_waitgroup_add_in_task,
 };
-use visitor::visit_ast;
 
-type ExpressionCheck = fn(&Expression, &mut Vec<LisetteDiagnostic>);
-type PatternCheck = fn(&Pattern, &mut Vec<LisetteDiagnostic>);
-
-const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
+const EXPRESSION_CHECKS: &[NodeCheck] = &[
     check_double_negation,
     check_self_comparison,
     check_unsigned_comparison,
@@ -130,48 +66,59 @@ const EXPRESSION_CHECKS: &[ExpressionCheck] = &[
     check_struct_attributes,
     check_attributes,
     check_enum_attributes,
+    check_duplicate_logical_operand,
+    check_expression_naming,
+    check_replaceable_with_zero_fill,
+    check_lost_query_mutation,
+    check_redundant_closure,
 ];
 
 const PATTERN_CHECKS: &[PatternCheck] = &[
     check_rest_only_slice_pattern,
     check_unnecessary_raw_string_pattern,
     check_invisible_in_string_pattern,
+    check_pattern_naming,
 ];
 
-pub struct AstLintGroup;
+pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts, sink: &LocalSink) {
+    let store = analysis.store;
 
-impl AstLintGroup {
-    pub fn check(&self, ctx: &LintContext) -> Vec<LisetteDiagnostic> {
-        let diagnostics = RefCell::new(Vec::new());
-        let is_d_lis = ctx.is_d_lis;
-        let files = ctx.files;
-        let store = ctx.store;
-        let module_id = ctx.module_id;
-        let source = ctx.source;
-        let facts = ctx.facts;
+    let mut modules: Vec<&Module> = store
+        .modules
+        .values()
+        .filter(|m| !m.is_internal())
+        .collect();
+    modules.sort_unstable_by(|a, b| a.id.cmp(&b.id));
 
-        visit_ast(
-            ctx.ast,
-            &mut |expression| {
-                let mut sink = diagnostics.borrow_mut();
-                for check in EXPRESSION_CHECKS {
-                    check(expression, &mut sink);
-                }
-                check_duplicate_logical_operand(expression, files, &mut sink);
-                check_expression_naming(expression, is_d_lis, &mut sink);
-                check_replaceable_with_zero_fill(expression, store, module_id, source, &mut sink);
-                check_lost_query_mutation(expression, store, &mut sink);
-                check_redundant_closure(expression, facts, &mut sink);
-            },
-            &mut |pattern| {
-                let mut sink = diagnostics.borrow_mut();
-                for check in PATTERN_CHECKS {
-                    check(pattern, &mut sink);
-                }
-                check_pattern_naming(pattern, is_d_lis, &mut sink);
-            },
-        );
+    if modules.len() < PARALLEL_THRESHOLD {
+        for module in &modules {
+            run_module(module, store, facts, sink);
+        }
+        return;
+    }
 
-        diagnostics.into_inner()
+    let worker_sinks: Vec<LocalSink> = modules
+        .par_iter()
+        .map(|module| {
+            let local_sink = LocalSink::new();
+            run_module(module, store, facts, &local_sink);
+            local_sink
+        })
+        .collect();
+    sink.extend(LocalSink::merge(worker_sinks));
+}
+
+fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
+    for file in module.files.values() {
+        let ctx = NodeCtx {
+            store,
+            facts,
+            files: &module.files,
+            module_id: &module.id,
+            source: &file.source,
+            is_d_lis: file.is_d_lis(),
+            sink,
+        };
+        walk_nodes(&file.items, &ctx, EXPRESSION_CHECKS, PATTERN_CHECKS);
     }
 }

--- a/crates/semantics/src/passes/mod.rs
+++ b/crates/semantics/src/passes/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod checks;
 mod deferred;
 mod fact_producers;
 mod lints;
+pub(crate) mod walk;
 
 pub use lints::Lint;
 

--- a/crates/semantics/src/passes/walk.rs
+++ b/crates/semantics/src/passes/walk.rs
@@ -1,7 +1,47 @@
+use diagnostics::LocalSink;
+use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{
     Expression, FormatStringPart, Literal, MatchArm, Pattern, RestPattern, SelectArm,
     SelectArmPattern,
 };
+use syntax::program::File;
+
+use crate::facts::Facts;
+use crate::store::Store;
+
+pub(crate) struct NodeCtx<'a> {
+    pub store: &'a Store,
+    pub facts: &'a Facts,
+    pub files: &'a HashMap<u32, File>,
+    pub module_id: &'a str,
+    pub source: &'a str,
+    pub is_d_lis: bool,
+    pub sink: &'a LocalSink,
+}
+
+pub(crate) type NodeCheck = fn(&Expression, &NodeCtx);
+pub(crate) type PatternCheck = fn(&Pattern, &NodeCtx);
+
+pub(crate) fn walk_nodes(
+    ast: &[Expression],
+    ctx: &NodeCtx,
+    expr_checks: &[NodeCheck],
+    pattern_checks: &[PatternCheck],
+) {
+    visit_ast(
+        ast,
+        &mut |expression| {
+            for check in expr_checks {
+                check(expression, ctx);
+            }
+        },
+        &mut |pattern| {
+            for check in pattern_checks {
+                check(pattern, ctx);
+            }
+        },
+    );
+}
 
 pub fn visit_ast<E, P>(ast: &[Expression], expression_visitor: &mut E, pattern_visitor: &mut P)
 where


### PR DESCRIPTION
Collapse checks and lints from two separate but nearly identical walkers into a single mechanism.
