### PR TITLE
fix: pin generic impl type params during interface satisfaction

### DIFF
--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -239,6 +239,17 @@ impl InferCtx<'_, '_> {
                 Type::Forall { .. } => self.instantiate(symbol_method).0,
                 _ => symbol_method.clone(),
             };
+            let receiver_to_pin = match symbol_method {
+                Type::Forall { .. } => match &instantiated_method {
+                    Type::Function(f) => f
+                        .params
+                        .first()
+                        .filter(|p| !p.is_receiver_placeholder())
+                        .map(Type::strip_refs),
+                    _ => None,
+                },
+                _ => None,
+            };
             let impl_method_without_receiver = Self::remove_first_param(&instantiated_method);
 
             // Strip bounds before comparing - bounds are checked separately via bounds_equivalent
@@ -264,21 +275,35 @@ impl InferCtx<'_, '_> {
             )
             .unwrap_or_else(|| impl_method_without_receiver.clone());
 
+            let candidate_ty = ty.strip_refs().resolve_in(&self.env);
+            let mut receiver_pinned = true;
+            let mut resolved_impl_method = None;
             self.scopes.increment_type_param_depth();
             let sig_match = self.speculatively(|this| {
-                InferCtx::new(this, store).try_unify(
+                let mut ctx = InferCtx::new(this, store);
+                if let Some(receiver) = &receiver_to_pin {
+                    ctx.try_unify(receiver, &candidate_ty, &Span::dummy())
+                        .inspect_err(|_| receiver_pinned = false)?;
+                }
+                let result = ctx.try_unify(
                     &strip_bounds(&substituted_method),
                     &strip_bounds(&impl_for_unify),
                     &Span::dummy(),
-                )
+                );
+                if result.is_err() {
+                    resolved_impl_method = Some(impl_method_without_receiver.resolve_in(&ctx.env));
+                }
+                result
             });
             self.scopes.decrement_type_param_depth();
 
-            if sig_match.is_err() {
+            if !receiver_pinned {
+                missing.push((method_name.to_string(), method_ty.clone()));
+            } else if sig_match.is_err() {
                 incompatible.push((
                     method_name.to_string(),
                     substituted_method,
-                    impl_method_without_receiver.clone(),
+                    resolved_impl_method.unwrap_or(impl_method_without_receiver),
                 ));
             } else if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
                 && let Some(module) = store.module_for_qualified_name(id.as_str())

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1635,6 +1635,108 @@ fn generic_interface_with_type_parameter_satisfied() {
 }
 
 #[test]
+fn generic_impl_satisfies_interface_for_matching_instantiation() {
+    infer(
+        r#"
+interface IntGetter { fn get(self) -> int }
+struct Box<T> { value: T }
+impl<T> Box<T> { fn get(self) -> T { self.value } }
+fn want(g: IntGetter) -> int { g.get() }
+fn main() {
+  let b: Box<int> = Box { value: 1 }
+  let _ = want(b)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_impl_mismatched_instantiation_rejected() {
+    infer(
+        r#"
+interface IntGetter { fn get(self) -> int }
+struct Box<T> { value: T }
+impl<T> Box<T> { fn get(self) -> T { self.value } }
+fn want(g: IntGetter) -> int { g.get() }
+fn main() {
+  let b: Box<string> = Box { value: "hello" }
+  let _ = want(b)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn generic_impl_mismatched_param_position_rejected() {
+    infer(
+        r#"
+interface IntSetter { fn set(self, v: int) }
+struct Box<T> { value: T }
+impl<T> Box<T> { fn set(self, v: T) {} }
+fn want(s: IntSetter) { s.set(1) }
+fn main() {
+  let b: Box<string> = Box { value: "hi" }
+  want(b)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn constrained_generic_impl_receiver_mismatch_rejected() {
+    infer(
+        r#"
+interface Same { fn same(self) -> int }
+struct Pair<A, B> { a: A, b: B }
+impl<A> Pair<A, A> { fn same(self) -> int { 1 } }
+fn want(s: Same) -> int { s.same() }
+fn main() {
+  let p: Pair<int, string> = Pair { a: 1, b: "x" }
+  let _ = want(p)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn constrained_generic_impl_receiver_match_accepted() {
+    infer(
+        r#"
+interface Same { fn same(self) -> int }
+struct Pair<A, B> { a: A, b: B }
+impl<A> Pair<A, A> { fn same(self) -> int { 1 } }
+fn want(s: Same) -> int { s.same() }
+fn main() {
+  let p: Pair<int, int> = Pair { a: 1, b: 2 }
+  let _ = want(p)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_impl_satisfies_generic_interface_for_matching_instantiation() {
+    infer(
+        r#"
+interface Getter<U> { fn get(self) -> U }
+struct Box<T> { value: T }
+impl<T> Box<T> { fn get(self) -> T { self.value } }
+fn want(g: Getter<string>) -> string { g.get() }
+fn main() {
+  let b: Box<string> = Box { value: "hi" }
+  let _ = want(b)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn unconstrained_bounded_type_param_produces_error() {
     infer(
         r#"


### PR DESCRIPTION
Prevent a generic type satisfying an interface for the wrong instantiation, when the impl method's type param does not match what the interface requires. Previously this passed checking, with the failure coming up later as a Go error.

```rs
interface IntGetter { fn get(self) -> int }

struct Box<T> { value: T }

impl<T> Box<T> {
  fn get(self) -> T { self.value }
}

fn want(g: IntGetter) -> int { g.get() }

fn main() {
  let b: Box<string> = Box { value: "hello" }
  let _ = want(b) // error: Box does not implement IntGetter, get expected fn () -> int, found fn () -> string
}
```
