### PR TITLE
fix: stack overflow when zero-filling a function-alias field

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -692,6 +692,7 @@ fn has_zero_nominal(
                 Type::Forall { body, .. } => body.as_ref().clone(),
                 other => other.clone(),
             };
+            let underlying = store.peel_alias(&underlying);
             let map = build_substitution(alias_ty, params);
             let resolved = if map.is_empty() {
                 underlying

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1736,6 +1736,32 @@ fn test() {
 }
 
 #[test]
+fn infer_struct_zero_fill_function_alias_field() {
+    let input = r#"
+type F = fn() -> int
+struct A { g: F, x: int }
+
+fn test() {
+  let _a = A { .. };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_zero_fill_generic_function_alias_field() {
+    let input = r#"
+type F<T> = fn(T) -> T
+struct A { g: F<int>, x: int }
+
+fn test() {
+  let _a = A { .. };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_enum_struct_variant_zero_fill_no_zero_for_field() {
     let input = r#"
 enum Action {

--- a/tests/ui/errors/snapshots/infer_struct_zero_fill_function_alias_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_zero_fill_function_alias_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Field has no zero value
+   ╭─[test.lis:6:16]
+ 5 │ fn test() {
+ 6 │   let _a = A { .. };
+   ·                ─┬
+   ·                 ╰── no zero available
+ 7 │ }
+   ╰────
+  help: Field `g` of type `fn () -> int` has no zero value. Provide an explicit value, or wrap the field type in `Option<T>` · code: [infer.field_no_zero]

--- a/tests/ui/errors/snapshots/infer_struct_zero_fill_generic_function_alias_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_zero_fill_generic_function_alias_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Field has no zero value
+   ╭─[test.lis:6:16]
+ 5 │ fn test() {
+ 6 │   let _a = A { .. };
+   ·                ─┬
+   ·                 ╰── no zero available
+ 7 │ }
+   ╰────
+  help: Field `g` of type `fn (int) -> int` has no zero value. Provide an explicit value, or wrap the field type in `Option<T>` · code: [infer.field_no_zero]


### PR DESCRIPTION
Zero-filling a struct field whose type is an alias to a fn type no longer crashes the checker with a stack overflow. It now reports the same `field_no_zero` diagnostic the non-alias form gives.

```rs
type F = fn() -> int
struct A { g: F, x: int }

fn main() {
  let _ = A { .. } // Field g of type fn () -> int has no zero value
}
```
