### PR TITLE
feat: add collapsible if lint

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -405,6 +405,13 @@ pub fn identical_if_branches(span: &Span) -> LisetteDiagnostic {
         .with_help("Remove the `if` and keep a single copy of the branch body")
 }
 
+pub fn collapsible_if(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::info("Collapsible `if`")
+        .with_lint_code("collapsible_if")
+        .with_span_label(span, "can be merged into the outer `if`")
+        .with_help("Merge this nested `if` into the outer condition with `&&`")
+}
+
 pub fn identical_match_arms(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Identical match arms")
         .with_lint_code("identical_match_arms")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/collapsible_if.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/collapsible_if.rs
@@ -1,0 +1,48 @@
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{Expression, Span};
+
+pub fn check_collapsible_if(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::If {
+        condition,
+        consequence,
+        alternative,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if !is_missing_else(alternative) {
+        return;
+    }
+
+    let Expression::Block { items, .. } = consequence.as_ref() else {
+        return;
+    };
+    let [
+        Expression::If {
+            condition: inner_condition,
+            alternative: inner_alternative,
+            span: inner_span,
+            ..
+        },
+    ] = items.as_slice()
+    else {
+        return;
+    };
+    if !is_missing_else(inner_alternative) {
+        return;
+    }
+
+    if !condition.get_type().is_boolean() || !inner_condition.get_type().is_boolean() {
+        return;
+    }
+
+    let inner_if_keyword_span = Span::new(inner_span.file_id, inner_span.byte_offset, 2);
+    ctx.sink
+        .push(diagnostics::lint::collapsible_if(&inner_if_keyword_span));
+}
+
+fn is_missing_else(alternative: &Expression) -> bool {
+    matches!(alternative, Expression::Unit { .. })
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,4 +1,5 @@
 mod bool_literal_comparison;
+mod collapsible_if;
 mod double_negation;
 mod dup_arg;
 mod duplicate_cutset;
@@ -51,6 +52,7 @@ mod verbose_failure_propagation;
 mod waitgroup_add_in_task;
 
 pub use bool_literal_comparison::check_bool_literal_comparison;
+pub use collapsible_if::check_collapsible_if;
 pub use double_negation::check_double_negation;
 pub use dup_arg::check_dup_arg;
 pub use duplicate_cutset::check_duplicate_cutset;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -13,10 +13,10 @@ use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
-    check_bool_literal_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
-    check_duplicate_logical_operand, check_empty_match_arm, check_excess_parens_on_condition,
-    check_expression_naming, check_goos_goarch_comparison, check_identical_if_branches,
-    check_identical_match_arms, check_integer_division_to_zero,
+    check_bool_literal_comparison, check_collapsible_if, check_double_negation, check_dup_arg,
+    check_duplicate_cutset, check_duplicate_logical_operand, check_empty_match_arm,
+    check_excess_parens_on_condition, check_expression_naming, check_goos_goarch_comparison,
+    check_identical_if_branches, check_identical_match_arms, check_integer_division_to_zero,
     check_invisible_in_string_expression, check_invisible_in_string_pattern, check_let_and_return,
     check_loop_runs_once, check_lost_query_mutation, check_manual_bytes_equal,
     check_manual_compound_assignment, check_manual_equal_fold, check_manual_is_empty,
@@ -50,6 +50,7 @@ const EXPRESSION_CHECKS: &[NodeCheck] = &[
     check_manual_is_empty,
     check_bool_literal_comparison,
     check_identical_if_branches,
+    check_collapsible_if,
     check_identical_match_arms,
     check_loop_runs_once,
     check_empty_match_arm,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2833,6 +2833,115 @@ fn main() {
 }
 
 #[test]
+fn collapsible_if() {
+    assert_lint_snapshot!(
+        r#"
+pub fn check(a: bool, b: bool) {
+  let mut count = 0
+  if a {
+    if b {
+      count += 1
+    }
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_outer_else_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub fn check(a: bool, b: bool) {
+  let mut count = 0
+  if a {
+    if b {
+      count += 1
+    }
+  } else {
+    count += 2
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_inner_else_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub fn check(a: bool, b: bool) {
+  let mut count = 0
+  if a {
+    if b {
+      count += 1
+    } else {
+      count += 2
+    }
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_extra_statement_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub fn check(a: bool, b: bool) {
+  let mut count = 0
+  if a {
+    count += 5
+    if b {
+      count += 1
+    }
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_inner_if_let_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub fn check(a: bool, x: Option<int>) {
+  let mut count = 0
+  if a {
+    if let Some(v) = x {
+      count += v
+    }
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_named_bool_condition_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Flag(bool)
+
+pub fn check(a: Flag, b: bool) {
+  let mut count = 0
+  if a {
+    if b {
+      count += 1
+    }
+  }
+  let _ = count
+}
+"#
+    );
+}
+
+#[test]
 fn identical_match_arms_literals() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/collapsible_if.snap
+++ b/tests/ui/lint/snapshots/collapsible_if.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Collapsible `if`
+   ╭─[test.lis:5:5]
+ 4 │   if a {
+ 5 │     if b {
+   ·     ─┬
+   ·      ╰── can be merged into the outer `if`
+ 6 │       count += 1
+   ╰────
+  help: Merge this nested `if` into the outer condition with `&&` · code: [lint.collapsible_if]


### PR DESCRIPTION
Adds a lint that flags a nested `if` with no `else` that can fold into the outer condition with `&&`.

```
  [info] Collapsible `if`
   ╭─[test.lis:5:5]
 4 │   if a {
 5 │     if b {
   ·     ─┬
   ·      ╰── can be merged into the outer `if`
 6 │       count += 1
   ╰────
  help: Merge this nested `if` into the outer condition with `&&` · code: [lint.collapsible_if]
```