### PR TITLE
refactor: continue collapsing emit layer into IR

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -628,23 +628,6 @@ pub(crate) fn try_emit_lowered_tail_return(
     }
 }
 
-/// String-context bridge over `try_emit_lowered_tail_return`.
-pub(crate) fn render_lowered_tail_return(
-    planner: &mut Planner,
-    output: &mut String,
-    expression: &syntax::ast::Expression,
-    fx: &mut EmitEffects,
-) -> bool {
-    match try_emit_lowered_tail_return(planner, expression, fx) {
-        Some(statements) => {
-            let block = LoweredBlock { statements };
-            Renderer.render_lowered_block(output, &block);
-            true
-        }
-        None => false,
-    }
-}
-
 fn lowered_tail_fallback(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
@@ -653,16 +636,11 @@ fn lowered_tail_fallback(
     hoist_hint: Option<&str>,
     fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
-    let mut setup = String::new();
-    let value = planner.emit_value(&mut setup, expression, ExpressionContext::value(), fx);
+    let (mut statements, value) = planner.lower_value(expression, ExpressionContext::value(), fx);
     let value = match hoist_hint {
-        Some(hint) => planner.hoist_tmp_value(&mut setup, hint, &value),
+        Some(hint) => planner.hoist_tmp_value_statement(&mut statements, hint, &value),
         None => value,
     };
-    let mut statements = Vec::new();
-    if !setup.is_empty() {
-        statements.push(LoweredStatement::RawGo(setup));
-    }
     statements.extend(emit_lowered_result_return(
         planner, &value, return_ty, shape, fx,
     ));
@@ -684,17 +662,13 @@ fn emit_lowered_tuple_tail(
         let stages: Vec<StagedExpression> = elements
             .iter()
             .enumerate()
-            .map(|(i, e)| {
-                let mut setup = String::new();
-                let value = match slot_tys.get(i) {
-                    Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
-                        emit_nullable_slot_value(planner, &mut setup, e, slot_ty, fx)
-                    }
-                    _ => {
-                        planner.emit_composite_value(&mut setup, e, ExpressionContext::value(), fx)
-                    }
-                };
-                StagedExpression::new(setup, value, e)
+            .map(|(i, e)| match slot_tys.get(i) {
+                Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
+                    let mut setup = String::new();
+                    let value = emit_nullable_slot_value(planner, &mut setup, e, slot_ty, fx);
+                    StagedExpression::new(setup, value, e)
+                }
+                _ => planner.stage_composite(e, ExpressionContext::value(), fx),
             })
             .collect();
         let (mut statements, parts) = planner.sequence_structured(stages, "_ret");
@@ -728,49 +702,33 @@ fn emit_lowered_partial_tail(
     } = expression
         && let Some(variant) = callee.as_partial_constructor()
     {
-        let mut setup = String::new();
+        let mut statements = Vec::new();
         let ret = match variant {
             "Ok" => {
-                let v = planner.emit_composite_value(
-                    &mut setup,
-                    &args[0],
-                    ExpressionContext::value(),
-                    fx,
-                );
+                let (setup, v) =
+                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                statements.extend(setup);
                 multi_value_return(vec![v, "nil".to_string()])
             }
             "Err" => {
-                let e = planner.emit_composite_value(
-                    &mut setup,
-                    &args[0],
-                    ExpressionContext::value(),
-                    fx,
-                );
+                let (setup, e) =
+                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                statements.extend(setup);
                 let ok_ty = planner.facts.peel_alias(&return_ty).ok_type();
                 let ok_ty_str = planner.go_type_string(&ok_ty, fx);
                 multi_value_return(vec![format!("*new({})", ok_ty_str), e])
             }
             "Both" => {
-                let v = planner.emit_composite_value(
-                    &mut setup,
-                    &args[0],
-                    ExpressionContext::value(),
-                    fx,
-                );
-                let e = planner.emit_composite_value(
-                    &mut setup,
-                    &args[1],
-                    ExpressionContext::value(),
-                    fx,
-                );
+                let (setup_v, v) =
+                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                statements.extend(setup_v);
+                let (setup_e, e) =
+                    planner.lower_composite_value(&args[1], ExpressionContext::value(), fx);
+                statements.extend(setup_e);
                 multi_value_return(vec![v, e])
             }
             _ => unreachable!("as_partial_constructor only returns Ok/Err/Both"),
         };
-        let mut statements = Vec::new();
-        if !setup.is_empty() {
-            statements.push(LoweredStatement::RawGo(setup));
-        }
         statements.push(ret);
         return statements;
     }

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -41,7 +41,6 @@ impl GoCallStrategy {
 }
 
 impl Planner<'_> {
-    /// String-context bridge over `lower_go_wrapped_call`.
     pub(crate) fn emit_go_wrapped_call(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -9,7 +9,6 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
 use crate::types::shape::{CollectionKind, NullableCollectionElement, NullableCollectionShape};
-use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -53,7 +52,6 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
-    /// String-context bridge over `lower_sentinel_wrapping`.
     pub(crate) fn emit_sentinel_wrapping(
         &mut self,
         output: &mut String,
@@ -91,7 +89,6 @@ impl Planner<'_> {
         (statements, outcome)
     }
 
-    /// String-context bridge over `lower_comma_ok_wrapping`.
     pub(crate) fn emit_comma_ok_wrapping(
         &mut self,
         output: &mut String,
@@ -203,7 +200,6 @@ impl Planner<'_> {
         (statements, outcome)
     }
 
-    /// String-context bridge over `lower_nil_check_option_wrap`.
     pub(crate) fn emit_nil_check_option_wrap(
         &mut self,
         output: &mut String,
@@ -268,24 +264,19 @@ impl Planner<'_> {
         address: bool,
         fx: &mut EmitEffects,
     ) -> String {
-        let opt_var = self.fresh_var(Some("opt"));
-        self.declare(&opt_var);
-        let slot_var = self.fresh_var(Some(slot_hint));
-        self.declare(&slot_var);
-
-        fx.require_stdlib();
-
-        let amp = if address { "&" } else { "" };
-        write_line!(output, "{} := {}", opt_var, option_value);
-        write_line!(output, "var {} {}", slot_var, slot_ty);
-        write_line!(output, "if {}.Tag == {} {{", opt_var, OPTION_SOME_TAG);
-        write_line!(output, "{} = {}{}.SomeVal", slot_var, amp, opt_var);
-        output.push_str("}\n");
-
+        let mut statements = Vec::new();
+        let slot_var = self.plan_option_projection(
+            &mut statements,
+            option_value,
+            slot_hint,
+            slot_ty,
+            address,
+            fx,
+        );
+        output.push_str(&Renderer.render_setup(&statements));
         slot_var
     }
 
-    /// Typed counterpart of `emit_option_projection`.
     pub(crate) fn plan_option_projection(
         &mut self,
         statements: &mut Vec<LoweredStatement>,

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -8,6 +8,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{
     Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR,
 };
+use crate::control_flow::propagation::plain_return;
 use crate::is_order_sensitive;
 use crate::names::go_name;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement};
@@ -52,11 +53,11 @@ pub(super) enum ResolvedSink {
     Return,
 }
 
-/// `slot = value` / `return value` as a `RawGo` leaf.
+/// `slot = value` (a `RawGo` leaf) or a structured `return value`.
 pub(super) fn leaf_statement(sink: &ResolvedSink, value: &str) -> LoweredStatement {
     match sink {
         ResolvedSink::Slot(name) => LoweredStatement::RawGo(format!("{} = {}\n", name, value)),
-        ResolvedSink::Return => LoweredStatement::RawGo(format!("return {}\n", value)),
+        ResolvedSink::Return => plain_return(value.to_string()),
     }
 }
 
@@ -100,7 +101,6 @@ impl Planner<'_> {
         }
     }
 
-    /// Typed counterpart of `extract_go_returns`.
     fn push_go_returns(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
@@ -138,7 +138,7 @@ impl Planner<'_> {
                 Some(name.to_string())
             }
             WrapperTarget::Return => {
-                statements.push(LoweredStatement::RawGo(format!("return {}\n", value_expr)));
+                statements.push(plain_return(value_expr.to_string()));
                 None
             }
         }
@@ -191,7 +191,6 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
-    /// String-context bridge over `lower_partial_wrapping`.
     pub(crate) fn emit_partial_wrapping(
         &mut self,
         output: &mut String,
@@ -312,7 +311,6 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
-    /// String-context bridge over `lower_result_wrapping`.
     pub(crate) fn emit_result_wrapping(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -45,7 +45,6 @@ impl Planner<'_> {
         output.push_str("}\n");
     }
 
-    /// String-context bridge over `lower_block_as_body`.
     pub(crate) fn emit_block(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -79,9 +79,7 @@ impl Planner<'_> {
         if last.diverges().is_some() || last.get_type().is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
-                statements.push(LoweredStatement::RawGo(
-                    "panic(\"unreachable\")\n".to_string(),
-                ));
+                statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;
         }
@@ -103,12 +101,8 @@ impl Planner<'_> {
             ];
         }
 
-        let mut statements = Vec::new();
-        let mut buffer = String::new();
-        let final_expression = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
-        if !buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(buffer));
-        }
+        let (mut statements, final_expression) =
+            self.lower_value(last, ExpressionContext::value(), fx);
         if final_expression.is_empty() {
             statements.push(self.lower_try_unit_return(fallible, fx));
         } else {
@@ -184,10 +178,7 @@ impl Planner<'_> {
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty, fx)
             };
-            statements.push(LoweredStatement::RawGo(format!(
-                "return {}\n",
-                values.join(", ")
-            )));
+            statements.push(plain_return(values.join(", ")));
         } else {
             fx.require_stdlib();
             let err_return = {
@@ -265,9 +256,7 @@ impl Planner<'_> {
         if item_ty.is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
-                statements.push(LoweredStatement::RawGo(
-                    "panic(\"unreachable\")\n".to_string(),
-                ));
+                statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;
         }
@@ -277,12 +266,7 @@ impl Planner<'_> {
                 self.lower_zero_return(fallible.ok_ty(), fx),
             ];
         }
-        let mut statements = Vec::new();
-        let mut buffer = String::new();
-        let expression = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
-        if !buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(buffer));
-        }
+        let (mut statements, expression) = self.lower_value(last, ExpressionContext::value(), fx);
         statements.push(plain_return(expression));
         statements
     }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -179,9 +179,8 @@ impl Planner<'_> {
         iterable: &Expression,
         fx: &mut EmitEffects,
     ) -> (String, String, bool) {
-        let (prologue, iter_raw) = self.capture_emission(&mut String::new(), |this, buffer| {
-            this.emit_operand(buffer, iterable, ExpressionContext::value(), fx)
-        });
+        let mut prologue = String::new();
+        let iter_raw = self.emit_operand(&mut prologue, iterable, ExpressionContext::value(), fx);
         let iterable_ty = iterable.get_type();
         let iter_expression = if iterable_ty.is_ref() {
             format!("*{}", iter_raw)

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -12,7 +12,6 @@ use crate::plan::bodies::{
 };
 use crate::plan::calls::{CallReturnShape, CalleePlan};
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
-use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -83,20 +82,6 @@ impl Planner<'_> {
             }
         };
         (statements, value)
-    }
-
-    /// String-context bridge over `lower_propagate`.
-    pub(crate) fn emit_propagate(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        result_var_name: Option<&str>,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let (statements, value) = self.lower_propagate(expression, result_var_name, fx);
-        let block = LoweredBlock { statements };
-        Renderer.render_lowered_block(output, &block);
-        value
     }
 
     /// `Err(...)?` and `None?` already emitted `return ...`. Declare the
@@ -205,38 +190,6 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn emit_return(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) {
-        let return_ctx = self.return_ctx();
-        let is_unit = return_ctx.ty().is_some_and(Type::is_unit);
-
-        if is_unit {
-            let is_pure = matches!(
-                expression,
-                Expression::Unit { .. }
-                    | Expression::Identifier { .. }
-                    | Expression::Literal { .. }
-            );
-            if !is_pure {
-                self.emit_statement(output, expression, fx);
-            }
-            output.push_str("return\n");
-        } else if !transition::render_lowered_tail_return(self, output, expression, fx)
-            && !self.emit_wrapped_return(output, expression, fx)
-        {
-            let expression_string =
-                self.emit_value(output, expression, ExpressionContext::value(), fx);
-            let return_ty = return_ctx.ty();
-            let expression_string =
-                self.apply_type_coercion(output, return_ty, expression, expression_string, fx);
-            write_line!(output, "return {}", expression_string);
-        }
-    }
-
     /// Build a `ReturnStatementPlan`, dispatching on return shape.
     pub(crate) fn build_return_plan(
         &mut self,
@@ -244,16 +197,11 @@ impl Planner<'_> {
         directive: String,
         fx: &mut EmitEffects,
     ) -> ReturnStatementPlan {
-        let body_block = |body_text: String| LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(body_text)],
-        };
-
         let return_ctx = self.return_ctx();
         let is_unit = return_ctx.ty().is_some_and(Type::is_unit);
         if is_unit {
-            // Mirror emit_return's unit path: impure expressions run as a
-            // statement before the bare `return`; pure ones (Unit, Identifier,
-            // Literal) emit nothing.
+            // Unit return: impure expressions run as a statement before the
+            // bare `return`; pure ones (Unit, Identifier, Literal) emit nothing.
             let is_pure = matches!(
                 expression,
                 Expression::Unit { .. }
@@ -263,9 +211,10 @@ impl Planner<'_> {
             let side_effect = if is_pure {
                 None
             } else {
-                let mut buffer = String::new();
-                self.emit_statement(&mut buffer, expression, fx);
-                (!buffer.is_empty()).then(|| body_block(buffer))
+                let body = LoweredBlock {
+                    statements: vec![self.lower_statement(expression, fx)],
+                };
+                (!Renderer.renders_empty(&body)).then_some(body)
             };
             return ReturnStatementPlan {
                 directive,
@@ -394,24 +343,6 @@ impl Planner<'_> {
         statements.extend(setup);
         statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
         Some(statements)
-    }
-
-    /// String-context bridge over `lower_wrapped_return`. Returns `true`
-    /// when a wrapped return was emitted.
-    pub(crate) fn emit_wrapped_return(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> bool {
-        match self.lower_wrapped_return(expression, fx) {
-            Some(statements) => {
-                let block = LoweredBlock { statements };
-                Renderer.render_lowered_block(output, &block);
-                true
-            }
-            None => false,
-        }
     }
 
     fn wrapped_value_return(

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -10,7 +10,7 @@ use crate::patterns::sites::{
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan, SelectStatementPlan,
 };
-use crate::plan::placement::emit_unreachable_panic_if_needed;
+use crate::plan::placement::unreachable_panic_if_needed;
 use crate::utils::contains_call;
 use syntax::ast::{Expression, MatchArm, Pattern, SelectArm, SelectArmPattern, TypedPattern};
 use syntax::types::unqualified_name;
@@ -49,11 +49,7 @@ impl Planner<'_> {
         });
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        let mut setup_buffer = String::new();
-        let prep = self.preprocess_select_arms(&mut setup_buffer, arms, needs_retry_loop, fx);
-        if !setup_buffer.is_empty() {
-            setup.push(LoweredStatement::RawGo(setup_buffer));
-        }
+        let prep = self.preprocess_select_arms(&mut setup, arms, needs_retry_loop, fx);
 
         self.enter_scope();
         let arm_plans = self.lower_select_arms(arms, &prep, place, fx);
@@ -66,10 +62,8 @@ impl Planner<'_> {
             !arm_plans.is_empty() && arm_plans.iter().all(|arm| arm.body().ends_with_diverge());
         let exhaustive = all_arms_diverge || if needs_retry_loop { false } else { has_default };
         let mut postlude: Vec<LoweredStatement> = Vec::new();
-        let mut panic_buffer = String::new();
-        emit_unreachable_panic_if_needed(&mut panic_buffer, place, exhaustive);
-        if !panic_buffer.is_empty() {
-            postlude.push(LoweredStatement::RawGo(panic_buffer));
+        if let Some(panic) = unreachable_panic_if_needed(place, exhaustive) {
+            postlude.push(panic);
         }
 
         SelectStatementPlan {
@@ -147,7 +141,7 @@ impl Planner<'_> {
     /// in source order, not on each retry.
     fn preprocess_select_arms(
         &mut self,
-        output: &mut String,
+        setup: &mut Vec<LoweredStatement>,
         arms: &[SelectArm],
         needs_retry_loop: bool,
         fx: &mut EmitEffects,
@@ -161,8 +155,7 @@ impl Planner<'_> {
                 SelectArmPattern::Send {
                     send_expression, ..
                 } => {
-                    let parts =
-                        self.prepare_send_arm(output, send_expression, needs_retry_loop, fx);
+                    let parts = self.prepare_send_arm(setup, send_expression, needs_retry_loop, fx);
                     send_parts.push(Some(parts));
                     channel_operands.push(None);
                     channel_shadows.push(None);
@@ -173,14 +166,14 @@ impl Planner<'_> {
                     ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.emit_channel_operand(output, receive_expression, fx);
+                    let ch = self.lower_channel_operand(setup, receive_expression, fx);
                     if is_some_pattern(binding) && needs_retry_loop {
-                        let shadow = self.hoist_tmp_value(output, "ch", &ch);
+                        let shadow = self.hoist_tmp_value_statement(setup, "ch", &ch);
                         channel_operands.push(Some(ch));
                         channel_shadows.push(Some(shadow));
                     } else {
                         let ch = if needs_retry_loop && channel_has_call {
-                            self.hoist_tmp_value(output, "ch", &ch)
+                            self.hoist_tmp_value_statement(setup, "ch", &ch)
                         } else {
                             ch
                         };
@@ -193,9 +186,9 @@ impl Planner<'_> {
                     receive_expression, ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.emit_channel_operand(output, receive_expression, fx);
+                    let ch = self.lower_channel_operand(setup, receive_expression, fx);
                     let ch = if needs_retry_loop && channel_has_call {
-                        self.hoist_tmp_value(output, "ch", &ch)
+                        self.hoist_tmp_value_statement(setup, "ch", &ch)
                     } else {
                         ch
                     };
@@ -218,22 +211,25 @@ impl Planner<'_> {
         }
     }
 
-    fn emit_channel_operand(
+    fn lower_channel_operand(
         &mut self,
-        output: &mut String,
+        setup: &mut Vec<LoweredStatement>,
         receive_expression: &Expression,
         fx: &mut EmitEffects,
     ) -> String {
         let unwrapped = receive_expression.unwrap_parens();
         if let Some((channel, "receive", _)) = extract_channel_op(unwrapped) {
-            let ch = self.emit_value(output, channel, ExpressionContext::value(), fx);
+            let (op_setup, ch) = self.lower_value(channel, ExpressionContext::value(), fx);
+            setup.extend(op_setup);
             return if channel.get_type().is_ref() {
                 cancel_deref_of_address(ch)
             } else {
                 ch
             };
         }
-        self.emit_value(output, receive_expression, ExpressionContext::value(), fx)
+        let (op_setup, ch) = self.lower_value(receive_expression, ExpressionContext::value(), fx);
+        setup.extend(op_setup);
+        ch
     }
 
     fn fresh_ok_var(&mut self) -> String {
@@ -475,7 +471,7 @@ impl Planner<'_> {
 
     fn prepare_send_arm(
         &mut self,
-        output: &mut String,
+        setup: &mut Vec<LoweredStatement>,
         send_expression: &Expression,
         needs_hoist: bool,
         fx: &mut EmitEffects,
@@ -483,20 +479,22 @@ impl Planner<'_> {
         let unwrapped = send_expression.unwrap_parens();
         if let Some((channel, member, args)) = extract_channel_op(unwrapped) {
             let ch_has_call = needs_hoist && contains_call(channel);
-            let mut ch = self.emit_value(output, channel, ExpressionContext::value(), fx);
+            let (op_setup, mut ch) = self.lower_value(channel, ExpressionContext::value(), fx);
+            setup.extend(op_setup);
             if channel.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }
             if ch_has_call {
-                ch = self.hoist_tmp_value(output, "ch", &ch);
+                ch = self.hoist_tmp_value_statement(setup, "ch", &ch);
             }
             match member {
                 "send" if !args.is_empty() => {
                     let val_has_call = needs_hoist && contains_call(&args[0]);
-                    let mut val =
-                        self.emit_composite_value(output, &args[0], ExpressionContext::value(), fx);
+                    let (val_setup, mut val) =
+                        self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                    setup.extend(val_setup);
                     if val_has_call {
-                        val = self.hoist_tmp_value(output, "send_val", &val);
+                        val = self.hoist_tmp_value_statement(setup, "send_val", &val);
                     }
                     SendArmParts::Send(ch, val)
                 }
@@ -505,12 +503,14 @@ impl Planner<'_> {
             }
         } else {
             let expression_has_call = needs_hoist && contains_call(send_expression);
-            let mut ch = self.emit_value(output, send_expression, ExpressionContext::value(), fx);
+            let (op_setup, mut ch) =
+                self.lower_value(send_expression, ExpressionContext::value(), fx);
+            setup.extend(op_setup);
             if send_expression.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }
             if expression_has_call {
-                ch = self.hoist_tmp_value(output, "ch", &ch);
+                ch = self.hoist_tmp_value_statement(setup, "ch", &ch);
             }
             SendArmParts::Receive(ch)
         }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -60,7 +60,6 @@ impl Planner<'_> {
             .collect();
         let (mut setup, emitted_values) = self.sequence_structured(stages, "_field");
 
-        let mut tail = String::new();
         let mut field_names: Vec<String> = Vec::new();
         let mut field_values: Vec<String> = Vec::new();
         for (slot, f) in kept.iter().enumerate() {
@@ -94,7 +93,7 @@ impl Planner<'_> {
                 // Never-typed spread base diverges — emit as statement and
                 // return a zero-value struct literal (dead code follows).
                 if base.get_type().is_never() {
-                    self.emit_statement(&mut tail, base, fx);
+                    setup.push(self.lower_statement(base, fx));
                     format!("{}{{}}", ctx.go_type)
                 } else {
                     let mut field_side_effects: Vec<bool> = Vec::new();
@@ -124,9 +123,6 @@ impl Planner<'_> {
             }
         };
 
-        if !tail.is_empty() {
-            setup.push(LoweredStatement::RawGo(tail));
-        }
         value_plan_from_statements(setup, value)
     }
 

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -43,43 +43,38 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> String {
-        if let Some(strategy) = self.classify_go_fn_value(expression) {
-            if self.go_fn_matches_lowered_slot(expression, &strategy, ctx) {
-                return self.emit_operand(output, expression, ctx, fx);
-            }
-            if self.go_fn_needs_lowered_tuple_adapter(expression, ctx) {
-                return self.emit_go_fn_lowered_tuple_adapter(output, expression, fx);
-            }
-            return self.emit_go_fn_wrapper(output, expression, &strategy, fx);
-        }
-
-        if self.is_go_array_return_value(expression) {
-            return self.emit_array_return_wrapper(output, expression, fx);
-        }
-
-        self.emit_operand(output, expression, ctx, fx)
+        let (setup, value) = self.lower_value(expression, ctx, fx);
+        output.push_str(&Renderer.render_setup(&setup));
+        value
     }
 
-    /// Typed counterpart of `emit_value`.
     pub(crate) fn lower_value(
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
-        if self.classify_go_fn_value(expression).is_some()
-            || self.is_go_array_return_value(expression)
-        {
+        if let Some(strategy) = self.classify_go_fn_value(expression) {
+            if !self.go_fn_matches_lowered_slot(expression, &strategy, ctx) {
+                let mut buffer = String::new();
+                let value = if self.go_fn_needs_lowered_tuple_adapter(expression, ctx) {
+                    self.emit_go_fn_lowered_tuple_adapter(&mut buffer, expression, fx)
+                } else {
+                    self.emit_go_fn_wrapper(&mut buffer, expression, &strategy, fx)
+                };
+                return (setup_from_string(buffer), value);
+            }
+        } else if self.is_go_array_return_value(expression) {
             let mut buffer = String::new();
-            let value = self.emit_value(&mut buffer, expression, ctx, fx);
+            let value = self.emit_array_return_wrapper(&mut buffer, expression, fx);
             return (setup_from_string(buffer), value);
         }
+
         let plan = self.plan_operand(expression, ctx, fx);
         let staged = StagedExpression::from_plan(plan, expression);
         (staged.setup, staged.value)
     }
 
-    /// Typed counterpart of `emit_composite_value`.
     pub(crate) fn lower_composite_value(
         &mut self,
         expression: &Expression,
@@ -204,130 +199,84 @@ impl Planner<'_> {
         Renderer.render_value(output, &plan)
     }
 
-    /// String-emit body for expression kinds not yet lowered to a
-    /// structured `ValuePlan`.
-    pub(crate) fn emit_operand_raw(
+    /// Plan a value-position leaf expression (one `plan_operand` does not lower
+    /// structurally) into a `ValuePlan`.
+    pub(crate) fn plan_operand_leaf(
         &mut self,
-        output: &mut String,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> String {
+    ) -> ValuePlan {
         match expression {
-            Expression::Literal { literal, ty, .. } => self.emit_literal(output, literal, ty, fx),
+            Expression::Literal { literal, ty, .. } => {
+                let mut buffer = String::new();
+                let value = self.emit_literal(&mut buffer, literal, ty, fx);
+                value_plan_from_statements(setup_from_string(buffer), value)
+            }
             Expression::Identifier { value, ty, .. } => {
+                let mut buffer = String::new();
                 let raw = self.emit_identifier(value, ty, ctx, fx);
-                self.maybe_lower_tagged_fn_ref(output, expression, ty, raw, ctx, fx)
+                let value =
+                    self.maybe_lower_tagged_fn_ref(&mut buffer, expression, ty, raw, ctx, fx);
+                value_plan_from_statements(setup_from_string(buffer), value)
             }
-            Expression::Binary { .. } => {
-                unreachable!("Binary is handled structurally by plan_operand")
+            Expression::Call { ty, .. } => {
+                let mut buffer = String::new();
+                let value = match self.classify_call(expression) {
+                    CallBoundary::GoWrapped(strategy) => {
+                        self.emit_go_wrapped_call(&mut buffer, expression, &strategy, ty, fx)
+                    }
+                    CallBoundary::LoweredCallee(shape) => {
+                        fx.require_stdlib();
+                        let call_str = self.emit_call(&mut buffer, expression, Some(ty), ctx, fx);
+                        emit_callee_abi_wrapping(self, &mut buffer, &shape, &call_str, ty, fx)
+                    }
+                    CallBoundary::Plain => {
+                        self.emit_call(&mut buffer, expression, Some(ty), ctx, fx)
+                    }
+                };
+                value_plan_from_statements(setup_from_string(buffer), value)
             }
-            Expression::Unary { .. } => {
-                unreachable!("Unary is handled structurally by plan_operand")
-            }
-            Expression::Call { ty, .. } => match self.classify_call(expression) {
-                CallBoundary::GoWrapped(strategy) => {
-                    self.emit_go_wrapped_call(output, expression, &strategy, ty, fx)
-                }
-                CallBoundary::LoweredCallee(shape) => {
-                    fx.require_stdlib();
-                    let call_str = self.emit_call(output, expression, Some(ty), ctx, fx);
-                    emit_callee_abi_wrapping(self, output, &shape, &call_str, ty, fx)
-                }
-                CallBoundary::Plain => self.emit_call(output, expression, Some(ty), ctx, fx),
-            },
-            Expression::DotAccess { .. } => {
-                unreachable!("DotAccess is handled structurally by plan_operand")
-            }
-            Expression::IndexedAccess { .. } => {
-                unreachable!("IndexedAccess is handled structurally by plan_operand")
-            }
-            Expression::StructCall { .. } => {
-                unreachable!("StructCall is handled structurally by plan_operand")
-            }
-            Expression::Paren { .. } => {
-                unreachable!("Paren is handled structurally by plan_operand")
-            }
-            Expression::Reference { .. } => {
-                unreachable!("Reference is handled structurally by plan_operand")
-            }
-            Expression::Task { .. } => {
-                unreachable!("Task is handled structurally by plan_operand")
-            }
-            Expression::Defer { .. } => {
-                unreachable!("Defer is handled structurally by plan_operand")
-            }
-            Expression::RawGo { text } => text.clone(),
-            Expression::Unit { .. } => "struct{}{}".to_string(),
-            Expression::NoOp => String::new(),
+            Expression::RawGo { text } => ValuePlan::Operand(text.clone()),
+            Expression::Unit { .. } => ValuePlan::Operand("struct{}{}".to_string()),
+            Expression::NoOp => ValuePlan::Operand(String::new()),
             Expression::Lambda {
                 params, body, ty, ..
-            } => self.emit_lambda(params, body, ty, ctx, fx),
-            Expression::Function {
+            }
+            | Expression::Function {
                 params, body, ty, ..
-            } => self.emit_lambda(params, body, ty, ctx, fx),
-            Expression::Propagate { expression, .. } => {
-                self.emit_propagate(output, expression, None, fx)
-            }
-            Expression::TryBlock { .. } => {
-                unreachable!("TryBlock is handled structurally by plan_operand")
-            }
-            Expression::RecoverBlock { .. } => {
-                unreachable!("RecoverBlock is handled structurally by plan_operand")
-            }
-            Expression::Tuple { .. } => {
-                unreachable!("Tuple is handled structurally by plan_operand")
-            }
-            Expression::If { .. } => {
-                unreachable!("If is handled structurally by plan_operand")
-            }
-            Expression::Loop { .. } => {
-                unreachable!("Loop is handled structurally by plan_operand")
-            }
-            Expression::Match { ty, .. } | Expression::Select { ty, .. } if !ty.is_never() => {
-                unreachable!("non-never Match/Select is handled structurally by plan_operand")
-            }
+            } => ValuePlan::Operand(self.emit_lambda(params, body, ty, ctx, fx)),
             Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
-            | Expression::Block { ty, .. } => self.emit_to_operand_temp(output, expression, ty, fx),
-            Expression::IfLet { .. } => {
-                unreachable!("IfLet should be desugared to Match before emit")
+            | Expression::Block { ty, .. } => {
+                let mut buffer = String::new();
+                let value = self.emit_to_operand_temp(&mut buffer, expression, ty, fx);
+                value_plan_from_statements(setup_from_string(buffer), value)
             }
             Expression::Return {
                 expression: return_expression,
                 ..
             } => {
-                self.emit_return(output, return_expression, fx);
-                String::new()
-            }
-            Expression::Range { .. } => {
-                unreachable!("Range is handled structurally by plan_operand")
-            }
-            Expression::Cast { .. } => {
-                unreachable!("Cast is handled structurally by plan_operand")
+                let plan = self.build_return_plan(return_expression, String::new(), fx);
+                value_plan_from_statements(vec![LoweredStatement::Return(plan)], String::new())
             }
             Expression::Assignment { target, value, .. } => {
-                self.emit_assignment_operand(output, target, value, fx);
-                "struct{}{}".to_string()
+                let mut buffer = String::new();
+                self.emit_assignment_operand(&mut buffer, target, value, fx);
+                value_plan_from_statements(setup_from_string(buffer), "struct{}{}".to_string())
             }
-            _ => unreachable!("unexpected expression in emit: {:?}", expression),
+            Expression::IfLet { .. } => {
+                unreachable!("IfLet should be desugared to Match before emit")
+            }
+            _ => unreachable!(
+                "unexpected leaf expression in plan_operand: {:?}",
+                expression
+            ),
         }
     }
 
     /// Emit a Go tuple literal. `in_tail` widens slot types to the declared
     /// return slots so per-element coercion matches the return site.
-    pub(crate) fn emit_tuple_value(
-        &mut self,
-        output: &mut String,
-        elements: &[Expression],
-        ty: &Type,
-        in_tail: bool,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let plan = self.plan_tuple_value(elements, ty, in_tail, fx);
-        Renderer.render_value(output, &plan)
-    }
-
     /// Plan a tuple literal as `lisette.MakeTupleN(...)`.
     pub(crate) fn plan_tuple_value(
         &mut self,
@@ -462,15 +411,7 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, format!("&{}", tmp));
         }
 
-        let (mut setup, emitted) =
-            if self.classify_go_fn_value(inner).is_some() || self.is_go_array_return_value(inner) {
-                let mut buffer = String::new();
-                let value = self.emit_value(&mut buffer, inner, ExpressionContext::value(), fx);
-                (setup_from_string(buffer), value)
-            } else {
-                let staged = self.stage_operand(inner, ExpressionContext::value(), fx);
-                (staged.setup, staged.value)
-            };
+        let (mut setup, emitted) = self.lower_value(inner, ExpressionContext::value(), fx);
 
         let value = if inner.get_type() == *ty {
             emitted

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -395,17 +395,6 @@ impl<'a> Planner<'a> {
         tmp
     }
 
-    pub(crate) fn capture_emission<F, R>(&mut self, output: &mut String, f: F) -> (String, R)
-    where
-        F: FnOnce(&mut Self, &mut String) -> R,
-    {
-        let before = output.len();
-        let value = f(self, output);
-        let captured = output[before..].to_string();
-        output.truncate(before);
-        (captured, value)
-    }
-
     /// Run `f` inside a fresh scope to build a `LoweredBlock`, returning `None`
     /// when it renders empty.
     pub(crate) fn capture_scoped_block<F>(&mut self, f: F) -> Option<LoweredBlock>

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,14 +1,12 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::AbiShape;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::tree_emitter::TreePlanner;
-use crate::plan::bodies::{LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::plan::calls::CallReturnShape;
 use crate::state::bindings::BindingValue;
-use crate::write_line;
 use syntax::ast::{Expression, MatchArm, Pattern};
 
 /// How to render the subject declaration line, based on body usage.
@@ -36,25 +34,18 @@ impl Planner<'_> {
         let mut statements: Vec<LoweredStatement> = Vec::new();
 
         if subject.get_type().is_never() {
-            let mut buffer = String::new();
-            self.emit_statement(&mut buffer, subject, fx);
-            statements.push(LoweredStatement::RawGo(buffer));
+            statements.push(self.lower_statement(subject, fx));
             return LoweredBlock { statements };
         }
 
-        let mut fusion_buffer = String::new();
-        if self.try_emit_fused_lowered_match(&mut fusion_buffer, subject, arms, place, fx) {
-            statements.push(LoweredStatement::RawGo(fusion_buffer));
+        if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place, fx) {
+            statements.extend(fused);
             return LoweredBlock { statements };
         }
 
         let subject_ty = subject.get_type();
-        let mut setup_buffer = String::new();
         let (subject_var, declaration) =
-            self.emit_match_subject_var(&mut setup_buffer, subject, arms, fx);
-        if !setup_buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(setup_buffer));
-        }
+            self.lower_match_subject_var(&mut statements, subject, arms, fx);
 
         let block = self.lower_match_tree(arms, subject_var.clone(), subject_ty, place, fx);
         let used = block.references_var(&subject_var);
@@ -96,37 +87,30 @@ impl Planner<'_> {
 
     /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
     /// when the scrutinee is a lowered call with simple `Ok`/`Err` arms.
-    fn try_emit_fused_lowered_match(
+    fn lower_fused_lowered_match(
         &mut self,
-        output: &mut String,
         subject: &Expression,
         arms: &[MatchArm],
         place: &PlacePlan,
         fx: &mut EmitEffects,
-    ) -> bool {
-        let Some(plan) = self.plan_call(subject) else {
-            return false;
-        };
+    ) -> Option<Vec<LoweredStatement>> {
+        let plan = self.plan_call(subject)?;
         let CallReturnShape::Lowered(shape) = plan.return_shape else {
-            return false;
+            return None;
         };
         // Match-fusion only handles `Result`'s binary `Ok`/`Err` arms;
         // Partial (3-way) and Option (Some/None) fall through to lift-then-match.
         if !matches!(shape, AbiShape::ResultTuple | AbiShape::BareError) {
-            return false;
+            return None;
         }
-        let Some((ok_arm, err_arm)) = classify_result_arms(arms) else {
-            return false;
-        };
+        let (ok_arm, err_arm) = classify_result_arms(arms)?;
 
         // Err always carries a payload; Ok may not under BareError.
         let ok_binding = simple_payload_binding(ok_arm);
         let err_binding = simple_payload_binding(err_arm);
-        if err_binding.is_none() {
-            return false;
-        }
+        err_binding?;
         if ok_binding.is_none() && !ok_arm_payload_is_omitted(ok_arm, &shape) {
-            return false;
+            return None;
         }
         let ok_name = ok_binding.filter(|n| *n != "_");
         let err_name = err_binding.filter(|n| *n != "_");
@@ -140,47 +124,54 @@ impl Planner<'_> {
         };
         let err_var = self.fresh_var(Some("ret"));
         self.declare(&err_var);
-        let call_str = self.emit_call(output, subject, None, ExpressionContext::value(), fx);
-        match &val_var {
-            Some(v) => write_line!(output, "{}, {} := {}", v, err_var, call_str),
+
+        let (mut statements, call_str) =
+            self.lower_call(subject, None, ExpressionContext::value(), fx);
+        let bind_line = match &val_var {
+            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
             None => match shape {
-                AbiShape::ResultTuple => write_line!(output, "_, {} := {}", err_var, call_str),
-                AbiShape::BareError => write_line!(output, "{} := {}", err_var, call_str),
+                AbiShape::ResultTuple => format!("_, {} := {}\n", err_var, call_str),
+                AbiShape::BareError => format!("{} := {}\n", err_var, call_str),
                 AbiShape::PartialTuple
                 | AbiShape::CommaOk
                 | AbiShape::NullableReturn
                 | AbiShape::Tuple { .. } => unreachable!("rejected above"),
             },
-        }
+        };
+        statements.push(LoweredStatement::RawGo(bind_line));
 
-        write_line!(output, "if {} == nil {{", err_var);
-        self.emit_fused_arm(
-            output,
+        let then_body = self.lower_fused_arm(
             ok_name.zip(val_var.as_deref()),
             &ok_arm.expression,
             place,
             fx,
         );
-        output.push_str("} else {\n");
-        self.emit_fused_arm(
-            output,
+        let else_body = self.lower_fused_arm(
             err_name.map(|n| (n, err_var.as_str())),
             &err_arm.expression,
             place,
             fx,
         );
-        output.push_str("}\n");
-        true
+        statements.push(LoweredStatement::If(IfPlan {
+            directive: String::new(),
+            condition_setup: String::new(),
+            condition: format!("{} == nil", err_var),
+            then_body,
+            else_arm: ElseArm::Else {
+                body: else_body,
+                inline: false,
+            },
+        }));
+        Some(statements)
     }
 
-    fn emit_fused_arm(
+    fn lower_fused_arm(
         &mut self,
-        output: &mut String,
         binding: Option<(&str, &str)>,
         body: &Expression,
         place: &PlacePlan,
         fx: &mut EmitEffects,
-    ) {
+    ) -> LoweredBlock {
         self.scope.push_binding_frame();
         let bound = binding.map(|(name, value)| {
             let go_name = self.scope.bind(name, name);
@@ -188,19 +179,24 @@ impl Planner<'_> {
             (go_name, value.to_string())
         });
         let body_block = self.lower_block_to_place(body, place, fx);
+        let mut statements = Vec::new();
         if let Some((go_name, value)) = &bound {
-            write_line!(output, "{} := {}", go_name, value);
+            statements.push(LoweredStatement::TempBind {
+                name: go_name.clone(),
+                value: value.clone(),
+            });
             if !body_block.references_var(go_name) {
-                write_line!(output, "_ = {}", go_name);
+                statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
             }
         }
-        Renderer.render_lowered_block(output, &body_block);
+        statements.extend(body_block.statements);
         self.scope.pop_binding_frame();
+        LoweredBlock { statements }
     }
 
-    fn emit_match_subject_var(
+    fn lower_match_subject_var(
         &mut self,
-        output: &mut String,
+        setup: &mut Vec<LoweredStatement>,
         subject: &Expression,
         arms: &[MatchArm],
         fx: &mut EmitEffects,
@@ -223,17 +219,17 @@ impl Planner<'_> {
             }
         }
         if matches!(subject, Expression::Literal { .. }) {
-            return (
-                self.emit_operand(output, subject, ExpressionContext::value(), fx),
-                SubjectDeclaration::None,
-            );
+            let staged = self.stage_operand(subject, ExpressionContext::value(), fx);
+            setup.extend(staged.setup);
+            return (staged.value, SubjectDeclaration::None);
         }
         let var = self.fresh_var(Some("subject"));
         self.declare(&var);
-        let expression = self.emit_composite_value(output, subject, ExpressionContext::value(), fx);
+        let staged = self.stage_composite(subject, ExpressionContext::value(), fx);
+        setup.extend(staged.setup);
         let declaration = SubjectDeclaration::Deferred {
             var: var.clone(),
-            expression,
+            expression: staged.value,
         };
         (var, declaration)
     }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -17,7 +17,7 @@ use crate::patterns::binding_emit::{
     tree_binding_statements,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
-use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::state::bindings::BindingValue;
 use crate::write_line;
 
@@ -97,7 +97,7 @@ struct LetElseAlternatives<'s> {
 impl Planner<'_> {
     fn resolve_pattern_subject(
         &mut self,
-        output: &mut String,
+        setup: &mut Vec<LoweredStatement>,
         subject: PatternSubject<'_>,
         fx: &mut EmitEffects,
     ) -> ResolvedSubject {
@@ -121,7 +121,9 @@ impl Planner<'_> {
                 }
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
-                let expression = self.emit_value(output, scrutinee, ExpressionContext::value(), fx);
+                let (op_setup, expression) =
+                    self.lower_value(scrutinee, ExpressionContext::value(), fx);
+                setup.extend(op_setup);
                 ResolvedSubject::Composite { var, expression }
             }
         }
@@ -137,8 +139,8 @@ impl Planner<'_> {
         subject_ty: &Type,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let mut prologue = String::new();
-        let resolved = self.resolve_pattern_subject(&mut prologue, subject, fx);
+        let mut statements = Vec::new();
+        let resolved = self.resolve_pattern_subject(&mut statements, subject, fx);
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
         fx.extend(&info.effects);
 
@@ -151,10 +153,6 @@ impl Planner<'_> {
         tree_binding_statements(self, &mut body, &info.bindings, &effective, &[]);
         let body_block = LoweredBlock { statements: body };
 
-        let mut statements = Vec::new();
-        if !prologue.is_empty() {
-            statements.push(LoweredStatement::RawGo(prologue));
-        }
         let mut declaration = String::new();
         resolved.emit_declaration(&mut declaration, &body_block);
         if !declaration.is_empty() {
@@ -188,9 +186,9 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let value_ty = scrutinee.get_type();
-        let mut prologue = String::new();
+        let mut statements = Vec::new();
         let resolved = self.resolve_pattern_subject(
-            &mut prologue,
+            &mut statements,
             PatternSubject::expression(scrutinee, ap.pattern, Some("subject")),
             fx,
         );
@@ -206,10 +204,6 @@ impl Planner<'_> {
         };
         let body_block = LoweredBlock { statements: body };
 
-        let mut statements = Vec::new();
-        if !prologue.is_empty() {
-            statements.push(LoweredStatement::RawGo(prologue));
-        }
         let mut declaration = String::new();
         resolved.emit_declaration(&mut declaration, &body_block);
         if !declaration.is_empty() {
@@ -219,50 +213,62 @@ impl Planner<'_> {
         statements
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn emit_while_let(
+    /// Resolve a while-let scrutinee to its loop-subject var, returning any
+    /// setup statements (none when the scrutinee is an inlinable identifier).
+    fn while_let_subject(
         &mut self,
-        output: &mut String,
         pattern: &Pattern,
-        typed: Option<&TypedPattern>,
         scrutinee: &Expression,
-        body: &Expression,
-        needs_label: bool,
         fx: &mut EmitEffects,
-    ) {
-        self.set_current_loop_label_if_needed(needs_label);
-        if let Some(label) = self.current_loop_label() {
-            write_line!(output, "{}:", label);
-        }
-        output.push_str("for {\n");
-
-        let inline_var = if let Expression::Identifier { value, .. } = scrutinee {
+    ) -> (String, Vec<LoweredStatement>) {
+        if let Expression::Identifier { value, .. } = scrutinee {
             let has_collision = pattern_binds_name(pattern, value);
             let bound_to_inline = matches!(
                 self.scope.resolve_identifier_binding(value),
                 Some(BindingValue::InlineExpr(_))
             );
             if !has_collision && !value.contains('.') && !bound_to_inline {
-                Some(self.scope.resolve_or_escape_go_name(value))
-            } else {
-                None
+                return (self.scope.resolve_or_escape_go_name(value), Vec::new());
             }
-        } else {
-            None
-        };
-        let subject_var = inline_var.unwrap_or_else(|| {
-            let var = self.fresh_var(Some("subject"));
-            let expression = self.emit_operand(output, scrutinee, ExpressionContext::value(), fx);
-            write_line!(output, "{} := {}", var, expression);
-            var
+        }
+        let var = self.fresh_var(Some("subject"));
+        let staged = self.stage_operand(scrutinee, ExpressionContext::value(), fx);
+        let mut setup = staged.setup;
+        setup.push(LoweredStatement::TempBind {
+            name: var.clone(),
+            value: staged.value,
         });
+        (var, setup)
+    }
 
+    pub(crate) fn lower_while_let(
+        &mut self,
+        pattern: &Pattern,
+        typed: Option<&TypedPattern>,
+        scrutinee: &Expression,
+        body: &Expression,
+        needs_label: bool,
+        fx: &mut EmitEffects,
+    ) -> LoweredBlock {
+        self.set_current_loop_label_if_needed(needs_label);
+        let label = self.current_loop_label().map(str::to_string);
         let scrutinee_ty = scrutinee.get_type();
+        let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee, fx);
+
+        // Or-patterns with bindings render an `if/else if` chain that closes its
+        // own `for`, so they cannot wrap in a structured `Loop`; bridge them as
+        // one `RawGo`.
         if let Pattern::Or { patterns, .. } = pattern
             && pattern_has_bindings(pattern)
         {
+            let mut buffer = String::new();
+            if let Some(label) = &label {
+                write_line!(buffer, "{}:", label);
+            }
+            buffer.push_str("for {\n");
+            buffer.push_str(&Renderer.render_setup(&subject_setup));
             self.emit_while_let_or_pattern(
-                output,
+                &mut buffer,
                 patterns,
                 TypedSubject {
                     var: &subject_var,
@@ -271,24 +277,69 @@ impl Planner<'_> {
                 body,
                 fx,
             );
-            return;
+            return LoweredBlock {
+                statements: vec![LoweredStatement::RawGo(buffer)],
+            };
         }
 
         let info = decision_tree::collect_pattern_info(self, pattern, typed, &scrutinee_ty);
         fx.extend(&info.effects);
-        let (effective, ok_var) = apply_refutable_root_assertion(self, output, &info, &subject_var);
-        let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
-        write_line!(output, "if {} {{", condition);
-        self.enter_scope();
-
-        if !matches!(pattern, Pattern::Or { .. }) {
-            emit_tree_bindings_with_consumers(self, output, &info.bindings, &effective, &[body]);
+        let mut loop_body = subject_setup;
+        let mut assertion = String::new();
+        let (effective, ok_var) =
+            apply_refutable_root_assertion(self, &mut assertion, &info, &subject_var);
+        if !assertion.is_empty() {
+            loop_body.push(LoweredStatement::RawGo(assertion));
         }
+        let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
 
-        let block = self.lower_block_as_body(body, fx);
-        Renderer.render_lowered_block(output, &block);
+        self.enter_scope();
+        let mut then_body: Vec<LoweredStatement> = Vec::new();
+        if !matches!(pattern, Pattern::Or { .. }) {
+            let mut bindings = String::new();
+            emit_tree_bindings_with_consumers(
+                self,
+                &mut bindings,
+                &info.bindings,
+                &effective,
+                &[body],
+            );
+            if !bindings.is_empty() {
+                then_body.push(LoweredStatement::RawGo(bindings));
+            }
+        }
+        then_body.extend(self.lower_block_as_body(body, fx).statements);
+        self.exit_scope();
 
-        self.emit_while_let_break_else(output);
+        loop_body.push(LoweredStatement::If(IfPlan {
+            directive: String::new(),
+            condition_setup: String::new(),
+            condition,
+            then_body: LoweredBlock {
+                statements: then_body,
+            },
+            else_arm: ElseArm::Else {
+                body: LoweredBlock {
+                    statements: vec![LoweredStatement::Break {
+                        directive: String::new(),
+                        label: label.clone(),
+                    }],
+                },
+                inline: false,
+            },
+        }));
+
+        LoweredBlock {
+            statements: vec![LoweredStatement::Loop(LoopPlan {
+                directive: String::new(),
+                prologue: String::new(),
+                label,
+                header: "for {\n".to_string(),
+                body: LoweredBlock {
+                    statements: loop_body,
+                },
+            })],
+        }
     }
 
     fn lower_let_else_single_pattern(

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -16,7 +16,7 @@ use crate::plan::bodies::{
     ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan, SwitchCasePlan,
     SwitchKind, SwitchStatementPlan,
 };
-use crate::plan::placement::emit_unreachable_panic_if_needed;
+use crate::plan::placement::unreachable_panic_if_needed;
 use crate::state::bindings::{BindingValue, InlineExpr};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -179,10 +179,8 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         place: &PlacePlan,
     ) {
         self.emit_chain_root_decision(statements, &plan.tree, place);
-        let mut tail_buffer = String::new();
-        emit_unreachable_panic_if_needed(&mut tail_buffer, place, plan.chain_tail_is_exhaustive);
-        if !tail_buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(tail_buffer));
+        if let Some(panic) = unreachable_panic_if_needed(place, plan.chain_tail_is_exhaustive) {
+            statements.push(panic);
         }
     }
 
@@ -294,9 +292,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             let ctx = WalkCtx::retry_loop(place, None);
             self.walk(statements, &plan.tree, &ctx);
             if use_direct_return && !plan.root_has_unguarded_terminal {
-                statements.push(LoweredStatement::RawGo(
-                    "panic(\"unreachable\")\n".to_string(),
-                ));
+                statements.push(LoweredStatement::UnreachablePanic);
             }
             return;
         }
@@ -1052,13 +1048,9 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
 /// Build the post-switch unreachable panic (when the place requires a tail
 /// return and the switch is non-exhaustive), as a `RawGo` postlude.
 fn switch_postlude(place: &PlacePlan, has_default: bool) -> Vec<LoweredStatement> {
-    let mut panic_buffer = String::new();
-    emit_unreachable_panic_if_needed(&mut panic_buffer, place, has_default);
-    if panic_buffer.is_empty() {
-        Vec::new()
-    } else {
-        vec![LoweredStatement::RawGo(panic_buffer)]
-    }
+    unreachable_panic_if_needed(place, has_default)
+        .into_iter()
+        .collect()
 }
 
 /// Compute `ends_with_diverge` of `body_statements`, then move them into `statements`.

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -2,7 +2,7 @@
 //! consumes. `RawGo` is a transitional node holding pre-rendered Go.
 
 use crate::plan::values::ValuePlan;
-use crate::utils::{output_ends_with_diverge, output_references_var};
+use crate::utils::output_references_var;
 use syntax::types::Type;
 
 /// Destination for a lowered block's tail. The enclosing function's return
@@ -63,6 +63,13 @@ pub(crate) enum LoweredStatement {
         closure_close: String,
     },
     RawGo(String),
+    /// Raw Go whose tail diverges (a never-typed call such as `panic(...)`).
+    /// Tracked separately from `RawGo` so divergence is structural rather than
+    /// re-derived by scanning text.
+    DivergingRawGo(String),
+    /// `panic("unreachable")` tail after a non-exhaustive branch in return
+    /// position — a structured diverging leaf.
+    UnreachablePanic,
 }
 
 /// A source `const` (or `var` when the value is not Go-const-eligible).
@@ -481,7 +488,8 @@ impl LoweredStatement {
             LoweredStatement::Switch(plan) => plan.ends_with_diverge(),
             LoweredStatement::WhileLet(plan) => plan.body.ends_with_diverge(),
             LoweredStatement::TempBind { .. } | LoweredStatement::ClosureBind { .. } => false,
-            LoweredStatement::RawGo(code) => output_ends_with_diverge(code),
+            LoweredStatement::RawGo(_) => false,
+            LoweredStatement::DivergingRawGo(_) | LoweredStatement::UnreachablePanic => true,
         }
     }
 
@@ -590,7 +598,10 @@ impl LoweredStatement {
                     || body.references_var(var)
                     || output_references_var(closure_close, var)
             }
-            LoweredStatement::RawGo(code) => output_references_var(code, var),
+            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
+                output_references_var(code, var)
+            }
+            LoweredStatement::UnreachablePanic => false,
         }
     }
 }

--- a/crates/emit/src/plan/invariants.rs
+++ b/crates/emit/src/plan/invariants.rs
@@ -27,7 +27,9 @@ fn walk_statement(statement: &LoweredStatement, issues: &mut Vec<String>, path: 
         | LoweredStatement::Assign(_)
         | LoweredStatement::Expression(_)
         | LoweredStatement::TempBind { .. }
-        | LoweredStatement::RawGo(_) => {}
+        | LoweredStatement::RawGo(_)
+        | LoweredStatement::DivergingRawGo(_)
+        | LoweredStatement::UnreachablePanic => {}
         LoweredStatement::ClosureBind { body, .. } => {
             walk_block(body, issues, &format!("{}/ClosureBind", path))
         }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -11,7 +11,6 @@ use crate::plan::bodies::{
 };
 use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
 use crate::plan::values::setup_from_string;
-use crate::write_line;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
 
@@ -372,19 +371,17 @@ impl Planner<'_> {
                 },
             }
         } else {
-            let mut rendered = String::new();
-            self.emit_discard(&mut rendered, unwrapped, fx);
             ExpressionStatementForm::Discard {
                 body: LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(rendered)],
+                    statements: self.lower_discard_value(unwrapped, fx),
                 },
             }
         };
         LoweredStatement::Expression(ExpressionStatementPlan { directive, form })
     }
 
-    /// Lower `while let P = scrutinee { body }` via the `emit_while_let` string
-    /// bridge, wrapped as a `WhileLet` statement.
+    /// Lower `while let P = scrutinee { body }`, wrapped as a `WhileLet`
+    /// statement.
     fn lower_while_let_statement(
         &mut self,
         expression: &Expression,
@@ -402,10 +399,8 @@ impl Planner<'_> {
             unreachable!("lower_while_let_statement requires a WhileLet expression");
         };
         let directive = self.maybe_line_directive(&expression.get_span());
-        let mut buffer = String::new();
         self.push_loop("_");
-        self.emit_while_let(
-            &mut buffer,
+        let body = self.lower_while_let(
             pattern,
             typed_pattern.as_ref(),
             scrutinee,
@@ -414,9 +409,6 @@ impl Planner<'_> {
             fx,
         );
         self.pop_loop();
-        let body = LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(buffer)],
-        };
         LoweredStatement::WhileLet(WhileLetPlan { directive, body })
     }
 
@@ -434,6 +426,21 @@ impl Planner<'_> {
         plan
     }
 
+    fn lower_condition(
+        &mut self,
+        condition: &Expression,
+        fx: &mut EmitEffects,
+    ) -> (String, String) {
+        let mut setup = String::new();
+        let value = self.emit_operand(
+            &mut setup,
+            condition,
+            ExpressionContext::value().condition(),
+            fx,
+        );
+        (setup, value)
+    }
+
     fn lower_while(
         &mut self,
         directive: String,
@@ -443,14 +450,7 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.push_loop("_");
-        let (setup, rendered) = self.capture_emission(&mut String::new(), |this, buffer| {
-            this.emit_operand(
-                buffer,
-                condition,
-                ExpressionContext::value().condition(),
-                fx,
-            )
-        });
+        let (setup, rendered) = self.lower_condition(condition, fx);
         let header = if !setup.is_empty() {
             // Condition produced setup statements (temps); they must re-run each
             // iteration, so move everything inside the loop.
@@ -696,9 +696,7 @@ impl Planner<'_> {
         let mut statements = setup_from_string(self.maybe_line_directive(return_span));
         statements.push(self.lower_statement(last, fx));
         if !is_go_never(last) {
-            statements.push(LoweredStatement::RawGo(
-                "panic(\"unreachable\")\n".to_string(),
-            ));
+            statements.push(LoweredStatement::UnreachablePanic);
         }
         statements
     }
@@ -710,21 +708,30 @@ impl Planner<'_> {
         last: &Expression,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let mut buffer = String::new();
         if requires_temp_var(last) {
-            let expression_string =
-                self.emit_operand(&mut buffer, last, ExpressionContext::value(), fx);
-            if !expression_string.is_empty() {
-                write_line!(buffer, "return {}", expression_string);
+            let staged = self.stage_operand(last, ExpressionContext::value(), fx);
+            let mut statements = staged.setup;
+            if !staged.value.is_empty() {
+                statements.push(plain_return(staged.value));
             }
+            statements
         } else {
-            let expression_string = self.emit_tail_value(&mut buffer, last, fx);
+            let (mut statements, expression_string) = self.lower_tail_value(last, fx);
             let return_ctx = self.return_ctx();
-            let expression_string =
-                self.apply_type_coercion(&mut buffer, return_ctx.ty(), last, expression_string, fx);
-            write_line!(buffer, "return {}", expression_string);
+            let mut coercion = String::new();
+            let expression_string = self.apply_type_coercion(
+                &mut coercion,
+                return_ctx.ty(),
+                last,
+                expression_string,
+                fx,
+            );
+            if !coercion.is_empty() {
+                statements.push(LoweredStatement::RawGo(coercion));
+            }
+            statements.push(plain_return(expression_string));
+            statements
         }
-        vec![LoweredStatement::RawGo(buffer)]
     }
 
     pub(crate) fn lower_if(
@@ -736,15 +743,7 @@ impl Planner<'_> {
         place: &PlacePlan,
         fx: &mut EmitEffects,
     ) -> IfPlan {
-        let (condition_setup, condition_string) =
-            self.capture_emission(&mut String::new(), |this, buffer| {
-                this.emit_operand(
-                    buffer,
-                    condition,
-                    ExpressionContext::value().condition(),
-                    fx,
-                )
-            });
+        let (condition_setup, condition_string) = self.lower_condition(condition, fx);
         let condition = wrap_if_struct_literal(condition_string);
 
         self.enter_scope();
@@ -786,15 +785,7 @@ impl Planner<'_> {
             ..
         } = alternative
         {
-            let (condition_setup, condition_string) =
-                self.capture_emission(&mut String::new(), |this, buffer| {
-                    this.emit_operand(
-                        buffer,
-                        condition,
-                        ExpressionContext::value().condition(),
-                        fx,
-                    )
-                });
+            let (condition_setup, condition_string) = self.lower_condition(condition, fx);
             let condition = wrap_if_struct_literal(condition_string);
 
             // With-setup else-if renders as a nested block (`} else { setup; if

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -14,21 +14,17 @@ use crate::plan::values::{ValuePlan, setup_from_string, value_plan_from_statemen
 use crate::statements::assignments::is_lvalue_chain;
 use crate::types::native::NativeGoType;
 use crate::utils::contains_call;
-use crate::write_line;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
 
 /// Append `panic("unreachable")` after a branch construct in return position
 /// when the branch can fall through (no exhaustive default arm). Go would
 /// otherwise reject the function for missing a tail return.
-pub(crate) fn emit_unreachable_panic_if_needed(
-    output: &mut String,
+pub(crate) fn unreachable_panic_if_needed(
     place: &PlacePlan,
     is_exhaustive: bool,
-) {
-    if place.is_return() && !is_exhaustive {
-        output.push_str("panic(\"unreachable\")\n");
-    }
+) -> Option<LoweredStatement> {
+    (place.is_return() && !is_exhaustive).then_some(LoweredStatement::UnreachablePanic)
 }
 
 /// True when discarding `expression` is safe to omit: its value has no
@@ -185,45 +181,56 @@ pub(crate) fn expression_contains_binding(expression: &Expression, name: &str) -
 }
 
 impl Planner<'_> {
-    pub(crate) fn emit_discard(
+    /// Lower a discarded expression into structured statements: a bare
+    /// side-effecting call (`f()`), a `_ = value` discard, or a propagate.
+    pub(crate) fn lower_discard_value(
         &mut self,
-        output: &mut String,
         value: &Expression,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Vec<LoweredStatement> {
         let unwrapped = value.unwrap_parens();
 
         if is_side_effect_free_discard(unwrapped) {
-            return;
+            return Vec::new();
         }
 
         if let Expression::Propagate { expression, .. } = unwrapped {
-            self.emit_propagate(output, expression, Some("_"), fx);
-            return;
+            return self.lower_propagate(expression, Some("_"), fx).0;
         }
 
         let value_ty = value.get_type();
         if value_ty.is_unit() || value_ty.is_variable() || value_ty.is_never() {
-            let value_expression = self.emit_operand(output, value, ExpressionContext::value(), fx);
-            if !value_expression.is_empty() {
+            let staged = self.stage_operand(value, ExpressionContext::value(), fx);
+            let mut statements = staged.setup;
+            if !staged.value.is_empty() {
                 if matches!(unwrapped, Expression::Call { .. }) {
-                    write_line!(output, "{}", value_expression);
+                    let line = format!("{}\n", staged.value);
+                    // A never-typed call (e.g. `panic(...)`) diverges.
+                    statements.push(if value_ty.is_never() {
+                        LoweredStatement::DivergingRawGo(line)
+                    } else {
+                        LoweredStatement::RawGo(line)
+                    });
                 } else {
-                    write_line!(output, "_ = {}", value_expression);
+                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", staged.value)));
                 }
             }
-            return;
+            return statements;
         }
 
-        if let Expression::Call { .. } = unwrapped
-            && let Some(raw) = self.emit_go_call_discarded(output, unwrapped, fx)
-        {
-            write_line!(output, "{}", raw);
-            return;
+        if let Expression::Call { .. } = unwrapped {
+            let mut buffer = String::new();
+            if let Some(raw) = self.emit_go_call_discarded(&mut buffer, unwrapped, fx) {
+                let mut statements = setup_from_string(buffer);
+                statements.push(LoweredStatement::RawGo(format!("{}\n", raw)));
+                return statements;
+            }
         }
 
-        let value_expression = self.emit_operand(output, value, ExpressionContext::value(), fx);
-        write_line!(output, "_ = {}", value_expression);
+        let staged = self.stage_operand(value, ExpressionContext::value(), fx);
+        let mut statements = staged.setup;
+        statements.push(LoweredStatement::RawGo(format!("_ = {}\n", staged.value)));
+        statements
     }
 
     /// Emit a unit-typed call as a statement, then store `struct{}{}` into
@@ -234,12 +241,10 @@ impl Planner<'_> {
         var: &str,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let mut buffer = String::new();
-        let call_str = self.emit_value(&mut buffer, value, ExpressionContext::value(), fx);
+        let (mut statements, call_str) = self.lower_value(value, ExpressionContext::value(), fx);
         if !call_str.is_empty() {
-            write_line!(buffer, "{call_str}");
+            statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
         }
-        let mut statements = setup_from_string(buffer);
         statements.push(simple_assign(
             var,
             ValuePlan::Operand("struct{}{}".to_string()),
@@ -471,9 +476,7 @@ impl Planner<'_> {
         if last.get_type().is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
             if !is_go_never(last) {
-                statements.push(LoweredStatement::RawGo(
-                    "panic(\"unreachable\")\n".to_string(),
-                ));
+                statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;
         }
@@ -493,11 +496,14 @@ impl Planner<'_> {
             };
             return self.lower_branching_to_block(last, &place, fx).statements;
         }
-        let mut buffer = String::new();
-        let expression_string = self.emit_value(&mut buffer, last, ExpressionContext::value(), fx);
+        let (mut setup, expression_string) = self.lower_value(last, ExpressionContext::value(), fx);
+        let mut coercion_buffer = String::new();
         let expression_string =
-            self.apply_type_coercion(&mut buffer, target_ty, last, expression_string, fx);
-        let value = value_plan_from_statements(setup_from_string(buffer), expression_string);
+            self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression_string, fx);
+        if !coercion_buffer.is_empty() {
+            setup.push(LoweredStatement::RawGo(coercion_buffer));
+        }
+        let value = value_plan_from_statements(setup, expression_string);
         vec![simple_assign(var, value)]
     }
 
@@ -535,8 +541,8 @@ impl Planner<'_> {
         let receiver_is_lvalue =
             is_lvalue_chain(unwrapped) && !self.contains_newtype_access(unwrapped);
 
-        let mut buffer = String::new();
-        let value = if receiver_is_lvalue {
+        let (value, mut statements) = if receiver_is_lvalue {
+            let mut buffer = String::new();
             let mut args_buffer = String::new();
             let args_str = self.emit_append_args(
                 &mut args_buffer,
@@ -552,12 +558,15 @@ impl Planner<'_> {
             let receiver_lv =
                 self.emit_left_value_capturing(&mut buffer, unwrapped, rhs_has_setup, fx);
             buffer.push_str(&args_buffer);
-            format!("append({}, {})", receiver_lv, args_str)
+            (
+                format!("append({}, {})", receiver_lv, args_str),
+                setup_from_string(buffer),
+            )
         } else {
-            self.emit_value(&mut buffer, last, ExpressionContext::value(), fx)
+            let (setup, value) = self.lower_value(last, ExpressionContext::value(), fx);
+            (value, setup)
         };
 
-        let mut statements = setup_from_string(buffer);
         statements.push(simple_assign(var, ValuePlan::Operand(value)));
         Some(statements)
     }
@@ -596,18 +605,19 @@ impl Planner<'_> {
         format!("{}{}", args_str, suffix)
     }
 
-    /// Emit `last` as a tail value. Tuple literals widen slot types to the
+    /// Lower `last` as a tail value. Tuple literals widen slot types to the
     /// return-slot types.
-    pub(crate) fn emit_tail_value(
+    pub(crate) fn lower_tail_value(
         &mut self,
-        output: &mut String,
         last: &Expression,
         fx: &mut EmitEffects,
-    ) -> String {
+    ) -> (Vec<LoweredStatement>, String) {
         if let Expression::Tuple { elements, ty, .. } = last {
-            self.emit_tuple_value(output, elements, ty, true, fx)
+            let plan = self.plan_tuple_value(elements, ty, true, fx);
+            let staged = StagedExpression::from_plan(plan, last);
+            (staged.setup, staged.value)
         } else {
-            self.emit_value(output, last, ExpressionContext::value(), fx)
+            self.lower_value(last, ExpressionContext::value(), fx)
         }
     }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -78,28 +78,18 @@ impl ValuePlan {
 }
 
 impl Planner<'_> {
-    /// String-emit bridge: capture `emit_value`'s setup buffer as one `RawGo`
-    /// statement.
     pub(crate) fn plan_value(
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let mut setup_buffer = String::new();
-        let value = self.emit_value(&mut setup_buffer, expression, ctx, fx);
-        if setup_buffer.is_empty() {
-            ValuePlan::Operand(value)
-        } else {
-            ValuePlan::Composite {
-                setup: vec![LoweredStatement::RawGo(setup_buffer)],
-                value,
-            }
-        }
+        let (setup, value) = self.lower_value(expression, ctx, fx);
+        value_plan_from_statements(setup, value)
     }
 
-    /// Plan a value-position expression into a structured `ValuePlan`.
-    /// Unconverted leaf kinds bridge through `emit_operand_raw` as `Operand`.
+    /// Plan a value-position expression into a structured `ValuePlan`. Leaf
+    /// kinds route through `plan_operand_leaf`.
     pub(crate) fn plan_operand(
         &mut self,
         expression: &Expression,
@@ -167,6 +157,10 @@ impl Planner<'_> {
                 let (setup, value) = self.lower_recover_block(items, ty, fx);
                 value_plan_from_statements(setup, value)
             }
+            Expression::Propagate { expression, .. } => {
+                let (setup, value) = self.lower_propagate(expression, None, fx);
+                value_plan_from_statements(setup, value)
+            }
             Expression::If { ty, .. } => {
                 let (setup, value) = self.plan_if_as_operand_temp(expression, ty, fx);
                 value_plan_from_statements(setup, value)
@@ -188,17 +182,9 @@ impl Planner<'_> {
                     let (setup, value) = self.lower_go_wrapped_call(expression, &strategy, ty, fx);
                     value_plan_from_statements(setup, value)
                 }
-                CallBoundary::LoweredCallee(_) => {
-                    let mut setup_buffer = String::new();
-                    let value = self.emit_operand_raw(&mut setup_buffer, expression, ctx, fx);
-                    value_plan_from_statements(setup_from_string(setup_buffer), value)
-                }
+                CallBoundary::LoweredCallee(_) => self.plan_operand_leaf(expression, ctx, fx),
             },
-            _ => {
-                let mut setup_buffer = String::new();
-                let value = self.emit_operand_raw(&mut setup_buffer, expression, ctx, fx);
-                value_plan_from_statements(setup_from_string(setup_buffer), value)
-            }
+            _ => self.plan_operand_leaf(expression, ctx, fx),
         }
     }
 }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -200,7 +200,10 @@ impl Renderer {
                 self.render_lowered_block(output, body);
                 output.push_str(closure_close);
             }
-            LoweredStatement::RawGo(code) => output.push_str(code),
+            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
+                output.push_str(code)
+            }
+            LoweredStatement::UnreachablePanic => output.push_str("panic(\"unreachable\")\n"),
         }
     }
 
@@ -418,7 +421,7 @@ impl Renderer {
     }
 
     /// Render a value plan: emit its setup statements (if any), then return the
-    /// value text. Data-driven counterpart of `emit_value`.
+    /// value text.
     pub(crate) fn render_value(&self, output: &mut String, plan: &ValuePlan) -> String {
         match plan {
             ValuePlan::Operand(value) => value.clone(),

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
@@ -14,20 +13,6 @@ use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
 impl Planner<'_> {
-    /// String-context bridge over `lower_statement`.
-    pub(crate) fn emit_statement(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) {
-        let statement = self.lower_statement(expression, fx);
-        let block = LoweredBlock {
-            statements: vec![statement],
-        };
-        Renderer.render_lowered_block(output, &block);
-    }
-
     /// Build an `AssignPlan`, dispatching on shape: never-typed, compound,
     /// discard, Go-nullable-field clear, or simple `target = value`.
     pub(crate) fn build_assignment_plan(
@@ -48,12 +33,10 @@ impl Planner<'_> {
         };
 
         if value.get_type().is_never() {
-            let mut buffer = String::new();
-            self.emit_statement(&mut buffer, value, fx);
             return AssignPlan {
                 directive,
                 form: AssignForm::NeverTyped {
-                    body: raw_body(vec![LoweredStatement::RawGo(buffer)]),
+                    body: raw_body(vec![self.lower_statement(value, fx)]),
                 },
             };
         }
@@ -96,12 +79,10 @@ impl Planner<'_> {
         }
 
         if self.target_binds_to_discard(target) {
-            let mut buffer = String::new();
-            self.emit_discard(&mut buffer, value, fx);
             return AssignPlan {
                 directive,
                 form: AssignForm::Discard {
-                    body: raw_body(vec![LoweredStatement::RawGo(buffer)]),
+                    body: raw_body(self.lower_discard_value(value, fx)),
                 },
             };
         }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::calls::go_interop::{GoCallStrategy, WrapperTarget};
 use crate::context::expression::ExpressionContext;
@@ -10,6 +9,7 @@ use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
 use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CalleePlan;
 use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
+use crate::plan::values::setup_from_string;
 use crate::types::native::NativeGoType;
 use crate::write_line;
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
@@ -164,15 +164,14 @@ impl Planner<'_> {
         }
     }
 
-    /// Emit a `let identifier = value` binding; `raw_go_name == None` is
-    /// unused.
-    pub(crate) fn emit_let_value(
+    /// Lower a `let identifier = value` binding to statements; `raw_go_name ==
+    /// None` is unused.
+    pub(crate) fn lower_let_value(
         &mut self,
-        output: &mut String,
         let_spec: LetSpec,
         raw_go_name: Option<&str>,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Vec<LoweredStatement> {
         let LetSpec {
             identifier,
             value,
@@ -180,32 +179,29 @@ impl Planner<'_> {
             ..
         } = let_spec;
         if is_unit_call(value) {
-            self.emit_let_unit_call(output, identifier, raw_go_name, value, fx);
-            return;
+            return self.lower_let_unit_call(identifier, raw_go_name, value, fx);
         }
         let needs_temp = requires_temp_var(value);
         let Some(raw_go_name) = raw_go_name else {
             self.scope.bind(identifier, "_");
-            if needs_temp {
-                self.emit_let_temp(output, "_", value, binding_ty, fx);
+            return if needs_temp {
+                self.lower_let_temp("_", value, binding_ty, fx)
             } else {
-                self.emit_discard(output, value, fx);
-            }
-            return;
+                self.lower_discard_value(value, fx)
+            };
         };
         if needs_temp {
             let go_identifier = escape_reserved(raw_go_name);
             if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
                 let fresh = self.fresh_var(Some(identifier));
-                self.emit_let_temp(output, &fresh, value, binding_ty, fx);
+                let statements = self.lower_let_temp(&fresh, value, binding_ty, fx);
                 self.scope.bind(identifier, &fresh);
-            } else {
-                self.scope.bind(identifier, raw_go_name);
-                self.emit_let_temp(output, &go_identifier, value, binding_ty, fx);
+                return statements;
             }
-            return;
+            self.scope.bind(identifier, raw_go_name);
+            return self.lower_let_temp(&go_identifier, value, binding_ty, fx);
         }
-        self.emit_let_direct(output, let_spec, raw_go_name, fx);
+        self.lower_let_direct(let_spec, raw_go_name, fx)
     }
 
     /// `let x = expr?`. Adds a leading `var x T` when the binding widens to
@@ -246,41 +242,47 @@ impl Planner<'_> {
         statements
     }
 
-    /// `let x = foo()` where `foo()` returns unit: emit the call as a
+    /// `let x = foo()` where `foo()` returns unit: run the call as a
     /// statement, then declare the binding as `struct{}{}`.
-    fn emit_let_unit_call(
+    fn lower_let_unit_call(
         &mut self,
-        output: &mut String,
         identifier: &str,
         raw_go_name: Option<&str>,
         value: &Expression,
         fx: &mut EmitEffects,
-    ) {
-        let value_expression = self.emit_value(output, value, ExpressionContext::value(), fx);
-        write_line!(output, "{}", value_expression);
+    ) -> Vec<LoweredStatement> {
+        let (mut statements, value_expression) =
+            self.lower_value(value, ExpressionContext::value(), fx);
+        statements.push(LoweredStatement::RawGo(format!("{}\n", value_expression)));
         let Some(raw_go_name) = raw_go_name else {
-            return;
+            return statements;
         };
         let escaped = escape_reserved(raw_go_name);
         if self.is_declared(&escaped) {
             let fresh = self.fresh_var(Some(identifier));
             self.declare(&fresh);
-            write_line!(output, "{} := struct{{}}{{}}", fresh);
+            statements.push(LoweredStatement::TempBind {
+                name: fresh.clone(),
+                value: "struct{}{}".to_string(),
+            });
             self.scope.bind(identifier, &fresh);
         } else {
             let go_identifier = self.scope.bind(identifier, raw_go_name);
             self.try_declare(&go_identifier);
-            write_line!(output, "{} := struct{{}}{{}}", go_identifier);
+            statements.push(LoweredStatement::TempBind {
+                name: go_identifier,
+                value: "struct{}{}".to_string(),
+            });
         }
+        statements
     }
 
-    fn emit_let_direct(
+    fn lower_let_direct(
         &mut self,
-        output: &mut String,
         let_spec: LetSpec,
         raw_go_name: &str,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Vec<LoweredStatement> {
         let LetSpec {
             identifier,
             value,
@@ -288,19 +290,14 @@ impl Planner<'_> {
             mutable,
         } = let_spec;
         if !mutable
-            && self.try_emit_let_into_wrapper_slot(
-                output,
-                identifier,
-                raw_go_name,
-                value,
-                binding_ty,
-                fx,
-            )
+            && let Some(statements) =
+                self.try_lower_let_into_wrapper_slot(identifier, raw_go_name, value, binding_ty, fx)
         {
-            return;
+            return statements;
         }
 
-        let value_expression = self.emit_value(output, value, ExpressionContext::value(), fx);
+        let (mut statements, value_expression) =
+            self.lower_value(value, ExpressionContext::value(), fx);
         let coercion = Coercion::resolve(
             self,
             &value.get_type(),
@@ -308,7 +305,7 @@ impl Planner<'_> {
             CoercionDirection::Internal,
         );
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression, fx);
-        output.push_str(&Renderer.render_setup(&coercion_setup));
+        statements.extend(coercion_setup);
         let value_expression = maybe_clone_subslice(self, value, mutable, value_expression, fx);
 
         let go_identifier = self.scope.bind(identifier, raw_go_name);
@@ -318,76 +315,83 @@ impl Planner<'_> {
             let fresh = self.fresh_var(Some(identifier));
             self.scope.bind(identifier, &fresh);
             self.try_declare(&fresh);
-            write_line!(output, "{} := {}", fresh, value_expression);
+            statements.push(LoweredStatement::TempBind {
+                name: fresh,
+                value: value_expression,
+            });
         } else if needs_explicit_type_declaration(self, value, binding_ty) {
             let var_ty = self.go_type_string(binding_ty, fx);
-            write_line!(
-                output,
-                "var {} {} = {}",
-                go_identifier,
-                var_ty,
-                value_expression
-            );
+            statements.push(LoweredStatement::RawGo(format!(
+                "var {} {} = {}\n",
+                go_identifier, var_ty, value_expression
+            )));
         } else {
-            write_line!(output, "{} := {}", go_identifier, value_expression);
+            statements.push(LoweredStatement::TempBind {
+                name: go_identifier,
+                value: value_expression,
+            });
         }
+        statements
     }
 
     /// Route a slot-style Go-interop wrapper into the let's Go name, removing
     /// the `name := result_N` alias.
-    fn try_emit_let_into_wrapper_slot(
+    fn try_lower_let_into_wrapper_slot(
         &mut self,
-        output: &mut String,
         identifier: &str,
         raw_go_name: &str,
         value: &Expression,
         binding_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> bool {
+    ) -> Option<Vec<LoweredStatement>> {
         let go_identifier = escape_reserved(raw_go_name);
         if self.is_declared(&go_identifier)
             || self.scope.is_active_assign_target(&go_identifier)
             || self.scope.has_binding_for_go_name(&go_identifier)
         {
-            return false;
+            return None;
         }
         if value.get_type() != *binding_ty {
-            return false;
+            return None;
         }
-        let Some(plan) = self.plan_call(value) else {
-            return false;
-        };
+        let plan = self.plan_call(value)?;
         let CalleePlan::GoInterop(strategy) = plan.callee else {
-            return false;
+            return None;
         };
         if matches!(strategy, GoCallStrategy::Tuple { .. }) {
-            return false;
+            return None;
         }
         let target = WrapperTarget::Slot(&go_identifier);
-        let outcome =
-            self.emit_go_wrapped_call_to(output, value, &strategy, binding_ty, target, fx);
-        if outcome.is_none() {
-            return false;
-        }
+        let mut buffer = String::new();
+        self.emit_go_wrapped_call_to(&mut buffer, value, &strategy, binding_ty, target, fx)?;
         // `open_wrapper_slot` / `emit_simple_wrapper_value` already declared
         // `go_identifier`; only the binding from the user-name still needs setup.
         self.scope.bind(identifier, go_identifier.as_ref());
-        true
+        Some(setup_from_string(buffer))
     }
 
-    fn emit_let_temp(
+    fn lower_let_temp(
         &mut self,
-        output: &mut String,
         name: &str,
         value: &Expression,
         binding_ty: &Type,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Vec<LoweredStatement> {
+        let mut statements = Vec::new();
         if !self.is_declared(name) {
-            self.emit_let_temp_var_declaration(output, name, value, binding_ty, fx);
+            let mut declaration = String::new();
+            self.emit_let_temp_var_declaration(&mut declaration, name, value, binding_ty, fx);
+            if !declaration.is_empty() {
+                statements.push(LoweredStatement::RawGo(declaration));
+            }
             self.try_declare(name);
         }
-        self.emit_assign(output, value, name, Some(binding_ty), fx);
+        let mut assignment = String::new();
+        self.emit_assign(&mut assignment, value, name, Some(binding_ty), fx);
+        if !assignment.is_empty() {
+            statements.push(LoweredStatement::RawGo(assignment));
+        }
+        statements
     }
 
     fn emit_let_temp_var_declaration(
@@ -463,10 +467,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
 
     /// Classify the binding and build the matching `LetForm`.
     pub(crate) fn build_form(mut self, fx: &mut EmitEffects) -> LetForm {
-        let wrap = |buffer: String| LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(buffer)],
-        };
-
         // Never-typed values diverge (break/continue/return). Declare the
         // binding so dead code can reference it, then emit the value as a
         // statement.
@@ -481,11 +481,11 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             } else {
                 None
             };
-            let mut buffer = String::new();
-            self.planner.emit_statement(&mut buffer, self.value, fx);
             return LetForm::Never {
                 declaration,
-                body: wrap(buffer),
+                body: LoweredBlock {
+                    statements: vec![self.planner.lower_statement(self.value, fx)],
+                },
             };
         }
 
@@ -594,9 +594,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             );
             return LoweredBlock { statements };
         }
-        let mut buffer = String::new();
-        self.planner.emit_let_value(
-            &mut buffer,
+        let statements = self.planner.lower_let_value(
             LetSpec {
                 identifier,
                 value: self.value,
@@ -606,23 +604,12 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             raw_go_name.as_deref(),
             fx,
         );
-        LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(buffer)],
-        }
+        LoweredBlock { statements }
     }
 
     fn lower_discard(&mut self, fx: &mut EmitEffects) -> LoweredBlock {
-        if let Expression::Propagate {
-            expression: inner, ..
-        } = self.value.unwrap_parens()
-        {
-            let statements = self.planner.lower_propagate_statement(inner, fx);
-            return LoweredBlock { statements };
-        }
-        let mut buffer = String::new();
-        self.planner.emit_discard(&mut buffer, self.value, fx);
         LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(buffer)],
+            statements: self.planner.lower_discard_value(self.value, fx),
         }
     }
 

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -200,23 +200,3 @@ pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {
         _ => false,
     }
 }
-
-/// True when the last emitted Go line is `break`, `continue`, `return`, or `panic`.
-pub(crate) fn output_ends_with_diverge(output: &str) -> bool {
-    output
-        .trim_end()
-        .lines()
-        .next_back()
-        .is_some_and(is_diverge_line)
-}
-
-fn is_diverge_line(line: &str) -> bool {
-    let trimmed = line.trim();
-    trimmed == "break"
-        || trimmed.starts_with("break ")
-        || trimmed == "continue"
-        || trimmed.starts_with("continue ")
-        || trimmed == "return"
-        || trimmed.starts_with("return ")
-        || trimmed.starts_with("panic(")
-}

--- a/tests/spec/emit/snapshots/interop_array_return_if_tail.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_if_tail.snap
@@ -12,11 +12,10 @@ func get(cond bool) func([]uint8) []uint8 {
 			arr_1 := sha256.Sum256(arg0)
 			return arr_1[:]
 		}
-	} else {
-		return func(arg0 []byte) []byte {
-			arr_2 := sha256.Sum224(arg0)
-			return arr_2[:]
-		}
+	}
+	return func(arg0 []byte) []byte {
+		arr_2 := sha256.Sum224(arg0)
+		return arr_2[:]
 	}
 }
 


### PR DESCRIPTION
Continues the refactor of the emit layer, moving more codegen off the string path and onto the structured path.

The one snapshot change is intended, still valid but cleaner than before.