### PR TITLE
perf: share function signatures via Arc instead of deep-cloning

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -641,6 +641,7 @@ impl InferCtx<'_, '_> {
             unreachable!();
         };
 
+        let f = std::sync::Arc::make_mut(f);
         let receiver_ty = f.params.remove(0);
         if !f.param_mutability.is_empty() {
             f.param_mutability.remove(0);

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -628,6 +628,7 @@ impl InferCtx<'_, '_> {
                 && let Type::Function(ref mut f) = instantiated
                 && !f.params.is_empty()
             {
+                let f = std::sync::Arc::make_mut(f);
                 let receiver_param = f.params.remove(0);
                 if !f.param_mutability.is_empty() {
                     f.param_mutability.remove(0);

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -382,7 +382,7 @@ impl InferCtx<'_, '_> {
 
         let (pattern_ty, params) = match value_constructor_type {
             Type::Function(f) => {
-                let f = *f;
+                let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                 (*f.return_type, f.params)
             }
             Type::Nominal { .. } | Type::Compound { .. } | Type::Simple(_) => {
@@ -530,7 +530,7 @@ impl InferCtx<'_, '_> {
             span,
         };
         let typed = TypedPattern::Const {
-            qualified_name: qualified.into(),
+            qualified_name: qualified,
             ty: resolved_ty,
             value: const_value,
         };
@@ -946,7 +946,7 @@ impl InferCtx<'_, '_> {
         let (value_constructor_type, map) = self.instantiate(&ty);
 
         let pattern_ty = match value_constructor_type {
-            Type::Function(f) => *f.return_type,
+            Type::Function(f) => (*f.return_type).clone(),
             Type::Nominal { .. } => value_constructor_type,
             _ => return None,
         };

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -242,27 +242,25 @@ impl InferCtx<'_, '_> {
 
         let qualified: Option<EcoString> = if binding_id.is_none() {
             self.lookup_qualified_name(store, &value)
-                .map(EcoString::from)
         } else {
             None
         };
 
         if let Some(ref qname) = qualified
-            && let Some(definition_span) = self.get_definition_name_span(store, qname.as_str())
-        {
-            self.facts.add_usage(span, definition_span);
-        }
-
-        if let Some(ref qname) = qualified
             && let Some(definition) = store.get_definition(qname.as_str())
-            && let DefinitionBody::TypeAlias { .. } = &definition.body
-            && !self.scopes.is_callee_context()
-            && !self.scopes.is_dot_access_base()
         {
-            let underlying = definition.ty.unwrap_forall();
-            if self.is_enum_type(store, underlying) {
-                self.sink
-                    .push(diagnostics::infer::namespace_alias_used_as_value(span));
+            if let Some(definition_span) = definition.name_span() {
+                self.facts.add_usage(span, definition_span);
+            }
+            if let DefinitionBody::TypeAlias { .. } = &definition.body
+                && !self.scopes.is_callee_context()
+                && !self.scopes.is_dot_access_base()
+            {
+                let underlying = definition.ty.unwrap_forall();
+                if self.is_enum_type(store, underlying) {
+                    self.sink
+                        .push(diagnostics::infer::namespace_alias_used_as_value(span));
+                }
             }
         }
 

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -111,7 +111,7 @@ impl InferCtx<'_, '_> {
             {
                 let struct_ty = struct_ty.clone();
                 let struct_fields = struct_fields.clone();
-                let struct_id_str = struct_id.to_string();
+                let struct_id_str: EcoString = struct_id.into();
                 let alias_underlying = if matches!(&alias_ty, Type::Forall { .. }) {
                     None
                 } else {
@@ -172,7 +172,7 @@ impl InferCtx<'_, '_> {
             if let Some(variant_fields) = variant_fields {
                 let (instantiated_ty, map) = self.instantiate(&alias_ty);
                 let enum_ty = match instantiated_ty {
-                    Type::Function(f) => *f.return_type,
+                    Type::Function(f) => (*f.return_type).clone(),
                     _ => instantiated_ty,
                 };
                 return self.infer_struct_call_for_enum_variant(
@@ -192,7 +192,7 @@ impl InferCtx<'_, '_> {
             let (value_constructor_type, map) = self.instantiate(&ty);
 
             let pattern_ty = match value_constructor_type {
-                Type::Function(f) => *f.return_type,
+                Type::Function(f) => (*f.return_type).clone(),
                 Type::Nominal { .. } => value_constructor_type,
                 _ => {
                     self.sink
@@ -246,7 +246,7 @@ impl InferCtx<'_, '_> {
     fn infer_struct_call_for_struct(
         &mut self,
         struct_name: EcoString,
-        qualified_name: String,
+        qualified_name: EcoString,
         struct_ty: Type,
         struct_fields: Vec<syntax::ast::StructFieldDefinition>,
         field_assignments: Vec<StructFieldAssignment>,

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -286,9 +286,8 @@ impl InferCtx<'_, '_> {
                 }
             }
             Function(f) => {
-                let f = *f;
-                for p in f.params {
-                    self.collapse_vars_to_error(&p, span);
+                for p in &f.params {
+                    self.collapse_vars_to_error(p, span);
                 }
                 self.collapse_vars_to_error(&f.return_type, span);
             }

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -322,21 +322,25 @@ impl<'s> TaskState<'s> {
         None
     }
 
-    pub(crate) fn lookup_qualified_name(&self, store: &Store, type_name: &str) -> Option<String> {
+    pub(crate) fn lookup_qualified_name(
+        &self,
+        store: &Store,
+        type_name: &str,
+    ) -> Option<EcoString> {
         if let Some((prefix, simple_name)) = type_name.split_once('.')
             && let Some(module_id) = self.imports.prefix_to_module.get(prefix)
             && let Some(imported_module) = store.get_module(module_id)
             && let Some((qualified_name, _)) =
                 self.resolve_in_imported_module(imported_module, simple_name)
         {
-            return Some(qualified_name);
+            return Some(qualified_name.into());
         }
 
         let module = store.get_module(&self.cursor.module_id)?;
         let qualified_name = Symbol::from_parts(&module.id, type_name);
 
         if module.definitions.contains_key(qualified_name.as_str()) {
-            return Some(qualified_name.to_string());
+            return Some(qualified_name.as_eco().clone());
         }
 
         for imported_module_id in &self.imports.unprefixed_imports {
@@ -346,7 +350,7 @@ impl<'s> TaskState<'s> {
                     .definitions
                     .contains_key(qualified_name.as_str())
                 {
-                    return Some(qualified_name.to_string());
+                    return Some(qualified_name.as_eco().clone());
                 }
             }
         }
@@ -494,7 +498,7 @@ impl<'s> TaskState<'s> {
         let qualified_name = self.lookup_qualified_name(store, type_name)?;
         let ty = store.get_type(&qualified_name)?.clone();
 
-        Some((qualified_name, ty))
+        Some((qualified_name.to_string(), ty))
     }
 
     pub(crate) fn resolve_type_from_prelude(

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -345,7 +345,7 @@ impl TaskState<'_> {
                 let fn_ty = if has_self_receiver {
                     match fn_ty {
                         Type::Function(f) => {
-                            let f = *f;
+                            let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                             let param_mutability = if f.param_mutability.is_empty() {
                                 vec![]
                             } else {

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -470,7 +470,7 @@ impl Store {
                 underlying_ty,
             },
             Type::Function(f) => {
-                let f = *f;
+                let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                 Type::function(
                     f.params.iter().map(|p| self.peel_alias_deep(p)).collect(),
                     f.param_mutability,

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -18,4 +18,4 @@ serde = ["dep:serde", "ecow/serde"]
 [dependencies]
 ecow.workspace = true
 rustc-hash.workspace = true
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive", "rc"], optional = true }

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::Borrow;
 use std::cell::OnceCell;
+use std::sync::Arc;
 
 use ecow::EcoString;
 
@@ -326,7 +327,7 @@ pub enum Type {
     /// Dot-access on this type resolves to the module's exports.
     ImportNamespace(EcoString),
 
-    Function(Box<FunctionType>),
+    Function(Arc<FunctionType>),
 
     /// Type variable handle. Binding state lives in a `TypeEnv` owned by the
     /// checker; the inline `hint` is display metadata set at allocation time
@@ -473,7 +474,7 @@ impl Type {
         bounds: Vec<Bound>,
         return_type: Box<Type>,
     ) -> Type {
-        Type::Function(Box::new(FunctionType {
+        Type::Function(Arc::new(FunctionType {
             params,
             param_mutability,
             bounds,
@@ -1330,7 +1331,7 @@ impl Type {
     pub fn with_receiver_placeholder(self) -> Type {
         match self {
             Type::Function(f) => {
-                let f = *f;
+                let f = Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                 let mut new_params = vec![Type::ReceiverPlaceholder];
                 new_params.extend(f.params);
 


### PR DESCRIPTION
Speeds up semantic analysis by sharing function signatures instead of deep-copying them.

A function's signature is copied constantly during type checking, on every lookup, on every generic instantiation, every time a signature is brought into scope. Each copy previously cloned the whole structure, but the signature now lives behind a reference-counted pointer. As a smaller extension, `lookup_qualified_name` now returns an `EcoString` so short qualified names (the common case) stay inline and skip a heap allocation.

On a multi-module project, this PR cuts allocations during semantic analysis by ~25%.

Follow-up to #607