### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.3.4](https://github.com/ivov/lisette/compare/lisette-v0.3.3...lisette-v0.3.4) - 2026-06-11
+
+- docs: document embedding imported Go types [#695](https://github.com/ivov/lisette/pull/695) [`d027dbd`](https://github.com/ivov/lisette/commit/d027dbd8ec971099ddf9961b01c36fc205c2c4de)
+- fix: adjust diagnostics for `var` [#694](https://github.com/ivov/lisette/pull/694) [`8617a15`](https://github.com/ivov/lisette/commit/8617a159bc39d8e924a95bad3fb675d655ee5e41)
+- feat: promote methods through unexported Go embeds [#693](https://github.com/ivov/lisette/pull/693) [`14e9316`](https://github.com/ivov/lisette/commit/14e9316e8671b9bff0dfa2bc73a2b2302d3a4570)
+- fix: enforce sealing of imported Go interfaces [#692](https://github.com/ivov/lisette/pull/692) [`b1db049`](https://github.com/ivov/lisette/commit/b1db049e9ea419202a1ce8e915fa06015891eb55)
+- test: render snapshot descriptions as yaml literal blocks [#691](https://github.com/ivov/lisette/pull/691) [`ff2c70a`](https://github.com/ivov/lisette/commit/ff2c70a8c33826036d1ceacfca74f8c127080a71)
+- feat: add `lis emit` to CLI [#689](https://github.com/ivov/lisette/pull/689) [`f130d63`](https://github.com/ivov/lisette/commit/f130d637e2e92effb117d373f0de530ae1faaa27)
+- refactor: reshape `lis run` onto build-then-exec [#688](https://github.com/ivov/lisette/pull/688) [`bd807f9`](https://github.com/ivov/lisette/commit/bd807f9c8feadc49745987782d37ce62ae90073d)
+- feat: broaden imported types accepted as embed targets [#687](https://github.com/ivov/lisette/pull/687) [`a3edafa`](https://github.com/ivov/lisette/commit/a3edafaee78dbcfb70a1b7e2bfd1f00c229d0b33)
+- chore: upgrade to `insta` 1.48.0 [#686](https://github.com/ivov/lisette/pull/686) [`eb77a81`](https://github.com/ivov/lisette/commit/eb77a815657c2c8322a183ee5fb99d0591f52c31)
+- perf: parallelize module registration [#685](https://github.com/ivov/lisette/pull/685) [`d197b78`](https://github.com/ivov/lisette/commit/d197b784586764656ab9370612084da6635c416f)
+- refactor: replace text-scanned liveness with structural tracking [#683](https://github.com/ivov/lisette/pull/683) [`35aa700`](https://github.com/ivov/lisette/commit/35aa700eddbb79300640c57501fc4e8fb372625d)
+- fix: reject non-comparable interface and unknown equality [#682](https://github.com/ivov/lisette/pull/682) [`ddd6bc0`](https://github.com/ivov/lisette/commit/ddd6bc0a77c406a3594b38ba87c1c8e855362a0f)
+- refactor: de-flatten imported struct embeds [#681](https://github.com/ivov/lisette/pull/681) [`1bd8dfc`](https://github.com/ivov/lisette/commit/1bd8dfc792cfc4cd08c6161c4cee5a4d7096f11c)
+- feat: broaden match-to-if-let lint coverage [#680](https://github.com/ivov/lisette/pull/680) [`244fe2a`](https://github.com/ivov/lisette/commit/244fe2a1d913a0984d43c06916a631413deca981)
+- perf: dispatch ast walk checks by expression kind [#679](https://github.com/ivov/lisette/pull/679) [`202244a`](https://github.com/ivov/lisette/commit/202244a7b4508d756c45a27dff094ba355997be0)
+- perf: memoize global enum layouts and generic constraints in emit [#677](https://github.com/ivov/lisette/pull/677) [`1827dc0`](https://github.com/ivov/lisette/commit/1827dc074299531db010307c295872ef8cb6e196)
+- test: add imported types to embed harness [#676](https://github.com/ivov/lisette/pull/676) [`aeeca19`](https://github.com/ivov/lisette/commit/aeeca1901c8f80b540d7d2ccad7447fab31911bd)
+- feat: embedding for generic structs [#674](https://github.com/ivov/lisette/pull/674) [`2fef804`](https://github.com/ivov/lisette/commit/2fef804c25897eb32ac48ed05d06fd21fa606a70)
+- perf: freeze types in place instead of rebuilding the ast [#673](https://github.com/ivov/lisette/pull/673) [`156652c`](https://github.com/ivov/lisette/commit/156652c8a3b90159ea8980d2fa8a158ac67c04d2)
+- fix: reject namespace used as a value [#671](https://github.com/ivov/lisette/pull/671) [`c9e1eec`](https://github.com/ivov/lisette/commit/c9e1eecd2a257d019dddbacd798c81999e9a981d)
+- feat: hover and go-to-definition on promoted members [#667](https://github.com/ivov/lisette/pull/667) [`f181b25`](https://github.com/ivov/lisette/commit/f181b25a1bd16f7978aa51cc77b1ec1123934a0c)
+
 ## [0.3.3](https://github.com/ivov/lisette/compare/lisette-v0.3.2...lisette-v0.3.3) - 2026-06-08
 
 - feat: support embedding in native structs [#666](https://github.com/ivov/lisette/pull/666) [`eec2ea2`](https://github.com/ivov/lisette/commit/eec2ea2e9154af0209afefe183f9522eb7c4e2aa)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-benchmark"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "lisette-deps",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bincode",
  "ecow",
@@ -783,11 +783,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.3.3", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.3.3", path = "../format" }
-emit = { package = "lisette-emit", version = "0.3.3", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.3.3", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.3.4", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.4", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.3.4", path = "../format" }
+emit = { package = "lisette-emit", version = "0.3.4", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.3.4", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.4", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.3.4", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.3.4", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.4", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.3.3", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
-format = { package = "lisette-format", version = "0.3.3", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.3.4", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.4", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.3.4", path = "../deps" }
+format = { package = "lisette-format", version = "0.3.4", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.3.3", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.3.3", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.3.3", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.3.3", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.3.4", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.3.4", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.3.4", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.3.4", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.3.4 (upcoming)

- docs: document embedding imported Go types [#695](https://github.com/ivov/lisette/pull/695) [`d027dbd`](https://github.com/ivov/lisette/commit/d027dbd8ec971099ddf9961b01c36fc205c2c4de)
- fix: adjust diagnostics for `var` [#694](https://github.com/ivov/lisette/pull/694) [`8617a15`](https://github.com/ivov/lisette/commit/8617a159bc39d8e924a95bad3fb675d655ee5e41)
- feat: promote methods through unexported Go embeds [#693](https://github.com/ivov/lisette/pull/693) [`14e9316`](https://github.com/ivov/lisette/commit/14e9316e8671b9bff0dfa2bc73a2b2302d3a4570)
- fix: enforce sealing of imported Go interfaces [#692](https://github.com/ivov/lisette/pull/692) [`b1db049`](https://github.com/ivov/lisette/commit/b1db049e9ea419202a1ce8e915fa06015891eb55)
- test: render snapshot descriptions as yaml literal blocks [#691](https://github.com/ivov/lisette/pull/691) [`ff2c70a`](https://github.com/ivov/lisette/commit/ff2c70a8c33826036d1ceacfca74f8c127080a71)
- feat: add `lis emit` to CLI [#689](https://github.com/ivov/lisette/pull/689) [`f130d63`](https://github.com/ivov/lisette/commit/f130d637e2e92effb117d373f0de530ae1faaa27)
- refactor: reshape `lis run` onto build-then-exec [#688](https://github.com/ivov/lisette/pull/688) [`bd807f9`](https://github.com/ivov/lisette/commit/bd807f9c8feadc49745987782d37ce62ae90073d)
- feat: broaden imported types accepted as embed targets [#687](https://github.com/ivov/lisette/pull/687) [`a3edafa`](https://github.com/ivov/lisette/commit/a3edafaee78dbcfb70a1b7e2bfd1f00c229d0b33)
- chore: upgrade to `insta` 1.48.0 [#686](https://github.com/ivov/lisette/pull/686) [`eb77a81`](https://github.com/ivov/lisette/commit/eb77a815657c2c8322a183ee5fb99d0591f52c31)
- perf: parallelize module registration [#685](https://github.com/ivov/lisette/pull/685) [`d197b78`](https://github.com/ivov/lisette/commit/d197b784586764656ab9370612084da6635c416f)
- refactor: replace text-scanned liveness with structural tracking [#683](https://github.com/ivov/lisette/pull/683) [`35aa700`](https://github.com/ivov/lisette/commit/35aa700eddbb79300640c57501fc4e8fb372625d)
- fix: reject non-comparable interface and unknown equality [#682](https://github.com/ivov/lisette/pull/682) [`ddd6bc0`](https://github.com/ivov/lisette/commit/ddd6bc0a77c406a3594b38ba87c1c8e855362a0f)
- refactor: de-flatten imported struct embeds [#681](https://github.com/ivov/lisette/pull/681) [`1bd8dfc`](https://github.com/ivov/lisette/commit/1bd8dfc792cfc4cd08c6161c4cee5a4d7096f11c)
- feat: broaden match-to-if-let lint coverage [#680](https://github.com/ivov/lisette/pull/680) [`244fe2a`](https://github.com/ivov/lisette/commit/244fe2a1d913a0984d43c06916a631413deca981)
- perf: dispatch ast walk checks by expression kind [#679](https://github.com/ivov/lisette/pull/679) [`202244a`](https://github.com/ivov/lisette/commit/202244a7b4508d756c45a27dff094ba355997be0)
- perf: memoize global enum layouts and generic constraints in emit [#677](https://github.com/ivov/lisette/pull/677) [`1827dc0`](https://github.com/ivov/lisette/commit/1827dc074299531db010307c295872ef8cb6e196)
- test: add imported types to embed harness [#676](https://github.com/ivov/lisette/pull/676) [`aeeca19`](https://github.com/ivov/lisette/commit/aeeca1901c8f80b540d7d2ccad7447fab31911bd)
- feat: embedding for generic structs [#674](https://github.com/ivov/lisette/pull/674) [`2fef804`](https://github.com/ivov/lisette/commit/2fef804c25897eb32ac48ed05d06fd21fa606a70)
- perf: freeze types in place instead of rebuilding the ast [#673](https://github.com/ivov/lisette/pull/673) [`156652c`](https://github.com/ivov/lisette/commit/156652c8a3b90159ea8980d2fa8a158ac67c04d2)
- fix: reject namespace used as a value [#671](https://github.com/ivov/lisette/pull/671) [`c9e1eec`](https://github.com/ivov/lisette/commit/c9e1eecd2a257d019dddbacd798c81999e9a981d)
- feat: hover and go-to-definition on promoted members [#667](https://github.com/ivov/lisette/pull/667) [`f181b25`](https://github.com/ivov/lisette/commit/f181b25a1bd16f7978aa51cc77b1ec1123934a0c)
