### PR TITLE
feat: offer lsp attribute completions on `#[`

### DIFF
--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -1,4 +1,5 @@
 use syntax::ast::{Attribute, AttributeArg, StructFieldDefinition};
+use syntax::attributes::is_serialization_key;
 
 #[derive(Default)]
 pub(super) struct TagConfig {
@@ -252,13 +253,6 @@ fn interpret_tag_attribute(attribute: &Attribute) -> Option<TagConfig> {
 
         _ => None,
     }
-}
-
-fn is_serialization_key(key: &str) -> bool {
-    matches!(
-        key,
-        "json" | "xml" | "yaml" | "toml" | "db" | "bson" | "mapstructure" | "msgpack"
-    )
 }
 
 pub(super) fn format_tag_string(

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -2,6 +2,8 @@ use rustc_hash::FxHashSet;
 use tower_lsp::lsp_types::*;
 
 use syntax::ast::Expression;
+use syntax::attributes::{AttributeInfo, AttributeTarget, attributes_for};
+use syntax::lex::{Lexer, Token, TokenKind as Tk};
 use syntax::program::DefinitionBody;
 use syntax::types::Type;
 
@@ -368,5 +370,420 @@ fn is_instance_method(ty: &syntax::types::Type, type_id: &str) -> bool {
             type_name(&f.params[0]).is_some_and(|name| name == type_id)
         }
         _ => false,
+    }
+}
+
+pub(crate) fn attribute_completions(source: &str, offset: usize) -> Option<Vec<CompletionItem>> {
+    let tokens = Lexer::new(source, 0).lex().tokens;
+    let split = tokens.partition_point(|t| (t.byte_offset as usize) < offset);
+    let (before, after) = tokens.split_at(split);
+
+    if !in_attribute_name_position(before) {
+        return None;
+    }
+
+    let items = match enclosing_context(before) {
+        EnclosingContext::Struct => collect(attributes_for(AttributeTarget::StructField)),
+        EnclosingContext::Parenthesized | EnclosingContext::Enum | EnclosingContext::Function => {
+            Vec::new()
+        }
+        EnclosingContext::Impl => match following_item(after).item {
+            FollowingItem::Target(AttributeTarget::Function) | FollowingItem::Unknown => {
+                collect(attributes_for(AttributeTarget::Function))
+            }
+            _ => Vec::new(),
+        },
+        // An interface accepts an attribute only on a bare `fn`, not `pub fn`.
+        EnclosingContext::Interface => match following_item(after) {
+            Following {
+                item: FollowingItem::Target(AttributeTarget::Function),
+                is_pub: false,
+            }
+            | Following {
+                item: FollowingItem::Unknown,
+                is_pub: false,
+            } => collect(attributes_for(AttributeTarget::Function)),
+            _ => Vec::new(),
+        },
+        EnclosingContext::TopLevel => match following_item(after).item {
+            FollowingItem::Target(target) => collect(attributes_for(target)),
+            FollowingItem::Invalid => Vec::new(),
+            FollowingItem::Unknown => collect(top_level_attributes()),
+        },
+    };
+
+    Some(items)
+}
+
+fn collect<'a>(infos: impl Iterator<Item = &'a AttributeInfo>) -> Vec<CompletionItem> {
+    infos.map(attribute_item).collect()
+}
+
+fn attribute_item(info: &AttributeInfo) -> CompletionItem {
+    CompletionItem {
+        label: info.name.to_string(),
+        kind: Some(CompletionItemKind::KEYWORD),
+        detail: Some(info.detail.to_string()),
+        ..Default::default()
+    }
+}
+
+fn top_level_attributes() -> impl Iterator<Item = &'static AttributeInfo> {
+    syntax::attributes::ATTRIBUTES.iter().filter(|a| {
+        a.applies_to(AttributeTarget::Struct)
+            || a.applies_to(AttributeTarget::Enum)
+            || a.applies_to(AttributeTarget::Function)
+    })
+}
+
+fn in_attribute_name_position(before: &[Token]) -> bool {
+    let end = match before.last() {
+        Some(t) if t.kind == Tk::Identifier => before.len() - 1,
+        _ => before.len(),
+    };
+    end >= 2 && before[end - 1].kind == Tk::LeftSquareBracket && before[end - 2].kind == Tk::Hash
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EnclosingContext {
+    Parenthesized,
+    Struct,
+    Enum,
+    Impl,
+    Interface,
+    Function,
+    TopLevel,
+}
+
+fn enclosing_context(before: &[Token]) -> EnclosingContext {
+    enum Frame {
+        Paren,
+        Brace(EnclosingContext),
+    }
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut pending = EnclosingContext::TopLevel;
+    for token in before {
+        match token.kind {
+            Tk::LeftCurlyBrace => {
+                stack.push(Frame::Brace(pending));
+                pending = EnclosingContext::TopLevel;
+            }
+            Tk::LeftParen => stack.push(Frame::Paren),
+            Tk::RightCurlyBrace | Tk::RightParen => {
+                stack.pop();
+            }
+            Tk::Semicolon => pending = EnclosingContext::TopLevel,
+            Tk::Struct => pending = EnclosingContext::Struct,
+            Tk::Enum => pending = EnclosingContext::Enum,
+            Tk::Impl => pending = EnclosingContext::Impl,
+            Tk::Interface => pending = EnclosingContext::Interface,
+            Tk::Function => pending = EnclosingContext::Function,
+            _ => {}
+        }
+    }
+    for frame in stack.iter().rev() {
+        match frame {
+            Frame::Paren => return EnclosingContext::Parenthesized,
+            Frame::Brace(EnclosingContext::TopLevel) => continue,
+            Frame::Brace(context) => return *context,
+        }
+    }
+    EnclosingContext::TopLevel
+}
+
+enum FollowingItem {
+    Target(AttributeTarget),
+    /// A declaration that rejects attributes (`interface`, `impl`, `const`, ...).
+    Invalid,
+    Unknown,
+}
+
+/// The following item, plus whether it carries `pub` (rejected on an interface
+/// method).
+struct Following {
+    item: FollowingItem,
+    is_pub: bool,
+}
+
+/// Classifies the definition following the in-progress attribute.
+fn following_item(after: &[Token]) -> Following {
+    let kind = |i: usize| after.get(i).map(|t| t.kind);
+    let mut i = 0;
+
+    // Skip the rest of the current attribute: optional name, `( ... )`, and `]`.
+    if kind(i) == Some(Tk::Identifier) {
+        i += 1;
+    }
+    if kind(i) == Some(Tk::LeftParen) {
+        i = skip_balanced(after, i, Tk::LeftParen, Tk::RightParen);
+    }
+    if kind(i) == Some(Tk::RightSquareBracket) {
+        i += 1;
+    }
+
+    let mut is_pub = false;
+    loop {
+        let item = match kind(i) {
+            Some(Tk::Comment | Tk::Semicolon) => {
+                i += 1;
+                continue;
+            }
+            // A doc comment must come before the attribute, not after it.
+            Some(Tk::DocComment) => FollowingItem::Invalid,
+            Some(Tk::Hash) if kind(i + 1) == Some(Tk::LeftSquareBracket) => {
+                i = skip_stacked_attribute(after, i);
+                continue;
+            }
+            Some(Tk::Pub) => {
+                is_pub = true;
+                i += 1;
+                continue;
+            }
+            Some(Tk::Struct) => FollowingItem::Target(AttributeTarget::Struct),
+            Some(Tk::Enum) => FollowingItem::Target(AttributeTarget::Enum),
+            Some(Tk::Function) => FollowingItem::Target(AttributeTarget::Function),
+            Some(Tk::Interface | Tk::Impl | Tk::Const | Tk::Var | Tk::Import | Tk::Type) => {
+                FollowingItem::Invalid
+            }
+            _ => FollowingItem::Unknown,
+        };
+        return Following { item, is_pub };
+    }
+}
+
+fn skip_balanced(after: &[Token], mut i: usize, open: Tk, close: Tk) -> usize {
+    let mut depth = 0;
+    while i < after.len() {
+        if after[i].kind == open {
+            depth += 1;
+        } else if after[i].kind == close {
+            depth -= 1;
+        }
+        i += 1;
+        if depth == 0 {
+            break;
+        }
+    }
+    i
+}
+
+/// Index past a stacked `#[ ... ]` (a `]` inside a string arg is its own token).
+fn skip_stacked_attribute(after: &[Token], mut i: usize) -> usize {
+    while i < after.len() && after[i].kind != Tk::RightSquareBracket {
+        i += 1;
+    }
+    if i < after.len() {
+        i += 1;
+    }
+    i
+}
+
+#[cfg(test)]
+mod attribute_completion_tests {
+    use super::*;
+
+    /// Runs `attribute_completions` with the cursor at the `|` marker (which is
+    /// stripped before scanning) and returns the offered labels, or `None` when
+    /// the cursor is not in attribute position.
+    fn labels_at(src_with_cursor: &str) -> Option<Vec<String>> {
+        let offset = src_with_cursor
+            .find('|')
+            .expect("test input needs a `|` cursor");
+        let source = src_with_cursor.replacen('|', "", 1);
+        attribute_completions(&source, offset)
+            .map(|items| items.into_iter().map(|i| i.label).collect())
+    }
+
+    #[test]
+    fn top_level_struct_offers_serialization_tag_and_display() {
+        let labels = labels_at("#[|\nstruct Point { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(labels.contains(&"display".to_string()));
+        assert!(labels.contains(&"tag".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn top_level_enum_offers_iterate_display_and_json() {
+        let labels = labels_at("#[|\nenum Direction { North, South }").unwrap();
+        assert!(labels.contains(&"iterate".to_string()));
+        assert!(labels.contains(&"display".to_string()));
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"xml".to_string()));
+        assert!(!labels.contains(&"tag".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn struct_field_offers_serialization_and_tag_not_display() {
+        let labels = labels_at("struct S {\n  #[|\n  x: int\n}").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(labels.contains(&"tag".to_string()));
+        assert!(!labels.contains(&"display".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn method_in_impl_offers_allow_only() {
+        let labels = labels_at("impl S {\n  #[|\n  fn run(self) {}\n}").unwrap();
+        assert_eq!(labels, vec!["allow".to_string()]);
+    }
+
+    #[test]
+    fn method_in_interface_offers_allow_only() {
+        let labels = labels_at("interface I {\n  #[|\n  fn run(self)\n}").unwrap();
+        assert_eq!(labels, vec!["allow".to_string()]);
+    }
+
+    #[test]
+    fn interface_parent_impl_offers_nothing() {
+        let labels = labels_at("interface Child {\n  #[|\n  impl Parent\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn comment_between_attribute_and_enum_resolves_target() {
+        let labels = labels_at("#[|\n// note\nenum E { A }").unwrap();
+        assert!(labels.contains(&"iterate".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn doc_comment_after_attribute_offers_nothing() {
+        let labels = labels_at("#[|\n/// doc\nstruct S {}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn interface_pub_fn_offers_nothing() {
+        let labels = labels_at("interface I {\n  #[|\n  pub fn run(self)\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn impl_pub_fn_offers_allow() {
+        let labels = labels_at("impl S {\n  #[|\n  pub fn run(self) {}\n}").unwrap();
+        assert_eq!(labels, vec!["allow".to_string()]);
+    }
+
+    #[test]
+    fn interface_partial_pub_offers_nothing() {
+        let labels = labels_at("interface I {\n  #[|\n  pub\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn attribute_arg_backtick_paren_resolves_target() {
+        let labels = labels_at("#[|tag(`json:\")\"`)]\nstruct S { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn stacked_attribute_string_bracket_resolves_target() {
+        let labels = labels_at("#[|\n#[json(\"x]\")]\nstruct S { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+        assert!(!labels.contains(&"allow".to_string()));
+    }
+
+    #[test]
+    fn function_params_offer_nothing() {
+        let labels = labels_at("fn f(#[| x: int) {}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn tuple_struct_field_offers_nothing() {
+        let labels = labels_at("struct S(#[| int)").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn method_param_offers_nothing() {
+        let labels = labels_at("impl S {\n  fn m(#[| x: int) {}\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn enum_variant_position_offers_nothing() {
+        let labels = labels_at("enum E {\n  #[|\n  A\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn function_body_offers_nothing() {
+        let labels = labels_at("fn main() {\n  #[|\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn function_body_inside_nested_block_offers_nothing() {
+        let labels = labels_at("fn main() {\n  if true {\n    #[|\n  }\n}").unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn unknown_top_level_target_offers_full_union() {
+        let labels = labels_at("#[|").unwrap();
+        for expected in ["json", "display", "iterate", "allow", "tag"] {
+            assert!(labels.contains(&expected.to_string()), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn before_attribute_rejecting_declaration_offers_nothing() {
+        for decl in ["interface S {}", "impl S {}", "const X = 1", "type A = int"] {
+            let labels = labels_at(&format!("#[|\n{decl}")).unwrap();
+            assert!(
+                labels.is_empty(),
+                "expected nothing before `{decl}`, got {labels:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn partial_name_still_resolves_target() {
+        let labels = labels_at("#[js|\nstruct Point { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+    }
+
+    #[test]
+    fn stacked_attributes_resolve_to_following_item() {
+        let labels = labels_at("#[display]\n#[|\nstruct Point { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+    }
+
+    #[test]
+    fn pub_modifier_is_skipped() {
+        let labels = labels_at("#[|\npub struct Point { x: int }").unwrap();
+        assert!(labels.contains(&"json".to_string()));
+        assert!(!labels.contains(&"iterate".to_string()));
+    }
+
+    #[test]
+    fn not_in_attribute_position_yields_none() {
+        assert!(labels_at("let x = |5").is_none());
+        assert!(labels_at("fn main() { let y = |x }").is_none());
+    }
+
+    #[test]
+    fn hash_inside_string_is_not_an_attribute() {
+        assert!(labels_at("fn main() { let s = \"#[|\" }").is_none());
+    }
+
+    #[test]
+    fn closed_attribute_is_not_in_name_position() {
+        assert!(labels_at("#[json]|\nstruct Point { x: int }").is_none());
+    }
+
+    #[test]
+    fn cursor_in_argument_list_is_not_name_position() {
+        assert!(labels_at("struct S {\n  #[json(|\n  x: int\n}").is_none());
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,8 +19,8 @@ use tower_lsp::lsp_types::*;
 
 use crate::analysis::{offset_in_span, type_name};
 use crate::completion::{
-    DotContext, definition_to_completion_kind, detect_dot_context, get_instance_completions,
-    get_module_prefix, get_type_completions, resolve_variable_type,
+    DotContext, attribute_completions, definition_to_completion_kind, detect_dot_context,
+    get_instance_completions, get_module_prefix, get_type_completions, resolve_variable_type,
 };
 use crate::definition::{
     find_struct_field_span, is_go_typedef_span, lookup_definition_span,
@@ -76,7 +76,12 @@ impl LanguageServer for Backend {
                     work_done_progress_options: Default::default(),
                 })),
                 completion_provider: Some(CompletionOptions {
-                    trigger_characters: Some(vec![".".to_string()]),
+                    // `.` for member access; `#`/`[` to open attribute completions
+                    trigger_characters: Some(vec![
+                        ".".to_string(),
+                        "#".to_string(),
+                        "[".to_string(),
+                    ]),
                     ..Default::default()
                 }),
                 signature_help_provider: Some(SignatureHelpOptions {
@@ -1072,6 +1077,13 @@ impl LanguageServer for Backend {
         let Some(offset) = line_index.position_to_offset(position) else {
             return Ok(None);
         };
+
+        // An in-progress `#[ ... ]` is exclusive: when the cursor is in attribute
+        // position, offer only the attributes relevant to the target it attaches
+        // to, never the general keyword/identifier completions below.
+        if let Some(items) = attribute_completions(&file.source, offset as usize) {
+            return Ok(Some(CompletionResponse::Array(items)));
+        }
 
         if let Some(module_name) = get_module_prefix(&file.source, offset as usize)
             && let Some(imp) = file.imports().iter().find(|imp| {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -942,6 +942,84 @@ async fn completion_empty_file() {
 }
 
 #[tokio::test]
+async fn completion_attribute_on_struct() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "#[\nstruct Point { x: int, y: int }\n")
+        .await;
+
+    // Cursor right after `#[` on line 0.
+    let response = client.completion(TEST_URI, 0, 2).await;
+    let labels = completion_labels(&response.expect("attribute completions"));
+
+    // Relevant attributes for a struct, and none of the noise from before.
+    assert!(labels.contains(&"json".to_string()));
+    assert!(labels.contains(&"display".to_string()));
+    assert!(labels.contains(&"tag".to_string()));
+    assert!(!labels.contains(&"iterate".to_string()));
+    assert!(!labels.contains(&"allow".to_string()));
+    assert!(!labels.iter().any(|l| l == "fn" || l == "let" || l == "int"));
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_attribute_on_struct_field() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "struct Point {\n  #[\n  x: int\n}\n")
+        .await;
+
+    // Cursor right after `#[` on line 1.
+    let response = client.completion(TEST_URI, 1, 4).await;
+    let labels = completion_labels(&response.expect("attribute completions"));
+
+    assert!(labels.contains(&"json".to_string()));
+    assert!(labels.contains(&"tag".to_string()));
+    assert!(!labels.contains(&"display".to_string()));
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_attribute_on_enum() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "#[\nenum Direction { North, South }\n")
+        .await;
+
+    let response = client.completion(TEST_URI, 0, 2).await;
+    let labels = completion_labels(&response.expect("attribute completions"));
+
+    assert!(labels.contains(&"iterate".to_string()));
+    assert!(labels.contains(&"display".to_string()));
+    assert!(labels.contains(&"json".to_string()));
+    assert!(!labels.contains(&"tag".to_string()));
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_attribute_before_interface_is_empty() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(TEST_URI, "#[\ninterface Service {\n  fn run(self)\n}\n")
+        .await;
+
+    // Attributes are rejected on interfaces, so offer nothing rather than a
+    // union that would immediately parse as misplaced.
+    let response = client.completion(TEST_URI, 0, 2).await;
+    let labels = completion_labels(&response.expect("attribute completions"));
+    assert!(labels.is_empty(), "expected no completions, got {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_struct_call() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/semantics/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/attributes.rs
@@ -2,20 +2,7 @@ use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Attribute, AttributeArg, Expression, StructFieldDefinition};
-
-pub(crate) const SERIALIZATION_KEYS: &[&str] = &[
-    "json",
-    "xml",
-    "yaml",
-    "toml",
-    "db",
-    "bson",
-    "mapstructure",
-    "msgpack",
-];
-
-/// Recognized attributes that are not serialization keys.
-const OTHER_ATTRIBUTES: &[&str] = &["tag", "allow", "iterate", "display"];
+use syntax::attributes::is_serialization_key;
 
 pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
     let attributes = match expression {
@@ -69,11 +56,11 @@ pub fn check_struct_attributes(expression: &Expression, ctx: &NodeCtx) {
 fn check_unknown_attribute(attribute: &Attribute, sink: &LocalSink) {
     let name = &attribute.name;
 
-    if !is_known_attribute(name) {
+    if !syntax::attributes::is_known_attribute(name) {
         sink.push(diagnostics::lint::unknown_attribute(
             &attribute.span,
             name,
-            &known_attributes(),
+            &syntax::attributes::known_attribute_names(),
         ));
     }
 }
@@ -234,24 +221,4 @@ fn check_tag_with_alias(attribute: &Attribute, sink: &LocalSink) {
     {
         sink.push(diagnostics::lint::tag_has_alias(&attribute.span, key));
     }
-}
-
-/// The full set of recognized attributes, in display order, for diagnostics.
-fn known_attributes() -> Vec<&'static str> {
-    SERIALIZATION_KEYS
-        .iter()
-        .chain(OTHER_ATTRIBUTES.iter())
-        .copied()
-        .collect()
-}
-
-fn is_known_attribute(name: &str) -> bool {
-    // `go` is the Go-interop rail (e.g. `#[go(closed_domain)]`, `#[go(bit_flag_set)]`).
-    // Accepted but kept out of `known_attributes()` so it is not advertised as a
-    // general-purpose attribute in unknown-attribute help.
-    is_serialization_key(name) || OTHER_ATTRIBUTES.contains(&name) || name == "go"
-}
-
-fn is_serialization_key(key: &str) -> bool {
-    SERIALIZATION_KEYS.contains(&key)
 }

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -16,13 +16,13 @@ use syntax::program::UnusedInfo;
 use syntax::program::{File, FileImport};
 
 use super::Lint as LintEnum;
-use super::ast_walk::attributes::SERIALIZATION_KEYS;
 use super::from_facts::LintConfig;
 use extract::{AliasMap, extract_references, is_upper};
 use reference_graph::{
     EnumVariantId, EnumVariantInfo, ItemKind, ModuleItemId, ReferenceGraph, StructFieldId,
     StructFieldInfo,
 };
+use syntax::attributes::SERIALIZATION_KEYS;
 use visibility_constraints::check_visibility_constraints;
 
 struct RefLintResult {

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -1,0 +1,119 @@
+//! Canonical catalog of recognized attributes, shared by the `unknown_attribute`
+//! lint and LSP completions.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttributeTarget {
+    Struct,
+    StructField,
+    Enum,
+    /// A function or an `impl`/`interface` method.
+    Function,
+}
+
+pub struct AttributeInfo {
+    pub name: &'static str,
+    pub detail: &'static str,
+    targets: &'static [AttributeTarget],
+}
+
+impl AttributeInfo {
+    pub fn applies_to(&self, target: AttributeTarget) -> bool {
+        self.targets.contains(&target)
+    }
+}
+
+use AttributeTarget::*;
+
+pub const SERIALIZATION_KEYS: &[&str] = &[
+    "json",
+    "xml",
+    "yaml",
+    "toml",
+    "db",
+    "bson",
+    "mapstructure",
+    "msgpack",
+];
+
+/// In `unknown_attribute` display order. `#[go(...)]` is accepted (see
+/// [`is_known_attribute`]) but deliberately not advertised here.
+pub const ATTRIBUTES: &[AttributeInfo] = &[
+    AttributeInfo {
+        name: "json",
+        detail: "JSON serialization tag",
+        // Enums support `#[json]` (Marshal/UnmarshalJSON); other keys do not.
+        targets: &[Struct, StructField, Enum],
+    },
+    AttributeInfo {
+        name: "xml",
+        detail: "XML serialization tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "yaml",
+        detail: "YAML serialization tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "toml",
+        detail: "TOML serialization tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "db",
+        detail: "database column tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "bson",
+        detail: "BSON serialization tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "mapstructure",
+        detail: "mapstructure decoding tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "msgpack",
+        detail: "MessagePack serialization tag",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "tag",
+        detail: "Go struct tag (struct-level defaults or per-field)",
+        targets: &[Struct, StructField],
+    },
+    AttributeInfo {
+        name: "allow",
+        detail: "suppress a lint",
+        targets: &[Function],
+    },
+    AttributeInfo {
+        name: "iterate",
+        detail: "synthesize `variants` for an enum",
+        targets: &[Enum],
+    },
+    AttributeInfo {
+        name: "display",
+        detail: "derive `to_string`",
+        targets: &[Struct, Enum],
+    },
+];
+
+/// `go` is accepted but absent from [`ATTRIBUTES`] (the Go-interop rail).
+pub fn is_known_attribute(name: &str) -> bool {
+    name == "go" || ATTRIBUTES.iter().any(|a| a.name == name)
+}
+
+pub fn is_serialization_key(key: &str) -> bool {
+    SERIALIZATION_KEYS.contains(&key)
+}
+
+pub fn known_attribute_names() -> Vec<&'static str> {
+    ATTRIBUTES.iter().map(|a| a.name).collect()
+}
+
+pub fn attributes_for(target: AttributeTarget) -> impl Iterator<Item = &'static AttributeInfo> {
+    ATTRIBUTES.iter().filter(move |a| a.applies_to(target))
+}

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod ast_folder;
+pub mod attributes;
 pub mod desugar;
 mod display;
 pub mod lex;


### PR DESCRIPTION
Adds LSP completions for attributes: typing `#[` now suggests only attributes and only those valid at that spot, e.g. `display`/`json`/`iterate` on an enum.