### PR TITLE
feat: embedding for generic structs

### DIFF
--- a/crates/diagnostics/src/embed.rs
+++ b/crates/diagnostics/src/embed.rs
@@ -12,17 +12,6 @@ pub fn defined_type(target: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
-pub fn generic(target: &str, span: Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Cannot embed a generic type")
-        .with_infer_code("embed_generic")
-        .with_span_label(&span, "generic type")
-        .with_help(format!(
-            "Embedding `{}` is not supported in this version. Embed a non-generic struct, \
-             interface, or pointer.",
-            target
-        ))
-}
-
 pub fn imported_target(target: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot embed an imported type yet")
         .with_infer_code("embed_imported_target")

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -396,12 +396,6 @@ impl TaskState<'_> {
         let display = ty.to_string();
         let resolved = store.deep_resolve_alias(ty);
 
-        // Check the declared type too: alias substitution erases a generic alias's arguments.
-        if is_generic_instantiation(ty) || is_generic_instantiation(&resolved) {
-            self.sink.push(diagnostics::embed::generic(&display, span));
-            return;
-        }
-
         if resolved.is_option() {
             self.sink.push(diagnostics::embed::option_target(span));
             return;
@@ -429,9 +423,6 @@ impl TaskState<'_> {
                 Some(inner) if is_pointer_backed_newtype(store, &inner) => {
                     self.sink
                         .push(diagnostics::embed::pointer_backed_newtype(&display, span));
-                }
-                Some(inner) if is_generic_instantiation(&inner) => {
-                    self.sink.push(diagnostics::embed::generic(&display, span));
                 }
                 Some(inner) if is_deferred_local_target(store, &inner) => {
                     self.sink
@@ -804,15 +795,6 @@ fn embed_promotion_target(store: &Store, ty: &Type) -> Type {
         target = store.deep_resolve_alias(&inner);
     }
     target
-}
-
-fn is_generic_instantiation(ty: &Type) -> bool {
-    let mut target = ty.clone();
-    while target.is_option() || target.is_ref() {
-        let Some(inner) = target.inner() else { break };
-        target = inner;
-    }
-    matches!(target, Type::Nominal { params, .. } if !params.is_empty())
 }
 
 // A local tuple struct, newtype, or enum: needs the resolver, so hard-errored for now.

--- a/crates/semantics/src/promotion.rs
+++ b/crates/semantics/src/promotion.rs
@@ -2,9 +2,9 @@ use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::BTreeMap;
 
-use syntax::ast::Visibility;
-use syntax::program::MethodSignatures;
-use syntax::types::{CompoundKind, Symbol, Type};
+use syntax::ast::{Generic, Visibility};
+use syntax::program::{DefinitionBody, MethodSignatures};
+use syntax::types::{CompoundKind, Symbol, Type, build_substitution_map, substitute};
 
 use crate::store::Store;
 
@@ -116,8 +116,8 @@ fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
                 if !field.embedded {
                     continue;
                 }
-                // Resolve aliases first so an alias to `Ref<T>` peels as a pointer edge.
-                let resolved_field = store.deep_resolve_alias(&field.ty);
+                let field_ty = instantiate_field(store, &entry.ty, &field.ty);
+                let resolved_field = store.deep_resolve_alias(&field_ty);
                 let (target, is_pointer) = deref_once(&resolved_field);
                 let mut path = entry.embed_path.clone();
                 path.push(field.name.clone());
@@ -201,7 +201,7 @@ fn entry_candidate(store: &Store, ty: &Type, name: &str) -> Option<Candidate> {
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
             detail: CandidateDetail::Method {
-                ty: method_ty.clone(),
+                ty: instantiate_method(store, ty, method_ty)?,
             },
         });
     }
@@ -213,7 +213,7 @@ fn entry_candidate(store: &Store, ty: &Type, name: &str) -> Option<Candidate> {
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
             detail: CandidateDetail::Field {
-                ty: field.ty.clone(),
+                ty: instantiate_field(store, ty, &field.ty),
                 visibility: field.visibility,
             },
         });
@@ -352,6 +352,102 @@ fn ref_of(ty: &Type) -> Type {
     }
 }
 
+fn declaring_generics<'a>(store: &'a Store, id: &str) -> &'a [Generic] {
+    match store.get_definition(id).map(|d| &d.body) {
+        Some(
+            DefinitionBody::Struct { generics, .. }
+            | DefinitionBody::Enum { generics, .. }
+            | DefinitionBody::TypeAlias { generics, .. },
+        ) => generics,
+        Some(DefinitionBody::Interface { definition }) => &definition.generics,
+        _ => &[],
+    }
+}
+
+fn instantiate_field(store: &Store, container: &Type, member_ty: &Type) -> Type {
+    let Some(id) = container.get_qualified_id() else {
+        return member_ty.clone();
+    };
+    let args = container.get_type_params().unwrap_or_default();
+    if args.is_empty() {
+        return member_ty.clone();
+    }
+    substitute(
+        member_ty,
+        &build_substitution_map(declaring_generics(store, id), args),
+    )
+}
+
+fn instantiate_method(store: &Store, container: &Type, method_ty: &Type) -> Option<Type> {
+    let Some(id) = container.get_qualified_id() else {
+        return Some(method_ty.clone());
+    };
+    let args = container.get_type_params().unwrap_or_default();
+    let arity = declaring_generics(store, id).len();
+    if args.is_empty() || arity == 0 {
+        return Some(method_ty.clone());
+    }
+    if let Type::Forall { vars, body } = method_ty
+        && args.len() == arity
+        && vars.len() >= arity
+    {
+        let (impl_vars, method_vars) = vars.split_at(arity);
+        if receiver_is_simple(body, id, impl_vars) {
+            let map: HashMap<EcoString, Type> = impl_vars
+                .iter()
+                .cloned()
+                .zip(args.iter().cloned())
+                .collect();
+            let new_body = substitute(body, &map);
+            return Some(if method_vars.is_empty() {
+                new_body
+            } else {
+                Type::Forall {
+                    vars: method_vars.to_vec(),
+                    body: Box::new(new_body),
+                }
+            });
+        }
+    }
+    // Anything else is a specialized impl (`impl Container<int>`): it promotes
+    // only when its concrete receiver is exactly this instantiation, so a method
+    // declared for one instantiation never leaks onto another through promotion.
+    let receiver = method_receiver(method_ty)?;
+    (receiver.strip_refs() == *container).then(|| method_ty.clone())
+}
+
+/// The receiver (first parameter) of a method type, peeling any `Forall`.
+fn method_receiver(method_ty: &Type) -> Option<&Type> {
+    let body = match method_ty {
+        Type::Forall { body, .. } => body.as_ref(),
+        other => other,
+    };
+    match body {
+        Type::Function(f) => f.params.first(),
+        _ => None,
+    }
+}
+
+/// The method's receiver is `Container<v0, .., vk>` with the impl vars bare and
+/// in order, i.e. an unspecialized `impl<v..> Container<v..>`.
+fn receiver_is_simple(body: &Type, container_id: &str, impl_vars: &[EcoString]) -> bool {
+    let Type::Function(f) = body else {
+        return false;
+    };
+    let Some(receiver) = f.params.first() else {
+        return false;
+    };
+    let Type::Nominal { id, params, .. } = receiver.strip_refs() else {
+        return false;
+    };
+    id.as_str() == container_id
+        && params.len() == impl_vars.len()
+        && params
+            .iter()
+            .zip(impl_vars)
+            .all(|(p, v)| matches!(p, Type::Parameter(name) if name == v))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -456,6 +552,37 @@ mod tests {
             )
         }
 
+        fn generic_struct(
+            &mut self,
+            name: &str,
+            generics: Vec<&str>,
+            fields: Vec<StructFieldDefinition>,
+            methods: Vec<(&str, Type)>,
+        ) -> &mut Self {
+            let mut method_map = MethodSignatures::default();
+            for (n, t) in methods {
+                method_map.insert(n.into(), t);
+            }
+            self.insert(
+                name,
+                DefinitionBody::Struct {
+                    generics: generics
+                        .into_iter()
+                        .map(|g| Generic {
+                            name: g.into(),
+                            bounds: vec![],
+                            span: Span::dummy(),
+                        })
+                        .collect(),
+                    fields,
+                    kind: StructKind::Record,
+                    methods: method_map,
+                    constructor: None,
+                    attributes: Attributes::default(),
+                },
+            )
+        }
+
         fn interface(&mut self, name: &str, methods: Vec<&str>, parents: Vec<&str>) -> &mut Self {
             let mut method_map = MethodSignatures::default();
             for n in methods {
@@ -481,6 +608,30 @@ mod tests {
 
     fn pembed(target: &str) -> StructFieldDefinition {
         field(target, ref_of(&nominal(target)), true)
+    }
+
+    fn param(name: &str) -> Type {
+        Type::Parameter(name.into())
+    }
+
+    fn generic_nominal(name: &str, args: Vec<Type>) -> Type {
+        Type::Nominal {
+            id: Symbol::from_parts(MODULE, name),
+            params: args,
+            underlying_ty: None,
+        }
+    }
+
+    fn generic_value_method(owner: &str, impl_var: &str, ret: Type) -> Type {
+        Type::Forall {
+            vars: vec![impl_var.into()],
+            body: Box::new(Type::function(
+                vec![generic_nominal(owner, vec![param(impl_var)])],
+                vec![false],
+                vec![],
+                Box::new(ret),
+            )),
+        }
     }
 
     fn found(resolution: Resolution) -> ResolvedMember {
@@ -684,5 +835,197 @@ mod tests {
         assert!(!has_direct_embed(&b.store, &nominal("N0")));
         assert!(has_direct_embed(&b.store, &nominal("N1")));
         assert!(has_direct_embed(&b.store, &ref_of(&nominal("N1"))));
+    }
+
+    fn method_return(member: &ResolvedMember) -> Type {
+        match &member.kind {
+            MemberKind::Method { ty } => ty.get_function_ret().unwrap().clone(),
+            other => panic!("expected a method, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generic_embed_promotes_field_at_instantiation() {
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![field("value", param("T"), false)],
+            vec![],
+        );
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::int()]),
+                true,
+            )],
+            vec![],
+        );
+        let member = found(resolve_selector(&b.store, &nominal("Outer"), "value"));
+        match member.kind {
+            MemberKind::Field { ty, .. } => assert_eq!(ty, Type::int()),
+            other => panic!("expected a field, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generic_embed_promotes_method_at_instantiation() {
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![],
+            vec![("get", generic_value_method("Box", "T", param("T")))],
+        );
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::string()]),
+                true,
+            )],
+            vec![],
+        );
+        let member = found(resolve_selector(&b.store, &nominal("Outer"), "get"));
+        assert_eq!(method_return(&member), Type::string());
+    }
+
+    #[test]
+    fn generic_embedder_flows_its_param_into_the_target() {
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![],
+            vec![("get", generic_value_method("Box", "T", param("T")))],
+        );
+        b.generic_struct(
+            "Outer",
+            vec!["U"],
+            vec![field("Box", generic_nominal("Box", vec![param("U")]), true)],
+            vec![],
+        );
+        let member = found(resolve_selector(
+            &b.store,
+            &generic_nominal("Outer", vec![Type::int()]),
+            "get",
+        ));
+        assert_eq!(method_return(&member), Type::int());
+    }
+
+    #[test]
+    fn renamed_impl_param_is_captured() {
+        // struct param is `T`, but the method's impl var is `V` (`impl<V> Box<V>`).
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![],
+            vec![("get", generic_value_method("Box", "V", param("V")))],
+        );
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::int()]),
+                true,
+            )],
+            vec![],
+        );
+        let member = found(resolve_selector(&b.store, &nominal("Outer"), "get"));
+        assert_eq!(method_return(&member), Type::int());
+    }
+
+    #[test]
+    fn specialized_impl_method_is_skipped() {
+        let specialized = Type::Forall {
+            vars: vec!["V".into()],
+            body: Box::new(Type::function(
+                vec![generic_nominal(
+                    "Box",
+                    vec![Type::Compound {
+                        kind: CompoundKind::Slice,
+                        args: vec![param("V")],
+                    }],
+                )],
+                vec![false],
+                vec![],
+                Box::new(param("V")),
+            )),
+        };
+        let mut b = Builder::new();
+        b.generic_struct("Box", vec!["T"], vec![], vec![("weird", specialized)]);
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::int()]),
+                true,
+            )],
+            vec![],
+        );
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("Outer"), "weird"),
+            Resolution::NotFound
+        ));
+    }
+
+    /// A concrete `impl Box<int> { fn only_int(self: Box<int>) -> int }`, stored
+    /// without a `Forall` because it binds no type variables.
+    fn concrete_int_method() -> Type {
+        Type::function(
+            vec![generic_nominal("Box", vec![Type::int()])],
+            vec![false],
+            vec![],
+            Box::new(Type::int()),
+        )
+    }
+
+    #[test]
+    fn specialized_impl_does_not_promote_onto_other_instantiation() {
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![],
+            vec![("only_int", concrete_int_method())],
+        );
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::string()]),
+                true,
+            )],
+            vec![],
+        );
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("Outer"), "only_int"),
+            Resolution::NotFound
+        ));
+    }
+
+    #[test]
+    fn specialized_impl_promotes_onto_matching_instantiation() {
+        let mut b = Builder::new();
+        b.generic_struct(
+            "Box",
+            vec!["T"],
+            vec![],
+            vec![("only_int", concrete_int_method())],
+        );
+        b.struct_(
+            "Outer",
+            vec![field(
+                "Box",
+                generic_nominal("Box", vec![Type::int()]),
+                true,
+            )],
+            vec![],
+        );
+        let member = found(resolve_selector(&b.store, &nominal("Outer"), "only_int"));
+        assert_eq!(member.depth, 1);
+        assert_eq!(method_return(&member), Type::int());
     }
 }

--- a/tests/_embed_harness/corpus.rs
+++ b/tests/_embed_harness/corpus.rs
@@ -3,7 +3,7 @@
 //! `embed_*` error. Some rejections are expected to be lifted later, and their
 //! tests will start passing when that happens.
 
-use super::fixtures::{iface_node, smethod, struct_node, vembed};
+use super::fixtures::{iface_node, imethod, smethod, struct_node, vembed};
 use super::scenario::*;
 
 fn pembed(target: NodeId) -> Embed {
@@ -11,6 +11,7 @@ fn pembed(target: NodeId) -> Embed {
         target,
         edge: EdgeKind::Pointer,
         storage: Storage::Plain,
+        type_args: vec![],
     }
 }
 
@@ -71,6 +72,112 @@ pub fn mixed_embedding() -> Scenario {
     }
 }
 
+/// `struct Box<T> { Value: T }` with `fn Tag(self) -> string`: a generic base
+/// whose field is the parameter and whose method is monomorphic. The random
+/// generator stays monomorphic, so generic shapes are written here.
+fn generic_box(id: NodeId) -> Node {
+    Node {
+        id,
+        name: format!("N{id}"),
+        type_params: vec!["T".into()],
+        kind: NodeKind::Struct {
+            fields: vec![Field {
+                name: cased("value", Visibility::Public),
+                member_type: MemberType::TypeParam("T".into()),
+                visibility: Visibility::Public,
+            }],
+            embeds: vec![],
+            methods: vec![smethod("tag")],
+        },
+        origin: Origin::Native,
+    }
+}
+
+fn vembed_arg(target: NodeId, arg: MemberType) -> Embed {
+    Embed {
+        target,
+        edge: EdgeKind::Value,
+        storage: Storage::Plain,
+        type_args: vec![arg],
+    }
+}
+
+fn pembed_arg(target: NodeId, arg: MemberType) -> Embed {
+    Embed {
+        target,
+        edge: EdgeKind::Pointer,
+        storage: Storage::Plain,
+        type_args: vec![arg],
+    }
+}
+
+/// `N1` embeds `Box<int>` by value. Go promotes the method `Tag` and the field
+/// `Value` (instantiated to `int`) at depth 1; Lisette must agree.
+pub fn generic_embed_promotes() -> Scenario {
+    Scenario {
+        name: "generic_embed_promotes".into(),
+        seed: 0,
+        nodes: vec![
+            generic_box(0),
+            struct_node(
+                1,
+                vec![vembed_arg(0, MemberType::Basic(BasicType::Int))],
+                vec![],
+                vec![],
+            ),
+        ],
+        questions: vec![
+            sel(1, "Tag"),
+            Question::Selector {
+                root: 1,
+                member: "Value".into(),
+                kind: SelKind::Field,
+            },
+        ],
+    }
+}
+
+/// `N1` embeds `*Box<int>`. The method still promotes through the pointer edge.
+pub fn generic_embed_pointer() -> Scenario {
+    Scenario {
+        name: "generic_embed_pointer".into(),
+        seed: 0,
+        nodes: vec![
+            generic_box(0),
+            struct_node(
+                1,
+                vec![pembed_arg(0, MemberType::Basic(BasicType::Int))],
+                vec![],
+                vec![],
+            ),
+        ],
+        questions: vec![sel(1, "Tag")],
+    }
+}
+
+/// `N2` embeds `Box<int>` and satisfies interface `N0` through the promoted
+/// `Tag`.
+pub fn generic_embed_satisfies() -> Scenario {
+    Scenario {
+        name: "generic_embed_satisfies".into(),
+        seed: 0,
+        nodes: vec![
+            iface_node(0, vec![], vec![imethod("tag", BasicType::String)]),
+            generic_box(1),
+            struct_node(
+                2,
+                vec![vembed_arg(1, MemberType::Basic(BasicType::Int))],
+                vec![],
+                vec![],
+            ),
+        ],
+        questions: vec![Question::Satisfies {
+            type_id: 2,
+            interface: 0,
+        }],
+    }
+}
+
 /// Every scenario that goes through the full differential.
 pub fn differential_scenarios() -> Vec<Scenario> {
     let mut scenarios = super::fixtures::all();
@@ -78,6 +185,9 @@ pub fn differential_scenarios() -> Vec<Scenario> {
     scenarios.push(pointer_cycle());
     scenarios.push(pointer_diamond());
     scenarios.push(mixed_embedding());
+    scenarios.push(generic_embed_promotes());
+    scenarios.push(generic_embed_pointer());
+    scenarios.push(generic_embed_satisfies());
     scenarios
 }
 
@@ -113,12 +223,6 @@ pub fn reject_cases() -> Vec<RejectCase> {
             name: "defined_type",
             source: "struct MyInt(int)\nstruct Outer {\n  embed MyInt,\n}\n",
             code: "infer.embed_defined_type",
-            permanent: false,
-        },
-        RejectCase {
-            name: "generic",
-            source: "struct Box<T> {\n  pub value: T,\n}\nstruct Outer {\n  embed Box<int>,\n}\n",
-            code: "infer.embed_generic",
             permanent: false,
         },
         RejectCase {

--- a/tests/_embed_harness/fixtures.rs
+++ b/tests/_embed_harness/fixtures.rs
@@ -35,6 +35,7 @@ pub fn vembed(target: NodeId) -> Embed {
         target,
         edge: EdgeKind::Value,
         storage: Storage::Plain,
+        type_args: vec![],
     }
 }
 
@@ -43,6 +44,7 @@ pub fn pembed(target: NodeId) -> Embed {
         target,
         edge: EdgeKind::Pointer,
         storage: Storage::Plain,
+        type_args: vec![],
     }
 }
 
@@ -55,6 +57,7 @@ pub fn struct_node(
     Node {
         id,
         name: format!("N{id}"),
+        type_params: vec![],
         kind: NodeKind::Struct {
             fields,
             embeds,
@@ -68,6 +71,7 @@ pub fn iface_node(id: NodeId, embeds: Vec<Embed>, methods: Vec<Method>) -> Node 
     Node {
         id,
         name: format!("N{id}"),
+        type_params: vec![],
         kind: NodeKind::Interface { methods, embeds },
         origin: Origin::Native,
     }

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -280,6 +280,7 @@ mod tests {
                 nodes: vec![Node {
                     id: 0,
                     name: "N0".into(),
+                    type_params: vec![],
                     kind: NodeKind::NamedBasic {
                         underlying: basic,
                         methods: vec![Method {

--- a/tests/_embed_harness/random_scenarios.rs
+++ b/tests/_embed_harness/random_scenarios.rs
@@ -53,6 +53,7 @@ pub fn generate(seed: u64) -> Scenario {
         nodes.push(Node {
             id,
             name: format!("N{id}"),
+            type_params: vec![],
             kind,
             origin: Origin::Native,
         });
@@ -117,6 +118,7 @@ fn generate_struct_embeds(random: &mut Random, id: usize, existing: &[Node]) -> 
             target,
             edge,
             storage: Storage::Plain,
+            type_args: vec![],
         });
     }
     embeds
@@ -141,6 +143,7 @@ fn generate_interface_embeds(random: &mut Random, id: usize, existing: &[Node]) 
             target,
             edge: EdgeKind::Value,
             storage: Storage::Plain,
+            type_args: vec![],
         });
     }
     embeds

--- a/tests/_embed_harness/render_go.rs
+++ b/tests/_embed_harness/render_go.rs
@@ -28,16 +28,39 @@ pub fn render_go(scenario: &Scenario, mode: GoMode) -> String {
     out
 }
 
+fn go_generics(node: &Node) -> String {
+    if node.type_params.is_empty() {
+        return String::new();
+    }
+    let params: Vec<String> = node
+        .type_params
+        .iter()
+        .map(|p| format!("{p} any"))
+        .collect();
+    format!("[{}]", params.join(", "))
+}
+
+/// A node reference with optional type arguments: `Box` or `Box[int]`.
+fn go_node_ref(scenario: &Scenario, target: NodeId, type_args: &[MemberType]) -> String {
+    let name = scenario.node_name(target);
+    if type_args.is_empty() {
+        return name.to_string();
+    }
+    let args: Vec<String> = type_args.iter().map(|a| go_type(scenario, a)).collect();
+    format!("{name}[{}]", args.join(", "))
+}
+
 fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    let generics = go_generics(node);
     match &node.kind {
         NodeKind::Struct {
             fields,
             embeds,
             methods,
         } => {
-            out.push_str(&format!("type {} struct {{\n", node.name));
+            out.push_str(&format!("type {}{generics} struct {{\n", node.name));
             for embed in embeds {
-                let target = scenario.node_name(embed.target);
+                let target = go_node_ref(scenario, embed.target, &embed.type_args);
                 match embed.edge {
                     EdgeKind::Value => out.push_str(&format!("\t{target}\n")),
                     EdgeKind::Pointer => out.push_str(&format!("\t*{target}\n")),
@@ -52,13 +75,16 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
             }
             out.push_str("}\n");
             for method in methods {
-                render_method(scenario, &node.name, method, out);
+                render_method(scenario, node, method, out);
             }
         }
         NodeKind::Interface { methods, embeds } => {
-            out.push_str(&format!("type {} interface {{\n", node.name));
+            out.push_str(&format!("type {}{generics} interface {{\n", node.name));
             for embed in embeds {
-                out.push_str(&format!("\t{}\n", scenario.node_name(embed.target)));
+                out.push_str(&format!(
+                    "\t{}\n",
+                    go_node_ref(scenario, embed.target, &embed.type_args)
+                ));
             }
             for method in methods {
                 out.push_str(&format!(
@@ -76,16 +102,27 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
         } => {
             out.push_str(&format!("type {} {}\n", node.name, underlying.go()));
             for method in methods {
-                render_method(scenario, &node.name, method, out);
+                render_method(scenario, node, method, out);
             }
         }
     }
 }
 
-fn render_method(scenario: &Scenario, owner: &str, method: &Method, out: &mut String) {
+/// The receiver's type parameters without constraints: `[T]` or empty. Go names
+/// the params on a generic receiver but omits the `any` bound there.
+fn go_receiver_params(node: &Node) -> String {
+    if node.type_params.is_empty() {
+        return String::new();
+    }
+    format!("[{}]", node.type_params.join(", "))
+}
+
+fn render_method(scenario: &Scenario, node: &Node, method: &Method, out: &mut String) {
+    let owner = &node.name;
+    let recv_params = go_receiver_params(node);
     let receiver = match method.receiver {
-        Receiver::Value => format!("r {owner}"),
-        Receiver::Pointer => format!("r *{owner}"),
+        Receiver::Value => format!("r {owner}{recv_params}"),
+        Receiver::Pointer => format!("r *{owner}{recv_params}"),
     };
     out.push_str(&format!(
         "func ({}) {}({}) {} {{\n",
@@ -118,6 +155,7 @@ fn go_params(scenario: &Scenario, parameters: &[MemberType]) -> String {
 pub fn go_type(scenario: &Scenario, member_type: &MemberType) -> String {
     match member_type {
         MemberType::Basic(basic) => basic.go().to_string(),
+        MemberType::TypeParam(name) => name.clone(),
         MemberType::Node(id) => scenario.node_name(*id).to_string(),
         MemberType::Ref(inner) | MemberType::Option(inner) => {
             format!("*{}", go_type(scenario, inner))

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -121,7 +121,16 @@ fn push_declarations(scenario: &Scenario, out: &mut String) {
     }
 }
 
+fn lis_generics(node: &Node) -> String {
+    if node.type_params.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", node.type_params.join(", "))
+    }
+}
+
 fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    let generics = lis_generics(node);
     match &node.kind {
         NodeKind::Struct {
             fields,
@@ -129,9 +138,9 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
             methods,
         } => {
             if embeds.is_empty() && fields.is_empty() {
-                out.push_str(&format!("struct {} {{}}\n", node.name));
+                out.push_str(&format!("struct {}{generics} {{}}\n", node.name));
             } else {
-                out.push_str(&format!("struct {} {{\n", node.name));
+                out.push_str(&format!("struct {}{generics} {{\n", node.name));
                 for embed in embeds {
                     out.push_str(&format!("  embed {},\n", embed_type(scenario, embed)));
                 }
@@ -148,15 +157,18 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
                 }
                 out.push_str("}\n");
             }
-            render_impl(scenario, &node.name, methods, out);
+            render_impl(scenario, node, methods, out);
         }
         NodeKind::Interface { methods, embeds } => {
             if embeds.is_empty() && methods.is_empty() {
-                out.push_str(&format!("interface {} {{}}\n", node.name));
+                out.push_str(&format!("interface {}{generics} {{}}\n", node.name));
             } else {
-                out.push_str(&format!("interface {} {{\n", node.name));
+                out.push_str(&format!("interface {}{generics} {{\n", node.name));
                 for embed in embeds {
-                    out.push_str(&format!("  impl {}\n", scenario.node_name(embed.target)));
+                    out.push_str(&format!(
+                        "  embed {}\n",
+                        lis_node_ref(scenario, embed.target, &embed.type_args)
+                    ));
                 }
                 for method in methods {
                     out.push_str(&format!(
@@ -175,20 +187,22 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
         } => {
             // A tuple struct, not `type N = T`: an alias cannot carry methods.
             out.push_str(&format!("struct {}({})\n", node.name, underlying.lisette()));
-            render_impl(scenario, &node.name, methods, out);
+            render_impl(scenario, node, methods, out);
         }
     }
 }
 
-fn render_impl(scenario: &Scenario, owner: &str, methods: &[Method], out: &mut String) {
+fn render_impl(scenario: &Scenario, node: &Node, methods: &[Method], out: &mut String) {
     if methods.is_empty() {
         return;
     }
-    out.push_str(&format!("impl {owner} {{\n"));
+    let owner = &node.name;
+    let generics = lis_generics(node);
+    out.push_str(&format!("impl{generics} {owner}{generics} {{\n"));
     for method in methods {
         let receiver = match method.receiver {
             Receiver::Value => "self".to_string(),
-            Receiver::Pointer => format!("self: Ref<{owner}>"),
+            Receiver::Pointer => format!("self: Ref<{owner}{generics}>"),
         };
         let extra = lis_parameters(scenario, &method.signature.parameters);
         match &method.signature.return_type {
@@ -220,14 +234,24 @@ fn lis_parameters(scenario: &Scenario, parameters: &[MemberType]) -> String {
 }
 
 fn embed_type(scenario: &Scenario, embed: &Embed) -> String {
-    let target = scenario.node_name(embed.target);
+    let target = lis_node_ref(scenario, embed.target, &embed.type_args);
     match (embed.edge, embed.storage) {
-        (EdgeKind::Value, Storage::Plain) => target.to_string(),
+        (EdgeKind::Value, Storage::Plain) => target,
         (EdgeKind::Pointer, Storage::Plain) => format!("Ref<{target}>"),
         (EdgeKind::Value, Storage::Option) => format!("Option<{target}>"),
         (EdgeKind::Pointer, Storage::OptionPointer) => format!("Option<Ref<{target}>>"),
         (edge, storage) => panic!("invalid embed edge/storage pairing: {edge:?}/{storage:?}"),
     }
+}
+
+/// A node reference with optional type arguments: `Box` or `Box<int>`.
+fn lis_node_ref(scenario: &Scenario, target: NodeId, type_args: &[MemberType]) -> String {
+    let name = scenario.node_name(target);
+    if type_args.is_empty() {
+        return name.to_string();
+    }
+    let args: Vec<String> = type_args.iter().map(|a| lis_type(scenario, a)).collect();
+    format!("{name}<{}>", args.join(", "))
 }
 
 pub fn lis_type(scenario: &Scenario, member_type: &MemberType) -> String {
@@ -237,6 +261,7 @@ pub fn lis_type(scenario: &Scenario, member_type: &MemberType) -> String {
         MemberType::Ref(inner) => format!("Ref<{}>", lis_type(scenario, inner)),
         MemberType::Slice(inner) => format!("Slice<{}>", lis_type(scenario, inner)),
         MemberType::Option(inner) => format!("Option<{}>", lis_type(scenario, inner)),
+        MemberType::TypeParam(name) => name.clone(),
     }
 }
 
@@ -391,13 +416,78 @@ mod tests {
     #[test]
     fn multi_member_interface_parses() {
         let src = "interface N1 {\n  fn C(self) -> bool\n}\n\n\
-                   interface N0 {\n  impl N1\n  fn A(self) -> int\n  fn B(self) -> string\n}\n";
+                   interface N0 {\n  embed N1\n  fn A(self) -> int\n  fn B(self) -> string\n}\n";
         let result = syntax::build_ast(src, 0);
         assert!(
             !result.failed(),
             "multi-member interface parse: {:?}",
             result.errors
         );
+    }
+
+    #[test]
+    fn generic_node_renders_in_both_languages() {
+        let scenario = crate::_embed_harness::corpus::generic_embed_promotes();
+
+        let lis = render_lis_declarations(&scenario);
+        assert!(lis.contains("struct N0<T>"), "lisette header:\n{lis}");
+        assert!(lis.contains("impl<T> N0<T>"), "lisette impl:\n{lis}");
+        assert!(lis.contains("embed N0<int>"), "lisette embed:\n{lis}");
+
+        let go = render_go(&scenario, GoMode::TypeDefs);
+        assert!(go.contains("type N0[T any] struct"), "go header:\n{go}");
+        assert!(go.contains("func (r N0[T]) Tag()"), "go receiver:\n{go}");
+        assert!(go.contains("N0[int]"), "go embed:\n{go}");
+    }
+
+    #[test]
+    fn generic_interface_parent_renders_type_args_in_both_languages() {
+        let parent = Node {
+            id: 0,
+            name: "N0".into(),
+            type_params: vec!["T".into()],
+            kind: NodeKind::Interface {
+                methods: vec![Method {
+                    name: "Get".into(),
+                    receiver: Receiver::Value,
+                    signature: Signature {
+                        parameters: vec![],
+                        return_type: MemberType::TypeParam("T".into()),
+                    },
+                    visibility: Visibility::Public,
+                }],
+                embeds: vec![],
+            },
+            origin: Origin::Native,
+        };
+        let child = Node {
+            id: 1,
+            name: "N1".into(),
+            type_params: vec![],
+            kind: NodeKind::Interface {
+                methods: vec![],
+                embeds: vec![Embed {
+                    target: 0,
+                    edge: EdgeKind::Value,
+                    storage: Storage::Plain,
+                    type_args: vec![MemberType::Basic(BasicType::Int)],
+                }],
+            },
+            origin: Origin::Native,
+        };
+        let scenario = Scenario {
+            name: "generic_iface_parent".into(),
+            seed: 0,
+            nodes: vec![parent, child],
+            questions: vec![],
+        };
+        scenario.validate().unwrap();
+
+        let lis = render_lis_declarations(&scenario);
+        assert!(lis.contains("embed N0<int>"), "lisette embed:\n{lis}");
+
+        let go = render_go(&scenario, GoMode::TypeDefs);
+        assert!(go.contains("N0[int]"), "go embed:\n{go}");
     }
 
     #[test]

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -130,7 +130,7 @@ fn is_zero_constructible(scenario: &Scenario, id: NodeId) -> bool {
 
 fn zeroable(member_type: &MemberType) -> bool {
     match member_type {
-        MemberType::Ref(_) | MemberType::Node(_) => false,
+        MemberType::Ref(_) | MemberType::Node(_) | MemberType::TypeParam(_) => false,
         MemberType::Basic(_) | MemberType::Slice(_) | MemberType::Option(_) => true,
     }
 }

--- a/tests/_embed_harness/scenario.rs
+++ b/tests/_embed_harness/scenario.rs
@@ -18,6 +18,10 @@ pub struct Node {
     pub id: NodeId,
     /// `N{id}`; unique within the scenario by construction.
     pub name: String,
+    /// Generic parameter names (e.g. `["A"]`); empty for a monomorphic node.
+    /// A member may reference one via `MemberType::TypeParam`.
+    #[serde(default)]
+    pub type_params: Vec<String>,
     pub kind: NodeKind,
     pub origin: Origin,
 }
@@ -55,6 +59,10 @@ pub struct Embed {
     pub edge: EdgeKind,
     /// Pairs with `edge`: `Option` with `Value`, `OptionPointer` with `Pointer`.
     pub storage: Storage,
+    /// Type arguments when the target is generic (e.g. `[Basic(Int)]` for
+    /// `embed Box<int>`); length matches the target's `type_params`.
+    #[serde(default)]
+    pub type_args: Vec<MemberType>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -110,6 +118,8 @@ pub enum MemberType {
     Ref(Box<MemberType>),
     Slice(Box<MemberType>),
     Option(Box<MemberType>),
+    /// A reference to an enclosing node's generic parameter (e.g. `T`).
+    TypeParam(String),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -192,17 +202,29 @@ impl Scenario {
                         self.node_name(embed.target)
                     ));
                 }
+                if embed.type_args.len() != self.nodes[embed.target].type_params.len() {
+                    return Err(format!(
+                        "embed on `{}` gives {} type args for target `{}` with {} params",
+                        node.name,
+                        embed.type_args.len(),
+                        self.node_name(embed.target),
+                        self.nodes[embed.target].type_params.len()
+                    ));
+                }
+                for arg in &embed.type_args {
+                    self.check_member_type(arg, &node.type_params)?;
+                }
             }
             for field in node.kind.fields() {
                 check_casing(&field.name, field.visibility, &node.name)?;
-                self.check_member_type(&field.member_type)?;
+                self.check_member_type(&field.member_type, &node.type_params)?;
             }
             for method in node.kind.methods() {
                 check_casing(&method.name, method.visibility, &node.name)?;
                 for param in &method.signature.parameters {
-                    self.check_member_type(param)?;
+                    self.check_member_type(param, &node.type_params)?;
                 }
-                self.check_member_type(&method.signature.return_type)?;
+                self.check_member_type(&method.signature.return_type, &node.type_params)?;
             }
         }
         for question in &self.questions {
@@ -230,12 +252,19 @@ impl Scenario {
         Ok(())
     }
 
-    fn check_member_type(&self, member_type: &MemberType) -> Result<(), String> {
+    fn check_member_type(&self, member_type: &MemberType, scope: &[String]) -> Result<(), String> {
         match member_type {
             MemberType::Basic(_) => Ok(()),
+            MemberType::TypeParam(name) => {
+                if scope.iter().any(|param| param == name) {
+                    Ok(())
+                } else {
+                    Err(format!("type param `{name}` is not in scope"))
+                }
+            }
             MemberType::Node(id) => self.check_node_ref(*id, "member type"),
             MemberType::Ref(inner) | MemberType::Slice(inner) | MemberType::Option(inner) => {
-                self.check_member_type(inner)
+                self.check_member_type(inner, scope)
             }
         }
     }
@@ -343,6 +372,7 @@ mod tests {
         let leaf = Node {
             id: 0,
             name: "N0".into(),
+            type_params: vec![],
             kind: NodeKind::NamedBasic {
                 underlying: BasicType::Float,
                 methods: vec![Method {
@@ -361,6 +391,7 @@ mod tests {
         let interface = Node {
             id: 1,
             name: "N1".into(),
+            type_params: vec![],
             kind: NodeKind::Interface {
                 methods: vec![Method {
                     name: cased("speak", Visibility::Public),
@@ -381,6 +412,7 @@ mod tests {
         let outer = Node {
             id: 2,
             name: "N2".into(),
+            type_params: vec![],
             kind: NodeKind::Struct {
                 fields: vec![
                     Field {
@@ -401,11 +433,13 @@ mod tests {
                         target: 0,
                         edge: EdgeKind::Value,
                         storage: Storage::Plain,
+                        type_args: vec![],
                     },
                     Embed {
                         target: 1,
                         edge: EdgeKind::Value,
                         storage: Storage::Option,
+                        type_args: vec![],
                     },
                 ],
                 methods: vec![Method {
@@ -424,12 +458,14 @@ mod tests {
         let pointer_embedder = Node {
             id: 3,
             name: "N3".into(),
+            type_params: vec![],
             kind: NodeKind::Struct {
                 fields: vec![],
                 embeds: vec![Embed {
                     target: 2,
                     edge: EdgeKind::Pointer,
                     storage: Storage::OptionPointer,
+                    type_args: vec![],
                 }],
                 methods: vec![],
             },
@@ -494,7 +530,17 @@ mod tests {
                 target: 2,
                 edge: EdgeKind::Value,
                 storage: Storage::Plain,
+                type_args: vec![],
             });
+        }
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_scope_type_param() {
+        let mut scenario = kitchen_sink();
+        if let NodeKind::Struct { fields, .. } = &mut scenario.nodes[2].kind {
+            fields[0].member_type = MemberType::TypeParam("Z".into());
         }
         assert!(scenario.validate().is_err());
     }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -6083,19 +6083,20 @@ fn main() {}
 }
 
 #[test]
-fn embed_generic_instantiation_rejected() {
+fn embed_generic_instantiation_promotes() {
     infer(
         r#"
-struct Wrapper<T> { value: T }
+pub struct Wrapper<T> { pub value: T }
 struct S { embed Wrapper<int> }
+fn read(s: S) -> int { s.value }
 fn main() {}
 "#,
     )
-    .assert_infer_code("embed_generic");
+    .assert_no_errors();
 }
 
 #[test]
-fn embed_generic_alias_to_storage_rejected() {
+fn embed_generic_alias_to_storage_accepted() {
     infer(
         r#"
 pub struct Base { pub id: int }
@@ -6104,11 +6105,11 @@ struct S { embed P<Base> }
 fn main() {}
 "#,
     )
-    .assert_infer_code("embed_generic");
+    .assert_no_errors();
 }
 
 #[test]
-fn embed_generic_alias_under_ref_rejected() {
+fn embed_generic_alias_under_ref_accepted() {
     infer(
         r#"
 pub struct Base { pub id: int }
@@ -6117,7 +6118,7 @@ struct S { embed Ref<P<Base>> }
 fn main() {}
 "#,
     )
-    .assert_infer_code("embed_generic");
+    .assert_no_errors();
 }
 
 #[test]
@@ -6132,7 +6133,77 @@ struct S { embed ref.Ref<ref.Base> }
 fn main() {}
 "#;
     infer_with_go_typedefs(input, &[("go:example.com/ref", typedef)])
-        .assert_infer_code("embed_generic");
+        .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn generic_embed_promotes_method_to_instantiated_return() {
+    infer(
+        r#"
+pub struct Box<T> { pub value: T }
+impl<T> Box<T> { pub fn get(self) -> T { self.value } }
+struct Outer { embed Box<string> }
+fn use_it(o: Outer) -> string { o.get() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_embed_method_return_is_the_instantiated_type() {
+    infer(
+        r#"
+pub struct Box<T> { pub value: T }
+impl<T> Box<T> { pub fn get(self) -> T { self.value } }
+struct Outer { embed Box<int> }
+fn use_it(o: Outer) -> string { o.get() }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn generic_embedder_promotes_with_flowed_param() {
+    infer(
+        r#"
+pub struct Box<T> { pub value: T }
+impl<T> Box<T> { pub fn get(self) -> T { self.value } }
+struct Outer<U> { embed Box<U> }
+fn use_it(o: Outer<int>) -> int { o.get() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn specialized_impl_method_not_promoted_onto_other_instantiation() {
+    infer(
+        r#"
+pub struct Box<T> { pub value: T }
+impl Box<int> { pub fn only_int(self) -> int { 0 } }
+struct Outer { embed Box<string> }
+fn use_it(o: Outer) -> int { o.only_int() }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("member_not_found");
+}
+
+#[test]
+fn specialized_impl_method_promoted_onto_matching_instantiation() {
+    infer(
+        r#"
+pub struct Box<T> { pub value: T }
+impl Box<int> { pub fn only_int(self) -> int { 0 } }
+struct Outer { embed Box<int> }
+fn use_it(o: Outer) -> int { o.only_int() }
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
 }
 
 #[test]


### PR DESCRIPTION
Adds support for embedding generic structs.

```rs
pub struct Box<T> { pub value: T }
impl<T> Box<T> { pub fn get(self) -> T { self.value } }

struct Wrapper { embed Box<int> }

fn use_it(w: Wrapper) -> int { w.get() }
```

Also, the embedder itself may be generic and so flow its parameter into the embed, e.g. `struct Wrapper<U> { embed Box<U> }`

Relates to #581