### PR TITLE
feat: add `Result.wrap_err` to attach context to errors

### DIFF
--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -220,6 +220,11 @@ impl<T, E> Result<T, E> {
   fn or_else<F>(self, f: fn(E) -> Result<T, F>) -> Result<T, F>
 }
 
+impl<T> Result<T, error> {
+  /// Wraps the `Err` value with `msg` and the original error, leaving `Ok` unchanged.
+  fn wrap_err(self, msg: string) -> Result<T, error>
+}
+
 /// A result from an operation where both a value and an error may be
 /// simultaneously meaningful. Used for Go functions like `io.Reader.Read`
 /// where `(n > 0, io.EOF)` means "n bytes were read and the stream ended."

--- a/docs/reference/09-error-handling.md
+++ b/docs/reference/09-error-handling.md
@@ -53,6 +53,20 @@ fn get_name(id: int) -> Option<string> {
 }
 ```
 
+## Adding context to errors
+
+`?` propagates an error unchanged. To record where it passed through, `wrap_err` prepends a message to the error while keeping the original as the cause:
+
+```rs
+fn read_config(path: string) -> Result<Config, error> {
+  let file = os.Open(path).wrap_err("opening config file")?
+  let bytes = io.ReadAll(file).wrap_err("reading config file")?
+  parse_config(bytes)
+}
+```
+
+If `os.Open` fails, the propagated error reads `opening config file: open /etc/app.conf: no such file or directory`. The original error is preserved underneath, so `errors.Is` and `errors.As` still match against it.
+
 ## `try` blocks
 
 The `?` operator only works in functions that return `Result` or `Option`. 

--- a/prelude/result.go
+++ b/prelude/result.go
@@ -80,6 +80,13 @@ func ResultMapErr[T any, E any, F any](res Result[T, E], f func(E) F) Result[T, 
 	return Result[T, F]{Tag: ResultOk, OkVal: res.OkVal}
 }
 
+func ResultWrapErr[T any](res Result[T, error], msg string) Result[T, error] {
+	if res.Tag == ResultErr {
+		return Result[T, error]{Tag: ResultErr, ErrVal: fmt.Errorf("%s: %w", msg, res.ErrVal)}
+	}
+	return Result[T, error]{Tag: ResultOk, OkVal: res.OkVal}
+}
+
 func ResultMapOr[T any, U any, E any](res Result[T, E], def U, f func(T) U) U {
 	if res.Tag == ResultOk {
 		return f(res.OkVal)

--- a/prelude/result_test.go
+++ b/prelude/result_test.go
@@ -1,6 +1,9 @@
 package lisette
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestResultOk(t *testing.T) {
 	res := MakeResultOk[int, string](42)
@@ -108,6 +111,34 @@ func TestResultMapErr(t *testing.T) {
 	mapped := ResultMapErr(err, func(e string) int { return len(e) })
 	if mapped.Err().UnwrapOr(0) != 4 {
 		t.Fatal("expected 4")
+	}
+}
+
+func TestResultWrapErr(t *testing.T) {
+	sentinel := errors.New("disk full")
+	err := MakeResultErr[int, error](sentinel)
+	wrapped := ResultWrapErr(err, "saving file")
+	if wrapped.ErrVal.Error() != "saving file: disk full" {
+		t.Fatalf("expected wrapped message, got %q", wrapped.ErrVal.Error())
+	}
+	if !errors.Is(wrapped.ErrVal, sentinel) {
+		t.Fatal("expected wrapped error to unwrap to sentinel")
+	}
+}
+
+func TestResultWrapErrPassesThroughOk(t *testing.T) {
+	ok := MakeResultOk[int, error](42)
+	wrapped := ResultWrapErr(ok, "saving file")
+	if wrapped.UnwrapOr(0) != 42 {
+		t.Fatal("expected 42")
+	}
+}
+
+func TestResultWrapErrEscapesPercentInMessage(t *testing.T) {
+	err := MakeResultErr[int, error](errors.New("boom"))
+	wrapped := ResultWrapErr(err, "100% failure")
+	if wrapped.ErrVal.Error() != "100% failure: boom" {
+		t.Fatalf("expected literal percent preserved, got %q", wrapped.ErrVal.Error())
 	}
 }
 

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1497,3 +1497,34 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn wrap_err_propagation() {
+    let input = r#"
+fn load(r: Result<int, error>) -> Result<int, error> {
+  let n = r.wrap_err("loading config")?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_runtime_wraps_message() {
+    let input = r#"
+import "go:errors"
+
+fn test() {
+  let r: Result<int, error> = Err(errors.New("boom"))
+  match r.wrap_err("loading config") {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "loading config: boom" {
+        panic("wrong wrapped message")
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/wrap_err_propagation.snap
+++ b/tests/spec/emit/snapshots/wrap_err_propagation.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nfn load(r: Result<int, error>) -> Result<int, error> {\n  let n = r.wrap_err(\"loading config\")?\n  Ok(n)\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func load(r lisette.Result[int, error]) (int, error) {
+	check_1 := lisette.ResultWrapErr(r, "loading config")
+	if check_1.Tag != lisette.ResultOk {
+		return *new(int), check_1.ErrVal
+	}
+	n := check_1.OkVal
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/wrap_err_runtime_wraps_message.snap
+++ b/tests/spec/emit/snapshots/wrap_err_runtime_wraps_message.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: "input: \nimport \"go:errors\"\n\nfn test() {\n  let r: Result<int, error> = Err(errors.New(\"boom\"))\n  match r.wrap_err(\"loading config\") {\n    Ok(_) => panic(\"expected error\"),\n    Err(e) => {\n      if e.Error() != \"loading config: boom\" {\n        panic(\"wrong wrapped message\")\n      }\n    },\n  }\n}\n"
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func test() {
+	r := lisette.MakeResultErr[int, error](errors.New("boom"))
+	subject_1 := lisette.ResultWrapErr(r, "loading config")
+	if subject_1.Tag == lisette.ResultOk {
+		panic("expected error")
+	}
+	if subject_1.ErrVal.Error() != "loading config: boom" {
+		panic("wrong wrapped message")
+	}
+}

--- a/tests/spec/infer/try.rs
+++ b/tests/spec/infer/try.rs
@@ -884,3 +884,55 @@ fn paren_break_in_match_arm_rejected() {
     )
     .assert_infer_code("control_flow_in_expression");
 }
+
+#[test]
+fn wrap_err_on_error_result_propagates() {
+    infer(
+        r#"
+    struct MyErr { msg: string }
+
+    impl MyErr {
+      fn Error(self) -> string { self.msg }
+    }
+
+    fn run() -> Result<int, error> {
+      let r: Result<int, error> = Err(MyErr { msg: "boom" })
+      let n = r.wrap_err("context")?
+      Ok(n)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn wrap_err_returns_result_of_error() {
+    infer(
+        r#"
+    struct MyErr { msg: string }
+
+    impl MyErr {
+      fn Error(self) -> string { self.msg }
+    }
+
+    fn run() -> Result<int, error> {
+      let r: Result<int, error> = Err(MyErr { msg: "boom" })
+      r.wrap_err("context")
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn wrap_err_unavailable_on_non_error_result() {
+    infer(
+        r#"
+    fn run() {
+      let r: Result<int, string> = Err("boom")
+      let _ = r.wrap_err("context")
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}


### PR DESCRIPTION
Adds `wrap_err`, a method on `Result<T, error>` that prepends a message to an error while keeping the original error as its cause. This is the common Go idiom for adding context as an error travels up the stack.

Adding context previously meant a full `map_err` closure:

```rs
let file = os.Open(path).map_err(|err| fmt.Errorf("opening config file: %w", err))?
```

With `wrap_err` the same intent is one call:

```rs
let file = os.Open(path).wrap_err("opening config file")?
```

If `os.Open` fails, the propagated error reads `opening config file: open /etc/app.conf: no such file or directory` and the original error stays reachable through `errors.Is` and `errors.As`.

Suggested in #649
