### PR TITLE
fix: enforce pointer-receiver rule through generic bounds

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -421,7 +421,7 @@ impl InferCtx<'_, '_> {
         // leave gaps in the cached `underlying_ty` chain).
         let resolved_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
         self.unify(&resolved_expected, &return_ty, &span);
-        self.unify_trait_bounds(&bounds, &new_args, &span);
+        self.unify_trait_bounds(&bounds, &param_types, &new_args, &span);
 
         // Native mutating methods (append, extend, delete) are rewritten by
         // the emitter into mutations of the receiver binding. Require `mut`
@@ -949,7 +949,13 @@ impl InferCtx<'_, '_> {
         ));
     }
 
-    fn unify_trait_bounds(&mut self, bounds: &[Bound], args: &[Expression], fallback_span: &Span) {
+    fn unify_trait_bounds(
+        &mut self,
+        bounds: &[Bound],
+        signature_params: &[Type],
+        args: &[Expression],
+        fallback_span: &Span,
+    ) {
         let store = self.store;
         for bound in bounds {
             let resolved_ty = bound.generic.resolve_in(&self.env);
@@ -977,7 +983,13 @@ impl InferCtx<'_, '_> {
                 continue;
             };
 
-            let _ = self.satisfies_interface(&resolved_ty, &interface, &id, &params, &span);
+            if self
+                .satisfies_interface(&resolved_ty, &interface, &id, &params, &span)
+                .is_ok()
+                && !self.generic_absorbed_via_ref_param(&bound.generic, signature_params)
+            {
+                let _ = self.check_pointer_receivers(&resolved_ty, &interface, &id, &span);
+            }
         }
     }
 

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -80,10 +80,9 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    /// In Go, if any method has a pointer receiver, only a pointer to the
-    /// type satisfies the interface. This check runs only from `unify_constructors`
-    /// (direct value-to-interface assignment), not from bounds checking where the
-    /// emitter may absorb Ref<T> into the type parameter.
+    /// In Go, if any method has a pointer receiver, only a pointer satisfies the
+    /// interface. Runs on direct value-to-interface assignment and bounds checking,
+    /// minus generics absorbed via a `Ref<T>` param (see `generic_absorbed_via_ref_param`).
     pub(super) fn check_pointer_receivers(
         &self,
         ty: &Type,

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -2,7 +2,7 @@ use crate::checker::EnvResolve;
 use Type::{Function, Nominal};
 use diagnostics::LisetteDiagnostic;
 use syntax::ast::Span;
-use syntax::types::{Bound, Type, TypeVarId};
+use syntax::types::{Bound, CompoundKind, Type, TypeVarId};
 
 use crate::checker::infer::InferCtx;
 use crate::checker::type_env::VarState;
@@ -514,8 +514,11 @@ impl InferCtx<'_, '_> {
         let params_result = self.unify_pairs(f1.params.iter().zip(&f2.params), span);
         let return_type_result = self.try_unify(&f1.return_type, &f2.return_type, span);
 
-        for bound in f1.bounds.iter().chain(f2.bounds.iter()) {
-            self.check_function_bound(bound, span);
+        for bound in &f1.bounds {
+            self.check_function_bound(bound, &f1.params, span);
+        }
+        for bound in &f2.bounds {
+            self.check_function_bound(bound, &f2.params, span);
         }
 
         if !self.bounds_equivalent(&f1.bounds, &f2.bounds) {
@@ -563,7 +566,7 @@ impl InferCtx<'_, '_> {
         all_in(bounds1, bounds2) && all_in(bounds2, bounds1)
     }
 
-    fn check_function_bound(&mut self, bound: &Bound, span: &Span) {
+    fn check_function_bound(&mut self, bound: &Bound, signature_params: &[Type], span: &Span) {
         let store = self.store;
         let resolved_ty = bound.generic.resolve_in(&self.env);
 
@@ -584,7 +587,13 @@ impl InferCtx<'_, '_> {
             return;
         };
 
-        let _ = self.satisfies_interface(&resolved_ty, &interface, &id, &params, span);
+        if self
+            .satisfies_interface(&resolved_ty, &interface, &id, &params, span)
+            .is_ok()
+            && !self.generic_absorbed_via_ref_param(&bound.generic, signature_params)
+        {
+            let _ = self.check_pointer_receivers(&resolved_ty, &interface, &id, span);
+        }
     }
 
     /// Built-in bound recognition; falls through to the interface path on miss.
@@ -788,6 +797,27 @@ impl InferCtx<'_, '_> {
             "Change the type annotation to `{}` or convert the value to `{}`",
             actual, expected
         )
+    }
+
+    /// Whether the emitter absorbs this bounded generic into a pointer type argument
+    /// via a top-level `Ref<T>` param (`with_absorbed_ref_generics`), so the pointer
+    /// satisfies the interface. Decided from params alone, like the emitter.
+    pub(super) fn generic_absorbed_via_ref_param(&self, generic: &Type, params: &[Type]) -> bool {
+        let is_absorbed_param = |param: &Type| matches!(param.as_compound(), Some((CompoundKind::Ref, [inner, ..])) if inner == generic);
+
+        let Type::Var { id, .. } = generic else {
+            return params.iter().any(is_absorbed_param);
+        };
+
+        let mut absorbed = false;
+        for param in params {
+            if is_absorbed_param(param) {
+                absorbed = true;
+            } else if self.env.occurs(*id, param) {
+                return false;
+            }
+        }
+        absorbed
     }
 }
 

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4586,6 +4586,100 @@ fn test() { let _w: Worker = MyWorker { label: "t", count: 0 } }
 }
 
 #[test]
+fn pointer_receiver_through_value_bound_rejected() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: T) { x.bump() }
+fn main() { let c = Counter { n: 0 }; use_bound(c) }
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn pointer_receiver_through_ref_bound_accepted() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: Ref<T>) { x.bump() }
+fn main() { let mut c = Counter { n: 0 }; use_bound(&c) }
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn pointer_receiver_through_value_bound_function_value_rejected() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: T) { x.bump() }
+fn apply(f: fn(Counter)) { f(Counter { n: 0 }) }
+fn main() { apply(use_bound) }
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn pointer_receiver_through_ref_bound_function_value_accepted() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: Ref<T>) { x.bump() }
+fn apply(f: fn(Ref<Counter>)) { let mut c = Counter { n: 0 }; f(&c) }
+fn main() { apply(use_bound) }
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn pointer_receiver_through_mixed_value_and_ref_bound_rejected() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: T, y: Ref<T>) { x.bump(); y.bump() }
+fn main() {
+  let c = Counter { n: 0 }
+  let mut d = Counter { n: 0 }
+  use_bound(c, &d)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn pointer_receiver_through_repeated_ref_bound_accepted() {
+    infer(
+        r#"
+interface Bumper { fn bump(self) }
+struct Counter { n: int }
+impl Counter { fn bump(self: Ref<Counter>) { self.n += 1 } }
+fn use_bound<T: Bumper>(x: Ref<T>, y: Ref<T>) { x.bump(); y.bump() }
+fn main() {
+  let mut c = Counter { n: 0 }
+  let mut d = Counter { n: 0 }
+  use_bound(&c, &d)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn cast_to_type_alias_to_interface() {
     infer(
         r#"


### PR DESCRIPTION
Catch passing a value through a generic bound when that value only satisfies the bound through a pointer. Previously this passed checking and the failure surfaced only later as a Go compiler error.

```rs
interface Bumper { 
  fn bump(self)
}

struct Counter { n: int }

impl Counter {
  // pointer receiver
  fn bump(self: Ref<Counter>) {
    self.n += 1
  }
} 

fn use_bound<T: Bumper>(x: T) {
  x.bump()
}

fn main() {
  let c = Counter { n: 0 }
  use_bound(c) // error: Counter does not implement Bumper, so pass a Ref<Counter>
}
```