### PR TITLE
fix: keep f-string interpolations single-line

### DIFF
--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -237,6 +237,12 @@ impl<'a> Comments<'a> {
             .is_some_and(|c| c.start < position)
     }
 
+    pub(crate) fn source_slice(&self, offset: u32, length: u32) -> &'a str {
+        let start = (offset as usize).min(self.source.len());
+        let end = (start + length as usize).min(self.source.len());
+        &self.source[start..end]
+    }
+
     /// Source-scans for `needle needle` (e.g. `..`) in `[start, before)`, skipping comment text.
     pub(crate) fn next_pair_at(&self, needle: u8, start: u32, before: u32) -> Option<u32> {
         let bytes = self.source.as_bytes();

--- a/crates/format/src/formatter/expression.rs
+++ b/crates/format/src/formatter/expression.rs
@@ -237,8 +237,20 @@ impl<'a> Formatter<'a> {
                 }
                 FormatStringPart::Text(s) => docs.push(Document::string(s.clone())),
                 FormatStringPart::Expression(e) => {
+                    let rendered = self.expression(e).to_pretty_string(isize::MAX);
+                    let mut content = if rendered.contains('\n') {
+                        let span = e.get_span();
+                        self.comments
+                            .source_slice(span.byte_offset, span.byte_length)
+                            .to_string()
+                    } else {
+                        rendered
+                    };
+                    if content.starts_with('{') {
+                        content.insert(0, ' ');
+                    }
                     docs.push(Document::str("{"));
-                    docs.push(self.expression(e));
+                    docs.push(Document::string(content));
                     docs.push(Document::str("}"));
                 }
             }

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1457,6 +1457,42 @@ fn format_multiline_string_in_call_forces_arg_wrap() {
 }
 
 #[test]
+fn format_fstring_long_interpolation_stays_single_line() {
+    assert_format_snapshot!(
+        "fn test() { let msg = f\"You cannot use another ender pearl for {shared.format_duration(remaining)}.\" }"
+    );
+}
+
+#[test]
+fn format_fstring_interpolation_many_args_stays_single_line() {
+    assert_format_snapshot!(
+        "fn test() { let msg = f\"result {compute(first_argument, second_argument, third_argument, fourth_argument)}\" }"
+    );
+}
+
+#[test]
+fn format_fstring_struct_call_interpolation_stays_single_line() {
+    assert_format_snapshot!(
+        "fn test() { let msg = f\"point {Point { x: some_long_value_here, y: another_long_value_here, z: third_value }}\" }"
+    );
+}
+
+#[test]
+fn format_fstring_match_interpolation_stays_single_line() {
+    assert_format_snapshot!("fn test() { let m = f\"v {match x { 1 => \"a\", _ => \"b\" }}\" }");
+}
+
+#[test]
+fn format_fstring_block_interpolation_stays_single_line() {
+    assert_format_snapshot!("fn test() { let b = f\"v { { let a = 1; a } }\" }");
+}
+
+#[test]
+fn format_fstring_empty_block_interpolation_stays_single_line() {
+    assert_format_snapshot!("fn test() { let e = f\"v { {} }\" }");
+}
+
+#[test]
 fn comment_inside_or_pattern() {
     assert_format_snapshot!(
         "fn f(x: int) -> int {\n  match x {\n    1 |\n    // standalone comment\n    2 |\n    3 => 1,\n    _ => 0,\n  }\n}"

--- a/tests/spec/format/snapshots/format_fstring_block_interpolation_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_block_interpolation_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let b = f\"v { { let a = 1; a } }\" }"
+---
+fn test() {
+  let b = f"v { { let a = 1; a }}"
+}

--- a/tests/spec/format/snapshots/format_fstring_empty_block_interpolation_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_empty_block_interpolation_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let e = f\"v { {} }\" }"
+---
+fn test() {
+  let e = f"v { {}}"
+}

--- a/tests/spec/format/snapshots/format_fstring_interpolation_many_args_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_interpolation_many_args_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let msg = f\"result {compute(first_argument, second_argument, third_argument, fourth_argument)}\" }"
+---
+fn test() {
+  let msg = f"result {compute(first_argument, second_argument, third_argument, fourth_argument)}"
+}

--- a/tests/spec/format/snapshots/format_fstring_long_interpolation_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_long_interpolation_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let msg = f\"You cannot use another ender pearl for {shared.format_duration(remaining)}.\" }"
+---
+fn test() {
+  let msg = f"You cannot use another ender pearl for {shared.format_duration(remaining)}."
+}

--- a/tests/spec/format/snapshots/format_fstring_match_interpolation_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_match_interpolation_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let m = f\"v {match x { 1 => \"a\", _ => \"b\" }}\" }"
+---
+fn test() {
+  let m = f"v {match x { 1 => "a", _ => "b" }}"
+}

--- a/tests/spec/format/snapshots/format_fstring_struct_call_interpolation_stays_single_line.snap
+++ b/tests/spec/format/snapshots/format_fstring_struct_call_interpolation_stays_single_line.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "input: fn test() { let msg = f\"point {Point { x: some_long_value_here, y: another_long_value_here, z: third_value }}\" }"
+---
+fn test() {
+  let msg = f"point {Point { x: some_long_value_here, y: another_long_value_here, z: third_value }}"
+}


### PR DESCRIPTION
The formatter no longer splits f-string interpolations across multiple lines, which the compiler then rejects.

A long interpolation like this:

```
f"You cannot use another ender pearl for {shared.format_duration(remaining)}."
```

used to be reformatted into this, which no longer compiled:

```
f"You cannot use another ender pearl for {shared.format_duration(
  remaining,
)}."
```

This would break the build until the line was manually rejoined. Interpolations now stay on a single line regardless of length.

Fix #653
