### PR TITLE
refactor: introduce `embed` keyword

### DIFF
--- a/crates/diagnostics/src/embed.rs
+++ b/crates/diagnostics/src/embed.rs
@@ -1,0 +1,89 @@
+use crate::LisetteDiagnostic;
+use syntax::ast::Span;
+
+pub fn defined_type(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed this type")
+        .with_infer_code("embed_defined_type")
+        .with_span_label(&span, "not embeddable in this version")
+        .with_help(format!(
+            "Embedding `{}` is not supported in this version. Embed a record struct, an \
+             interface, or a pointer to one.",
+            target
+        ))
+}
+
+pub fn generic(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed a generic type")
+        .with_infer_code("embed_generic")
+        .with_span_label(&span, "generic type")
+        .with_help(format!(
+            "Embedding `{}` is not supported in this version. Embed a non-generic struct, \
+             interface, or pointer.",
+            target
+        ))
+}
+
+pub fn imported_target(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed an imported type yet")
+        .with_infer_code("embed_imported_target")
+        .with_span_label(&span, "imported embeds are not supported yet")
+        .with_help(format!(
+            "Embedding the imported Go type `{}` is not supported yet. For now, embed a \
+             Lisette struct or interface.",
+            target
+        ))
+}
+
+pub fn no_surface(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type cannot be embedded")
+        .with_infer_code("embed_no_surface")
+        .with_span_label(&span, "no methods or fields to promote")
+        .with_help(format!(
+            "`{}` has no selector surface, so embedding it would promote nothing. \
+             Embed a struct, interface, or a named type with methods, or use a named field.",
+            target
+        ))
+}
+
+pub fn pointer_to_interface(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed a pointer to an interface")
+        .with_infer_code("embed_pointer_to_interface")
+        .with_span_label(&span, "pointer to an interface")
+        .with_help(format!(
+            "`{}` embeds a pointer to an interface, which Go rejects. \
+             Embed the interface by value instead.",
+            target
+        ))
+}
+
+pub fn nested_ref(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed a pointer to a pointer")
+        .with_infer_code("embed_nested_ref")
+        .with_span_label(&span, "pointer to a pointer")
+        .with_help(format!(
+            "`{}` embeds a pointer to a pointer, which Go rejects. \
+             Embed `T` or `Ref<T>`.",
+            target
+        ))
+}
+
+pub fn pointer_backed_newtype(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed a pointer-backed type")
+        .with_infer_code("embed_pointer_backed_newtype")
+        .with_span_label(&span, "underlying type is a pointer")
+        .with_help(format!(
+            "`{}` is a defined type whose underlying type is a pointer, which Go rejects \
+             as an embedded field. Embed `T` or `Ref<T>`.",
+            target
+        ))
+}
+
+pub fn option_target(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed `Option<T>`")
+        .with_infer_code("embed_option_target")
+        .with_span_label(&span, "embedded type cannot be `Option`")
+        .with_help(
+            "An embed's nullability is the embedded type's own zero, so `embed` takes no \
+             `Option`. Embed `T` (or `Ref<T>` for a pointer) instead.",
+        )
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -3,6 +3,7 @@ mod result;
 mod sink;
 
 pub mod attribute;
+pub mod embed;
 pub mod emit;
 pub mod infer;
 pub mod lint;

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -34,6 +34,20 @@ impl Planner<'_> {
         }
     }
 
+    pub(crate) fn field_is_embedded(&self, struct_ty: &Type, field_name: &str) -> bool {
+        let resolved = self.facts.peel_alias(&struct_ty.strip_refs());
+        let Type::Nominal { id, .. } = &resolved else {
+            return false;
+        };
+        matches!(
+            self.facts.definition(id.as_str()),
+            Some(Definition {
+                body: DefinitionBody::Struct { fields, .. },
+                ..
+            }) if fields.iter().any(|f| f.name == field_name && f.embedded)
+        )
+    }
+
     pub(crate) fn field_is_public(&self, struct_ty: &Type, field_name: &str) -> bool {
         let resolved = self.facts.peel_alias(&struct_ty.strip_refs());
 

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -121,6 +121,16 @@ impl Planner<'_> {
         struct_attrs: &[Attribute],
         fx: &mut EmitEffects,
     ) -> (String, StringerField) {
+        if f.embedded {
+            let field_with_doc = format!("{}{}", emit_doc(&f.doc), self.go_type_string(&f.ty, fx));
+            let stringer_field = StringerField {
+                source_name: f.name.to_string(),
+                go_name: struct_field_go_name(f, struct_attrs),
+                is_function: is_raw_function_type(&f.ty),
+            };
+            return (field_with_doc, stringer_field);
+        }
+
         let tag_configs = interpret_field_attributes(f, struct_attrs);
         let needs_omitzero = is_option_type(&f.ty);
         let tag_string = format_tag_string(&f.name, &tag_configs, needs_omitzero);
@@ -274,6 +284,9 @@ pub(crate) fn struct_field_go_name(
     field: &StructFieldDefinition,
     struct_attrs: &[Attribute],
 ) -> String {
+    if field.embedded {
+        return go_name::escape_keyword(&field.name).into_owned();
+    }
     let needs_export =
         field.visibility.is_public() || !interpret_field_attributes(field, struct_attrs).is_empty();
     if needs_export {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -552,6 +552,8 @@ impl Planner<'_> {
         if let Some(ref enum_ctx) = ctx.enum_ctx {
             self.enum_struct_field_name(&enum_ctx.enum_id, &enum_ctx.variant_name, field_name)
                 .unwrap_or_else(|| go_name::make_exported(field_name))
+        } else if self.field_is_embedded(ty, field_name) {
+            go_name::escape_keyword(field_name).into_owned()
         } else if ctx.is_prelude || self.field_is_public(ty, field_name) {
             go_name::make_exported(field_name)
         } else {

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -175,7 +175,9 @@ impl<'a> Formatter<'a> {
                 .comments
                 .take_comments_before(field.name_span.byte_offset);
 
-            let field_definition = if field.visibility.is_public() {
+            let field_definition = if field.embedded {
+                Document::str("embed ").append(Self::annotation(&field.annotation))
+            } else if field.visibility.is_public() {
                 Document::str("pub ")
                     .append(Document::string(field.name.to_string()))
                     .append(": ")

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -155,6 +155,7 @@ pub struct CachedStructField {
     pub visibility: FieldVisibility,
     pub attributes: Vec<CachedAttribute>,
     pub doc: Option<String>,
+    pub embedded: bool,
 }
 
 impl CachedStructField {
@@ -173,6 +174,7 @@ impl CachedStructField {
                 .map(CachedAttribute::from_attribute)
                 .collect(),
             doc: field.doc.clone(),
+            embedded: field.embedded,
         }
     }
 
@@ -185,6 +187,7 @@ impl CachedStructField {
             visibility: self.visibility,
             attributes: self.attributes.iter().map(|a| a.to_attribute()).collect(),
             annotation: Annotation::Unknown,
+            embedded: self.embedded,
         }
     }
 }

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -773,6 +773,7 @@ impl<'s> TaskState<'s> {
                     name_span: Span::dummy(),
                     annotation: Annotation::Unknown,
                     ty,
+                    embedded: false,
                 }
             })
             .collect();

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -184,6 +184,7 @@ impl TaskState<'_> {
 
         self.register_module_iterate(store, id);
         self.register_module_display(store, id);
+        self.validate_module_embeds(store, id);
 
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = crate::call_classification::compute_module_ufcs(module, id);
@@ -424,6 +425,8 @@ impl TaskState<'_> {
         self.register_values(store, items, visibility);
         self.register_iterate(store, items);
         self.register_display(store, items);
+        let module_id = self.cursor.module_id.clone();
+        self.validate_module_embeds(store, &module_id);
     }
 
     pub fn register_type_names(

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -311,8 +311,14 @@ impl TaskState<'_> {
             .iter()
             .map(|f| {
                 let field_ty = self.convert_to_type(&*store, &f.annotation, span);
+                let visibility = if f.embedded {
+                    embed_field_visibility(&*store, &field_ty)
+                } else {
+                    f.visibility
+                };
                 StructFieldDefinition {
                     ty: field_ty,
+                    visibility,
                     ..f.clone()
                 }
             })
@@ -370,6 +376,92 @@ impl TaskState<'_> {
         );
 
         self.check_recursive_type(&*store, &qualified_name, name, name_span);
+    }
+
+    pub(super) fn validate_module_embeds(&mut self, store: &Store, module_id: &str) {
+        let Some(module) = store.get_module(module_id) else {
+            return;
+        };
+        for definition in module.definitions.values() {
+            let DefinitionBody::Struct { fields, .. } = &definition.body else {
+                continue;
+            };
+            for field in fields.iter().filter(|f| f.embedded) {
+                self.validate_embed_target(store, &field.ty, field.name_span);
+            }
+        }
+    }
+
+    fn validate_embed_target(&mut self, store: &Store, ty: &Type, span: Span) {
+        let display = ty.to_string();
+        let resolved = store.deep_resolve_alias(ty);
+
+        // Check the declared type too: alias substitution erases a generic alias's arguments.
+        if is_generic_instantiation(ty) || is_generic_instantiation(&resolved) {
+            self.sink.push(diagnostics::embed::generic(&display, span));
+            return;
+        }
+
+        if resolved.is_option() {
+            self.sink.push(diagnostics::embed::option_target(span));
+            return;
+        }
+
+        if is_imported_nominal(&embed_promotion_target(store, &resolved)) {
+            self.sink
+                .push(diagnostics::embed::imported_target(&display, span));
+            return;
+        }
+
+        if resolved.is_ref() {
+            match resolved
+                .inner()
+                .map(|inner| store.deep_resolve_alias(&inner))
+            {
+                Some(inner) if inner.is_ref() => {
+                    self.sink
+                        .push(diagnostics::embed::nested_ref(&display, span));
+                }
+                Some(inner) if store.is_interface(&inner) => {
+                    self.sink
+                        .push(diagnostics::embed::pointer_to_interface(&display, span));
+                }
+                Some(inner) if is_pointer_backed_newtype(store, &inner) => {
+                    self.sink
+                        .push(diagnostics::embed::pointer_backed_newtype(&display, span));
+                }
+                Some(inner) if is_generic_instantiation(&inner) => {
+                    self.sink.push(diagnostics::embed::generic(&display, span));
+                }
+                Some(inner) if is_deferred_local_target(store, &inner) => {
+                    self.sink
+                        .push(diagnostics::embed::defined_type(&display, span));
+                }
+                Some(inner)
+                    if is_embeddable_nominal(&inner) && has_selector_surface(store, &inner) => {}
+                _ => self
+                    .sink
+                    .push(diagnostics::embed::no_surface(&display, span)),
+            }
+            return;
+        }
+
+        if is_pointer_backed_newtype(store, &resolved) {
+            self.sink
+                .push(diagnostics::embed::pointer_backed_newtype(&display, span));
+            return;
+        }
+
+        if is_deferred_local_target(store, &resolved) {
+            self.sink
+                .push(diagnostics::embed::defined_type(&display, span));
+            return;
+        }
+
+        if !is_embeddable_nominal(&resolved) || !has_selector_surface(store, &resolved) {
+            self.sink
+                .push(diagnostics::embed::no_surface(&display, span));
+        }
     }
 
     /// Check whether a type is recursive without Ref indirection.
@@ -694,5 +786,94 @@ impl TaskState<'_> {
         for c in ty.children() {
             Self::collect_type_refs(c, refs);
         }
+    }
+}
+
+fn is_embeddable_nominal(ty: &Type) -> bool {
+    matches!(ty, Type::Nominal { .. }) && !ty.is_option()
+}
+
+fn is_imported_nominal(ty: &Type) -> bool {
+    matches!(ty, Type::Nominal { id, .. } if id.as_str().starts_with(syntax::types::GO_IMPORT_PREFIX))
+}
+
+fn embed_promotion_target(store: &Store, ty: &Type) -> Type {
+    let mut target = ty.clone();
+    while target.is_option() || target.is_ref() {
+        let Some(inner) = target.inner() else { break };
+        target = store.deep_resolve_alias(&inner);
+    }
+    target
+}
+
+fn is_generic_instantiation(ty: &Type) -> bool {
+    let mut target = ty.clone();
+    while target.is_option() || target.is_ref() {
+        let Some(inner) = target.inner() else { break };
+        target = inner;
+    }
+    matches!(target, Type::Nominal { params, .. } if !params.is_empty())
+}
+
+// A local tuple struct, newtype, or enum: needs the resolver, so hard-errored for now.
+fn is_deferred_local_target(store: &Store, ty: &Type) -> bool {
+    let Type::Nominal { id, .. } = ty else {
+        return false;
+    };
+    let id = id.as_str();
+    if id.starts_with(syntax::types::GO_IMPORT_PREFIX) {
+        return false;
+    }
+    match store.get_definition(id).map(|definition| &definition.body) {
+        Some(
+            DefinitionBody::Struct {
+                kind: StructKind::Record,
+                ..
+            }
+            | DefinitionBody::Interface { .. },
+        ) => false,
+        Some(_) => true,
+        None => false,
+    }
+}
+
+fn has_selector_surface(store: &Store, ty: &Type) -> bool {
+    if !store
+        .get_all_methods(ty, &rustc_hash::FxHashMap::default())
+        .is_empty()
+    {
+        return true;
+    }
+    let Type::Nominal { id, .. } = ty else {
+        return false;
+    };
+    let id = id.as_str();
+    let is_newtype = store.get_definition(id).is_some_and(Definition::is_newtype);
+    !is_newtype && store.fields_of(id).is_some_and(|fields| !fields.is_empty())
+}
+
+fn is_pointer_backed_newtype(store: &Store, ty: &Type) -> bool {
+    let Type::Nominal { id, .. } = ty else {
+        return false;
+    };
+    store
+        .get_type(id.as_str())
+        .and_then(Type::get_underlying)
+        .is_some_and(|underlying| store.deep_resolve_alias(underlying).is_ref())
+}
+
+// Mirror the written type's own visibility: peel storage (`Option`/`Ref`), not aliases.
+fn embed_field_visibility(store: &Store, field_ty: &Type) -> syntax::ast::Visibility {
+    let mut target = field_ty.clone();
+    while target.is_option() || target.is_ref() {
+        let Some(inner) = target.inner() else { break };
+        target = inner;
+    }
+    let public = matches!(&target, Type::Nominal { id, .. }
+        if store.get_definition(id.as_str()).is_some_and(|d| d.visibility().is_public()));
+    if public {
+        syntax::ast::Visibility::Public
+    } else {
+        syntax::ast::Visibility::Private
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/naming.rs
@@ -25,7 +25,7 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
             }
 
             if !is_d_lis {
-                for field in fields {
+                for field in fields.iter().filter(|f| !f.embedded) {
                     check_snake_case(
                         &field.name,
                         &field.name_span,

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -295,6 +295,7 @@ fn collect_items(
                                 parent_has_serialization_attr: has_serialization_attr,
                                 parent_has_display_attr: has_display_attr,
                                 has_tag_attribute,
+                                embedded: struct_field.embedded,
                             },
                         );
                     }

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -37,6 +37,7 @@ pub struct StructFieldInfo {
     pub parent_has_serialization_attr: bool,
     pub parent_has_display_attr: bool,
     pub has_tag_attribute: bool,
+    pub embedded: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -165,6 +166,7 @@ impl ReferenceGraph {
                     && !info.parent_has_serialization_attr
                     && !info.parent_has_display_attr
                     && !info.has_tag_attribute
+                    && !info.embedded
                     && !self.used_struct_fields.contains(*id)
                     && !id.field_name.starts_with('_')
             })

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -398,6 +398,10 @@ impl Store {
         }
     }
 
+    pub fn is_interface(&self, ty: &Type) -> bool {
+        matches!(ty, Type::Nominal { id, .. } if self.get_interface(id.as_str()).is_some())
+    }
+
     pub fn is_nilable_go_type(&self, ty: &Type) -> bool {
         if ty.is_ref() || matches!(ty, Type::Function(_)) {
             return true;

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -500,6 +500,7 @@ pub struct StructFieldDefinition {
     pub annotation: Annotation,
     pub visibility: Visibility,
     pub ty: Type,
+    pub embedded: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -450,6 +450,7 @@ impl<'source> Parser<'source> {
                 annotation,
                 visibility: Visibility::Private,
                 ty: Type::uninferred(),
+                embedded: false,
             });
 
             index += 1;
@@ -490,6 +491,20 @@ impl<'source> Parser<'source> {
             self.next();
         }
 
+        // `embed T`, but not a field named `embed` (`embed: T`).
+        if self.is(Identifier)
+            && self.current_token().text == "embed"
+            && self.stream.peek_ahead(1).kind != Colon
+        {
+            if visibility.is_public() {
+                self.track_error(
+                    "embedded field cannot be `pub`",
+                    "An embedded field takes no `pub`; its visibility derives from the embedded type.",
+                );
+            }
+            return self.parse_embedded_field(doc, attributes);
+        }
+
         if self.is_not(Identifier) {
             self.track_error("expected field name", "Field names must be identifiers.");
             return None;
@@ -509,7 +524,63 @@ impl<'source> Parser<'source> {
             name_span,
             annotation: self.parse_annotation(),
             ty: Type::uninferred(),
+            embedded: false,
         })
+    }
+
+    fn parse_embedded_field(
+        &mut self,
+        doc: Option<std::string::String>,
+        attributes: Vec<Attribute>,
+    ) -> Option<StructFieldDefinition> {
+        let start = self.current_token();
+        self.ensure(Identifier);
+
+        let annotation = self.parse_annotation();
+        let span = self.span_from_tokens(start);
+
+        let Some(name) = Self::embedded_field_name(&annotation) else {
+            self.track_error_at(
+                span,
+                "expected a named type after `embed`",
+                "`embed` requires a named type; a function or tuple type cannot be embedded.",
+            );
+            return None;
+        };
+
+        if let Some(attribute) = attributes.first() {
+            self.track_error_at(
+                attribute.span,
+                "embedded field cannot have attributes",
+                "An embedded field takes no attributes; its serialization follows Go's anonymous-field inlining.",
+            );
+        }
+
+        Some(StructFieldDefinition {
+            doc,
+            attributes: vec![],
+            visibility: Visibility::Private,
+            name,
+            name_span: span,
+            annotation,
+            ty: Type::uninferred(),
+            embedded: true,
+        })
+    }
+
+    fn embedded_field_name(annotation: &Annotation) -> Option<EcoString> {
+        let mut current = annotation;
+        loop {
+            let Annotation::Constructor { name, params, .. } = current else {
+                return None;
+            };
+            let segment = name.rsplit('.').next().unwrap_or(name);
+            if (segment == "Option" || segment == "Ref") && params.len() == 1 {
+                current = &params[0];
+                continue;
+            }
+            return Some(segment.into());
+        }
     }
 
     pub fn parse_const_definition(&mut self, doc: Option<std::string::String>) -> Expression {
@@ -696,31 +767,13 @@ impl<'source> Parser<'source> {
                 }
 
                 Impl => {
-                    if let Some((_, span)) = item_doc {
-                        self.error_detached_doc_comment(span);
-                    }
                     self.ensure(Impl);
+                    self.parse_interface_parent(item_doc, &mut seen_parents, &mut parents);
+                }
 
-                    let parent_start = self.current_token();
-                    let annotation = self.parse_annotation();
-                    let parent_span = self.span_from_tokens(parent_start);
-
-                    if let Annotation::Constructor { name, .. } = &annotation {
-                        if let Some((_, first_span)) =
-                            seen_parents.iter().find(|(n, _)| n == name.as_str())
-                        {
-                            self.error_duplicate_impl_parent(*first_span, parent_span);
-                        } else {
-                            seen_parents.push((name.clone(), parent_span));
-                        }
-                    }
-
-                    parents.push(ParentInterface {
-                        annotation,
-                        ty: Type::uninferred(),
-                        span: parent_span,
-                    });
-                    self.advance_if(Semicolon);
+                Identifier if self.current_token().text == "embed" => {
+                    self.next();
+                    self.parse_interface_parent(item_doc, &mut seen_parents, &mut parents);
                 }
 
                 _ => {
@@ -748,5 +801,35 @@ impl<'source> Parser<'source> {
             visibility: Visibility::Private,
             span: self.span_from_tokens(start),
         }
+    }
+
+    fn parse_interface_parent(
+        &mut self,
+        item_doc: Option<(std::string::String, Span)>,
+        seen_parents: &mut Vec<(EcoString, Span)>,
+        parents: &mut Vec<ParentInterface>,
+    ) {
+        if let Some((_, span)) = item_doc {
+            self.error_detached_doc_comment(span);
+        }
+
+        let parent_start = self.current_token();
+        let annotation = self.parse_annotation();
+        let parent_span = self.span_from_tokens(parent_start);
+
+        if let Annotation::Constructor { name, .. } = &annotation {
+            if let Some((_, first_span)) = seen_parents.iter().find(|(n, _)| n == name.as_str()) {
+                self.error_duplicate_impl_parent(*first_span, parent_span);
+            } else {
+                seen_parents.push((name.clone(), parent_span));
+            }
+        }
+
+        parents.push(ParentInterface {
+            annotation,
+            ty: Type::uninferred(),
+            span: parent_span,
+        });
+        self.advance_if(Semicolon);
     }
 }

--- a/tests/spec/emit/snapshots/embedded_field_untagged_under_struct_json.snap
+++ b/tests/spec/emit/snapshots/embedded_field_untagged_under_struct_json.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct inner { x: int }\n\n#[json]\nstruct Outer {\n  embed inner,\n}\n\nfn read(o: Outer) -> int {\n  o.inner.x\n}\n"
+---
+package main
+
+type inner struct {
+	x int
+}
+
+type Outer struct {
+	inner
+}
+
+func read(o Outer) int {
+	return o.inner.x
+}

--- a/tests/spec/emit/snapshots/embedded_lowercase_alias_field_keeps_case.snap
+++ b/tests/spec/emit/snapshots/embedded_lowercase_alias_field_keeps_case.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \npub struct Base { pub id: int }\ntype p = Base\n\nstruct Outer {\n  embed p,\n}\n\nfn read(o: Outer) -> int {\n  o.p.id\n}\n"
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+type p = Base
+
+type Outer struct {
+	p
+}
+
+func read(o Outer) int {
+	return o.p.Id
+}

--- a/tests/spec/emit/snapshots/embedded_pointer_field_emits_star_type.snap
+++ b/tests/spec/emit/snapshots/embedded_pointer_field_emits_star_type.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \npub struct Base { pub id: int }\n\nstruct Outer {\n  embed Ref<Base>,\n}\n\nfn make(b: Ref<Base>) -> Outer {\n  Outer { Base: b }\n}\n"
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+type Outer struct {
+	*Base
+}
+
+func make_(b *Base) Outer {
+	return Outer{Base: b}
+}

--- a/tests/spec/emit/snapshots/embedded_struct_field_emits_anonymously.snap
+++ b/tests/spec/emit/snapshots/embedded_struct_field_emits_anonymously.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \npub struct Base { pub id: int }\n\nstruct Outer {\n  embed Base,\n  extra: int,\n}\n\nfn make() -> Outer {\n  Outer { Base: Base { id: 1 }, extra: 2 }\n}\n"
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+type Outer struct {
+	Base
+	extra int
+}
+
+func make_() Outer {
+	return Outer{
+		Base:  Base{Id: 1},
+		extra: 2,
+	}
+}

--- a/tests/spec/emit/snapshots/embedded_unexported_field_key_matches_type.snap
+++ b/tests/spec/emit/snapshots/embedded_unexported_field_key_matches_type.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "input: \nstruct inner { x: int }\n\nstruct Outer {\n  embed inner,\n}\n\nfn make() -> Outer {\n  Outer { inner: inner { x: 1 } }\n}\n"
+---
+package main
+
+type inner struct {
+	x int
+}
+
+type Outer struct {
+	inner
+}
+
+func make_() Outer {
+	return Outer{inner: inner{x: 1}}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -10,6 +10,89 @@ struct Point { x: int, y: int }
 }
 
 #[test]
+fn embedded_struct_field_emits_anonymously() {
+    let input = r#"
+pub struct Base { pub id: int }
+
+struct Outer {
+  embed Base,
+  extra: int,
+}
+
+fn make() -> Outer {
+  Outer { Base: Base { id: 1 }, extra: 2 }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_pointer_field_emits_star_type() {
+    let input = r#"
+pub struct Base { pub id: int }
+
+struct Outer {
+  embed Ref<Base>,
+}
+
+fn make(b: Ref<Base>) -> Outer {
+  Outer { Base: b }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_unexported_field_key_matches_type() {
+    let input = r#"
+struct inner { x: int }
+
+struct Outer {
+  embed inner,
+}
+
+fn make() -> Outer {
+  Outer { inner: inner { x: 1 } }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_lowercase_alias_field_keeps_case() {
+    let input = r#"
+pub struct Base { pub id: int }
+type p = Base
+
+struct Outer {
+  embed p,
+}
+
+fn read(o: Outer) -> int {
+  o.p.id
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_field_untagged_under_struct_json() {
+    let input = r#"
+struct inner { x: int }
+
+#[json]
+struct Outer {
+  embed inner,
+}
+
+fn read(o: Outer) -> int {
+  o.inner.x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn iterate_enum_variants() {
     let input = r#"
 #[iterate]

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1799,3 +1799,8 @@ fn comment_same_line_trailing_between_call_args() {
 fn comment_same_line_trailing_before_inlinable_last_arg() {
     assert_format_snapshot!("fn f() {\n  foo(a, b, // trailing\n  |x| { x + 1 })\n}");
 }
+
+#[test]
+fn struct_embedded_field() {
+    assert_format_snapshot!("struct Outer {\n  embed Base,\n  embed Ref<Other>,\n  extra: int,\n}");
+}

--- a/tests/spec/format/snapshots/struct_embedded_field.snap
+++ b/tests/spec/format/snapshots/struct_embedded_field.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: struct Outer {\n  embed Base,\n  embed Ref<Other>,\n  extra: int,\n}"
+---
+struct Outer { embed Base, embed Ref<Other>, extra: int }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -5888,3 +5888,463 @@ fn read_id(holder: api.Holder) -> int {
 "#;
     infer_with_go_typedefs(input, &[("go:example.com/api", typedef)]).assert_no_errors();
 }
+
+#[test]
+fn embed_bare_builtin_rejected() {
+    infer(
+        r#"
+struct S { embed int }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_alias_to_builtin_rejected() {
+    infer(
+        r#"
+type N = int
+struct S { embed N }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_pointer_to_interface_rejected() {
+    infer(
+        r#"
+interface Greeter { fn hello(self) -> string }
+struct S { embed Ref<Greeter> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_pointer_to_interface");
+}
+
+#[test]
+fn embed_nested_ref_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct S { embed Ref<Ref<Base>> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_nested_ref");
+}
+
+#[test]
+fn embed_pointer_backed_newtype_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct P(Ref<Base>)
+struct S { embed P }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_pointer_backed_newtype");
+}
+
+#[test]
+fn embed_option_target_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct S { embed Option<Base> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_option_target");
+}
+
+#[test]
+fn embed_slice_rejected() {
+    infer(
+        r#"
+struct S { embed Slice<int> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_map_rejected() {
+    infer(
+        r#"
+struct S { embed Map<string, int> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_pointer_to_compound_rejected() {
+    infer(
+        r#"
+struct S { embed Ref<Slice<int>> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_ref_to_pointer_backed_newtype_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct P(Ref<Base>)
+struct S { embed Ref<P> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_pointer_backed_newtype");
+}
+
+#[test]
+fn embed_empty_struct_rejected() {
+    infer(
+        r#"
+struct Empty {}
+struct S { embed Empty }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_empty_interface_rejected() {
+    infer(
+        r#"
+interface EmptyI {}
+struct S { embed EmptyI }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_local_newtype_rejected() {
+    infer(
+        r#"
+struct Age(int)
+impl Age { pub fn bump(self) -> int { 1 } }
+struct S { embed Age }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_marker_with_only_methods_accepted() {
+    infer(
+        r#"
+struct Marker {}
+impl Marker { pub fn mark(self) -> int { 1 } }
+struct S { embed Marker }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn embed_interface_empty_through_parent_rejected() {
+    infer(
+        r#"
+interface Empty {}
+interface AlsoEmpty { embed Empty }
+struct S { embed AlsoEmpty }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_no_surface");
+}
+
+#[test]
+fn embed_multi_field_tuple_struct_rejected() {
+    infer(
+        r#"
+struct Pair(int, int)
+struct S { embed Pair }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_generic_instantiation_rejected() {
+    infer(
+        r#"
+struct Wrapper<T> { value: T }
+struct S { embed Wrapper<int> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_generic");
+}
+
+#[test]
+fn embed_generic_alias_to_storage_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+type P<T> = Ref<T>
+struct S { embed P<Base> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_generic");
+}
+
+#[test]
+fn embed_generic_alias_under_ref_rejected() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+type P<T> = T
+struct S { embed Ref<P<Base>> }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_generic");
+}
+
+#[test]
+fn embed_imported_generic_named_ref_not_confused_with_wrapper() {
+    let typedef = r#"
+pub struct Base { pub id: int }
+pub struct Ref<T> { pub value: T }
+"#;
+    let input = r#"
+import "go:example.com/ref"
+struct S { embed ref.Ref<ref.Base> }
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/ref", typedef)])
+        .assert_infer_code("embed_generic");
+}
+
+#[test]
+fn embed_imported_struct_deferred() {
+    let typedef = r#"
+pub struct NopHandler {}
+impl NopHandler { pub fn Handle(self: NopHandler) -> int }
+"#;
+    let input = r#"
+import "go:example.com/handler"
+struct Mine { embed handler.NopHandler }
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/handler", typedef)])
+        .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn embed_imported_type_named_ref_deferred() {
+    let typedef = r#"
+pub struct Ref { pub id: int }
+impl Ref { pub fn Get(self: Ref) -> int }
+"#;
+    let input = r#"
+import "go:example.com/ref"
+struct UsesRef { embed ref.Ref }
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/ref", typedef)])
+        .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn embed_local_enum_rejected() {
+    infer(
+        r#"
+enum E { A }
+impl E { pub fn mark(self) -> int { 1 } }
+struct S { embed E }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_defined_type_over_struct_rejected() {
+    infer(
+        r#"
+struct Base { x: int }
+struct P(Base)
+struct S { embed P }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_defined_type_over_interface_rejected() {
+    infer(
+        r#"
+interface I { fn m(self) -> int }
+struct P(I)
+struct S { embed P }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_recursive_newtype_rejected() {
+    infer(
+        r#"
+struct A(B)
+struct B(A)
+struct S { embed A }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_defined_type");
+}
+
+#[test]
+fn embed_qualified_prelude_ref_names_target() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct S { embed prelude.Ref<Base> }
+fn read(s: S) -> Ref<Base> { s.Base }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn embed_display_only_type_accepted() {
+    infer(
+        r#"
+#[display]
+struct Marker {}
+struct S { embed Marker }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn embed_of_public_type_is_accessible_across_modules() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "types",
+        "lib.lis",
+        r#"
+pub struct Base { pub id: int }
+pub struct Outer { embed Base }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "types"
+fn main() {
+  let o = types.Outer { Base: types.Base { id: 1 } }
+  let _ = o.Base
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn embed_of_private_type_not_accessible_across_modules() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "types",
+        "lib.lis",
+        r#"
+struct Base { pub id: int }
+pub struct Outer { embed Base }
+pub fn make() -> Outer { Outer { Base: Base { id: 1 } } }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "types"
+fn main() {
+  let o = types.make()
+  let _ = o.Base
+}
+"#,
+    );
+    infer_module("main", fs).assert_resolve_code("private_field_access");
+}
+
+#[test]
+fn embed_value_struct_accepted() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+struct S { embed Base }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn embed_transparent_alias_to_ref_accepted() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+type P = Ref<Base>
+struct S { embed P }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn embed_field_named_embed_still_parses() {
+    infer(
+        r#"
+struct S { embed: int }
+fn main() {
+  let _ = S { embed: 1 }
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn interface_embed_keyword_alias_satisfies() {
+    infer(
+        r#"
+interface Reader { fn read(self) -> int }
+interface ReadWriter { embed Reader }
+struct File { name: string }
+impl File { pub fn read(self) -> int { 0 } }
+fn use_rw(rw: ReadWriter) -> int { rw.read() }
+fn main() {
+  let _ = use_rw(File { name: "x" })
+}
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/spec/parse/snapshots/explicit_struct_in_binary_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/explicit_struct_in_binary_rhs_allowed.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Bar { x: int }\nfn test() {\n  let foo = 1;\n  if 
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/generic_struct_bounded.snap
+++ b/tests/spec/parse/snapshots/generic_struct_bounded.snap
@@ -56,6 +56,7 @@ description: "input: \nstruct Container<T: Clone> {\n  item: T,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/generic_struct_instantiation.snap
+++ b/tests/spec/parse/snapshots/generic_struct_instantiation.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Container<T> { value: T }\nfn test() {\n  let x = 
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/generic_struct_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_struct_unbounded.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Box<T> {\n  value: T,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_complex_return_type.snap
+++ b/tests/spec/parse/snapshots/impl_complex_return_type.snap
@@ -56,6 +56,7 @@ description: "input: \nstruct Container<T> {\n  items: Vec<T>,\n}\n\nimpl<T> Con
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_method_bodies.snap
+++ b/tests/spec/parse/snapshots/impl_method_bodies.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_method_with_params.snap
+++ b/tests/spec/parse/snapshots/impl_method_with_params.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_mixed_visibility_methods.snap
+++ b/tests/spec/parse/snapshots/impl_mixed_visibility_methods.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_multiple_methods.snap
+++ b/tests/spec/parse/snapshots/impl_multiple_methods.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_multiple_type_params.snap
+++ b/tests/spec/parse/snapshots/impl_multiple_type_params.snap
@@ -55,6 +55,7 @@ description: "input: \nstruct Pair<K, V> {\n  key: K,\n  value: V,\n}\n\nimpl<K,
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -78,6 +79,7 @@ description: "input: \nstruct Pair<K, V> {\n  key: K,\n  value: V,\n}\n\nimpl<K,
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_no_semicolons_after_methods.snap
+++ b/tests/spec/parse/snapshots/impl_no_semicolons_after_methods.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point {\n  x: int,\n  y: int,\n}\n\nimpl Point {\n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Point {\n  x: int,\n  y: int,\n}\n\nimpl Point {\n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_pub_method.snap
+++ b/tests/spec/parse/snapshots/impl_pub_method.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  p
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_simple.snap
+++ b/tests/spec/parse/snapshots/impl_simple.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Counter {\n  value: int,\n}\n\nimpl Counter {\n  f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/impl_with_generics.snap
+++ b/tests/spec/parse/snapshots/impl_with_generics.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Container<T> {\n  value: T,\n}\n\nimpl<T> Containe
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/pub_struct.snap
+++ b/tests/spec/parse/snapshots/pub_struct.snap
@@ -36,6 +36,7 @@ description: "input: \npub struct Point { x: int, y: int }\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \npub struct Point { x: int, y: int }\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/shorthand_struct_in_comparison_rhs_with_body_after.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_comparison_rhs_with_body_after.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test(other: Point) {\n  let x
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/shorthand_struct_in_logical_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_logical_rhs_allowed.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test(other: Point) {\n  let f
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/shorthand_struct_in_nested_if_condition.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_nested_if_condition.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test(foo: int, other: Point) 
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/shorthand_struct_in_parenthesized_condition.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_parenthesized_condition.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test(other: Point) {\n  let x
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/spread_struct_in_binary_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/spread_struct_in_binary_rhs_allowed.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Bar { x: int }\nfn test(base: Bar) {\n  let foo = 
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_complex_field_types.snap
+++ b/tests/spec/parse/snapshots/struct_complex_field_types.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Request<Body> {\n  method: string,\n  headers: Map
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -88,6 +89,7 @@ description: "input: \nstruct Request<Body> {\n  method: string,\n  headers: Map
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -121,6 +123,7 @@ description: "input: \nstruct Request<Body> {\n  method: string,\n  headers: Map
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_field_with_json_attribute.snap
+++ b/tests/spec/parse/snapshots/struct_field_with_json_attribute.snap
@@ -60,6 +60,7 @@ description: "input: \n#[json]\nstruct User {\n  #[json(omitempty)]\n  name: str
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_field_with_name_override.snap
+++ b/tests/spec/parse/snapshots/struct_field_with_name_override.snap
@@ -60,6 +60,7 @@ description: "input: \n#[json]\nstruct User {\n  #[json(\"userName\")]\n  name: 
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_field_with_skip.snap
+++ b/tests/spec/parse/snapshots/struct_field_with_skip.snap
@@ -60,6 +60,7 @@ description: "input: \n#[json]\nstruct User {\n  #[json(skip)]\n  password: stri
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_in_if_condition.snap
+++ b/tests/spec/parse/snapshots/struct_in_if_condition.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test(other: Point) -> bool {\
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_in_match_subject.snap
+++ b/tests/spec/parse/snapshots/struct_in_match_subject.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point { x: int }\nfn test() -> int {\n  let x = 42
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_mixed_visibility_fields.snap
+++ b/tests/spec/parse/snapshots/struct_mixed_visibility_fields.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Config {\n  pub name: string,\n  secret: string,\n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Config {\n  pub name: string,\n  secret: string,\n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -82,6 +84,7 @@ description: "input: \nstruct Config {\n  pub name: string,\n  secret: string,\n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_multiple_generics.snap
+++ b/tests/spec/parse/snapshots/struct_multiple_generics.snap
@@ -55,6 +55,7 @@ description: "input: \nstruct Pair<K, V> {\n  key: K,\n  value: V,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -78,6 +79,7 @@ description: "input: \nstruct Pair<K, V> {\n  key: K,\n  value: V,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_pub_fields.snap
+++ b/tests/spec/parse/snapshots/struct_pub_fields.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point {\n  pub x: int,\n  pub y: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Point {\n  pub x: int,\n  pub y: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_simple.snap
+++ b/tests/spec/parse/snapshots/struct_simple.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point {\n  x: int,\n  y: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Point {\n  x: int,\n  y: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/struct_trailing_comma.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Config {\n  timeout: int,\n  retries: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Config {\n  timeout: int,\n  retries: int,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_generic.snap
+++ b/tests/spec/parse/snapshots/struct_with_generic.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Container<T> {\n  value: T,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_json_attribute.snap
+++ b/tests/spec/parse/snapshots/struct_with_json_attribute.snap
@@ -46,6 +46,7 @@ description: "input: \n#[json]\nstruct User {\n  name: string,\n}\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_json_attribute_snake_case.snap
+++ b/tests/spec/parse/snapshots/struct_with_json_attribute_snake_case.snap
@@ -50,6 +50,7 @@ description: "input: \n#[json(snake_case)]\nstruct User {\n  first_name: string,
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_multiple_attributes.snap
+++ b/tests/spec/parse/snapshots/struct_with_multiple_attributes.snap
@@ -82,6 +82,7 @@ description: "input: \n#[json]\n#[db]\nstruct User {\n  #[json(omitempty)]\n  #[
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_negated_flag.snap
+++ b/tests/spec/parse/snapshots/struct_with_negated_flag.snap
@@ -64,6 +64,7 @@ description: "input: \n#[json(omitempty)]\nstruct User {\n  #[json(!omitempty)]\
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_tag_attribute_raw.snap
+++ b/tests/spec/parse/snapshots/struct_with_tag_attribute_raw.snap
@@ -60,6 +60,7 @@ description: "input: \n#[tag]\nstruct User {\n  #[tag(`json:\"name,omitempty\" v
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/struct_with_tag_attribute_structured.snap
+++ b/tests/spec/parse/snapshots/struct_with_tag_attribute_structured.snap
@@ -63,6 +63,7 @@ description: "input: \n#[tag]\nstruct User {\n  #[tag(\"json\", omitempty)]\n  n
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Record,

--- a/tests/spec/parse/snapshots/tuple_struct_complex_types.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_complex_types.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Container(Slice<int>, Map<string, bool>)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -88,6 +89,7 @@ description: "input: \nstruct Container(Slice<int>, Map<string, bool>)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/spec/parse/snapshots/tuple_struct_multiple_generics.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_multiple_generics.snap
@@ -55,6 +55,7 @@ description: "input: \nstruct Pair<A, B>(A, B)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -78,6 +79,7 @@ description: "input: \nstruct Pair<A, B>(A, B)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/spec/parse/snapshots/tuple_struct_simple.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_simple.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point(int, int)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Point(int, int)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/spec/parse/snapshots/tuple_struct_single_field.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_single_field.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct UserId(int)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/spec/parse/snapshots/tuple_struct_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_trailing_comma.snap
@@ -36,6 +36,7 @@ description: "input: \nstruct Point(int, int,)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
             StructFieldDefinition {
                 doc: None,
@@ -59,6 +60,7 @@ description: "input: \nstruct Point(int, int,)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/spec/parse/snapshots/tuple_struct_with_generics.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_with_generics.snap
@@ -46,6 +46,7 @@ description: "input: \nstruct Wrapper<T>(T)\n"
                 ty: Var {
                     id: uninferred,
                 },
+                embedded: false,
             },
         ],
         kind: Tuple,

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -443,6 +443,27 @@ fn test() {
 }
 
 #[test]
+fn parse_embed_bare_function_target() {
+    let input = r#"
+struct S {
+  embed fn() -> int,
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_embed_field_with_attribute() {
+    let input = r#"
+#[json]
+struct S {
+  #[json("base")] embed Base,
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn lex_binary_missing_digits() {
     let input = r#"let x = 0b"#;
     assert_lex_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/parse_embed_bare_function_target.snap
+++ b/tests/ui/errors/snapshots/parse_embed_bare_function_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:3]
+ 2 │ struct S {
+ 3 │   embed fn() -> int,
+   ·   ────────┬────────
+   ·           ╰── expected a named type after `embed`
+ 4 │ }
+   ╰────
+  help: `embed` requires a named type; a function or tuple type cannot be embedded · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_embed_field_with_attribute.snap
+++ b/tests/ui/errors/snapshots/parse_embed_field_with_attribute.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:4:3]
+ 3 │ struct S {
+ 4 │   #[json("base")] embed Base,
+   ·   ───────┬───────
+   ·          ╰── embedded field cannot have attributes
+ 5 │ }
+   ╰────
+  help: An embedded field takes no attributes; its serialization follows Go's anonymous-field inlining · code: [parse.syntax_error]


### PR DESCRIPTION
Introduces an `embed` keyword for struct embedding. This is scaffolding only with no semantics yet, i.e. embedded members are not promoted, so the embedded type's methods and fields are not reachable through the outer struct, and the outer struct does not satisfy interfaces through the embed.

Lis:

```rs
pub struct Base { pub id: int }

struct Outer {
  embed Base,
  extra: int,
}
```

Go:

```go
type Outer struct {
	Base
	extra int
}
```

Groundwork for #581