### PR TITLE
refactor: make the scope stack the single source for return context

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -3,7 +3,6 @@ use syntax::types::Type;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::{AbiShape, tuple_element_types};
 use crate::calls::go_interop::{TupleReturnLayout, WrapperTarget};
 use crate::context::expression::ExpressionContext;
@@ -619,17 +618,12 @@ pub(crate) fn lower_arg_to_tagged(
 pub(crate) fn try_emit_lowered_tail_return(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
-    return_ctx: &ReturnContext,
     fx: &mut EmitEffects,
 ) -> Option<Vec<LoweredStatement>> {
-    let shape = return_ctx.lowered_shape()?;
+    let shape = planner.return_ctx().lowered_shape()?;
     match shape {
-        AbiShape::PartialTuple => Some(emit_lowered_partial_tail(
-            planner, expression, return_ctx, fx,
-        )),
-        AbiShape::Tuple { arity } => Some(emit_lowered_tuple_tail(
-            planner, expression, arity, return_ctx, fx,
-        )),
+        AbiShape::PartialTuple => Some(emit_lowered_partial_tail(planner, expression, fx)),
+        AbiShape::Tuple { arity } => Some(emit_lowered_tuple_tail(planner, expression, arity, fx)),
         _ => None,
     }
 }
@@ -639,10 +633,9 @@ pub(crate) fn render_lowered_tail_return(
     planner: &mut Planner,
     output: &mut String,
     expression: &syntax::ast::Expression,
-    return_ctx: &ReturnContext,
     fx: &mut EmitEffects,
 ) -> bool {
-    match try_emit_lowered_tail_return(planner, expression, return_ctx, fx) {
+    match try_emit_lowered_tail_return(planner, expression, fx) {
         Some(statements) => {
             let block = LoweredBlock { statements };
             Renderer.render_lowered_block(output, &block);
@@ -656,14 +649,13 @@ fn emit_lowered_tuple_tail(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
     arity: usize,
-    return_ctx: &ReturnContext,
     fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     use syntax::ast::Expression;
     if let Expression::Tuple { elements, .. } = expression
         && elements.len() == arity
     {
-        let return_ty = return_ctx.expect_ty();
+        let return_ty = planner.return_ctx().expect_ty();
         let slot_tys = tuple_element_types(&planner.facts.peel_alias(&return_ty));
         let stages: Vec<StagedExpression> = elements
             .iter()
@@ -686,7 +678,7 @@ fn emit_lowered_tuple_tail(
         return statements;
     }
 
-    let return_ty = return_ctx.expect_ty();
+    let return_ty = planner.return_ctx().expect_ty();
     let mut setup = String::new();
     let value = planner.emit_value(&mut setup, expression, ExpressionContext::value(), fx);
     let temp = planner.hoist_tmp_value(&mut setup, "tup", &value);
@@ -707,11 +699,10 @@ fn emit_lowered_tuple_tail(
 fn emit_lowered_partial_tail(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
-    return_ctx: &ReturnContext,
     fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     use syntax::ast::Expression;
-    let return_ty = return_ctx.expect_ty();
+    let return_ty = planner.return_ctx().expect_ty();
 
     if let Expression::Call {
         expression: callee,

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -6,7 +6,6 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use super::NativeCallContext;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -182,7 +181,6 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         call_expression: &Expression,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> Option<String> {
         let Expression::Call {
@@ -214,7 +212,6 @@ impl Planner<'_> {
             call_ty: None,
             native_type: &native_type,
             method,
-            ambient_return_ctx: ambient,
         };
         match call_kind {
             CallKind::NativeMethod(_) => {
@@ -277,14 +274,7 @@ impl Planner<'_> {
                 return self.lower_assert_type(function, args, type_args, fx);
             }
             CalleePlan::UfcsMethod => {
-                return self.lower_ufcs_call(
-                    function,
-                    args,
-                    type_args,
-                    spread,
-                    ctx.ambient_return_ctx(),
-                    fx,
-                );
+                return self.lower_ufcs_call(function, args, type_args, spread, fx);
             }
             CalleePlan::NativeConstructor(kind)
             | CalleePlan::NativeMethod(kind)
@@ -299,21 +289,13 @@ impl Planner<'_> {
                     call_ty,
                     native_type: &native_type,
                     method,
-                    ambient_return_ctx: ctx.ambient_return_ctx(),
                 };
                 return self.lower_native_call(&native_ctx, fx);
             }
             CalleePlan::ReceiverMethodUfcs { is_public } => {
                 let method = extract_receiver_ufcs_method(function);
                 return self.lower_receiver_method_ufcs(
-                    function,
-                    args,
-                    type_args,
-                    &method,
-                    *is_public,
-                    spread,
-                    ctx.ambient_return_ctx(),
-                    fx,
+                    function, args, type_args, &method, *is_public, spread, fx,
                 );
             }
             CalleePlan::GoInterop(_) | CalleePlan::Regular => {}

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -6,7 +6,6 @@ mod ufcs;
 
 use crate::GoCallStrategy;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::abi::AbiShape;
 use crate::plan::calls::{CallReturnShape, CalleePlan};
 use crate::types::native::NativeGoType;
@@ -49,5 +48,4 @@ pub(super) struct NativeCallContext<'a> {
     pub call_ty: Option<&'a Type>,
     pub native_type: &'a NativeGoType,
     pub method: &'a str,
-    pub ambient_return_ctx: Option<&'a ReturnContext>,
 }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -2,7 +2,6 @@ use super::NativeCallContext;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::access::index_access::range_var_bounds;
 use crate::expressions::emission::StagedExpression;
@@ -336,7 +335,7 @@ impl Planner<'_> {
         };
 
         if matches!(ctx.native_type, NativeGoType::String) && ctx.method == "substring" {
-            return self.lower_string_substring(expression, ctx.args, ctx.ambient_return_ctx, fx);
+            return self.lower_string_substring(expression, ctx.args, fx);
         }
 
         let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
@@ -408,11 +407,7 @@ impl Planner<'_> {
 
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
-        let mut receiver_stage = self.stage_operand(
-            expression,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ctx.ambient_return_ctx),
-            fx,
-        );
+        let mut receiver_stage = self.stage_operand(expression, ExpressionContext::value(), fx);
         let receiver_is_call = matches!(expression.unwrap_parens(), Expression::Call { .. });
         if !receiver_is_call
             && reads_mutable_operand(expression)
@@ -425,23 +420,11 @@ impl Planner<'_> {
             receiver_stage.value = format!("*{}", receiver_stage.value);
         }
         all_stages.push(receiver_stage);
-        all_stages.extend(self.stage_native_method_args(
-            ctx.function,
-            ctx.args,
-            ctx.ambient_return_ctx,
-            fx,
-        ));
+        all_stages.extend(self.stage_native_method_args(ctx.function, ctx.args, fx));
 
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(1));
-        let (setup, all_values) = self.sequence_with_spread_structured(
-            all_stages,
-            ctx.spread,
-            false,
-            "_arg",
-            combine,
-            ctx.ambient_return_ctx,
-            fx,
-        );
+        let (setup, all_values) = self
+            .sequence_with_spread_structured(all_stages, ctx.spread, false, "_arg", combine, fx);
 
         let receiver = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
@@ -457,12 +440,7 @@ impl Planner<'_> {
             && ctx.method == "substring"
             && ctx.args.len() >= 2
         {
-            return self.lower_string_substring(
-                &ctx.args[0],
-                &ctx.args[1..],
-                ctx.ambient_return_ctx,
-                fx,
-            );
+            return self.lower_string_substring(&ctx.args[0], &ctx.args[1..], fx);
         }
 
         let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
@@ -511,8 +489,7 @@ impl Planner<'_> {
         ctx: &NativeCallContext,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
-        let mut stages =
-            self.stage_native_method_args(ctx.function, ctx.args, ctx.ambient_return_ctx, fx);
+        let mut stages = self.stage_native_method_args(ctx.function, ctx.args, fx);
         if let Some(receiver) = ctx.args.first()
             && !matches!(receiver.unwrap_parens(), Expression::Call { .. })
             && reads_mutable_operand(receiver)
@@ -522,22 +499,13 @@ impl Planner<'_> {
             self.pin_staged(&mut stages[0], "recv");
         }
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(0));
-        self.sequence_with_spread_structured(
-            stages,
-            ctx.spread,
-            false,
-            "_arg",
-            combine,
-            ctx.ambient_return_ctx,
-            fx,
-        )
+        self.sequence_with_spread_structured(stages, ctx.spread, false, "_arg", combine, fx)
     }
 
     fn lower_string_substring(
         &mut self,
         receiver_expr: &Expression,
         args: &[Expression],
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         fx.require_stdlib();
@@ -558,24 +526,13 @@ impl Planner<'_> {
             ..
         } = arg
         {
-            let mut stages = vec![self.stage_operand(
-                receiver_expr,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            )];
+            let mut stages =
+                vec![self.stage_operand(receiver_expr, ExpressionContext::value(), fx)];
             if let Some(s) = start.as_deref() {
-                stages.push(self.stage_operand(
-                    s,
-                    ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                    fx,
-                ));
+                stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
             }
             if let Some(e) = end.as_deref() {
-                stages.push(self.stage_operand(
-                    e,
-                    ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                    fx,
-                ));
+                stages.push(self.stage_operand(e, ExpressionContext::value(), fx));
             }
             let (setup, values) = self.sequence_structured(stages, "_arg");
             let mut bounds = values.iter().skip(1);
@@ -602,11 +559,7 @@ impl Planner<'_> {
         let range_kind = peel_to_range_type(&arg_ty)
             .and_then(|t| t.get_name())
             .expect("substring arg should resolve to a known range type");
-        let receiver_staged = self.stage_operand(
-            receiver_expr,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        );
+        let receiver_staged = self.stage_operand(receiver_expr, ExpressionContext::value(), fx);
         let range_staged = self.stage_or_capture(arg, "range", fx);
         let (setup, values) = self.sequence_structured(vec![receiver_staged, range_staged], "_arg");
         let (start, end) = range_var_bounds(&values[1], range_kind);

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -6,7 +6,6 @@ use rustc_hash::FxHashSet as HashSet;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
@@ -40,7 +39,6 @@ struct CallArgsContext<'a> {
     spread: Option<&'a Expression>,
     wrap_spread_to_any: bool,
     combine_variadic: Option<VariadicCombine>,
-    ambient_return_ctx: Option<&'a ReturnContext>,
 }
 
 /// Escape-aware close-quote search; plain `find` would collide with `\"` inside the literal.
@@ -153,7 +151,6 @@ impl<'a> Planner<'a> {
                 wrap_to_any,
                 "_arg",
                 combine,
-                expression_ctx.ambient_return_ctx(),
                 fx,
             );
             return (setup, format!("{}({})", go_name, args_strings.join(", ")));
@@ -185,7 +182,6 @@ impl<'a> Planner<'a> {
             spread,
             wrap_spread_to_any: spread_needs_any_wrap(function, spread),
             combine_variadic: call_plan.variadic_combine(0),
-            ambient_return_ctx: expression_ctx.ambient_return_ctx(),
         };
         let (args_setup, args_strings) = self.emit_call_args(args, &args_ctx, fx);
 
@@ -378,7 +374,6 @@ impl<'a> Planner<'a> {
             ctx.wrap_spread_to_any,
             "_arg",
             ctx.combine_variadic.as_ref().cloned(),
-            ctx.ambient_return_ctx,
             fx,
         )
     }
@@ -429,11 +424,7 @@ impl<'a> Planner<'a> {
                 fx,
             ),
             ArgumentPlan::RecursiveEnumPointer => {
-                let (mut setup, value) = self.lower_value(
-                    arg,
-                    ExpressionContext::value().with_ambient_return_ctx_opt(ctx.ambient_return_ctx),
-                    fx,
-                );
+                let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
                 if matches!(arg, Expression::Reference { .. }) || arg.get_type().is_ref() {
                     return (setup, value);
                 }
@@ -915,7 +906,7 @@ fn would_suppress_tagged_go(ctx: &CallArgsContext<'_>, effective_param_ty: Optio
 /// Compute the `ExpressionContext` for emitting a Direct or TaggedGoLowering
 /// argument's underlying value via `emit_composite_value`.
 fn direct_arg_emit_ctx<'b>(
-    ctx: &CallArgsContext<'b>,
+    _ctx: &CallArgsContext<'b>,
     effective_param_ty: Option<&'b Type>,
     suppress: bool,
 ) -> ExpressionContext<'b> {
@@ -924,7 +915,6 @@ fn direct_arg_emit_ctx<'b>(
     ExpressionContext::value()
         .with_forced_tagged_go_function(suppress)
         .with_unknown_argument_target(flows_to_unknown)
-        .with_ambient_return_ctx_opt(ctx.ambient_return_ctx)
 }
 
 pub(crate) fn effective_param_type(index: usize, fn_param_types: &[Type]) -> Option<&Type> {

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -5,7 +5,6 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::names::generics::extract_type_mapping;
@@ -80,7 +79,6 @@ impl Planner<'_> {
         args: &[Expression],
         type_args: &[Annotation],
         spread: Option<&Expression>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::DotAccess {
@@ -102,7 +100,7 @@ impl Planner<'_> {
         };
 
         let (mut setup, receiver_arg, emitted_args) =
-            self.lower_ufcs_call_args(function, receiver, args, spread, ambient, fx);
+            self.lower_ufcs_call_args(function, receiver, args, spread, fx);
         let receiver_arg =
             self.apply_receiver_coercion(&mut setup, receiver, receiver_arg, *coercion);
 
@@ -132,7 +130,6 @@ impl Planner<'_> {
         receiver: &Expression,
         args: &[Expression],
         spread: Option<&Expression>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, Vec<String>) {
         // The DotAccess function type curries `self` out, so its params line
@@ -147,14 +144,10 @@ impl Planner<'_> {
             self.ufcs_declared_user_params(receiver, function, formal_params.len());
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
-        all_stages.push(self.stage_operand(
-            receiver,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        ));
+        all_stages.push(self.stage_operand(receiver, ExpressionContext::value(), fx));
         for (i, arg) in args.iter().enumerate() {
             let declared = declared_params.and_then(|p| effective_param_type(i, p));
-            all_stages.push(self.stage_ufcs_arg(arg, declared, formal_params.get(i), ambient, fx));
+            all_stages.push(self.stage_ufcs_arg(arg, declared, formal_params.get(i), fx));
         }
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
 
@@ -168,9 +161,7 @@ impl Planner<'_> {
             self.finalize_spread_stage(&mut all_values, spread_index, false, combine, fx);
             (setup, all_values)
         } else {
-            self.sequence_with_spread_structured(
-                all_stages, spread, false, "_arg", combine, ambient, fx,
-            )
+            self.sequence_with_spread_structured(all_stages, spread, false, "_arg", combine, fx)
         };
         let receiver_arg = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
@@ -182,11 +173,10 @@ impl Planner<'_> {
         arg: &Expression,
         declared_param: Option<&Type>,
         formal_param: Option<&Type>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
         let Some(declared) = declared_param else {
-            return self.stage_prelude_arg(arg, formal_param, ambient, fx);
+            return self.stage_prelude_arg(arg, formal_param, fx);
         };
         let mut setup = String::new();
         if let Some(value) =
@@ -194,11 +184,7 @@ impl Planner<'_> {
         {
             return StagedExpression::new(setup, value, arg);
         }
-        self.stage_composite(
-            arg,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        )
+        self.stage_composite(arg, ExpressionContext::value(), fx)
     }
 
     fn build_ufcs_qualified_call(
@@ -259,7 +245,6 @@ impl Planner<'_> {
         method: &str,
         is_public: bool,
         spread: Option<&Expression>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let go_method = if is_public {
@@ -270,18 +255,12 @@ impl Planner<'_> {
 
         let stages: Vec<StagedExpression> = args
             .iter()
-            .map(|a| {
-                self.stage_composite(
-                    a,
-                    ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                    fx,
-                )
-            })
+            .map(|a| self.stage_composite(a, ExpressionContext::value(), fx))
             .collect();
 
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
-        let (setup, emitted_all) = self
-            .sequence_with_spread_structured(stages, spread, false, "_arg", combine, ambient, fx);
+        let (setup, emitted_all) =
+            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine, fx);
 
         let receiver = emitted_all[0].clone();
         let emitted_rest: Vec<String> = emitted_all[1..].to_vec();

--- a/crates/emit/src/context/expression.rs
+++ b/crates/emit/src/context/expression.rs
@@ -1,4 +1,3 @@
-use crate::ReturnContext;
 use syntax::types::Type;
 
 /// Whether the expression is being emitted as the callee of a call.
@@ -48,10 +47,6 @@ pub(crate) struct ExpressionContext<'a> {
     go_array_return_policy: GoArrayReturnPolicy,
     go_function_value_policy: GoFunctionValuePolicy,
     argument_target: ArgumentTarget,
-    /// Enclosing function/lambda/try/recover return context, for lowering
-    /// operand-position `?`/`return`. Propagated through operand recursion;
-    /// set at every statement/value-emission entry that knows it.
-    ambient_return_ctx: Option<&'a ReturnContext>,
 }
 
 impl<'a> ExpressionContext<'a> {
@@ -103,26 +98,6 @@ impl<'a> ExpressionContext<'a> {
 
     pub(crate) fn expected_slot_type(self) -> Option<&'a Type> {
         self.expected_slot_type
-    }
-
-    /// Set the enclosing return context, preserved across operand recursion.
-    pub(crate) fn with_ambient_return_ctx(mut self, return_ctx: &'a ReturnContext) -> Self {
-        self.ambient_return_ctx = Some(return_ctx);
-        self
-    }
-
-    /// Carry an already-resolved ambient return context across a context
-    /// rebuild (call args, tuple/struct field staging) without dropping it.
-    pub(crate) fn with_ambient_return_ctx_opt(
-        mut self,
-        return_ctx: Option<&'a ReturnContext>,
-    ) -> Self {
-        self.ambient_return_ctx = return_ctx;
-        self
-    }
-
-    pub(crate) fn ambient_return_ctx(self) -> Option<&'a ReturnContext> {
-        self.ambient_return_ctx
     }
 
     pub(crate) fn is_callee(self) -> bool {

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::write_line;
 use syntax::ast::Expression;
 
@@ -51,10 +50,9 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
-        let body = self.lower_block_as_body(expression, return_ctx, fx);
+        let body = self.lower_block_as_body(expression, fx);
         Renderer.render_lowered_block(output, &body);
     }
 }
@@ -66,7 +64,6 @@ impl Planner<'_> {
         header: &str,
         body: &Expression,
         needs_label: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         self.set_current_loop_label_if_needed(needs_label);
@@ -75,7 +72,7 @@ impl Planner<'_> {
         }
         output.push_str(header);
         self.enter_scope();
-        self.emit_block(output, body, return_ctx, fx);
+        self.emit_block(output, body, fx);
         self.exit_scope();
         output.push_str("}\n");
     }

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::names::go_name;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -170,8 +169,9 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
             .map(|t| self.planner.go_type_string(t, self.fx))
     }
 
-    /// Ok type from the supplied return context, with the fallible's own ok type as fallback.
-    pub(crate) fn contextual_ok_type_string(&mut self, return_ctx: &ReturnContext) -> String {
+    /// Ok type from the enclosing return context, with the fallible's own ok type as fallback.
+    pub(crate) fn contextual_ok_type_string(&mut self) -> String {
+        let return_ctx = self.planner.return_ctx();
         if let Some(ty) = return_ctx.ty() {
             let ok_ty = ty.ok_type();
             self.planner.go_type_string(&ok_ty, self.fx)
@@ -229,14 +229,10 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     }
 
     /// Emit a failure wrapper using the contextual ok type (from return context).
-    pub(crate) fn emit_contextual_failure(
-        &mut self,
-        error_value: Option<&str>,
-        return_ctx: &ReturnContext,
-    ) -> String {
+    pub(crate) fn emit_contextual_failure(&mut self, error_value: Option<&str>) -> String {
         self.fx.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
-        let inner_ty = self.contextual_ok_type_string(return_ctx);
+        let inner_ty = self.contextual_ok_type_string();
         if self.fallible.is_result() {
             let err_ty = self.err_type_string().expect("Result must have error type");
             format!(

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -18,13 +18,12 @@ impl Planner<'_> {
         &mut self,
         items: &[Expression],
         ty: &Type,
-        outer: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         fx.require_stdlib();
 
-        let fallback = self.current_return_ctx().cloned();
-        let effective_ty = resolve_fallible_block_type(items, ty, outer.or(fallback.as_ref()));
+        let return_ctx = self.return_ctx();
+        let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("`try` block must have Result or Option type");
 
@@ -37,8 +36,7 @@ impl Planner<'_> {
 
         let body_ctx = ReturnContext::TaggedBlock(effective_ty);
         self.push_return_ctx(body_ctx.clone());
-        let body = self
-            .with_fresh_scope(|planner| planner.lower_try_body(items, &fallible, &body_ctx, fx));
+        let body = self.with_fresh_scope(|planner| planner.lower_try_body(items, &fallible, fx));
         self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
@@ -54,7 +52,6 @@ impl Planner<'_> {
         &mut self,
         items: &[Expression],
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let Some((last, rest)) = items.split_last() else {
@@ -64,9 +61,9 @@ impl Planner<'_> {
         };
         let mut statements: Vec<LoweredStatement> = rest
             .iter()
-            .map(|item| self.lower_statement(item, return_ctx, fx))
+            .map(|item| self.lower_statement(item, fx))
             .collect();
-        statements.extend(self.lower_try_tail(last, fallible, return_ctx, fx));
+        statements.extend(self.lower_try_tail(last, fallible, fx));
         LoweredBlock { statements }
     }
 
@@ -77,11 +74,10 @@ impl Planner<'_> {
         &mut self,
         last: &Expression,
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         if last.diverges().is_some() || last.get_type().is_never() {
-            let mut statements = vec![self.lower_statement(last, return_ctx, fx)];
+            let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
                 statements.push(LoweredStatement::RawGo(
                     "panic(\"unreachable\")\n".to_string(),
@@ -102,19 +98,14 @@ impl Planner<'_> {
         );
         if is_statement_only || is_unit_call(last) {
             return vec![
-                self.lower_statement(last, return_ctx, fx),
+                self.lower_statement(last, fx),
                 self.lower_try_unit_return(fallible, fx),
             ];
         }
 
         let mut statements = Vec::new();
         let mut buffer = String::new();
-        let final_expression = self.emit_value(
-            &mut buffer,
-            last,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let final_expression = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
         if !buffer.is_empty() {
             statements.push(LoweredStatement::RawGo(buffer));
         }
@@ -155,7 +146,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let mut statements: Vec<LoweredStatement> = Vec::new();
@@ -185,6 +175,7 @@ impl Planner<'_> {
             _ => return None,
         };
 
+        let return_ctx = self.return_ctx();
         if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
             let values = if fallible.is_result() {
@@ -201,7 +192,7 @@ impl Planner<'_> {
             fx.require_stdlib();
             let err_return = {
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
-                fe.emit_contextual_failure(err_arg.as_deref(), return_ctx)
+                fe.emit_contextual_failure(err_arg.as_deref())
             };
             statements.push(plain_return(err_return));
         }
@@ -214,13 +205,12 @@ impl Planner<'_> {
         &mut self,
         items: &[Expression],
         ty: &Type,
-        outer: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         fx.require_stdlib();
 
-        let fallback = self.current_return_ctx().cloned();
-        let effective_ty = resolve_fallible_block_type(items, ty, outer.or(fallback.as_ref()));
+        let return_ctx = self.return_ctx();
+        let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("recover block type must be Result<T, PanicValue>");
 
@@ -230,9 +220,8 @@ impl Planner<'_> {
 
         let body_return_ctx = self.return_context_for_type(fallible.ok_ty().clone());
         self.push_return_ctx(body_return_ctx.clone());
-        let body = self.with_fresh_scope(|planner| {
-            planner.lower_recover_body_block(items, &fallible, &body_return_ctx, fx)
-        });
+        let body =
+            self.with_fresh_scope(|planner| planner.lower_recover_body_block(items, &fallible, fx));
         self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
@@ -248,7 +237,6 @@ impl Planner<'_> {
         &mut self,
         items: &[Expression],
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let Some((last, rest)) = items.split_last() else {
@@ -258,9 +246,9 @@ impl Planner<'_> {
         };
         let mut statements: Vec<LoweredStatement> = rest
             .iter()
-            .map(|item| self.lower_statement(item, return_ctx, fx))
+            .map(|item| self.lower_statement(item, fx))
             .collect();
-        statements.extend(self.lower_recover_tail(last, fallible, return_ctx, fx));
+        statements.extend(self.lower_recover_tail(last, fallible, fx));
         LoweredBlock { statements }
     }
 
@@ -271,12 +259,11 @@ impl Planner<'_> {
         &mut self,
         last: &Expression,
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let item_ty = last.get_type();
         if item_ty.is_never() {
-            let mut statements = vec![self.lower_statement(last, return_ctx, fx)];
+            let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
                 statements.push(LoweredStatement::RawGo(
                     "panic(\"unreachable\")\n".to_string(),
@@ -286,18 +273,13 @@ impl Planner<'_> {
         }
         if item_ty.is_unit() || item_ty.is_variable() {
             return vec![
-                self.lower_statement(last, return_ctx, fx),
+                self.lower_statement(last, fx),
                 self.lower_zero_return(fallible.ok_ty(), fx),
             ];
         }
         let mut statements = Vec::new();
         let mut buffer = String::new();
-        let expression = self.emit_value(
-            &mut buffer,
-            last,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let expression = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
         if !buffer.is_empty() {
             statements.push(LoweredStatement::RawGo(buffer));
         }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::patterns::binding_decls::pattern_has_bindings;
@@ -16,7 +15,6 @@ impl Planner<'_> {
     pub(crate) fn lower_for_statement(
         &mut self,
         full_expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredStatement {
         let Expression::For {
@@ -53,24 +51,20 @@ impl Planner<'_> {
         let label = self.current_loop_label().map(str::to_string);
 
         let (prologue, header, lowered_body) = if is_range {
-            self.lower_range_for(binding, iterable, body, return_ctx, fx)
+            self.lower_range_for(binding, iterable, body, fx)
         } else if let Some(range_shape) = stored_range {
-            self.lower_stored_range_for(binding, iterable, range_shape, body, return_ctx, fx)
+            self.lower_stored_range_for(binding, iterable, range_shape, body, fx)
         } else if let Some((kind, receiver)) = string_view {
             match kind {
-                StringViewKind::Runes => {
-                    self.lower_runes_for(binding, receiver, body, return_ctx, fx)
-                }
-                StringViewKind::Bytes => {
-                    self.lower_bytes_for(binding, receiver, body, return_ctx, fx)
-                }
+                StringViewKind::Runes => self.lower_runes_for(binding, receiver, body, fx),
+                StringViewKind::Bytes => self.lower_bytes_for(binding, receiver, body, fx),
             }
         } else if map_tuple {
-            self.lower_map_tuple_for(binding, iterable, body, return_ctx, fx)
+            self.lower_map_tuple_for(binding, iterable, body, fx)
         } else if is_simple {
-            self.lower_simple_for(binding, iterable, body, return_ctx, fx)
+            self.lower_simple_for(binding, iterable, body, fx)
         } else {
-            self.lower_pattern_site_for(binding, iterable, body, return_ctx, fx)
+            self.lower_pattern_site_for(binding, iterable, body, fx)
         };
 
         self.pop_loop();
@@ -91,7 +85,6 @@ impl Planner<'_> {
         iterable: &Expression,
         range_shape: RangeShape,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         self.enter_scope();
@@ -119,7 +112,7 @@ impl Planner<'_> {
                 unreachable!("RangeTo/RangeToInclusive are not iterable")
             }
         };
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -130,7 +123,6 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         self.enter_scope();
@@ -143,7 +135,7 @@ impl Planner<'_> {
         } else {
             format!("for _, {} := range {} {{\n", loop_var, receiver_str)
         };
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -154,7 +146,6 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         self.enter_scope();
@@ -176,7 +167,7 @@ impl Planner<'_> {
                 loop_var, receiver_var, index_var
             ));
         }
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -209,7 +200,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
@@ -223,7 +213,7 @@ impl Planner<'_> {
         } else {
             format!("for _, {} := range {} {{\n", loop_var, iter_expression)
         };
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -236,7 +226,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         let Pattern::Tuple { elements, .. } = &binding.pattern else {
@@ -256,7 +245,7 @@ impl Planner<'_> {
 
         self.enter_scope();
         let (header, lowered_body) = if first_is_simple && second_is_simple {
-            self.lower_map_tuple_simple_body(first, second, &iter_expression, body, return_ctx, fx)
+            self.lower_map_tuple_simple_body(first, second, &iter_expression, body, fx)
         } else {
             self.lower_map_tuple_compound_body(
                 first,
@@ -264,7 +253,6 @@ impl Planner<'_> {
                 &binding.ty,
                 &iter_expression,
                 body,
-                return_ctx,
                 fx,
             )
         };
@@ -279,7 +267,6 @@ impl Planner<'_> {
         second: &Pattern,
         iter_expression: &str,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, LoweredBlock) {
         let first_is_discard =
@@ -293,7 +280,7 @@ impl Planner<'_> {
             let value = self.bind_loop_pattern(second, None);
             format!("for {}, {} := range {} {{\n", key, value, iter_expression)
         };
-        (header, self.lower_block_as_body(body, return_ctx, fx))
+        (header, self.lower_block_as_body(body, fx))
     }
 
     /// Compound map-tuple element pattern: capture key/value into fresh vars,
@@ -306,7 +293,6 @@ impl Planner<'_> {
         binding_ty: &Type,
         iter_expression: &str,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, LoweredBlock) {
         let element_tys: &[Type] = match binding_ty {
@@ -340,7 +326,7 @@ impl Planner<'_> {
             second_ty,
             fx,
         );
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
 
         let mut inner = vec![LoweredStatement::RawGo(bindings)];
         inner.extend(lowered_body.statements);
@@ -366,7 +352,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
@@ -374,7 +359,7 @@ impl Planner<'_> {
         self.enter_scope();
         let (header, body_block) = if !pattern_has_bindings(&binding.pattern) {
             let header = format!("for range {} {{\n", iter_expression);
-            (header, self.lower_block_as_body(body, return_ctx, fx))
+            (header, self.lower_block_as_body(body, fx))
         } else {
             let item_var = self.fresh_var(Some("item"));
             let header = if is_channel {
@@ -391,7 +376,7 @@ impl Planner<'_> {
                 &binding.ty,
                 fx,
             );
-            let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+            let lowered_body = self.lower_block_as_body(body, fx);
 
             let mut inner = vec![LoweredStatement::RawGo(bindings)];
             inner.extend(lowered_body.statements);
@@ -414,7 +399,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (String, String, LoweredBlock) {
         let Expression::Range {
@@ -459,7 +443,7 @@ impl Planner<'_> {
                 loop_var, start_expression, loop_var
             ),
         };
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         (prologue, header, lowered_body)
     }

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::AbiShape;
 use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
@@ -22,7 +21,6 @@ struct WrappedReturnInfo<'a> {
     fallible: &'a Fallible,
     return_ty: &'a Type,
     lowered: Option<&'a AbiShape>,
-    return_ctx: &'a ReturnContext,
 }
 
 pub(crate) fn plain_return(value: String) -> LoweredStatement {
@@ -53,7 +51,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         result_var_name: Option<&str>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let expression_ty = expression.get_type();
@@ -64,8 +61,7 @@ impl Planner<'_> {
 
         // `Err(...)?` / `None?` literal already emits its own return.
         if let Some(var_name) = result_var_name
-            && let Some(head) =
-                self.try_lower_error_constructor(expression, &fallible, return_ctx, fx)
+            && let Some(head) = self.try_lower_error_constructor(expression, &fallible, fx)
         {
             statements.extend(head);
             self.declare_zero_for_dead_path(&mut statements, var_name, &fallible, fx);
@@ -75,7 +71,7 @@ impl Planner<'_> {
         fx.require_stdlib();
         let (check_setup, check_var) = self.hoist_propagate_check_var(expression, fx);
         statements.extend(check_setup);
-        statements.push(self.build_propagate_failure_check(&check_var, &fallible, return_ctx, fx));
+        statements.push(self.build_propagate_failure_check(&check_var, &fallible, fx));
 
         let ok_access = format!("{}.{}", check_var, fallible.ok_field());
         let value = match result_var_name {
@@ -95,10 +91,9 @@ impl Planner<'_> {
         output: &mut String,
         expression: &Expression,
         result_var_name: Option<&str>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> String {
-        let (statements, value) = self.lower_propagate(expression, result_var_name, return_ctx, fx);
+        let (statements, value) = self.lower_propagate(expression, result_var_name, fx);
         let block = LoweredBlock { statements };
         Renderer.render_lowered_block(output, &block);
         value
@@ -162,11 +157,11 @@ impl Planner<'_> {
         &mut self,
         check_var: &str,
         fallible: &Fallible,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredStatement {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
         let success_tag = fallible.success_tag();
+        let return_ctx = self.return_ctx();
 
         let values = if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
@@ -181,7 +176,7 @@ impl Planner<'_> {
         } else {
             let err_return = {
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
-                fe.emit_contextual_failure(Some(&format!("{}{}", check_var, err_field)), return_ctx)
+                fe.emit_contextual_failure(Some(&format!("{}{}", check_var, err_field)))
             };
             vec![err_return]
         };
@@ -193,10 +188,9 @@ impl Planner<'_> {
     pub(crate) fn lower_propagate_statement(
         &mut self,
         inner: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        self.lower_propagate(inner, Some("_"), return_ctx, fx).0
+        self.lower_propagate(inner, Some("_"), fx).0
     }
 
     fn bind_propagate_ok(&mut self, name: &str, ok_access: &str) -> LoweredStatement {
@@ -215,9 +209,9 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
+        let return_ctx = self.return_ctx();
         let is_unit = return_ctx.ty().is_some_and(Type::is_unit);
 
         if is_unit {
@@ -228,11 +222,11 @@ impl Planner<'_> {
                     | Expression::Literal { .. }
             );
             if !is_pure {
-                self.emit_statement(output, expression, return_ctx, fx);
+                self.emit_statement(output, expression, fx);
             }
             output.push_str("return\n");
-        } else if !transition::render_lowered_tail_return(self, output, expression, return_ctx, fx)
-            && !self.emit_wrapped_return(output, expression, return_ctx, fx)
+        } else if !transition::render_lowered_tail_return(self, output, expression, fx)
+            && !self.emit_wrapped_return(output, expression, fx)
         {
             let expression_string =
                 self.emit_value(output, expression, ExpressionContext::value(), fx);
@@ -247,7 +241,6 @@ impl Planner<'_> {
     pub(crate) fn build_return_plan(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         directive: String,
         fx: &mut EmitEffects,
     ) -> ReturnStatementPlan {
@@ -255,6 +248,7 @@ impl Planner<'_> {
             statements: vec![LoweredStatement::RawGo(body_text)],
         };
 
+        let return_ctx = self.return_ctx();
         let is_unit = return_ctx.ty().is_some_and(Type::is_unit);
         if is_unit {
             // Mirror emit_return's unit path: impure expressions run as a
@@ -270,7 +264,7 @@ impl Planner<'_> {
                 None
             } else {
                 let mut buffer = String::new();
-                self.emit_statement(&mut buffer, expression, return_ctx, fx);
+                self.emit_statement(&mut buffer, expression, fx);
                 (!buffer.is_empty()).then(|| body_block(buffer))
             };
             return ReturnStatementPlan {
@@ -279,9 +273,7 @@ impl Planner<'_> {
             };
         }
 
-        if let Some(statements) =
-            transition::try_emit_lowered_tail_return(self, expression, return_ctx, fx)
-        {
+        if let Some(statements) = transition::try_emit_lowered_tail_return(self, expression, fx) {
             return ReturnStatementPlan {
                 directive,
                 form: ReturnForm::LoweredAbi {
@@ -290,7 +282,7 @@ impl Planner<'_> {
             };
         }
 
-        if let Some(statements) = self.lower_wrapped_return(expression, return_ctx, fx) {
+        if let Some(statements) = self.lower_wrapped_return(expression, fx) {
             return ReturnStatementPlan {
                 directive,
                 form: ReturnForm::Wrapped {
@@ -328,10 +320,10 @@ impl Planner<'_> {
     pub(crate) fn lower_wrapped_return(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let expression_ty = expression.get_type();
+        let return_ctx = self.return_ctx();
 
         let return_ty = return_ctx
             .ty()
@@ -366,7 +358,6 @@ impl Planner<'_> {
                 &fallible,
                 &return_ty,
                 lowered.as_ref(),
-                return_ctx,
                 fx,
             ));
             return Some(statements);
@@ -376,7 +367,6 @@ impl Planner<'_> {
             fallible: &fallible,
             return_ty: &return_ty,
             lowered: lowered.as_ref(),
-            return_ctx,
         };
 
         if matches!(expression, Expression::Call { .. }) {
@@ -385,8 +375,7 @@ impl Planner<'_> {
         }
 
         if matches!(expression, Expression::If { .. } | Expression::Match { .. }) {
-            let block =
-                self.lower_branching_to_block(expression, &PlacePlan::Return(return_ctx), fx);
+            let block = self.lower_branching_to_block(expression, &PlacePlan::Return, fx);
             statements.extend(block.statements);
             return Some(statements);
         }
@@ -395,17 +384,13 @@ impl Planner<'_> {
             expression: inner, ..
         } = expression
         {
-            let (setup, value) = self.lower_propagate(inner, None, return_ctx, fx);
+            let (setup, value) = self.lower_propagate(inner, None, fx);
             statements.extend(setup);
             statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
             return Some(statements);
         }
 
-        let (setup, value) = self.lower_value(
-            expression,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let (setup, value) = self.lower_value(expression, ExpressionContext::value(), fx);
         statements.extend(setup);
         statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
         Some(statements)
@@ -417,10 +402,9 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> bool {
-        match self.lower_wrapped_return(expression, return_ctx, fx) {
+        match self.lower_wrapped_return(expression, fx) {
             Some(statements) => {
                 let block = LoweredBlock { statements };
                 Renderer.render_lowered_block(output, &block);
@@ -463,7 +447,6 @@ impl Planner<'_> {
             fallible,
             return_ty,
             lowered,
-            return_ctx,
         } = info;
         let Expression::Call {
             expression: call_expression,
@@ -475,11 +458,11 @@ impl Planner<'_> {
         };
         match fallible.classify_constructor(call_expression) {
             Some(ConstructorKind::Success) => {
-                self.lower_success_constructor_return(args, fallible, lowered, return_ctx, fx)
+                self.lower_success_constructor_return(args, fallible, lowered, fx)
             }
-            Some(ConstructorKind::Failure) => self.lower_failure_constructor_return(
-                args, fallible, return_ty, lowered, return_ctx, fx,
-            ),
+            Some(ConstructorKind::Failure) => {
+                self.lower_failure_constructor_return(args, fallible, return_ty, lowered, fx)
+            }
             None => self.lower_wrapped_passthrough_return(expression, return_ty, lowered, fx),
         }
     }
@@ -489,29 +472,22 @@ impl Planner<'_> {
         args: &[Expression],
         fallible: &Fallible,
         lowered: Option<&AbiShape>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
             let ok_arg = if matches!(shape, AbiShape::BareError) {
                 if !args.is_empty() {
-                    let (setup, _) = self.lower_composite_value(
-                        &args[0],
-                        ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                        fx,
-                    );
+                    let (setup, _) =
+                        self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
                     statements.extend(setup);
                 }
                 String::new()
             } else if args.is_empty() {
                 "struct{}{}".to_string()
             } else {
-                let (setup, value) = self.lower_composite_value(
-                    &args[0],
-                    ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                    fx,
-                );
+                let (setup, value) =
+                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
                 statements.extend(setup);
                 value
             };
@@ -519,11 +495,7 @@ impl Planner<'_> {
                 transition::lowered_ok_values(shape, &ok_arg),
             ));
         } else {
-            let (setup, arg) = self.lower_composite_value(
-                &args[0],
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            );
+            let (setup, arg) = self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
             let success = {
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
                 fe.emit_success(&arg)
@@ -540,7 +512,6 @@ impl Planner<'_> {
         fallible: &Fallible,
         return_ty: &Type,
         lowered: Option<&AbiShape>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
@@ -550,22 +521,16 @@ impl Planner<'_> {
                     transition::lowered_none_values(self, shape, return_ty, fx),
                 ));
             } else {
-                let (setup, err_expr) = self.lower_composite_value(
-                    &args[0],
-                    ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                    fx,
-                );
+                let (setup, err_expr) =
+                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
                 let values = transition::lowered_err_values(self, shape, return_ty, &err_expr, fx);
                 statements.extend(setup);
                 statements.push(transition::multi_value_return(values));
             }
         } else {
             let failure = if fallible.is_result() {
-                let (setup, arg) = self.lower_composite_value(
-                    &args[0],
-                    ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                    fx,
-                );
+                let (setup, arg) =
+                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
                 statements.extend(setup);
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
                 fe.emit_failure(Some(&arg))

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::{
@@ -51,13 +50,7 @@ impl Planner<'_> {
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let mut setup_buffer = String::new();
-        let prep = self.preprocess_select_arms(
-            &mut setup_buffer,
-            arms,
-            needs_retry_loop,
-            Some(place.return_ctx()),
-            fx,
-        );
+        let prep = self.preprocess_select_arms(&mut setup_buffer, arms, needs_retry_loop, fx);
         if !setup_buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(setup_buffer));
         }
@@ -157,7 +150,6 @@ impl Planner<'_> {
         output: &mut String,
         arms: &[SelectArm],
         needs_retry_loop: bool,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> SelectPrep {
         let mut send_parts: Vec<Option<SendArmParts>> = Vec::with_capacity(arms.len());
@@ -169,13 +161,8 @@ impl Planner<'_> {
                 SelectArmPattern::Send {
                     send_expression, ..
                 } => {
-                    let parts = self.prepare_send_arm(
-                        output,
-                        send_expression,
-                        needs_retry_loop,
-                        ambient,
-                        fx,
-                    );
+                    let parts =
+                        self.prepare_send_arm(output, send_expression, needs_retry_loop, fx);
                     send_parts.push(Some(parts));
                     channel_operands.push(None);
                     channel_shadows.push(None);
@@ -186,7 +173,7 @@ impl Planner<'_> {
                     ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.emit_channel_operand(output, receive_expression, ambient, fx);
+                    let ch = self.emit_channel_operand(output, receive_expression, fx);
                     if is_some_pattern(binding) && needs_retry_loop {
                         let shadow = self.hoist_tmp_value(output, "ch", &ch);
                         channel_operands.push(Some(ch));
@@ -206,7 +193,7 @@ impl Planner<'_> {
                     receive_expression, ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.emit_channel_operand(output, receive_expression, ambient, fx);
+                    let ch = self.emit_channel_operand(output, receive_expression, fx);
                     let ch = if needs_retry_loop && channel_has_call {
                         self.hoist_tmp_value(output, "ch", &ch)
                     } else {
@@ -235,29 +222,18 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         receive_expression: &Expression,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> String {
         let unwrapped = receive_expression.unwrap_parens();
         if let Some((channel, "receive", _)) = extract_channel_op(unwrapped) {
-            let ch = self.emit_value(
-                output,
-                channel,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            );
+            let ch = self.emit_value(output, channel, ExpressionContext::value(), fx);
             return if channel.get_type().is_ref() {
                 cancel_deref_of_address(ch)
             } else {
                 ch
             };
         }
-        self.emit_value(
-            output,
-            receive_expression,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        )
+        self.emit_value(output, receive_expression, ExpressionContext::value(), fx)
     }
 
     fn fresh_ok_var(&mut self) -> String {
@@ -502,18 +478,12 @@ impl Planner<'_> {
         output: &mut String,
         send_expression: &Expression,
         needs_hoist: bool,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> SendArmParts {
         let unwrapped = send_expression.unwrap_parens();
         if let Some((channel, member, args)) = extract_channel_op(unwrapped) {
             let ch_has_call = needs_hoist && contains_call(channel);
-            let mut ch = self.emit_value(
-                output,
-                channel,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            );
+            let mut ch = self.emit_value(output, channel, ExpressionContext::value(), fx);
             if channel.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }
@@ -523,12 +493,8 @@ impl Planner<'_> {
             match member {
                 "send" if !args.is_empty() => {
                     let val_has_call = needs_hoist && contains_call(&args[0]);
-                    let mut val = self.emit_composite_value(
-                        output,
-                        &args[0],
-                        ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                        fx,
-                    );
+                    let mut val =
+                        self.emit_composite_value(output, &args[0], ExpressionContext::value(), fx);
                     if val_has_call {
                         val = self.hoist_tmp_value(output, "send_val", &val);
                     }
@@ -539,12 +505,7 @@ impl Planner<'_> {
             }
         } else {
             let expression_has_call = needs_hoist && contains_call(send_expression);
-            let mut ch = self.emit_value(
-                output,
-                send_expression,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            );
+            let mut ch = self.emit_value(output, send_expression, ExpressionContext::value(), fx);
             if send_expression.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -47,7 +47,7 @@ impl Planner<'_> {
     ) {
         self.push_const_frame();
         self.push_return_ctx(return_ctx.clone());
-        self.emit_function_body_inner(output, body, should_return, return_ctx, fx);
+        self.emit_function_body_inner(output, body, should_return, fx);
         self.pop_return_ctx();
         self.pop_const_frame();
     }
@@ -57,10 +57,9 @@ impl Planner<'_> {
         output: &mut String,
         body: &Expression,
         should_return: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
-        let lowered = self.lower_function_body(body, should_return, return_ctx, fx);
+        let lowered = self.lower_function_body(body, should_return, fx);
         Renderer.render_lowered_block(output, &lowered);
     }
 

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::abi::AbiShape;
 use crate::abi::transition::emit_return_adapter;
 use crate::names::go_name;
@@ -398,11 +397,8 @@ impl Planner<'_> {
         &mut self,
         inferred: Vec<Type>,
         in_tail: bool,
-        ambient: Option<&ReturnContext>,
     ) -> Vec<Type> {
-        let Some(resolved) = ambient.cloned() else {
-            return inferred;
-        };
+        let resolved = self.return_ctx();
         let return_slots = resolved.ty().and_then(|ty| {
             let Type::Tuple(slots) = ty else {
                 return None;

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -3,7 +3,6 @@ use syntax::types::peel_to_range_type;
 
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::is_order_sensitive;
@@ -18,7 +17,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         index: &Expression,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Expression::Range {
@@ -28,18 +26,12 @@ impl Planner<'_> {
             ..
         } = index
         {
-            let (setup, value) = self.plan_range_slice(
-                expression,
-                start.as_deref(),
-                end.as_deref(),
-                *inclusive,
-                ambient,
-                fx,
-            );
+            let (setup, value) =
+                self.plan_range_slice(expression, start.as_deref(), end.as_deref(), *inclusive, fx);
             return value_plan_from_statements(setup, value);
         }
 
-        let base_staged = self.stage_base_with_deref(expression, ambient, fx);
+        let base_staged = self.stage_base_with_deref(expression, fx);
 
         // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`,
         // or `r: Prefix` where `type Prefix = RangeTo<int>`).
@@ -53,11 +45,7 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, value);
         }
 
-        let index_staged = self.stage_composite(
-            index,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        );
+        let index_staged = self.stage_composite(index, ExpressionContext::value(), fx);
         let (setup, values) = self.sequence_structured(vec![base_staged, index_staged], "_base");
         value_plan_from_statements(setup, format!("{}[{}]", values[0], values[1]))
     }
@@ -65,21 +53,12 @@ impl Planner<'_> {
     fn stage_base_with_deref(
         &mut self,
         expression: &Expression,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
         let Some(inner) = expression.deref_inner() else {
-            return self.stage_operand(
-                expression,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            );
+            return self.stage_operand(expression, ExpressionContext::value(), fx);
         };
-        let s = self.stage_operand(
-            inner,
-            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-            fx,
-        );
+        let s = self.stage_operand(inner, ExpressionContext::value(), fx);
         StagedExpression {
             value: format!("(*{})", s.value),
             setup: s.setup,
@@ -97,26 +76,17 @@ impl Planner<'_> {
         start: Option<&Expression>,
         end: Option<&Expression>,
         inclusive: bool,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
-        let base_staged = self.stage_base_with_deref(expression, ambient, fx);
+        let base_staged = self.stage_base_with_deref(expression, fx);
 
         let mut all_stages = vec![base_staged];
         if let Some(s) = start {
-            all_stages.push(self.stage_operand(
-                s,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            ));
+            all_stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
         }
         if let Some(e) = end {
-            all_stages.push(self.stage_operand(
-                e,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            ));
+            all_stages.push(self.stage_operand(e, ExpressionContext::value(), fx));
         }
         let (mut setup, values) = self.sequence_structured(all_stages, "_base");
         let base_str = values[0].clone();

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -94,10 +94,7 @@ impl Planner<'_> {
                 // Never-typed spread base diverges — emit as statement and
                 // return a zero-value struct literal (dead code follows).
                 if base.get_type().is_never() {
-                    let return_ctx = self
-                        .resolve_ambient_return_ctx(expression_ctx)
-                        .expect("never-typed spread base requires an enclosing return context");
-                    self.emit_statement(&mut tail, base, &return_ctx, fx);
+                    self.emit_statement(&mut tail, base, fx);
                     format!("{}{{}}", ctx.go_type)
                 } else {
                     let mut field_side_effects: Vec<bool> = Vec::new();

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -3,7 +3,6 @@ use std::fmt::Write;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -16,7 +15,6 @@ impl Planner<'_> {
         output: &mut String,
         literal: &Literal,
         ty: &Type,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> String {
         match literal {
@@ -50,7 +48,7 @@ impl Planner<'_> {
             Literal::Char(c) => {
                 format!("'{}'", convert_escape_sequences(c))
             }
-            Literal::FormatString(parts) => self.emit_format_string(output, parts, ambient, fx),
+            Literal::FormatString(parts) => self.emit_format_string(output, parts, fx),
             Literal::Slice(elements) => {
                 let element_lisette_ty = ty
                     .get_type_params()
@@ -69,13 +67,7 @@ impl Planner<'_> {
 
                 let stages: Vec<StagedExpression> = elements
                     .iter()
-                    .map(|e| {
-                        self.stage_composite(
-                            e,
-                            ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                            fx,
-                        )
-                    })
+                    .map(|e| self.stage_composite(e, ExpressionContext::value(), fx))
                     .collect();
                 let (setup, rendered) = self.sequence_structured(stages, "_v");
                 output.push_str(&Renderer.render_setup(&setup));
@@ -110,7 +102,6 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         parts: &[FormatStringPart],
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> String {
         let has_interpolation = parts
@@ -121,11 +112,7 @@ impl Planner<'_> {
             .iter()
             .filter_map(|p| {
                 if let FormatStringPart::Expression(e) = p {
-                    Some(self.stage_composite(
-                        e,
-                        ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                        fx,
-                    ))
+                    Some(self.stage_composite(e, ExpressionContext::value(), fx))
                 } else {
                     None
                 }

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -206,9 +206,7 @@ impl Planner<'_> {
         }
         if matches!(target, Expression::Call { .. }) {
             let mut buffer = String::new();
-            if let Some(negated) =
-                self.try_emit_negated_call(&mut buffer, target, ctx.ambient_return_ctx(), fx)
-            {
+            if let Some(negated) = self.try_emit_negated_call(&mut buffer, target, fx) {
                 return (setup_from_string(buffer), wrap(negated));
             }
         }

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
 use crate::context::expression::ExpressionContext;
@@ -116,14 +115,11 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         param_ty: Option<&syntax::types::Type>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
         let suppress =
             param_ty.is_some_and(|p| matches!(p.unwrap_forall(), syntax::types::Type::Function(_)));
-        let arg_ctx = ExpressionContext::value()
-            .with_forced_tagged_go_function(suppress)
-            .with_ambient_return_ctx_opt(ambient);
+        let arg_ctx = ExpressionContext::value().with_forced_tagged_go_function(suppress);
         let staged = self.stage_composite(expression, arg_ctx, fx);
 
         if suppress {
@@ -195,7 +191,6 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         args: &[Expression],
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> Vec<StagedExpression> {
         let fn_ty = function.get_type();
@@ -205,7 +200,7 @@ impl Planner<'_> {
         };
         args.iter()
             .enumerate()
-            .map(|(i, arg)| self.stage_prelude_arg(arg, formal_params.get(i), ambient, fx))
+            .map(|(i, arg)| self.stage_prelude_arg(arg, formal_params.get(i), fx))
             .collect()
     }
 
@@ -294,15 +289,10 @@ impl Planner<'_> {
         wrap_to_any: bool,
         prefix: &str,
         combine: Option<VariadicCombine>,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let spread_index = spread.map(|s| {
-            stages.push(self.stage_operand(
-                s,
-                ExpressionContext::value().with_ambient_return_ctx_opt(ambient),
-                fx,
-            ));
+            stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
             stages.len() - 1
         });
         let (setup, mut values) = self.sequence_structured(stages, prefix);

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -6,7 +6,6 @@ use crate::EmitEffects;
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::AbiShape;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::abi::transition::{emit_callee_abi_wrapping, emit_lisette_callback_wrapper};
@@ -215,9 +214,7 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> String {
         match expression {
-            Expression::Literal { literal, ty, .. } => {
-                self.emit_literal(output, literal, ty, ctx.ambient_return_ctx(), fx)
-            }
+            Expression::Literal { literal, ty, .. } => self.emit_literal(output, literal, ty, fx),
             Expression::Identifier { value, ty, .. } => {
                 let raw = self.emit_identifier(value, ty, ctx, fx);
                 self.maybe_lower_tagged_fn_ref(output, expression, ty, raw, ctx, fx)
@@ -270,10 +267,7 @@ impl Planner<'_> {
                 params, body, ty, ..
             } => self.emit_lambda(params, body, ty, ctx, fx),
             Expression::Propagate { expression, .. } => {
-                let return_ctx = self
-                    .resolve_ambient_return_ctx(ctx)
-                    .expect("operand-position propagate requires an enclosing return context");
-                self.emit_propagate(output, expression, None, &return_ctx, fx)
+                self.emit_propagate(output, expression, None, fx)
             }
             Expression::TryBlock { .. } => {
                 unreachable!("TryBlock is handled structurally by plan_operand")
@@ -295,9 +289,7 @@ impl Planner<'_> {
             }
             Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
-            | Expression::Block { ty, .. } => {
-                self.emit_to_operand_temp(output, expression, ty, ctx.ambient_return_ctx(), fx)
-            }
+            | Expression::Block { ty, .. } => self.emit_to_operand_temp(output, expression, ty, fx),
             Expression::IfLet { .. } => {
                 unreachable!("IfLet should be desugared to Match before emit")
             }
@@ -305,10 +297,7 @@ impl Planner<'_> {
                 expression: return_expression,
                 ..
             } => {
-                let return_ctx = self
-                    .resolve_ambient_return_ctx(ctx)
-                    .expect("operand-position return requires an enclosing return context");
-                self.emit_return(output, return_expression, &return_ctx, fx);
+                self.emit_return(output, return_expression, fx);
                 String::new()
             }
             Expression::Range { .. } => {
@@ -333,10 +322,9 @@ impl Planner<'_> {
         elements: &[Expression],
         ty: &Type,
         in_tail: bool,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> String {
-        let plan = self.plan_tuple_value(elements, ty, in_tail, ambient, fx);
+        let plan = self.plan_tuple_value(elements, ty, in_tail, fx);
         Renderer.render_value(output, &plan)
     }
 
@@ -346,7 +334,6 @@ impl Planner<'_> {
         elements: &[Expression],
         ty: &Type,
         in_tail: bool,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
         use value_plan_from_statements;
@@ -355,15 +342,14 @@ impl Planner<'_> {
             Type::Tuple(slots) => slots.clone(),
             _ => Vec::new(),
         };
-        let slot_types = self.resolve_tuple_slot_types(inferred_slot_types, in_tail, ambient);
+        let slot_types = self.resolve_tuple_slot_types(inferred_slot_types, in_tail);
 
         let stages: Vec<StagedExpression> = elements
             .iter()
             .enumerate()
             .map(|(i, e)| {
-                let element_ctx = ExpressionContext::value()
-                    .with_expected_slot_type(slot_types.get(i))
-                    .with_ambient_return_ctx_opt(ambient);
+                let element_ctx =
+                    ExpressionContext::value().with_expected_slot_type(slot_types.get(i));
                 self.stage_composite(e, element_ctx, fx)
             })
             .collect();
@@ -609,17 +595,10 @@ impl Planner<'_> {
         &mut self,
         keyword: &str,
         expression: &Expression,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Expression::Block { .. } = expression {
-            let return_ctx = ambient
-                .cloned()
-                .or_else(|| self.current_return_ctx().cloned())
-                .expect("async block body requires an enclosing return context");
-            let body = self.with_fresh_scope(|planner| {
-                planner.lower_block_as_body(expression, &return_ctx, fx)
-            });
+            let body = self.with_fresh_scope(|planner| planner.lower_block_as_body(expression, fx));
             let setup = vec![LoweredStatement::Expression(ExpressionStatementPlan {
                 directive: String::new(),
                 form: ExpressionStatementForm::AsyncBlock {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -34,10 +34,10 @@ pub use output::OutputFile;
 pub use output::imports;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
-use context::expression::ExpressionContext;
 use output::imports::ImportBuilder;
 use plan::ModulePlan;
 use plan::bodies::{LoweredBlock, LoweredStatement};
@@ -328,33 +328,26 @@ impl<'a> Planner<'a> {
         self.scope.current_loop_label()
     }
 
-    /// Scope-guarded push of the enclosing function/lambda/try/recover return
-    /// context. Operand-position `?` and `return` fall back to this stack when
-    /// the threaded `ExpressionContext::ambient_return_ctx` is absent.
+    /// Push the enclosing function/lambda/try/recover return context. This
+    /// scope stack is the single source of truth for return-context lowering;
+    /// all readers consult it via [`Planner::return_ctx`].
     pub(crate) fn push_return_ctx(&mut self, ctx: ReturnContext) {
-        self.scope.push_return_ctx(ctx);
+        self.scope.push_return_ctx(Rc::new(ctx));
     }
 
     pub(crate) fn pop_return_ctx(&mut self) {
         self.scope.pop_return_ctx();
     }
 
-    pub(crate) fn current_return_ctx(&self) -> Option<&ReturnContext> {
-        self.scope.current_return_ctx()
-    }
-
-    /// Prefer the explicitly-threaded ambient context (carries any local
-    /// override), then fall back to the enclosing function/lambda/try/recover
-    /// context maintained on the scope stack. Returns an owned clone since
-    /// callers typically need a `ReturnContext` value, not a borrow that
-    /// conflicts with later `&mut self` calls.
-    pub(crate) fn resolve_ambient_return_ctx(
-        &self,
-        ctx: ExpressionContext<'_>,
-    ) -> Option<ReturnContext> {
-        ctx.ambient_return_ctx()
-            .cloned()
-            .or_else(|| self.current_return_ctx().cloned())
+    /// The enclosing function/lambda/try/recover return context, maintained on
+    /// the scope stack and shared cheaply via `Rc`. Defaults to
+    /// `ReturnContext::None` outside any function body (e.g. module-level
+    /// collection). This is the single source of truth for return-context
+    /// lowering.
+    pub(crate) fn return_ctx(&self) -> Rc<ReturnContext> {
+        self.scope
+            .current_return_ctx()
+            .unwrap_or_else(|| Rc::new(ReturnContext::None))
     }
 
     /// `true` if this is a new declaration in the current block (use `:=`),

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -37,7 +37,7 @@ impl Planner<'_> {
 
         if subject.get_type().is_never() {
             let mut buffer = String::new();
-            self.emit_statement(&mut buffer, subject, place.return_ctx(), fx);
+            self.emit_statement(&mut buffer, subject, fx);
             statements.push(LoweredStatement::RawGo(buffer));
             return LoweredBlock { statements };
         }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -7,7 +7,6 @@ use syntax::types::Type;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::names::go_name;
@@ -186,7 +185,6 @@ impl Planner<'_> {
         binding_ty: &Type,
         scrutinee: &Expression,
         else_block: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let value_ty = scrutinee.get_type();
@@ -202,9 +200,9 @@ impl Planner<'_> {
         };
 
         let body = if matches!(ap.pattern, Pattern::Or { .. }) {
-            self.lower_let_else_or_pattern(ap, binding_ty, subject, else_block, return_ctx, fx)
+            self.lower_let_else_or_pattern(ap, binding_ty, subject, else_block, fx)
         } else {
-            self.lower_let_else_single_pattern(ap, subject, else_block, return_ctx, fx)
+            self.lower_let_else_single_pattern(ap, subject, else_block, fx)
         };
         let body_block = LoweredBlock { statements: body };
 
@@ -230,7 +228,6 @@ impl Planner<'_> {
         scrutinee: &Expression,
         body: &Expression,
         needs_label: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         self.set_current_loop_label_if_needed(needs_label);
@@ -272,7 +269,6 @@ impl Planner<'_> {
                     ty: &scrutinee_ty,
                 },
                 body,
-                return_ctx,
                 fx,
             );
             return;
@@ -289,7 +285,7 @@ impl Planner<'_> {
             emit_tree_bindings_with_consumers(self, output, &info.bindings, &effective, &[body]);
         }
 
-        let block = self.lower_block_as_body(body, return_ctx, fx);
+        let block = self.lower_block_as_body(body, fx);
         Renderer.render_lowered_block(output, &block);
 
         self.emit_while_let_break_else(output);
@@ -300,7 +296,6 @@ impl Planner<'_> {
         ap: AnnotatedPattern,
         subject: TypedSubject,
         else_block: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern, typed } = ap;
@@ -342,7 +337,7 @@ impl Planner<'_> {
             guard_parts.push(wrap_if_struct_literal(negated));
         }
         let guard = guard_parts.join(" || ");
-        let else_lowered = self.lower_block_as_body(else_block, return_ctx, fx);
+        let else_lowered = self.lower_block_as_body(else_block, fx);
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
             condition_setup: String::new(),
@@ -367,7 +362,6 @@ impl Planner<'_> {
         binding_ty: &Type,
         subject: TypedSubject,
         else_block: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern, typed } = ap;
@@ -444,7 +438,7 @@ impl Planner<'_> {
             }
             None => {
                 self.scope.restore_binding_snapshot(pre_let_snapshot);
-                let else_lowered = self.lower_block_as_body(else_block, return_ctx, fx);
+                let else_lowered = self.lower_block_as_body(else_block, fx);
                 self.scope
                     .restore_binding_snapshot(post_declaration_snapshot);
                 else_lowered
@@ -491,7 +485,6 @@ impl Planner<'_> {
         patterns: &[Pattern],
         subject: TypedSubject,
         body: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         let TypedSubject {
@@ -533,7 +526,7 @@ impl Planner<'_> {
 
             let overlays =
                 emit_tree_bindings_with_consumers(self, output, &info.bindings, effective, &[body]);
-            let block = self.lower_block_as_body(body, return_ctx, fx);
+            let block = self.lower_block_as_body(body, fx);
             Renderer.render_lowered_block(output, &block);
             drop_inline_overlays(self, &overlays);
         }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -1,43 +1,25 @@
 //! Lowered body IR: the typed vocabulary `plan::lower` produces and `render/`
 //! consumes. `RawGo` is a transitional node holding pre-rendered Go.
 
-use crate::ReturnContext;
 use crate::plan::values::ValuePlan;
 use crate::utils::{output_ends_with_diverge, output_references_var};
 use syntax::types::Type;
 
-/// Destination for a lowered block's tail. Every variant carries the enclosing
-/// function's `return_ctx` so nested `return`/`?` lower correctly regardless of
-/// the place's own destination; for `Return` it is also the tail target.
+/// Destination for a lowered block's tail. The enclosing function's return
+/// context (for nested `return`/`?`) is read from the scope stack via
+/// `Planner::return_ctx`; `Return` is also the tail target.
 pub(crate) enum PlacePlan<'a> {
-    Statement {
-        return_ctx: &'a ReturnContext,
-    },
-    Return(&'a ReturnContext),
+    Statement,
+    Return,
     Assign {
         local: &'a str,
         target_ty: Option<&'a Type>,
-        return_ctx: &'a ReturnContext,
     },
 }
 
-impl<'a> PlacePlan<'a> {
+impl PlacePlan<'_> {
     pub(crate) fn is_return(&self) -> bool {
-        matches!(self, PlacePlan::Return(_))
-    }
-
-    /// Construct a statement-position place for the given enclosing context.
-    pub(crate) fn statement(return_ctx: &'a ReturnContext) -> Self {
-        PlacePlan::Statement { return_ctx }
-    }
-
-    /// The enclosing function's return context (for nested `return`/`?`).
-    pub(crate) fn return_ctx(&self) -> &'a ReturnContext {
-        match self {
-            PlacePlan::Statement { return_ctx }
-            | PlacePlan::Return(return_ctx)
-            | PlacePlan::Assign { return_ctx, .. } => return_ctx,
-        }
+        matches!(self, PlacePlan::Return)
     }
 }
 

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
@@ -38,7 +37,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::If {
@@ -51,10 +49,6 @@ impl Planner<'_> {
             unreachable!("plan_if_as_operand_temp called on non-If expression");
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
-        let return_ctx = ambient
-            .cloned()
-            .or_else(|| self.current_return_ctx().cloned())
-            .expect("operand-position control flow requires an enclosing return context");
         let plan = self.lower_if(
             String::new(),
             condition,
@@ -63,7 +57,6 @@ impl Planner<'_> {
             &PlacePlan::Assign {
                 local: &result_var,
                 target_ty: Some(ty),
-                return_ctx: &return_ctx,
             },
             fx,
         );
@@ -77,20 +70,14 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
-        let return_ctx = ambient
-            .cloned()
-            .or_else(|| self.current_return_ctx().cloned())
-            .expect("operand-position control flow requires an enclosing return context");
         let block = self.lower_branching_to_block(
             expression,
             &PlacePlan::Assign {
                 local: &result_var,
                 target_ty: Some(ty),
-                return_ctx: &return_ctx,
             },
             fx,
         );
@@ -106,7 +93,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::Loop {
@@ -116,17 +102,12 @@ impl Planner<'_> {
             unreachable!("plan_loop_as_operand_temp called on non-Loop expression");
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
-        let return_ctx = ambient
-            .cloned()
-            .or_else(|| self.current_return_ctx().cloned())
-            .expect("operand-position control flow requires an enclosing return context");
         self.push_loop(result_var.clone());
         let plan = self.lower_loop_with_header(
             String::new(),
             "for {\n".to_string(),
             body,
             *needs_label,
-            &return_ctx,
             fx,
         );
         self.pop_loop();
@@ -137,19 +118,18 @@ impl Planner<'_> {
         &mut self,
         rest: &[Expression],
         last: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, bool) {
         let mut statements: Vec<LoweredStatement> = Vec::with_capacity(rest.len() + 1);
         for item in rest {
-            let statement = self.lower_statement(item, return_ctx, fx);
+            let statement = self.lower_statement(item, fx);
             let diverged = statement.blocks_fallthrough();
             statements.push(statement);
             if diverged {
                 return (statements, true);
             }
         }
-        statements.extend(self.lower_return_tail(last, return_ctx, fx));
+        statements.extend(self.lower_return_tail(last, fx));
         (statements, false)
     }
 
@@ -157,11 +137,10 @@ impl Planner<'_> {
         &mut self,
         body: &Expression,
         should_return: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         if !should_return {
-            return self.lower_block_as_body(body, return_ctx, fx);
+            return self.lower_block_as_body(body, fx);
         }
 
         let items: &[Expression] = if let Expression::Block { items, .. } = body {
@@ -176,7 +155,7 @@ impl Planner<'_> {
             };
         };
 
-        let (mut statements, diverged) = self.lower_body_until_diverge(rest, last, return_ctx, fx);
+        let (mut statements, diverged) = self.lower_body_until_diverge(rest, last, fx);
         if diverged {
             return LoweredBlock { statements };
         }
@@ -192,6 +171,7 @@ impl Planner<'_> {
         let is_unit_tail = !is_statement_only
             && !matches!(last, Expression::Return { .. })
             && last.get_type().is_unit();
+        let return_ctx = self.return_ctx();
         if (is_statement_only || is_unit_tail)
             && let Some(return_ty) = return_ctx.ty().filter(|ty| !ty.is_unit())
         {
@@ -212,7 +192,6 @@ impl Planner<'_> {
     pub(crate) fn lower_statement(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredStatement {
         match expression {
@@ -228,7 +207,7 @@ impl Planner<'_> {
                     condition,
                     consequence,
                     alternative,
-                    &PlacePlan::statement(return_ctx),
+                    &PlacePlan::Statement,
                     fx,
                 );
                 LoweredStatement::If(plan)
@@ -237,13 +216,7 @@ impl Planner<'_> {
                 body, needs_label, ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                LoweredStatement::Loop(self.lower_infinite_loop(
-                    directive,
-                    body,
-                    *needs_label,
-                    return_ctx,
-                    fx,
-                ))
+                LoweredStatement::Loop(self.lower_infinite_loop(directive, body, *needs_label, fx))
             }
             Expression::While {
                 condition,
@@ -257,17 +230,16 @@ impl Planner<'_> {
                     condition,
                     body,
                     *needs_label,
-                    return_ctx,
                     fx,
                 ))
             }
             Expression::Block { .. } => {
                 self.enter_scope();
-                let body = self.lower_block_as_body(expression, return_ctx, fx);
+                let body = self.lower_block_as_body(expression, fx);
                 self.exit_scope();
                 LoweredStatement::Block(body)
             }
-            Expression::For { .. } => self.lower_for_statement(expression, return_ctx, fx),
+            Expression::For { .. } => self.lower_for_statement(expression, fx),
             Expression::Continue { .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 LoweredStatement::Continue {
@@ -303,7 +275,7 @@ impl Planner<'_> {
                 expression: value, ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_return_plan(value, return_ctx, directive, fx);
+                let plan = self.build_return_plan(value, directive, fx);
                 LoweredStatement::Return(plan)
             }
             Expression::Let {
@@ -319,7 +291,6 @@ impl Planner<'_> {
                     value,
                     else_block.as_deref(),
                     *mutable,
-                    return_ctx,
                     directive,
                     fx,
                 );
@@ -336,7 +307,6 @@ impl Planner<'_> {
                     target,
                     value,
                     compound_operator.as_ref(),
-                    return_ctx,
                     directive,
                     fx,
                 );
@@ -344,19 +314,16 @@ impl Planner<'_> {
             }
             Expression::Match { subject, arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let body =
-                    self.lower_match_to_block(subject, arms, &PlacePlan::statement(return_ctx), fx);
+                let body = self.lower_match_to_block(subject, arms, &PlacePlan::Statement, fx);
                 LoweredStatement::Match(MatchStatementPlan { directive, body })
             }
             Expression::Select { arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let mut plan = self.lower_select(arms, &PlacePlan::statement(return_ctx), fx);
+                let mut plan = self.lower_select(arms, &PlacePlan::Statement, fx);
                 plan.directive = directive;
                 LoweredStatement::Select(plan)
             }
-            Expression::WhileLet { .. } => {
-                self.lower_while_let_statement(expression, return_ctx, fx)
-            }
+            Expression::WhileLet { .. } => self.lower_while_let_statement(expression, fx),
             // Top-level items (Struct/Enum/etc) shouldn't appear inside
             // function bodies, but dispatch handles them defensively. They
             // carry their own directive (via `emit_top_item`) so the wrapper
@@ -375,7 +342,7 @@ impl Planner<'_> {
                 }
                 LoweredStatement::RawGo(buffer)
             }
-            _ => self.lower_expression_statement(expression, return_ctx, fx),
+            _ => self.lower_expression_statement(expression, fx),
         }
     }
 
@@ -385,7 +352,6 @@ impl Planner<'_> {
     fn lower_expression_statement(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredStatement {
         let unwrapped = expression.unwrap_parens();
@@ -394,11 +360,7 @@ impl Planner<'_> {
             unwrapped,
             Expression::Task { .. } | Expression::Defer { .. }
         ) {
-            let value = self.plan_operand(
-                unwrapped,
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            );
+            let value = self.plan_operand(unwrapped, ExpressionContext::value(), fx);
             ExpressionStatementForm::Async { value }
         } else if let Expression::Propagate {
             expression: inner, ..
@@ -406,12 +368,12 @@ impl Planner<'_> {
         {
             ExpressionStatementForm::Propagate {
                 body: LoweredBlock {
-                    statements: self.lower_propagate_statement(inner, return_ctx, fx),
+                    statements: self.lower_propagate_statement(inner, fx),
                 },
             }
         } else {
             let mut rendered = String::new();
-            self.emit_discard(&mut rendered, unwrapped, return_ctx, fx);
+            self.emit_discard(&mut rendered, unwrapped, fx);
             ExpressionStatementForm::Discard {
                 body: LoweredBlock {
                     statements: vec![LoweredStatement::RawGo(rendered)],
@@ -426,7 +388,6 @@ impl Planner<'_> {
     fn lower_while_let_statement(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredStatement {
         let Expression::WhileLet {
@@ -450,7 +411,6 @@ impl Planner<'_> {
             scrutinee,
             body,
             *needs_label,
-            return_ctx,
             fx,
         );
         self.pop_loop();
@@ -465,18 +425,11 @@ impl Planner<'_> {
         directive: String,
         body: &Expression,
         needs_label: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.push_loop("_");
-        let plan = self.lower_loop_with_header(
-            directive,
-            "for {\n".to_string(),
-            body,
-            needs_label,
-            return_ctx,
-            fx,
-        );
+        let plan =
+            self.lower_loop_with_header(directive, "for {\n".to_string(), body, needs_label, fx);
         self.pop_loop();
         plan
     }
@@ -487,7 +440,6 @@ impl Planner<'_> {
         condition: &Expression,
         body: &Expression,
         needs_label: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.push_loop("_");
@@ -514,8 +466,7 @@ impl Planner<'_> {
         } else {
             format!("for {} {{\n", wrap_if_struct_literal(rendered))
         };
-        let plan =
-            self.lower_loop_with_header(directive, header, body, needs_label, return_ctx, fx);
+        let plan = self.lower_loop_with_header(directive, header, body, needs_label, fx);
         self.pop_loop();
         plan
     }
@@ -528,13 +479,12 @@ impl Planner<'_> {
         header: String,
         body: &Expression,
         needs_label: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.set_current_loop_label_if_needed(needs_label);
         let label = self.current_loop_label().map(str::to_string);
         self.enter_scope();
-        let lowered_body = self.lower_block_as_body(body, return_ctx, fx);
+        let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         LoopPlan {
             directive,
@@ -550,7 +500,6 @@ impl Planner<'_> {
     pub(crate) fn lower_block_as_body(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
@@ -560,7 +509,7 @@ impl Planner<'_> {
         };
         let statements = items
             .iter()
-            .map(|item| self.lower_statement(item, return_ctx, fx))
+            .map(|item| self.lower_statement(item, fx))
             .collect();
         LoweredBlock { statements }
     }
@@ -611,15 +560,11 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         match place {
-            PlacePlan::Statement { return_ctx } => {
-                self.lower_block_as_body(expression, return_ctx, fx)
+            PlacePlan::Statement => self.lower_block_as_body(expression, fx),
+            PlacePlan::Return => self.lower_block_to_return(expression, fx),
+            PlacePlan::Assign { local, target_ty } => {
+                self.lower_block_to_assign(expression, local, *target_ty, fx)
             }
-            PlacePlan::Return(return_ctx) => self.lower_block_to_return(expression, return_ctx, fx),
-            PlacePlan::Assign {
-                local,
-                target_ty,
-                return_ctx,
-            } => self.lower_block_to_assign(expression, local, *target_ty, return_ctx, fx),
         }
     }
 
@@ -631,18 +576,15 @@ impl Planner<'_> {
         expression: &Expression,
         local: &str,
         target_ty: Option<&Type>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         if expression.get_type().is_result() || expression.get_type().is_option() {
             return LoweredBlock {
-                statements: self
-                    .lower_option_result_assignment(local, target_ty, expression, return_ctx, fx),
+                statements: self.lower_option_result_assignment(local, target_ty, expression, fx),
             };
         }
         LoweredBlock {
-            statements: self
-                .lower_block_to_var(expression, local, target_ty, false, return_ctx, fx),
+            statements: self.lower_block_to_var(expression, local, target_ty, false, fx),
         }
     }
 
@@ -652,7 +594,6 @@ impl Planner<'_> {
     fn lower_block_to_return(
         &mut self,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
@@ -667,7 +608,7 @@ impl Planner<'_> {
             };
         };
 
-        let (statements, _) = self.lower_body_until_diverge(rest, last, return_ctx, fx);
+        let (statements, _) = self.lower_body_until_diverge(rest, last, fx);
         LoweredBlock { statements }
     }
 
@@ -678,7 +619,6 @@ impl Planner<'_> {
     pub(crate) fn lower_return_tail(
         &mut self,
         last: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
@@ -691,13 +631,13 @@ impl Planner<'_> {
 
         if last.get_type().is_unit() {
             if !matches!(last, Expression::Unit { .. }) {
-                statements.push(self.lower_statement(last, return_ctx, fx));
+                statements.push(self.lower_statement(last, fx));
             }
             return statements;
         }
 
         if last.get_type().is_never() {
-            return self.lower_never_return_tail(last, &return_span, return_ctx, fx);
+            return self.lower_never_return_tail(last, &return_span, fx);
         }
 
         let directive = self.maybe_line_directive(&return_span);
@@ -713,7 +653,7 @@ impl Planner<'_> {
                     condition,
                     consequence,
                     alternative,
-                    &PlacePlan::Return(return_ctx),
+                    &PlacePlan::Return,
                     fx,
                 );
                 statements.push(LoweredStatement::If(plan));
@@ -722,12 +662,11 @@ impl Planner<'_> {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                let block =
-                    self.lower_match_to_block(subject, arms, &PlacePlan::Return(return_ctx), fx);
+                let block = self.lower_match_to_block(subject, arms, &PlacePlan::Return, fx);
                 statements.extend(block.statements);
             }
             Expression::Select { arms, .. } => {
-                let mut plan = self.lower_select(arms, &PlacePlan::Return(return_ctx), fx);
+                let mut plan = self.lower_select(arms, &PlacePlan::Return, fx);
                 plan.directive = directive;
                 statements.push(LoweredStatement::Select(plan));
             }
@@ -735,12 +674,12 @@ impl Planner<'_> {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                if let Some(tail) = try_emit_lowered_tail_return(self, last, return_ctx, fx) {
+                if let Some(tail) = try_emit_lowered_tail_return(self, last, fx) {
                     statements.extend(tail);
-                } else if let Some(wrapped) = self.lower_wrapped_return(last, return_ctx, fx) {
+                } else if let Some(wrapped) = self.lower_wrapped_return(last, fx) {
                     statements.extend(wrapped);
                 } else {
-                    statements.extend(self.lower_plain_return_tail(last, return_ctx, fx));
+                    statements.extend(self.lower_plain_return_tail(last, fx));
                 }
             }
         }
@@ -752,11 +691,10 @@ impl Planner<'_> {
         &mut self,
         last: &Expression,
         return_span: &syntax::ast::Span,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = setup_from_string(self.maybe_line_directive(return_span));
-        statements.push(self.lower_statement(last, return_ctx, fx));
+        statements.push(self.lower_statement(last, fx));
         if !is_go_never(last) {
             statements.push(LoweredStatement::RawGo(
                 "panic(\"unreachable\")\n".to_string(),
@@ -770,25 +708,20 @@ impl Planner<'_> {
     fn lower_plain_return_tail(
         &mut self,
         last: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut buffer = String::new();
         if requires_temp_var(last) {
-            let expression_string = self.emit_operand(
-                &mut buffer,
-                last,
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            );
+            let expression_string =
+                self.emit_operand(&mut buffer, last, ExpressionContext::value(), fx);
             if !expression_string.is_empty() {
                 write_line!(buffer, "return {}", expression_string);
             }
         } else {
-            let expression_string = self.emit_tail_value(&mut buffer, last, return_ctx, fx);
-            let return_ty = return_ctx.ty();
+            let expression_string = self.emit_tail_value(&mut buffer, last, fx);
+            let return_ctx = self.return_ctx();
             let expression_string =
-                self.apply_type_coercion(&mut buffer, return_ty, last, expression_string, fx);
+                self.apply_type_coercion(&mut buffer, return_ctx.ty(), last, expression_string, fx);
             write_line!(buffer, "return {}", expression_string);
         }
         vec![LoweredStatement::RawGo(buffer)]

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::analyze::inline_uses::region_blocks_inline;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
@@ -190,7 +189,6 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         value: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         let unwrapped = value.unwrap_parens();
@@ -200,18 +198,13 @@ impl Planner<'_> {
         }
 
         if let Expression::Propagate { expression, .. } = unwrapped {
-            self.emit_propagate(output, expression, Some("_"), return_ctx, fx);
+            self.emit_propagate(output, expression, Some("_"), fx);
             return;
         }
 
         let value_ty = value.get_type();
         if value_ty.is_unit() || value_ty.is_variable() || value_ty.is_never() {
-            let value_expression = self.emit_operand(
-                output,
-                value,
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            );
+            let value_expression = self.emit_operand(output, value, ExpressionContext::value(), fx);
             if !value_expression.is_empty() {
                 if matches!(unwrapped, Expression::Call { .. }) {
                     write_line!(output, "{}", value_expression);
@@ -229,12 +222,7 @@ impl Planner<'_> {
             return;
         }
 
-        let value_expression = self.emit_operand(
-            output,
-            value,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let value_expression = self.emit_operand(output, value, ExpressionContext::value(), fx);
         write_line!(output, "_ = {}", value_expression);
     }
 
@@ -265,14 +253,12 @@ impl Planner<'_> {
         expression: &Expression,
         var: &str,
         target_ty: Option<&Type>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         let ty = expression.get_type();
         let is_fallible = ty.is_result() || ty.is_option();
         if is_fallible {
-            let statements =
-                self.lower_option_result_assignment(var, target_ty, expression, return_ctx, fx);
+            let statements = self.lower_option_result_assignment(var, target_ty, expression, fx);
             output.push_str(&Renderer.render_setup(&statements));
             return;
         }
@@ -282,7 +268,7 @@ impl Planner<'_> {
         } = expression
         {
             self.push_loop(var);
-            self.emit_labeled_loop(output, "for {\n", body, *needs_label, return_ctx, fx);
+            self.emit_labeled_loop(output, "for {\n", body, *needs_label, fx);
             self.pop_loop();
             return;
         }
@@ -291,14 +277,13 @@ impl Planner<'_> {
             && items.len() > 1
         {
             output.push_str("{\n");
-            let statements =
-                self.lower_block_to_var(expression, var, target_ty, true, return_ctx, fx);
+            let statements = self.lower_block_to_var(expression, var, target_ty, true, fx);
             output.push_str(&Renderer.render_setup(&statements));
             output.push_str("}\n");
             return;
         }
 
-        let statements = self.lower_block_to_var(expression, var, target_ty, false, return_ctx, fx);
+        let statements = self.lower_block_to_var(expression, var, target_ty, false, fx);
         output.push_str(&Renderer.render_setup(&statements));
     }
 
@@ -306,16 +291,11 @@ impl Planner<'_> {
         &mut self,
         target_var: &str,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut buffer = String::new();
-        let expression_string = self.emit_operand(
-            &mut buffer,
-            expression,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let expression_string =
+            self.emit_operand(&mut buffer, expression, ExpressionContext::value(), fx);
         let value = value_plan_from_statements(setup_from_string(buffer), expression_string);
         vec![simple_assign(target_var, value)]
     }
@@ -329,7 +309,6 @@ impl Planner<'_> {
         target_var: &str,
         target_ty: Option<&Type>,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let ty = target_ty
@@ -337,7 +316,7 @@ impl Planner<'_> {
             .cloned()
             .unwrap_or_else(|| expression.get_type());
         let Some(fallible) = Fallible::from_type(&ty) else {
-            return self.lower_plain_assign(target_var, expression, return_ctx, fx);
+            return self.lower_plain_assign(target_var, expression, fx);
         };
 
         let actual_expression = if let Expression::Block { items, .. } = expression {
@@ -361,7 +340,7 @@ impl Planner<'_> {
                     Some(ConstructorKind::Success) => fallible.ok_constructor(),
                     Some(ConstructorKind::Failure) => fallible.err_constructor(),
                     None => {
-                        return self.lower_plain_assign(target_var, expression, return_ctx, fx);
+                        return self.lower_plain_assign(target_var, expression, fx);
                     }
                 };
                 if kind == Some(ConstructorKind::Success)
@@ -374,7 +353,7 @@ impl Planner<'_> {
                         let arg = fe.planner.emit_composite_value(
                             &mut arg_buffer,
                             &args[0],
-                            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
+                            ExpressionContext::value(),
                             fe.fx,
                         );
                         (
@@ -402,10 +381,10 @@ impl Planner<'_> {
                     };
                     vec![simple_assign(target_var, ValuePlan::Operand(call_str))]
                 } else {
-                    self.lower_plain_assign(target_var, expression, return_ctx, fx)
+                    self.lower_plain_assign(target_var, expression, fx)
                 }
             }
-            _ => self.lower_block_to_var(expression, target_var, None, false, return_ctx, fx),
+            _ => self.lower_block_to_var(expression, target_var, None, false, fx),
         }
     }
 
@@ -419,7 +398,6 @@ impl Planner<'_> {
         var: &str,
         target_ty: Option<&Type>,
         has_go_braces: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let is_block = matches!(expression, Expression::Block { .. });
@@ -435,9 +413,9 @@ impl Planner<'_> {
         if let Some((last, rest)) = items.split_last() {
             let is_new_target = self.scope.try_acquire_assign_target(var);
             for item in rest {
-                statements.push(self.lower_statement(item, return_ctx, fx));
+                statements.push(self.lower_statement(item, fx));
             }
-            statements.extend(self.lower_assign_tail(last, var, target_ty, return_ctx, fx));
+            statements.extend(self.lower_assign_tail(last, var, target_ty, fx));
             if is_new_target {
                 self.scope.release_assign_target(var);
             }
@@ -475,7 +453,6 @@ impl Planner<'_> {
         last: &Expression,
         var: &str,
         target_ty: Option<&Type>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         if matches!(
@@ -489,10 +466,10 @@ impl Planner<'_> {
                 | Expression::For { .. }
                 | Expression::Const { .. }
         ) {
-            return vec![self.lower_statement(last, return_ctx, fx)];
+            return vec![self.lower_statement(last, fx)];
         }
         if last.get_type().is_never() {
-            let mut statements = vec![self.lower_statement(last, return_ctx, fx)];
+            let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
                 statements.push(LoweredStatement::RawGo(
                     "panic(\"unreachable\")\n".to_string(),
@@ -503,7 +480,7 @@ impl Planner<'_> {
         if is_unit_call(last) {
             return self.lower_unit_call_into_var(last, var, fx);
         }
-        if let Some(statements) = self.lower_append_to_var(var, last, return_ctx, fx) {
+        if let Some(statements) = self.lower_append_to_var(var, last, fx) {
             return statements;
         }
         if matches!(
@@ -513,17 +490,11 @@ impl Planner<'_> {
             let place = PlacePlan::Assign {
                 local: var,
                 target_ty,
-                return_ctx,
             };
             return self.lower_branching_to_block(last, &place, fx).statements;
         }
         let mut buffer = String::new();
-        let expression_string = self.emit_value(
-            &mut buffer,
-            last,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let expression_string = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
         let expression_string =
             self.apply_type_coercion(&mut buffer, target_ty, last, expression_string, fx);
         let value = value_plan_from_statements(setup_from_string(buffer), expression_string);
@@ -535,7 +506,6 @@ impl Planner<'_> {
         &mut self,
         var: &str,
         last: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let Expression::Call {
@@ -574,7 +544,6 @@ impl Planner<'_> {
                 args,
                 (**spread).as_ref(),
                 is_extend,
-                return_ctx,
                 fx,
             );
             let rhs_has_setup = !args_buffer.is_empty()
@@ -585,12 +554,7 @@ impl Planner<'_> {
             buffer.push_str(&args_buffer);
             format!("append({}, {})", receiver_lv, args_str)
         } else {
-            self.emit_value(
-                &mut buffer,
-                last,
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            )
+            self.emit_value(&mut buffer, last, ExpressionContext::value(), fx)
         };
 
         let mut statements = setup_from_string(buffer);
@@ -617,29 +581,15 @@ impl Planner<'_> {
         args: &[Expression],
         spread: Option<&Expression>,
         is_extend: bool,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> String {
         let stages: Vec<StagedExpression> = args
             .iter()
-            .map(|a| {
-                self.stage_composite(
-                    a,
-                    ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                    fx,
-                )
-            })
+            .map(|a| self.stage_composite(a, ExpressionContext::value(), fx))
             .collect();
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
-        let (setup, emitted_args) = self.sequence_with_spread_structured(
-            stages,
-            spread,
-            false,
-            "_arg",
-            combine,
-            Some(return_ctx),
-            fx,
-        );
+        let (setup, emitted_args) =
+            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine, fx);
         output.push_str(&Renderer.render_setup(&setup));
         let args_str = emitted_args.join(", ");
         let suffix = if is_extend { "..." } else { "" };
@@ -652,18 +602,12 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         last: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> String {
         if let Expression::Tuple { elements, ty, .. } = last {
-            self.emit_tuple_value(output, elements, ty, true, Some(return_ctx), fx)
+            self.emit_tuple_value(output, elements, ty, true, fx)
         } else {
-            self.emit_value(
-                output,
-                last,
-                ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-                fx,
-            )
+            self.emit_value(output, last, ExpressionContext::value(), fx)
         }
     }
 
@@ -672,17 +616,14 @@ impl Planner<'_> {
         output: &mut String,
         expression: &Expression,
         ty: &Type,
-        ambient: Option<&ReturnContext>,
         fx: &mut EmitEffects,
     ) -> String {
-        let return_ctx = ambient
-            .cloned()
-            .or_else(|| self.current_return_ctx().cloned())
-            .expect("operand-temp emission requires an enclosing return context");
+        let return_ctx = self.return_ctx();
+        let _return_ctx = return_ctx.as_ref();
         if let Expression::Block { items, .. } = expression {
             if ty.is_never() || ty.is_unit() || matches!(ty, Type::Var { .. } | Type::Forall { .. })
             {
-                self.emit_block(output, expression, &return_ctx, fx);
+                self.emit_block(output, expression, fx);
                 return String::new();
             }
             let result_var = self.declare_result_var(output, ty, fx);
@@ -690,14 +631,8 @@ impl Planner<'_> {
             if needs_braces {
                 output.push_str("{\n");
             }
-            let statements = self.lower_block_to_var(
-                expression,
-                &result_var,
-                None,
-                needs_braces,
-                &return_ctx,
-                fx,
-            );
+            let statements =
+                self.lower_block_to_var(expression, &result_var, None, needs_braces, fx);
             output.push_str(&Renderer.render_setup(&statements));
             if needs_braces {
                 output.push_str("}\n");
@@ -710,12 +645,12 @@ impl Planner<'_> {
         {
             let result_var = self.declare_result_var(output, ty, fx);
             self.push_loop(result_var.clone());
-            self.emit_labeled_loop(output, "for {\n", body, *needs_label, &return_ctx, fx);
+            self.emit_labeled_loop(output, "for {\n", body, *needs_label, fx);
             self.pop_loop();
             return result_var;
         }
         let result_var = self.declare_result_var(output, ty, fx);
-        self.emit_assign(output, expression, &result_var, Some(ty), &return_ctx, fx);
+        self.emit_assign(output, expression, &result_var, Some(ty), fx);
         result_var
     }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -118,7 +118,7 @@ impl Planner<'_> {
             } => self.plan_cast(expression, target_type, ty, ctx, fx),
             Expression::IndexedAccess {
                 expression, index, ..
-            } => self.plan_index_access(expression, index, ctx.ambient_return_ctx(), fx),
+            } => self.plan_index_access(expression, index, fx),
             Expression::Binary {
                 operator,
                 left,
@@ -131,7 +131,7 @@ impl Planner<'_> {
                 ..
             } => self.plan_unary(operator, expression, ctx, fx),
             Expression::Tuple { elements, ty, .. } => {
-                self.plan_tuple_value(elements, ty, false, ctx.ambient_return_ctx(), fx)
+                self.plan_tuple_value(elements, ty, false, fx)
             }
             Expression::Range {
                 start,
@@ -155,36 +155,28 @@ impl Planner<'_> {
             Expression::DotAccess { .. } => self.plan_dot_access(expression, ctx, fx),
             Expression::Task {
                 expression: inner, ..
-            } => self.plan_async_wrapper("go", inner, ctx.ambient_return_ctx(), fx),
+            } => self.plan_async_wrapper("go", inner, fx),
             Expression::Defer {
                 expression: inner, ..
-            } => self.plan_async_wrapper("defer", inner, ctx.ambient_return_ctx(), fx),
+            } => self.plan_async_wrapper("defer", inner, fx),
             Expression::TryBlock { items, ty, .. } => {
-                let (setup, value) = self.lower_try_block(items, ty, ctx.ambient_return_ctx(), fx);
+                let (setup, value) = self.lower_try_block(items, ty, fx);
                 value_plan_from_statements(setup, value)
             }
             Expression::RecoverBlock { items, ty, .. } => {
-                let (setup, value) =
-                    self.lower_recover_block(items, ty, ctx.ambient_return_ctx(), fx);
+                let (setup, value) = self.lower_recover_block(items, ty, fx);
                 value_plan_from_statements(setup, value)
             }
             Expression::If { ty, .. } => {
-                let (setup, value) =
-                    self.plan_if_as_operand_temp(expression, ty, ctx.ambient_return_ctx(), fx);
+                let (setup, value) = self.plan_if_as_operand_temp(expression, ty, fx);
                 value_plan_from_statements(setup, value)
             }
             Expression::Loop { ty, .. } => {
-                let (setup, value) =
-                    self.plan_loop_as_operand_temp(expression, ty, ctx.ambient_return_ctx(), fx);
+                let (setup, value) = self.plan_loop_as_operand_temp(expression, ty, fx);
                 value_plan_from_statements(setup, value)
             }
             Expression::Match { ty, .. } | Expression::Select { ty, .. } if !ty.is_never() => {
-                let (setup, value) = self.plan_branching_as_operand_temp(
-                    expression,
-                    ty,
-                    ctx.ambient_return_ctx(),
-                    fx,
-                );
+                let (setup, value) = self.plan_branching_as_operand_temp(expression, ty, fx);
                 value_plan_from_statements(setup, value)
             }
             Expression::Call { ty, .. } => match self.classify_call(expression) {

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
+use std::rc::Rc;
 
 use crate::Bindings;
 use crate::ReturnContext;
@@ -13,7 +14,7 @@ pub(crate) struct ScopeState {
     declared: Vec<HashSet<String>>,
     scope_depth: usize,
     loop_stack: Vec<LoopContext>,
-    return_ctx_stack: Vec<ReturnContext>,
+    return_ctx_stack: Vec<Rc<ReturnContext>>,
     assign_targets: HashSet<String>,
     go_const_bindings: Vec<HashSet<String>>,
 }
@@ -182,7 +183,7 @@ impl ScopeState {
         self.loop_stack.pop();
     }
 
-    pub(crate) fn push_return_ctx(&mut self, ctx: ReturnContext) {
+    pub(crate) fn push_return_ctx(&mut self, ctx: Rc<ReturnContext>) {
         self.return_ctx_stack.push(ctx);
     }
 
@@ -190,8 +191,8 @@ impl ScopeState {
         self.return_ctx_stack.pop();
     }
 
-    pub(crate) fn current_return_ctx(&self) -> Option<&ReturnContext> {
-        self.return_ctx_stack.last()
+    pub(crate) fn current_return_ctx(&self) -> Option<Rc<ReturnContext>> {
+        self.return_ctx_stack.last().cloned()
     }
 
     pub(crate) fn current_loop_result_var(&self) -> Option<&str> {

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,7 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::ReturnContext;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
@@ -20,10 +19,9 @@ impl Planner<'_> {
         &mut self,
         output: &mut String,
         expression: &Expression,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
-        let statement = self.lower_statement(expression, return_ctx, fx);
+        let statement = self.lower_statement(expression, fx);
         let block = LoweredBlock {
             statements: vec![statement],
         };
@@ -37,7 +35,6 @@ impl Planner<'_> {
         target: &Expression,
         value: &Expression,
         compound_operator: Option<&BinaryOperator>,
-        return_ctx: &ReturnContext,
         directive: String,
         fx: &mut EmitEffects,
     ) -> AssignPlan {
@@ -52,7 +49,7 @@ impl Planner<'_> {
 
         if value.get_type().is_never() {
             let mut buffer = String::new();
-            self.emit_statement(&mut buffer, value, return_ctx, fx);
+            self.emit_statement(&mut buffer, value, fx);
             return AssignPlan {
                 directive,
                 form: AssignForm::NeverTyped {
@@ -100,7 +97,7 @@ impl Planner<'_> {
 
         if self.target_binds_to_discard(target) {
             let mut buffer = String::new();
-            self.emit_discard(&mut buffer, value, return_ctx, fx);
+            self.emit_discard(&mut buffer, value, fx);
             return AssignPlan {
                 directive,
                 form: AssignForm::Discard {
@@ -141,11 +138,7 @@ impl Planner<'_> {
         // `target = value`. Stage RHS first (so the target capture knows
         // whether RHS produced setup), capture the target, then fold RHS
         // setup + coercion setup into the value plan in emission order.
-        let rhs_staged = self.stage_composite(
-            value,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let rhs_staged = self.stage_composite(value, ExpressionContext::value(), fx);
         let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
         let mut target_setup = String::new();
         let target_str = if is_order_sensitive(target) {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::ReturnContext;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::calls::go_interop::{GoCallStrategy, WrapperTarget};
 use crate::context::expression::ExpressionContext;
@@ -122,7 +121,6 @@ fn resolve_let_temp_declaration_ty(
     planner: &mut Planner,
     value: &Expression,
     binding_ty: &Type,
-    return_ctx: &ReturnContext,
 ) -> Type {
     let value_ty = value.get_type();
     let widens_to_interface =
@@ -144,7 +142,7 @@ fn resolve_let_temp_declaration_ty(
         Expression::If { .. } | Expression::Match { .. } | Expression::Select { .. }
     );
     if is_branching && let Type::Tuple(slots) = &base {
-        Type::Tuple(planner.resolve_tuple_slot_types(slots.clone(), false, Some(return_ctx)))
+        Type::Tuple(planner.resolve_tuple_slot_types(slots.clone(), false))
     } else {
         base
     }
@@ -172,7 +170,6 @@ impl Planner<'_> {
         output: &mut String,
         let_spec: LetSpec,
         raw_go_name: Option<&str>,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         let LetSpec {
@@ -189,9 +186,9 @@ impl Planner<'_> {
         let Some(raw_go_name) = raw_go_name else {
             self.scope.bind(identifier, "_");
             if needs_temp {
-                self.emit_let_temp(output, "_", value, binding_ty, return_ctx, fx);
+                self.emit_let_temp(output, "_", value, binding_ty, fx);
             } else {
-                self.emit_discard(output, value, return_ctx, fx);
+                self.emit_discard(output, value, fx);
             }
             return;
         };
@@ -199,15 +196,15 @@ impl Planner<'_> {
             let go_identifier = escape_reserved(raw_go_name);
             if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
                 let fresh = self.fresh_var(Some(identifier));
-                self.emit_let_temp(output, &fresh, value, binding_ty, return_ctx, fx);
+                self.emit_let_temp(output, &fresh, value, binding_ty, fx);
                 self.scope.bind(identifier, &fresh);
             } else {
                 self.scope.bind(identifier, raw_go_name);
-                self.emit_let_temp(output, &go_identifier, value, binding_ty, return_ctx, fx);
+                self.emit_let_temp(output, &go_identifier, value, binding_ty, fx);
             }
             return;
         }
-        self.emit_let_direct(output, let_spec, raw_go_name, return_ctx, fx);
+        self.emit_let_direct(output, let_spec, raw_go_name, fx);
     }
 
     /// `let x = expr?`. Adds a leading `var x T` when the binding widens to
@@ -218,7 +215,6 @@ impl Planner<'_> {
         raw_go_name: Option<&str>,
         value: &Expression,
         binding_ty: &Type,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let Expression::Propagate {
@@ -229,7 +225,7 @@ impl Planner<'_> {
         };
         let Some(raw_go_name) = raw_go_name else {
             self.scope.bind(identifier, "_");
-            return self.lower_propagate(inner, Some("_"), return_ctx, fx).0;
+            return self.lower_propagate(inner, Some("_"), fx).0;
         };
         let go_identifier = self.choose_let_go_name(identifier, raw_go_name, false);
         let widens_to_interface =
@@ -243,10 +239,7 @@ impl Planner<'_> {
             )));
             self.declare(&go_identifier);
         }
-        statements.extend(
-            self.lower_propagate(inner, Some(&go_identifier), return_ctx, fx)
-                .0,
-        );
+        statements.extend(self.lower_propagate(inner, Some(&go_identifier), fx).0);
         self.scope.bind(identifier, &go_identifier);
         self.try_declare(&go_identifier);
         statements
@@ -285,7 +278,6 @@ impl Planner<'_> {
         output: &mut String,
         let_spec: LetSpec,
         raw_go_name: &str,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         let LetSpec {
@@ -307,12 +299,7 @@ impl Planner<'_> {
             return;
         }
 
-        let value_expression = self.emit_value(
-            output,
-            value,
-            ExpressionContext::value().with_ambient_return_ctx(return_ctx),
-            fx,
-        );
+        let value_expression = self.emit_value(output, value, ExpressionContext::value(), fx);
         let coercion = Coercion::resolve(
             self,
             &value.get_type(),
@@ -392,14 +379,13 @@ impl Planner<'_> {
         name: &str,
         value: &Expression,
         binding_ty: &Type,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         if !self.is_declared(name) {
-            self.emit_let_temp_var_declaration(output, name, value, binding_ty, return_ctx, fx);
+            self.emit_let_temp_var_declaration(output, name, value, binding_ty, fx);
             self.try_declare(name);
         }
-        self.emit_assign(output, value, name, Some(binding_ty), return_ctx, fx);
+        self.emit_assign(output, value, name, Some(binding_ty), fx);
     }
 
     fn emit_let_temp_var_declaration(
@@ -408,13 +394,13 @@ impl Planner<'_> {
         name: &str,
         value: &Expression,
         binding_ty: &Type,
-        return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
     ) {
         if name == "_" {
             return;
         }
-        let resolved_ty = resolve_let_temp_declaration_ty(self, value, binding_ty, return_ctx);
+        let return_ctx = self.return_ctx();
+        let resolved_ty = resolve_let_temp_declaration_ty(self, value, binding_ty);
         let has_variable_ok_ty = matches!(
             value,
             Expression::TryBlock { .. } | Expression::RecoverBlock { .. }
@@ -454,7 +440,6 @@ pub(crate) struct LetPlanner<'a, 'e> {
     value: &'a Expression,
     else_block: Option<&'a Expression>,
     mutable: bool,
-    return_ctx: &'a ReturnContext,
 }
 
 impl<'a, 'e> LetPlanner<'a, 'e> {
@@ -464,7 +449,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
         value: &'a Expression,
         else_block: Option<&'a Expression>,
         mutable: bool,
-        return_ctx: &'a ReturnContext,
     ) -> Self {
         Self {
             planner,
@@ -472,7 +456,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             value,
             else_block,
             mutable,
-            return_ctx,
         }
     }
 
@@ -497,8 +480,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 None
             };
             let mut buffer = String::new();
-            self.planner
-                .emit_statement(&mut buffer, self.value, self.return_ctx, fx);
+            self.planner.emit_statement(&mut buffer, self.value, fx);
             return LetForm::Never {
                 declaration,
                 body: wrap(buffer),
@@ -518,7 +500,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                     &self.binding.ty,
                     self.value,
                     else_block,
-                    self.return_ctx,
                     fx,
                 );
                 LetForm::LetElse {
@@ -607,7 +588,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 raw_go_name.as_deref(),
                 self.value,
                 &self.binding.ty,
-                self.return_ctx,
                 fx,
             );
             return LoweredBlock { statements };
@@ -622,7 +602,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 mutable: self.mutable,
             },
             raw_go_name.as_deref(),
-            self.return_ctx,
             fx,
         );
         LoweredBlock {
@@ -635,14 +614,11 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             expression: inner, ..
         } = self.value.unwrap_parens()
         {
-            let statements = self
-                .planner
-                .lower_propagate_statement(inner, self.return_ctx, fx);
+            let statements = self.planner.lower_propagate_statement(inner, fx);
             return LoweredBlock { statements };
         }
         let mut buffer = String::new();
-        self.planner
-            .emit_discard(&mut buffer, self.value, self.return_ctx, fx);
+        self.planner.emit_discard(&mut buffer, self.value, fx);
         LoweredBlock {
             statements: vec![LoweredStatement::RawGo(buffer)],
         }
@@ -687,13 +663,9 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             .collect();
 
         let mut setup = String::new();
-        let call_str = self.planner.emit_call(
-            &mut setup,
-            self.value,
-            None,
-            ExpressionContext::value().with_ambient_return_ctx(self.return_ctx),
-            fx,
-        );
+        let call_str =
+            self.planner
+                .emit_call(&mut setup, self.value, None, ExpressionContext::value(), fx);
 
         for (identifier, go_name) in planned.iter().flatten() {
             self.planner.scope.bind(*identifier, go_name);
@@ -748,12 +720,10 @@ impl Planner<'_> {
         value: &Expression,
         else_block: Option<&Expression>,
         mutable: bool,
-        return_ctx: &ReturnContext,
         directive: String,
         fx: &mut EmitEffects,
     ) -> LetPlan {
-        let form =
-            LetPlanner::new(self, binding, value, else_block, mutable, return_ctx).build_form(fx);
+        let form = LetPlanner::new(self, binding, value, else_block, mutable).build_form(fx);
         LetPlan { directive, form }
     }
 }


### PR DESCRIPTION
Collapses the three carriers of a function's return context into the scope stack as the single source of truth.
