### PR TITLE
fix: resolve shadowed builtin types in type position

### DIFF
--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -327,6 +327,23 @@ impl<'s> TaskState<'s> {
         store: &Store,
         type_name: &str,
     ) -> Option<EcoString> {
+        self.lookup_qualified_name_in_scope(store, type_name, false)
+    }
+
+    fn lookup_qualified_name_in_type_position(
+        &self,
+        store: &Store,
+        type_name: &str,
+    ) -> Option<EcoString> {
+        self.lookup_qualified_name_in_scope(store, type_name, true)
+    }
+
+    fn lookup_qualified_name_in_scope(
+        &self,
+        store: &Store,
+        type_name: &str,
+        prefer_type: bool,
+    ) -> Option<EcoString> {
         if let Some((prefix, simple_name)) = type_name.split_once('.')
             && let Some(module_id) = self.imports.prefix_to_module.get(prefix)
             && let Some(imported_module) = store.get_module(module_id)
@@ -336,26 +353,29 @@ impl<'s> TaskState<'s> {
             return Some(qualified_name.into());
         }
 
-        let module = store.get_module(&self.cursor.module_id)?;
-        let qualified_name = Symbol::from_parts(&module.id, type_name);
+        let module_ids = std::iter::once(self.cursor.module_id.as_str())
+            .chain(self.imports.unprefixed_imports.iter().map(String::as_str));
 
-        if module.definitions.contains_key(qualified_name.as_str()) {
-            return Some(qualified_name.as_eco().clone());
-        }
+        let mut value_fallback: Option<EcoString> = None;
+        for module_id in module_ids {
+            let Some(module) = store.get_module(module_id) else {
+                continue;
+            };
+            let qualified_name = Symbol::from_parts(module_id, type_name);
+            let Some(definition) = module.definitions.get(qualified_name.as_str()) else {
+                continue;
+            };
 
-        for imported_module_id in &self.imports.unprefixed_imports {
-            if let Some(imported_module) = store.get_module(imported_module_id) {
-                let qualified_name = Symbol::from_parts(imported_module_id, type_name);
-                if imported_module
-                    .definitions
-                    .contains_key(qualified_name.as_str())
-                {
-                    return Some(qualified_name.as_eco().clone());
+            if prefer_type && definition.is_value(qualified_name.as_str()) {
+                if value_fallback.is_none() {
+                    value_fallback = Some(qualified_name.as_eco().clone());
                 }
+            } else {
+                return Some(qualified_name.as_eco().clone());
             }
         }
 
-        None
+        value_fallback
     }
 
     pub(crate) fn get_definition_name_span(
@@ -495,7 +515,7 @@ impl<'s> TaskState<'s> {
             return None;
         }
 
-        let qualified_name = self.lookup_qualified_name(store, type_name)?;
+        let qualified_name = self.lookup_qualified_name_in_type_position(store, type_name)?;
         let ty = store.get_type(&qualified_name)?.clone();
 
         Some((qualified_name.to_string(), ty))

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -239,17 +239,10 @@ impl TaskState<'_> {
         type_name: &str,
     ) -> Option<(&'static str, Option<String>)> {
         let definition = store.get_definition(qualified_name)?;
-        if !matches!(definition.body, DefinitionBody::Value { .. }) {
+        if !definition.is_value(qualified_name) {
             return None;
         }
         let body = definition.ty.unwrap_forall();
-
-        if body
-            .get_qualified_id()
-            .is_some_and(|id| id == qualified_name)
-        {
-            return None;
-        }
 
         let is_function = matches!(body, Type::Function(_));
         let enum_id = match body {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -165,6 +165,11 @@ impl Definition {
     pub fn is_type_alias(&self) -> bool {
         matches!(self.body, DefinitionBody::TypeAlias { .. })
     }
+
+    pub fn is_value(&self, qualified_name: &str) -> bool {
+        matches!(self.body, DefinitionBody::Value { .. })
+            && self.ty.unwrap_forall().get_qualified_id() != Some(qualified_name)
+    }
 }
 
 pub type MethodSignatures = HashMap<EcoString, Type>;

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -5814,3 +5814,77 @@ fn guarded(f: Flag, x: int) -> int {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn go_const_named_unknown_does_not_shadow_builtin_unknown_type() {
+    let typedef = r#"
+pub struct Locale(int)
+
+pub const Unknown: Locale = 0
+
+pub var Marshal: fn(Unknown) -> Result<Slice<byte>, error>
+pub var Logger: fn(int, int, string, VarArgs<Unknown>) -> ()
+"#;
+    let input = r#"
+import "go:example.com/discord"
+
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/discord", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn go_const_named_never_does_not_shadow_builtin_never_type() {
+    let typedef = r#"
+pub struct Status(int)
+
+pub const Never: Status = 0
+
+pub var Abort: fn() -> Never
+"#;
+    let input = r#"
+import "go:example.com/api"
+
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/api", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn go_value_in_type_position_without_shadowed_type_still_errors() {
+    let typedef = r#"
+pub struct Status(int)
+
+pub const Pending: Status = 0
+
+pub var Read: fn() -> Pending
+"#;
+    let input = r#"
+import "go:example.com/api"
+
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/api", typedef)])
+        .assert_resolve_code("value_in_type_position");
+}
+
+#[test]
+fn go_local_type_shadowing_prelude_unknown_resolves_locally_before_its_definition() {
+    let typedef = r#"
+pub struct Holder {
+  pub value: Unknown
+}
+
+pub struct Unknown {
+  pub id: int
+}
+"#;
+    let input = r#"
+import "go:example.com/api"
+
+fn read_id(holder: api.Holder) -> int {
+  holder.value.id
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/api", typedef)]).assert_no_errors();
+}


### PR DESCRIPTION
In a type position, a builtin type now wins over a same-named Go package value.

```rs
import "go:fmt"
import "go:github.com/bwmarrin/discordgo"

const TOKEN = "token"

fn main() {
  let _discord = try {
    discordgo.New("Bot" + TOKEN)?
  }

  fmt.Println("Hello world!")
}
```

Fix #623