### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.3.3](https://github.com/ivov/lisette/compare/lisette-v0.3.2...lisette-v0.3.3) - 2026-06-08
+
+- feat: support embedding in native structs [#666](https://github.com/ivov/lisette/pull/666) [`eec2ea2`](https://github.com/ivov/lisette/commit/eec2ea2e9154af0209afefe183f9522eb7c4e2aa)
+- refactor: replace `impl` with `embed` for interface embedding [#664](https://github.com/ivov/lisette/pull/664) [`18d7902`](https://github.com/ivov/lisette/commit/18d79026991e050a0cd5374446afe516e96faabf)
+- test: differential harness for struct and interface embedding [#663](https://github.com/ivov/lisette/pull/663) [`b580f92`](https://github.com/ivov/lisette/commit/b580f923dd102c51add906243c1f33ed22770e76)
+- fix: skip `manual_map_or` lint on side-effecting match arms [#662](https://github.com/ivov/lisette/pull/662) [`ecb5ed8`](https://github.com/ivov/lisette/commit/ecb5ed88879a4df169d36771bdc4787898e4a66f)
+- fix: type unexported singleton vars by their implemented interface [#661](https://github.com/ivov/lisette/pull/661) [`be8e0f2`](https://github.com/ivov/lisette/commit/be8e0f25064fd1c7b4c8d396ab1f6557929f3718)
+- fix: prevent go types from shadowing prelude generics [#660](https://github.com/ivov/lisette/pull/660) [`e0f036b`](https://github.com/ivov/lisette/commit/e0f036b24ae7720562e957c6f58d39b16abc14d6)
+- feat: add `Result.wrap_err` to attach context to errors [#658](https://github.com/ivov/lisette/pull/658) [`668cab7`](https://github.com/ivov/lisette/commit/668cab75790dec794d65bbd90c50d5216f4cf0f0)
+- fix: keep f-string interpolations single-line [#657](https://github.com/ivov/lisette/pull/657) [`ee4f66a`](https://github.com/ivov/lisette/commit/ee4f66a18635437ec5dc7013332ee675d8d4fa9e)
+
 ## [0.3.2](https://github.com/ivov/lisette/compare/lisette-v0.3.1...lisette-v0.3.2) - 2026-06-07
 
 - fix: cross-module reference tracking in unused lints [#651](https://github.com/ivov/lisette/pull/651) [`64b9dc7`](https://github.com/ivov/lisette/commit/64b9dc7568da079be41bd55e30fa6bfcec6689a2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bincode",
  "ecow",
@@ -791,11 +791,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.3.2", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.3.2", path = "../format" }
-emit = { package = "lisette-emit", version = "0.3.2", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.3.2", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.3.3", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.3.3", path = "../format" }
+emit = { package = "lisette-emit", version = "0.3.3", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.3.3", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.3.2", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
-format = { package = "lisette-format", version = "0.3.2", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.3.3", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
+format = { package = "lisette-format", version = "0.3.3", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.2", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.2", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.3.2", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.2", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.3.3 (upcoming)

- feat: support embedding in native structs [#666](https://github.com/ivov/lisette/pull/666) [`eec2ea2`](https://github.com/ivov/lisette/commit/eec2ea2e9154af0209afefe183f9522eb7c4e2aa)
- refactor: replace `impl` with `embed` for interface embedding [#664](https://github.com/ivov/lisette/pull/664) [`18d7902`](https://github.com/ivov/lisette/commit/18d79026991e050a0cd5374446afe516e96faabf)
- test: differential harness for struct and interface embedding [#663](https://github.com/ivov/lisette/pull/663) [`b580f92`](https://github.com/ivov/lisette/commit/b580f923dd102c51add906243c1f33ed22770e76)
- fix: skip `manual_map_or` lint on side-effecting match arms [#662](https://github.com/ivov/lisette/pull/662) [`ecb5ed8`](https://github.com/ivov/lisette/commit/ecb5ed88879a4df169d36771bdc4787898e4a66f)
- fix: type unexported singleton vars by their implemented interface [#661](https://github.com/ivov/lisette/pull/661) [`be8e0f2`](https://github.com/ivov/lisette/commit/be8e0f25064fd1c7b4c8d396ab1f6557929f3718)
- fix: prevent go types from shadowing prelude generics [#660](https://github.com/ivov/lisette/pull/660) [`e0f036b`](https://github.com/ivov/lisette/commit/e0f036b24ae7720562e957c6f58d39b16abc14d6)
- feat: add `Result.wrap_err` to attach context to errors [#658](https://github.com/ivov/lisette/pull/658) [`668cab7`](https://github.com/ivov/lisette/commit/668cab75790dec794d65bbd90c50d5216f4cf0f0)
- fix: keep f-string interpolations single-line [#657](https://github.com/ivov/lisette/pull/657) [`ee4f66a`](https://github.com/ivov/lisette/commit/ee4f66a18635437ec5dc7013332ee675d8d4fa9e)
