### PR TITLE
refactor: store type attributes as a map

### DIFF
--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use syntax::ast::{
     Annotation, AttributeArg, Generic, Span, StructKind, Visibility as FieldVisibility,
 };
-use syntax::program::{Definition, DefinitionBody, Interface, MethodSignatures, Visibility};
+use syntax::program::{
+    Attributes, Definition, DefinitionBody, Interface, MethodSignatures, Visibility,
+};
 use syntax::types::Type;
 
 /// Span stored as file index + byte offsets.
@@ -342,7 +344,7 @@ pub enum CachedDefinitionBody {
         generics: Vec<CachedGeneric>,
         variants: Vec<CachedEnumVariant>,
         methods: HashMap<String, Type>,
-        display: bool,
+        attributes: Attributes,
     },
     Struct {
         generics: Vec<CachedGeneric>,
@@ -350,9 +352,7 @@ pub enum CachedDefinitionBody {
         kind: StructKind,
         methods: HashMap<String, Type>,
         constructor: Option<Type>,
-        display: bool,
-        closed_domain: bool,
-        anon_struct: bool,
+        attributes: Attributes,
     },
     Interface {
         definition: CachedInterface,
@@ -394,7 +394,7 @@ impl CachedDefinition {
                 generics,
                 variants,
                 methods,
-                display,
+                attributes,
             } => CachedDefinitionBody::Enum {
                 generics: generics
                     .iter()
@@ -405,7 +405,7 @@ impl CachedDefinition {
                     .map(|v| CachedEnumVariant::from_variant(v, file_id_to_index))
                     .collect(),
                 methods: Self::convert_methods(methods),
-                display: *display,
+                attributes: attributes.clone(),
             },
             DefinitionBody::Struct {
                 generics,
@@ -413,9 +413,7 @@ impl CachedDefinition {
                 kind,
                 methods,
                 constructor,
-                display,
-                closed_domain,
-                anon_struct,
+                attributes,
             } => CachedDefinitionBody::Struct {
                 generics: generics
                     .iter()
@@ -428,9 +426,7 @@ impl CachedDefinition {
                 kind: *kind,
                 methods: Self::convert_methods(methods),
                 constructor: constructor.clone(),
-                display: *display,
-                closed_domain: *closed_domain,
-                anon_struct: *anon_struct,
+                attributes: attributes.clone(),
             },
             DefinitionBody::Interface { definition } => CachedDefinitionBody::Interface {
                 definition: CachedInterface::from_interface(definition, file_id_to_index),
@@ -491,12 +487,12 @@ impl CachedDefinition {
                 generics,
                 variants,
                 methods,
-                display,
+                attributes,
             } => DefinitionBody::Enum {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 variants: variants.iter().map(|v| v.to_variant(file_ids)).collect(),
                 methods: Self::restore_methods(methods),
-                display: *display,
+                attributes: attributes.clone(),
             },
             CachedDefinitionBody::Struct {
                 generics,
@@ -504,18 +500,14 @@ impl CachedDefinition {
                 kind,
                 methods,
                 constructor,
-                display,
-                closed_domain,
-                anon_struct,
+                attributes,
             } => DefinitionBody::Struct {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 fields: fields.iter().map(|f| f.to_field(file_ids)).collect(),
                 kind: *kind,
                 methods: Self::restore_methods(methods),
                 constructor: constructor.clone(),
-                display: *display,
-                closed_domain: *closed_domain,
-                anon_struct: *anon_struct,
+                attributes: attributes.clone(),
             },
             CachedDefinitionBody::Interface { definition } => DefinitionBody::Interface {
                 definition: definition.to_interface(file_ids),

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -14,7 +14,9 @@ use syntax::ast::{
     Annotation, Attribute, AttributeArg, Binding, EnumVariant, Expression, Generic, Span,
     StructKind, Visibility as SyntacticVisibility,
 };
-use syntax::program::{Definition, DefinitionBody, File, FileImport, Visibility};
+use syntax::program::{
+    Attributes, Definition, DefinitionBody, File, FileImport, TypeAttribute, Visibility,
+};
 use syntax::types::{Symbol, Type};
 
 use super::{FileContextKind, TaskState};
@@ -64,6 +66,28 @@ pub(super) fn has_anon_struct_attribute(attributes: &[Attribute]) -> bool {
     extract_attribute_flags(attributes, "go")
         .iter()
         .any(|flag| flag == "anon_struct")
+}
+
+pub(super) fn collect_enum_attributes(attributes: &[Attribute]) -> Attributes {
+    let mut map = Attributes::default();
+    if has_display_attribute(attributes) {
+        map.insert(TypeAttribute::Display, ());
+    }
+    map
+}
+
+pub(super) fn collect_struct_attributes(attributes: &[Attribute]) -> Attributes {
+    let mut map = Attributes::default();
+    if has_display_attribute(attributes) {
+        map.insert(TypeAttribute::Display, ());
+    }
+    if has_closed_domain_attribute(attributes) {
+        map.insert(TypeAttribute::ClosedDomain, ());
+    }
+    if has_anon_struct_attribute(attributes) {
+        map.insert(TypeAttribute::AnonStruct, ());
+    }
+    map
 }
 
 fn canonical_const_literal(expression: &Expression) -> Option<syntax::ast::Literal> {
@@ -564,7 +588,7 @@ impl TaskState<'_> {
                     variants,
                     span,
                     doc,
-                    has_display_attribute(attributes),
+                    collect_enum_attributes(attributes),
                 ),
                 Expression::Struct {
                     name,
@@ -585,9 +609,7 @@ impl TaskState<'_> {
                     *kind,
                     span,
                     doc,
-                    has_display_attribute(attributes),
-                    has_closed_domain_attribute(attributes),
-                    has_anon_struct_attribute(attributes),
+                    collect_struct_attributes(attributes),
                 ),
                 Expression::Interface {
                     name,

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -3,7 +3,7 @@ use syntax::ast::{
     Annotation, EnumFieldDefinition, EnumVariant, Generic, Span, StructFieldDefinition, StructKind,
     VariantFields,
 };
-use syntax::program::{Definition, DefinitionBody, MethodSignatures, Visibility};
+use syntax::program::{Attributes, Definition, DefinitionBody, MethodSignatures, Visibility};
 use syntax::types::Type;
 
 use super::enum_variant_constructor_type;
@@ -21,7 +21,7 @@ impl TaskState<'_> {
         variants: &[EnumVariant],
         span: &Span,
         doc: &Option<String>,
-        display: bool,
+        attributes: Attributes,
     ) {
         let qualified_name = self.qualify_name(name);
         let enum_ty = store
@@ -122,7 +122,7 @@ impl TaskState<'_> {
                     generics: generics.to_vec(),
                     variants: new_variants,
                     methods: MethodSignatures::default(),
-                    display,
+                    attributes,
                 },
             },
         );
@@ -295,9 +295,7 @@ impl TaskState<'_> {
         kind: StructKind,
         span: &Span,
         doc: &Option<String>,
-        display: bool,
-        closed_domain: bool,
-        anon_struct: bool,
+        attributes: Attributes,
     ) {
         let qualified_name = self.qualify_name(name);
         let struct_ty = store
@@ -366,9 +364,7 @@ impl TaskState<'_> {
                     kind,
                     methods: Default::default(),
                     constructor: None,
-                    display,
-                    closed_domain,
-                    anon_struct,
+                    attributes,
                 },
             },
         );

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -634,7 +634,7 @@ fn method_lookup_key(ty: &Type) -> Option<Symbol> {
 mod closed_domain_tests {
     use super::*;
     use syntax::ast::StructKind;
-    use syntax::program::Visibility;
+    use syntax::program::{Attributes, TypeAttribute, Visibility};
 
     fn nominal_int(id: &str) -> Type {
         Type::Nominal {
@@ -645,6 +645,10 @@ mod closed_domain_tests {
     }
 
     fn struct_def(ty: Type, closed_domain: bool) -> Definition {
+        let mut attributes = Attributes::default();
+        if closed_domain {
+            attributes.insert(TypeAttribute::ClosedDomain, ());
+        }
         Definition {
             visibility: Visibility::Public,
             ty,
@@ -657,9 +661,7 @@ mod closed_domain_tests {
                 kind: StructKind::Tuple,
                 methods: Default::default(),
                 constructor: None,
-                display: false,
-                closed_domain,
-                anon_struct: false,
+                attributes,
             },
         }
     }

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -17,6 +17,16 @@ pub struct Definition {
     pub body: DefinitionBody,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TypeAttribute {
+    Display,
+    ClosedDomain,
+    AnonStruct,
+}
+
+pub type Attributes = HashMap<TypeAttribute, ()>;
+
 #[derive(Debug, Clone)]
 pub enum DefinitionBody {
     TypeAlias {
@@ -28,7 +38,7 @@ pub enum DefinitionBody {
         generics: Vec<Generic>,
         variants: Vec<EnumVariant>,
         methods: MethodSignatures,
-        display: bool,
+        attributes: Attributes,
     },
     Struct {
         generics: Vec<Generic>,
@@ -36,10 +46,7 @@ pub enum DefinitionBody {
         kind: StructKind,
         methods: MethodSignatures,
         constructor: Option<Type>,
-        display: bool,
-        closed_domain: bool,
-        /// `#[go(anon_struct)]`: emit renders this as inline `struct{...}`.
-        anon_struct: bool,
+        attributes: Attributes,
     },
     Interface {
         definition: Interface,
@@ -137,32 +144,28 @@ impl Definition {
         }
     }
 
+    pub fn attributes(&self) -> Option<&Attributes> {
+        match &self.body {
+            DefinitionBody::Struct { attributes, .. } | DefinitionBody::Enum { attributes, .. } => {
+                Some(attributes)
+            }
+            _ => None,
+        }
+    }
+
     pub fn is_display(&self) -> bool {
-        matches!(
-            &self.body,
-            DefinitionBody::Struct { display: true, .. }
-                | DefinitionBody::Enum { display: true, .. }
-        )
+        self.attributes()
+            .is_some_and(|a| a.contains_key(&TypeAttribute::Display))
     }
 
     pub fn is_closed_domain(&self) -> bool {
-        matches!(
-            &self.body,
-            DefinitionBody::Struct {
-                closed_domain: true,
-                ..
-            }
-        )
+        self.attributes()
+            .is_some_and(|a| a.contains_key(&TypeAttribute::ClosedDomain))
     }
 
     pub fn is_anon_struct(&self) -> bool {
-        matches!(
-            &self.body,
-            DefinitionBody::Struct {
-                anon_struct: true,
-                ..
-            }
-        )
+        self.attributes()
+            .is_some_and(|a| a.contains_key(&TypeAttribute::AnonStruct))
     }
 
     pub fn is_type_definition(&self) -> bool {

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -4,7 +4,9 @@ mod file;
 mod module;
 mod resolution;
 
-pub use definition::{Definition, DefinitionBody, Interface, MethodSignatures, Visibility};
+pub use definition::{
+    Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute, Visibility,
+};
 pub use emit_input::{EmitInput, MutationInfo, UnusedInfo};
 pub use file::{File, FileImport};
 pub use module::{Module, ModuleId, ModuleInfo};

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -323,9 +323,7 @@ fn store_get_definition_domain_style_go_module() {
                 kind: syntax::ast::StructKind::Record,
                 methods: Default::default(),
                 constructor: None,
-                display: false,
-                closed_domain: false,
-                anon_struct: false,
+                attributes: Default::default(),
             },
         },
     );


### PR DESCRIPTION
Collapse the `display`, `closed_domain`, and `anon_struct` boolean fields on structs into a single attributes map.
