### PR TITLE
refactor: add misplaced attribute diagnostic

### DIFF
--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -233,6 +233,21 @@ impl<'source> Parser<'source> {
             Function => self.parse_function(None, vec![]),
             Const => self.parse_const_definition(None),
 
+            Hash => {
+                let attributes = self.parse_attributes();
+                if let Some(attribute) = attributes.first() {
+                    self.error_misplaced_attribute(attribute.span);
+                }
+                if self.is(RightCurlyBrace) || self.at_eof() {
+                    ast::Expression::Unit {
+                        ty: Type::uninferred(),
+                        span: self.span_from_token(self.current_token()),
+                    }
+                } else {
+                    self.parse_block_item()
+                }
+            }
+
             Let => self.parse_let(),
             Return => self.parse_return(),
             For => self.parse_for(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -545,6 +545,24 @@ interface Child {
 }
 
 #[test]
+fn parse_attribute_inside_function_body() {
+    let input = r#"
+fn main() {
+  let command = "add"
+
+  #[iterate]
+  let result = match command {
+    "add" => 1,
+    _ => 0,
+  }
+
+  let _ = result
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_missing_closing_brace() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/parse_attribute_inside_function_body.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_inside_function_body.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Attribute not supported on target
+   ╭─[test.lis:5:3]
+ 4 │ 
+ 5 │   #[iterate]
+   ·   ─────┬────
+   ·        ╰── not supported on target
+ 6 │   let result = match command {
+   ╰────
+  help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]


### PR DESCRIPTION
Adds an error when attempting to use an attribute anywhere not at the top level.

```
  [error] Attribute not supported on target
   ╭─[test.lis:5:3]
 4 │ 
 5 │   #[iterate]
   ·   ─────┬────
   ·        ╰── not supported on target
 6 │   let result = match command {
   ╰────
  help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]
```