### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.3.2](https://github.com/ivov/lisette/compare/lisette-v0.3.1...lisette-v0.3.2) - 2026-06-07
+
+- fix: cross-module reference tracking in unused lints [#651](https://github.com/ivov/lisette/pull/651) [`64b9dc7`](https://github.com/ivov/lisette/commit/64b9dc7568da079be41bd55e30fa6bfcec6689a2)
+- refactor: introduce `embed` keyword [#650](https://github.com/ivov/lisette/pull/650) [`cd78bfb`](https://github.com/ivov/lisette/commit/cd78bfb99d3cced87bbc8a5608056bf42d40730b)
+- feat: lint for type limit comparison [#648](https://github.com/ivov/lisette/pull/648) [`f8757f5`](https://github.com/ivov/lisette/commit/f8757f544fe3ee4e2c6feb47ac0571b38d621799)
+- fix: classify compound wrappers by qualified id [#646](https://github.com/ivov/lisette/pull/646) [`192df75`](https://github.com/ivov/lisette/commit/192df7584e18dfd9d2a5b6dc99c50b9415a8e357)
+- refactor: store type attributes as a map [#647](https://github.com/ivov/lisette/pull/647) [`7063de2`](https://github.com/ivov/lisette/commit/7063de2914f225f5d5dcfbc88b55ee673b8d22d3)
+- feat: bind go anonymous struct types [#644](https://github.com/ivov/lisette/pull/644) [`3a44617`](https://github.com/ivov/lisette/commit/3a44617f42e92ef9f78f30f68242b82ecd4f9a49)
+- feat: add redundant else lint [#643](https://github.com/ivov/lisette/pull/643) [`8f8b584`](https://github.com/ivov/lisette/commit/8f8b584ccc306e5e97a3e02712c2fcf30a2cc62e)
+- feat: add manual find simplification lint [#642](https://github.com/ivov/lisette/pull/642) [`6e44a27`](https://github.com/ivov/lisette/commit/6e44a2756a23130fc3425cb390b60e84bfe522ab)
+- fix: tuple-struct and newtype pattern exhaustiveness [#641](https://github.com/ivov/lisette/pull/641) [`1fd5350`](https://github.com/ivov/lisette/commit/1fd5350668096e4b5db576fa2350fef326393fc0)
+- test: move sync tests in-process [#640](https://github.com/ivov/lisette/pull/640) [`85d8c44`](https://github.com/ivov/lisette/commit/85d8c443f23f4269e0297043226637ad38351795)
+- fix: zero-fill emit for newtype and tuple-struct fields [#637](https://github.com/ivov/lisette/pull/637) [`8b68e65`](https://github.com/ivov/lisette/commit/8b68e65e20fd477c0b3b879f929cac2700c638fe)
+
 ## [0.3.1](https://github.com/ivov/lisette/compare/lisette-v0.3.0...lisette-v0.3.1) - 2026-06-06
 
 - feat: add map_or_else to Result [#633](https://github.com/ivov/lisette/pull/633) [`d5939f7`](https://github.com/ivov/lisette/commit/d5939f7ecfe7321a90ed017f9d0f95a693c75d74)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bincode",
  "ecow",
@@ -791,11 +791,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.3.1", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.1", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.3.1", path = "../format" }
-emit = { package = "lisette-emit", version = "0.3.1", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.3.1", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.1", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.3.1", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.3.2", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.3.2", path = "../format" }
+emit = { package = "lisette-emit", version = "0.3.2", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.3.2", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.3.1", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.1", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.3.1", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.1", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.3.1", path = "../deps" }
-format = { package = "lisette-format", version = "0.3.1", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.3.2", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
+format = { package = "lisette-format", version = "0.3.2", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.1", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.1", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.3.1", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.1", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.3.2 (upcoming)

- fix: cross-module reference tracking in unused lints [#651](https://github.com/ivov/lisette/pull/651) [`64b9dc7`](https://github.com/ivov/lisette/commit/64b9dc7568da079be41bd55e30fa6bfcec6689a2)
- refactor: introduce `embed` keyword [#650](https://github.com/ivov/lisette/pull/650) [`cd78bfb`](https://github.com/ivov/lisette/commit/cd78bfb99d3cced87bbc8a5608056bf42d40730b)
- feat: lint for type limit comparison [#648](https://github.com/ivov/lisette/pull/648) [`f8757f5`](https://github.com/ivov/lisette/commit/f8757f544fe3ee4e2c6feb47ac0571b38d621799)
- fix: classify compound wrappers by qualified id [#646](https://github.com/ivov/lisette/pull/646) [`192df75`](https://github.com/ivov/lisette/commit/192df7584e18dfd9d2a5b6dc99c50b9415a8e357)
- refactor: store type attributes as a map [#647](https://github.com/ivov/lisette/pull/647) [`7063de2`](https://github.com/ivov/lisette/commit/7063de2914f225f5d5dcfbc88b55ee673b8d22d3)
- feat: bind go anonymous struct types [#644](https://github.com/ivov/lisette/pull/644) [`3a44617`](https://github.com/ivov/lisette/commit/3a44617f42e92ef9f78f30f68242b82ecd4f9a49)
- feat: add redundant else lint [#643](https://github.com/ivov/lisette/pull/643) [`8f8b584`](https://github.com/ivov/lisette/commit/8f8b584ccc306e5e97a3e02712c2fcf30a2cc62e)
- feat: add manual find simplification lint [#642](https://github.com/ivov/lisette/pull/642) [`6e44a27`](https://github.com/ivov/lisette/commit/6e44a2756a23130fc3425cb390b60e84bfe522ab)
- fix: tuple-struct and newtype pattern exhaustiveness [#641](https://github.com/ivov/lisette/pull/641) [`1fd5350`](https://github.com/ivov/lisette/commit/1fd5350668096e4b5db576fa2350fef326393fc0)
- test: move sync tests in-process [#640](https://github.com/ivov/lisette/pull/640) [`85d8c44`](https://github.com/ivov/lisette/commit/85d8c443f23f4269e0297043226637ad38351795)
- fix: zero-fill emit for newtype and tuple-struct fields [#637](https://github.com/ivov/lisette/pull/637) [`8b68e65`](https://github.com/ivov/lisette/commit/8b68e65e20fd477c0b3b879f929cac2700c638fe)
