### PR TITLE
fix: exclude `#[display]` struct fields from the unused-field lint

### DIFF
--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -280,6 +280,8 @@ fn collect_items(
                         false
                     });
 
+                    let has_display_attr = attributes.iter().any(|a| a.name == "display");
+
                     for struct_field in fields {
                         let field_id = StructFieldId::new(name, &struct_field.name);
                         let has_tag_attribute =
@@ -291,6 +293,7 @@ fn collect_items(
                                 is_public: struct_field.visibility == Visibility::Public,
                                 parent_is_public: is_public,
                                 parent_has_serialization_attr: has_serialization_attr,
+                                parent_has_display_attr: has_display_attr,
                                 has_tag_attribute,
                             },
                         );

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -35,6 +35,7 @@ pub struct StructFieldInfo {
     pub is_public: bool,
     pub parent_is_public: bool,
     pub parent_has_serialization_attr: bool,
+    pub parent_has_display_attr: bool,
     pub has_tag_attribute: bool,
 }
 
@@ -162,6 +163,7 @@ impl ReferenceGraph {
                 !info.is_public
                     && !info.parent_is_public
                     && !info.parent_has_serialization_attr
+                    && !info.parent_has_display_attr
                     && !info.has_tag_attribute
                     && !self.used_struct_fields.contains(*id)
                     && !id.field_name.starts_with('_')

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4049,6 +4049,23 @@ fn main() {
 }
 
 #[test]
+fn display_struct_fields_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+#[display]
+struct Point {
+  x: int,
+  y: int,
+}
+
+fn main() {
+  let _p = Point { x: 1, y: 2 }
+}
+"#
+    );
+}
+
+#[test]
 fn field_with_tag_attribute_not_unused() {
     assert_no_lint_warnings!(
         r#"


### PR DESCRIPTION
`#[display]` struct fields are no longer flagged as unused, since the attribute reads them all.