### PR TITLE
RFC: tail call optimization

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3012,52 +3012,49 @@ pub fn reference_aliases_sibling(ref_span: Span, var_name: &str) -> LisetteDiagn
         ))
 }
 
-pub fn tailcall_unit_return(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
+pub fn tailcall_unit_return(name_span: Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`#[tailcall]` on `{}`: unit-returning functions are not supported",
         function_name
     ))
     .with_infer_code("tailcall_unit_return")
-    .with_span_label(name_span, "function returns no value")
+    .with_span_label(&name_span, "function returns no value")
     .with_help(
         "Tier 1 tail-call optimization requires a return type so the lowering pipeline can intercept tail-position calls. Add a return type, or remove `#[tailcall]`.",
     )
 }
 
-pub fn tailcall_method_form_unsupported(
-    call_span: &Span,
-    function_name: &str,
-) -> LisetteDiagnostic {
+pub fn tailcall_method_form_unsupported(call_span: Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`#[tailcall]` on `{}`: method-form recursion is not yet supported",
         function_name
     ))
     .with_infer_code("tailcall_method_form_unsupported")
-    .with_span_label(call_span, "method-form self-call")
+    .with_span_label(&call_span, "method-form self-call")
     .with_help(
         "Tier 1 only detects direct calls like `name(...)`. Method-form recursion (`receiver.name(...)`) is deferred to tier 2. Rewrite the call as a free function, or remove `#[tailcall]`.",
     )
 }
 
-pub fn tailcall_no_self_call(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
+pub fn tailcall_no_self_call(name_span: Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`#[tailcall]` on `{}`: no recursive self-call found",
         function_name
     ))
     .with_infer_code("tailcall_no_self_call")
-    .with_span_label(name_span, "function is not recursive")
+    .with_span_label(&name_span, "function is not recursive")
     .with_help(
         "`#[tailcall]` is only meaningful on functions that call themselves. Remove the attribute, or make the function recursive.",
     )
 }
 
-pub fn tailcall_not_in_tail_position(call_span: &Span, function_name: &str) -> LisetteDiagnostic {
+pub fn tailcall_not_in_tail_position(call_span: Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "Recursive call to `{}` is not in tail position",
         function_name
     ))
     .with_infer_code("tailcall_not_in_tail_position")
-    .with_span_label(call_span, "this call result is consumed before returning")
+    .with_span_label(&call_span, "this call result is consumed before returning")
     .with_help(
         "A tail call's result must be returned directly. Move work that follows the call into the recursive arguments, or remove `#[tailcall]`.",
     )

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3020,7 +3020,7 @@ pub fn tailcall_unit_return(name_span: Span, function_name: &str) -> LisetteDiag
     .with_infer_code("tailcall_unit_return")
     .with_span_label(&name_span, "function returns no value")
     .with_help(
-        "Tier 1 tail-call optimization requires a return type so the lowering pipeline can intercept tail-position calls. Add a return type, or remove `#[tailcall]`.",
+        "`#[tailcall]` requires a return type so the recursive call can be intercepted. Add a return type, or remove `#[tailcall]`.",
     )
 }
 
@@ -3032,7 +3032,7 @@ pub fn tailcall_method_form_unsupported(call_span: Span, function_name: &str) ->
     .with_infer_code("tailcall_method_form_unsupported")
     .with_span_label(&call_span, "method-form self-call")
     .with_help(
-        "Tier 1 only detects direct calls like `name(...)`. Method-form recursion (`receiver.name(...)`) is deferred to tier 2. Rewrite the call as a free function, or remove `#[tailcall]`.",
+        "Only direct calls like `name(...)` are recognized for tail-call optimization. Rewrite `receiver.name(...)` as a free function call, or remove `#[tailcall]`.",
     )
 }
 

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3024,6 +3024,21 @@ pub fn tailcall_unit_return(name_span: &Span, function_name: &str) -> LisetteDia
     )
 }
 
+pub fn tailcall_method_form_unsupported(
+    call_span: &Span,
+    function_name: &str,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!(
+        "`#[tailcall]` on `{}`: method-form recursion is not yet supported",
+        function_name
+    ))
+    .with_infer_code("tailcall_method_form_unsupported")
+    .with_span_label(call_span, "method-form self-call")
+    .with_help(
+        "Tier 1 only detects direct calls like `name(...)`. Method-form recursion (`receiver.name(...)`) is deferred to tier 2. Rewrite the call as a free function, or remove `#[tailcall]`.",
+    )
+}
+
 pub fn tailcall_no_self_call(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`#[tailcall]` on `{}`: no recursive self-call found",

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3011,3 +3011,27 @@ pub fn reference_aliases_sibling(ref_span: Span, var_name: &str) -> LisetteDiagn
             var_name
         ))
 }
+
+pub fn tailcall_no_self_call(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!(
+        "`#[tailcall]` on `{}`: no recursive self-call found",
+        function_name
+    ))
+    .with_infer_code("tailcall_no_self_call")
+    .with_span_label(name_span, "function is not recursive")
+    .with_help(
+        "`#[tailcall]` is only meaningful on functions that call themselves. Remove the attribute, or make the function recursive.",
+    )
+}
+
+pub fn tailcall_not_in_tail_position(call_span: &Span, function_name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!(
+        "Recursive call to `{}` is not in tail position",
+        function_name
+    ))
+    .with_infer_code("tailcall_not_in_tail_position")
+    .with_span_label(call_span, "this call result is consumed before returning")
+    .with_help(
+        "A tail call's result must be returned directly. Move work that follows the call into the recursive arguments, or remove `#[tailcall]`.",
+    )
+}

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3012,6 +3012,18 @@ pub fn reference_aliases_sibling(ref_span: Span, var_name: &str) -> LisetteDiagn
         ))
 }
 
+pub fn tailcall_unit_return(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!(
+        "`#[tailcall]` on `{}`: unit-returning functions are not supported",
+        function_name
+    ))
+    .with_infer_code("tailcall_unit_return")
+    .with_span_label(name_span, "function returns no value")
+    .with_help(
+        "Tier 1 tail-call optimization requires a return type so the lowering pipeline can intercept tail-position calls. Add a return type, or remove `#[tailcall]`.",
+    )
+}
+
 pub fn tailcall_no_self_call(name_span: &Span, function_name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`#[tailcall]` on `{}`: no recursive self-call found",

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -367,6 +367,22 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) {
         let should_return = !function_definition.return_type.is_unit();
+        let is_tail_call =
+            crate::passes::tail_call::has_tailcall_attribute(&function_definition.attributes);
+        if is_tail_call {
+            let param_go_names = crate::passes::tail_call::resolve_param_go_names(
+                self,
+                &function_definition.params,
+                &deferred_patterns,
+            );
+            self.function_state
+                .set_tail_call(crate::state::module_state::TailCallState {
+                    function_name: function_definition.name.to_string(),
+                    param_count: function_definition.params.len(),
+                    param_go_names,
+                });
+            body.push_str("for {\n");
+        }
         for (var_name, pattern, typed, param_ty) in deferred_patterns {
             self.emit_irrefutable_pattern_site(
                 body,
@@ -376,21 +392,6 @@ impl Planner<'_> {
                 &param_ty,
                 fx,
             );
-        }
-        let is_tail_call =
-            crate::passes::tail_call::has_tailcall_attribute(&function_definition.attributes);
-        if is_tail_call {
-            let param_go_names = crate::passes::tail_call::resolve_param_go_names(
-                self,
-                &function_definition.params,
-            );
-            self.function_state
-                .set_tail_call(crate::state::module_state::TailCallState {
-                    function_name: function_definition.name.to_string(),
-                    param_count: function_definition.params.len(),
-                    param_go_names,
-                });
-            body.push_str("for {\n");
         }
         self.emit_function_body(
             body,

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -367,8 +367,10 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) {
         let should_return = !function_definition.return_type.is_unit();
-        let is_tail_call =
-            crate::passes::tail_call::has_tailcall_attribute(&function_definition.attributes);
+        let is_tail_call = function_definition
+            .attributes
+            .iter()
+            .any(|a| a.name == "tailcall");
         if is_tail_call {
             let param_go_names = crate::passes::tail_call::resolve_param_go_names(
                 self,

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -377,6 +377,21 @@ impl Planner<'_> {
                 fx,
             );
         }
+        let is_tail_call =
+            crate::passes::tail_call::has_tailcall_attribute(&function_definition.attributes);
+        if is_tail_call {
+            let param_go_names = crate::passes::tail_call::resolve_param_go_names(
+                self,
+                &function_definition.params,
+            );
+            self.function_state
+                .set_tail_call(crate::state::module_state::TailCallState {
+                    function_name: function_definition.name.to_string(),
+                    param_count: function_definition.params.len(),
+                    param_go_names,
+                });
+            body.push_str("for {\n");
+        }
         self.emit_function_body(
             body,
             &function_definition.body,
@@ -384,6 +399,10 @@ impl Planner<'_> {
             return_ctx,
             fx,
         );
+        if is_tail_call {
+            body.push_str("}\n");
+            self.function_state.clear_tail_call();
+        }
     }
 
     fn emit_receiver_part(

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod definitions;
 pub(crate) mod expressions;
 pub(crate) mod names;
 mod output;
+pub(crate) mod passes;
 pub(crate) mod patterns;
 mod plan;
 mod render;

--- a/crates/emit/src/passes/mod.rs
+++ b/crates/emit/src/passes/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod tail_call;

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -1,8 +1,12 @@
-use syntax::ast::{Attribute, Binding, Expression, Pattern};
+use syntax::ast::{Attribute, Binding, Expression, Pattern, TypedPattern};
+use syntax::types::Type;
 
 use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+
+/// Mirrors the tuple in `crates/emit/src/definitions/functions.rs`.
+pub(crate) type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
 
 pub(crate) fn has_tailcall_attribute(attributes: &[Attribute]) -> bool {
     attributes.iter().any(|a| a.name == "tailcall")
@@ -59,7 +63,17 @@ pub(crate) fn emit_reassign_and_continue(
     out
 }
 
-pub(crate) fn resolve_param_go_names(planner: &Planner<'_>, params: &[Binding]) -> Vec<String> {
+/// Resolve each param's Go name. For `Identifier` patterns, look up via the
+/// scope. For destructuring patterns (Tuple, Struct, EnumVariant, …), use the
+/// synthesized `arg_N` temp from the deferred destructure for that param —
+/// reassignment then writes to the temp and the destructure is re-run at the
+/// top of each loop iteration. WildCard becomes `_`.
+pub(crate) fn resolve_param_go_names(
+    planner: &Planner<'_>,
+    params: &[Binding],
+    deferred: &[DeferredParamDestructure],
+) -> Vec<String> {
+    let mut deferred_iter = deferred.iter();
     params
         .iter()
         .map(|p| match &p.pattern {
@@ -68,7 +82,11 @@ pub(crate) fn resolve_param_go_names(planner: &Planner<'_>, params: &[Binding]) 
                 .resolve_binding_go_name(identifier)
                 .map(str::to_string)
                 .unwrap_or_else(|| identifier.to_string()),
-            _ => "_".to_string(),
+            Pattern::WildCard { .. } => "_".to_string(),
+            _ => deferred_iter
+                .next()
+                .map(|d| d.0.clone())
+                .unwrap_or_else(|| "_".to_string()),
         })
         .collect()
 }

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Attribute, Binding, Expression, Pattern, TypedPattern};
+use syntax::ast::{Binding, Expression, Pattern, TypedPattern};
 use syntax::types::Type;
 
 use crate::EmitEffects;
@@ -6,10 +6,6 @@ use crate::Planner;
 use crate::context::expression::ExpressionContext;
 
 pub(crate) type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
-
-pub(crate) fn has_tailcall_attribute(attributes: &[Attribute]) -> bool {
-    attributes.iter().any(|a| a.name == "tailcall")
-}
 
 pub(crate) struct TailSelfCallMatch<'a> {
     pub args: &'a [Expression],

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -5,15 +5,12 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 
-/// Mirrors the tuple in `crates/emit/src/definitions/functions.rs`.
 pub(crate) type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
 
 pub(crate) fn has_tailcall_attribute(attributes: &[Attribute]) -> bool {
     attributes.iter().any(|a| a.name == "tailcall")
 }
 
-/// If the planner is in tail-call mode and `call` is a self-call with matching
-/// arity, return its args. Otherwise None.
 pub(crate) fn match_tail_self_call<'a>(
     planner: &Planner<'_>,
     call: &'a Expression,
@@ -22,7 +19,6 @@ pub(crate) fn match_tail_self_call<'a>(
     call.self_call_to(&state.function_name, state.param_count)
 }
 
-/// Emit the Go for "reassign params + continue" given the recursive args.
 pub(crate) fn emit_reassign_and_continue(
     planner: &mut Planner<'_>,
     args: &[Expression],
@@ -51,11 +47,6 @@ pub(crate) fn emit_reassign_and_continue(
     out
 }
 
-/// Resolve each param's Go name. For `Identifier` patterns, look up via the
-/// scope. For destructuring patterns (Tuple, Struct, EnumVariant, …), use the
-/// synthesized `arg_N` temp from the deferred destructure for that param —
-/// reassignment then writes to the temp and the destructure is re-run at the
-/// top of each loop iteration. WildCard becomes `_`.
 pub(crate) fn resolve_param_go_names(
     planner: &Planner<'_>,
     params: &[Binding],

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -11,17 +11,27 @@ pub(crate) fn has_tailcall_attribute(attributes: &[Attribute]) -> bool {
     attributes.iter().any(|a| a.name == "tailcall")
 }
 
+pub(crate) struct TailSelfCallMatch<'a> {
+    pub args: &'a [Expression],
+    pub param_go_names: Vec<String>,
+}
+
 pub(crate) fn match_tail_self_call<'a>(
     planner: &Planner<'_>,
     call: &'a Expression,
-) -> Option<&'a [Expression]> {
+) -> Option<TailSelfCallMatch<'a>> {
     let state = planner.function_state.tail_call()?;
-    call.self_call_to(&state.function_name, state.param_count)
+    let args = call.self_call_to(&state.function_name, state.param_count)?;
+    Some(TailSelfCallMatch {
+        args,
+        param_go_names: state.param_go_names.clone(),
+    })
 }
 
 pub(crate) fn emit_reassign_and_continue(
     planner: &mut Planner<'_>,
     args: &[Expression],
+    param_go_names: &[String],
     fx: &mut EmitEffects,
 ) -> String {
     let mut setup = String::new();
@@ -30,17 +40,10 @@ pub(crate) fn emit_reassign_and_continue(
         .map(|arg| planner.emit_value(&mut setup, arg, ExpressionContext::value(), fx))
         .collect();
 
-    let param_names = planner
-        .function_state
-        .tail_call()
-        .expect("tail-call state must be set when calling emit_reassign_and_continue")
-        .param_go_names
-        .clone();
-
     let mut out = setup;
     out.push_str(&format!(
         "{} = {}\n",
-        param_names.join(", "),
+        param_go_names.join(", "),
         arg_strs.join(", ")
     ));
     out.push_str("continue\n");

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -19,19 +19,7 @@ pub(crate) fn match_tail_self_call<'a>(
     call: &'a Expression,
 ) -> Option<&'a [Expression]> {
     let state = planner.function_state.tail_call()?;
-    let Expression::Call {
-        expression, args, ..
-    } = call
-    else {
-        return None;
-    };
-    let Expression::Identifier { value, .. } = expression.as_ref() else {
-        return None;
-    };
-    if value.as_str() != state.function_name || args.len() != state.param_count {
-        return None;
-    }
-    Some(args.as_slice())
+    call.self_call_to(&state.function_name, state.param_count)
 }
 
 /// Emit the Go for "reassign params + continue" given the recursive args.

--- a/crates/emit/src/passes/tail_call.rs
+++ b/crates/emit/src/passes/tail_call.rs
@@ -1,0 +1,74 @@
+use syntax::ast::{Attribute, Binding, Expression, Pattern};
+
+use crate::EmitEffects;
+use crate::Planner;
+use crate::context::expression::ExpressionContext;
+
+pub(crate) fn has_tailcall_attribute(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|a| a.name == "tailcall")
+}
+
+/// If the planner is in tail-call mode and `call` is a self-call with matching
+/// arity, return its args. Otherwise None.
+pub(crate) fn match_tail_self_call<'a>(
+    planner: &Planner<'_>,
+    call: &'a Expression,
+) -> Option<&'a [Expression]> {
+    let state = planner.function_state.tail_call()?;
+    let Expression::Call {
+        expression, args, ..
+    } = call
+    else {
+        return None;
+    };
+    let Expression::Identifier { value, .. } = expression.as_ref() else {
+        return None;
+    };
+    if value.as_str() != state.function_name || args.len() != state.param_count {
+        return None;
+    }
+    Some(args.as_slice())
+}
+
+/// Emit the Go for "reassign params + continue" given the recursive args.
+pub(crate) fn emit_reassign_and_continue(
+    planner: &mut Planner<'_>,
+    args: &[Expression],
+    fx: &mut EmitEffects,
+) -> String {
+    let mut setup = String::new();
+    let arg_strs: Vec<String> = args
+        .iter()
+        .map(|arg| planner.emit_value(&mut setup, arg, ExpressionContext::value(), fx))
+        .collect();
+
+    let param_names = planner
+        .function_state
+        .tail_call()
+        .expect("tail-call state must be set when calling emit_reassign_and_continue")
+        .param_go_names
+        .clone();
+
+    let mut out = setup;
+    out.push_str(&format!(
+        "{} = {}\n",
+        param_names.join(", "),
+        arg_strs.join(", ")
+    ));
+    out.push_str("continue\n");
+    out
+}
+
+pub(crate) fn resolve_param_go_names(planner: &Planner<'_>, params: &[Binding]) -> Vec<String> {
+    params
+        .iter()
+        .map(|p| match &p.pattern {
+            Pattern::Identifier { identifier, .. } => planner
+                .scope
+                .resolve_binding_go_name(identifier)
+                .map(str::to_string)
+                .unwrap_or_else(|| identifier.to_string()),
+            _ => "_".to_string(),
+        })
+        .collect()
+}

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -735,9 +735,13 @@ impl Planner<'_> {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                if let Some(args) = crate::passes::tail_call::match_tail_self_call(self, last) {
-                    let recur =
-                        crate::passes::tail_call::emit_reassign_and_continue(self, args, fx);
+                if let Some(matched) = crate::passes::tail_call::match_tail_self_call(self, last) {
+                    let recur = crate::passes::tail_call::emit_reassign_and_continue(
+                        self,
+                        matched.args,
+                        &matched.param_go_names,
+                        fx,
+                    );
                     statements.push(LoweredStatement::RawGo(recur));
                 } else if let Some(tail) = try_emit_lowered_tail_return(self, last, return_ctx, fx)
                 {

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -735,7 +735,12 @@ impl Planner<'_> {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                if let Some(tail) = try_emit_lowered_tail_return(self, last, return_ctx, fx) {
+                if let Some(args) = crate::passes::tail_call::match_tail_self_call(self, last) {
+                    let recur =
+                        crate::passes::tail_call::emit_reassign_and_continue(self, args, fx);
+                    statements.push(LoweredStatement::RawGo(recur));
+                } else if let Some(tail) = try_emit_lowered_tail_return(self, last, return_ctx, fx)
+                {
                     statements.extend(tail);
                 } else if let Some(wrapped) = self.lower_wrapped_return(last, return_ctx, fx) {
                     statements.extend(wrapped);

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -98,6 +98,13 @@ impl ModuleState {
 pub(crate) struct FunctionEmissionState {
     absorbed_ref_generics: HashSet<String>,
     eager_operand_capture: bool,
+    tail_call: Option<TailCallState>,
+}
+
+pub(crate) struct TailCallState {
+    pub function_name: String,
+    pub param_count: usize,
+    pub param_go_names: Vec<String>,
 }
 
 impl FunctionEmissionState {
@@ -115,5 +122,17 @@ impl FunctionEmissionState {
 
     pub(crate) fn set_eager_operand_capture(&mut self, value: bool) -> bool {
         std::mem::replace(&mut self.eager_operand_capture, value)
+    }
+
+    pub(crate) fn tail_call(&self) -> Option<&TailCallState> {
+        self.tail_call.as_ref()
+    }
+
+    pub(crate) fn set_tail_call(&mut self, state: TailCallState) {
+        self.tail_call = Some(state);
+    }
+
+    pub(crate) fn clear_tail_call(&mut self) {
+        self.tail_call = None;
     }
 }

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod pub_type_export;
 pub(crate) mod receivers;
 pub(crate) mod repeated_if_condition;
 pub(crate) mod stringer_signature;
+pub(crate) mod tail_call;
 pub(crate) mod temp_producing;
 pub(crate) mod unchanging_loop_condition;
 pub(crate) mod visibility;

--- a/crates/semantics/src/passes/checks/node_walk.rs
+++ b/crates/semantics/src/passes/checks/node_walk.rs
@@ -6,7 +6,7 @@ use super::{
     const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop, empty_range,
     enum_variant_value, index_out_of_bounds, irrefutable_patterns, nan_comparison, newtype,
     oversized_shift, predeclared_shadowing, pub_type_export, receivers, repeated_if_condition,
-    stringer_signature, temp_producing, unchanging_loop_condition,
+    stringer_signature, tail_call, temp_producing, unchanging_loop_condition,
 };
 
 const NODE_CHECKS: &[NodeCheck] = &[
@@ -23,6 +23,7 @@ const NODE_CHECKS: &[NodeCheck] = &[
     stringer_signature::check,
     predeclared_shadowing::check,
     pub_type_export::check,
+    tail_call::check,
     temp_producing::check,
     newtype::check,
     enum_variant_value::check,

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -49,9 +49,6 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     }
 }
 
-/// Look for any `<receiver>.<name>(...)` call anywhere in the body. Used as a
-/// fallback diagnostic when no identifier-form self-calls are detected — the
-/// user likely wrote method-form recursion, which tier 1 does not transform.
 fn find_method_form_self_call(expr: &Expression, name: &str) -> Option<Span> {
     if let Expression::Call {
         expression, span, ..

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -72,6 +72,11 @@ struct Analysis {
     non_tail_calls: Vec<Span>,
 }
 
+/// Walks the function body collecting self-call sites with their tail/non-tail
+/// classification. Invariant: only called on the function body root (or via
+/// recursion into a tail-propagating child). Never called on arbitrary
+/// fragments, so `Return.expression` may safely re-mark its inner as tail —
+/// `return X` is always in tail position from the function's perspective.
 fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut Analysis) {
     if let Some(span) = self_call_span(expr, name, param_count) {
         if tail {

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -1,0 +1,187 @@
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{Expression, MatchArm, Span};
+
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::Function {
+        attributes,
+        name,
+        name_span,
+        params,
+        body,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if !attributes.iter().any(|a| a.name == "tailcall") {
+        return;
+    }
+
+    let mut analysis = Analysis::default();
+    walk(body, true, name, params.len(), &mut analysis);
+
+    if analysis.tail_calls.is_empty() && analysis.non_tail_calls.is_empty() {
+        ctx.sink
+            .push(diagnostics::infer::tailcall_no_self_call(name_span, name));
+        return;
+    }
+
+    for span in &analysis.non_tail_calls {
+        ctx.sink
+            .push(diagnostics::infer::tailcall_not_in_tail_position(
+                span, name,
+            ));
+    }
+}
+
+#[derive(Default)]
+struct Analysis {
+    tail_calls: Vec<Span>,
+    non_tail_calls: Vec<Span>,
+}
+
+fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut Analysis) {
+    if let Some(span) = self_call_span(expr, name, param_count) {
+        if tail {
+            out.tail_calls.push(span);
+        } else {
+            out.non_tail_calls.push(span);
+        }
+        if let Expression::Call { args, .. } = expr {
+            for arg in args {
+                walk(arg, false, name, param_count, out);
+            }
+        }
+        return;
+    }
+
+    match expr {
+        Expression::Block { items, .. } => {
+            if let Some((last, rest)) = items.split_last() {
+                for item in rest {
+                    walk(item, false, name, param_count, out);
+                }
+                walk(last, tail, name, param_count, out);
+            }
+        }
+        Expression::If {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            walk(condition, false, name, param_count, out);
+            walk(consequence, tail, name, param_count, out);
+            walk(alternative, tail, name, param_count, out);
+        }
+        Expression::Match { subject, arms, .. } => {
+            walk(subject, false, name, param_count, out);
+            for MatchArm {
+                expression, guard, ..
+            } in arms
+            {
+                if let Some(g) = guard {
+                    walk(g, false, name, param_count, out);
+                }
+                walk(expression, tail, name, param_count, out);
+            }
+        }
+        Expression::IfLet {
+            scrutinee,
+            consequence,
+            alternative,
+            ..
+        } => {
+            walk(scrutinee, false, name, param_count, out);
+            walk(consequence, tail, name, param_count, out);
+            walk(alternative, tail, name, param_count, out);
+        }
+        Expression::WhileLet {
+            scrutinee, body, ..
+        } => {
+            walk(scrutinee, false, name, param_count, out);
+            walk(body, false, name, param_count, out);
+        }
+        Expression::While {
+            condition, body, ..
+        } => {
+            walk(condition, false, name, param_count, out);
+            walk(body, false, name, param_count, out);
+        }
+        Expression::Loop { body, .. } => {
+            walk(body, false, name, param_count, out);
+        }
+        Expression::For { iterable, body, .. } => {
+            walk(iterable, false, name, param_count, out);
+            walk(body, false, name, param_count, out);
+        }
+        Expression::Let { value, .. } => {
+            walk(value, false, name, param_count, out);
+        }
+        Expression::Return { expression, .. } => {
+            walk(expression, true, name, param_count, out);
+        }
+        Expression::Paren { expression, .. } => {
+            walk(expression, tail, name, param_count, out);
+        }
+        Expression::Call {
+            expression, args, ..
+        } => {
+            walk(expression, false, name, param_count, out);
+            for arg in args {
+                walk(arg, false, name, param_count, out);
+            }
+        }
+        Expression::Binary { left, right, .. } => {
+            walk(left, false, name, param_count, out);
+            walk(right, false, name, param_count, out);
+        }
+        Expression::Unary { expression, .. } => {
+            walk(expression, false, name, param_count, out);
+        }
+        Expression::DotAccess { expression, .. } => {
+            walk(expression, false, name, param_count, out);
+        }
+        Expression::Tuple { elements, .. } => {
+            for e in elements {
+                walk(e, false, name, param_count, out);
+            }
+        }
+        Expression::StructCall {
+            field_assignments, ..
+        } => {
+            for fa in field_assignments {
+                walk(&fa.value, false, name, param_count, out);
+            }
+        }
+        Expression::TryBlock { items, .. } | Expression::RecoverBlock { items, .. } => {
+            for item in items {
+                walk(item, false, name, param_count, out);
+            }
+        }
+        Expression::Task { expression, .. } | Expression::Defer { expression, .. } => {
+            walk(expression, false, name, param_count, out);
+        }
+        _ => {}
+    }
+}
+
+fn self_call_span(expr: &Expression, name: &str, param_count: usize) -> Option<Span> {
+    let Expression::Call {
+        expression,
+        args,
+        span,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    let Expression::Identifier { value, .. } = expression.as_ref() else {
+        return None;
+    };
+    if value.as_str() != name || args.len() != param_count {
+        return None;
+    }
+    Some(*span)
+}

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -21,7 +21,7 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
 
     if return_type.is_unit() {
         ctx.sink
-            .push(diagnostics::infer::tailcall_unit_return(name_span, name));
+            .push(diagnostics::infer::tailcall_unit_return(*name_span, name));
         return;
     }
 
@@ -32,11 +32,11 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
         if let Some(call_span) = find_method_form_self_call(body, name) {
             ctx.sink
                 .push(diagnostics::infer::tailcall_method_form_unsupported(
-                    &call_span, name,
+                    call_span, name,
                 ));
         } else {
             ctx.sink
-                .push(diagnostics::infer::tailcall_no_self_call(name_span, name));
+                .push(diagnostics::infer::tailcall_no_self_call(*name_span, name));
         }
         return;
     }
@@ -44,7 +44,7 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     for span in &analysis.non_tail_calls {
         ctx.sink
             .push(diagnostics::infer::tailcall_not_in_tail_position(
-                span, name,
+                *span, name,
             ));
     }
 }

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -28,7 +28,7 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     let mut analysis = Analysis::default();
     walk(body, true, name, params.len(), &mut analysis);
 
-    if analysis.tail_calls.is_empty() && analysis.non_tail_calls.is_empty() {
+    if !analysis.has_tail_call && analysis.non_tail_calls.is_empty() {
         if let Some(call_span) = find_method_form_self_call(body, name) {
             ctx.sink
                 .push(diagnostics::infer::tailcall_method_form_unsupported(
@@ -68,7 +68,7 @@ fn find_method_form_self_call(expr: &Expression, name: &str) -> Option<Span> {
 
 #[derive(Default)]
 struct Analysis {
-    tail_calls: Vec<Span>,
+    has_tail_call: bool,
     non_tail_calls: Vec<Span>,
 }
 
@@ -80,7 +80,7 @@ struct Analysis {
 fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut Analysis) {
     if let Some(span) = self_call_span(expr, name, param_count) {
         if tail {
-            out.tail_calls.push(span);
+            out.has_tail_call = true;
         } else {
             out.non_tail_calls.push(span);
         }

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -7,6 +7,7 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
         name,
         name_span,
         params,
+        return_type,
         body,
         ..
     } = expression
@@ -15,6 +16,12 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     };
 
     if !attributes.iter().any(|a| a.name == "tailcall") {
+        return;
+    }
+
+    if return_type.is_unit() {
+        ctx.sink
+            .push(diagnostics::infer::tailcall_unit_return(name_span, name));
         return;
     }
 

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -29,8 +29,15 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     walk(body, true, name, params.len(), &mut analysis);
 
     if analysis.tail_calls.is_empty() && analysis.non_tail_calls.is_empty() {
-        ctx.sink
-            .push(diagnostics::infer::tailcall_no_self_call(name_span, name));
+        if let Some(call_span) = find_method_form_self_call(body, name) {
+            ctx.sink
+                .push(diagnostics::infer::tailcall_method_form_unsupported(
+                    &call_span, name,
+                ));
+        } else {
+            ctx.sink
+                .push(diagnostics::infer::tailcall_no_self_call(name_span, name));
+        }
         return;
     }
 
@@ -40,6 +47,23 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
                 span, name,
             ));
     }
+}
+
+/// Look for any `<receiver>.<name>(...)` call anywhere in the body. Used as a
+/// fallback diagnostic when no identifier-form self-calls are detected — the
+/// user likely wrote method-form recursion, which tier 1 does not transform.
+fn find_method_form_self_call(expr: &Expression, name: &str) -> Option<Span> {
+    if let Expression::Call {
+        expression, span, ..
+    } = expr
+        && let Expression::DotAccess { member, .. } = expression.as_ref()
+        && member.as_str() == name
+    {
+        return Some(*span);
+    }
+    expr.children()
+        .iter()
+        .find_map(|child| find_method_form_self_call(child, name))
 }
 
 #[derive(Default)]

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -194,7 +194,15 @@ fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut
         Expression::Task { expression, .. } | Expression::Defer { expression, .. } => {
             walk(expression, false, name, param_count, out);
         }
-        _ => {}
+        // Conservative fallback for variants that wrap or consume their children
+        // (Cast, IndexedAccess, Reference, Propagate, Range, Assignment, …). The
+        // inner value is consumed by the wrapping expression, so children are
+        // never in tail position from the function's perspective.
+        other => {
+            for child in other.children().iter() {
+                walk(child, false, name, param_count, out);
+            }
+        }
     }
 }
 

--- a/crates/semantics/src/passes/checks/tail_call.rs
+++ b/crates/semantics/src/passes/checks/tail_call.rs
@@ -78,16 +78,14 @@ struct Analysis {
 /// fragments, so `Return.expression` may safely re-mark its inner as tail —
 /// `return X` is always in tail position from the function's perspective.
 fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut Analysis) {
-    if let Some(span) = self_call_span(expr, name, param_count) {
+    if let Some(args) = expr.self_call_to(name, param_count) {
         if tail {
             out.has_tail_call = true;
         } else {
-            out.non_tail_calls.push(span);
+            out.non_tail_calls.push(expr.get_span());
         }
-        if let Expression::Call { args, .. } = expr {
-            for arg in args {
-                walk(arg, false, name, param_count, out);
-            }
+        for arg in args {
+            walk(arg, false, name, param_count, out);
         }
         return;
     }
@@ -209,23 +207,4 @@ fn walk(expr: &Expression, tail: bool, name: &str, param_count: usize, out: &mut
             }
         }
     }
-}
-
-fn self_call_span(expr: &Expression, name: &str, param_count: usize) -> Option<Span> {
-    let Expression::Call {
-        expression,
-        args,
-        span,
-        ..
-    } = expr
-    else {
-        return None;
-    };
-    let Expression::Identifier { value, .. } = expression.as_ref() else {
-        return None;
-    };
-    if value.as_str() != name || args.len() != param_count {
-        return None;
-    }
-    Some(*span)
 }

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -15,7 +15,7 @@ pub(crate) const SERIALIZATION_KEYS: &[&str] = &[
 ];
 
 /// Recognized attributes that are not serialization keys.
-const OTHER_ATTRIBUTES: &[&str] = &["tag", "allow", "iterate", "display"];
+const OTHER_ATTRIBUTES: &[&str] = &["tag", "allow", "iterate", "display", "tailcall"];
 
 pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
     let attributes = match expression {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1079,12 +1079,13 @@ impl Expression {
 
     /// If this is a `Call` to an identifier matching `name` with `arity` args,
     /// return the args. Otherwise None. Used to detect direct self-calls.
+    /// Peels through `Paren` wrappers so `(f(x))` matches the same as `f(x)`.
     /// `Call.type_args` is ignored — a generic self-call (`self::<T>(...)`) is
     /// still a self-call regardless of which monomorphisation it targets.
     pub fn self_call_to(&self, name: &str, arity: usize) -> Option<&[Expression]> {
         let Expression::Call {
             expression, args, ..
-        } = self
+        } = self.unwrap_parens()
         else {
             return None;
         };

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1077,6 +1077,24 @@ impl Expression {
         }
     }
 
+    /// If this is a `Call` to an identifier matching `name` with `arity` args,
+    /// return the args. Otherwise None. Used to detect direct self-calls.
+    pub fn self_call_to(&self, name: &str, arity: usize) -> Option<&[Expression]> {
+        let Expression::Call {
+            expression, args, ..
+        } = self
+        else {
+            return None;
+        };
+        let Expression::Identifier { value, .. } = expression.as_ref() else {
+            return None;
+        };
+        if value.as_str() != name || args.len() != arity {
+            return None;
+        }
+        Some(args.as_slice())
+    }
+
     pub fn as_option_constructor(&self) -> Option<std::result::Result<(), ()>> {
         let variant = match self {
             Expression::Identifier { value, .. } => Some(value.as_str()),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -403,6 +403,7 @@ pub struct FunctionDefinition {
     pub return_type: Type,
     pub annotation: Annotation,
     pub ty: Type,
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1031,6 +1032,7 @@ impl Expression {
                 return_annotation,
                 return_type,
                 ty,
+                attributes,
                 ..
             } => FunctionDefinition {
                 name: name.clone(),
@@ -1041,6 +1043,7 @@ impl Expression {
                 return_type: return_type.clone(),
                 annotation: return_annotation.clone(),
                 ty: ty.clone(),
+                attributes: attributes.clone(),
             },
             _ => panic!("to_function_signature called on non-Function expression"),
         }
@@ -1057,6 +1060,7 @@ impl Expression {
                 return_type,
                 body,
                 ty,
+                attributes,
                 ..
             } => FunctionDefinition {
                 name: name.clone(),
@@ -1067,6 +1071,7 @@ impl Expression {
                 return_type: return_type.clone(),
                 annotation: return_annotation.clone(),
                 ty: ty.clone(),
+                attributes: attributes.clone(),
             },
             _ => panic!("to_function_definition called on non-Function expression"),
         }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1079,6 +1079,8 @@ impl Expression {
 
     /// If this is a `Call` to an identifier matching `name` with `arity` args,
     /// return the args. Otherwise None. Used to detect direct self-calls.
+    /// `Call.type_args` is ignored — a generic self-call (`self::<T>(...)`) is
+    /// still a self-call regardless of which monomorphisation it targets.
     pub fn self_call_to(&self, name: &str, arity: usize) -> Option<&[Expression]> {
         let Expression::Call {
             expression, args, ..

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1722,3 +1722,18 @@ fn collatz(n: int, steps: int) -> int {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn tailcall_destructured_param_reassigns_temp() {
+    let input = r#"
+#[tailcall]
+fn sum_pair((a, b): (int, int), acc: int) -> int {
+  if a == 0 {
+    acc + b
+  } else {
+    sum_pair((a - 1, b), acc + a)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1680,3 +1680,45 @@ fn run() -> Option<int> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn tailcall_factorial_emits_loop() {
+    let input = r#"
+#[tailcall]
+fn factorial(n: int, acc: int) -> int {
+  if n <= 1 { acc } else { factorial(n - 1, acc * n) }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tailcall_match_emits_loop() {
+    let input = r#"
+#[tailcall]
+fn recmatch(a: int, b: int) -> int {
+  match a {
+    0 => b,
+    _ => recmatch(a - 1, b + 1),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tailcall_nested_else_if_emits_loop() {
+    let input = r#"
+#[tailcall]
+fn collatz(n: int, steps: int) -> int {
+  if n == 1 {
+    steps
+  } else if n % 2 == 0 {
+    collatz(n / 2, steps + 1)
+  } else {
+    collatz(3 * n + 1, steps + 1)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1737,3 +1737,38 @@ fn sum_pair((a, b): (int, int), acc: int) -> int {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn tailcall_via_explicit_return() {
+    let input = r#"
+#[tailcall]
+fn sum_to(n: int, acc: int) -> int {
+  if n == 0 {
+    return acc
+  }
+  return sum_to(n - 1, acc + n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tailcall_inside_paren() {
+    let input = r#"
+#[tailcall]
+fn factorial(n: int, acc: int) -> int {
+  if n <= 1 { acc } else { (factorial(n - 1, acc * n)) }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unannotated_recursion_unchanged_by_tailcall_pass() {
+    let input = r#"
+fn factorial(n: int, acc: int) -> int {
+  if n <= 1 { acc } else { factorial(n - 1, acc * n) }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/tailcall_destructured_param_reassigns_temp.snap
+++ b/tests/spec/emit/snapshots/tailcall_destructured_param_reassigns_temp.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1738
+description: "input: \n#[tailcall]\nfn sum_pair((a, b): (int, int), acc: int) -> int {\n  if a == 0 {\n    acc + b\n  } else {\n    sum_pair((a - 1, b), acc + a)\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func sum_pair(arg_1 lisette.Tuple2[int, int], acc int) int {
+	for {
+		a := arg_1.First
+		b := arg_1.Second
+		if a == 0 {
+			return acc + b
+		}
+		arg_1, acc = lisette.MakeTuple2(a-1, b), acc+a
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/tailcall_factorial_emits_loop.snap
+++ b/tests/spec/emit/snapshots/tailcall_factorial_emits_loop.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1692
+description: "input: \n#[tailcall]\nfn factorial(n: int, acc: int) -> int {\n  if n <= 1 { acc } else { factorial(n - 1, acc * n) }\n}\n"
+---
+package main
+
+func factorial(n, acc int) int {
+	for {
+		if n <= 1 {
+			return acc
+		}
+		n, acc = n-1, acc*n
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/tailcall_inside_paren.snap
+++ b/tests/spec/emit/snapshots/tailcall_inside_paren.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1763
+description: "input: \n#[tailcall]\nfn factorial(n: int, acc: int) -> int {\n  if n <= 1 { acc } else { (factorial(n - 1, acc * n)) }\n}\n"
+---
+package main
+
+func factorial(n, acc int) int {
+	for {
+		if n <= 1 {
+			return acc
+		}
+		n, acc = n-1, acc*n
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/tailcall_match_emits_loop.snap
+++ b/tests/spec/emit/snapshots/tailcall_match_emits_loop.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1706
+description: "input: \n#[tailcall]\nfn recmatch(a: int, b: int) -> int {\n  match a {\n    0 => b,\n    _ => recmatch(a - 1, b + 1),\n  }\n}\n"
+---
+package main
+
+func recmatch(a, b int) int {
+	for {
+		if a == 0 {
+			return b
+		}
+		a, b = a-1, b+1
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/tailcall_nested_else_if_emits_loop.snap
+++ b/tests/spec/emit/snapshots/tailcall_nested_else_if_emits_loop.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1723
+description: "input: \n#[tailcall]\nfn collatz(n: int, steps: int) -> int {\n  if n == 1 {\n    steps\n  } else if n % 2 == 0 {\n    collatz(n / 2, steps + 1)\n  } else {\n    collatz(3 * n + 1, steps + 1)\n  }\n}\n"
+---
+package main
+
+func collatz(n, steps int) int {
+	for {
+		if n == 1 {
+			return steps
+		} else if n%2 == 0 {
+			n, steps = n/2, steps+1
+			continue
+		}
+		n, steps = 3*n+1, steps+1
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/tailcall_via_explicit_return.snap
+++ b/tests/spec/emit/snapshots/tailcall_via_explicit_return.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1752
+description: "input: \n#[tailcall]\nfn sum_to(n: int, acc: int) -> int {\n  if n == 0 {\n    return acc\n  }\n  return sum_to(n - 1, acc + n)\n}\n"
+---
+package main
+
+func sum_to(n, acc int) int {
+	for {
+		if n == 0 {
+			return acc
+		}
+		n, acc = n-1, acc+n
+		continue
+	}
+}

--- a/tests/spec/emit/snapshots/unannotated_recursion_unchanged_by_tailcall_pass.snap
+++ b/tests/spec/emit/snapshots/unannotated_recursion_unchanged_by_tailcall_pass.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+assertion_line: 1773
+description: "input: \nfn factorial(n: int, acc: int) -> int {\n  if n <= 1 { acc } else { factorial(n - 1, acc * n) }\n}\n"
+---
+package main
+
+func factorial(n, acc int) int {
+	if n <= 1 {
+		return acc
+	}
+	return factorial(n-1, acc*n)
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9076,3 +9076,34 @@ fn bad(n: int64) -> int {
 "#
     );
 }
+
+#[test]
+fn tailcall_inside_loop_is_not_tail() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int) -> int {
+  loop {
+    bad(n - 1)
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tailcall_let_then_identifier_breaks_tail() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int) -> int {
+  if n == 0 {
+    0
+  } else {
+    let result = bad(n - 1)
+    result
+  }
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9060,3 +9060,19 @@ impl Counter {
 "#
     );
 }
+
+#[test]
+fn tailcall_call_wrapped_in_cast_is_not_tail() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int64) -> int {
+  if n == 0 {
+    0
+  } else {
+    bad(n - 1) as int
+  }
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9040,3 +9040,23 @@ fn loop_forever(n: int) {
 "#
     );
 }
+
+#[test]
+fn tailcall_method_form_rejected() {
+    assert_lint_snapshot!(
+        r#"
+struct Counter { n: int }
+
+impl Counter {
+  #[tailcall]
+  fn count_down(self, acc: int) -> int {
+    if self.n == 0 {
+      acc
+    } else {
+      Counter { n: self.n - 1 }.count_down(acc + 1)
+    }
+  }
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -8992,3 +8992,39 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn tailcall_on_non_recursive_body() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int) -> int {
+  n + 1
+}
+"#
+    );
+}
+
+#[test]
+fn tailcall_on_if_without_self_call() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int) -> int {
+  if n <= 0 { 0 } else { n + 1 }
+}
+"#
+    );
+}
+
+#[test]
+fn tailcall_recursive_call_not_in_tail_position() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn bad(n: int) -> int {
+  if n <= 0 { 0 } else { 1 + bad(n - 1) }
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9028,3 +9028,15 @@ fn bad(n: int) -> int {
 "#
     );
 }
+
+#[test]
+fn tailcall_unit_return_rejected() {
+    assert_lint_snapshot!(
+        r#"
+#[tailcall]
+fn loop_forever(n: int) {
+  loop_forever(n + 1)
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/tailcall_call_wrapped_in_cast_is_not_tail.snap
+++ b/tests/ui/lint/snapshots/tailcall_call_wrapped_in_cast_is_not_tail.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8303
+---
+  [info] Redundant cast
+   ╭─[test.lis:7:5]
+ 6 │   } else {
+ 7 │     bad(n - 1) as int
+   ·     ────────┬────────
+   ·             ╰── casting `int` to itself has no effect
+ 8 │   }
+   ╰────
+  help: Remove the unnecessary cast · code: [infer.redundant_cast]

--- a/tests/ui/lint/snapshots/tailcall_inside_loop_is_not_tail.snap
+++ b/tests/ui/lint/snapshots/tailcall_inside_loop_is_not_tail.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8319
+---
+  [error] Recursive call to `bad` is not in tail position
+   ╭─[test.lis:5:5]
+ 4 │   loop {
+ 5 │     bad(n - 1)
+   ·     ─────┬────
+   ·          ╰── this call result is consumed before returning
+ 6 │   }
+   ╰────
+  help: A tail call's result must be returned directly. Move work that follows the call into the recursive arguments, or remove `#[tailcall]` · code: [infer.tailcall_not_in_tail_position]

--- a/tests/ui/lint/snapshots/tailcall_let_then_identifier_breaks_tail.snap
+++ b/tests/ui/lint/snapshots/tailcall_let_then_identifier_breaks_tail.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8333
+---
+  [error] Recursive call to `bad` is not in tail position
+   ╭─[test.lis:7:18]
+ 6 │   } else {
+ 7 │     let result = bad(n - 1)
+   ·                  ─────┬────
+   ·                       ╰── this call result is consumed before returning
+ 8 │     result
+   ╰────
+  help: A tail call's result must be returned directly. Move work that follows the call into the recursive arguments, or remove `#[tailcall]` · code: [infer.tailcall_not_in_tail_position]

--- a/tests/ui/lint/snapshots/tailcall_method_form_rejected.snap
+++ b/tests/ui/lint/snapshots/tailcall_method_form_rejected.snap
@@ -10,4 +10,4 @@ assertion_line: 8283
     ·                             ╰── method-form self-call
  11 │     }
     ╰────
-  help: Tier 1 only detects direct calls like `name(...)`. Method-form recursion (`receiver.name(...)`) is deferred to tier 2. Rewrite the call as a free function, or remove `#[tailcall]` · code: [infer.tailcall_method_form_unsupported]
+  help: Only direct calls like `name(...)` are recognized for tail-call optimization. Rewrite `receiver.name(...)` as a free function call, or remove `#[tailcall]` · code: [infer.tailcall_method_form_unsupported]

--- a/tests/ui/lint/snapshots/tailcall_method_form_rejected.snap
+++ b/tests/ui/lint/snapshots/tailcall_method_form_rejected.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8283
+---
+  [error] `#[tailcall]` on `count_down`: method-form recursion is not yet supported
+    ╭─[test.lis:10:7]
+  9 │     } else {
+ 10 │       Counter { n: self.n - 1 }.count_down(acc + 1)
+    ·       ──────────────────────┬──────────────────────
+    ·                             ╰── method-form self-call
+ 11 │     }
+    ╰────
+  help: Tier 1 only detects direct calls like `name(...)`. Method-form recursion (`receiver.name(...)`) is deferred to tier 2. Rewrite the call as a free function, or remove `#[tailcall]` · code: [infer.tailcall_method_form_unsupported]

--- a/tests/ui/lint/snapshots/tailcall_on_if_without_self_call.snap
+++ b/tests/ui/lint/snapshots/tailcall_on_if_without_self_call.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8247
+---
+  [error] `#[tailcall]` on `bad`: no recursive self-call found
+   ╭─[test.lis:3:4]
+ 2 │ #[tailcall]
+ 3 │ fn bad(n: int) -> int {
+   ·    ─┬─
+   ·     ╰── function is not recursive
+ 4 │   if n <= 0 { 0 } else { n + 1 }
+   ╰────
+  help: `#[tailcall]` is only meaningful on functions that call themselves. Remove the attribute, or make the function recursive · code: [infer.tailcall_no_self_call]

--- a/tests/ui/lint/snapshots/tailcall_on_non_recursive_body.snap
+++ b/tests/ui/lint/snapshots/tailcall_on_non_recursive_body.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8235
+---
+  [error] `#[tailcall]` on `bad`: no recursive self-call found
+   ╭─[test.lis:3:4]
+ 2 │ #[tailcall]
+ 3 │ fn bad(n: int) -> int {
+   ·    ─┬─
+   ·     ╰── function is not recursive
+ 4 │   n + 1
+   ╰────
+  help: `#[tailcall]` is only meaningful on functions that call themselves. Remove the attribute, or make the function recursive · code: [infer.tailcall_no_self_call]

--- a/tests/ui/lint/snapshots/tailcall_recursive_call_not_in_tail_position.snap
+++ b/tests/ui/lint/snapshots/tailcall_recursive_call_not_in_tail_position.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8259
+---
+  [error] Recursive call to `bad` is not in tail position
+   ╭─[test.lis:4:30]
+ 3 │ fn bad(n: int) -> int {
+ 4 │   if n <= 0 { 0 } else { 1 + bad(n - 1) }
+   ·                              ─────┬────
+   ·                                   ╰── this call result is consumed before returning
+ 5 │ }
+   ╰────
+  help: A tail call's result must be returned directly. Move work that follows the call into the recursive arguments, or remove `#[tailcall]` · code: [infer.tailcall_not_in_tail_position]

--- a/tests/ui/lint/snapshots/tailcall_unit_return_rejected.snap
+++ b/tests/ui/lint/snapshots/tailcall_unit_return_rejected.snap
@@ -10,4 +10,4 @@ assertion_line: 8271
    ·          ╰── function returns no value
  4 │   loop_forever(n + 1)
    ╰────
-  help: Tier 1 tail-call optimization requires a return type so the lowering pipeline can intercept tail-position calls. Add a return type, or remove `#[tailcall]` · code: [infer.tailcall_unit_return]
+  help: `#[tailcall]` requires a return type so the recursive call can be intercepted. Add a return type, or remove `#[tailcall]` · code: [infer.tailcall_unit_return]

--- a/tests/ui/lint/snapshots/tailcall_unit_return_rejected.snap
+++ b/tests/ui/lint/snapshots/tailcall_unit_return_rejected.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+assertion_line: 8271
+---
+  [error] `#[tailcall]` on `loop_forever`: unit-returning functions are not supported
+   ╭─[test.lis:3:4]
+ 2 │ #[tailcall]
+ 3 │ fn loop_forever(n: int) {
+   ·    ──────┬─────
+   ·          ╰── function returns no value
+ 4 │   loop_forever(n + 1)
+   ╰────
+  help: Tier 1 tail-call optimization requires a return type so the lowering pipeline can intercept tail-position calls. Add a return type, or remove `#[tailcall]` · code: [infer.tailcall_unit_return]

--- a/tests/ui/lint/snapshots/unknown_attribute.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui/lint/mod.rs
+assertion_line: 4947
 ---
   [warning] Unknown attribute
    ╭─[test.lis:2:1]
@@ -9,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ pub struct User {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[tailcall]` · code: [lint.unknown_attribute]

--- a/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui/lint/mod.rs
+assertion_line: 4959
 ---
   [warning] Unknown attribute
    ╭─[test.lis:2:1]
@@ -9,4 +10,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ enum Color {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[tailcall]` · code: [lint.unknown_attribute]


### PR DESCRIPTION
**This is only a POC, and is currently a WIP.**

## TLDR

Have the compiler turn this:

```rust
#[tailcall]
fn factorial(n: int, acc: int) -> int {
  if n <= 1 { acc } else { factorial(n - 1, acc * n) }
}
```

into:

```go
func factorial(n, acc int) int {
    for {
        if n <= 1 {
            return acc
        }
        n, acc = n-1, acc*n
        continue
    }
}
```

Strictly opt-in via an attribute. Compiler verifies the function actually is tail-recursive and errors out if not. One stack frame regardless of depth. 


## Bikeshed and nitpicks

### Terminology

Strictly speaking this is a source-level transform, not machine-level TCO. "Real" TCO (like in OCaml) emits a `JMP` instead of a `CALL` instruction, transparently, not an source/byte code change. 

Lisette rewrites a tail-recursive function as a `for` loop at codegen time, before the Go compiler sees it. 

The user-visible effect is the same: Constant stack for tail-recursive code. 

The field uses "TCO" loosely. Scala has `@tailrec`, Kotlin `tailrec`, and Clojure  `recur` all get called TCO even being source/bytecode transforms. 

This RFC uses "TCO" in that loose sense. The more precise phrasing would be "tail recursion to loop transformation" if precision matters.

### Attribute name

`#[tailcall]` is just a working name. 

Some alternatives worth considering:

 `#[tail]` 
 `#[recur]` 
 `#[tco]` 
 `#[loop]` 
 `#[rec]` 
 `#[tailrec]` 

## Why

Lisette is an expression-based language. Pattern matching with arms returning values, `if`-as-expression, accumulator-passing, `let`-then-result. All of these make recursion the obvious shape for a lot of work. Tree walks, state machines, folds, parser combinators, anything reducing over some structure.

Go does not do TCO. Each recursive call grows the stack. Go stacks are growable so it does not crash immediately (in fact, Go supports quite deep recursion), but you pay copy plus pointer-fixup cost on each  growth, and you eventually hit the goroutine max (default ~1 GB). On top of that, a function written as recursion in Lisette compiles to recursion in Go even when the structure trivially loops.

The TCO pass closes that gap. Same source, no stack growth, no pattern shift required from the user.

This is not huge for hot-path performance. The win is that a class of programs you can already write in Lisette stops blowing up at scale. A 10,000-deep tree walk becomes a 1-frame loop instead of a slow march toward the goroutine stack limit.

### How the Go stack grows

Goroutines start with a 2 KB stack and grow up to ~1 GB by default. Since Go 1.4 the growth is contiguous: when you exhaust the current stack (checked at every function), the runtime allocates a new stack twice the size, copies all live frames into it, and walks each frame to fix up every pointer that pointed into the old stack. Stack maps generated by the compiler say where the pointers live.

The pointer-fixup step is the expensive part, not the copy.

For a 10,000-deep recursion you hit 5–10 doubling events. Each one is O(current stack size). That is amortized O(1) per call, but bursty. The whole current stack gets touched at each doubling. With about 64 bytes per frame that is roughly 640 KB of state held live, paid for by repeated allocate-copy-fixup passes during the climb.

The function still works. It just costs you, both in space and in those doubling spikes. The TCO transform turns the same recursion into a single frame with parameter reassignment. No allocations, no copies, no pointer fixups, no growth events. The function runs in constant stack regardless of input depth.


## What `#[tailcall]` does

When annotation function:

```rust
#[tailcall]
fn foo(args) -> int { ... }
```

The compiler:

1. Walks the body looking for self-calls.
2. Confirms each self-call is in tail position (its result flows directly to the functions return no work happens after the call returns).
3. If yes: emits the function as `for { ... }` and rewrites each tail self-call to parameter reassignment plus `continue`.
4. If no: errors out and wont compile.

No silent fallthroughs. If you annotate it, the compiler either delivers TCO or refuses to compile.

## Examples

### Linear accumulator

```rust
#[tailcall]
fn sum_to(n: int, acc: int) -> int {
  if n == 0 { acc } else { sum_to(n - 1, acc + n) }
}
```

```go
func sum_to(n, acc int) int {
    for {
        if n == 0 {
            return acc
        }
        n, acc = n-1, acc+n
        continue
    }
}
```

### Match-based dispatch

```rust
#[tailcall]
fn step(state: int, steps: int) -> int {
  match state {
    0 => steps,
    _ => step(state - 1, steps + 1),
  }
}
```

```go
func step(state, steps int) int {
    for {
        if state == 0 {
            return steps
        }
        state, steps = state-1, steps+1
        continue
    }
}
```

### Nested `else if`

```rust
#[tailcall]
fn collatz(n: int, steps: int) -> int {
  if n == 1 {
    steps
  } else if n % 2 == 0 {
    collatz(n / 2, steps + 1)
  } else {
    collatz(3 * n + 1, steps + 1)
  }
}
```

```go
func collatz(n, steps int) int {
    for {
        if n == 1 {
            return steps
        } else if n%2 == 0 {
            n, steps = n/2, steps+1
            continue
        }
        n, steps = 3*n+1, steps+1
        continue
    }
}
```

### Tree walk via explicit work-stack

This is the kind of program that benefits the most. Binary tree sum without growing the stack:

```rust
struct Node {
  value: int,
  left: Option<Ref<Node>>,
  right: Option<Ref<Node>>,
}

#[tailcall]
fn sum_walk(stack: Slice<Ref<Node>>, acc: int) -> int {
  let len = stack.length()
  if len == 0 {
    acc
  } else {
    let node = stack[len - 1]
    let rest = stack[..len - 1]
    let with_left = match node.left { Some(l) => rest.append(l), None => rest }
    let new_stack = match node.right { Some(r) => with_left.append(r), None => with_left }
    sum_walk(new_stack, acc + node.value)
  }
}
```

A deep skewed (left leaning) tree walks in one frame. Without TCO, the same program is bounded by the goroutine stack limit and eventually blows up as the tree grows.

The above (on my M1 mac) stackoverflows sometime after the tree size reaches 3M (without `#[tailcall]`). However, memory usage grows seven fold in the non optimised version. I did not really benchmark this properly, just run both versions once using `runtime.ReadMemStats()`

```
┌────────────┬─────────────┬──────────┬─────────────────────────────┐
│   Metric   │ Without TCO │ With TCO │         From where          │
├────────────┼─────────────┼──────────┼─────────────────────────────┤
│ Alloc      │ 137 MB      │ 153 MB   │ Live heap (the tree)        │
├────────────┼─────────────┼──────────┼─────────────────────────────┤
│ TotalAlloc │ 137 MB      │ 160 MB   │ Cumulative heap allocations │
├────────────┼─────────────┼──────────┼─────────────────────────────┤
│ Sys        │ 1181 MB     │ 178 MB   │ Total memory from the OS    │
├────────────┼─────────────┼──────────┼─────────────────────────────┤
│ NumGC      │ 4           │ 5        │ GC cycles run               │
└────────────┴─────────────┴──────────┴─────────────────────────────┘
```
Notice, the memory usage does not explode in the TCO version.

### Rejected: not actually tail

```rust
#[tailcall]
fn bad(n: int) -> int {
  if n <= 0 { 0 } else { 1 + bad(n - 1) }
}
```

```
error: Recursive call to `bad` is not in tail position
   ╭─[src/main.lis:3:30]
 2 │ fn bad(n: int) -> int {
 3 │   if n <= 0 { 0 } else { 1 + bad(n - 1) }
   ·                              ─────┬─────
   ·                                   ╰── this call result is consumed before returning
   ╰────
  help: A tail call's result must be returned directly. Move work that follows the call into the
        recursive arguments, or remove `#[tailcall]`.
```

There is no way to fix this without restructuring or dropping the annotation. The loudness is the point. A silent fallback to ordinary recursion would defeat the safety story.

## What is NOT supported

Support for some of these (eg. mutual recursion / recursive method calls) could be added later

### Not allowed
- Unit-returning functions.
- Method (impl block) recursion (`self.foobar(...)`). 
- Any self-call not in tail position.
- Lambdas (cant annotate an lambda).

### Functions that looks non-recursive

- Mutual recursion (`A` calls `B` calls `A`) is not detected.
- Recursion through a value (`let f = func; f(x)`).
- Recursion through interface dispatch.

### Detected, but flagged as not in tail position

- Self-call inside `try`/`recover`/`defer`/`task` constructs.
- Self-call inside any loop body (`for`/`while`/`loop`/`while let`).
- Self-call wrapped in `cast`, `&ref`, `expr?`
- `let x = f(...); x`. The bare `x` trailing is technically tail, but we reject it. Workaround: rewrite as the bare `f(...)`.


## Edge cases worth knowing

Generated Go differs from source shape. Stack traces no longer show recursion. `delve` users see one frame where normally they would see many. This is the same tradeoff Go declined to make globally, pushed down to be opt-in only, per-function.

Pointer-style param reassignment. Each iteration writes to the param slot. For destructured params like`(a, b): (int, int)`, the destructure is re-run inside the loop so locals refresh. This works but costs a lookup/assignment per iteration.

The tco walker uses an exhaustive match plus a fallback that treats unknown Expression variants as non-tail. New AST variants that should be tail-propagating need an explicit arm added.

## Pros and cons

The good:

- Lets users write the idiomatic recursive code without paying the stack cost.
- Enables tree walks, state machines, parsers that currently can stack overflow.
- Opt-in. Zero impact on un-annotated code. Easy to revert per-function.
- Reduces memory use many fold, depending on the use-case.
- Fail fast. If the compiler cant honor the annotation, it errors out.
- Does not change the language. `#[tailcall]` is the only new surface.

The bad:

- Adds a compiler pass and a small bit of state plumbing on the planner. More moving parts.
- The transformed Go can be harder to debug. Recursion that was visible in stack traces becomes a loop.
- Easy to write a function that looks tail-recursive, but is not (`f(x) + 1`).
- Scope creep risk. Method and mutual recursion are tempting follow-ups, but at the same time makes the feature way more complex.

Other languages handle this very differently. 

- OCaml require TCO (favours recursion over looping).
- Go refused it [explicitly.](https://groups.google.com/g/golang-nuts/c/nOS2FEiIAaM/m/miAg83qEn-AJ)

- Scala has`@tailrec`.
- Clojure has `recur`.
- JavaScript has TCO in the spec but IIRC only one (safari) engine ships it.


## Compability

- No language-level changes outside the attribute.
- No new keywords.
- No BC breaks. Un-annotated functions emit exactly as before.
- No runtime support needed.

## Finally

Do we want/need this feature at all? It might be outside Lisettes scope, and that is totally fine. Go is way better at handling recursion than, say V8 so this might be unnecessary feature after all.  Either way i had fun implementing this.

If yes, there is still some more work to be done :)
