### PR TITLE
fix: tuple-struct and newtype pattern exhaustiveness

### DIFF
--- a/crates/semantics/src/passes/checks/pattern_analysis/maranget.rs
+++ b/crates/semantics/src/passes/checks/pattern_analysis/maranget.rs
@@ -48,6 +48,13 @@ fn column_count(rows: &[Row]) -> usize {
     rows.first().map(|r| r.len()).unwrap_or(0)
 }
 
+fn pad_columns(mut witness: Row, width: usize) -> Row {
+    if witness.len() < width {
+        witness.resize(width, Wildcard);
+    }
+    witness
+}
+
 fn classify_case(rows: &[Row], unions: &UnionTable) -> AlgorithmCase {
     let columns = column_count(rows);
 
@@ -100,10 +107,12 @@ fn find_witnesses(rows: &[Row], unions: &UnionTable) -> Vec<Row> {
         }
 
         AlgorithmCase::OnlyWildcardsOrLiterals => {
+            let remaining = column_count(rows).saturating_sub(1);
             let specialized = specialize_by_wildcard(rows);
             find_witnesses(&specialized, unions)
                 .into_iter()
-                .map(|mut witness| {
+                .map(|witness| {
+                    let mut witness = pad_columns(witness, remaining);
                     witness.insert(0, Wildcard);
                     witness
                 })
@@ -115,8 +124,12 @@ fn find_witnesses(rows: &[Row], unions: &UnionTable) -> Vec<Row> {
             union,
             seen_tags,
         } => {
+            let remaining = column_count(rows).saturating_sub(1);
             let specialized = specialize_by_wildcard(rows);
-            let rest = find_witnesses(&specialized, unions);
+            let rest: Vec<Row> = find_witnesses(&specialized, unions)
+                .into_iter()
+                .map(|witness| pad_columns(witness, remaining))
+                .collect();
 
             if rest.is_empty() {
                 return vec![];

--- a/crates/semantics/src/passes/checks/pattern_analysis/normalize.rs
+++ b/crates/semantics/src/passes/checks/pattern_analysis/normalize.rs
@@ -1,7 +1,7 @@
 use crate::store::Store;
 use syntax::ast::{Literal, MatchArm, TypedPattern};
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{Type, unqualified_name};
+use syntax::types::{SubstitutionMap, Type, build_substitution_map, substitute, unqualified_name};
 
 use super::NormalizedPattern::Wildcard;
 use super::inhabitance::{InhabitanceCache, is_inhabited, is_variant_inhabited};
@@ -21,10 +21,38 @@ fn make_type_key(name: &str, type_args: &[Type]) -> String {
     }
 }
 
+/// Map a definition's generics to a pattern's type args, so a field declared
+/// `T` resolves to its concrete type at this position. Empty for non-generics.
+fn field_substitution_map(
+    ctx: &NormalizationContext,
+    type_name: &str,
+    type_args: &[Type],
+) -> SubstitutionMap {
+    let generics = match ctx.store.get_definition(type_name).map(|d| &d.body) {
+        Some(DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. }) => {
+            generics.as_slice()
+        }
+        _ => &[],
+    };
+    build_substitution_map(generics, type_args)
+}
+
 pub struct NormalizationContext<'a> {
     pub store: &'a Store,
     pub cache: &'a InhabitanceCache,
     pub scrutinee_type: Option<Type>,
+}
+
+impl<'a> NormalizationContext<'a> {
+    /// Child context for a nested field/element, carrying that position's type
+    /// as the scrutinee so the interface-implementer path can fire there.
+    fn at_position(&self, scrutinee_type: Option<Type>) -> NormalizationContext<'a> {
+        NormalizationContext {
+            store: self.store,
+            cache: self.cache,
+            scrutinee_type,
+        }
+    }
 }
 
 fn try_normalize_interface_implementer(
@@ -139,11 +167,16 @@ pub fn normalize_typed_pattern(
             variant_name,
             fields,
             type_args,
+            field_types,
             ..
         } => {
             let patterns: Vec<NormalizedPattern> = fields
                 .iter()
-                .map(|f| normalize_typed_pattern(f, unions, ctx))
+                .enumerate()
+                .map(|(i, f)| {
+                    let child = ctx.at_position(field_types.get(i).cloned());
+                    normalize_typed_pattern(f, unions, &child)
+                })
                 .collect();
 
             let enum_def = ctx.store.get_definition(enum_name);
@@ -170,9 +203,19 @@ pub fn normalize_typed_pattern(
             }
 
             let type_name = make_type_key(enum_name, type_args);
+            let enum_body = enum_def.map(|d| &d.body);
+
+            // Tuple struct / newtype tags are the bare type name (like record
+            // structs); enum variants are `Type.Variant`.
+            let is_struct_def = matches!(enum_body, Some(DefinitionBody::Struct { .. }));
+            let tag = if is_struct_def {
+                enum_name.to_string()
+            } else {
+                format!("{}.{}", enum_name, unqualified_name(variant_name))
+            };
 
             if unions.get(&type_name).is_none() {
-                let alternatives = match enum_def.map(|d| &d.body) {
+                let alternatives = match enum_body {
                     Some(DefinitionBody::Enum {
                         variants, generics, ..
                     }) => variants
@@ -185,14 +228,28 @@ pub fn normalize_typed_pattern(
                             arity: v.fields.len(),
                         })
                         .collect(),
+                    Some(DefinitionBody::Struct {
+                        fields: struct_fields,
+                        generics,
+                        ..
+                    }) if super::inhabitance::is_struct_inhabited(
+                        struct_fields,
+                        type_args,
+                        generics,
+                        ctx.store,
+                        ctx.cache,
+                    ) =>
+                    {
+                        vec![Constructor {
+                            tag_id: tag.clone(),
+                            arity: struct_fields.len(),
+                        }]
+                    }
                     _ => vec![],
                 };
 
                 unions.insert(type_name.clone(), alternatives);
             }
-
-            let variant_name = unqualified_name(variant_name);
-            let tag = format!("{}.{}", enum_name, variant_name);
 
             NormalizedPattern::Constructor {
                 type_name,
@@ -208,6 +265,7 @@ pub fn normalize_typed_pattern(
             pattern_fields,
             type_args,
         } => {
+            let substitution = field_substitution_map(ctx, enum_name, type_args);
             let patterns = variant_fields
                 .iter()
                 .map(|f| {
@@ -215,7 +273,8 @@ pub fn normalize_typed_pattern(
                         .iter()
                         .find_map(|(name, pattern)| {
                             if *name == f.name {
-                                Some(normalize_typed_pattern(pattern, unions, ctx))
+                                let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
+                                Some(normalize_typed_pattern(pattern, unions, &child))
                             } else {
                                 None
                             }
@@ -262,6 +321,7 @@ pub fn normalize_typed_pattern(
             pattern_fields,
             type_args,
         } => {
+            let substitution = field_substitution_map(ctx, struct_name, type_args);
             let patterns: Vec<NormalizedPattern> = struct_fields
                 .iter()
                 .map(|f| {
@@ -269,7 +329,8 @@ pub fn normalize_typed_pattern(
                         .iter()
                         .find_map(|(name, pattern)| {
                             if *name == f.name {
-                                Some(normalize_typed_pattern(pattern, unions, ctx))
+                                let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
+                                Some(normalize_typed_pattern(pattern, unions, &child))
                             } else {
                                 None
                             }
@@ -396,9 +457,10 @@ fn normalize_slice(
         }
     };
 
+    let element_ctx = ctx.at_position(Some(element_type.clone()));
     let mut result = tail;
     for element in prefix.iter().rev() {
-        let head = normalize_typed_pattern(element, unions, ctx);
+        let head = normalize_typed_pattern(element, unions, &element_ctx);
         result = NormalizedPattern::Constructor {
             type_name: type_name.clone(),
             tag: "NonEmptySlice".to_string(),
@@ -425,9 +487,18 @@ fn normalize_tuple(
         unions.insert(type_name.clone(), vec![constructor]);
     }
 
+    let element_types = match ctx.scrutinee_type.as_ref().map(|t| ctx.store.peel_alias(t)) {
+        Some(Type::Tuple(types)) => Some(types),
+        _ => None,
+    };
+
     let patterns = elements
         .iter()
-        .map(|e| normalize_typed_pattern(e, unions, ctx))
+        .enumerate()
+        .map(|(i, e)| {
+            let child = ctx.at_position(element_types.as_ref().and_then(|ts| ts.get(i).cloned()));
+            normalize_typed_pattern(e, unions, &child)
+        })
         .collect();
 
     NormalizedPattern::Constructor {

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -16,6 +16,21 @@ fn test(p: Pair) -> int {
 }
 
 #[test]
+fn tuple_struct_refutable_field_pattern_keeps_literal_test() {
+    let input = r#"
+struct MP(int, string)
+
+fn test(p: MP) -> int {
+  match p {
+    MP(0, _) => 1,
+    MP(n, _) => n,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn generic_tuple_struct_pattern() {
     let input = r#"
 struct Box<T>(T)

--- a/tests/spec/emit/snapshots/tuple_struct_refutable_field_pattern_keeps_literal_test.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_refutable_field_pattern_keeps_literal_test.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/patterns.rs
+description: "input: \nstruct MP(int, string)\n\nfn test(p: MP) -> int {\n  match p {\n    MP(0, _) => 1,\n    MP(n, _) => n,\n  }\n}\n"
+---
+package main
+
+type MP struct {
+	F0 int
+	F1 string
+}
+
+func test(p MP) int {
+	if p.F0 == 0 {
+		return 1
+	}
+	return p.F0
+}

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -1,4 +1,4 @@
-use crate::spec::infer::infer;
+use crate::spec::infer::{infer, infer_with_go_typedefs};
 
 #[test]
 fn test_exhaustive_enum_all_variants() {
@@ -1786,6 +1786,143 @@ fn classify(s: string) -> int {
 }
 "#;
     infer(input).assert_redundancy_error();
+}
+
+#[test]
+fn test_tuple_struct_refutable_field_non_exhaustive() {
+    let input = r#"
+struct MP(int, string)
+
+fn test(p: MP) -> int {
+  match p {
+    MP(0, _) => 1,
+  }
+}
+"#;
+    infer(input).assert_exhaustiveness_error();
+}
+
+#[test]
+fn test_tuple_struct_refutable_field_arm_reachable() {
+    let input = r#"
+struct MP(int, string)
+
+fn test(p: MP) -> int {
+  match p {
+    MP(0, _) => 1,
+    MP(n, _) => n,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_tuple_struct_refutable_field_exhaustive_with_wildcard() {
+    let input = r#"
+struct MP(int, string)
+
+fn test(p: MP) -> int {
+  match p {
+    MP(0, _) => 1,
+    MP(_, _) => 2,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_newtype_refutable_field_non_exhaustive() {
+    let input = r#"
+struct N(int)
+
+fn test(n: N) -> int {
+  match n {
+    N(0) => 1,
+  }
+}
+"#;
+    infer(input).assert_exhaustiveness_error();
+}
+
+#[test]
+fn test_newtype_refutable_field_arm_reachable() {
+    let input = r#"
+struct N(int)
+
+fn test(n: N) -> int {
+  match n {
+    N(0) => 1,
+    N(x) => x,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_generic_struct_interface_field_keeps_catchall_reachable() {
+    let input = r#"
+import "go:example.com/events"
+
+struct Wrapper<T> { value: T }
+
+fn describe(w: Wrapper<events.Event>) -> int {
+  match w {
+    Wrapper { value: events.Token(s) } => s.length(),
+    _ => 0,
+  }
+}
+"#;
+    let typedef = r#"
+pub interface Event {}
+pub struct Token(string)
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/events", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn test_generic_struct_variant_interface_field_keeps_catchall_reachable() {
+    let input = r#"
+import "go:example.com/events"
+
+enum Holder<T> {
+  Wrap { item: T },
+}
+
+fn describe(h: Holder<events.Event>) -> int {
+  match h {
+    Holder.Wrap { item: events.Token(s) } => s.length(),
+    _ => 0,
+  }
+}
+"#;
+    let typedef = r#"
+pub interface Event {}
+pub struct Token(string)
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/events", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn test_slice_of_interface_element_keeps_catchall_reachable() {
+    let input = r#"
+import "go:example.com/events"
+
+fn describe(es: Slice<events.Event>) -> int {
+  match es {
+    [] => 0,
+    [events.Token(s), ..] => s.length(),
+    _ => 1,
+  }
+}
+"#;
+    let typedef = r#"
+pub interface Event {}
+pub struct Token(string)
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/events", typedef)]).assert_no_errors();
 }
 
 #[test]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2464,6 +2464,20 @@ fn test() {
 }
 
 #[test]
+fn match_non_exhaustive_tuple_struct_field_literal() {
+    let input = r#"
+struct MP(int, string)
+
+fn test(p: MP) -> int {
+  match p {
+    MP(0, _) => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_uninferred_binding_type() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/match_non_exhaustive_tuple_struct_field_literal.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_tuple_struct_field_literal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `match` is not exhaustive
+   ╭─[test.lis:5:3]
+ 4 │ fn test(p: MP) -> int {
+ 5 │   match p {
+   ·   ───┬───
+   ·      ╰── not all patterns covered
+ 6 │     MP(0, _) => 1,
+   ╰────
+  help: Handle the missing case `MP(_, _)`, e.g. `MP(_, _) => { ... }` · code: [infer.non_exhaustive]


### PR DESCRIPTION
A `match` on a tuple struct or newtype that destructures a literal field was being treated as covering the whole type. The literal was silently dropped, so non-exhaustive matches compiled and ran with the wrong behavior.

```rs
struct MP(int, string)

fn f(p: MP) -> int {
  match p {
    MP(0, _) => 1,
  }
}
```

This is now correctly reported as non-exhaustive. Newtypes like `N(0)` are covered as well.
