### PR TITLE
fix: reject namespace used as a value

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2877,13 +2877,11 @@ pub fn namespace_alias_used_as_value(span: Span) -> LisetteDiagnostic {
         .with_help("Access a member instead, e.g. `alias.VariantName`")
 }
 
-pub fn let_binding_module_namespace(module_name: &str, span: Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Cannot bind a module namespace to a variable")
-        .with_infer_code("let_binding_module_namespace")
+pub fn module_namespace_used_as_value(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot use a module namespace as a value")
+        .with_infer_code("module_namespace_used_as_value")
         .with_span_label(&span, "module namespaces are not runtime values")
-        .with_help(format!(
-            "Use an import alias instead: `import alias \"{module_name}\"`"
-        ))
+        .with_help(format!("Access a member instead, e.g. `{name}.Member`"))
 }
 
 pub fn let_binding_enum_type(type_name: &str, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -163,16 +163,8 @@ impl InferCtx<'_, '_> {
             ));
         }
 
-        // Reject module namespace bindings: `let u = utils`
-        if let Some(module_id) = new_value.get_type().as_import_namespace() {
-            self.sink
-                .push(diagnostics::infer::let_binding_module_namespace(
-                    module_id,
-                    new_value.get_span(),
-                ));
-        }
         // Reject enum type bindings: `let c = utils.Color`
-        else if let Expression::DotAccess {
+        if let Expression::DotAccess {
             expression: inner,
             member,
             ..

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -277,6 +277,13 @@ impl InferCtx<'_, '_> {
             }
         };
 
+        if ty.as_import_namespace().is_some() && !self.scopes.is_dot_access_base() {
+            self.sink
+                .push(diagnostics::infer::module_namespace_used_as_value(
+                    &value, span,
+                ));
+        }
+
         let (identifier_ty, _) = self.instantiate(&ty);
 
         self.unify(expected_ty, &identifier_ty, &span);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8270,3 +8270,27 @@ fn main() {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn infer_package_name_as_call_argument() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(fmt)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_package_name_as_bare_expression() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  fmt
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/infer_enum_type_via_module_alias_used_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_enum_type_via_module_alias_used_as_value.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Cannot bind a module namespace to a variable
+  [error] Cannot use a module namespace as a value
    ╭─[main.lis:5:11]
  4 │ fn main() {
  5 │   let u = utils
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·             ╰── module namespaces are not runtime values
  6 │ }
    ╰────
-  help: Use an import alias instead: `import alias "utils"` · code: [infer.let_binding_module_namespace]
+  help: Access a member instead, e.g. `utils.Member` · code: [infer.module_namespace_used_as_value]

--- a/tests/ui/errors/snapshots/infer_package_name_as_bare_expression.snap
+++ b/tests/ui/errors/snapshots/infer_package_name_as_bare_expression.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use a module namespace as a value
+   ╭─[test.lis:5:3]
+ 4 │ fn main() {
+ 5 │   fmt
+   ·   ─┬─
+   ·    ╰── module namespaces are not runtime values
+ 6 │ }
+   ╰────
+  help: Access a member instead, e.g. `fmt.Member` · code: [infer.module_namespace_used_as_value]

--- a/tests/ui/errors/snapshots/infer_package_name_as_call_argument.snap
+++ b/tests/ui/errors/snapshots/infer_package_name_as_call_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot use a module namespace as a value
+   ╭─[test.lis:5:15]
+ 4 │ fn main() {
+ 5 │   fmt.Println(fmt)
+   ·               ─┬─
+   ·                ╰── module namespaces are not runtime values
+ 6 │ }
+   ╰────
+  help: Access a member instead, e.g. `fmt.Member` · code: [infer.module_namespace_used_as_value]


### PR DESCRIPTION
A module namespace used as a value now errors out, instead of emitting invalid Go.

```
  [error] Cannot use a module namespace as a value
   ╭─[test.lis:5:15]
 4 │ fn main() {
 5 │   fmt.Println(fmt)
   ·               ─┬─
   ·                ╰── module namespaces are not runtime values
 6 │ }
   ╰────
  help: Access a member instead, e.g. `fmt.Member` · code: [infer.module_namespace_used_as_value]
```

Fix #669
