### PR TITLE
fix: suggest `cmp.Ordered` bound when comparing unbounded generics

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1022,6 +1022,16 @@ pub fn not_orderable(ty: &Type, span: Span) -> LisetteDiagnostic {
         .with_help("Use comparison operators only with numeric, string, or boolean types")
 }
 
+pub fn param_needs_ordered_bound(param: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type mismatch")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("expected orderable, found `{}`", param))
+        .with_help(format!(
+            "`{param}` is an unconstrained type parameter. Add a `cmp.Ordered` bound to compare it, \
+             e.g. `<{param}: cmp.Ordered>` and add `import \"go:cmp\"` at the top"
+        ))
+}
+
 pub fn not_comparable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Type mismatch")
         .with_infer_code("type_mismatch")

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -668,9 +668,11 @@ impl InferCtx<'_, '_> {
             return;
         }
 
-        if let Type::Parameter(name) = &resolved_ty
-            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Ordered)
-        {
+        if let Type::Parameter(name) = &resolved_ty {
+            if !self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Ordered) {
+                self.sink
+                    .push(diagnostics::infer::param_needs_ordered_bound(name, *span));
+            }
             return;
         }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1459,6 +1459,16 @@ fn test(a: complex64, b: complex64) -> bool {
 }
 
 #[test]
+fn infer_compare_unbounded_param_suggests_ordered_bound() {
+    let input = r#"
+fn largest<T>(a: T, b: T) -> T {
+  if a > b { a } else { b }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_unindexable_type() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_compare_unbounded_param_suggests_ordered_bound.snap
+++ b/tests/ui/errors/snapshots/infer_compare_unbounded_param_suggests_ordered_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:3:6]
+ 2 │ fn largest<T>(a: T, b: T) -> T {
+ 3 │   if a > b { a } else { b }
+   ·      ┬
+   ·      ╰── expected orderable, found `T`
+ 4 │ }
+   ╰────
+  help: `T` is an unconstrained type parameter. Add a `cmp.Ordered` bound to compare it, e.g. `<T: cmp.Ordered>` and add `import "go:cmp"` at the top · code: [infer.type_mismatch]


### PR DESCRIPTION
Comparing an unconstrained generic with `<` and `>` now suggests adding a `cmp.Ordered` bound and where to import it from.
