### PR TITLE
perf: dispatch ast walk checks by expression kind

### DIFF
--- a/crates/semantics/src/passes/checks/node_walk.rs
+++ b/crates/semantics/src/passes/checks/node_walk.rs
@@ -1,6 +1,9 @@
-use syntax::ast::Expression;
+use std::sync::LazyLock;
 
-use crate::passes::walk::{NodeCheck, NodeCtx, walk_nodes};
+use syntax::ast::Expression;
+use syntax::ast::ExpressionKind::*;
+
+use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
 
 use super::{
     const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop, empty_range,
@@ -9,27 +12,59 @@ use super::{
     stringer_signature, temp_producing, unchanging_loop_condition,
 };
 
-const NODE_CHECKS: &[NodeCheck] = &[
-    nan_comparison::check,
-    empty_range::check,
-    empty_infinite_loop::check,
-    oversized_shift::check,
-    repeated_if_condition::check,
-    index_out_of_bounds::check,
-    decimal_file_mode::check,
-    duplicate_bindings::check,
-    irrefutable_patterns::check,
-    receivers::check,
-    stringer_signature::check,
-    predeclared_shadowing::check,
-    pub_type_export::check,
-    temp_producing::check,
-    newtype::check,
-    enum_variant_value::check,
-    unchanging_loop_condition::check,
-    const_naming::check,
-];
+static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
+    CheckTable::new(
+        &[
+            (nan_comparison::check, &[Binary]),
+            (empty_range::check, &[Range]),
+            (empty_infinite_loop::check, &[Loop]),
+            (oversized_shift::check, &[Binary]),
+            (repeated_if_condition::check, &[If]),
+            (index_out_of_bounds::check, &[IndexedAccess]),
+            (decimal_file_mode::check, &[Literal]),
+            (
+                duplicate_bindings::check,
+                &[Let, For, IfLet, WhileLet, Match, Select, Function, Lambda],
+            ),
+            (
+                irrefutable_patterns::check,
+                &[Let, For, Function, Lambda, Select],
+            ),
+            (receivers::check, &[ImplBlock]),
+            (stringer_signature::check, &[ImplBlock]),
+            (
+                predeclared_shadowing::check,
+                &[Enum, Struct, TypeAlias, Interface, Function, ImplBlock],
+            ),
+            (
+                pub_type_export::check,
+                &[Struct, Enum, TypeAlias, Interface],
+            ),
+            (
+                temp_producing::check,
+                &[
+                    Call,
+                    StructCall,
+                    Binary,
+                    Unary,
+                    Reference,
+                    Cast,
+                    If,
+                    While,
+                    IndexedAccess,
+                    Range,
+                    Literal,
+                ],
+            ),
+            (newtype::check, &[Assignment, Reference]),
+            (enum_variant_value::check, &[Identifier, DotAccess]),
+            (unchanging_loop_condition::check, &[While]),
+            (const_naming::check, &[Const]),
+        ],
+        &[],
+    )
+});
 
 pub(crate) fn run(items: &[Expression], ctx: &NodeCtx) {
-    walk_nodes(items, ctx, NODE_CHECKS, &[]);
+    walk_nodes(items, ctx, &NODE_CHECKS);
 }

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -2,10 +2,12 @@ pub(crate) mod attributes;
 pub(crate) mod casing;
 mod checks;
 
+use std::sync::LazyLock;
+
 use crate::context::AnalysisContext;
 use crate::facts::Facts;
 use crate::passes::PARALLEL_THRESHOLD;
-use crate::passes::walk::{NodeCheck, NodeCtx, PatternCheck, walk_nodes};
+use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
 use crate::store::Store;
 use diagnostics::LocalSink;
 use rayon::prelude::*;
@@ -35,73 +37,88 @@ use checks::{
     check_verbose_failure_propagation, check_waitgroup_add_in_task,
 };
 
-const EXPRESSION_CHECKS: &[NodeCheck] = &[
-    check_double_negation,
-    check_self_comparison,
-    check_unsigned_comparison,
-    check_type_limit_comparison,
-    check_non_negative_comparison,
-    check_goos_goarch_comparison,
-    check_redundant_operation,
-    check_integer_division_to_zero,
-    check_self_assignment,
-    check_manual_compound_assignment,
-    check_manual_bytes_equal,
-    check_manual_replace_all,
-    check_redundant_sprintf,
-    check_manual_equal_fold,
-    check_manual_find,
-    check_manual_is_empty,
-    check_bool_literal_comparison,
-    check_identical_if_branches,
-    check_collapsible_if,
-    check_identical_match_arms,
-    check_loop_runs_once,
-    check_empty_match_arm,
-    check_excess_parens_on_condition,
-    check_match_literal_collection,
-    check_match_on_bool,
-    check_match_single_binding,
-    check_negated_equality,
-    check_let_and_return,
-    check_unnecessary_bool,
-    check_unnecessary_range_loop,
-    check_unnecessary_return,
-    check_single_arm_match,
-    check_single_arm_select,
-    check_redundant_slice_bounds,
-    check_redundant_pattern_matching,
-    check_manual_map,
-    check_manual_map_or,
-    check_manual_time_since,
-    check_manual_time_until,
-    check_manual_unwrap_or,
-    check_uninterpolated_fstring,
-    check_unnecessary_raw_string_expression,
-    check_invisible_in_string_expression,
-    check_verbose_failure_propagation,
-    check_dup_arg,
-    check_duplicate_cutset,
-    check_waitgroup_add_in_task,
-    check_struct_attributes,
-    check_attributes,
-    check_enum_attributes,
-    check_duplicate_logical_operand,
-    check_expression_naming,
-    check_replaceable_with_zero_fill,
-    check_lost_query_mutation,
-    check_redundant_closure,
-    check_redundant_else,
-    check_out_of_domain_value,
-    check_embed_over_impl,
-];
+static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
+    use syntax::ast::ExpressionKind::*;
+    use syntax::ast::PatternKind;
 
-const PATTERN_CHECKS: &[PatternCheck] = &[
-    check_rest_only_slice_pattern,
-    check_unnecessary_raw_string_pattern,
-    check_invisible_in_string_pattern,
-    check_pattern_naming,
-];
+    CheckTable::new(
+        &[
+            (check_double_negation, &[Unary]),
+            (check_self_comparison, &[Binary]),
+            (check_unsigned_comparison, &[Binary]),
+            (check_type_limit_comparison, &[Binary]),
+            (check_non_negative_comparison, &[Binary]),
+            (check_goos_goarch_comparison, &[Binary]),
+            (check_redundant_operation, &[Binary]),
+            (check_integer_division_to_zero, &[Binary]),
+            (check_self_assignment, &[Assignment]),
+            (check_manual_compound_assignment, &[Assignment]),
+            (check_manual_bytes_equal, &[Binary]),
+            (check_manual_replace_all, &[Call]),
+            (check_redundant_sprintf, &[Call]),
+            (check_manual_equal_fold, &[Binary]),
+            (check_manual_find, &[Call]),
+            (check_manual_is_empty, &[Binary]),
+            (check_bool_literal_comparison, &[Binary]),
+            (check_identical_if_branches, &[If]),
+            (check_collapsible_if, &[If]),
+            (check_identical_match_arms, &[Match]),
+            (check_loop_runs_once, &[Loop, While, WhileLet, For]),
+            (check_empty_match_arm, &[Match]),
+            (check_excess_parens_on_condition, &[If, While, Match]),
+            (check_match_literal_collection, &[Match]),
+            (check_match_on_bool, &[Match]),
+            (check_match_single_binding, &[Match]),
+            (check_negated_equality, &[Unary]),
+            (check_let_and_return, &[Block]),
+            (check_unnecessary_bool, &[If]),
+            (check_unnecessary_range_loop, &[For]),
+            (check_unnecessary_return, &[Function]),
+            (check_single_arm_match, &[Match]),
+            (check_single_arm_select, &[Select]),
+            (check_redundant_slice_bounds, &[IndexedAccess]),
+            (check_redundant_pattern_matching, &[Match]),
+            (check_manual_map, &[Match]),
+            (check_manual_map_or, &[Match]),
+            (check_manual_time_since, &[Call]),
+            (check_manual_time_until, &[Call]),
+            (check_manual_unwrap_or, &[Match]),
+            (check_uninterpolated_fstring, &[Literal]),
+            (check_unnecessary_raw_string_expression, &[Literal]),
+            (check_invisible_in_string_expression, &[Literal]),
+            (check_verbose_failure_propagation, &[Match]),
+            (check_dup_arg, &[Call]),
+            (check_duplicate_cutset, &[Call]),
+            (check_waitgroup_add_in_task, &[Function, Lambda]),
+            (check_struct_attributes, &[Struct]),
+            (check_attributes, &[Function]),
+            (check_enum_attributes, &[Enum]),
+            (check_duplicate_logical_operand, &[Binary]),
+            (
+                check_expression_naming,
+                &[Struct, Enum, TypeAlias, Interface, Function],
+            ),
+            (check_replaceable_with_zero_fill, &[StructCall]),
+            (check_lost_query_mutation, &[Call]),
+            (check_redundant_closure, &[Lambda]),
+            (check_redundant_else, &[Block]),
+            (check_out_of_domain_value, &[Literal, Unary, Call]),
+            (check_embed_over_impl, &[Interface]),
+        ],
+        &[
+            (
+                check_rest_only_slice_pattern,
+                &[PatternKind::Slice, PatternKind::Or],
+            ),
+            (
+                check_unnecessary_raw_string_pattern,
+                &[PatternKind::Literal],
+            ),
+            (check_invisible_in_string_pattern, &[PatternKind::Literal]),
+            (check_pattern_naming, &[PatternKind::Identifier]),
+        ],
+    )
+});
 
 pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts, sink: &LocalSink) {
     let store = analysis.store;
@@ -143,6 +160,6 @@ fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
             sink,
             claimed_spans: Default::default(),
         };
-        walk_nodes(&file.items, &ctx, EXPRESSION_CHECKS, PATTERN_CHECKS);
+        walk_nodes(&file.items, &ctx, &LINT_CHECKS);
     }
 }

--- a/crates/semantics/src/passes/walk.rs
+++ b/crates/semantics/src/passes/walk.rs
@@ -3,8 +3,8 @@ use std::cell::RefCell;
 use diagnostics::LocalSink;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use syntax::ast::{
-    Expression, FormatStringPart, Literal, MatchArm, Pattern, RestPattern, SelectArm,
-    SelectArmPattern, Span,
+    Expression, ExpressionKind, FormatStringPart, Literal, MatchArm, Pattern, PatternKind,
+    RestPattern, SelectArm, SelectArmPattern, Span,
 };
 use syntax::program::File;
 
@@ -27,21 +27,47 @@ pub(crate) struct NodeCtx<'a> {
 pub(crate) type NodeCheck = fn(&Expression, &NodeCtx);
 pub(crate) type PatternCheck = fn(&Pattern, &NodeCtx);
 
-pub(crate) fn walk_nodes(
-    ast: &[Expression],
-    ctx: &NodeCtx,
-    expr_checks: &[NodeCheck],
-    pattern_checks: &[PatternCheck],
-) {
+pub(crate) struct CheckTable {
+    expression_buckets: [Vec<NodeCheck>; ExpressionKind::COUNT],
+    pattern_buckets: [Vec<PatternCheck>; PatternKind::COUNT],
+}
+
+impl CheckTable {
+    pub(crate) fn new(
+        expression_checks: &[(NodeCheck, &[ExpressionKind])],
+        pattern_checks: &[(PatternCheck, &[PatternKind])],
+    ) -> Self {
+        let mut expression_buckets: [Vec<NodeCheck>; ExpressionKind::COUNT] =
+            std::array::from_fn(|_| Vec::new());
+        for (check, kinds) in expression_checks {
+            for kind in *kinds {
+                expression_buckets[*kind as usize].push(*check);
+            }
+        }
+        let mut pattern_buckets: [Vec<PatternCheck>; PatternKind::COUNT] =
+            std::array::from_fn(|_| Vec::new());
+        for (check, kinds) in pattern_checks {
+            for kind in *kinds {
+                pattern_buckets[*kind as usize].push(*check);
+            }
+        }
+        Self {
+            expression_buckets,
+            pattern_buckets,
+        }
+    }
+}
+
+pub(crate) fn walk_nodes(ast: &[Expression], ctx: &NodeCtx, checks: &CheckTable) {
     visit_ast(
         ast,
         &mut |expression| {
-            for check in expr_checks {
+            for check in &checks.expression_buckets[expression.kind() as usize] {
                 check(expression, ctx);
             }
         },
         &mut |pattern| {
-            for check in pattern_checks {
+            for check in &checks.pattern_buckets[pattern.kind() as usize] {
                 check(pattern, ctx);
             }
         },

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -296,7 +296,42 @@ pub enum Pattern {
     },
 }
 
+/// Dataless variant index of [`Pattern`], usable as an array index.
+#[derive(Clone, Copy)]
+pub enum PatternKind {
+    Literal,
+    Unit,
+    EnumVariant,
+    Struct,
+    Tuple,
+    WildCard,
+    Identifier,
+    Slice,
+    Or,
+    AsBinding,
+}
+
+impl PatternKind {
+    // Relies on `AsBinding` staying the last variant.
+    pub const COUNT: usize = PatternKind::AsBinding as usize + 1;
+}
+
 impl Pattern {
+    pub fn kind(&self) -> PatternKind {
+        match self {
+            Pattern::Literal { .. } => PatternKind::Literal,
+            Pattern::Unit { .. } => PatternKind::Unit,
+            Pattern::EnumVariant { .. } => PatternKind::EnumVariant,
+            Pattern::Struct { .. } => PatternKind::Struct,
+            Pattern::Tuple { .. } => PatternKind::Tuple,
+            Pattern::WildCard { .. } => PatternKind::WildCard,
+            Pattern::Identifier { .. } => PatternKind::Identifier,
+            Pattern::Slice { .. } => PatternKind::Slice,
+            Pattern::Or { .. } => PatternKind::Or,
+            Pattern::AsBinding { .. } => PatternKind::AsBinding,
+        }
+    }
+
     pub fn get_span(&self) -> Span {
         match self {
             Pattern::Identifier { span, .. } => *span,
@@ -963,7 +998,112 @@ pub enum Expression {
     NoOp,
 }
 
+/// Dataless variant index of [`Expression`], usable as an array index.
+#[derive(Clone, Copy)]
+pub enum ExpressionKind {
+    Literal,
+    Function,
+    Lambda,
+    Block,
+    Let,
+    Identifier,
+    Call,
+    If,
+    IfLet,
+    Match,
+    Tuple,
+    StructCall,
+    DotAccess,
+    Assignment,
+    Return,
+    Propagate,
+    TryBlock,
+    RecoverBlock,
+    ImplBlock,
+    Binary,
+    Unary,
+    Paren,
+    Const,
+    VariableDeclaration,
+    RawGo,
+    Loop,
+    While,
+    WhileLet,
+    For,
+    Break,
+    Continue,
+    Enum,
+    Struct,
+    TypeAlias,
+    ModuleImport,
+    Reference,
+    Interface,
+    IndexedAccess,
+    Task,
+    Defer,
+    Select,
+    Unit,
+    Range,
+    Cast,
+    NoOp,
+}
+
+impl ExpressionKind {
+    // Relies on `NoOp` staying the last variant.
+    pub const COUNT: usize = ExpressionKind::NoOp as usize + 1;
+}
+
 impl Expression {
+    pub fn kind(&self) -> ExpressionKind {
+        match self {
+            Expression::Literal { .. } => ExpressionKind::Literal,
+            Expression::Function { .. } => ExpressionKind::Function,
+            Expression::Lambda { .. } => ExpressionKind::Lambda,
+            Expression::Block { .. } => ExpressionKind::Block,
+            Expression::Let { .. } => ExpressionKind::Let,
+            Expression::Identifier { .. } => ExpressionKind::Identifier,
+            Expression::Call { .. } => ExpressionKind::Call,
+            Expression::If { .. } => ExpressionKind::If,
+            Expression::IfLet { .. } => ExpressionKind::IfLet,
+            Expression::Match { .. } => ExpressionKind::Match,
+            Expression::Tuple { .. } => ExpressionKind::Tuple,
+            Expression::StructCall { .. } => ExpressionKind::StructCall,
+            Expression::DotAccess { .. } => ExpressionKind::DotAccess,
+            Expression::Assignment { .. } => ExpressionKind::Assignment,
+            Expression::Return { .. } => ExpressionKind::Return,
+            Expression::Propagate { .. } => ExpressionKind::Propagate,
+            Expression::TryBlock { .. } => ExpressionKind::TryBlock,
+            Expression::RecoverBlock { .. } => ExpressionKind::RecoverBlock,
+            Expression::ImplBlock { .. } => ExpressionKind::ImplBlock,
+            Expression::Binary { .. } => ExpressionKind::Binary,
+            Expression::Unary { .. } => ExpressionKind::Unary,
+            Expression::Paren { .. } => ExpressionKind::Paren,
+            Expression::Const { .. } => ExpressionKind::Const,
+            Expression::VariableDeclaration { .. } => ExpressionKind::VariableDeclaration,
+            Expression::RawGo { .. } => ExpressionKind::RawGo,
+            Expression::Loop { .. } => ExpressionKind::Loop,
+            Expression::While { .. } => ExpressionKind::While,
+            Expression::WhileLet { .. } => ExpressionKind::WhileLet,
+            Expression::For { .. } => ExpressionKind::For,
+            Expression::Break { .. } => ExpressionKind::Break,
+            Expression::Continue { .. } => ExpressionKind::Continue,
+            Expression::Enum { .. } => ExpressionKind::Enum,
+            Expression::Struct { .. } => ExpressionKind::Struct,
+            Expression::TypeAlias { .. } => ExpressionKind::TypeAlias,
+            Expression::ModuleImport { .. } => ExpressionKind::ModuleImport,
+            Expression::Reference { .. } => ExpressionKind::Reference,
+            Expression::Interface { .. } => ExpressionKind::Interface,
+            Expression::IndexedAccess { .. } => ExpressionKind::IndexedAccess,
+            Expression::Task { .. } => ExpressionKind::Task,
+            Expression::Defer { .. } => ExpressionKind::Defer,
+            Expression::Select { .. } => ExpressionKind::Select,
+            Expression::Unit { .. } => ExpressionKind::Unit,
+            Expression::Range { .. } => ExpressionKind::Range,
+            Expression::Cast { .. } => ExpressionKind::Cast,
+            Expression::NoOp => ExpressionKind::NoOp,
+        }
+    }
+
     pub fn is_noop(&self) -> bool {
         matches!(self, Expression::NoOp)
     }


### PR DESCRIPTION
Every AST node visited by the common `walk_nodes` traversal was being passed to every check, but nearly all matched the wrong variant and returned immediately. Checks are now registered in a `CheckTable` categorized by `ExpressionKind` and `PatternKind`, so each node only dispatches to the checks that can fire on it.

The semantic analysis benchmark on 100 modules is now ~9% faster.