### PR TITLE
test: add imported types to embed harness

### DIFF
--- a/tests/_embed_harness/corpus.rs
+++ b/tests/_embed_harness/corpus.rs
@@ -178,6 +178,62 @@ pub fn generic_embed_satisfies() -> Scenario {
     }
 }
 
+/// `image.Point` as an imported node: a flat stdlib struct (`X`/`Y`, value `String`).
+fn image_point() -> Node {
+    Node {
+        id: 0,
+        name: "Point".into(),
+        type_params: vec![],
+        kind: NodeKind::Struct {
+            fields: vec![
+                Field {
+                    name: "X".into(),
+                    member_type: MemberType::Basic(BasicType::Int),
+                    visibility: Visibility::Public,
+                },
+                Field {
+                    name: "Y".into(),
+                    member_type: MemberType::Basic(BasicType::Int),
+                    visibility: Visibility::Public,
+                },
+            ],
+            embeds: vec![],
+            methods: vec![Method {
+                name: "String".into(),
+                receiver: Receiver::Value,
+                signature: Signature {
+                    parameters: vec![],
+                    return_type: MemberType::Basic(BasicType::String),
+                },
+                visibility: Visibility::Public,
+            }],
+        },
+        origin: Origin::Imported {
+            pkg: "image".into(),
+        },
+    }
+}
+
+/// Fixture for the `Origin::Imported` renderer test; not yet in the differential.
+pub fn imported_struct_embed() -> Scenario {
+    Scenario {
+        name: "imported_struct_embed".into(),
+        seed: 0,
+        nodes: vec![
+            image_point(),
+            struct_node(1, vec![vembed(0)], vec![], vec![]),
+        ],
+        questions: vec![
+            Question::Selector {
+                root: 1,
+                member: "X".into(),
+                kind: SelKind::Field,
+            },
+            sel(1, "String"),
+        ],
+    }
+}
+
 /// Every scenario that goes through the full differential.
 pub fn differential_scenarios() -> Vec<Scenario> {
     let mut scenarios = super::fixtures::all();

--- a/tests/_embed_harness/render_go.rs
+++ b/tests/_embed_harness/render_go.rs
@@ -14,8 +14,9 @@ pub fn render_go(scenario: &Scenario, mode: GoMode) -> String {
     let mut out = String::new();
     match mode {
         GoMode::TypeDefs => out.push_str("package p\n\n"),
-        GoMode::RunMain(_) => out.push_str("package main\n\nimport \"fmt\"\n\n"),
+        GoMode::RunMain(_) => out.push_str("package main\n\n"),
     }
+    emit_go_imports(scenario, &mode, &mut out);
 
     for node in &scenario.nodes {
         render_node(scenario, node, &mut out);
@@ -26,6 +27,31 @@ pub fn render_go(scenario: &Scenario, mode: GoMode) -> String {
         render_main(scenario, printed, &mut out);
     }
     out
+}
+
+fn emit_go_imports(scenario: &Scenario, mode: &GoMode, out: &mut String) {
+    let mut paths: Vec<&str> = Vec::new();
+    if matches!(mode, GoMode::RunMain(_)) {
+        paths.push("fmt");
+    }
+    for node in &scenario.nodes {
+        if let Some(pkg) = node.origin.pkg()
+            && !paths.contains(&pkg)
+        {
+            paths.push(pkg);
+        }
+    }
+    match paths.as_slice() {
+        [] => {}
+        [one] => out.push_str(&format!("import \"{one}\"\n\n")),
+        many => {
+            out.push_str("import (\n");
+            for path in many {
+                out.push_str(&format!("\t\"{path}\"\n"));
+            }
+            out.push_str(")\n\n");
+        }
+    }
 }
 
 fn go_generics(node: &Node) -> String {
@@ -42,15 +68,18 @@ fn go_generics(node: &Node) -> String {
 
 /// A node reference with optional type arguments: `Box` or `Box[int]`.
 fn go_node_ref(scenario: &Scenario, target: NodeId, type_args: &[MemberType]) -> String {
-    let name = scenario.node_name(target);
+    let name = scenario.node_ref(target);
     if type_args.is_empty() {
-        return name.to_string();
+        return name;
     }
     let args: Vec<String> = type_args.iter().map(|a| go_type(scenario, a)).collect();
     format!("{name}[{}]", args.join(", "))
 }
 
 fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    if node.origin.pkg().is_some() {
+        return; // imported nodes are referenced, not defined
+    }
     let generics = go_generics(node);
     match &node.kind {
         NodeKind::Struct {
@@ -156,7 +185,7 @@ pub fn go_type(scenario: &Scenario, member_type: &MemberType) -> String {
     match member_type {
         MemberType::Basic(basic) => basic.go().to_string(),
         MemberType::TypeParam(name) => name.clone(),
-        MemberType::Node(id) => scenario.node_name(*id).to_string(),
+        MemberType::Node(id) => scenario.node_ref(*id),
         MemberType::Ref(inner) | MemberType::Option(inner) => {
             format!("*{}", go_type(scenario, inner))
         }

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -115,8 +115,27 @@ pub fn render_lis_run(scenario: &Scenario, printed: &[PrintedQuestion]) -> Strin
 }
 
 fn push_declarations(scenario: &Scenario, out: &mut String) {
+    emit_lis_imports(scenario, out);
     for node in &scenario.nodes {
         render_node(scenario, node, out);
+        out.push('\n');
+    }
+}
+
+/// Renders only the `import "go:<pkg>"`; the stdlib typedef is auto-loaded.
+fn emit_lis_imports(scenario: &Scenario, out: &mut String) {
+    let mut pkgs: Vec<&str> = Vec::new();
+    for node in &scenario.nodes {
+        if let Some(pkg) = node.origin.pkg()
+            && !pkgs.contains(&pkg)
+        {
+            pkgs.push(pkg);
+        }
+    }
+    for pkg in &pkgs {
+        out.push_str(&format!("import \"go:{pkg}\"\n"));
+    }
+    if !pkgs.is_empty() {
         out.push('\n');
     }
 }
@@ -130,6 +149,9 @@ fn lis_generics(node: &Node) -> String {
 }
 
 fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
+    if node.origin.pkg().is_some() {
+        return; // imported nodes are referenced, not defined
+    }
     let generics = lis_generics(node);
     match &node.kind {
         NodeKind::Struct {
@@ -246,9 +268,9 @@ fn embed_type(scenario: &Scenario, embed: &Embed) -> String {
 
 /// A node reference with optional type arguments: `Box` or `Box<int>`.
 fn lis_node_ref(scenario: &Scenario, target: NodeId, type_args: &[MemberType]) -> String {
-    let name = scenario.node_name(target);
+    let name = scenario.node_ref(target);
     if type_args.is_empty() {
-        return name.to_string();
+        return name;
     }
     let args: Vec<String> = type_args.iter().map(|a| lis_type(scenario, a)).collect();
     format!("{name}<{}>", args.join(", "))
@@ -257,7 +279,7 @@ fn lis_node_ref(scenario: &Scenario, target: NodeId, type_args: &[MemberType]) -
 pub fn lis_type(scenario: &Scenario, member_type: &MemberType) -> String {
     match member_type {
         MemberType::Basic(basic) => basic.lisette().to_string(),
-        MemberType::Node(id) => scenario.node_name(*id).to_string(),
+        MemberType::Node(id) => scenario.node_ref(*id),
         MemberType::Ref(inner) => format!("Ref<{}>", lis_type(scenario, inner)),
         MemberType::Slice(inner) => format!("Slice<{}>", lis_type(scenario, inner)),
         MemberType::Option(inner) => format!("Option<{}>", lis_type(scenario, inner)),
@@ -438,6 +460,30 @@ mod tests {
         assert!(go.contains("type N0[T any] struct"), "go header:\n{go}");
         assert!(go.contains("func (r N0[T]) Tag()"), "go receiver:\n{go}");
         assert!(go.contains("N0[int]"), "go embed:\n{go}");
+    }
+
+    #[test]
+    fn imported_node_renders_as_package_reference() {
+        let scenario = crate::_embed_harness::corpus::imported_struct_embed();
+
+        let lis = render_lis_declarations(&scenario);
+        assert!(
+            lis.contains("import \"go:image\""),
+            "lisette import:\n{lis}"
+        );
+        assert!(lis.contains("embed image.Point"), "lisette embed:\n{lis}");
+        assert!(
+            !lis.contains("struct Point"),
+            "imported Point must not be defined:\n{lis}"
+        );
+
+        let go = render_go(&scenario, GoMode::TypeDefs);
+        assert!(go.contains("import \"image\""), "go import:\n{go}");
+        assert!(go.contains("\timage.Point\n"), "go anonymous field:\n{go}");
+        assert!(
+            !go.contains("type Point struct"),
+            "imported Point must not be defined:\n{go}"
+        );
     }
 
     #[test]

--- a/tests/_embed_harness/scenario.rs
+++ b/tests/_embed_harness/scenario.rs
@@ -138,12 +138,25 @@ pub enum Visibility {
     Private,
 }
 
-/// Every node is `Native` today. `Imported` is an unused seam for bindgen-derived
-/// nodes, where only the renderer leaf case and node factory change.
+/// A node declared in the generated source, or a reference to a real Go package type.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Origin {
     Native,
     Imported { pkg: String },
+}
+
+impl Origin {
+    pub fn pkg(&self) -> Option<&str> {
+        match self {
+            Origin::Native => None,
+            Origin::Imported { pkg } => Some(pkg),
+        }
+    }
+
+    /// The reference qualifier: the last path segment (`net/url` -> `url`).
+    pub fn alias(&self) -> Option<&str> {
+        self.pkg().map(|pkg| pkg.rsplit('/').next().unwrap_or(pkg))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -176,11 +189,28 @@ impl Scenario {
         &self.nodes[id].name
     }
 
+    /// How a node is referenced in source: `Name`, or `alias.Name` if imported.
+    pub fn node_ref(&self, id: NodeId) -> String {
+        let node = &self.nodes[id];
+        match node.origin.alias() {
+            Some(alias) => format!("{alias}.{}", node.name),
+            None => node.name.clone(),
+        }
+    }
+
     /// Invariants the renderers rely on; a failure is a generator/corpus bug.
     pub fn validate(&self) -> Result<(), String> {
         for (index, node) in self.nodes.iter().enumerate() {
             if node.id != index {
                 return Err(format!("node {} has id {}", index, node.id));
+            }
+            if let Some(pkg) = node.origin.pkg()
+                && pkg.starts_with("go:")
+            {
+                return Err(format!(
+                    "imported node `{}` has Lisette-prefixed pkg `{pkg}`; use the raw Go path",
+                    node.name
+                ));
             }
             for embed in node.kind.embeds() {
                 self.check_node_ref(embed.target, "embed target")?;
@@ -404,9 +434,7 @@ mod tests {
                 }],
                 embeds: vec![],
             },
-            origin: Origin::Imported {
-                pkg: "go:fmt".into(),
-            },
+            origin: Origin::Imported { pkg: "fmt".into() },
         };
 
         let outer = Node {
@@ -509,6 +537,15 @@ mod tests {
     fn validate_rejects_bad_id() {
         let mut scenario = kitchen_sink();
         scenario.nodes[1].id = 99;
+        assert!(scenario.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_go_prefixed_imported_pkg() {
+        let mut scenario = kitchen_sink();
+        scenario.nodes[1].origin = Origin::Imported {
+            pkg: "go:fmt".into(),
+        };
         assert!(scenario.validate().is_err());
     }
 

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -6206,6 +6206,8 @@ fn main() {}
     .assert_no_errors();
 }
 
+// Imported embeds stay deferred until bindgen emits a faithful embed representation.
+
 #[test]
 fn embed_imported_struct_deferred() {
     let typedef = r#"
@@ -6234,6 +6236,49 @@ fn main() {}
 "#;
     infer_with_go_typedefs(input, &[("go:example.com/ref", typedef)])
         .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn embed_imported_interface_deferred() {
+    let typedef = r#"
+pub interface Reader {
+  fn Read(self) -> int
+}
+"#;
+    let input = r#"
+import "go:example.com/io"
+struct Mine { embed io.Reader }
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/io", typedef)])
+        .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn embed_imported_newtype_deferred() {
+    let typedef = r#"
+pub struct Count(int)
+impl Count { pub fn Value(self: Count) -> int }
+"#;
+    let input = r#"
+import "go:example.com/metric"
+struct Mine { embed metric.Count }
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/metric", typedef)])
+        .assert_infer_code("embed_imported_target");
+}
+
+#[test]
+fn embed_stdlib_struct_deferred() {
+    infer(
+        r#"
+import "go:image"
+struct Marker { embed image.Point }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("embed_imported_target");
 }
 
 #[test]


### PR DESCRIPTION
Extends the embedding harness to represent imported Go package types. Coverage asserts that embedding an imported type stays deferred across structs, interfaces, and newtypes.

Relates to #581