### PR TITLE
perf: stop cloning function and lambda signatures twice

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -190,16 +190,15 @@ impl InferCtx<'_, '_> {
 
         self.scopes.pop();
 
-        let fn_forall_ty = if generics.is_empty() {
-            base_fn_ty.clone()
+        let fn_ty = if generics.is_empty() {
+            base_fn_ty
         } else {
-            Type::Forall {
+            let fn_forall_ty = Type::Forall {
                 vars: generics.iter().map(|g| g.name.clone()).collect(),
                 body: Box::new(base_fn_ty),
-            }
+            };
+            self.instantiate(&fn_forall_ty).0
         };
-
-        let (fn_ty, _) = self.instantiate(&fn_forall_ty);
 
         self.unify(expected_ty, &fn_ty, &span);
 
@@ -269,15 +268,13 @@ impl InferCtx<'_, '_> {
 
         self.scopes.pop();
 
-        let (fn_ty, _) = self.instantiate(&base_fn_ty);
-
-        self.unify(expected_ty, &fn_ty, &span);
+        self.unify(expected_ty, &base_fn_ty, &span);
 
         Expression::Lambda {
             params: new_params,
             return_annotation,
             body: new_body.into(),
-            ty: fn_ty,
+            ty: base_fn_ty,
             span,
         }
     }


### PR DESCRIPTION
A non-generic function or lambda had its signature built once, then cloned into a `Forall` wrapper, then cloned a second time by `instantiate` (a non-`Forall` instantiate is an identity clone), three copies of one signature. It is now used directly.