### PR TITLE
test: differential harness for struct and interface embedding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,18 @@ jobs:
           go: 'true'
       - run: just test-e2e-suite
 
+  embed-diff:
+    name: Embed differential
+    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: ./.github/actions/setup-rust
+        with:
+          just: 'true'
+          go: 'true'
+      - run: just test-embed-diff
+
   prelude-go:
     name: Prelude tests
     if: ${{ !startsWith(github.head_ref, 'release-plz-') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,8 @@ dependencies = [
  "lisette-syntax",
  "miette",
  "rustc-hash",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 

--- a/justfile
+++ b/justfile
@@ -44,6 +44,9 @@ test-e2e-smoke:
 test-e2e-suite:
     cargo test -p tests --test e2e_suite -- --nocapture
 
+test-embed-diff:
+    cargo test -p tests --test embed_diff -- --nocapture
+
 test-cov:
     cargo llvm-cov -p tests -p lisette-lsp --test suite --test lsp --html --open
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,6 +16,8 @@ deps = { package = "lisette-deps", path = "../crates/deps" }
 rustc-hash.workspace = true
 insta.workspace = true
 miette.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tempfile = "3"
 
 [[test]]
@@ -33,3 +35,7 @@ path = "e2e_learn.rs"
 [[test]]
 name = "e2e_suite"
 path = "e2e_suite.rs"
+
+[[test]]
+name = "embed_diff"
+path = "embed_diff.rs"

--- a/tests/_embed_harness/compare.rs
+++ b/tests/_embed_harness/compare.rs
@@ -1,0 +1,261 @@
+//! Compares Lisette's answer to Go's for each question and classifies the
+//! result: they agree (Match), Lisette rejected something Go accepts
+//! (Incomplete, fine for now), or Lisette accepted something Go rejects
+//! (OverAccept, a failure).
+
+use super::go_answerer::{GoAnswer, GoAnswers};
+use super::lisette_answer::{LisetteAnswer, LisetteAnswers, Outcome};
+use super::scenario::{Question, Scenario};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    Match,
+    Incomplete,
+    OverAccept(OverAcceptKind),
+    /// A harness-integrity failure (parse, Go answer, or shape mismatch). Always
+    /// fails the suite.
+    Gate(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverAcceptKind {
+    ResolvesButGoRejects,
+    SatisfiesButGoDenies,
+    PickedOneWhereGoAmbiguous,
+}
+
+impl Verdict {
+    pub fn is_over_accept(&self) -> bool {
+        matches!(self, Verdict::OverAccept(_))
+    }
+
+    pub fn is_gate(&self) -> bool {
+        matches!(self, Verdict::Gate(_))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Comparison {
+    pub question_index: usize,
+    pub label: String,
+    pub verdict: Verdict,
+    /// Human-readable detail about Go's answer, for the report.
+    pub detail: String,
+}
+
+/// A satisfaction question contributes two comparisons (value and pointer forms).
+pub fn compare(scenario: &Scenario, go: &GoAnswers, lisette: &LisetteAnswers) -> Vec<Comparison> {
+    if let Some(fatal) = &go.fatal_error {
+        return gate_all(scenario, &format!("Go answer error: {fatal}"));
+    }
+    if lisette.parse_failed {
+        return gate_all(scenario, "rendered Lisette failed to parse");
+    }
+    if go.results.len() != scenario.questions.len()
+        || lisette.questions.len() != scenario.questions.len()
+    {
+        return gate_all(scenario, "question count mismatch between Go and Lisette");
+    }
+
+    let mut out = Vec::new();
+    for (i, question) in scenario.questions.iter().enumerate() {
+        let expected = &go.results[i];
+        match (question, &lisette.questions[i]) {
+            (Question::Selector { root, member, .. }, LisetteAnswer::Selector(outcome)) => {
+                out.push(Comparison {
+                    question_index: i,
+                    label: format!("{}.{}", scenario.node_name(*root), member),
+                    verdict: compare_selector(expected, outcome),
+                    detail: selector_detail(expected),
+                });
+            }
+            (
+                Question::Satisfies { type_id, interface },
+                LisetteAnswer::Satisfies { value, pointer },
+            ) => {
+                let type_name = scenario.node_name(*type_id);
+                let interface_name = scenario.node_name(*interface);
+                out.push(Comparison {
+                    question_index: i,
+                    label: format!("{type_name} : {interface_name} (value)"),
+                    verdict: compare_satisfies(expected.satisfies_value, value),
+                    detail: format!("go: value={}", expected.satisfies_value),
+                });
+                out.push(Comparison {
+                    question_index: i,
+                    label: format!("{type_name} : {interface_name} (pointer)"),
+                    verdict: compare_satisfies(expected.satisfies_pointer, pointer),
+                    detail: format!("go: pointer={}", expected.satisfies_pointer),
+                });
+            }
+            _ => out.push(Comparison {
+                question_index: i,
+                label: "<mismatch>".into(),
+                verdict: Verdict::Gate("question/answer kind mismatch".into()),
+                detail: String::new(),
+            }),
+        }
+    }
+    out
+}
+
+fn compare_selector(go: &GoAnswer, lisette: &Outcome) -> Verdict {
+    match (go.resolves, go.ambiguous, lisette.resolves()) {
+        (true, _, true) => Verdict::Match,
+        (true, _, false) => Verdict::Incomplete,
+        (false, false, false) => Verdict::Match,
+        (false, false, true) => Verdict::OverAccept(OverAcceptKind::ResolvesButGoRejects),
+        (false, true, false) => Verdict::Incomplete,
+        (false, true, true) => Verdict::OverAccept(OverAcceptKind::PickedOneWhereGoAmbiguous),
+    }
+}
+
+fn compare_satisfies(go_satisfies: bool, lisette: &Outcome) -> Verdict {
+    match (go_satisfies, lisette.resolves()) {
+        (true, true) => Verdict::Match,
+        (true, false) => Verdict::Incomplete,
+        (false, true) => Verdict::OverAccept(OverAcceptKind::SatisfiesButGoDenies),
+        (false, false) => Verdict::Match,
+    }
+}
+
+fn selector_detail(go: &GoAnswer) -> String {
+    if go.resolves {
+        let type_token = go
+            .resolved_type
+            .as_ref()
+            .map(|t| t.display())
+            .unwrap_or_default();
+        format!(
+            "go: {} on {} depth={} indirect={} : {type_token}",
+            go.member_kind, go.declaring_type, go.depth, go.indirect,
+        )
+    } else if go.ambiguous {
+        "go: ambiguous".into()
+    } else {
+        "go: not found".into()
+    }
+}
+
+fn gate_all(scenario: &Scenario, reason: &str) -> Vec<Comparison> {
+    let count = scenario.questions.len().max(1);
+    (0..count)
+        .map(|i| Comparison {
+            question_index: i,
+            label: scenario.name.clone(),
+            verdict: Verdict::Gate(reason.to_string()),
+            detail: String::new(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+    use crate::_embed_harness::go_answerer::{GoAnswerer, go_available};
+    use crate::_embed_harness::lisette_answer::lisette_answers;
+
+    fn answerer_or_skip() -> Option<GoAnswerer> {
+        if !go_available() {
+            eprintln!("skipping comparator test: `go` toolchain not found");
+            return None;
+        }
+        Some(GoAnswerer::build().expect("answerer builds"))
+    }
+
+    fn only(scenario: &Scenario, answerer: &GoAnswerer) -> Verdict {
+        let go = answerer.answer(scenario).unwrap();
+        let lisette = lisette_answers(scenario);
+        let comparisons = compare(scenario, &go, &lisette);
+        comparisons[0].verdict.clone()
+    }
+
+    #[test]
+    fn direct_method_matches() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        assert_eq!(only(&fixtures::direct_method(), &answerer), Verdict::Match);
+    }
+
+    #[test]
+    fn promoted_method_is_incomplete() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        assert_eq!(
+            only(&fixtures::value_embed_method(), &answerer),
+            Verdict::Incomplete
+        );
+    }
+
+    #[test]
+    fn diamond_is_incomplete_not_over_accept() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        assert_eq!(only(&fixtures::diamond(), &answerer), Verdict::Incomplete);
+    }
+
+    #[test]
+    fn direct_satisfaction_matches() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        assert_eq!(
+            only(&fixtures::interface_direct_satisfaction(), &answerer),
+            Verdict::Match
+        );
+    }
+
+    #[test]
+    fn promoted_satisfaction_is_incomplete() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        assert_eq!(
+            only(&fixtures::interface_promoted_satisfaction(), &answerer),
+            Verdict::Incomplete
+        );
+    }
+
+    #[test]
+    fn interface_conflict_matches_no_over_accept() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let scenario = fixtures::interface_conflict();
+        let go = answerer.answer(&scenario).unwrap();
+        let lisette = lisette_answers(&scenario);
+        for comparison in compare(&scenario, &go, &lisette) {
+            assert!(
+                !comparison.verdict.is_over_accept(),
+                "{}: unexpected over-accept ({:?})",
+                comparison.label,
+                comparison.verdict
+            );
+        }
+    }
+
+    #[test]
+    fn no_over_acceptance_across_all_fixtures() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        for scenario in fixtures::all() {
+            let go = answerer.answer(&scenario).unwrap();
+            let lisette = lisette_answers(&scenario);
+            for comparison in compare(&scenario, &go, &lisette) {
+                assert!(
+                    !comparison.verdict.is_over_accept() && !comparison.verdict.is_gate(),
+                    "{} / {}: {:?} ({})",
+                    scenario.name,
+                    comparison.label,
+                    comparison.verdict,
+                    comparison.detail
+                );
+            }
+        }
+    }
+}

--- a/tests/_embed_harness/corpus.rs
+++ b/tests/_embed_harness/corpus.rs
@@ -1,0 +1,172 @@
+//! Hand-written test cases the generator cannot produce: cyclic graphs, the
+//! conflicting-interface case, and inputs that must be rejected with a specific
+//! `embed_*` error. Some rejections are expected to be lifted later, and their
+//! tests will start passing when that happens.
+
+use super::fixtures::{iface_node, smethod, struct_node, vembed};
+use super::scenario::*;
+
+fn pembed(target: NodeId) -> Embed {
+    Embed {
+        target,
+        edge: EdgeKind::Pointer,
+        storage: Storage::Plain,
+    }
+}
+
+fn sel(root: NodeId, member: &str) -> Question {
+    Question::Selector {
+        root,
+        member: member.into(),
+        kind: SelKind::Method,
+    }
+}
+
+/// `N0` embeds `*N1` and `N1` embeds `N0` by value; the pointer edge breaks the
+/// cycle, so Go accepts the mutually-recursive types. A DAG cannot express this.
+pub fn pointer_cycle() -> Scenario {
+    Scenario {
+        name: "pointer_cycle".into(),
+        seed: 0,
+        nodes: vec![
+            struct_node(0, vec![pembed(1)], vec![], vec![smethod("a")]),
+            struct_node(1, vec![vembed(0)], vec![], vec![smethod("b")]),
+        ],
+        questions: vec![sel(0, "A"), sel(0, "B"), sel(1, "B"), sel(1, "A")],
+    }
+}
+
+/// A three-node diamond where the shared base is reached by two pointer edges.
+pub fn pointer_diamond() -> Scenario {
+    Scenario {
+        name: "pointer_diamond".into(),
+        seed: 0,
+        nodes: vec![
+            struct_node(0, vec![], vec![], vec![smethod("m")]),
+            struct_node(1, vec![pembed(0)], vec![], vec![]),
+            struct_node(2, vec![pembed(0)], vec![], vec![]),
+            struct_node(3, vec![vembed(1), vembed(2)], vec![], vec![]),
+        ],
+        questions: vec![sel(3, "M")],
+    }
+}
+
+/// `N2` embeds interface `N0` and struct `N1`, which also satisfies `N0`.
+pub fn mixed_embedding() -> Scenario {
+    Scenario {
+        name: "mixed_embedding".into(),
+        seed: 0,
+        nodes: vec![
+            iface_node(0, vec![], vec![smethod("speak")]),
+            struct_node(1, vec![], vec![], vec![smethod("speak")]),
+            struct_node(2, vec![vembed(0), vembed(1)], vec![], vec![]),
+        ],
+        questions: vec![
+            sel(2, "Speak"),
+            Question::Satisfies {
+                type_id: 2,
+                interface: 0,
+            },
+        ],
+    }
+}
+
+/// Every scenario that goes through the full differential.
+pub fn differential_scenarios() -> Vec<Scenario> {
+    let mut scenarios = super::fixtures::all();
+    scenarios.push(super::fixtures::interface_conflict());
+    scenarios.push(pointer_cycle());
+    scenarios.push(pointer_diamond());
+    scenarios.push(mixed_embedding());
+    scenarios
+}
+
+pub struct RejectCase {
+    pub name: &'static str,
+    pub source: &'static str,
+    pub code: &'static str,
+    /// `false` for a rejection a later phase is expected to lift.
+    pub permanent: bool,
+}
+
+pub fn reject_cases() -> Vec<RejectCase> {
+    vec![
+        RejectCase {
+            name: "pointer_to_interface",
+            source: "interface I {\n  fn m(self) -> int\n}\nstruct Outer {\n  embed Ref<I>,\n}\n",
+            code: "infer.embed_pointer_to_interface",
+            permanent: true,
+        },
+        RejectCase {
+            name: "nested_ref",
+            source: "struct Base {\n  pub x: int,\n}\nstruct Outer {\n  embed Ref<Ref<Base>>,\n}\n",
+            code: "infer.embed_nested_ref",
+            permanent: true,
+        },
+        RejectCase {
+            name: "option_target",
+            source: "struct Base {\n  pub x: int,\n}\nstruct Outer {\n  embed Option<Base>,\n}\n",
+            code: "infer.embed_option_target",
+            permanent: false,
+        },
+        RejectCase {
+            name: "defined_type",
+            source: "struct MyInt(int)\nstruct Outer {\n  embed MyInt,\n}\n",
+            code: "infer.embed_defined_type",
+            permanent: false,
+        },
+        RejectCase {
+            name: "generic",
+            source: "struct Box<T> {\n  pub value: T,\n}\nstruct Outer {\n  embed Box<int>,\n}\n",
+            code: "infer.embed_generic",
+            permanent: false,
+        },
+        RejectCase {
+            name: "no_surface",
+            source: "struct Empty {}\nstruct Outer {\n  embed Empty,\n}\n",
+            code: "infer.embed_no_surface",
+            permanent: true,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::lisette_answer::declarations_register_cleanly;
+
+    #[test]
+    fn some_reject_cases_are_deferred() {
+        let deferred = reject_cases().iter().filter(|case| !case.permanent).count();
+        assert!(deferred > 0, "expected some deferred reject cases");
+    }
+
+    #[test]
+    fn corpus_scenarios_validate() {
+        for scenario in differential_scenarios() {
+            scenario
+                .validate()
+                .unwrap_or_else(|e| panic!("{}: {e}", scenario.name));
+        }
+    }
+
+    #[test]
+    fn pointer_cycle_decls_register() {
+        declarations_register_cleanly(&pointer_cycle())
+            .unwrap_or_else(|codes| panic!("pointer_cycle decls rejected: {codes:?}"));
+    }
+
+    #[test]
+    fn reject_cases_raise_their_codes() {
+        for case in reject_cases() {
+            let codes = crate::_embed_harness::lisette_answer::check_codes(case.source)
+                .unwrap_or_else(|| panic!("{}: expected a rejection, but it compiled", case.name));
+            assert!(
+                codes.iter().any(|c| c == case.code),
+                "{}: expected `{}`, got {codes:?}",
+                case.name,
+                case.code
+            );
+        }
+    }
+}

--- a/tests/_embed_harness/fixtures.rs
+++ b/tests/_embed_harness/fixtures.rs
@@ -1,0 +1,205 @@
+use super::scenario::*;
+
+fn string_ret() -> Signature {
+    Signature {
+        parameters: vec![],
+        return_type: MemberType::Basic(BasicType::String),
+    }
+}
+
+/// A public, value-receiver, string-returning (identity) method.
+pub fn smethod(base: &str) -> Method {
+    Method {
+        name: cased(base, Visibility::Public),
+        receiver: Receiver::Value,
+        signature: string_ret(),
+        visibility: Visibility::Public,
+    }
+}
+
+/// A public interface method returning the given basic type.
+pub fn imethod(base: &str, return_type: BasicType) -> Method {
+    Method {
+        name: cased(base, Visibility::Public),
+        receiver: Receiver::Value,
+        signature: Signature {
+            parameters: vec![],
+            return_type: MemberType::Basic(return_type),
+        },
+        visibility: Visibility::Public,
+    }
+}
+
+pub fn vembed(target: NodeId) -> Embed {
+    Embed {
+        target,
+        edge: EdgeKind::Value,
+        storage: Storage::Plain,
+    }
+}
+
+pub fn pembed(target: NodeId) -> Embed {
+    Embed {
+        target,
+        edge: EdgeKind::Pointer,
+        storage: Storage::Plain,
+    }
+}
+
+pub fn struct_node(
+    id: NodeId,
+    embeds: Vec<Embed>,
+    fields: Vec<Field>,
+    methods: Vec<Method>,
+) -> Node {
+    Node {
+        id,
+        name: format!("N{id}"),
+        kind: NodeKind::Struct {
+            fields,
+            embeds,
+            methods,
+        },
+        origin: Origin::Native,
+    }
+}
+
+pub fn iface_node(id: NodeId, embeds: Vec<Embed>, methods: Vec<Method>) -> Node {
+    Node {
+        id,
+        name: format!("N{id}"),
+        kind: NodeKind::Interface { methods, embeds },
+        origin: Origin::Native,
+    }
+}
+
+fn sel(root: NodeId, member: &str) -> Question {
+    Question::Selector {
+        root,
+        member: member.into(),
+        kind: SelKind::Method,
+    }
+}
+
+/// `N0` has a direct method `M`; question `N0.M`. Resolves at depth 0 in both
+/// languages: a MATCH today, and the simplest case that can actually be run.
+pub fn direct_method() -> Scenario {
+    Scenario {
+        name: "direct_method".into(),
+        seed: 0,
+        nodes: vec![struct_node(0, vec![], vec![], vec![smethod("m")])],
+        questions: vec![sel(0, "M")],
+    }
+}
+
+/// `N1` embeds `N0` (value); question `N1.M`. Go promotes `M` at depth 1; Lisette
+/// does not yet, so INCOMPLETE.
+pub fn value_embed_method() -> Scenario {
+    Scenario {
+        name: "value_embed_method".into(),
+        seed: 0,
+        nodes: vec![
+            struct_node(0, vec![], vec![], vec![smethod("m")]),
+            struct_node(1, vec![vembed(0)], vec![], vec![]),
+        ],
+        questions: vec![sel(1, "M")],
+    }
+}
+
+/// `N1` embeds `*N0` (pointer); question `N1.M`. Go promotes `M` at depth 1 with an
+/// indirection; Lisette does not yet, so INCOMPLETE.
+pub fn pointer_embed_method() -> Scenario {
+    Scenario {
+        name: "pointer_embed_method".into(),
+        seed: 0,
+        nodes: vec![
+            struct_node(0, vec![], vec![], vec![smethod("m")]),
+            struct_node(1, vec![pembed(0)], vec![], vec![]),
+        ],
+        questions: vec![sel(1, "M")],
+    }
+}
+
+/// Diamond: `N3` embeds `N1` and `N2`, both embedding `N0`. `N0.M` is reachable
+/// at depth 2 via two subobjects, so `N3.M` is AMBIGUOUS in Go. Lisette does not
+/// promote yet, so INCOMPLETE, and must never silently pick one path.
+pub fn diamond() -> Scenario {
+    Scenario {
+        name: "diamond".into(),
+        seed: 0,
+        nodes: vec![
+            struct_node(0, vec![], vec![], vec![smethod("m")]),
+            struct_node(1, vec![vembed(0)], vec![], vec![]),
+            struct_node(2, vec![vembed(0)], vec![], vec![]),
+            struct_node(3, vec![vembed(1), vembed(2)], vec![], vec![]),
+        ],
+        questions: vec![sel(3, "M")],
+    }
+}
+
+/// `N1` declares `speak` directly and so satisfies interface `N0`: a MATCH.
+pub fn interface_direct_satisfaction() -> Scenario {
+    Scenario {
+        name: "interface_direct_satisfaction".into(),
+        seed: 0,
+        nodes: vec![
+            iface_node(0, vec![], vec![imethod("speak", BasicType::String)]),
+            struct_node(1, vec![], vec![], vec![smethod("speak")]),
+        ],
+        questions: vec![Question::Satisfies {
+            type_id: 1,
+            interface: 0,
+        }],
+    }
+}
+
+/// `N2` embeds `N1`, which declares `speak`, so Go has `N2` satisfy interface
+/// `N0` via promotion. Lisette does not promote yet, so INCOMPLETE.
+pub fn interface_promoted_satisfaction() -> Scenario {
+    Scenario {
+        name: "interface_promoted_satisfaction".into(),
+        seed: 0,
+        nodes: vec![
+            iface_node(0, vec![], vec![imethod("speak", BasicType::String)]),
+            struct_node(1, vec![], vec![], vec![smethod("speak")]),
+            struct_node(2, vec![vembed(1)], vec![], vec![]),
+        ],
+        questions: vec![Question::Satisfies {
+            type_id: 2,
+            interface: 0,
+        }],
+    }
+}
+
+/// Two embedded interfaces declare `M` with different signatures, so the
+/// composed interface `N2` is a duplicate-method error in Go. `N3` declares
+/// `M() string`, matching only `N1`, so Go has `N3` not satisfy `N2`. Lisette
+/// rejects `N2` at registration, agreeing.
+pub fn interface_conflict() -> Scenario {
+    Scenario {
+        name: "interface_conflict".into(),
+        seed: 0,
+        nodes: vec![
+            iface_node(0, vec![], vec![imethod("m", BasicType::Int)]),
+            iface_node(1, vec![], vec![imethod("m", BasicType::String)]),
+            iface_node(2, vec![vembed(0), vembed(1)], vec![]),
+            struct_node(3, vec![], vec![], vec![smethod("m")]),
+        ],
+        questions: vec![Question::Satisfies {
+            type_id: 3,
+            interface: 2,
+        }],
+    }
+}
+
+/// Every fixture, for tests that want to sweep all of them.
+pub fn all() -> Vec<Scenario> {
+    vec![
+        direct_method(),
+        value_embed_method(),
+        pointer_embed_method(),
+        diamond(),
+        interface_direct_satisfaction(),
+        interface_promoted_satisfaction(),
+    ]
+}

--- a/tests/_embed_harness/go_answerer.rs
+++ b/tests/_embed_harness/go_answerer.rs
@@ -1,0 +1,307 @@
+//! Asks Go's own type checker (the `go/types` package, via a small Go program
+//! in `tests/embed_go_answerer`) for the correct answer to each question. The rest
+//! of the harness compares Lisette against these answers.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use super::render_go::{GoMode, render_go};
+use super::scenario::{Question, Scenario};
+
+#[derive(Serialize)]
+struct Request<'a> {
+    #[serde(rename = "goSource")]
+    go_source: &'a str,
+    questions: Vec<GoQuestion>,
+}
+
+/// A flat question matching the Go side; irrelevant fields are sent empty.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoQuestion {
+    pub kind: String,
+    pub root: String,
+    pub member: String,
+    pub type_name: String,
+    pub interface: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GoAnswers {
+    #[serde(default)]
+    pub fatal_error: Option<String>,
+    /// Type-checker errors (e.g. a deliberate `duplicate method`).
+    #[serde(default)]
+    pub type_errors: Vec<String>,
+    pub results: Vec<GoAnswer>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GoAnswer {
+    #[serde(default)]
+    pub resolves: bool,
+    #[serde(default)]
+    pub ambiguous: bool,
+    #[serde(default)]
+    pub member_kind: String,
+    #[serde(default)]
+    pub declaring_type: String,
+    #[serde(default)]
+    pub depth: i64,
+    #[serde(default)]
+    pub indirect: bool,
+    #[serde(default)]
+    pub resolved_type: Option<CanonicalType>,
+    #[serde(default)]
+    pub satisfies_value: bool,
+    #[serde(default)]
+    pub satisfies_pointer: bool,
+}
+
+/// The answerer's language-neutral type token (mirrors the Go `CanonicalType`).
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalType {
+    pub kind: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub element: Option<Box<CanonicalType>>,
+    #[serde(default)]
+    pub parameters: Vec<CanonicalType>,
+    #[serde(default)]
+    pub return_type: Option<Box<CanonicalType>>,
+}
+
+impl CanonicalType {
+    /// A compact, human-readable rendering for triage reports.
+    pub fn display(&self) -> String {
+        match self.kind.as_str() {
+            "basic" | "named" => self.name.clone(),
+            "ref" => format!("*{}", child(&self.element)),
+            "slice" => format!("[]{}", child(&self.element)),
+            "func" => {
+                let parameters: Vec<String> =
+                    self.parameters.iter().map(CanonicalType::display).collect();
+                format!(
+                    "fn({}) -> {}",
+                    parameters.join(", "),
+                    child(&self.return_type)
+                )
+            }
+            other => format!("<{other}>"),
+        }
+    }
+}
+
+fn child(node: &Option<Box<CanonicalType>>) -> String {
+    node.as_ref().map(|c| c.display()).unwrap_or_default()
+}
+
+/// Is the Go toolchain available? Tests and the runner skip gracefully if not.
+pub fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+pub struct GoAnswerer {
+    binary: PathBuf,
+}
+
+impl GoAnswerer {
+    /// Build the answerer binary and reuse it across queries. The `go build`
+    /// runs exactly once per process even when many tests call this in parallel,
+    /// so they do not race on the same output path.
+    pub fn build() -> Result<GoAnswerer, String> {
+        static BINARY: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+        let binary = BINARY.get_or_init(build_binary).clone()?;
+        Ok(GoAnswerer { binary })
+    }
+
+    pub fn query(&self, go_source: &str, questions: Vec<GoQuestion>) -> Result<GoAnswers, String> {
+        let payload = serde_json::to_vec(&Request {
+            go_source,
+            questions,
+        })
+        .map_err(|e| format!("serialize answerer request: {e}"))?;
+
+        let mut child = Command::new(&self.binary)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn answerer: {e}"))?;
+        child
+            .stdin
+            .take()
+            .expect("piped stdin")
+            .write_all(&payload)
+            .map_err(|e| format!("write answerer stdin: {e}"))?;
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("wait for answerer: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "answerer exited non-zero: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        serde_json::from_slice(&output.stdout).map_err(|e| {
+            format!(
+                "parse answerer response: {e}\nstdout: {}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        })
+    }
+
+    /// Render the scenario to Go and ask the answerer about each of its questions.
+    pub fn answer(&self, scenario: &Scenario) -> Result<GoAnswers, String> {
+        let go = render_go(scenario, GoMode::TypeDefs);
+        self.query(&go, go_questions(scenario))
+    }
+}
+
+pub fn go_questions(scenario: &Scenario) -> Vec<GoQuestion> {
+    scenario
+        .questions
+        .iter()
+        .map(|question| match question {
+            Question::Selector { root, member, .. } => GoQuestion {
+                kind: "selector".into(),
+                root: scenario.node_name(*root).into(),
+                member: member.clone(),
+                type_name: String::new(),
+                interface: String::new(),
+            },
+            Question::Satisfies { type_id, interface } => GoQuestion {
+                kind: "satisfies".into(),
+                root: String::new(),
+                member: String::new(),
+                type_name: scenario.node_name(*type_id).into(),
+                interface: scenario.node_name(*interface).into(),
+            },
+        })
+        .collect()
+}
+
+fn build_binary() -> Result<PathBuf, String> {
+    let binary = answerer_binary_path();
+    if let Some(parent) = binary.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create answerer target dir: {e}"))?;
+    }
+    let output = Command::new("go")
+        .arg("build")
+        .arg("-o")
+        .arg(&binary)
+        .arg(".")
+        .current_dir(answerer_src_dir())
+        .output()
+        .map_err(|e| format!("spawn `go build`: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "answerer `go build` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(binary)
+}
+
+fn answerer_src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("embed_go_answerer")
+}
+
+fn answerer_binary_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("tests crate has a parent")
+        .join("target/embed_go_answerer/answerer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+
+    fn answerer_or_skip() -> Option<GoAnswerer> {
+        if !go_available() {
+            eprintln!("skipping answerer test: `go` toolchain not found");
+            return None;
+        }
+        Some(GoAnswerer::build().expect("answerer builds"))
+    }
+
+    #[test]
+    fn direct_method_resolves_at_depth_zero() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let response = answerer.answer(&fixtures::direct_method()).unwrap();
+        let sel = &response.results[0];
+        assert!(sel.resolves, "direct method should resolve");
+        assert_eq!(sel.member_kind, "method");
+        assert_eq!(sel.depth, 0);
+        assert_eq!(sel.declaring_type, "N0");
+    }
+
+    #[test]
+    fn value_embed_promotes_at_depth_one() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let response = answerer.answer(&fixtures::value_embed_method()).unwrap();
+        let sel = &response.results[0];
+        assert!(sel.resolves);
+        assert_eq!(sel.depth, 1);
+        assert_eq!(sel.declaring_type, "N0");
+    }
+
+    #[test]
+    fn diamond_selector_is_ambiguous() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let response = answerer.answer(&fixtures::diamond()).unwrap();
+        let sel = &response.results[0];
+        assert!(!sel.resolves, "an ambiguous selector does not resolve");
+        assert!(sel.ambiguous, "diamond `N3.M` is ambiguous in Go");
+    }
+
+    #[test]
+    fn pointer_embed_promotes() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let response = answerer.answer(&fixtures::pointer_embed_method()).unwrap();
+        let sel = &response.results[0];
+        assert!(sel.resolves);
+        assert_eq!(sel.depth, 1);
+    }
+
+    #[test]
+    fn satisfaction_direct_and_promoted() {
+        let Some(answerer) = answerer_or_skip() else {
+            return;
+        };
+        let direct = answerer
+            .answer(&fixtures::interface_direct_satisfaction())
+            .unwrap();
+        assert!(direct.results[0].satisfies_value, "direct satisfaction");
+
+        let promoted = answerer
+            .answer(&fixtures::interface_promoted_satisfaction())
+            .unwrap();
+        assert!(
+            promoted.results[0].satisfies_value,
+            "satisfaction through a promoted method"
+        );
+    }
+}

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -1,0 +1,334 @@
+//! Lisette's side of the comparison. Renders a graph to Lisette, runs the real
+//! type checker, and decides for each question whether Lisette accepted it by
+//! seeing which error diagnostics land inside that question's function. Reads only
+//! public diagnostic codes, so it survives changes to the checker's internals.
+
+use deps::TypedefLocator;
+use diagnostics::LisetteDiagnostic;
+use semantics::analyze::{AnalyzeInput, CompilePhase, SemanticConfig, analyze};
+use semantics::loader::MemoryLoader;
+use semantics::store::ENTRY_MODULE_ID;
+
+use super::render_lis::{QuestionSpans, render_lis_declarations, render_lis_questions};
+use super::scenario::Scenario;
+
+const ENTRY_FILE_ID: u32 = 0;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    Resolves,
+    Rejects { codes: Vec<String> },
+}
+
+impl Outcome {
+    pub fn resolves(&self) -> bool {
+        matches!(self, Outcome::Resolves)
+    }
+
+    pub fn has_code(&self, code: &str) -> bool {
+        matches!(self, Outcome::Rejects { codes } if codes.iter().any(|c| c == code))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum LisetteAnswer {
+    Selector(Outcome),
+    Satisfies { value: Outcome, pointer: Outcome },
+}
+
+#[derive(Debug, Clone)]
+pub struct LisetteAnswers {
+    /// The rendered Lisette failed to parse: a renderer bug.
+    pub parse_failed: bool,
+    /// Error codes outside every question span (declaration- or sink-level);
+    /// expected empty.
+    pub unattributed: Vec<String>,
+    /// Aligned 1:1 with `scenario.questions`.
+    pub questions: Vec<LisetteAnswer>,
+}
+
+pub fn lisette_answers(scenario: &Scenario) -> LisetteAnswers {
+    let rendered = render_lis_questions(scenario);
+    let checked = check(&rendered.source);
+    if checked.parse_failed {
+        return LisetteAnswers {
+            parse_failed: true,
+            unattributed: vec![],
+            questions: vec![],
+        };
+    }
+
+    let errors: Vec<(usize, String)> = checked
+        .errors
+        .iter()
+        .filter(|d| d.is_error())
+        .filter_map(|d| {
+            d.location_offset()
+                .map(|offset| (offset, d.code_str().unwrap_or("").to_string()))
+        })
+        .collect();
+    let mut attributed = vec![false; errors.len()];
+
+    let questions = rendered
+        .spans
+        .iter()
+        .map(|span| match span {
+            QuestionSpans::Selector { range } => {
+                LisetteAnswer::Selector(outcome(codes_in(&errors, *range, &mut attributed)))
+            }
+            QuestionSpans::Satisfies { value, pointer } => LisetteAnswer::Satisfies {
+                value: outcome(codes_in(&errors, *value, &mut attributed)),
+                pointer: outcome(codes_in(&errors, *pointer, &mut attributed)),
+            },
+        })
+        .collect();
+
+    let unattributed = errors
+        .iter()
+        .zip(&attributed)
+        .filter(|(_, done)| !**done)
+        .map(|((_, code), _)| code.clone())
+        .collect();
+
+    LisetteAnswers {
+        parse_failed: false,
+        unattributed,
+        questions,
+    }
+}
+
+/// Does the declarations-only rendering register without errors? A failure is a
+/// renderer bug (a decls-only file has no member accesses to resolve).
+pub fn declarations_register_cleanly(scenario: &Scenario) -> Result<(), Vec<String>> {
+    let source = render_lis_declarations(scenario);
+    let checked = check(&source);
+    if checked.parse_failed {
+        return Err(vec!["parse failed".to_string()]);
+    }
+    let codes: Vec<String> = checked
+        .errors
+        .iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.code_str().unwrap_or("<no code>").to_string())
+        .collect();
+    if codes.is_empty() { Ok(()) } else { Err(codes) }
+}
+
+/// Check a raw Lisette source and return its error codes (`None` if it compiles
+/// cleanly). Used by the corpus reject cases.
+pub fn check_codes(source: &str) -> Option<Vec<String>> {
+    let checked = check(source);
+    if checked.parse_failed {
+        return Some(vec!["parse.failed".to_string()]);
+    }
+    let codes: Vec<String> = checked
+        .errors
+        .iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.code_str().unwrap_or("<no code>").to_string())
+        .collect();
+    if codes.is_empty() { None } else { Some(codes) }
+}
+
+struct Checked {
+    parse_failed: bool,
+    errors: Vec<LisetteDiagnostic>,
+}
+
+/// Compile a self-contained Lisette source through the real checker.
+fn check(source: &str) -> Checked {
+    let build = syntax::build_ast(source, ENTRY_FILE_ID);
+    if build.failed() {
+        return Checked {
+            parse_failed: true,
+            errors: vec![],
+        };
+    }
+
+    let mut loader = MemoryLoader::new();
+    loader.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let output = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: false,
+            standalone_mode: false,
+            load_siblings: true,
+        },
+        loader: &loader,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
+        ast: build.ast,
+        project_root: None,
+        locator: TypedefLocator::default(),
+        compile_phase: CompilePhase::Check,
+        go_module: String::new(),
+        disable_cache: true,
+    });
+
+    Checked {
+        parse_failed: false,
+        errors: output.result.errors,
+    }
+}
+
+fn codes_in(
+    errors: &[(usize, String)],
+    range: (usize, usize),
+    attributed: &mut [bool],
+) -> Vec<String> {
+    let mut codes = Vec::new();
+    for (i, (offset, code)) in errors.iter().enumerate() {
+        if *offset >= range.0 && *offset < range.1 {
+            attributed[i] = true;
+            codes.push(code.clone());
+        }
+    }
+    codes
+}
+
+fn outcome(codes: Vec<String>) -> Outcome {
+    if codes.is_empty() {
+        Outcome::Resolves
+    } else {
+        Outcome::Rejects { codes }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+
+    fn selector_outcome(scenario: &Scenario) -> Outcome {
+        match &lisette_answers(scenario).questions[0] {
+            LisetteAnswer::Selector(outcome) => outcome.clone(),
+            other => panic!("expected a selector answer, got {other:?}"),
+        }
+    }
+
+    fn satisfies_value(scenario: &Scenario) -> Outcome {
+        match &lisette_answers(scenario).questions[0] {
+            LisetteAnswer::Satisfies { value, .. } => value.clone(),
+            other => panic!("expected a satisfies answer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn direct_method_resolves() {
+        assert_eq!(
+            selector_outcome(&fixtures::direct_method()),
+            Outcome::Resolves
+        );
+    }
+
+    #[test]
+    fn promoted_method_is_rejected_today() {
+        let outcome = selector_outcome(&fixtures::value_embed_method());
+        assert!(
+            outcome.has_code("infer.member_not_found"),
+            "expected member_not_found, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn diamond_selector_is_rejected_today() {
+        let outcome = selector_outcome(&fixtures::diamond());
+        assert!(
+            !outcome.resolves(),
+            "diamond promotion must not resolve yet"
+        );
+    }
+
+    #[test]
+    fn direct_satisfaction_resolves() {
+        assert_eq!(
+            satisfies_value(&fixtures::interface_direct_satisfaction()),
+            Outcome::Resolves
+        );
+    }
+
+    #[test]
+    fn promoted_satisfaction_is_rejected_today() {
+        let outcome = satisfies_value(&fixtures::interface_promoted_satisfaction());
+        assert!(
+            outcome.has_code("infer.interface_not_implemented"),
+            "expected interface_not_implemented, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn all_fixtures_have_clean_decls() {
+        for scenario in fixtures::all() {
+            declarations_register_cleanly(&scenario).unwrap_or_else(|codes| {
+                panic!("{}: decls did not register: {codes:?}", scenario.name)
+            });
+        }
+    }
+
+    #[test]
+    fn every_basic_type_is_a_valid_newtype() {
+        use crate::_embed_harness::scenario::*;
+        for basic in BasicType::ALL {
+            let scenario = Scenario {
+                name: format!("newtype_{}", basic.lisette()),
+                seed: 0,
+                nodes: vec![Node {
+                    id: 0,
+                    name: "N0".into(),
+                    kind: NodeKind::NamedBasic {
+                        underlying: basic,
+                        methods: vec![Method {
+                            name: "M".into(),
+                            receiver: Receiver::Value,
+                            signature: Signature {
+                                parameters: vec![],
+                                return_type: MemberType::Basic(BasicType::String),
+                            },
+                            visibility: Visibility::Public,
+                        }],
+                    },
+                    origin: Origin::Native,
+                }],
+                questions: vec![],
+            };
+            declarations_register_cleanly(&scenario)
+                .unwrap_or_else(|codes| panic!("newtype over `{}`: {codes:?}", basic.lisette()));
+        }
+    }
+
+    /// A duplicate-method interface is rejected at registration, so Lisette does
+    /// not over-accept it; Go denies satisfaction too, so they agree.
+    #[test]
+    fn interface_conflict_is_caught_at_registration() {
+        let scenario = fixtures::interface_conflict();
+        let decls = declarations_register_cleanly(&scenario);
+        assert!(
+            matches!(&decls, Err(codes) if codes.iter().any(|c| c == "infer.interface_method_conflict")),
+            "expected interface_method_conflict at registration, got {decls:?}"
+        );
+        match &lisette_answers(&scenario).questions[0] {
+            LisetteAnswer::Satisfies { value, .. } => {
+                assert!(
+                    !value.resolves(),
+                    "conflicted interface must not be satisfied"
+                );
+            }
+            other => panic!("expected a satisfies answer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_unattributed_errors_on_fixtures() {
+        for scenario in fixtures::all() {
+            let v = lisette_answers(&scenario);
+            assert!(!v.parse_failed, "{}: parse failed", scenario.name);
+            assert!(
+                v.unattributed.is_empty(),
+                "{}: unattributed errors {:?}",
+                scenario.name,
+                v.unattributed
+            );
+        }
+    }
+}

--- a/tests/_embed_harness/mod.rs
+++ b/tests/_embed_harness/mod.rs
@@ -1,0 +1,22 @@
+pub mod compare;
+pub mod go_answerer;
+pub mod lisette_answer;
+pub mod random_scenarios;
+pub mod render_go;
+pub mod render_lis;
+pub mod run_check;
+pub mod runner;
+pub mod scenario;
+
+#[cfg(test)]
+pub mod corpus;
+#[cfg(test)]
+pub mod fixtures;
+
+use scenario::NodeId;
+
+#[derive(Clone, Debug)]
+pub struct PrintedQuestion {
+    pub root: NodeId,
+    pub member: String,
+}

--- a/tests/_embed_harness/random_scenarios.rs
+++ b/tests/_embed_harness/random_scenarios.rs
@@ -1,0 +1,333 @@
+//! Generates random graphs from a seed (same seed, same graph, so any failure
+//! reproduces). Embeds always point to an earlier type, which keeps every graph
+//! acyclic and therefore valid Go; cycles and other special shapes are written
+//! by hand in `corpus.rs` instead.
+
+use super::scenario::*;
+
+/// splitmix64: one `u64` of state, reproducible from the seed alone.
+pub struct Random {
+    state: u64,
+}
+
+impl Random {
+    pub fn new(seed: u64) -> Self {
+        Random { state: seed }
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// A value in `0..n` (returns 0 for `n == 0`, never panics).
+    pub fn below(&mut self, n: usize) -> usize {
+        if n == 0 {
+            0
+        } else {
+            (self.next_u64() % n as u64) as usize
+        }
+    }
+
+    pub fn one_in(&mut self, n: u64) -> bool {
+        self.next_u64().is_multiple_of(n)
+    }
+
+    pub fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
+        let index = self.below(items.len());
+        &items[index]
+    }
+}
+
+/// Generate a scenario from a seed. Deterministic: same seed, same scenario.
+pub fn generate(seed: u64) -> Scenario {
+    let mut random = Random::new(seed);
+    let node_count = 2 + random.below(6); // 2..=7
+
+    let mut nodes: Vec<Node> = Vec::with_capacity(node_count);
+    for id in 0..node_count {
+        let kind = generate_kind(&mut random, id, &nodes);
+        nodes.push(Node {
+            id,
+            name: format!("N{id}"),
+            kind,
+            origin: Origin::Native,
+        });
+    }
+
+    let questions = generate_questions(&mut random, &nodes);
+    let scenario = Scenario {
+        name: format!("generate_{seed}"),
+        seed,
+        nodes,
+        questions,
+    };
+    debug_assert!(
+        scenario.validate().is_ok(),
+        "generated invalid scenario: {seed}"
+    );
+    scenario
+}
+
+fn generate_kind(random: &mut Random, id: usize, existing: &[Node]) -> NodeKind {
+    match random.below(10) {
+        0..=5 => NodeKind::Struct {
+            embeds: generate_struct_embeds(random, id, existing),
+            fields: generate_fields(random),
+            methods: generate_methods(random),
+        },
+        6..=7 => NodeKind::Interface {
+            embeds: generate_interface_embeds(random, id, existing),
+            methods: generate_interface_methods(random),
+        },
+        _ => NodeKind::NamedBasic {
+            underlying: *random.pick(&[
+                BasicType::Int,
+                BasicType::Float,
+                BasicType::String,
+                BasicType::Bool,
+            ]),
+            methods: generate_methods(random),
+        },
+    }
+}
+
+fn generate_struct_embeds(random: &mut Random, id: usize, existing: &[Node]) -> Vec<Embed> {
+    let candidates: Vec<usize> = (0..id).filter(|&j| embeddable(&existing[j])).collect();
+    if candidates.is_empty() {
+        return vec![];
+    }
+    let mut embeds = Vec::new();
+    let mut used = Vec::new();
+    for _ in 0..random.below(3) {
+        let target = *random.pick(&candidates);
+        if used.contains(&target) {
+            continue;
+        }
+        used.push(target);
+        let edge = if existing[target].kind.is_interface() || random.one_in(2) {
+            EdgeKind::Value
+        } else {
+            EdgeKind::Pointer
+        };
+        embeds.push(Embed {
+            target,
+            edge,
+            storage: Storage::Plain,
+        });
+    }
+    embeds
+}
+
+fn generate_interface_embeds(random: &mut Random, id: usize, existing: &[Node]) -> Vec<Embed> {
+    let interfaces: Vec<usize> = (0..id)
+        .filter(|&j| existing[j].kind.is_interface() && embeddable(&existing[j]))
+        .collect();
+    if interfaces.is_empty() {
+        return vec![];
+    }
+    let mut embeds = Vec::new();
+    let mut used = Vec::new();
+    for _ in 0..random.below(3) {
+        let target = *random.pick(&interfaces);
+        if used.contains(&target) {
+            continue;
+        }
+        used.push(target);
+        embeds.push(Embed {
+            target,
+            edge: EdgeKind::Value,
+            storage: Storage::Plain,
+        });
+    }
+    embeds
+}
+
+/// Whether this node can be embedded today without a declaration rejection.
+fn embeddable(node: &Node) -> bool {
+    match &node.kind {
+        NodeKind::Struct {
+            fields, methods, ..
+        } => !fields.is_empty() || !methods.is_empty(),
+        NodeKind::Interface { methods, .. } => !methods.is_empty(),
+        NodeKind::NamedBasic { .. } => false,
+    }
+}
+
+/// Identity methods named from a small pool, so distinct nodes can share a name
+/// (the source of diamonds and ambiguity when both feed a common descendant).
+fn generate_methods(random: &mut Random) -> Vec<Method> {
+    let mut methods = Vec::new();
+    let mut used = Vec::new();
+    for _ in 0..random.below(3) {
+        let name = method_name(random);
+        if used.contains(&name) {
+            continue;
+        }
+        used.push(name.clone());
+        methods.push(Method {
+            name,
+            receiver: if random.one_in(2) {
+                Receiver::Pointer
+            } else {
+                Receiver::Value
+            },
+            signature: Signature {
+                parameters: vec![],
+                return_type: MemberType::Basic(BasicType::String),
+            },
+            visibility: Visibility::Public,
+        });
+    }
+    methods
+}
+
+fn generate_interface_methods(random: &mut Random) -> Vec<Method> {
+    let mut methods = Vec::new();
+    let mut used = Vec::new();
+    for _ in 0..(1 + random.below(2)) {
+        let name = method_name(random);
+        if used.contains(&name) {
+            continue;
+        }
+        used.push(name.clone());
+        methods.push(Method {
+            name,
+            receiver: Receiver::Value,
+            signature: Signature {
+                parameters: vec![],
+                return_type: MemberType::Basic(BasicType::String),
+            },
+            visibility: Visibility::Public,
+        });
+    }
+    methods
+}
+
+fn generate_fields(random: &mut Random) -> Vec<Field> {
+    let mut fields = Vec::new();
+    let mut used = Vec::new();
+    for _ in 0..random.below(2) {
+        let name = field_name(random);
+        if used.contains(&name) {
+            continue;
+        }
+        used.push(name.clone());
+        let basic = *random.pick(&[BasicType::Int, BasicType::String, BasicType::Bool]);
+        let member_type = match random.below(3) {
+            0 => MemberType::Ref(Box::new(MemberType::Basic(basic))),
+            1 => MemberType::Slice(Box::new(MemberType::Basic(basic))),
+            _ => MemberType::Basic(basic),
+        };
+        fields.push(Field {
+            name,
+            member_type,
+            visibility: Visibility::Public,
+        });
+    }
+    fields
+}
+
+fn generate_questions(random: &mut Random, nodes: &[Node]) -> Vec<Question> {
+    let roots: Vec<usize> = nodes
+        .iter()
+        .filter(|n| !n.kind.is_interface())
+        .map(|n| n.id)
+        .collect();
+    let interfaces: Vec<usize> = nodes
+        .iter()
+        .filter(|n| n.kind.is_interface())
+        .map(|n| n.id)
+        .collect();
+
+    let mut questions = Vec::new();
+    if !roots.is_empty() {
+        for _ in 0..(1 + random.below(3)) {
+            let root = *random.pick(&roots);
+            questions.push(Question::Selector {
+                root,
+                member: method_name(random),
+                kind: SelKind::Method,
+            });
+            if random.one_in(2) {
+                questions.push(Question::Selector {
+                    root,
+                    member: field_name(random),
+                    kind: SelKind::Field,
+                });
+            }
+        }
+        for _ in 0..random.below(3) {
+            if interfaces.is_empty() {
+                break;
+            }
+            questions.push(Question::Satisfies {
+                type_id: *random.pick(&roots),
+                interface: *random.pick(&interfaces),
+            });
+        }
+    }
+    questions
+}
+
+fn method_name(random: &mut Random) -> String {
+    cased(&format!("m{}", random.below(3)), Visibility::Public)
+}
+
+fn field_name(random: &mut Random) -> String {
+    cased(&format!("f{}", random.below(2)), Visibility::Public)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_deterministic() {
+        for seed in [0u64, 1, 42, 9999, u64::MAX] {
+            assert_eq!(
+                generate(seed),
+                generate(seed),
+                "seed {seed} produced different scenarios"
+            );
+        }
+    }
+
+    #[test]
+    fn distinct_seeds_differ() {
+        assert_ne!(generate(1), generate(2));
+    }
+
+    #[test]
+    fn generated_scenarios_validate() {
+        for seed in 0..500 {
+            let scenario = generate(seed);
+            scenario
+                .validate()
+                .unwrap_or_else(|e| panic!("seed {seed} invalid: {e}"));
+        }
+    }
+
+    #[test]
+    fn generated_scenarios_register_cleanly() {
+        use crate::_embed_harness::lisette_answer::declarations_register_cleanly;
+        for seed in 0..500 {
+            declarations_register_cleanly(&generate(seed))
+                .unwrap_or_else(|codes| panic!("seed {seed} has declaration errors: {codes:?}"));
+        }
+    }
+
+    #[test]
+    fn generated_scenarios_have_questions_mostly() {
+        let with_questions = (0..200)
+            .filter(|&s| !generate(s).questions.is_empty())
+            .count();
+        assert!(
+            with_questions > 150,
+            "too few generated scenarios had questions: {with_questions}"
+        );
+    }
+}

--- a/tests/_embed_harness/render_go.rs
+++ b/tests/_embed_harness/render_go.rs
@@ -1,0 +1,199 @@
+//! Turns a graph into Go source. Uses the same type and member names as the
+//! Lisette renderer, so if the two behave differently it is a real difference,
+//! not a naming mismatch.
+
+use super::PrintedQuestion;
+use super::scenario::*;
+
+pub enum GoMode<'a> {
+    TypeDefs,
+    RunMain(&'a [PrintedQuestion]),
+}
+
+pub fn render_go(scenario: &Scenario, mode: GoMode) -> String {
+    let mut out = String::new();
+    match mode {
+        GoMode::TypeDefs => out.push_str("package p\n\n"),
+        GoMode::RunMain(_) => out.push_str("package main\n\nimport \"fmt\"\n\n"),
+    }
+
+    for node in &scenario.nodes {
+        render_node(scenario, node, &mut out);
+        out.push('\n');
+    }
+
+    if let GoMode::RunMain(printed) = mode {
+        render_main(scenario, printed, &mut out);
+    }
+    out
+}
+
+fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    match &node.kind {
+        NodeKind::Struct {
+            fields,
+            embeds,
+            methods,
+        } => {
+            out.push_str(&format!("type {} struct {{\n", node.name));
+            for embed in embeds {
+                let target = scenario.node_name(embed.target);
+                match embed.edge {
+                    EdgeKind::Value => out.push_str(&format!("\t{target}\n")),
+                    EdgeKind::Pointer => out.push_str(&format!("\t*{target}\n")),
+                }
+            }
+            for field in fields {
+                out.push_str(&format!(
+                    "\t{} {}\n",
+                    field.name,
+                    go_type(scenario, &field.member_type)
+                ));
+            }
+            out.push_str("}\n");
+            for method in methods {
+                render_method(scenario, &node.name, method, out);
+            }
+        }
+        NodeKind::Interface { methods, embeds } => {
+            out.push_str(&format!("type {} interface {{\n", node.name));
+            for embed in embeds {
+                out.push_str(&format!("\t{}\n", scenario.node_name(embed.target)));
+            }
+            for method in methods {
+                out.push_str(&format!(
+                    "\t{}({}) {}\n",
+                    method.name,
+                    go_params(scenario, &method.signature.parameters),
+                    go_type(scenario, &method.signature.return_type),
+                ));
+            }
+            out.push_str("}\n");
+        }
+        NodeKind::NamedBasic {
+            underlying,
+            methods,
+        } => {
+            out.push_str(&format!("type {} {}\n", node.name, underlying.go()));
+            for method in methods {
+                render_method(scenario, &node.name, method, out);
+            }
+        }
+    }
+}
+
+fn render_method(scenario: &Scenario, owner: &str, method: &Method, out: &mut String) {
+    let receiver = match method.receiver {
+        Receiver::Value => format!("r {owner}"),
+        Receiver::Pointer => format!("r *{owner}"),
+    };
+    out.push_str(&format!(
+        "func ({}) {}({}) {} {{\n",
+        receiver,
+        method.name,
+        go_params(scenario, &method.signature.parameters),
+        go_type(scenario, &method.signature.return_type),
+    ));
+    match &method.signature.return_type {
+        MemberType::Basic(BasicType::String) => {
+            out.push_str(&format!("\treturn \"{}.{}\"\n", owner, method.name));
+        }
+        other => panic!(
+            "concrete method {}.{} must return string for identity (got {other:?})",
+            owner, method.name
+        ),
+    }
+    out.push_str("}\n");
+}
+
+fn go_params(scenario: &Scenario, parameters: &[MemberType]) -> String {
+    parameters
+        .iter()
+        .enumerate()
+        .map(|(i, member_type)| format!("p{i} {}", go_type(scenario, member_type)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub fn go_type(scenario: &Scenario, member_type: &MemberType) -> String {
+    match member_type {
+        MemberType::Basic(basic) => basic.go().to_string(),
+        MemberType::Node(id) => scenario.node_name(*id).to_string(),
+        MemberType::Ref(inner) | MemberType::Option(inner) => {
+            format!("*{}", go_type(scenario, inner))
+        }
+        MemberType::Slice(inner) => format!("[]{}", go_type(scenario, inner)),
+    }
+}
+
+fn render_main(scenario: &Scenario, printed: &[PrintedQuestion], out: &mut String) {
+    out.push_str("func main() {\n");
+    for question in printed {
+        let root = scenario.node_name(question.root);
+        // Block-scope each question so `r` can be reused and stays addressable.
+        out.push_str("\t{\n");
+        out.push_str(&format!("\t\tvar r {root}\n"));
+        out.push_str(&format!("\t\tfmt.Println(r.{}())\n", question.member));
+        out.push_str("\t}\n");
+    }
+    out.push_str("}\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+
+    fn assert_snap(name: &str, value: String) {
+        insta::with_settings!({ prepend_module_to_snapshot => false, omit_expression => true }, {
+            insta::assert_snapshot!(name, value);
+        });
+    }
+
+    #[test]
+    fn declarations_diamond() {
+        let scenario = fixtures::diamond();
+        scenario.validate().unwrap();
+        assert_snap(
+            "go_declarations_diamond",
+            render_go(&scenario, GoMode::TypeDefs),
+        );
+    }
+
+    #[test]
+    fn declarations_interface() {
+        let scenario = fixtures::interface_direct_satisfaction();
+        assert_snap(
+            "go_declarations_interface",
+            render_go(&scenario, GoMode::TypeDefs),
+        );
+    }
+
+    #[test]
+    fn run_main_direct() {
+        let scenario = fixtures::direct_method();
+        let printed = [PrintedQuestion {
+            root: 0,
+            member: "M".into(),
+        }];
+        assert_snap(
+            "go_run_direct",
+            render_go(&scenario, GoMode::RunMain(&printed)),
+        );
+    }
+
+    #[test]
+    fn every_node_name_appears() {
+        for scenario in fixtures::all() {
+            let go = render_go(&scenario, GoMode::TypeDefs);
+            for node in &scenario.nodes {
+                assert!(
+                    go.contains(&node.name),
+                    "{}: Go rendering omits node `{}`",
+                    scenario.name,
+                    node.name
+                );
+            }
+        }
+    }
+}

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -1,0 +1,416 @@
+//! Turns a graph into Lisette source, in three forms: the declarations alone;
+//! the declarations plus one function per question (so Lisette's answer can be read
+//! from compiler errors); and a runnable `main`. Names and structure match the
+//! Go renderer.
+
+use std::collections::BTreeSet;
+
+use super::PrintedQuestion;
+use super::scenario::*;
+
+/// Byte ranges of the question functions, aligned 1:1 with `scenario.questions`, so a
+/// diagnostic can be attributed to the question that produced it.
+pub enum QuestionSpans {
+    Selector {
+        range: (usize, usize),
+    },
+    Satisfies {
+        value: (usize, usize),
+        pointer: (usize, usize),
+    },
+}
+
+pub struct RenderedQuestions {
+    pub source: String,
+    pub spans: Vec<QuestionSpans>,
+}
+
+/// Type declarations and `impl` blocks only.
+pub fn render_lis_declarations(scenario: &Scenario) -> String {
+    let mut out = String::new();
+    push_declarations(scenario, &mut out);
+    out
+}
+
+pub fn render_lis_questions(scenario: &Scenario) -> RenderedQuestions {
+    let mut out = String::new();
+    push_declarations(scenario, &mut out);
+
+    let mut interfaces: BTreeSet<NodeId> = BTreeSet::new();
+    for question in &scenario.questions {
+        if let Question::Satisfies { interface, .. } = question {
+            interfaces.insert(*interface);
+        }
+    }
+    for interface in &interfaces {
+        out.push_str(&format!(
+            "fn {}(_v: {}) {{\n}}\n\n",
+            sink_name(scenario.node_name(*interface)),
+            scenario.node_name(*interface),
+        ));
+    }
+
+    let mut spans = Vec::with_capacity(scenario.questions.len());
+    for (i, question) in scenario.questions.iter().enumerate() {
+        match question {
+            Question::Selector { root, member, kind } => {
+                let access = match kind {
+                    SelKind::Method => format!("r.{member}()"),
+                    SelKind::Field => format!("r.{member}"),
+                };
+                let start = out.len();
+                out.push_str(&format!(
+                    "fn __sel_{i}(r: {}) {{\n  let _ = {access}\n}}\n\n",
+                    scenario.node_name(*root),
+                ));
+                let end = out.len();
+                spans.push(QuestionSpans::Selector {
+                    range: (start, end),
+                });
+            }
+            Question::Satisfies { type_id, interface } => {
+                let sink = sink_name(scenario.node_name(*interface));
+                let type_name = scenario.node_name(*type_id);
+
+                let v_start = out.len();
+                out.push_str(&format!(
+                    "fn __sat_v_{i}(x: {type_name}) {{\n  {sink}(x)\n}}\n\n",
+                ));
+                let v_end = out.len();
+
+                let p_start = out.len();
+                out.push_str(&format!(
+                    "fn __sat_p_{i}(x: Ref<{type_name}>) {{\n  {sink}(x)\n}}\n\n",
+                ));
+                let p_end = out.len();
+
+                spans.push(QuestionSpans::Satisfies {
+                    value: (v_start, v_end),
+                    pointer: (p_start, p_end),
+                });
+            }
+        }
+    }
+
+    RenderedQuestions { source: out, spans }
+}
+
+pub fn render_lis_run(scenario: &Scenario, printed: &[PrintedQuestion]) -> String {
+    let mut out = String::new();
+    out.push_str("import \"go:fmt\"\n\n");
+    push_declarations(scenario, &mut out);
+
+    out.push_str("fn main() {\n");
+    for (i, question) in printed.iter().enumerate() {
+        out.push_str(&format!(
+            "  let r{i} = {}\n",
+            lis_zero_construct(scenario, question.root)
+        ));
+        out.push_str(&format!("  fmt.Println(r{i}.{}())\n", question.member));
+    }
+    out.push_str("}\n");
+    out
+}
+
+fn push_declarations(scenario: &Scenario, out: &mut String) {
+    for node in &scenario.nodes {
+        render_node(scenario, node, out);
+        out.push('\n');
+    }
+}
+
+fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    match &node.kind {
+        NodeKind::Struct {
+            fields,
+            embeds,
+            methods,
+        } => {
+            if embeds.is_empty() && fields.is_empty() {
+                out.push_str(&format!("struct {} {{}}\n", node.name));
+            } else {
+                out.push_str(&format!("struct {} {{\n", node.name));
+                for embed in embeds {
+                    out.push_str(&format!("  embed {},\n", embed_type(scenario, embed)));
+                }
+                for field in fields {
+                    let visibility = match field.visibility {
+                        Visibility::Public => "pub ",
+                        Visibility::Private => "",
+                    };
+                    out.push_str(&format!(
+                        "  {visibility}{}: {},\n",
+                        field.name,
+                        lis_type(scenario, &field.member_type)
+                    ));
+                }
+                out.push_str("}\n");
+            }
+            render_impl(scenario, &node.name, methods, out);
+        }
+        NodeKind::Interface { methods, embeds } => {
+            if embeds.is_empty() && methods.is_empty() {
+                out.push_str(&format!("interface {} {{}}\n", node.name));
+            } else {
+                out.push_str(&format!("interface {} {{\n", node.name));
+                for embed in embeds {
+                    out.push_str(&format!("  impl {}\n", scenario.node_name(embed.target)));
+                }
+                for method in methods {
+                    out.push_str(&format!(
+                        "  fn {}(self{}) -> {}\n",
+                        method.name,
+                        lis_parameters(scenario, &method.signature.parameters),
+                        lis_type(scenario, &method.signature.return_type),
+                    ));
+                }
+                out.push_str("}\n");
+            }
+        }
+        NodeKind::NamedBasic {
+            underlying,
+            methods,
+        } => {
+            // A tuple struct, not `type N = T`: an alias cannot carry methods.
+            out.push_str(&format!("struct {}({})\n", node.name, underlying.lisette()));
+            render_impl(scenario, &node.name, methods, out);
+        }
+    }
+}
+
+fn render_impl(scenario: &Scenario, owner: &str, methods: &[Method], out: &mut String) {
+    if methods.is_empty() {
+        return;
+    }
+    out.push_str(&format!("impl {owner} {{\n"));
+    for method in methods {
+        let receiver = match method.receiver {
+            Receiver::Value => "self".to_string(),
+            Receiver::Pointer => format!("self: Ref<{owner}>"),
+        };
+        let extra = lis_parameters(scenario, &method.signature.parameters);
+        match &method.signature.return_type {
+            MemberType::Basic(BasicType::String) => {
+                out.push_str(&format!(
+                    "  fn {}({receiver}{extra}) -> string {{\n    \"{}.{}\"\n  }}\n",
+                    method.name, owner, method.name,
+                ));
+            }
+            other => panic!(
+                "concrete method {}.{} must return string for identity (got {other:?})",
+                owner, method.name
+            ),
+        }
+    }
+    out.push_str("}\n");
+}
+
+fn lis_parameters(scenario: &Scenario, parameters: &[MemberType]) -> String {
+    if parameters.is_empty() {
+        return String::new();
+    }
+    let rendered: Vec<String> = parameters
+        .iter()
+        .enumerate()
+        .map(|(i, member_type)| format!("p{i}: {}", lis_type(scenario, member_type)))
+        .collect();
+    format!(", {}", rendered.join(", "))
+}
+
+fn embed_type(scenario: &Scenario, embed: &Embed) -> String {
+    let target = scenario.node_name(embed.target);
+    match (embed.edge, embed.storage) {
+        (EdgeKind::Value, Storage::Plain) => target.to_string(),
+        (EdgeKind::Pointer, Storage::Plain) => format!("Ref<{target}>"),
+        (EdgeKind::Value, Storage::Option) => format!("Option<{target}>"),
+        (EdgeKind::Pointer, Storage::OptionPointer) => format!("Option<Ref<{target}>>"),
+        (edge, storage) => panic!("invalid embed edge/storage pairing: {edge:?}/{storage:?}"),
+    }
+}
+
+pub fn lis_type(scenario: &Scenario, member_type: &MemberType) -> String {
+    match member_type {
+        MemberType::Basic(basic) => basic.lisette().to_string(),
+        MemberType::Node(id) => scenario.node_name(*id).to_string(),
+        MemberType::Ref(inner) => format!("Ref<{}>", lis_type(scenario, inner)),
+        MemberType::Slice(inner) => format!("Slice<{}>", lis_type(scenario, inner)),
+        MemberType::Option(inner) => format!("Option<{}>", lis_type(scenario, inner)),
+    }
+}
+
+fn lis_zero_construct(scenario: &Scenario, id: NodeId) -> String {
+    let node = scenario.node(id);
+    match &node.kind {
+        NodeKind::Struct { .. } => format!("{} {{ .. }}", node.name),
+        NodeKind::NamedBasic { underlying, .. } => {
+            format!("{}({})", node.name, basic_zero_lit(*underlying))
+        }
+        NodeKind::Interface { .. } => {
+            panic!(
+                "cannot construct interface root `{}` for the build arm",
+                node.name
+            )
+        }
+    }
+}
+
+fn basic_zero_lit(basic: BasicType) -> &'static str {
+    match basic {
+        BasicType::Int | BasicType::Byte | BasicType::Rune => "0",
+        BasicType::Float => "0.0",
+        BasicType::String => "\"\"",
+        BasicType::Bool => "false",
+    }
+}
+
+fn sink_name(interface: &str) -> String {
+    format!("__sink_{interface}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+    use crate::_embed_harness::render_go::{GoMode, render_go};
+
+    fn assert_snap(name: &str, value: String) {
+        insta::with_settings!({ prepend_module_to_snapshot => false, omit_expression => true }, {
+            insta::assert_snapshot!(name, value);
+        });
+    }
+
+    #[test]
+    fn declarations_diamond() {
+        let scenario = fixtures::diamond();
+        assert_snap(
+            "lis_declarations_diamond",
+            render_lis_declarations(&scenario),
+        );
+    }
+
+    #[test]
+    fn declarations_interface() {
+        let scenario = fixtures::interface_direct_satisfaction();
+        assert_snap(
+            "lis_declarations_interface",
+            render_lis_declarations(&scenario),
+        );
+    }
+
+    #[test]
+    fn questions_value_embed() {
+        let scenario = fixtures::value_embed_method();
+        assert_snap(
+            "lis_questions_value_embed",
+            render_lis_questions(&scenario).source,
+        );
+    }
+
+    #[test]
+    fn questions_satisfaction() {
+        let scenario = fixtures::interface_promoted_satisfaction();
+        assert_snap(
+            "lis_questions_satisfaction",
+            render_lis_questions(&scenario).source,
+        );
+    }
+
+    #[test]
+    fn run_direct() {
+        let scenario = fixtures::direct_method();
+        let printed = [PrintedQuestion {
+            root: 0,
+            member: "M".into(),
+        }];
+        assert_snap("lis_run_direct", render_lis_run(&scenario, &printed));
+    }
+
+    #[test]
+    fn question_spans_align() {
+        for scenario in fixtures::all() {
+            let rendered = render_lis_questions(&scenario);
+            assert_eq!(
+                rendered.spans.len(),
+                scenario.questions.len(),
+                "{}: span count mismatch",
+                scenario.name
+            );
+            for (question, span) in scenario.questions.iter().zip(&rendered.spans) {
+                match (question, span) {
+                    (Question::Selector { .. }, QuestionSpans::Selector { range }) => {
+                        check_range(&rendered.source, *range, "__sel_");
+                    }
+                    (Question::Satisfies { .. }, QuestionSpans::Satisfies { value, pointer }) => {
+                        check_range(&rendered.source, *value, "__sat_v_");
+                        check_range(&rendered.source, *pointer, "__sat_p_");
+                    }
+                    _ => panic!("{}: question/span kind mismatch", scenario.name),
+                }
+            }
+        }
+    }
+
+    fn check_range(source: &str, (start, end): (usize, usize), needle: &str) {
+        assert!(start < end && end <= source.len(), "range out of bounds");
+        assert!(
+            source[start..end].contains(needle),
+            "range does not contain `{needle}`"
+        );
+    }
+
+    #[test]
+    fn rendered_lisette_parses() {
+        for scenario in fixtures::all() {
+            let struct_root = scenario.nodes.iter().find(|n| !n.kind.is_interface());
+            let printed: Vec<PrintedQuestion> = struct_root
+                .map(|n| {
+                    vec![PrintedQuestion {
+                        root: n.id,
+                        member: "M".into(),
+                    }]
+                })
+                .unwrap_or_default();
+            for (label, src) in [
+                ("declarations", render_lis_declarations(&scenario)),
+                ("questions", render_lis_questions(&scenario).source),
+                ("run", render_lis_run(&scenario, &printed)),
+            ] {
+                let result = syntax::build_ast(&src, 0);
+                assert!(
+                    !result.failed(),
+                    "{} ({label}) failed to parse: {:?}\n--- source ---\n{src}",
+                    scenario.name,
+                    result.errors
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn multi_member_interface_parses() {
+        let src = "interface N1 {\n  fn C(self) -> bool\n}\n\n\
+                   interface N0 {\n  impl N1\n  fn A(self) -> int\n  fn B(self) -> string\n}\n";
+        let result = syntax::build_ast(src, 0);
+        assert!(
+            !result.failed(),
+            "multi-member interface parse: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn renderers_agree_on_node_names() {
+        for scenario in fixtures::all() {
+            let go = render_go(&scenario, GoMode::TypeDefs);
+            let lis = render_lis_declarations(&scenario);
+            for node in &scenario.nodes {
+                assert!(
+                    go.contains(&node.name) && lis.contains(&node.name),
+                    "{}: renderers disagree on node `{}`",
+                    scenario.name,
+                    node.name
+                );
+            }
+        }
+    }
+}

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -1,0 +1,292 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use deps::TypedefLocator;
+use emit::{EmitOptions, Planner};
+use semantics::analyze::{AnalyzeInput, CompilePhase, SemanticConfig, analyze};
+use semantics::loader::MemoryLoader;
+use semantics::store::ENTRY_MODULE_ID;
+
+use super::PrintedQuestion;
+use super::go_answerer::GoAnswers;
+use super::lisette_answer::{LisetteAnswer, LisetteAnswers};
+use super::render_go::{GoMode, render_go};
+use super::render_lis::render_lis_run;
+use super::scenario::{EdgeKind, MemberType, NodeId, NodeKind, Question, Scenario};
+
+const ENTRY_FILE_ID: u32 = 0;
+const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
+
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// No question was eligible to run on this scenario yet.
+    Skipped,
+    /// Emitted Go and hand-written Go produced identical stdout.
+    Match,
+    /// A divergence or failure; the message explains.
+    Divergence(String),
+}
+
+pub fn run_check(scenario: &Scenario, go: &GoAnswers, lisette: &LisetteAnswers) -> RunOutcome {
+    let printed = runnable_questions(scenario, go, lisette);
+    if printed.is_empty() {
+        return RunOutcome::Skipped;
+    }
+
+    let work_dir = match tempfile::TempDir::new() {
+        Ok(dir) => dir,
+        Err(err) => return RunOutcome::Divergence(format!("temp dir: {err}")),
+    };
+    let work = work_dir.path();
+
+    let emitted = match emit_and_write(scenario, &printed, work) {
+        Ok(Emit::Done(out)) => out,
+        Ok(Emit::NotRunnable(_codes)) => return RunOutcome::Skipped,
+        Err(err) => return RunOutcome::Divergence(format!("emit io: {err}")),
+    };
+    let handwritten = match write_handwritten(scenario, &printed, work) {
+        Ok(out) => out,
+        Err(err) => return RunOutcome::Divergence(format!("handwritten: {err}")),
+    };
+
+    let emitted_out = match go_run(&emitted) {
+        Ok(out) => out,
+        Err(err) => return RunOutcome::Divergence(format!("`go run` (emitted): {err}")),
+    };
+    let handwritten_out = match go_run(&handwritten) {
+        Ok(out) => out,
+        Err(err) => return RunOutcome::Divergence(format!("`go run` (handwritten): {err}")),
+    };
+
+    if emitted_out == handwritten_out {
+        RunOutcome::Match
+    } else {
+        RunOutcome::Divergence(format!(
+            "stdout differs:\n  emitted:     {emitted_out:?}\n  handwritten: {handwritten_out:?}"
+        ))
+    }
+}
+
+/// Selector questions safe to run now: a method both sides resolve, on a
+/// constructible root, at depth 0 (declared directly, so a zero value cannot
+/// nil-dereference through an embed). Promoted calls qualify once promotion is
+/// implemented and receivers can be constructed safely.
+fn runnable_questions(
+    scenario: &Scenario,
+    go: &GoAnswers,
+    lisette: &LisetteAnswers,
+) -> Vec<PrintedQuestion> {
+    let mut printed = Vec::new();
+    for (i, question) in scenario.questions.iter().enumerate() {
+        let Question::Selector { root, member, .. } = question else {
+            continue;
+        };
+        let expected = &go.results[i];
+        let lisette_resolves =
+            matches!(&lisette.questions[i], LisetteAnswer::Selector(o) if o.resolves());
+        if expected.resolves
+            && expected.depth == 0
+            && expected.member_kind == "method"
+            && lisette_resolves
+            && is_zero_constructible(scenario, *root)
+        {
+            printed.push(PrintedQuestion {
+                root: *root,
+                member: member.clone(),
+            });
+        }
+    }
+    printed
+}
+
+/// Whether this node be built as a zero value.
+fn is_zero_constructible(scenario: &Scenario, id: NodeId) -> bool {
+    match &scenario.node(id).kind {
+        NodeKind::NamedBasic { .. } => true,
+        NodeKind::Interface { .. } => false,
+        NodeKind::Struct { fields, embeds, .. } => {
+            fields.iter().all(|field| zeroable(&field.member_type))
+                && embeds.iter().all(|embed| match embed.edge {
+                    EdgeKind::Pointer => false,
+                    EdgeKind::Value => {
+                        matches!(scenario.node(embed.target).kind, NodeKind::Interface { .. })
+                            || is_zero_constructible(scenario, embed.target)
+                    }
+                })
+        }
+    }
+}
+
+fn zeroable(member_type: &MemberType) -> bool {
+    match member_type {
+        MemberType::Ref(_) | MemberType::Node(_) => false,
+        MemberType::Basic(_) | MemberType::Slice(_) | MemberType::Option(_) => true,
+    }
+}
+
+struct GoDir {
+    path: PathBuf,
+}
+
+enum Emit {
+    Done(GoDir),
+    /// The rendered Lisette did not type-check, with the error codes seen.
+    NotRunnable(Vec<String>),
+}
+
+fn emit_and_write(
+    scenario: &Scenario,
+    printed: &[PrintedQuestion],
+    work: &Path,
+) -> Result<Emit, String> {
+    let module = format!("lisette/embed_emitted_{}", scenario.name);
+    let lisette = render_lis_run(scenario, printed);
+    let build = syntax::build_ast(&lisette, ENTRY_FILE_ID);
+    if build.failed() {
+        return Ok(Emit::NotRunnable(vec!["parse".to_string()]));
+    }
+
+    let mut loader = MemoryLoader::new();
+    loader.add_file(ENTRY_MODULE_ID, "main.lis", &lisette);
+    let output = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: false,
+            standalone_mode: false,
+            load_siblings: true,
+        },
+        loader: &loader,
+        source: lisette.clone(),
+        filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
+        ast: build.ast,
+        project_root: None,
+        locator: TypedefLocator::default(),
+        compile_phase: CompilePhase::Emit,
+        go_module: module.clone(),
+        disable_cache: true,
+    });
+    let result = output.result;
+    if !result.errors.is_empty() {
+        let codes = result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str().map(str::to_string))
+            .collect();
+        return Ok(Emit::NotRunnable(codes));
+    }
+
+    let files = Planner::emit(
+        &result.into_emit_input(),
+        &module,
+        EmitOptions { debug: false },
+    );
+    let dir = work.join("emitted");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    for file in &files {
+        fs::write(dir.join(&file.name), file.to_go()).map_err(|e| e.to_string())?;
+    }
+    write_go_mod(&dir, &module, true)?;
+    Ok(Emit::Done(GoDir { path: dir }))
+}
+
+fn write_handwritten(
+    scenario: &Scenario,
+    printed: &[PrintedQuestion],
+    work: &Path,
+) -> Result<GoDir, String> {
+    let module = format!("lisette/embed_hand_{}", scenario.name);
+    let go = render_go(scenario, GoMode::RunMain(printed));
+    let dir = work.join("handwritten");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    fs::write(dir.join("main.go"), go).map_err(|e| e.to_string())?;
+    write_go_mod(&dir, &module, false)?;
+    Ok(GoDir { path: dir })
+}
+
+fn go_run(dir: &GoDir) -> Result<String, String> {
+    let output = Command::new("go")
+        .args(["run", "."])
+        .current_dir(&dir.path)
+        .env("NO_COLOR", "1")
+        .output()
+        .map_err(|e| format!("spawn `go run`: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).into_owned());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn write_go_mod(dir: &Path, module: &str, with_prelude: bool) -> Result<(), String> {
+    let go_version = go_version();
+    let mut content = format!("module {module}\n\ngo {go_version}\n");
+    if with_prelude {
+        let prelude = prelude_dir()
+            .canonicalize()
+            .map_err(|e| format!("canonicalize prelude: {e}"))?;
+        content.push_str(&format!(
+            "\nrequire {PRELUDE_IMPORT_PATH} v0.0.0\n\nreplace {PRELUDE_IMPORT_PATH} => {}\n",
+            prelude.display()
+        ));
+    }
+    fs::write(dir.join("go.mod"), content).map_err(|e| e.to_string())
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("tests crate has a parent")
+        .to_path_buf()
+}
+
+fn prelude_dir() -> PathBuf {
+    repo_root().join("prelude")
+}
+
+fn go_version() -> String {
+    let raw = fs::read_to_string(repo_root().join("go-version")).unwrap_or_else(|_| "1.25".into());
+    let trimmed = raw.trim();
+    let mut parts = trimmed.split('.');
+    let major = parts.next().unwrap_or("1");
+    let minor = parts.next().unwrap_or("25");
+    format!("{major}.{minor}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+    use crate::_embed_harness::go_answerer::{GoAnswerer, go_available};
+    use crate::_embed_harness::lisette_answer::lisette_answers;
+
+    #[test]
+    fn direct_method_runs_identically() {
+        if !go_available() {
+            eprintln!("skipping build-arm test: `go` toolchain not found");
+            return;
+        }
+        let answerer = GoAnswerer::build().expect("answerer builds");
+        let scenario = fixtures::direct_method();
+        let go = answerer.answer(&scenario).unwrap();
+        let lisette = lisette_answers(&scenario);
+        match run_check(&scenario, &go, &lisette) {
+            RunOutcome::Match => {}
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn promotion_scenarios_skip_today() {
+        if !go_available() {
+            return;
+        }
+        let answerer = GoAnswerer::build().expect("answerer builds");
+        let scenario = fixtures::value_embed_method();
+        let go = answerer.answer(&scenario).unwrap();
+        let lisette = lisette_answers(&scenario);
+        assert!(matches!(
+            run_check(&scenario, &go, &lisette),
+            RunOutcome::Skipped
+        ));
+    }
+}

--- a/tests/_embed_harness/runner.rs
+++ b/tests/_embed_harness/runner.rs
@@ -1,0 +1,249 @@
+use super::compare::{Comparison, Verdict, compare};
+use super::go_answerer::GoAnswerer;
+use super::lisette_answer::{LisetteAnswers, lisette_answers};
+use super::run_check::{RunOutcome, run_check};
+use super::scenario::Scenario;
+
+pub struct ScenarioReport {
+    pub name: String,
+    pub seed: u64,
+    pub gate_failure: Option<String>,
+    pub not_comparable: Option<String>,
+    pub comparisons: Vec<Comparison>,
+    pub build: RunOutcome,
+}
+
+pub fn run_scenario(answerer: &GoAnswerer, scenario: &Scenario) -> ScenarioReport {
+    if let Err(err) = scenario.validate() {
+        return gate(scenario, format!("invalid scenario: {err}"));
+    }
+
+    let go = match answerer.answer(scenario) {
+        Ok(answers) => answers,
+        Err(err) => return gate(scenario, format!("answerer query failed: {err}")),
+    };
+    let lisette = lisette_answers(scenario);
+
+    match eligibility(&go, &lisette) {
+        Eligibility::RendererFault(reason) => return gate(scenario, reason),
+        Eligibility::NotComparable(reason) => return not_comparable(scenario, reason),
+        Eligibility::Comparable => {}
+    }
+
+    let comparisons = compare(scenario, &go, &lisette);
+    let build = run_check(scenario, &go, &lisette);
+
+    ScenarioReport {
+        name: scenario.name.clone(),
+        seed: scenario.seed,
+        gate_failure: None,
+        not_comparable: None,
+        comparisons,
+        build,
+    }
+}
+
+enum Eligibility {
+    Comparable,
+    /// A renderer or generator bug: the suite must fail.
+    RendererFault(String),
+    /// A legitimate Lisette declaration rejection: the scenario is skipped.
+    NotComparable(String),
+}
+
+/// Decide whether a scenario can be compared per question. The generated Go must
+/// type-check and the rendered Lisette must parse, or it is a bug. If Lisette
+/// rejects a declaration (e.g. `embed_defined_type`), its answers to unrelated
+/// questions cannot be trusted, so the scenario is skipped rather than compared.
+/// It is skipped, not forced to Incomplete. Forcing it would let a real
+/// over-acceptance hide as a Match.
+fn eligibility(go: &super::go_answerer::GoAnswers, lisette: &LisetteAnswers) -> Eligibility {
+    if let Some(fatal) = &go.fatal_error {
+        return Eligibility::RendererFault(format!(
+            "Go could not parse the generated source: {fatal}"
+        ));
+    }
+    let unexpected: Vec<&String> = go
+        .type_errors
+        .iter()
+        .filter(|err| {
+            !err.contains("duplicate method") && !err.contains("other declaration of method")
+        })
+        .collect();
+    if !unexpected.is_empty() {
+        return Eligibility::RendererFault(format!("unexpected Go type errors: {unexpected:?}"));
+    }
+    if lisette.parse_failed {
+        return Eligibility::RendererFault("rendered Lisette failed to parse".to_string());
+    }
+    let renderer_faults: Vec<&String> = lisette
+        .unattributed
+        .iter()
+        .filter(|code| code.contains("type_not_found") || code.starts_with("parse."))
+        .collect();
+    if !renderer_faults.is_empty() {
+        return Eligibility::RendererFault(format!(
+            "Lisette renderer fault in declarations: {renderer_faults:?}"
+        ));
+    }
+    if !lisette.unattributed.is_empty() {
+        return Eligibility::NotComparable(format!(
+            "Lisette declaration rejection: {:?}",
+            lisette.unattributed
+        ));
+    }
+    Eligibility::Comparable
+}
+
+fn gate(scenario: &Scenario, reason: String) -> ScenarioReport {
+    ScenarioReport {
+        name: scenario.name.clone(),
+        seed: scenario.seed,
+        gate_failure: Some(reason),
+        not_comparable: None,
+        comparisons: vec![],
+        build: RunOutcome::Skipped,
+    }
+}
+
+fn not_comparable(scenario: &Scenario, reason: String) -> ScenarioReport {
+    ScenarioReport {
+        name: scenario.name.clone(),
+        seed: scenario.seed,
+        gate_failure: None,
+        not_comparable: Some(reason),
+        comparisons: vec![],
+        build: RunOutcome::Skipped,
+    }
+}
+
+#[derive(Default)]
+pub struct Summary {
+    pub matches: usize,
+    pub incompletes: usize,
+    /// Scenarios skipped because Lisette rejected a declaration.
+    pub not_comparable: usize,
+    pub gate_failures: Vec<String>,
+    pub over_accepts: Vec<String>,
+    pub build_divergences: Vec<String>,
+}
+
+impl Summary {
+    /// Fraction of decided comparisons where Lisette matches Go; rises as
+    /// promotion is implemented.
+    pub fn acceptance(&self) -> f64 {
+        let decided = self.matches + self.incompletes;
+        if decided == 0 {
+            0.0
+        } else {
+            self.matches as f64 / decided as f64
+        }
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.gate_failures.is_empty()
+            && self.over_accepts.is_empty()
+            && self.build_divergences.is_empty()
+    }
+}
+
+pub fn summarize(reports: &[ScenarioReport]) -> Summary {
+    let mut summary = Summary::default();
+    for report in reports {
+        if let Some(reason) = &report.gate_failure {
+            summary
+                .gate_failures
+                .push(format!("[{} seed={}] {reason}", report.name, report.seed));
+            continue;
+        }
+        if report.not_comparable.is_some() {
+            summary.not_comparable += 1;
+            continue;
+        }
+        for comparison in &report.comparisons {
+            classify(report, comparison, &mut summary);
+        }
+        if let RunOutcome::Divergence(message) = &report.build {
+            summary
+                .build_divergences
+                .push(format!("[{} seed={}] {message}", report.name, report.seed));
+        }
+    }
+    summary
+}
+
+fn classify(report: &ScenarioReport, comparison: &Comparison, summary: &mut Summary) {
+    match &comparison.verdict {
+        Verdict::Match => summary.matches += 1,
+        Verdict::Incomplete => summary.incompletes += 1,
+        Verdict::Gate(reason) => summary
+            .gate_failures
+            .push(format!("[{} seed={}] {reason}", report.name, report.seed)),
+        Verdict::OverAccept(kind) => summary
+            .over_accepts
+            .push(over_accept_line(report, comparison, *kind)),
+    }
+}
+
+fn over_accept_line(
+    report: &ScenarioReport,
+    comparison: &Comparison,
+    kind: super::compare::OverAcceptKind,
+) -> String {
+    format!(
+        "[{} seed={}] question #{} `{}`: {:?} ({})",
+        report.name,
+        report.seed,
+        comparison.question_index,
+        comparison.label,
+        kind,
+        comparison.detail,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::_embed_harness::fixtures;
+    use crate::_embed_harness::go_answerer::go_available;
+    use crate::_embed_harness::random_scenarios::generate;
+
+    #[test]
+    fn generated_sweep_is_sound() {
+        if !go_available() {
+            eprintln!("skipping runner sweep: `go` toolchain not found");
+            return;
+        }
+        let answerer = GoAnswerer::build().expect("answerer builds");
+        let reports: Vec<_> = (0..120)
+            .map(|seed| run_scenario(&answerer, &generate(seed)))
+            .collect();
+        let summary = summarize(&reports);
+        assert!(
+            summary.is_clean(),
+            "generated sweep not clean:\n  gate: {:?}\n  over-accepts: {:?}\n  build: {:?}",
+            summary.gate_failures,
+            summary.over_accepts,
+            summary.build_divergences,
+        );
+    }
+
+    #[test]
+    fn fixtures_run_clean() {
+        if !go_available() {
+            return;
+        }
+        let answerer = GoAnswerer::build().expect("answerer builds");
+        let reports: Vec<_> = fixtures::all()
+            .iter()
+            .map(|scenario| run_scenario(&answerer, scenario))
+            .collect();
+        let summary = summarize(&reports);
+        assert!(
+            summary.is_clean(),
+            "fixtures not clean: {:?}",
+            summary.over_accepts
+        );
+        assert!(summary.matches > 0 && summary.incompletes > 0);
+    }
+}

--- a/tests/_embed_harness/scenario.rs
+++ b/tests/_embed_harness/scenario.rs
@@ -1,0 +1,518 @@
+use serde::{Deserialize, Serialize};
+
+/// A node's identity: its index into [`Scenario::nodes`].
+pub type NodeId = usize;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Scenario {
+    pub name: String,
+    /// 0 for hand-written corpus cases; a generated divergence reproduces from
+    /// `name` + `seed`.
+    pub seed: u64,
+    pub nodes: Vec<Node>,
+    pub questions: Vec<Question>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Node {
+    pub id: NodeId,
+    /// `N{id}`; unique within the scenario by construction.
+    pub name: String,
+    pub kind: NodeKind,
+    pub origin: Origin,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum NodeKind {
+    Struct {
+        fields: Vec<Field>,
+        embeds: Vec<Embed>,
+        methods: Vec<Method>,
+    },
+    Interface {
+        methods: Vec<Method>,
+        /// Go requires embedded interface parents to be interfaces.
+        embeds: Vec<Embed>,
+    },
+    /// A Lisette newtype (`struct Celsius(float64)` plus an `impl`); lowers to a
+    /// named Go scalar with methods.
+    NamedBasic {
+        underlying: BasicType,
+        methods: Vec<Method>,
+    },
+}
+
+/// An anonymous embedded field. No visibility axis: Lisette rejects `pub embed`,
+/// so the field's name and exportedness follow the target type's casing.
+///
+/// `edge` and `storage` are orthogonal so a nilable pointer edge
+/// (`Option<Ref<T>>`) stays representable; folding them would force it to drop
+/// its pointer-ness.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Embed {
+    pub target: NodeId,
+    /// `Value` => `embed T` / `T`; `Pointer` => `embed Ref<T>` / `*T`.
+    pub edge: EdgeKind,
+    /// Pairs with `edge`: `Option` with `Value`, `OptionPointer` with `Pointer`.
+    pub storage: Storage,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EdgeKind {
+    Value,
+    Pointer,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Storage {
+    Plain,
+    /// `Option<T>`: a nilable value edge.
+    Option,
+    /// `Option<Ref<T>>`: a nilable pointer edge.
+    OptionPointer,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Field {
+    pub name: String,
+    pub member_type: MemberType,
+    pub visibility: Visibility,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Method {
+    pub name: String,
+    pub receiver: Receiver,
+    pub signature: Signature,
+    pub visibility: Visibility,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Receiver {
+    Value,
+    Pointer,
+}
+
+/// Concrete methods return `string` (their own qualified name), so when the
+/// generated code runs, its output names the declaration that answered. That is
+/// how we confirm the right member was resolved.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Signature {
+    pub parameters: Vec<MemberType>,
+    pub return_type: MemberType,
+}
+
+/// A closed type universe so both renderers translate it exhaustively.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum MemberType {
+    Basic(BasicType),
+    Node(NodeId),
+    Ref(Box<MemberType>),
+    Slice(Box<MemberType>),
+    Option(Box<MemberType>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BasicType {
+    Int,
+    Float,
+    String,
+    Bool,
+    Byte,
+    Rune,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Visibility {
+    Public,
+    Private,
+}
+
+/// Every node is `Native` today. `Imported` is an unused seam for bindgen-derived
+/// nodes, where only the renderer leaf case and node factory change.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Origin {
+    Native,
+    Imported { pkg: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Question {
+    Selector {
+        root: NodeId,
+        member: String,
+        kind: SelKind,
+    },
+    Satisfies {
+        type_id: NodeId,
+        interface: NodeId,
+    },
+}
+
+/// How a selector question is spelled in Lisette: a render hint (Lisette cannot
+/// uniformly take a method value), not an answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SelKind {
+    Field,
+    Method,
+}
+
+impl Scenario {
+    pub fn node(&self, id: NodeId) -> &Node {
+        &self.nodes[id]
+    }
+
+    pub fn node_name(&self, id: NodeId) -> &str {
+        &self.nodes[id].name
+    }
+
+    /// Invariants the renderers rely on; a failure is a generator/corpus bug.
+    pub fn validate(&self) -> Result<(), String> {
+        for (index, node) in self.nodes.iter().enumerate() {
+            if node.id != index {
+                return Err(format!("node {} has id {}", index, node.id));
+            }
+            for embed in node.kind.embeds() {
+                self.check_node_ref(embed.target, "embed target")?;
+                match (embed.edge, embed.storage) {
+                    (_, Storage::Plain)
+                    | (EdgeKind::Value, Storage::Option)
+                    | (EdgeKind::Pointer, Storage::OptionPointer) => {}
+                    (edge, storage) => {
+                        return Err(format!(
+                            "embed on `{}` pairs {edge:?} edge with {storage:?} storage",
+                            node.name
+                        ));
+                    }
+                }
+                if node.kind.is_interface() && !self.nodes[embed.target].kind.is_interface() {
+                    return Err(format!(
+                        "interface `{}` embeds non-interface `{}`",
+                        node.name,
+                        self.node_name(embed.target)
+                    ));
+                }
+            }
+            for field in node.kind.fields() {
+                check_casing(&field.name, field.visibility, &node.name)?;
+                self.check_member_type(&field.member_type)?;
+            }
+            for method in node.kind.methods() {
+                check_casing(&method.name, method.visibility, &node.name)?;
+                for param in &method.signature.parameters {
+                    self.check_member_type(param)?;
+                }
+                self.check_member_type(&method.signature.return_type)?;
+            }
+        }
+        for question in &self.questions {
+            match question {
+                Question::Selector { root, .. } => self.check_node_ref(*root, "selector root")?,
+                Question::Satisfies { type_id, interface } => {
+                    self.check_node_ref(*type_id, "satisfies type")?;
+                    self.check_node_ref(*interface, "satisfies interface")?;
+                    if !self.nodes[*interface].kind.is_interface() {
+                        return Err(format!(
+                            "satisfies question targets non-interface `{}`",
+                            self.node_name(*interface)
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_node_ref(&self, id: NodeId, what: &str) -> Result<(), String> {
+        if id >= self.nodes.len() {
+            return Err(format!("{what} references out-of-range node {id}"));
+        }
+        Ok(())
+    }
+
+    fn check_member_type(&self, member_type: &MemberType) -> Result<(), String> {
+        match member_type {
+            MemberType::Basic(_) => Ok(()),
+            MemberType::Node(id) => self.check_node_ref(*id, "member type"),
+            MemberType::Ref(inner) | MemberType::Slice(inner) | MemberType::Option(inner) => {
+                self.check_member_type(inner)
+            }
+        }
+    }
+}
+
+impl NodeKind {
+    pub fn embeds(&self) -> &[Embed] {
+        match self {
+            NodeKind::Struct { embeds, .. } | NodeKind::Interface { embeds, .. } => embeds,
+            NodeKind::NamedBasic { .. } => &[],
+        }
+    }
+
+    pub fn methods(&self) -> &[Method] {
+        match self {
+            NodeKind::Struct { methods, .. }
+            | NodeKind::Interface { methods, .. }
+            | NodeKind::NamedBasic { methods, .. } => methods,
+        }
+    }
+
+    pub fn fields(&self) -> &[Field] {
+        match self {
+            NodeKind::Struct { fields, .. } => fields,
+            _ => &[],
+        }
+    }
+
+    pub fn is_interface(&self) -> bool {
+        matches!(self, NodeKind::Interface { .. })
+    }
+}
+
+impl BasicType {
+    pub const ALL: [BasicType; 6] = [
+        BasicType::Int,
+        BasicType::Float,
+        BasicType::String,
+        BasicType::Bool,
+        BasicType::Byte,
+        BasicType::Rune,
+    ];
+
+    /// The Lisette spelling. Lisette names the 64-bit float `float64` (there is
+    /// no `float` type); the others match Go.
+    pub fn lisette(self) -> &'static str {
+        match self {
+            BasicType::Int => "int",
+            BasicType::Float => "float64",
+            BasicType::String => "string",
+            BasicType::Bool => "bool",
+            BasicType::Byte => "byte",
+            BasicType::Rune => "rune",
+        }
+    }
+
+    /// The Go spelling.
+    pub fn go(self) -> &'static str {
+        match self {
+            BasicType::Int => "int",
+            BasicType::Float => "float64",
+            BasicType::String => "string",
+            BasicType::Bool => "bool",
+            BasicType::Byte => "byte",
+            BasicType::Rune => "rune",
+        }
+    }
+}
+
+/// The shared casing accessor both renderers and the generator route through,
+/// so an identifier can never export in one language and not the other. Public
+/// => leading uppercase (exported in Go); Private => leading lowercase.
+pub fn cased(base: &str, visibility: Visibility) -> String {
+    let mut chars = base.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let rest: String = chars.collect();
+    match visibility {
+        Visibility::Public => format!("{}{}", first.to_uppercase(), rest),
+        Visibility::Private => format!("{}{}", first.to_lowercase(), rest),
+    }
+}
+
+fn check_casing(name: &str, visibility: Visibility, owner: &str) -> Result<(), String> {
+    let Some(first) = name.chars().next() else {
+        return Err(format!("empty member name on `{owner}`"));
+    };
+    let exported = first.is_uppercase();
+    let want_exported = matches!(visibility, Visibility::Public);
+    if exported != want_exported {
+        return Err(format!(
+            "member `{name}` on `{owner}` has casing inconsistent with its visibility"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Touches every variant.
+    fn kitchen_sink() -> Scenario {
+        let leaf = Node {
+            id: 0,
+            name: "N0".into(),
+            kind: NodeKind::NamedBasic {
+                underlying: BasicType::Float,
+                methods: vec![Method {
+                    name: cased("m0", Visibility::Public),
+                    receiver: Receiver::Value,
+                    signature: Signature {
+                        parameters: vec![],
+                        return_type: MemberType::Basic(BasicType::String),
+                    },
+                    visibility: Visibility::Public,
+                }],
+            },
+            origin: Origin::Native,
+        };
+
+        let interface = Node {
+            id: 1,
+            name: "N1".into(),
+            kind: NodeKind::Interface {
+                methods: vec![Method {
+                    name: cased("speak", Visibility::Public),
+                    receiver: Receiver::Value,
+                    signature: Signature {
+                        parameters: vec![],
+                        return_type: MemberType::Basic(BasicType::Int),
+                    },
+                    visibility: Visibility::Public,
+                }],
+                embeds: vec![],
+            },
+            origin: Origin::Imported {
+                pkg: "go:fmt".into(),
+            },
+        };
+
+        let outer = Node {
+            id: 2,
+            name: "N2".into(),
+            kind: NodeKind::Struct {
+                fields: vec![
+                    Field {
+                        name: cased("count", Visibility::Public),
+                        member_type: MemberType::Basic(BasicType::Int),
+                        visibility: Visibility::Public,
+                    },
+                    Field {
+                        name: cased("nested", Visibility::Private),
+                        member_type: MemberType::Slice(Box::new(MemberType::Ref(Box::new(
+                            MemberType::Option(Box::new(MemberType::Node(0))),
+                        )))),
+                        visibility: Visibility::Private,
+                    },
+                ],
+                embeds: vec![
+                    Embed {
+                        target: 0,
+                        edge: EdgeKind::Value,
+                        storage: Storage::Plain,
+                    },
+                    Embed {
+                        target: 1,
+                        edge: EdgeKind::Value,
+                        storage: Storage::Option,
+                    },
+                ],
+                methods: vec![Method {
+                    name: cased("own", Visibility::Private),
+                    receiver: Receiver::Pointer,
+                    signature: Signature {
+                        parameters: vec![MemberType::Basic(BasicType::Byte)],
+                        return_type: MemberType::Basic(BasicType::String),
+                    },
+                    visibility: Visibility::Private,
+                }],
+            },
+            origin: Origin::Native,
+        };
+
+        let pointer_embedder = Node {
+            id: 3,
+            name: "N3".into(),
+            kind: NodeKind::Struct {
+                fields: vec![],
+                embeds: vec![Embed {
+                    target: 2,
+                    edge: EdgeKind::Pointer,
+                    storage: Storage::OptionPointer,
+                }],
+                methods: vec![],
+            },
+            origin: Origin::Native,
+        };
+
+        Scenario {
+            name: "kitchen_sink".into(),
+            seed: 0,
+            nodes: vec![leaf, interface, outer, pointer_embedder],
+            questions: vec![
+                Question::Selector {
+                    root: 3,
+                    member: "M0".into(),
+                    kind: SelKind::Method,
+                },
+                Question::Satisfies {
+                    type_id: 2,
+                    interface: 1,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let scenario = kitchen_sink();
+        let json = serde_json::to_string(&scenario).expect("serialize");
+        let back: Scenario = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(scenario, back);
+    }
+
+    #[test]
+    fn kitchen_sink_validates() {
+        kitchen_sink()
+            .validate()
+            .expect("kitchen sink is a valid scenario");
+    }
+
+    #[test]
+    fn validate_rejects_bad_id() {
+        let mut scenario = kitchen_sink();
+        scenario.nodes[1].id = 99;
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_casing_visibility_mismatch() {
+        let mut scenario = kitchen_sink();
+        if let NodeKind::Struct { fields, .. } = &mut scenario.nodes[2].kind {
+            fields[0].name = "count".into();
+            fields[0].visibility = Visibility::Public;
+        }
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_interface_embedding_struct() {
+        let mut scenario = kitchen_sink();
+        if let NodeKind::Interface { embeds, .. } = &mut scenario.nodes[1].kind {
+            embeds.push(Embed {
+                target: 2,
+                edge: EdgeKind::Value,
+                storage: Storage::Plain,
+            });
+        }
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_storage_edge_mismatch() {
+        let mut scenario = kitchen_sink();
+        if let NodeKind::Struct { embeds, .. } = &mut scenario.nodes[2].kind {
+            embeds[0].edge = EdgeKind::Value;
+            embeds[0].storage = Storage::OptionPointer;
+        }
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn basic_type_spellings() {
+        assert_eq!(BasicType::Float.lisette(), "float64");
+        assert_eq!(BasicType::Float.go(), "float64");
+        assert_eq!(BasicType::ALL.len(), 6);
+    }
+}

--- a/tests/_embed_harness/snapshots/go_declarations_diamond.snap
+++ b/tests/_embed_harness/snapshots/go_declarations_diamond.snap
@@ -1,0 +1,23 @@
+---
+source: tests/_embed_harness/render_go.rs
+---
+package p
+
+type N0 struct {
+}
+func (r N0) M() string {
+	return "N0.M"
+}
+
+type N1 struct {
+	N0
+}
+
+type N2 struct {
+	N0
+}
+
+type N3 struct {
+	N1
+	N2
+}

--- a/tests/_embed_harness/snapshots/go_declarations_interface.snap
+++ b/tests/_embed_harness/snapshots/go_declarations_interface.snap
@@ -1,0 +1,14 @@
+---
+source: tests/_embed_harness/render_go.rs
+---
+package p
+
+type N0 interface {
+	Speak() string
+}
+
+type N1 struct {
+}
+func (r N1) Speak() string {
+	return "N1.Speak"
+}

--- a/tests/_embed_harness/snapshots/go_run_direct.snap
+++ b/tests/_embed_harness/snapshots/go_run_direct.snap
@@ -1,0 +1,19 @@
+---
+source: tests/_embed_harness/render_go.rs
+---
+package main
+
+import "fmt"
+
+type N0 struct {
+}
+func (r N0) M() string {
+	return "N0.M"
+}
+
+func main() {
+	{
+		var r N0
+		fmt.Println(r.M())
+	}
+}

--- a/tests/_embed_harness/snapshots/lis_declarations_diamond.snap
+++ b/tests/_embed_harness/snapshots/lis_declarations_diamond.snap
@@ -1,0 +1,22 @@
+---
+source: tests/_embed_harness/render_lis.rs
+---
+struct N0 {}
+impl N0 {
+  fn M(self) -> string {
+    "N0.M"
+  }
+}
+
+struct N1 {
+  embed N0,
+}
+
+struct N2 {
+  embed N0,
+}
+
+struct N3 {
+  embed N1,
+  embed N2,
+}

--- a/tests/_embed_harness/snapshots/lis_declarations_interface.snap
+++ b/tests/_embed_harness/snapshots/lis_declarations_interface.snap
@@ -1,0 +1,13 @@
+---
+source: tests/_embed_harness/render_lis.rs
+---
+interface N0 {
+  fn Speak(self) -> string
+}
+
+struct N1 {}
+impl N1 {
+  fn Speak(self) -> string {
+    "N1.Speak"
+  }
+}

--- a/tests/_embed_harness/snapshots/lis_questions_satisfaction.snap
+++ b/tests/_embed_harness/snapshots/lis_questions_satisfaction.snap
@@ -1,0 +1,28 @@
+---
+source: tests/_embed_harness/render_lis.rs
+---
+interface N0 {
+  fn Speak(self) -> string
+}
+
+struct N1 {}
+impl N1 {
+  fn Speak(self) -> string {
+    "N1.Speak"
+  }
+}
+
+struct N2 {
+  embed N1,
+}
+
+fn __sink_N0(_v: N0) {
+}
+
+fn __sat_v_0(x: N2) {
+  __sink_N0(x)
+}
+
+fn __sat_p_0(x: Ref<N2>) {
+  __sink_N0(x)
+}

--- a/tests/_embed_harness/snapshots/lis_questions_value_embed.snap
+++ b/tests/_embed_harness/snapshots/lis_questions_value_embed.snap
@@ -1,0 +1,17 @@
+---
+source: tests/_embed_harness/render_lis.rs
+---
+struct N0 {}
+impl N0 {
+  fn M(self) -> string {
+    "N0.M"
+  }
+}
+
+struct N1 {
+  embed N0,
+}
+
+fn __sel_0(r: N1) {
+  let _ = r.M()
+}

--- a/tests/_embed_harness/snapshots/lis_run_direct.snap
+++ b/tests/_embed_harness/snapshots/lis_run_direct.snap
@@ -1,0 +1,16 @@
+---
+source: tests/_embed_harness/render_lis.rs
+---
+import "go:fmt"
+
+struct N0 {}
+impl N0 {
+  fn M(self) -> string {
+    "N0.M"
+  }
+}
+
+fn main() {
+  let r0 = N0 { .. }
+  fmt.Println(r0.M())
+}

--- a/tests/embed_diff.rs
+++ b/tests/embed_diff.rs
@@ -1,0 +1,65 @@
+//! Differential tests for Go-style struct and interface embedding. Each test
+//! builds a small graph of embedded types, renders it to both Go and Lisette,
+//! and checks that Lisette resolves member access and interface satisfaction
+//! the same way Go does. Lisette may reject what Go accepts as promotion is
+//! yet to be built, but Lisette must never accept what Go rejects.
+
+mod _embed_harness;
+
+use _embed_harness::corpus::differential_scenarios;
+use _embed_harness::go_answerer::{GoAnswerer, go_available};
+use _embed_harness::random_scenarios::generate;
+use _embed_harness::runner::{run_scenario, summarize};
+
+/// Override with `EMBED_DIFF_N` for a deeper sweep.
+const DEFAULT_SEEDS: u64 = 200;
+
+#[test]
+fn embed_differential() {
+    if !go_available() {
+        eprintln!("SKIP embed_differential: the `go` toolchain is required but was not found");
+        return;
+    }
+
+    let answerer = GoAnswerer::build().expect("the go/types answerer builds");
+    let seeds: u64 = std::env::var("EMBED_DIFF_N")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_SEEDS);
+
+    let mut reports = Vec::new();
+    for scenario in differential_scenarios() {
+        reports.push(run_scenario(&answerer, &scenario));
+    }
+    for seed in 0..seeds {
+        reports.push(run_scenario(&answerer, &generate(seed)));
+    }
+
+    let summary = summarize(&reports);
+
+    eprintln!("embed differential: {} scenarios", reports.len());
+    eprintln!(
+        "  match={} incomplete={} not_comparable={}",
+        summary.matches, summary.incompletes, summary.not_comparable
+    );
+    eprintln!("  agreement with Go: {:.1}%", summary.acceptance() * 100.0);
+
+    // Lisette rejecting what Go accepts (Incomplete) is expected while promotion
+    // is unimplemented, but accepting what Go rejects is a real bug. Gate
+    // failures and build divergences are faults in the harness or codegen.
+    assert!(
+        summary.over_accepts.is_empty(),
+        "OVER-ACCEPTANCE: Lisette accepts what Go rejects (each reproducible from its seed):\n{}",
+        summary.over_accepts.join("\n"),
+    );
+    assert!(
+        summary.gate_failures.is_empty(),
+        "harness gate failures (renderer/answerer integrity):\n{}",
+        summary.gate_failures.join("\n"),
+    );
+    assert!(
+        summary.build_divergences.is_empty(),
+        "emit-and-build divergences (emitted Go misbehaves vs hand-written):\n{}",
+        summary.build_divergences.join("\n"),
+    );
+}

--- a/tests/embed_go_answerer/go.mod
+++ b/tests/embed_go_answerer/go.mod
@@ -1,0 +1,3 @@
+module lisette/embed_go_answerer
+
+go 1.25

--- a/tests/embed_go_answerer/main.go
+++ b/tests/embed_go_answerer/main.go
@@ -1,0 +1,270 @@
+// Command embed_go_answerer type-checks a generated Go package with go/types and
+// answers selector and satisfaction questions (LookupFieldOrMethod, Implements,
+// AssignableTo). Protocol: a JSON Request on stdin, a JSON Response on stdout.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+)
+
+type Request struct {
+	GoSource  string     `json:"goSource"`
+	Questions []Question `json:"questions"`
+}
+
+type Question struct {
+	Kind      string `json:"kind"` // "selector" | "satisfies"
+	Root      string `json:"root"`
+	Member    string `json:"member"`
+	TypeName  string `json:"typeName"`
+	Interface string `json:"interface"`
+}
+
+type Response struct {
+	// FatalError is set only when the package could not be parsed at all; a
+	// type error (e.g. a deliberate duplicate-method interface) is reported in
+	// TypeErrors and does not stop question answering.
+	FatalError string   `json:"fatalError,omitempty"`
+	TypeErrors []string `json:"typeErrors,omitempty"`
+	Results    []Answer `json:"results"`
+}
+
+type Answer struct {
+	Kind string `json:"kind"`
+
+	// selector
+	Resolves      bool           `json:"resolves"`
+	Ambiguous     bool           `json:"ambiguous"`
+	MemberKind    string         `json:"memberKind,omitempty"`
+	DeclaringType string         `json:"declaringType,omitempty"`
+	Depth         int            `json:"depth"`
+	Indirect      bool           `json:"indirect"`
+	ResolvedType  *CanonicalType `json:"resolvedType,omitempty"`
+
+	// satisfies
+	SatisfiesValue   bool `json:"satisfiesValue"`
+	SatisfiesPointer bool `json:"satisfiesPointer"`
+	Assignable       bool `json:"assignable"`
+}
+
+// CanonicalType is a language-neutral type token both sides lower into, so the Rust
+// comparator never string-compares Go and Lisette spellings.
+type CanonicalType struct {
+	Kind       string           `json:"kind"` // "basic"|"named"|"ref"|"slice"|"func"|"other"
+	Name       string           `json:"name,omitempty"`
+	Element    *CanonicalType   `json:"element,omitempty"`
+	Parameters []*CanonicalType `json:"parameters,omitempty"`
+	ReturnType *CanonicalType   `json:"returnType,omitempty"`
+}
+
+func main() {
+	var req Request
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		writeResponse(Response{FatalError: fmt.Sprintf("decode request: %v", err)})
+		return
+	}
+	writeResponse(run(req))
+}
+
+func writeResponse(resp Response) {
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(resp); err != nil {
+		fmt.Fprintf(os.Stderr, "encode response: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(req Request) Response {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", req.GoSource, 0)
+	if err != nil {
+		return Response{FatalError: fmt.Sprintf("parse: %v", err)}
+	}
+
+	var typeErrors []string
+	conf := types.Config{
+		Importer: importer.Default(),
+		// Collect but do not abort: a deliberately malformed interface still
+		// answers every other question.
+		Error: func(err error) { typeErrors = append(typeErrors, err.Error()) },
+	}
+	pkg, _ := conf.Check("p", fset, []*ast.File{file}, nil)
+
+	results := make([]Answer, 0, len(req.Questions))
+	for _, question := range req.Questions {
+		switch question.Kind {
+		case "selector":
+			results = append(results, selectorAnswer(pkg, question))
+		case "satisfies":
+			results = append(results, satisfiesAnswer(pkg, question))
+		default:
+			results = append(results, Answer{Kind: question.Kind})
+		}
+	}
+	return Response{TypeErrors: typeErrors, Results: results}
+}
+
+func selectorAnswer(pkg *types.Package, question Question) Answer {
+	res := Answer{Kind: "selector"}
+	root := lookupNamed(pkg, question.Root)
+	if root == nil {
+		return res
+	}
+	obj, index, indirect := types.LookupFieldOrMethod(root, true, pkg, question.Member)
+	if obj == nil {
+		// go/types signals ambiguity by returning a non-nil index path with a
+		// nil object; a nil index means simply not found.
+		res.Ambiguous = index != nil
+		return res
+	}
+	res.Resolves = true
+	// index is the embedded fields traversed plus the final member step, so the
+	// embedding depth (0 == declared directly on root) is len(index)-1.
+	res.Depth = len(index) - 1
+	res.Indirect = indirect
+	switch o := obj.(type) {
+	case *types.Var:
+		res.MemberKind = "field"
+		res.ResolvedType = canonical(o.Type())
+		res.DeclaringType = fieldDeclaringType(root, index)
+	case *types.Func:
+		res.MemberKind = "method"
+		res.ResolvedType = canonical(o.Type())
+		res.DeclaringType = methodDeclaringType(o)
+	}
+	return res
+}
+
+func satisfiesAnswer(pkg *types.Package, question Question) Answer {
+	res := Answer{Kind: "satisfies"}
+	subject := lookupNamed(pkg, question.TypeName)
+	interfaceType := lookupNamed(pkg, question.Interface)
+	if subject == nil || interfaceType == nil {
+		return res
+	}
+	underlying, ok := interfaceType.Underlying().(*types.Interface)
+	if !ok {
+		return res
+	}
+	res.SatisfiesValue = types.Implements(subject, underlying)
+	res.SatisfiesPointer = types.Implements(types.NewPointer(subject), underlying)
+	res.Assignable = types.AssignableTo(subject, interfaceType)
+	return res
+}
+
+func lookupNamed(pkg *types.Package, name string) *types.Named {
+	if pkg == nil {
+		return nil
+	}
+	obj := pkg.Scope().Lookup(name)
+	if obj == nil {
+		return nil
+	}
+	tn, ok := obj.(*types.TypeName)
+	if !ok {
+		return nil
+	}
+	named, _ := tn.Type().(*types.Named)
+	return named
+}
+
+func methodDeclaringType(fn *types.Func) string {
+	signature, ok := fn.Type().(*types.Signature)
+	if !ok || signature.Recv() == nil {
+		return ""
+	}
+	return namedName(signature.Recv().Type())
+}
+
+// fieldDeclaringType walks the embedding index to the struct that declares the
+// field (everything but the last index step navigates embedded fields).
+func fieldDeclaringType(root types.Type, index []int) string {
+	if len(index) == 0 {
+		return ""
+	}
+	cur := root
+	for _, step := range index[:len(index)-1] {
+		st := structOf(cur)
+		if st == nil || step >= st.NumFields() {
+			return ""
+		}
+		cur = st.Field(step).Type()
+	}
+	return namedName(cur)
+}
+
+func structOf(t types.Type) *types.Struct {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	if named, ok := t.(*types.Named); ok {
+		t = named.Underlying()
+	}
+	st, _ := t.(*types.Struct)
+	return st
+}
+
+func namedName(t types.Type) string {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	if named, ok := t.(*types.Named); ok {
+		return named.Obj().Name()
+	}
+	return ""
+}
+
+func canonical(t types.Type) *CanonicalType {
+	switch u := t.(type) {
+	case *types.Basic:
+		return &CanonicalType{Kind: "basic", Name: basicName(u)}
+	case *types.Named:
+		return &CanonicalType{Kind: "named", Name: u.Obj().Name()}
+	case *types.Pointer:
+		return &CanonicalType{Kind: "ref", Element: canonical(u.Elem())}
+	case *types.Slice:
+		return &CanonicalType{Kind: "slice", Element: canonical(u.Elem())}
+	case *types.Signature:
+		c := &CanonicalType{Kind: "func"}
+		for i := 0; i < u.Params().Len(); i++ {
+			c.Parameters = append(c.Parameters, canonical(u.Params().At(i).Type()))
+		}
+		switch u.Results().Len() {
+		case 0:
+			c.ReturnType = &CanonicalType{Kind: "basic", Name: "unit"}
+		case 1:
+			c.ReturnType = canonical(u.Results().At(0).Type())
+		default:
+			c.ReturnType = &CanonicalType{Kind: "other", Name: "tuple"}
+		}
+		return c
+	default:
+		return &CanonicalType{Kind: "other", Name: t.String()}
+	}
+}
+
+func basicName(b *types.Basic) string {
+	switch b.Kind() {
+	case types.Int:
+		return "int"
+	case types.Float64:
+		return "float"
+	case types.String:
+		return "string"
+	case types.Bool:
+		return "bool"
+	case types.Uint8: // byte
+		return "byte"
+	case types.Int32: // rune
+		return "rune"
+	default:
+		return b.Name()
+	}
+}


### PR DESCRIPTION
Lis will be adding Go-style embedding, where one type absorbs another type's fields and methods. These promotion rules are intricate and easy to get subtly wrong, which would lead to Lis accepting code that Go would reject.

This PR adds a test harness that checks Lisette's embedding behavior against Go itself. We generate many small embedding scenarios, render each one to both Go and Lisette, ask Go's own type checker (`go/types`) for the correct answer, and verify that Lis resolves member access and interface satisfaction the same way. This harness is the executable spec that the upcoming implementation will be written to pass.

Groundwork for #581