### PR TITLE
refactor: rebuild tree-sitter parser if stale in nvim

### DIFF
--- a/editors/nvim/ftplugin/lisette.lua
+++ b/editors/nvim/ftplugin/lisette.lua
@@ -4,4 +4,7 @@ vim.bo.tabstop = 2
 vim.bo.expandtab = true
 vim.bo.suffixesadd = ".lis"
 
-pcall(vim.treesitter.start, 0, "lisette")
+local ok, err = pcall(vim.treesitter.start, 0, "lisette")
+if not ok then
+  vim.notify("Lisette: failed to start syntax highlighting:\n" .. tostring(err), vim.log.levels.WARN)
+end

--- a/editors/nvim/plugin/lisette.lua
+++ b/editors/nvim/plugin/lisette.lua
@@ -2,7 +2,22 @@ local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h
 local parser_src = vim.fn.fnamemodify(plugin_dir, ":h") .. "/tree-sitter-lisette/src"
 local parser_so = plugin_dir .. "/parser/lisette.so"
 
-if vim.fn.filereadable(parser_so) == 0 and vim.fn.isdirectory(parser_src) == 1 then
+local function parser_is_stale()
+  if vim.fn.isdirectory(parser_src) == 0 then
+    return false
+  end
+  local so_time = vim.fn.getftime(parser_so)
+  if so_time == -1 then
+    return true
+  end
+  local src_time = math.max(
+    vim.fn.getftime(parser_src .. "/parser.c"),
+    vim.fn.getftime(parser_src .. "/scanner.c")
+  )
+  return src_time > so_time
+end
+
+if parser_is_stale() then
   vim.fn.mkdir(plugin_dir .. "/parser", "p")
   local result = vim.fn.system({
     "cc", "-o", parser_so, "-I", parser_src,


### PR DESCRIPTION
The nvim plugin was only compiling the tree-sitter parser when `lisette.so` was missing, so a grammar change left a stale parser in place.