### PR TITLE
fix: zero-fill emit for newtype and tuple-struct fields

### DIFF
--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -336,15 +336,26 @@ impl Planner<'_> {
                 if go_name::is_go_import(id.as_str()) {
                     return self.go_imported_zero(ty, id.as_str(), fx);
                 }
+
+                if let Some(underlying) = self.get_newtype_underlying(ty) {
+                    let go_ty = self.go_type_string(ty, fx);
+                    let inner = self.lisette_zero(&underlying, fx);
+                    return format!("{}({})", go_ty, inner);
+                }
+
                 if let Some(fields) =
                     self.lookup_unspecified_fields(ty, "", None, &HashSet::default())
                 {
                     let go_ty = self.go_type_string(ty, fx);
+                    let is_tuple = self.is_tuple_struct_type(ty);
                     let pairs: Vec<(String, String)> = fields
                         .into_iter()
-                        .filter(|(_, field_ty)| !field_ty.is_slice())
-                        .map(|(name, field_ty)| {
-                            let go_name = if self.field_is_public(ty, &name) {
+                        .enumerate()
+                        .filter(|(_, (_, field_ty))| !field_ty.is_slice())
+                        .map(|(index, (name, field_ty))| {
+                            let go_name = if is_tuple {
+                                format!("F{}", index)
+                            } else if self.field_is_public(ty, &name) {
                                 go_name::make_exported(&name)
                             } else {
                                 go_name::escape_keyword(&name).into_owned()
@@ -360,10 +371,15 @@ impl Planner<'_> {
                 format!("{}{{}}", self.go_type_string(ty, fx))
             }
             Type::Tuple(elements) => {
-                let go_ty = self.go_type_string(ty, fx);
                 let parts: Vec<String> =
                     elements.iter().map(|e| self.lisette_zero(e, fx)).collect();
-                format!("{}{{{}}}", go_ty, parts.join(", "))
+                fx.require_stdlib();
+                format!(
+                    "{}.MakeTuple{}({})",
+                    go_name::GO_STDLIB_PKG,
+                    parts.len(),
+                    parts.join(", ")
+                )
             }
             _ => format!("{}{{}}", self.go_type_string(ty, fx)),
         }

--- a/tests/spec/emit/snapshots/newtype_field_zero_fill_casts.snap
+++ b/tests/spec/emit/snapshots/newtype_field_zero_fill_casts.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct GameModeParam(string)\n\nstruct Inner { pub x: int }\nstruct Wrapper(Inner)\n\nstruct Name(string)\nstruct DoubleName(Name)\n\nstruct Command {\n  pub gamemode: GameModeParam,\n  pub wrapper: Wrapper,\n  pub double: DoubleName,\n}\n\nfn register() -> Command {\n  Command { .. }\n}\n"
+---
+package main
+
+type GameModeParam string
+
+type Inner struct {
+	X int
+}
+
+type Wrapper Inner
+
+type Name string
+
+type DoubleName Name
+
+type Command struct {
+	Gamemode GameModeParam
+	Wrapper  Wrapper
+	Double   DoubleName
+}
+
+func register() Command {
+	return Command{
+		Gamemode: GameModeParam(""),
+		Wrapper:  Wrapper(Inner{X: 0}),
+		Double:   DoubleName(Name("")),
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_field_zero_fill_uses_constructor.snap
+++ b/tests/spec/emit/snapshots/tuple_field_zero_fill_uses_constructor.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct Probe {\n  pub pair: (int, string),\n  pub nested: (Option<int>, (int, int)),\n}\n\nfn make() -> Probe {\n  Probe { .. }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Probe struct {
+	Pair   lisette.Tuple2[int, string]
+	Nested lisette.Tuple2[lisette.Option[int], lisette.Tuple2[int, int]]
+}
+
+func make_() Probe {
+	return Probe{
+		Pair:   lisette.MakeTuple2(0, ""),
+		Nested: lisette.MakeTuple2(lisette.MakeOptionNone[int](), lisette.MakeTuple2(0, 0)),
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_struct_field_zero_fill_uses_f_names.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_field_zero_fill_uses_f_names.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct MP(int, string)\n\nstruct Holder {\n  pub p: MP,\n}\n\nfn make() -> Holder {\n  Holder { .. }\n}\n"
+---
+package main
+
+type MP struct {
+	F0 int
+	F1 string
+}
+
+type Holder struct {
+	P MP
+}
+
+func make_() Holder {
+	return Holder{P: MP{
+		F0: 0,
+		F1: "",
+	}}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1022,6 +1022,61 @@ fn test(id: UserId) -> int {
 }
 
 #[test]
+fn newtype_field_zero_fill_casts() {
+    let input = r#"
+struct GameModeParam(string)
+
+struct Inner { pub x: int }
+struct Wrapper(Inner)
+
+struct Name(string)
+struct DoubleName(Name)
+
+struct Command {
+  pub gamemode: GameModeParam,
+  pub wrapper: Wrapper,
+  pub double: DoubleName,
+}
+
+fn register() -> Command {
+  Command { .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_struct_field_zero_fill_uses_f_names() {
+    let input = r#"
+struct MP(int, string)
+
+struct Holder {
+  pub p: MP,
+}
+
+fn make() -> Holder {
+  Holder { .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_field_zero_fill_uses_constructor() {
+    let input = r#"
+struct Probe {
+  pub pair: (int, string),
+  pub nested: (Option<int>, (int, int)),
+}
+
+fn make() -> Probe {
+  Probe { .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_multi_field_def() {
     let input = r#"
 struct Point(int, int)


### PR DESCRIPTION
Fix #635