### PR TITLE
feat: hover and go-to-definition on promoted members

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -938,6 +938,17 @@ pub fn member_not_found(
     diagnostic
 }
 
+pub fn promoted_method_expression(member: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Unsupported method expression")
+        .with_infer_code("promoted_method_expression")
+        .with_span_label(&span, format!("`{}` is a promoted method", member))
+        .with_help(format!(
+            "A method expression on a promoted method is not supported. Call it on a \
+             value (`v.{}(...)`) or reach it through the embedded field.",
+            member
+        ))
+}
+
 pub fn ambiguous_selector(
     ty: &Type,
     member: &str,

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -69,6 +69,7 @@ pub(crate) fn resolve_struct_call_field(
 pub(crate) fn resolve_dot_access_definition(
     expression: &Expression,
     member: &str,
+    dot_access_span: Span,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<syntax::ast::Span> {
@@ -159,7 +160,14 @@ pub(crate) fn resolve_dot_access_definition(
         None
     };
 
-    result.or_else(resolve_by_type)
+    result.or_else(resolve_by_type).or_else(|| {
+        snapshot
+            .facts()
+            .usages
+            .iter()
+            .find(|usage| usage.usage_span == dot_access_span)
+            .map(|usage| usage.definition_span)
+    })
 }
 
 /// True when the span points into a generated `go:` typedef file. Used by rename

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -533,8 +533,9 @@ pub(crate) fn get_hover_doc(
         Expression::DotAccess {
             expression: base,
             member,
+            span,
             ..
-        } => resolve_dot_access_definition(base, member, file, snapshot)
+        } => resolve_dot_access_definition(base, member, *span, file, snapshot)
             .and_then(|span| find_doc_at_definition_span(span, snapshot))
             .or_else(|| resolve_dot_access_doc(base, member, file, snapshot)),
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -307,8 +307,11 @@ impl LanguageServer for Backend {
             }
 
             syntax::ast::Expression::DotAccess {
-                expression, member, ..
-            } => resolve_dot_access_definition(expression, member, file, &snapshot),
+                expression,
+                member,
+                span,
+                ..
+            } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
 
             syntax::ast::Expression::StructCall {
                 name,
@@ -586,8 +589,11 @@ impl LanguageServer for Backend {
                     .and_then(|d| d.name_span()),
 
                 syntax::ast::Expression::DotAccess {
-                    expression, member, ..
-                } => resolve_dot_access_definition(expression, member, file, &snapshot),
+                    expression,
+                    member,
+                    span,
+                    ..
+                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
 
                 syntax::ast::Expression::Match { arms, .. } => {
                     resolve_match_pattern_definition(arms, offset, file, &snapshot)
@@ -858,7 +864,8 @@ impl LanguageServer for Backend {
                 span,
                 ..
             } if !member.is_empty() => {
-                let resolved = resolve_dot_access_definition(expression, member, file, &snapshot);
+                let resolved =
+                    resolve_dot_access_definition(expression, member, *span, file, &snapshot);
                 if let Some(definition_span) = resolved
                     && !is_go_typedef_span(&snapshot, &definition_span)
                 {
@@ -974,8 +981,11 @@ impl LanguageServer for Backend {
                 }
 
                 syntax::ast::Expression::DotAccess {
-                    expression, member, ..
-                } => resolve_dot_access_definition(expression, member, file, &snapshot)
+                    expression,
+                    member,
+                    span,
+                    ..
+                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot)
                     .filter(|s| !is_go_typedef_span(&snapshot, s)),
 
                 syntax::ast::Expression::Match { arms, .. } => {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -153,6 +153,64 @@ async fn goto_definition_function_parameter() {
     client.shutdown().await;
 }
 
+const EMBED_SRC: &str = r#"struct Base {
+  pub id: int,
+}
+impl Base {
+  pub fn describe(self) -> string { "b" }
+}
+struct Wrapper {
+  embed Base,
+}
+fn use_method(w: Wrapper) -> string {
+  w.describe()
+}
+fn use_field(w: Wrapper) -> int {
+  w.id
+}"#;
+
+#[tokio::test]
+async fn goto_definition_promoted_method() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, EMBED_SRC).await;
+
+    let response = client.goto_definition(TEST_URI, 10, 6).await;
+    let loc = definition_location(&response.expect("response")).expect("location");
+    assert_eq!(loc.range.start.line, 4);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_promoted_field() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, EMBED_SRC).await;
+
+    let response = client.goto_definition(TEST_URI, 13, 4).await;
+    let loc = definition_location(&response.expect("response")).expect("location");
+    assert_eq!(loc.range.start.line, 1);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_promoted_method_shows_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, EMBED_SRC).await;
+
+    let hover = client.hover(TEST_URI, 10, 6).await.expect("hover");
+    assert!(
+        hover_content(&hover).contains("string"),
+        "hover content: {}",
+        hover_content(&hover)
+    );
+
+    client.shutdown().await;
+}
+
 #[tokio::test]
 async fn references_finds_all_usages() {
     let mut client = TestClient::new().await;

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -337,6 +337,16 @@ impl InferCtx<'_, '_> {
         }
     }
 
+    fn method_is_promoted(&self, deref_ty: &Type, member: &str) -> bool {
+        let Type::Nominal { id, .. } = deref_ty.strip_refs() else {
+            return false;
+        };
+        !self
+            .store
+            .get_own_methods(id.as_str())
+            .is_some_and(|methods| methods.contains_key(member))
+    }
+
     fn get_available_member_names(&self, ty: &Type) -> Vec<String> {
         let store = self.store;
         let deref_ty = ty.strip_refs();
@@ -690,6 +700,21 @@ impl InferCtx<'_, '_> {
             .get_all_methods(store, &args.deref_ty)
             .get(args.member_name)
             .cloned()?;
+
+        // Promoted method expressions (`Type.M`) are not lowered yet; reject
+        // cleanly rather than mis-resolve (own ones resolve via the qualified path).
+        if self.is_type_level_receiver(args.expression)
+            && self.method_is_promoted(&args.deref_ty, args.member_name)
+        {
+            self.sink
+                .push(diagnostics::infer::promoted_method_expression(
+                    args.member_name,
+                    *args.span,
+                ));
+            self.unify(args.expected_ty, &Type::Error, args.span);
+            let kind = DotAccessKind::InstanceMethod { is_exported: false };
+            return Some((args.build_dot_access(Type::Error, Some(kind), None), kind));
+        }
 
         self.check_instance_method_access(&args.deref_ty, &method_ty, args);
 

--- a/tests/_embed_harness/render_go.rs
+++ b/tests/_embed_harness/render_go.rs
@@ -134,6 +134,8 @@ fn render_main(scenario: &Scenario, printed: &[PrintedQuestion], out: &mut Strin
         out.push_str("\t{\n");
         out.push_str(&format!("\t\tvar r {root}\n"));
         out.push_str(&format!("\t\tfmt.Println(r.{}())\n", question.member));
+        out.push_str(&format!("\t\tf := r.{}\n", question.member));
+        out.push_str("\t\tfmt.Println(f())\n");
         out.push_str("\t}\n");
     }
     out.push_str("}\n");

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -107,6 +107,8 @@ pub fn render_lis_run(scenario: &Scenario, printed: &[PrintedQuestion]) -> Strin
             lis_zero_construct(scenario, question.root)
         ));
         out.push_str(&format!("  fmt.Println(r{i}.{}())\n", question.member));
+        out.push_str(&format!("  let f{i} = r{i}.{}\n", question.member));
+        out.push_str(&format!("  fmt.Println(f{i}())\n"));
     }
     out.push_str("}\n");
     out

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -9,7 +9,7 @@ use semantics::loader::MemoryLoader;
 use semantics::store::ENTRY_MODULE_ID;
 
 use super::PrintedQuestion;
-use super::go_answerer::GoAnswers;
+use super::go_answerer::{GoAnswer, GoAnswers};
 use super::lisette_answer::{LisetteAnswer, LisetteAnswers};
 use super::render_go::{GoMode, render_go};
 use super::render_lis::render_lis_run;
@@ -68,10 +68,8 @@ pub fn run_check(scenario: &Scenario, go: &GoAnswers, lisette: &LisetteAnswers) 
     }
 }
 
-/// Selector questions safe to run now: a method both sides resolve, on a
-/// constructible root, at depth 0 (declared directly, so a zero value cannot
-/// nil-dereference through an embed). Promoted calls qualify once promotion is
-/// implemented and receivers can be constructed safely.
+/// Selector questions whose method both sides resolve and that are safe to call
+/// on a zero-valued receiver (see `safe_to_run`).
 fn runnable_questions(
     scenario: &Scenario,
     go: &GoAnswers,
@@ -86,8 +84,8 @@ fn runnable_questions(
         let lisette_resolves =
             matches!(&lisette.questions[i], LisetteAnswer::Selector(o) if o.resolves());
         if expected.resolves
-            && expected.depth == 0
             && expected.member_kind == "method"
+            && safe_to_run(scenario, expected)
             && lisette_resolves
             && is_zero_constructible(scenario, *root)
         {
@@ -98,6 +96,18 @@ fn runnable_questions(
         }
     }
     printed
+}
+
+/// A promoted (depth > 0) method runs only with no pointer indirection and a
+/// struct declaring type, so dispatch never hits a nil pointer or interface.
+fn safe_to_run(scenario: &Scenario, expected: &GoAnswer) -> bool {
+    if expected.depth == 0 {
+        return true;
+    }
+    !expected.indirect
+        && scenario.nodes.iter().any(|node| {
+            node.name == expected.declaring_type && matches!(node.kind, NodeKind::Struct { .. })
+        })
 }
 
 /// Whether this node be built as a zero value.
@@ -276,12 +286,27 @@ mod tests {
     }
 
     #[test]
-    fn promotion_scenarios_skip_today() {
+    fn promoted_value_method_runs_identically() {
         if !go_available() {
             return;
         }
         let answerer = GoAnswerer::build().expect("answerer builds");
         let scenario = fixtures::value_embed_method();
+        let go = answerer.answer(&scenario).unwrap();
+        let lisette = lisette_answers(&scenario);
+        match run_check(&scenario, &go, &lisette) {
+            RunOutcome::Match => {}
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pointer_embed_method_skips() {
+        if !go_available() {
+            return;
+        }
+        let answerer = GoAnswerer::build().expect("answerer builds");
+        let scenario = fixtures::pointer_embed_method();
         let go = answerer.answer(&scenario).unwrap();
         let lisette = lisette_answers(&scenario);
         assert!(matches!(

--- a/tests/_embed_harness/snapshots/go_run_direct.snap
+++ b/tests/_embed_harness/snapshots/go_run_direct.snap
@@ -15,5 +15,7 @@ func main() {
 	{
 		var r N0
 		fmt.Println(r.M())
+		f := r.M
+		fmt.Println(f())
 	}
 }

--- a/tests/_embed_harness/snapshots/lis_run_direct.snap
+++ b/tests/_embed_harness/snapshots/lis_run_direct.snap
@@ -13,4 +13,6 @@ impl N0 {
 fn main() {
   let r0 = N0 { .. }
   fmt.Println(r0.M())
+  let f0 = r0.M
+  fmt.Println(f0())
 }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -6392,6 +6392,38 @@ fn main() {}
 }
 
 #[test]
+fn promoted_method_expression_is_rejected() {
+    infer(
+        r#"
+struct Base { pub id: int }
+impl Base { fn describe(self) -> string { "b" } }
+struct Outer { embed Base }
+fn use_it() {
+  let _ = Outer.describe
+}
+fn main() {}
+"#,
+    )
+    .assert_infer_code("promoted_method_expression");
+}
+
+#[test]
+fn own_method_expression_still_resolves() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+fn use_it(b: Base) -> string {
+  let f = Base.describe
+  f(b)
+}
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn promoted_field_resolves_through_value_embed() {
     infer(
         r#"


### PR DESCRIPTION
Go-to-definition and hover in the LSP server now resolve promoted members (gained via embedding) to their declaration in the embedded type.