### PR TITLE
feat: support embedding in native structs

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -938,6 +938,26 @@ pub fn member_not_found(
     diagnostic
 }
 
+pub fn ambiguous_selector(
+    ty: &Type,
+    member: &str,
+    sources: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    let from = sources.join("` and `");
+    LisetteDiagnostic::error("Ambiguous member")
+        .with_infer_code("ambiguous_selector")
+        .with_span_label(
+            &span,
+            format!("`{}` is promoted from more than one embed", member),
+        )
+        .with_help(format!(
+            "`{}` is promoted into `{}` from `{}`, so the selection is ambiguous. \
+             Reach it through the embedded field that declares the one you want.",
+            member, ty, from
+        ))
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum UnwrapWrapper {
     Option,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -9,6 +9,7 @@ use syntax::types::{Symbol, Type, substitute, unqualified_name};
 use super::super::addressability::check_is_non_addressable;
 use super::primitives::contains_deref;
 use crate::checker::infer::InferCtx;
+use crate::promotion::{self, MemberKind, Resolution};
 
 impl InferCtx<'_, '_> {
     pub(super) fn infer_dot_access_or_qualified_path(
@@ -239,6 +240,7 @@ impl InferCtx<'_, '_> {
 
         let resolved = self
             .as_struct_field(&args)
+            .or_else(|| self.as_promoted_field(&args))
             .or_else(|| self.as_tuple_element(&args))
             .or_else(|| self.as_module_member(&args))
             .or_else(|| self.as_enum_variant(&args))
@@ -266,6 +268,24 @@ impl InferCtx<'_, '_> {
                 ));
             }
             return expression;
+        }
+
+        if promotion::has_direct_embed(self.store, &args.deref_ty)
+            && let Resolution::Ambiguous { sources } =
+                promotion::resolve_selector(self.store, &args.deref_ty, &member)
+        {
+            let names: Vec<String> = sources
+                .iter()
+                .map(|s| s.last_segment().to_string())
+                .collect();
+            self.sink.push(diagnostics::infer::ambiguous_selector(
+                &args.deref_ty,
+                &member,
+                &names,
+                span,
+            ));
+            self.unify(expected_ty, &Type::Error, &span);
+            return args.build_dot_access(Type::Error, None, None);
         }
 
         let available_members = self.get_available_member_names(&resolved_expression_ty);
@@ -479,6 +499,57 @@ impl InferCtx<'_, '_> {
         Some((args.build_dot_access(field_ty, Some(kind), None), kind))
     }
 
+    fn as_promoted_field(
+        &mut self,
+        args: &DotAccessResolutionArgs,
+    ) -> Option<(Expression, DotAccessKind)> {
+        let store = self.store;
+        if !matches!(args.deref_ty, Type::Nominal { .. })
+            || !promotion::has_direct_embed(store, &args.deref_ty)
+        {
+            return None;
+        }
+
+        let Resolution::Found(member) =
+            promotion::resolve_selector(store, &args.deref_ty, args.member_name)
+        else {
+            return None;
+        };
+        let MemberKind::Field {
+            ty: field_ty,
+            visibility,
+        } = member.kind
+        else {
+            return None;
+        };
+
+        if let Some(field) = store
+            .fields_of(member.declaring_type.as_str())
+            .and_then(|fields| fields.iter().find(|f| f.name == args.member_name))
+        {
+            self.facts.add_usage(*args.span, field.name_span);
+        }
+
+        let declaring_module = store
+            .module_for_qualified_name(member.declaring_type.as_str())
+            .unwrap_or_else(|| member.declaring_type.as_str());
+        let is_cross_module = declaring_module != self.cursor.module_id;
+        if is_cross_module && !visibility.is_public() {
+            self.sink.push(diagnostics::infer::private_field_access(
+                args.member_name,
+                args.deref_ty.get_qualified_name().as_str(),
+                *args.span,
+            ));
+        }
+
+        self.unify(args.expected_ty, &field_ty, args.span);
+
+        let kind = DotAccessKind::StructField {
+            is_exported: visibility.is_public() || is_cross_module,
+        };
+        Some((args.build_dot_access(field_ty, Some(kind), None), kind))
+    }
+
     fn as_tuple_element(
         &mut self,
         args: &DotAccessResolutionArgs,
@@ -674,21 +745,34 @@ impl InferCtx<'_, '_> {
     ) {
         let store = self.store;
         if let Type::Nominal { .. } = deref_ty {
-            let qualified_name = deref_ty.get_qualified_name();
-            let method_key = qualified_name.with_segment(args.member_name);
+            let outer = deref_ty.get_qualified_name();
+            let direct_key = outer.with_segment(args.member_name);
+
+            let declaring = if store.get_definition(&direct_key).is_some()
+                || !promotion::has_direct_embed(store, deref_ty)
+            {
+                outer
+            } else if let Resolution::Found(member) =
+                promotion::resolve_selector(store, deref_ty, args.member_name)
+            {
+                member.declaring_type
+            } else {
+                outer
+            };
+            let method_key = declaring.with_segment(args.member_name);
 
             if let Some(definition_span) = self.get_definition_name_span(store, &method_key) {
                 self.facts.add_usage(*args.span, definition_span);
             }
 
-            if self.is_foreign_type(&qualified_name)
+            if self.is_foreign_type(&declaring)
                 && let Some(def) = store.get_definition(&method_key)
                 && matches!(def.body, DefinitionBody::Value { .. })
                 && !def.visibility.is_public()
             {
                 self.sink.push(diagnostics::infer::private_method_access(
                     args.member_name,
-                    &qualified_name,
+                    &declaring,
                     *args.span,
                 ));
             }

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::facts::{BindingIdAllocator, Facts};
+use crate::promotion;
 use crate::store::Store;
 use diagnostics::LocalSink;
 use ecow::EcoString;
@@ -555,18 +556,25 @@ impl<'s> TaskState<'s> {
             return Rc::new(store.get_all_methods(&peeled, &empty));
         }
 
-        if let Some(cached) = self.method_cache.borrow().get(cache_key.as_str()) {
+        let is_embedder = promotion::has_direct_embed(store, &resolved);
+        let is_generic = matches!(&resolved, Type::Nominal { params, .. } if !params.is_empty());
+        let cacheable = !(is_embedder && is_generic);
+
+        if cacheable && let Some(cached) = self.method_cache.borrow().get(cache_key.as_str()) {
             return cached.clone();
         }
 
-        let empty = HashMap::default();
-        // Pass the env-resolved type so the store's env-less `resolve()` stays
-        // identity-safe: `Type::Var` chains are chased once here rather than
-        // silently returning empty methods in the store.
-        let methods = Rc::new(store.get_all_methods(&resolved, &empty));
-        self.method_cache
-            .borrow_mut()
-            .insert(cache_key, methods.clone());
+        let methods = if is_embedder {
+            Rc::new(promotion::promoted_method_set(store, &resolved))
+        } else {
+            let empty = HashMap::default();
+            Rc::new(store.get_all_methods(&resolved, &empty))
+        };
+        if cacheable {
+            self.method_cache
+                .borrow_mut()
+                .insert(cache_key, methods.clone());
+        }
         methods
     }
 

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -4,7 +4,7 @@ use syntax::ast::{
     Visibility as SyntacticVisibility,
 };
 use syntax::program::{Definition, DefinitionBody, Interface, Visibility};
-use syntax::types::{Symbol, Type, unqualified_name};
+use syntax::types::{Symbol, Type, build_substitution_map, substitute, unqualified_name};
 
 use super::{extract_attribute_flags, has_recursive_instantiation, wrap_with_impl_generics};
 use crate::checker::TaskState;
@@ -482,21 +482,27 @@ impl TaskState<'_> {
         let mut method_visited = rustc_hash::FxHashSet::default();
 
         for parent_ty in &interface.parents {
-            if let Some(parent_id) = parent_ty.get_qualified_id() {
-                let parent_name = unqualified_name(parent_id);
-                self.collect_interface_methods(
-                    store,
-                    parent_id,
-                    parent_name,
-                    &mut inherited_methods,
-                    &mut method_visited,
-                );
-            }
+            let parent_name = parent_ty
+                .get_qualified_id()
+                .map(unqualified_name)
+                .unwrap_or_default();
+            self.collect_interface_methods(
+                store,
+                parent_ty,
+                parent_name,
+                &mut inherited_methods,
+                &mut method_visited,
+            );
         }
 
-        // Check for conflicts: same method name with different types from different sources
         let mut seen: rustc_hash::FxHashMap<String, (Type, String)> =
             rustc_hash::FxHashMap::default();
+        for (method_name, method_ty) in &interface.methods {
+            seen.insert(
+                method_name.to_string(),
+                (method_ty.clone(), interface_name.to_string()),
+            );
+        }
         for (method_name, method_ty, source) in &inherited_methods {
             if let Some((existing_ty, existing_source)) = seen.get(method_name) {
                 if existing_ty != method_ty {
@@ -555,36 +561,45 @@ impl TaskState<'_> {
     fn collect_interface_methods(
         &self,
         store: &Store,
-        interface_id: &str,
+        interface_ty: &Type,
         source_name: &str,
         methods: &mut Vec<(String, Type, String)>,
         visited: &mut rustc_hash::FxHashSet<String>,
     ) {
-        if !visited.insert(interface_id.to_string()) {
+        let Some(interface_id) = interface_ty.get_qualified_id() else {
+            return;
+        };
+        let type_args = interface_ty.get_type_params().unwrap_or_default();
+
+        let key = if type_args.is_empty() {
+            interface_id.to_string()
+        } else {
+            let args: Vec<String> = type_args.iter().map(Type::to_string).collect();
+            format!("{interface_id}<{}>", args.join(","))
+        };
+        if !visited.insert(key) {
             return;
         }
 
-        if let Some(interface) = store.get_interface(interface_id) {
-            for (method_name, method_ty) in &interface.methods {
-                methods.push((
-                    method_name.to_string(),
-                    method_ty.clone(),
-                    source_name.to_string(),
-                ));
-            }
+        let Some(interface) = store.get_interface(interface_id) else {
+            return;
+        };
+        let map = build_substitution_map(&interface.generics, type_args);
+        for (method_name, method_ty) in &interface.methods {
+            methods.push((
+                method_name.to_string(),
+                substitute(method_ty, &map),
+                source_name.to_string(),
+            ));
+        }
 
-            for parent_ty in &interface.parents {
-                if let Some(parent_id) = parent_ty.get_qualified_id() {
-                    let parent_simple = unqualified_name(parent_id);
-                    self.collect_interface_methods(
-                        store,
-                        parent_id,
-                        parent_simple,
-                        methods,
-                        visited,
-                    );
-                }
-            }
+        for parent_ty in &interface.parents {
+            let instantiated = substitute(parent_ty, &map);
+            let parent_name = instantiated
+                .get_qualified_id()
+                .map(unqualified_name)
+                .unwrap_or(source_name);
+            self.collect_interface_methods(store, &instantiated, parent_name, methods, visited);
         }
     }
 

--- a/crates/semantics/src/lib.rs
+++ b/crates/semantics/src/lib.rs
@@ -11,6 +11,7 @@ pub mod module_graph;
 pub mod passes;
 pub mod path;
 pub mod prelude;
+pub mod promotion;
 pub mod store;
 
 use syntax::ast::Expression;

--- a/crates/semantics/src/promotion.rs
+++ b/crates/semantics/src/promotion.rs
@@ -1,0 +1,688 @@
+use ecow::EcoString;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::collections::BTreeMap;
+
+use syntax::ast::Visibility;
+use syntax::program::MethodSignatures;
+use syntax::types::{CompoundKind, Symbol, Type};
+
+use crate::store::Store;
+
+#[derive(Clone, Debug)]
+pub enum MemberKind {
+    Field {
+        ty: Type,
+        visibility: Visibility,
+    },
+    /// `ty` already carries the effective receiver: value embeds keep the
+    /// declared receiver, promoted methods are re-pointed at the embedder.
+    Method {
+        ty: Type,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedMember {
+    pub name: EcoString,
+    pub depth: usize,
+    pub embed_path: Vec<EcoString>,
+    pub declaring_type: Symbol,
+    pub indirect: bool,
+    pub kind: MemberKind,
+}
+
+#[derive(Clone, Debug)]
+pub enum Resolution {
+    Found(ResolvedMember),
+    Ambiguous { sources: Vec<Symbol> },
+    NotFound,
+}
+
+pub fn has_direct_embed(store: &Store, ty: &Type) -> bool {
+    let Type::Nominal { id, .. } = store.deep_resolve_alias(&ty.strip_refs()) else {
+        return false;
+    };
+    store
+        .fields_of(id.as_str())
+        .is_some_and(|fields| fields.iter().any(|f| f.embedded))
+}
+
+pub fn resolve_selector(store: &Store, outer: &Type, name: &str) -> Resolution {
+    let entries = walk(store, outer);
+    resolve_in_entries(store, &entries, outer, name)
+}
+
+pub fn promoted_method_set(store: &Store, outer: &Type) -> MethodSignatures {
+    let entries = walk(store, outer);
+
+    let mut names: HashSet<EcoString> = HashSet::default();
+    for entry in &entries {
+        collect_member_names(store, &entry.ty, &mut names);
+    }
+
+    let mut result = MethodSignatures::default();
+    for name in names {
+        if let Resolution::Found(member) = resolve_in_entries(store, &entries, outer, &name)
+            && let MemberKind::Method { ty } = member.kind
+        {
+            result.insert(name, ty);
+        }
+    }
+    result
+}
+
+#[derive(Clone)]
+struct Entry {
+    ty: Type,
+    depth: usize,
+    /// A pointer edge was crossed on the path to this subobject.
+    indirect: bool,
+    /// Reached by more than one path at this depth, so its members collide.
+    multiples: bool,
+    embed_path: Vec<EcoString>,
+}
+
+fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
+    let mut visited: Vec<Entry> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::default();
+
+    let Some(root) = nominal_entry(store, outer.clone(), 0, false, false, Vec::new()) else {
+        return visited;
+    };
+    let mut current = vec![root];
+    let mut depth = 0;
+
+    while !current.is_empty() {
+        let mut next: Vec<Entry> = Vec::new();
+
+        for entry in &current {
+            // Seen at a shallower depth: shadows here, and breaks cycles.
+            if !seen.insert(type_key(&entry.ty)) {
+                continue;
+            }
+            visited.push(entry.clone());
+
+            // Interfaces contribute their method set but have no fields to descend.
+            let Some(id) = entry.ty.get_qualified_id() else {
+                continue;
+            };
+            if store.get_interface(id).is_some() {
+                continue;
+            }
+            let Some(fields) = store.fields_of(id) else {
+                continue;
+            };
+            for field in fields {
+                if !field.embedded {
+                    continue;
+                }
+                // Resolve aliases first so an alias to `Ref<T>` peels as a pointer edge.
+                let resolved_field = store.deep_resolve_alias(&field.ty);
+                let (target, is_pointer) = deref_once(&resolved_field);
+                let mut path = entry.embed_path.clone();
+                path.push(field.name.clone());
+                if let Some(child) = nominal_entry(
+                    store,
+                    target,
+                    depth + 1,
+                    entry.indirect || is_pointer,
+                    entry.multiples,
+                    path,
+                ) {
+                    next.push(child);
+                }
+            }
+        }
+
+        current = consolidate(next);
+        depth += 1;
+    }
+
+    visited
+}
+
+/// Resolve `name` to its shallowest candidate; a lone non-`multiples` hit wins,
+/// anything else is ambiguous.
+fn resolve_in_entries(store: &Store, entries: &[Entry], outer: &Type, name: &str) -> Resolution {
+    let mut by_depth: BTreeMap<usize, Vec<(&Entry, Candidate)>> = BTreeMap::new();
+    for entry in entries {
+        if let Some(candidate) = entry_candidate(store, &entry.ty, name) {
+            by_depth
+                .entry(entry.depth)
+                .or_default()
+                .push((entry, candidate));
+        }
+    }
+
+    let Some((_, candidates)) = by_depth.into_iter().next() else {
+        return Resolution::NotFound;
+    };
+
+    if let [(entry, candidate)] = candidates.as_slice()
+        && !entry.multiples
+    {
+        return Resolution::Found(build_member(outer, name, entry, candidate));
+    }
+
+    let mut sources: Vec<Symbol> = candidates
+        .iter()
+        .map(|(_, c)| c.declaring_type.clone())
+        .collect();
+    sources.sort();
+    sources.dedup();
+    Resolution::Ambiguous { sources }
+}
+
+struct Candidate {
+    declaring_type: Symbol,
+    detail: CandidateDetail,
+}
+
+enum CandidateDetail {
+    Field { ty: Type, visibility: Visibility },
+    Method { ty: Type },
+}
+
+/// The field or method a type declares under `name`. A method shadows a
+/// same-named field, as gc checks attached methods first.
+fn entry_candidate(store: &Store, ty: &Type, name: &str) -> Option<Candidate> {
+    let id = ty.get_qualified_id()?;
+
+    if store.get_interface(id).is_some() {
+        let methods = store.get_all_methods(ty, &Default::default());
+        let method_ty = methods.get(name)?.clone();
+        return Some(Candidate {
+            declaring_type: Symbol::from_raw(id),
+            detail: CandidateDetail::Method { ty: method_ty },
+        });
+    }
+
+    if let Some(method_ty) = store.get_own_methods(id).and_then(|m| m.get(name)) {
+        return Some(Candidate {
+            declaring_type: Symbol::from_raw(id),
+            detail: CandidateDetail::Method {
+                ty: method_ty.clone(),
+            },
+        });
+    }
+
+    if let Some(field) = store
+        .fields_of(id)
+        .and_then(|fields| fields.iter().find(|f| f.name == name))
+    {
+        return Some(Candidate {
+            declaring_type: Symbol::from_raw(id),
+            detail: CandidateDetail::Field {
+                ty: field.ty.clone(),
+                visibility: field.visibility,
+            },
+        });
+    }
+
+    None
+}
+
+fn build_member(outer: &Type, name: &str, entry: &Entry, candidate: &Candidate) -> ResolvedMember {
+    let kind = match &candidate.detail {
+        CandidateDetail::Field { ty, visibility } => MemberKind::Field {
+            ty: ty.clone(),
+            visibility: *visibility,
+        },
+        CandidateDetail::Method { ty } => {
+            // Only promoted methods are re-pointed; a depth-0 receiver is already
+            // the outer type, and rewriting it would break generics. A promoted
+            // method stays pointer-only when its receiver is a pointer and no
+            // pointer edge was crossed.
+            let method_ty = if entry.depth == 0 {
+                ty.clone()
+            } else if !entry.indirect && method_has_pointer_receiver(ty) {
+                ty.with_replaced_first_param(&ref_of(outer))
+            } else {
+                ty.with_replaced_first_param(outer)
+            };
+            MemberKind::Method { ty: method_ty }
+        }
+    };
+
+    ResolvedMember {
+        name: name.into(),
+        depth: entry.depth,
+        embed_path: entry.embed_path.clone(),
+        declaring_type: candidate.declaring_type.clone(),
+        indirect: entry.indirect,
+        kind,
+    }
+}
+
+/// Every field and method name a type exposes.
+fn collect_member_names(store: &Store, ty: &Type, names: &mut HashSet<EcoString>) {
+    let Some(id) = ty.get_qualified_id() else {
+        return;
+    };
+    if store.get_interface(id).is_some() {
+        for key in store.get_all_methods(ty, &Default::default()).keys() {
+            names.insert(key.clone());
+        }
+        return;
+    }
+    if let Some(methods) = store.get_own_methods(id) {
+        for key in methods.keys() {
+            names.insert(key.clone());
+        }
+    }
+    if let Some(fields) = store.fields_of(id) {
+        for field in fields {
+            names.insert(field.name.clone());
+        }
+    }
+}
+
+/// Build an entry for `target` if it resolves (through aliases) to a nominal type.
+fn nominal_entry(
+    store: &Store,
+    target: Type,
+    depth: usize,
+    indirect: bool,
+    multiples: bool,
+    embed_path: Vec<EcoString>,
+) -> Option<Entry> {
+    let resolved = store.deep_resolve_alias(&target);
+    if !matches!(resolved, Type::Nominal { .. }) {
+        return None;
+    }
+    Some(Entry {
+        ty: resolved,
+        depth,
+        indirect,
+        multiples,
+        embed_path,
+    })
+}
+
+/// gc's `consolidateMultiples`: dedup by type, flagging any reached by more than
+/// one path so its members resolve as ambiguous.
+fn consolidate(list: Vec<Entry>) -> Vec<Entry> {
+    let mut result: Vec<Entry> = Vec::with_capacity(list.len());
+    let mut index_of: HashMap<String, usize> = HashMap::default();
+    for entry in list {
+        let key = type_key(&entry.ty);
+        if let Some(&i) = index_of.get(&key) {
+            result[i].multiples = true;
+        } else {
+            index_of.insert(key, result.len());
+            result.push(entry);
+        }
+    }
+    result
+}
+
+/// Type identity for `seen`/`multiples`: qualified id plus any type arguments.
+fn type_key(ty: &Type) -> String {
+    match ty {
+        Type::Nominal { id, params, .. } if params.is_empty() => id.as_str().to_string(),
+        Type::Nominal { id, params, .. } => {
+            let args: Vec<String> = params.iter().map(type_key).collect();
+            format!("{}<{}>", id, args.join(","))
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Strip one `Ref`, reporting whether it was present (a pointer edge).
+fn deref_once(ty: &Type) -> (Type, bool) {
+    if ty.is_ref() {
+        (ty.inner().unwrap_or(Type::Error), true)
+    } else {
+        (ty.clone(), false)
+    }
+}
+
+fn method_has_pointer_receiver(method_ty: &Type) -> bool {
+    let body = match method_ty {
+        Type::Forall { body, .. } => body.as_ref(),
+        other => other,
+    };
+    matches!(body, Type::Function(f) if f.params.first().is_some_and(Type::is_ref))
+}
+
+fn ref_of(ty: &Type) -> Type {
+    Type::Compound {
+        kind: CompoundKind::Ref,
+        args: vec![ty.clone()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::ast::{Annotation, Span, StructFieldDefinition, StructKind};
+    use syntax::program::Visibility as ProgVis;
+    use syntax::program::{Attributes, Definition, DefinitionBody, Interface};
+
+    const MODULE: &str = "m";
+
+    fn nominal(name: &str) -> Type {
+        Type::Nominal {
+            id: Symbol::from_parts(MODULE, name),
+            params: vec![],
+            underlying_ty: None,
+        }
+    }
+
+    fn value_method(owner: &str) -> Type {
+        Type::function(
+            vec![nominal(owner)],
+            vec![false],
+            vec![],
+            Box::new(Type::string()),
+        )
+    }
+
+    fn pointer_method(owner: &str) -> Type {
+        Type::function(
+            vec![ref_of(&nominal(owner))],
+            vec![false],
+            vec![],
+            Box::new(Type::string()),
+        )
+    }
+
+    /// An interface method as stored after registration: receiver already stripped.
+    fn interface_method() -> Type {
+        Type::function(vec![], vec![], vec![], Box::new(Type::string()))
+    }
+
+    fn field(name: &str, ty: Type, embedded: bool) -> StructFieldDefinition {
+        StructFieldDefinition {
+            doc: None,
+            attributes: vec![],
+            name: name.into(),
+            name_span: Span::dummy(),
+            annotation: Annotation::Unknown,
+            visibility: Visibility::Public,
+            ty,
+            embedded,
+        }
+    }
+
+    struct Builder {
+        store: Store,
+    }
+
+    impl Builder {
+        fn new() -> Self {
+            let mut store = Store::new();
+            store.add_module(MODULE);
+            Builder { store }
+        }
+
+        fn insert(&mut self, name: &str, body: DefinitionBody) -> &mut Self {
+            let def = Definition {
+                visibility: ProgVis::Public,
+                ty: nominal(name),
+                name: Some(name.into()),
+                name_span: None,
+                doc: None,
+                body,
+            };
+            self.store
+                .get_module_mut(MODULE)
+                .unwrap()
+                .definitions
+                .insert(Symbol::from_parts(MODULE, name), def);
+            self
+        }
+
+        fn struct_(
+            &mut self,
+            name: &str,
+            fields: Vec<StructFieldDefinition>,
+            methods: Vec<(&str, Type)>,
+        ) -> &mut Self {
+            let mut method_map = MethodSignatures::default();
+            for (n, t) in methods {
+                method_map.insert(n.into(), t);
+            }
+            self.insert(
+                name,
+                DefinitionBody::Struct {
+                    generics: vec![],
+                    fields,
+                    kind: StructKind::Record,
+                    methods: method_map,
+                    constructor: None,
+                    attributes: Attributes::default(),
+                },
+            )
+        }
+
+        fn interface(&mut self, name: &str, methods: Vec<&str>, parents: Vec<&str>) -> &mut Self {
+            let mut method_map = MethodSignatures::default();
+            for n in methods {
+                method_map.insert(n.into(), interface_method());
+            }
+            self.insert(
+                name,
+                DefinitionBody::Interface {
+                    definition: Interface {
+                        name: name.into(),
+                        generics: vec![],
+                        parents: parents.into_iter().map(nominal).collect(),
+                        methods: method_map,
+                    },
+                },
+            )
+        }
+    }
+
+    fn vembed(target: &str) -> StructFieldDefinition {
+        field(target, nominal(target), true)
+    }
+
+    fn pembed(target: &str) -> StructFieldDefinition {
+        field(target, ref_of(&nominal(target)), true)
+    }
+
+    fn found(resolution: Resolution) -> ResolvedMember {
+        match resolution {
+            Resolution::Found(member) => member,
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    fn is_pointer_receiver(member: &ResolvedMember) -> bool {
+        match &member.kind {
+            MemberKind::Method { ty } => ty.get_function_params().unwrap()[0].is_ref(),
+            other => panic!("expected a method, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn direct_method_at_depth_zero() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        let member = found(resolve_selector(&b.store, &nominal("N0"), "m"));
+        assert_eq!(member.depth, 0);
+        assert!(!is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn value_embed_promotes_value_method() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "m"));
+        assert_eq!(member.depth, 1);
+        assert_eq!(member.embed_path, vec![EcoString::from("N0")]);
+        assert!(!member.indirect);
+        assert!(!is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn value_embed_of_pointer_method_is_pointer_only() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("pm", pointer_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "pm"));
+        assert!(!member.indirect);
+        assert!(is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn pointer_embed_puts_pointer_method_in_value_set() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("pm", pointer_method("N0"))]);
+        b.struct_("N1", vec![pembed("N0")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "pm"));
+        assert!(member.indirect);
+        assert!(!is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn pointer_embed_of_value_method_is_value() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![pembed("N0")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "m"));
+        assert!(member.indirect);
+        assert!(!is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn diamond_is_ambiguous() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        b.struct_("N2", vec![vembed("N0")], vec![]);
+        b.struct_("N3", vec![vembed("N1"), vembed("N2")], vec![]);
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("N3"), "m"),
+            Resolution::Ambiguous { .. }
+        ));
+    }
+
+    #[test]
+    fn shallower_path_shadows_deeper_diamond() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        b.struct_("N3", vec![vembed("N0"), vembed("N1")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N3"), "m"));
+        assert_eq!(member.depth, 1);
+    }
+
+    #[test]
+    fn own_member_shadows_promoted() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![("m", value_method("N1"))]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "m"));
+        assert_eq!(member.depth, 0);
+        assert_eq!(member.declaring_type.as_str(), "m.N1");
+    }
+
+    #[test]
+    fn field_promotes() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![field("f", Type::int(), false)], vec![]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N1"), "f"));
+        assert_eq!(member.depth, 1);
+        assert!(matches!(member.kind, MemberKind::Field { .. }));
+    }
+
+    #[test]
+    fn field_and_method_collide_across_embeds() {
+        let mut b = Builder::new();
+        b.struct_("A", vec![field("x", Type::int(), false)], vec![]);
+        b.struct_("B", vec![], vec![("x", value_method("B"))]);
+        b.struct_("N2", vec![vembed("A"), vembed("B")], vec![]);
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("N2"), "x"),
+            Resolution::Ambiguous { .. }
+        ));
+    }
+
+    #[test]
+    fn pointer_cycle_terminates_and_resolves() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![pembed("N1")], vec![("a", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![("bb", value_method("N1"))]);
+        assert_eq!(
+            found(resolve_selector(&b.store, &nominal("N0"), "a")).depth,
+            0
+        );
+        assert_eq!(
+            found(resolve_selector(&b.store, &nominal("N0"), "bb")).depth,
+            1
+        );
+        assert_eq!(
+            found(resolve_selector(&b.store, &nominal("N1"), "a")).depth,
+            1
+        );
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("N0"), "absent"),
+            Resolution::NotFound
+        ));
+    }
+
+    #[test]
+    fn embedded_interface_promotes_value_callable() {
+        let mut b = Builder::new();
+        b.interface("I", vec!["speak"], vec![]);
+        b.struct_("N2", vec![vembed("I")], vec![]);
+        let member = found(resolve_selector(&b.store, &nominal("N2"), "speak"));
+        assert_eq!(member.depth, 1);
+        assert!(!is_pointer_receiver(&member));
+    }
+
+    #[test]
+    fn struct_embedding_interface_and_struct_with_same_method_is_ambiguous() {
+        let mut b = Builder::new();
+        b.interface("I", vec!["speak"], vec![]);
+        b.struct_("S", vec![], vec![("speak", value_method("S"))]);
+        b.struct_("N2", vec![vembed("I"), vembed("S")], vec![]);
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("N2"), "speak"),
+            Resolution::Ambiguous { .. }
+        ));
+        assert!(!promoted_method_set(&b.store, &nominal("N2")).contains_key("speak"));
+    }
+
+    #[test]
+    fn method_set_includes_promoted_excludes_ambiguous() {
+        let mut b = Builder::new();
+        b.struct_(
+            "N0",
+            vec![],
+            vec![("m", value_method("N0")), ("pm", pointer_method("N0"))],
+        );
+        b.struct_("N1", vec![vembed("N0")], vec![("o", value_method("N1"))]);
+        let set = promoted_method_set(&b.store, &nominal("N1"));
+        assert!(set.contains_key("o"));
+        assert!(set.contains_key("m"));
+        assert!(set.contains_key("pm"));
+        assert!(!set.get("m").unwrap().get_function_params().unwrap()[0].is_ref());
+        assert!(set.get("pm").unwrap().get_function_params().unwrap()[0].is_ref());
+    }
+
+    #[test]
+    fn method_set_drops_ambiguous_diamond_member() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        b.struct_("N2", vec![vembed("N0")], vec![]);
+        b.struct_("N3", vec![vembed("N1"), vembed("N2")], vec![]);
+        assert!(!promoted_method_set(&b.store, &nominal("N3")).contains_key("m"));
+    }
+
+    #[test]
+    fn has_direct_embed_detects_embeds() {
+        let mut b = Builder::new();
+        b.struct_("N0", vec![field("f", Type::int(), false)], vec![]);
+        b.struct_("N1", vec![vembed("N0")], vec![]);
+        assert!(!has_direct_embed(&b.store, &nominal("N0")));
+        assert!(has_direct_embed(&b.store, &nominal("N1")));
+        assert!(has_direct_embed(&b.store, &ref_of(&nominal("N1"))));
+    }
+}

--- a/docs/reference/06-structs-and-enums.md
+++ b/docs/reference/06-structs-and-enums.md
@@ -99,6 +99,33 @@ Private fields can only be accessed within the same module. Use `pub struct` to 
 
 📚 See [`12-modules.md`](12-modules.md) and [`15-attributes.md`](15-attributes.md)
 
+### Embedding
+
+A struct can embed another struct. This makes the inner struct's methods and fields accessible directly on the outer struct:
+
+```rust
+struct Logger {
+  pub prefix: string,
+}
+
+impl Logger {
+  pub fn log(self) -> string { self.prefix }
+}
+
+struct Server {
+  embed Logger, // brings in `prefix` and `log`
+  pub port: int,
+}
+
+let l = Logger { prefix: "[api]" }
+let s = Server { Logger: l, port: 8080 }
+
+let _ = s.prefix // `Server` accesses `Logger` field directly
+let _ = s.log() // `Server` accesses `Logger` method directly
+```
+
+An embedded type must be a non-generic struct defined in Lisette. Embedding use cases will be expanded in future.
+
 ## Enums
 
 An enum defines a type with a fixed set of variants.

--- a/tests/_embed_harness/compare.rs
+++ b/tests/_embed_harness/compare.rs
@@ -100,13 +100,18 @@ pub fn compare(scenario: &Scenario, go: &GoAnswers, lisette: &LisetteAnswers) ->
 }
 
 fn compare_selector(go: &GoAnswer, lisette: &Outcome) -> Verdict {
-    match (go.resolves, go.ambiguous, lisette.resolves()) {
-        (true, _, true) => Verdict::Match,
-        (true, _, false) => Verdict::Incomplete,
-        (false, false, false) => Verdict::Match,
-        (false, false, true) => Verdict::OverAccept(OverAcceptKind::ResolvesButGoRejects),
-        (false, true, false) => Verdict::Incomplete,
-        (false, true, true) => Verdict::OverAccept(OverAcceptKind::PickedOneWhereGoAmbiguous),
+    match (go.resolves, go.ambiguous) {
+        (true, _) if lisette.resolves() => Verdict::Match,
+        (true, _) => Verdict::Incomplete,
+        (false, false) if lisette.resolves() => {
+            Verdict::OverAccept(OverAcceptKind::ResolvesButGoRejects)
+        }
+        (false, false) => Verdict::Match,
+        (false, true) if lisette.resolves() => {
+            Verdict::OverAccept(OverAcceptKind::PickedOneWhereGoAmbiguous)
+        }
+        (false, true) if lisette.is_ambiguous() => Verdict::Match,
+        (false, true) => Verdict::Incomplete,
     }
 }
 
@@ -180,22 +185,22 @@ mod tests {
     }
 
     #[test]
-    fn promoted_method_is_incomplete() {
+    fn promoted_method_matches() {
         let Some(answerer) = answerer_or_skip() else {
             return;
         };
         assert_eq!(
             only(&fixtures::value_embed_method(), &answerer),
-            Verdict::Incomplete
+            Verdict::Match
         );
     }
 
     #[test]
-    fn diamond_is_incomplete_not_over_accept() {
+    fn diamond_matches_go_ambiguity() {
         let Some(answerer) = answerer_or_skip() else {
             return;
         };
-        assert_eq!(only(&fixtures::diamond(), &answerer), Verdict::Incomplete);
+        assert_eq!(only(&fixtures::diamond(), &answerer), Verdict::Match);
     }
 
     #[test]
@@ -210,13 +215,13 @@ mod tests {
     }
 
     #[test]
-    fn promoted_satisfaction_is_incomplete() {
+    fn promoted_satisfaction_matches() {
         let Some(answerer) = answerer_or_skip() else {
             return;
         };
         assert_eq!(
             only(&fixtures::interface_promoted_satisfaction(), &answerer),
-            Verdict::Incomplete
+            Verdict::Match
         );
     }
 

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -28,6 +28,10 @@ impl Outcome {
     pub fn has_code(&self, code: &str) -> bool {
         matches!(self, Outcome::Rejects { codes } if codes.iter().any(|c| c == code))
     }
+
+    pub fn is_ambiguous(&self) -> bool {
+        self.has_code("infer.ambiguous_selector")
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -223,20 +227,20 @@ mod tests {
     }
 
     #[test]
-    fn promoted_method_is_rejected_today() {
-        let outcome = selector_outcome(&fixtures::value_embed_method());
-        assert!(
-            outcome.has_code("infer.member_not_found"),
-            "expected member_not_found, got {outcome:?}"
+    fn promoted_method_resolves() {
+        assert_eq!(
+            selector_outcome(&fixtures::value_embed_method()),
+            Outcome::Resolves,
+            "a value-embedded method must promote"
         );
     }
 
     #[test]
-    fn diamond_selector_is_rejected_today() {
+    fn diamond_selector_is_ambiguous() {
         let outcome = selector_outcome(&fixtures::diamond());
         assert!(
-            !outcome.resolves(),
-            "diamond promotion must not resolve yet"
+            outcome.is_ambiguous(),
+            "diamond promotion must report ambiguity, got {outcome:?}"
         );
     }
 
@@ -249,11 +253,11 @@ mod tests {
     }
 
     #[test]
-    fn promoted_satisfaction_is_rejected_today() {
-        let outcome = satisfies_value(&fixtures::interface_promoted_satisfaction());
-        assert!(
-            outcome.has_code("infer.interface_not_implemented"),
-            "expected interface_not_implemented, got {outcome:?}"
+    fn promoted_satisfaction_resolves() {
+        assert_eq!(
+            satisfies_value(&fixtures::interface_promoted_satisfaction()),
+            Outcome::Resolves,
+            "a value embedding the declarer must satisfy the interface"
         );
     }
 

--- a/tests/_embed_harness/runner.rs
+++ b/tests/_embed_harness/runner.rs
@@ -244,6 +244,10 @@ mod tests {
             "fixtures not clean: {:?}",
             summary.over_accepts
         );
-        assert!(summary.matches > 0 && summary.incompletes > 0);
+        assert!(summary.matches > 0);
+        assert_eq!(
+            summary.incompletes, 0,
+            "a base fixture regressed to incomplete"
+        );
     }
 }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -4252,7 +4252,7 @@ fn take(c: C) {}
 fn main() { take(S {}) }
 "#,
     );
-    infer_module("main", fs).assert_infer_code("interface_not_implemented");
+    infer_module("main", fs).assert_infer_code("interface_method_conflict");
 }
 
 #[test]
@@ -6295,6 +6295,34 @@ fn main() {
 }
 
 #[test]
+fn promoted_member_resolves_across_modules() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "types",
+        "lib.lis",
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+pub struct Outer { embed Base }
+pub fn make() -> Outer { Outer { Base: Base { id: 1 } } }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "types"
+fn main() {
+  let o = types.make()
+  let _ = o.describe()
+  let _ = o.id
+}
+"#,
+    );
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
 fn embed_value_struct_accepted() {
     infer(
         r#"
@@ -6347,6 +6375,289 @@ fn main() {
 "#,
     )
     .assert_no_errors();
+}
+
+#[test]
+fn promoted_method_resolves_through_value_embed() {
+    infer(
+        r#"
+struct Base { pub id: int }
+impl Base { fn describe(self) -> string { "b" } }
+struct Outer { embed Base }
+fn use_it(o: Outer) -> string { o.describe() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_field_resolves_through_value_embed() {
+    infer(
+        r#"
+struct Base { pub id: int }
+struct Outer { embed Base, pub tag: string }
+fn read_id(o: Outer) -> int { o.id }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_member_resolves_two_levels_deep() {
+    infer(
+        r#"
+struct Leaf { pub value: int }
+impl Leaf { fn shout(self) -> string { "x" } }
+struct Mid { embed Leaf }
+struct Top { embed Mid }
+fn use_it(t: Top) -> string { t.shout() }
+fn read(t: Top) -> int { t.value }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn own_method_shadows_promoted() {
+    infer(
+        r#"
+struct Base { pub id: int }
+impl Base { fn name(self) -> string { "base" } }
+struct Outer { embed Base }
+impl Outer { fn name(self) -> string { "outer" } }
+fn use_it(o: Outer) -> string { o.name() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn diamond_promotion_is_ambiguous() {
+    infer(
+        r#"
+struct A { pub x: int }
+impl A { fn m(self) -> string { "a" } }
+struct B { embed A }
+struct C { embed A }
+struct D { embed B, embed C }
+fn use_it(d: D) -> string { d.m() }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("ambiguous_selector");
+}
+
+#[test]
+fn ambiguous_field_and_method_collision() {
+    infer(
+        r#"
+struct A { pub x: int }
+struct B {}
+impl B { fn x(self) -> string { "b" } }
+struct Outer { embed A, embed B }
+fn use_it(o: Outer) -> int { o.x }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("ambiguous_selector");
+}
+
+#[test]
+fn value_embed_satisfies_interface_via_promotion() {
+    infer(
+        r#"
+pub interface Speaker { fn speak(self) -> string }
+struct Base {}
+impl Base { pub fn speak(self) -> string { "hi" } }
+struct Outer { embed Base }
+fn take(s: Speaker) -> string { s.speak() }
+fn main() {
+  let _ = take(Outer { Base: Base {} })
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn pointer_embed_promotes_pointer_receiver_method_as_value_callable() {
+    infer(
+        r#"
+pub interface Bumper { fn bump(self) -> int }
+struct Counter { pub n: int }
+impl Counter { pub fn bump(self: Ref<Counter>) -> int { self.n } }
+struct Holder { embed Ref<Counter> }
+fn take(b: Bumper) -> int { b.bump() }
+fn main() {
+  let _ = take(Holder { Counter: &Counter { n: 0 } })
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_method_through_alias_to_ref_embed() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+type P = Ref<Base>
+struct S { embed P }
+fn use_it(s: S) -> string { s.describe() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn interface_local_method_conflicts_with_parent() {
+    infer(
+        r#"
+interface P { fn m(self) -> string }
+interface Q {
+  embed P
+  fn m(self) -> int
+}
+fn main() {}
+"#,
+    )
+    .assert_infer_code("interface_method_conflict");
+}
+
+#[test]
+fn ambiguous_selector_through_ref_receiver() {
+    infer(
+        r#"
+struct A { pub x: int }
+impl A { fn m(self) -> string { "a" } }
+struct B { embed A }
+struct C { embed A }
+struct D { embed B, embed C }
+fn f(r: Ref<D>) -> string { r.m() }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("ambiguous_selector");
+}
+
+#[test]
+fn generic_own_method_through_embedder_keeps_receiver_return_link() {
+    infer(
+        r#"
+struct Base { pub id: int }
+struct Outer<T> { embed Base, pub value: T }
+impl<T> Outer<T> { fn get(self) -> T { self.value } }
+fn f() -> int {
+  let o = Outer { Base: Base { id: 1 }, value: "s" }
+  o.get()
+}
+fn main() {}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn promoted_method_on_distinct_generic_instantiations() {
+    infer(
+        r#"
+struct Base { pub id: int }
+impl Base { fn describe(self) -> string { "b" } }
+struct Outer<T> { embed Base, pub value: T }
+fn main() {
+  let oi = Outer { Base: Base { id: 1 }, value: 1 }
+  let os = Outer { Base: Base { id: 1 }, value: "s" }
+  let _ = oi.describe()
+  let _ = os.describe()
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn interface_diamond_matching_type_args_is_fine() {
+    infer(
+        r#"
+interface Base<T> { fn get(self) -> T }
+interface Left { embed Base<int> }
+interface Right { embed Base<int> }
+interface Q {
+  embed Left
+  embed Right
+}
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_member_through_alias_to_embedder() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+struct Outer { embed Base, pub tag: string }
+type A = Outer
+fn promoted_method(a: A) -> string { a.describe() }
+fn promoted_field(a: A) -> int { a.id }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn cross_module_promoted_private_method_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "types",
+        "lib.lis",
+        r#"
+struct Base { pub id: int }
+impl Base { fn secret(self) -> int { 1 } }
+pub struct Outer { embed Base }
+pub fn make() -> Outer { Outer { Base: Base { id: 1 } } }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "types"
+fn main() {
+  let o = types.make()
+  let _ = o.secret()
+}
+"#,
+    );
+    infer_module("main", fs).assert_resolve_code("private_method_access");
+}
+
+#[test]
+fn value_embed_of_pointer_receiver_method_does_not_satisfy_by_value() {
+    // The promoted `bump` keeps its pointer receiver, so a value `Holder` is not
+    // in the interface's value method set; only `Ref<Holder>` satisfies.
+    infer(
+        r#"
+pub interface Bumper { fn bump(self) -> int }
+struct Counter { pub n: int }
+impl Counter { pub fn bump(self: Ref<Counter>) -> int { self.n } }
+struct Holder { embed Counter }
+fn take(b: Bumper) -> int { b.bump() }
+fn main() {
+  let _ = take(Holder { Counter: Counter { n: 0 } })
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
 }
 
 #[test]


### PR DESCRIPTION
Adds member promotion for embedded structs. A struct can now embed another struct, so the inner type's methods and fields become accessible directly on the outer struct.

```rs
struct Logger {
  pub prefix: string,
}

impl Logger {
  pub fn log(self) -> string { self.prefix }
}

struct Server {
  embed Logger,
  pub port: int,
}

let l = Logger { prefix: "[api]" }
let s = Server { Logger: l, port: 8080 }
let _ = s.prefix //  `Server` accesses `Logger` field directly
let _ = s.log()  // `Server` accesses `Logger` method directly
```

This is only a first step! This PR adds support for embedding non-generic structs defined in Lis only. Many cases are not supported yet, e.g. embedding a generic type, embedding imported Go types, embedding a defined type over a struct or scalar. Unsupported cases lead to a compile error and will be unlocked in future.

Relates to #581