### PR TITLE
perf: cache module field projections, skip redundant type resolves

### DIFF
--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -274,6 +274,8 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         } else {
             let allocator = binding_ids.clone();
             let ufcs_shared = Arc::new(std::mem::take(&mut checker.ufcs_methods));
+            // Share register-built projections so workers do not rebuild them.
+            let fields_shared = Arc::new(checker.module_fields_snapshot());
             let store_ref: &Store = &store;
 
             type WorkerOutput = (Vec<(String, File)>, Facts, LocalSink);
@@ -283,6 +285,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
                     let local_sink = LocalSink::new();
                     let mut worker = TaskState::new(&local_sink, allocator.clone());
                     worker.ufcs_shared = Some(ufcs_shared.clone());
+                    worker.module_fields_shared = Some(fields_shared.clone());
                     InferCtx::new(&mut worker, store_ref).infer_module(&module_id, files);
                     let typed_files = std::mem::take(&mut worker.typed_files);
                     let facts = std::mem::replace(&mut worker.facts, Facts::new(allocator.clone()));

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -38,18 +38,18 @@ impl<'a> FreezeFolder<'a> {
 
     pub fn freeze_facts(&self, facts: &mut crate::facts::Facts) {
         for check in &mut facts.generic_call_checks {
-            check.return_ty = self.env.resolve(&check.return_ty);
+            self.env.resolve_in_place(&mut check.return_ty);
         }
         for check in &mut facts.empty_collection_checks {
-            check.ty = self.env.resolve(&check.ty);
+            self.env.resolve_in_place(&mut check.ty);
         }
         for check in &mut facts.statement_tail_checks {
-            check.expected_ty = self.env.resolve(&check.expected_ty);
+            self.env.resolve_in_place(&mut check.expected_ty);
         }
     }
 
     fn freeze_ty(&self, ty: &mut Type) {
-        *ty = self.env.resolve(ty);
+        self.env.resolve_in_place(ty);
     }
 
     fn freeze_binding(&self, binding: &mut Binding) {

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -44,8 +44,9 @@ impl Cursor {
 
 #[derive(Debug, Default)]
 pub struct ImportState {
-    /// Module prefix -> (struct fields, module type)
-    pub imported_modules: HashMap<String, (Vec<StructFieldDefinition>, Type)>,
+    /// Module prefix -> (struct fields, module type). Fields are `Arc`-shared
+    /// since the same module is put in scope once per file.
+    pub imported_modules: HashMap<String, (Arc<[StructFieldDefinition]>, Type)>,
     /// Import prefix -> actual module_id in Store (e.g., "http" -> "go:net/http")
     pub prefix_to_module: HashMap<String, String>,
     /// Modules whose exports are available without prefix (current module and prelude)
@@ -108,6 +109,12 @@ pub struct TaskState<'s> {
     /// transitively requires checking `T` against the same interface.
     pub satisfying_stack: rustc_hash::FxHashSet<(String, String)>,
     method_cache: RefCell<HashMap<EcoString, Rc<MethodSignatures>>>,
+    /// Per-module field projection, cached to avoid rebuilding it (and recloning
+    /// every type) on each file-context entry.
+    module_fields_cache: RefCell<HashMap<EcoString, Arc<[StructFieldDefinition]>>>,
+    /// Register-phase projections shared read-only with inference workers, so
+    /// workers reuse them instead of rebuilding.
+    pub module_fields_shared: Option<Arc<HashMap<EcoString, Arc<[StructFieldDefinition]>>>>,
     pub ufcs_methods: HashSet<(String, String)>,
     /// When set, parallel workers read UFCS methods from here instead of cloning into `ufcs_methods`.
     pub ufcs_shared: Option<Arc<HashSet<(String, String)>>>,
@@ -131,6 +138,8 @@ impl<'s> TaskState<'s> {
             facts: Facts::new(binding_ids),
             satisfying_stack: rustc_hash::FxHashSet::default(),
             method_cache: RefCell::new(HashMap::default()),
+            module_fields_cache: RefCell::new(HashMap::default()),
+            module_fields_shared: None,
             ufcs_methods: HashSet::default(),
             ufcs_shared: None,
             typed_files: Vec::new(),
@@ -700,22 +709,18 @@ impl<'s> TaskState<'s> {
         }
     }
 
-    pub fn put_module_in_scope(&mut self, store: &Store, module_id: &str, prefix: Option<String>) {
-        let Some(prefix) = prefix else {
-            self.imports
-                .unprefixed_imports
-                .insert(module_id.to_string());
-            return;
-        };
+    fn module_struct_fields(&self, module: &Module) -> Arc<[StructFieldDefinition]> {
+        if let Some(shared) = &self.module_fields_shared
+            && let Some(fields) = shared.get(module.id.as_str())
+        {
+            return fields.clone();
+        }
+        if let Some(cached) = self.module_fields_cache.borrow().get(module.id.as_str()) {
+            return cached.clone();
+        }
 
-        let module = store
-            .get_module(module_id)
-            .expect("module must exist when putting in scope");
-
-        let imported_module_id = module.id.clone();
         let module_prefix = format!("{}.", module.id);
-
-        let module_struct_fields: Vec<_> = module
+        let fields: Vec<StructFieldDefinition> = module
             .definitions
             .iter()
             .filter(|(qn, _)| module.is_public(qn))
@@ -747,6 +752,34 @@ impl<'s> TaskState<'s> {
                 }
             })
             .collect();
+
+        let shared: Arc<[StructFieldDefinition]> = fields.into();
+        self.module_fields_cache
+            .borrow_mut()
+            .insert(module.id.clone().into(), shared.clone());
+        shared
+    }
+
+    /// Cached projections so far, to seed workers' `module_fields_shared`.
+    pub fn module_fields_snapshot(&self) -> HashMap<EcoString, Arc<[StructFieldDefinition]>> {
+        self.module_fields_cache.borrow().clone()
+    }
+
+    pub fn put_module_in_scope(&mut self, store: &Store, module_id: &str, prefix: Option<String>) {
+        let Some(prefix) = prefix else {
+            self.imports
+                .unprefixed_imports
+                .insert(module_id.to_string());
+            return;
+        };
+
+        let module = store
+            .get_module(module_id)
+            .expect("module must exist when putting in scope");
+
+        let imported_module_id = module.id.clone();
+
+        let module_struct_fields = self.module_struct_fields(module);
 
         let ty = Type::ImportNamespace(imported_module_id.clone().into());
 

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -101,46 +101,112 @@ impl TypeEnv {
     /// reserved sentinel ids like `IGNORED`/`UNINFERRED`) are preserved as-is.
     /// Used both during inference and as the post-inference freeze pass.
     pub fn resolve(&self, ty: &Type) -> Type {
+        self.resolve_changed(ty).unwrap_or_else(|| ty.clone())
+    }
+
+    /// Resolve `ty` in place; skips the clone-and-rebuild when nothing is bound.
+    /// Returns whether anything changed.
+    pub fn resolve_in_place(&self, ty: &mut Type) -> bool {
+        if let Some(resolved) = self.resolve_changed(ty) {
+            *ty = resolved;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns `Some` only when resolving `ty` would change it (some bound var
+    /// is reachable), allocating just the changed spine. `None` means unchanged.
+    fn resolve_changed(&self, ty: &Type) -> Option<Type> {
         match ty {
             Type::Var { id, .. } if !id.is_reserved() => match &self.entries[Self::slot(*id)] {
-                VarState::Unbound { .. } => ty.clone(),
-                VarState::Bound(bound) => self.resolve(bound),
+                VarState::Unbound { .. } => None,
+                VarState::Bound(bound) => Some(self.resolve(bound)),
             },
             Type::Nominal {
                 id,
                 params,
                 underlying_ty,
-            } => Type::Nominal {
-                id: id.clone(),
-                params: params.iter().map(|p| self.resolve(p)).collect(),
-                underlying_ty: underlying_ty.as_ref().map(|u| Box::new(self.resolve(u))),
-            },
-            Type::Compound { kind, args } => Type::Compound {
-                kind: *kind,
-                args: args.iter().map(|a| self.resolve(a)).collect(),
-            },
-            Type::Function(f) => Type::function(
-                f.params.iter().map(|p| self.resolve(p)).collect(),
-                f.param_mutability.clone(),
-                f.bounds
-                    .iter()
-                    .map(|b| Bound {
-                        param_name: b.param_name.clone(),
-                        generic: self.resolve(&b.generic),
-                        ty: self.resolve(&b.ty),
-                    })
-                    .collect(),
-                Box::new(self.resolve(&f.return_type)),
-            ),
-            Type::Forall { vars, body } => Type::Forall {
-                vars: vars.clone(),
-                body: Box::new(self.resolve(body)),
-            },
-            Type::Tuple(elements) => {
-                Type::Tuple(elements.iter().map(|e| self.resolve(e)).collect())
+            } => {
+                let new_params = self.resolve_slice(params);
+                let new_underlying = underlying_ty
+                    .as_ref()
+                    .and_then(|u| self.resolve_changed(u).map(Box::new));
+                if new_params.is_none() && new_underlying.is_none() {
+                    return None;
+                }
+                Some(Type::Nominal {
+                    id: id.clone(),
+                    params: new_params.unwrap_or_else(|| params.clone()),
+                    underlying_ty: new_underlying
+                        .map(Some)
+                        .unwrap_or_else(|| underlying_ty.clone()),
+                })
             }
-            _ => ty.clone(),
+            Type::Compound { kind, args } => self
+                .resolve_slice(args)
+                .map(|args| Type::Compound { kind: *kind, args }),
+            Type::Function(f) => {
+                let new_params = self.resolve_slice(&f.params);
+                let new_return = self.resolve_changed(&f.return_type).map(Box::new);
+                let new_bounds = self.resolve_bounds(&f.bounds);
+                if new_params.is_none() && new_return.is_none() && new_bounds.is_none() {
+                    return None;
+                }
+                Some(Type::function(
+                    new_params.unwrap_or_else(|| f.params.clone()),
+                    f.param_mutability.clone(),
+                    new_bounds.unwrap_or_else(|| f.bounds.clone()),
+                    new_return.unwrap_or_else(|| f.return_type.clone()),
+                ))
+            }
+            Type::Forall { vars, body } => self.resolve_changed(body).map(|body| Type::Forall {
+                vars: vars.clone(),
+                body: Box::new(body),
+            }),
+            Type::Tuple(elements) => self.resolve_slice(elements).map(Type::Tuple),
+            _ => None,
         }
+    }
+
+    /// [`resolve_changed`] over a slice; `Some` only if an element changed.
+    fn resolve_slice(&self, items: &[Type]) -> Option<Vec<Type>> {
+        let mut out: Option<Vec<Type>> = None;
+        for (i, item) in items.iter().enumerate() {
+            match self.resolve_changed(item) {
+                Some(resolved) => {
+                    out.get_or_insert_with(|| items[..i].to_vec())
+                        .push(resolved);
+                }
+                None => {
+                    if let Some(v) = out.as_mut() {
+                        v.push(item.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Bound-list variant of [`resolve_slice`].
+    fn resolve_bounds(&self, bounds: &[Bound]) -> Option<Vec<Bound>> {
+        let mut out: Option<Vec<Bound>> = None;
+        for (i, b) in bounds.iter().enumerate() {
+            let new_generic = self.resolve_changed(&b.generic);
+            let new_ty = self.resolve_changed(&b.ty);
+            if new_generic.is_none() && new_ty.is_none() {
+                if let Some(v) = out.as_mut() {
+                    v.push(b.clone());
+                }
+                continue;
+            }
+            out.get_or_insert_with(|| bounds[..i].to_vec()).push(Bound {
+                param_name: b.param_name.clone(),
+                generic: new_generic.unwrap_or_else(|| b.generic.clone()),
+                ty: new_ty.unwrap_or_else(|| b.ty.clone()),
+            });
+        }
+        out
     }
 
     /// Occurs check: does `id` appear anywhere inside `ty` (following Var


### PR DESCRIPTION
Speeds up semantic analysis by removing repeated work, with no change to behavior or diagnostics. On a multi-module project this cuts heap allocations during analysis by ~20%.

Follow-up to #601 and #604
