### PR TITLE
refactor: dedupe emit coercion, call, and abi helpers

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -3,7 +3,7 @@ use syntax::types::Type;
 
 use crate::EmitEffects;
 use crate::Planner;
-use crate::calls::go_interop::WrapperTarget;
+use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::plan::bodies::LoweredStatement;
 use crate::types::shape::NullableCollectionShape;
@@ -63,50 +63,6 @@ impl Coercion {
         Self { kind }
     }
 
-    pub(crate) fn apply(
-        self,
-        planner: &mut Planner,
-        output: &mut String,
-        value: String,
-        fx: &mut EmitEffects,
-    ) -> String {
-        match self.kind {
-            CoercionKind::Identity => value,
-            CoercionKind::WrapAsInterface(plan) => {
-                let adapter_name = planner.ensure_adapter_type(plan, fx);
-                format!("{}{{inner: {}}}", adapter_name, value)
-            }
-            CoercionKind::WrapNewtype { ty } => {
-                let type_name = planner.go_type_string(&ty, fx);
-                format!("{}({})", type_name, value)
-            }
-            CoercionKind::UnwrapNullableOption { ty } => {
-                let inner = planner.go_type_string(&ty.ok_type(), fx);
-                planner.emit_option_projection(output, &value, "unwrap", &inner, false, fx)
-            }
-            CoercionKind::UnwrapPointerOption { ty } => {
-                let ptr = format!("*{}", planner.go_type_string(&ty.ok_type(), fx));
-                planner.emit_option_projection(output, &value, "ptr", &ptr, true, fx)
-            }
-            CoercionKind::UnwrapNullableCollection { ty, shape } => {
-                planner.emit_collection_nullable_unwrap(output, &value, &ty, &shape, fx)
-            }
-            CoercionKind::UnwrapOptionToAny => {
-                planner.emit_option_projection(output, &value, "unwrap", "any", false, fx)
-            }
-            CoercionKind::WrapNullableOption { ty } => planner
-                .emit_nil_check_option_wrap(output, &value, &ty, WrapperTarget::FreshSlot, fx)
-                .expect("wrapper produced no slot"),
-            CoercionKind::WrapPointerOption { ty } => {
-                planner.emit_pointer_to_option_wrap(output, &value, &ty, fx)
-            }
-            CoercionKind::WrapNullableCollection { ty, shape } => {
-                planner.emit_collection_nullable_wrap(output, &value, &ty, &shape, fx)
-            }
-        }
-    }
-
-    /// Typed counterpart of `apply`.
     pub(crate) fn lower(
         self,
         planner: &mut Planner,
@@ -170,7 +126,9 @@ impl Planner<'_> {
             target,
             CoercionDirection::Internal,
         );
-        coercion.apply(self, output, emitted, fx)
+        let (setup, value) = coercion.lower(self, emitted, fx);
+        output.push_str(&Renderer.render_setup(&setup));
+        value
     }
 }
 

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -645,6 +645,30 @@ pub(crate) fn render_lowered_tail_return(
     }
 }
 
+fn lowered_tail_fallback(
+    planner: &mut Planner,
+    expression: &syntax::ast::Expression,
+    return_ty: &Type,
+    shape: &AbiShape,
+    hoist_hint: Option<&str>,
+    fx: &mut EmitEffects,
+) -> Vec<LoweredStatement> {
+    let mut setup = String::new();
+    let value = planner.emit_value(&mut setup, expression, ExpressionContext::value(), fx);
+    let value = match hoist_hint {
+        Some(hint) => planner.hoist_tmp_value(&mut setup, hint, &value),
+        None => value,
+    };
+    let mut statements = Vec::new();
+    if !setup.is_empty() {
+        statements.push(LoweredStatement::RawGo(setup));
+    }
+    statements.extend(emit_lowered_result_return(
+        planner, &value, return_ty, shape, fx,
+    ));
+    statements
+}
+
 fn emit_lowered_tuple_tail(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
@@ -679,21 +703,14 @@ fn emit_lowered_tuple_tail(
     }
 
     let return_ty = planner.return_ctx().expect_ty();
-    let mut setup = String::new();
-    let value = planner.emit_value(&mut setup, expression, ExpressionContext::value(), fx);
-    let temp = planner.hoist_tmp_value(&mut setup, "tup", &value);
-    let mut statements = Vec::new();
-    if !setup.is_empty() {
-        statements.push(LoweredStatement::RawGo(setup));
-    }
-    statements.extend(emit_lowered_result_return(
+    lowered_tail_fallback(
         planner,
-        &temp,
+        expression,
         &return_ty,
         &AbiShape::Tuple { arity },
+        Some("tup"),
         fx,
-    ));
-    statements
+    )
 }
 
 fn emit_lowered_partial_tail(
@@ -758,20 +775,14 @@ fn emit_lowered_partial_tail(
         return statements;
     }
 
-    let mut setup = String::new();
-    let value = planner.emit_value(&mut setup, expression, ExpressionContext::value(), fx);
-    let mut statements = Vec::new();
-    if !setup.is_empty() {
-        statements.push(LoweredStatement::RawGo(setup));
-    }
-    statements.extend(emit_lowered_result_return(
+    lowered_tail_fallback(
         planner,
-        &value,
+        expression,
         &return_ty,
         &AbiShape::PartialTuple,
+        None,
         fx,
-    ));
-    statements
+    )
 }
 
 /// `Some(x)`/`None` collapse to `x`/`nil`; other Option expressions

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -322,28 +322,6 @@ impl Planner<'_> {
     }
 
     /// Wrap a Go `*T` (T value-typed) into Lisette `Option<T>`.
-    pub(crate) fn emit_pointer_to_option_wrap(
-        &mut self,
-        output: &mut String,
-        ptr_value: &str,
-        option_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> String {
-        fx.require_stdlib();
-        let inner_ty_str = self.go_type_string(&option_ty.ok_type(), fx);
-        let option_var = self.fresh_var(Some("option"));
-        self.declare(&option_var);
-        write_line!(
-            output,
-            "{} := lisette.OptionFromPointer[{}]({})",
-            option_var,
-            inner_ty_str,
-            ptr_value
-        );
-        option_var
-    }
-
-    /// Typed counterpart of `emit_pointer_to_option_wrap`.
     pub(crate) fn plan_pointer_to_option_wrap(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
@@ -372,86 +350,6 @@ impl Planner<'_> {
         outcome.expect("FreshSlot produces a slot")
     }
 
-    pub(crate) fn emit_collection_nullable_wrap(
-        &mut self,
-        output: &mut String,
-        raw_value: &str,
-        collection_ty: &Type,
-        shape: &NullableCollectionShape,
-        fx: &mut EmitEffects,
-    ) -> String {
-        fx.require_stdlib();
-
-        let lisette_collection_ty = self.go_type_string(collection_ty, fx);
-        let src_var = self.fresh_var(Some("src"));
-        self.declare(&src_var);
-        let wrapped_var = self.fresh_var(Some("wrapped"));
-        self.declare(&wrapped_var);
-        let index_var = self.fresh_var(Some("i"));
-        self.declare(&index_var);
-        let val_var = self.fresh_var(Some("v"));
-        self.declare(&val_var);
-
-        write_line!(output, "{} := {}", src_var, raw_value);
-        write_line!(
-            output,
-            "{} := make({}, len({}))",
-            wrapped_var,
-            lisette_collection_ty,
-            src_var
-        );
-
-        write_line!(
-            output,
-            "for {}, {} := range {} {{",
-            index_var,
-            val_var,
-            src_var
-        );
-
-        match &shape.element {
-            NullableCollectionElement::Option(opt_ty) => {
-                let fallible = Fallible::from_type(opt_ty).expect("Option type expected");
-                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
-                let is_interface = self.is_interface_option(opt_ty);
-                if is_interface {
-                    write_line!(output, "if !lisette.IsNilInterface({}) {{", val_var);
-                } else {
-                    write_line!(output, "if {} != nil {{", val_var);
-                }
-                let some_input = if is_pointer_bridged {
-                    format!("*{}", val_var)
-                } else {
-                    val_var.clone()
-                };
-                let mut fe = FalliblePlanner::new(self, &fallible, fx);
-                let some_wrapper = fe.emit_success(&some_input);
-                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, some_wrapper);
-                output.push_str("} else {\n");
-                let mut fe = FalliblePlanner::new(self, &fallible, fx);
-                let none_wrapper = fe.emit_failure(None);
-                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, none_wrapper);
-                output.push_str("}\n");
-            }
-            NullableCollectionElement::Nested(inner_shape) => {
-                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
-                let inner_var = self.emit_collection_nullable_wrap(
-                    output,
-                    &val_var,
-                    &inner_lisette_ty,
-                    inner_shape,
-                    fx,
-                );
-                write_line!(output, "{}[{}] = {}", wrapped_var, index_var, inner_var);
-            }
-        }
-
-        output.push_str("}\n");
-
-        wrapped_var
-    }
-
-    /// Typed counterpart of `emit_collection_nullable_wrap`.
     pub(crate) fn plan_collection_nullable_wrap(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
@@ -554,85 +452,6 @@ impl Planner<'_> {
         wrapped_var
     }
 
-    pub(crate) fn emit_collection_nullable_unwrap(
-        &mut self,
-        output: &mut String,
-        lisette_value: &str,
-        collection_ty: &Type,
-        shape: &NullableCollectionShape,
-        fx: &mut EmitEffects,
-    ) -> String {
-        fx.require_stdlib();
-        let raw_collection_ty = self.shape_raw_collection_ty(shape, fx);
-
-        let src_var = self.fresh_var(Some("src"));
-        self.declare(&src_var);
-        let unwrapped_var = self.fresh_var(Some("unwrapped"));
-        self.declare(&unwrapped_var);
-        let index_var = self.fresh_var(Some("i"));
-        self.declare(&index_var);
-        let val_var = self.fresh_var(Some("v"));
-        self.declare(&val_var);
-
-        write_line!(output, "{} := {}", src_var, lisette_value);
-        write_line!(
-            output,
-            "{} := make({}, len({}))",
-            unwrapped_var,
-            raw_collection_ty,
-            src_var
-        );
-
-        write_line!(
-            output,
-            "for {}, {} := range {} {{",
-            index_var,
-            val_var,
-            src_var
-        );
-
-        match &shape.element {
-            NullableCollectionElement::Option(opt_ty) => {
-                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
-                let is_map = matches!(shape.kind, CollectionKind::Map);
-                let emit_nil_else = is_map || is_pointer_bridged;
-                let some_assignment = if is_pointer_bridged {
-                    format!("&{}.SomeVal", val_var)
-                } else {
-                    format!("{}.SomeVal", val_var)
-                };
-                write_line!(output, "if {}.Tag == {} {{", val_var, OPTION_SOME_TAG);
-                write_line!(
-                    output,
-                    "{}[{}] = {}",
-                    unwrapped_var,
-                    index_var,
-                    some_assignment
-                );
-                if emit_nil_else {
-                    output.push_str("} else {\n");
-                    write_line!(output, "{}[{}] = nil", unwrapped_var, index_var);
-                }
-                output.push_str("}\n");
-            }
-            NullableCollectionElement::Nested(inner_shape) => {
-                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
-                let inner_var = self.emit_collection_nullable_unwrap(
-                    output,
-                    &val_var,
-                    &inner_lisette_ty,
-                    inner_shape,
-                    fx,
-                );
-                write_line!(output, "{}[{}] = {}", unwrapped_var, index_var, inner_var);
-            }
-        }
-        output.push_str("}\n");
-
-        unwrapped_var
-    }
-
-    /// Typed counterpart of `emit_collection_nullable_unwrap`.
     pub(crate) fn plan_collection_nullable_unwrap(
         &mut self,
         statements: &mut Vec<LoweredStatement>,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -6,6 +6,7 @@ use rustc_hash::FxHashSet as HashSet;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
+use crate::abi::AbiShape;
 use crate::abi::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
@@ -534,15 +535,11 @@ impl<'a> Planner<'a> {
 
     /// Detect whether `arg`'s fn-shape disagrees with the callee's generic
     /// param shape (Lisette callback adapter trigger). Pure detection.
-    pub(crate) fn detect_lowered_fn_arg_shape(
+    fn fn_arg_shapes(
         &self,
         arg: &Expression,
-        generic_param_ty: Option<&Type>,
-    ) -> Option<()> {
-        if is_tagged_shape_fn_value(arg) {
-            return None;
-        }
-        let raw_param_ty = generic_param_ty?;
+        raw_param_ty: &Type,
+    ) -> Option<(Option<AbiShape>, Type, AbiShape)> {
         let variadic_inner = (raw_param_ty.get_name() == Some("VarArgs"))
             .then(|| raw_param_ty.inner())
             .flatten();
@@ -560,6 +557,19 @@ impl<'a> Planner<'a> {
         let arg_ret = arg_fn.get_function_ret()?;
         let arg_shape = self.classify_direct_emission(arg_ret)?;
 
+        Some((param_shape, arg_fn, arg_shape))
+    }
+
+    pub(crate) fn detect_lowered_fn_arg_shape(
+        &self,
+        arg: &Expression,
+        generic_param_ty: Option<&Type>,
+    ) -> Option<()> {
+        if is_tagged_shape_fn_value(arg) {
+            return None;
+        }
+        let raw_param_ty = generic_param_ty?;
+        let (param_shape, _arg_fn, arg_shape) = self.fn_arg_shapes(arg, raw_param_ty)?;
         if param_shape.as_ref() == Some(&arg_shape) {
             return None;
         }
@@ -572,24 +582,7 @@ impl<'a> Planner<'a> {
         generic_param_ty: &Type,
         fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
-        let raw_param_ty = generic_param_ty;
-        let variadic_inner = (raw_param_ty.get_name() == Some("VarArgs"))
-            .then(|| raw_param_ty.inner())
-            .flatten();
-        let param_ty = variadic_inner.as_ref().unwrap_or(raw_param_ty);
-        let param_fn = self
-            .facts
-            .resolve_to_function_type(param_ty.unwrap_forall())?;
-        let param_ret = param_fn.get_function_ret()?;
-        let param_shape = self.classify_direct_emission(param_ret);
-
-        let arg_ty = arg.get_type();
-        let arg_fn = self
-            .facts
-            .resolve_to_function_type(arg_ty.unwrap_forall())?;
-        let arg_ret = arg_fn.get_function_ret()?;
-        let arg_shape = self.classify_direct_emission(arg_ret)?;
-
+        let (param_shape, arg_fn, arg_shape) = self.fn_arg_shapes(arg, generic_param_ty)?;
         let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
         let mut buffer = String::new();
         let adapted = emit_fn_arg_shape_adapter(
@@ -804,11 +797,7 @@ impl<'a> Planner<'a> {
     ) -> Option<NullableCoerceKind> {
         let param_ty = effective_param_ty?;
         let arg_ty = arg.get_type();
-        let check_ty = if param_ty.get_name() == Some("VarArgs") {
-            param_ty.inner().unwrap_or_else(|| param_ty.clone())
-        } else {
-            param_ty.clone()
-        };
+        let check_ty = varargs_inner_or_self(param_ty);
 
         if arg_ty.is_option() && check_ty.resolves_to_unknown() {
             return Some(NullableCoerceKind::OptionToUnknown);
@@ -839,13 +828,7 @@ impl<'a> Planner<'a> {
         let arg_ty = arg.get_type();
         match kind {
             NullableCoerceKind::OptionToUnknown => {
-                let check_ty = if effective_param_ty.get_name() == Some("VarArgs") {
-                    effective_param_ty
-                        .inner()
-                        .unwrap_or_else(|| effective_param_ty.clone())
-                } else {
-                    effective_param_ty.clone()
-                };
+                let check_ty = varargs_inner_or_self(effective_param_ty);
                 if arg.is_none_literal() {
                     return (Vec::new(), "nil".to_string());
                 }
@@ -876,6 +859,15 @@ impl<'a> Planner<'a> {
         let (coercion_setup, coerced) = coercion.lower(self, value, fx);
         setup.extend(coercion_setup);
         (setup, coerced)
+    }
+}
+
+/// The element type of a `VarArgs<T>`, or the type itself when not variadic.
+fn varargs_inner_or_self(ty: &Type) -> Type {
+    if ty.get_name() == Some("VarArgs") {
+        ty.inner().unwrap_or_else(|| ty.clone())
+    } else {
+        ty.clone()
     }
 }
 

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -80,7 +80,9 @@ impl Planner<'_> {
                         &element_lisette_ty,
                         CoercionDirection::Internal,
                     );
-                    wrapped.push(coercion.apply(self, output, emitted, fx));
+                    let (coercion_setup, coerced) = coercion.lower(self, emitted, fx);
+                    output.push_str(&Renderer.render_setup(&coercion_setup));
+                    wrapped.push(coerced);
                 }
                 let elements = wrapped;
 

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -527,7 +527,8 @@ impl Planner<'_> {
         {
             let coercion =
                 Coercion::resolve(self, &value.get_type(), ty, CoercionDirection::ToGoBoundary);
-            let unwrapped = coercion.apply(self, output, rhs_staged.value, fx);
+            let (coercion_setup, unwrapped) = coercion.lower(self, rhs_staged.value, fx);
+            output.push_str(&Renderer.render_setup(&coercion_setup));
             write_line!(output, "{} = {}", target_str, unwrapped);
         } else {
             write_line!(output, "{} = {}", target_str, rhs_staged.value);

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,5 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::Renderer;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::calls::go_interop::{GoCallStrategy, WrapperTarget};
 use crate::context::expression::ExpressionContext;
@@ -306,7 +307,8 @@ impl Planner<'_> {
             binding_ty,
             CoercionDirection::Internal,
         );
-        let value_expression = coercion.apply(self, output, value_expression, fx);
+        let (coercion_setup, value_expression) = coercion.lower(self, value_expression, fx);
+        output.push_str(&Renderer.render_setup(&coercion_setup));
         let value_expression = maybe_clone_subslice(self, value, mutable, value_expression, fx);
 
         let go_identifier = self.scope.bind(identifier, raw_go_name);


### PR DESCRIPTION
Removes a few duplicated string-emission helpers in the emit layer.
