### PR TITLE
feat: add map_or_else to Result

### DIFF
--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -210,6 +210,9 @@ impl<T, E> Result<T, E> {
   /// Returns `default` if `Err`, otherwise applies `f` to the `Ok` value.
   fn map_or<U>(self, default: U, f: fn(T) -> U) -> U
 
+  /// Applies `default` to the `Err` value, or `f` to the `Ok` value.
+  fn map_or_else<U>(self, default: fn(E) -> U, f: fn(T) -> U) -> U
+
   /// Calls `f` with the `Ok` value, leaving `Err` unchanged.
   fn and_then<U>(self, f: fn(T) -> Result<U, E>) -> Result<U, E>
 

--- a/prelude/result.go
+++ b/prelude/result.go
@@ -87,6 +87,13 @@ func ResultMapOr[T any, U any, E any](res Result[T, E], def U, f func(T) U) U {
 	return def
 }
 
+func ResultMapOrElse[T any, U any, E any](res Result[T, E], def func(E) U, f func(T) U) U {
+	if res.Tag == ResultOk {
+		return f(res.OkVal)
+	}
+	return def(res.ErrVal)
+}
+
 func ResultAndThen[T any, U any, E any](res Result[T, E], f func(T) Result[U, E]) Result[U, E] {
 	if res.Tag == ResultOk {
 		return f(res.OkVal)

--- a/prelude/result_test.go
+++ b/prelude/result_test.go
@@ -81,6 +81,28 @@ func TestResultMap(t *testing.T) {
 	}
 }
 
+func TestResultMapOr(t *testing.T) {
+	ok := MakeResultOk[int, string](21)
+	err := MakeResultErr[int, string]("fail")
+	if ResultMapOr(ok, -1, func(v int) int { return v * 2 }) != 42 {
+		t.Fatal("expected 42")
+	}
+	if ResultMapOr(err, -1, func(v int) int { return v * 2 }) != -1 {
+		t.Fatal("expected -1")
+	}
+}
+
+func TestResultMapOrElse(t *testing.T) {
+	ok := MakeResultOk[int, string](21)
+	err := MakeResultErr[int, string]("fail")
+	if ResultMapOrElse(ok, func(e string) int { return len(e) }, func(v int) int { return v * 2 }) != 42 {
+		t.Fatal("expected 42")
+	}
+	if ResultMapOrElse(err, func(e string) int { return len(e) }, func(v int) int { return v * 2 }) != 4 {
+		t.Fatal("expected 4")
+	}
+}
+
 func TestResultMapErr(t *testing.T) {
 	err := MakeResultErr[int, string]("fail")
 	mapped := ResultMapErr(err, func(e string) int { return len(e) })

--- a/tests/e2e_smoke_project/src/main.lis
+++ b/tests/e2e_smoke_project/src/main.lis
@@ -3006,6 +3006,12 @@ fn test_result_map_or() -> int {
   result
 }
 
+fn test_result_map_or_else() -> int {
+  let res: Result<int, string> = Err("error")
+  let result = res.map_or_else(|e| e.length() * 20, |x| x * 2)
+  result
+}
+
 // Non-UFCS to UFCS method chaining (filter returns Option, then map is UFCS)
 fn test_option_filter_then_map() -> int {
   let opt = Some(10)
@@ -4019,6 +4025,7 @@ fn main() {
   report("result_map", test_result_map(), 100)
   report("result_and_then", test_result_and_then(), 100)
   report("result_map_or", test_result_map_or(), 100)
+  report("result_map_or_else", test_result_map_or_else(), 100)
 
   section("non-ufcs to ufcs chaining")
   report("option_filter_then_map", test_option_filter_then_map(), 100)

--- a/tests/spec/emit/snapshots/e2e_smoke.snap
+++ b/tests/spec/emit/snapshots/e2e_smoke.snap
@@ -513,6 +513,7 @@ option_flatten: PASS
 result_map: PASS
 result_and_then: PASS
 result_map_or: PASS
+result_map_or_else: PASS
 
 // non-ufcs to ufcs chaining
 


### PR DESCRIPTION
Adds a `map_or_else()` method to `Result` in the prelude.

```rs
import "go:fmt"

fn describe(result: Result<int, string>) -> string {
  result.map_or_else(
    |error| f"request failed: {error}",
    |status| f"received status {status}",
  )
}

fn main() {
  fmt.Println(describe(Ok(200))) // received status 200
  fmt.Println(describe(Err("connection refused"))) // request failed: connection refused
}
```
