### PR TITLE
perf: memoize global enum layouts and generic constraints in emit

### DIFF
--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -223,7 +223,7 @@ impl Planner<'_> {
                 // name is recorded once (coalescing is intentional, not a
                 // collision); per-variant duplicates are out of scope here.
                 let qualified = self.facts.qualified_current(name);
-                if let Some(layout) = self.module.enum_layout(&qualified) {
+                if let Some(layout) = self.enum_layout(&qualified) {
                     let mut seen: HashSet<&str> = HashSet::default();
                     for (variant, layout_variant) in variants.iter().zip(&layout.variants) {
                         for field in &layout_variant.fields {

--- a/crates/emit/src/analyze/constraint_collector.rs
+++ b/crates/emit/src/analyze/constraint_collector.rs
@@ -11,19 +11,22 @@ use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 impl Planner<'_> {
     pub(crate) fn collect_generic_constraints(&mut self, files: &[&File], fx: &mut EmitEffects) {
-        let mut table = GenericConstraintTable::default();
+        let base_cell = self.facts.generic_base();
+        let base = base_cell.get_or_init(|| {
+            let mut t = GenericConstraintTable::default();
+            self.seed_global_definitions(&mut t);
+            self.for_each_definition_type(|key, names, ty| {
+                collect_demands_from_type(ty, key, names, &mut t);
+            });
+            self.propagate_constraints(&mut t);
+            t
+        });
+        let mut table = base.clone();
 
-        self.seed_global_definitions(&mut table);
         self.seed_local_functions(files, &mut table);
         self.seed_local_impl_blocks(files, &mut table, fx);
-
-        self.for_each_definition_type(|key, names, ty| {
-            collect_demands_from_type(ty, key, names, &mut table);
-        });
         self.collect_demands_from_local_functions(files, &mut table);
         self.collect_demands_from_local_impl_blocks(files, &mut table);
-
-        self.propagate_constraints(&mut table);
 
         self.module.set_generic_constraints(table);
     }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -9,6 +10,7 @@ use syntax::types::{Symbol, Type};
 
 use crate::classify_go_return_type;
 use crate::context::lowering::LineIndex;
+use crate::names::constraints::GenericConstraintTable;
 use crate::names::go_name;
 use crate::{EmitOptions, GlobalEmitData, GoCallStrategy};
 
@@ -24,6 +26,7 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) options: EmitOptions,
     pub(crate) line_indexes: Arc<HashMap<u32, LineIndex>>,
     pub(crate) globals: Arc<GlobalEmitData>,
+    pub(crate) generic_base: Arc<OnceLock<GenericConstraintTable>>,
     pub(crate) current_module: ModuleId,
 }
 
@@ -39,6 +42,7 @@ pub(crate) struct EmitFacts<'a> {
     options: EmitOptions,
     line_indexes: Arc<HashMap<u32, LineIndex>>,
     globals: Arc<GlobalEmitData>,
+    generic_base: Arc<OnceLock<GenericConstraintTable>>,
     current_module: ModuleId,
 }
 
@@ -56,8 +60,13 @@ impl<'a> EmitFacts<'a> {
             options: config.options,
             line_indexes: config.line_indexes,
             globals: config.globals,
+            generic_base: config.generic_base,
             current_module: config.current_module,
         }
+    }
+
+    pub(crate) fn generic_base(&self) -> Arc<OnceLock<GenericConstraintTable>> {
+        self.generic_base.clone()
     }
 
     pub(crate) fn module_for_qualified_name<'b>(&self, id: &'b str) -> Option<&'b str>

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::Planner;
@@ -224,56 +226,53 @@ impl Planner<'_> {
 }
 
 impl Planner<'_> {
-    /// Pre-compute enum layouts for all known enum definitions.
-    pub(crate) fn collect_enum_layouts(&mut self) {
-        let enum_definitions: Vec<_> = self
-            .facts
-            .iter_definitions()
-            .filter_map(|(id, definition)| {
-                if let Definition {
-                    name: Some(name),
-                    body:
-                        DefinitionBody::Enum {
-                            generics, variants, ..
-                        },
-                    ..
-                } = definition
-                {
-                    if name == "Option" || name == "Result" || name == "Partial" {
-                        return None;
-                    }
-                    Some((id.to_string(), generics.clone(), variants.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        for (enum_id, generics, variants) in enum_definitions {
-            let mut field_types = FieldTypeMap::default();
-            for (vi, variant) in variants.iter().enumerate() {
-                for (fi, field) in variant.fields.iter().enumerate() {
-                    let mut go_type = self.go_type(&field.ty).code;
-                    let recursive = is_recursive_type(&field.ty, &enum_id);
-
-                    if recursive {
-                        go_type = format!("*{}", go_type);
-                    }
-
-                    let is_function = !recursive && is_raw_function_type(&field.ty);
-                    field_types.insert(
-                        (vi, fi),
-                        FieldTypeInfo {
-                            go_type,
-                            is_function,
-                        },
-                    );
-                }
-            }
-
-            let layout = EnumLayout::new(&enum_id, &generics, &variants, &field_types);
-            self.module.record_enum_layout(enum_id, layout);
+    pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<Rc<EnumLayout>> {
+        if let Some(layout) = self.module.enum_layout(enum_id) {
+            return Some(layout);
         }
+        let layout = self.compute_enum_layout(enum_id)?;
+        self.module.record_enum_layout(enum_id.to_string(), layout);
+        self.module.enum_layout(enum_id)
+    }
+
+    fn compute_enum_layout(&self, enum_id: &str) -> Option<EnumLayout> {
+        let Definition {
+            name: Some(name),
+            body: DefinitionBody::Enum {
+                generics, variants, ..
+            },
+            ..
+        } = self.facts.definition(enum_id)?
+        else {
+            return None;
+        };
+
+        if name == "Option" || name == "Result" || name == "Partial" {
+            return None;
+        }
+
+        let mut field_types = FieldTypeMap::default();
+        for (vi, variant) in variants.iter().enumerate() {
+            for (fi, field) in variant.fields.iter().enumerate() {
+                let mut go_type = self.go_type(&field.ty).code;
+                let recursive = is_recursive_type(&field.ty, enum_id);
+
+                if recursive {
+                    go_type = format!("*{}", go_type);
+                }
+
+                let is_function = !recursive && is_raw_function_type(&field.ty);
+                field_types.insert(
+                    (vi, fi),
+                    FieldTypeInfo {
+                        go_type,
+                        is_function,
+                    },
+                );
+            }
+        }
+
+        Some(EnumLayout::new(enum_id, generics, variants, &field_types))
     }
 
     pub(crate) fn enum_struct_field_name(
@@ -282,8 +281,7 @@ impl Planner<'_> {
         variant_name: &str,
         field_name: &str,
     ) -> Option<String> {
-        self.module
-            .enum_layout(enum_id)?
+        self.enum_layout(enum_id)?
             .struct_field_name(variant_name, field_name)
     }
 
@@ -293,8 +291,7 @@ impl Planner<'_> {
         variant_name: &str,
         field_index: usize,
     ) -> Option<String> {
-        self.module
-            .enum_layout(enum_id)?
+        self.enum_layout(enum_id)?
             .tuple_field_name(variant_name, field_index)
     }
 
@@ -344,7 +341,7 @@ impl Planner<'_> {
 
     pub(crate) fn is_enum_field_pointer(&self, ty: &Type, variant: &str, index: usize) -> bool {
         if let Type::Nominal { id, .. } = ty
-            && let Some(layout) = self.module.enum_layout(id.as_ref())
+            && let Some(layout) = self.enum_layout(id.as_ref())
             && let Some(variant_layout) = layout.get_variant(variant)
             && let Some(field) = variant_layout.fields.get(index)
         {

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -418,7 +418,7 @@ impl Planner<'_> {
             return HashSet::default();
         };
 
-        let Some(layout) = self.module.enum_layout(&enum_id) else {
+        let Some(layout) = self.enum_layout(&enum_id) else {
             return HashSet::default();
         };
 
@@ -458,7 +458,7 @@ impl Planner<'_> {
                     for key in self.facts.make_function_keys() {
                         if let Some((e_name, v_name)) = key.split_once('.')
                             && e_name == enum_name
-                            && let Some(layout) = self.module.enum_layout(&enum_id)
+                            && let Some(layout) = self.enum_layout(&enum_id)
                             && let Some(v) = layout.get_variant(v_name)
                             && v.fields.len() == f.params.len()
                         {

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -52,7 +52,7 @@ impl Planner<'_> {
         let emit_string = synthesize && !has_user_string;
         let emit_go_string = synthesize && !has_user_go_string;
         let needs_fmt = emit_string || emit_go_string || has_json;
-        let layout = self.module.enum_layout(&enum_id).unwrap();
+        let layout = self.enum_layout(&enum_id).unwrap();
         let mut result = layout.emit_definition(&generics_string);
         if emit_string {
             result.push_str("\n\n");

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -500,7 +500,7 @@ impl Planner<'_> {
 
         let tag_constant = self.resolve_variant(name, enum_id, fx);
 
-        let pointer_fields = if let Some(layout) = self.module.enum_layout(enum_id) {
+        let pointer_fields = if let Some(layout) = self.enum_layout(enum_id) {
             if let Some(variant) = layout.get_variant(&variant_name) {
                 variant
                     .fields

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -36,8 +36,10 @@ pub use output::imports;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
+use names::constraints::GenericConstraintTable;
 use output::imports::ImportBuilder;
 use plan::ModulePlan;
 use plan::bodies::{LoweredBlock, LoweredStatement};
@@ -236,7 +238,12 @@ impl<'a> Planner<'a> {
             HashMap::default()
         });
 
-        let globals = Arc::new(GlobalEmitData::compute(&analysis.definitions));
+        let shared = SharedEmitContext {
+            options,
+            line_indexes,
+            globals: Arc::new(GlobalEmitData::compute(&analysis.definitions)),
+            generic_base: Arc::new(OnceLock::new()),
+        };
 
         let mut work: Vec<(&ModuleId, &syntax::program::ModuleInfo)> = analysis
             .modules
@@ -248,15 +255,7 @@ impl<'a> Planner<'a> {
         const PARALLEL_THRESHOLD: usize = 4;
 
         let emit_one = |&(module_id, module_info): &(&ModuleId, &syntax::program::ModuleInfo)| {
-            emit_module(
-                analysis,
-                go_module,
-                &options,
-                &line_indexes,
-                &globals,
-                module_id,
-                module_info,
-            )
+            emit_module(analysis, go_module, &shared, module_id, module_info)
         };
 
         let mut output: Vec<OutputFile> = if work.len() < PARALLEL_THRESHOLD {
@@ -294,6 +293,7 @@ impl<'a> Planner<'a> {
             options: EmitOptions { debug },
             line_indexes,
             globals,
+            generic_base: Arc::new(OnceLock::new()),
             current_module: config.module_id.to_string(),
         });
         Self::new(facts)
@@ -524,12 +524,19 @@ impl<'a> Planner<'a> {
     }
 }
 
+/// Emit state built once in [`Planner::emit`] and shared (by `&`) across every
+/// module worker: options plus the three computed-once `Arc`s.
+struct SharedEmitContext {
+    options: EmitOptions,
+    line_indexes: Arc<HashMap<u32, LineIndex>>,
+    globals: Arc<GlobalEmitData>,
+    generic_base: Arc<OnceLock<GenericConstraintTable>>,
+}
+
 fn emit_module<'a>(
     analysis: &'a EmitInput,
     go_module: &str,
-    options: &EmitOptions,
-    line_indexes: &Arc<HashMap<u32, LineIndex>>,
-    globals: &Arc<GlobalEmitData>,
+    shared_emit_ctx: &SharedEmitContext,
     module_id: &str,
     module_info: &syntax::program::ModuleInfo,
 ) -> Vec<OutputFile> {
@@ -542,9 +549,10 @@ fn emit_module<'a>(
         go_module_ids: &analysis.go_module_ids,
         entry_module: analysis.entry_module_id.to_string(),
         go_module: go_module.to_string(),
-        options: options.clone(),
-        line_indexes: line_indexes.clone(),
-        globals: globals.clone(),
+        options: shared_emit_ctx.options.clone(),
+        line_indexes: shared_emit_ctx.line_indexes.clone(),
+        globals: shared_emit_ctx.globals.clone(),
+        generic_base: shared_emit_ctx.generic_base.clone(),
         current_module: module_id.to_string(),
     });
     let mut planner: Planner<'a> = Planner::new(facts);

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -42,7 +42,6 @@ impl Planner<'_> {
         self.collect_local_exported_method_names(files);
         self.collect_user_to_string_types(files);
         self.collect_generic_constraints(files, &mut collection_effects);
-        self.collect_enum_layouts();
         self.collect_escape_remap(files);
         let collision_diagnostics = self.detect_name_collisions(files);
         let mut make_functions_by_file =

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -6,7 +9,7 @@ use crate::names::constraints::{GenericConstraintTable, ParamConstraintSet};
 
 #[derive(Default)]
 pub(crate) struct ModuleState {
-    enum_layouts: HashMap<String, EnumLayout>,
+    enum_layouts: RefCell<HashMap<String, Rc<EnumLayout>>>,
     tag_exported_fields: HashSet<String>,
     exported_method_names: HashSet<String>,
     user_to_string_types: HashSet<String>,
@@ -17,16 +20,18 @@ pub(crate) struct ModuleState {
 }
 
 impl ModuleState {
-    pub(crate) fn record_enum_layout(&mut self, enum_id: String, layout: EnumLayout) {
-        self.enum_layouts.insert(enum_id, layout);
+    pub(crate) fn record_enum_layout(&self, enum_id: String, layout: EnumLayout) {
+        self.enum_layouts
+            .borrow_mut()
+            .insert(enum_id, Rc::new(layout));
     }
 
-    pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<&EnumLayout> {
-        self.enum_layouts.get(enum_id)
+    pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<Rc<EnumLayout>> {
+        self.enum_layouts.borrow().get(enum_id).cloned()
     }
 
     pub(crate) fn has_enum_layout(&self, enum_id: &str) -> bool {
-        self.enum_layouts.contains_key(enum_id)
+        self.enum_layouts.borrow().contains_key(enum_id)
     }
 
     pub(crate) fn record_tag_exported_field(&mut self, key: String) {


### PR DESCRIPTION
Speeds up codegen, especially on projects with many modules.

During emit, we compute the layout of every enum and the generic-constraint table, and these are the same no matter which module is being emitted. These were being recomputed from scratch for every module. They are now computed once and reused across modules. On a 100-module benchmark, this makes the emit phase ~4 times faster.