### PR TITLE
fix: reject non-comparable interface and unknown equality

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1073,6 +1073,16 @@ pub fn not_comparable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic 
         ))
 }
 
+pub fn not_comparable_interface(ty: &Type, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type mismatch")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("`{}` cannot be compared with `==`", ty))
+        .with_help(
+            "An interface value's comparability depends on its runtime type, so `==` and `!=` \
+             are not allowed here. Compare the concrete values instead",
+        )
+}
+
 pub fn not_orderable_bound(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Bound not satisfied")
         .with_infer_code("not_orderable_bound")

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -16,6 +16,9 @@ pub(crate) fn check_not_comparable(
     store: &Store,
     ty: &Type,
 ) -> Option<&'static str> {
+    let resolved = store.deep_resolve_alias(ty);
+    let ty = &resolved;
+
     if matches!(ty, Type::Function(_)) {
         return Some("functions");
     }
@@ -33,6 +36,14 @@ pub(crate) fn check_not_comparable(
 
     if matches!(ty, Type::Var { .. }) {
         return None;
+    }
+
+    if ty.is_unknown() {
+        return Some("interface values");
+    }
+
+    if let Some(underlying) = ty.get_underlying() {
+        return check_not_comparable(env, store, underlying);
     }
 
     if matches!(ty, Type::Parameter(_)) {
@@ -74,6 +85,7 @@ pub(crate) fn check_not_comparable(
                     }
                 }
             }
+            DefinitionBody::Interface { .. } => return Some("interface values"),
             _ => {}
         }
     }
@@ -433,7 +445,9 @@ impl InferCtx<'_, '_> {
                         );
                     }
                 }
-                self.ensure_comparable(left_operand_ty, left_span);
+                if self.ensure_comparable(left_operand_ty, left_span) {
+                    self.ensure_comparable(right_operand_ty, right_span);
+                }
                 self.type_bool()
             }
 
@@ -683,21 +697,29 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    fn ensure_comparable(&mut self, ty: &Type, span: &Span) {
+    fn ensure_comparable(&mut self, ty: &Type, span: &Span) -> bool {
         let store = self.store;
         let resolved = ty.resolve_in(&self.env);
         if resolved.is_error() {
-            return;
+            return true;
         }
         if let Type::Parameter(name) = &resolved
             && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
         {
-            return;
+            return true;
         }
-        if let Some(reason) = check_not_comparable(&self.env, store, &resolved) {
+        let Some(reason) = check_not_comparable(&self.env, store, &resolved) else {
+            return true;
+        };
+        if is_interface_or_unknown(store, &resolved) {
+            self.sink.push(diagnostics::infer::not_comparable_interface(
+                &resolved, *span,
+            ));
+        } else {
             self.sink
                 .push(diagnostics::infer::not_comparable(&resolved, reason, *span));
         }
+        false
     }
 
     fn unify_binary_operands(
@@ -1053,6 +1075,11 @@ fn literal_can_adapt_to(kind: &LiteralKind, target: &Type) -> bool {
         LiteralKind::Boolean => named_backed_by(SimpleKind::Bool),
         LiteralKind::None => false,
     }
+}
+
+fn is_interface_or_unknown(store: &Store, ty: &Type) -> bool {
+    let resolved = store.deep_resolve_alias(ty);
+    resolved.is_unknown() || store.is_interface(&resolved)
 }
 
 fn is_nominal_defined_type(ty: &Type, store: &Store) -> bool {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5998,6 +5998,136 @@ fn test() {
 }
 
 #[test]
+fn infer_not_comparable_interface() {
+    let input = r#"
+interface Shape {
+  fn area(self) -> float64
+}
+
+fn test(a: Shape, b: Shape) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_unknown() {
+    let input = r#"
+fn test(a: Unknown, b: Unknown) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_struct_with_interface_field() {
+    let input = r#"
+interface Shape {
+  fn area(self) -> float64
+}
+
+struct Holder {
+  shape: Shape,
+}
+
+fn test(a: Holder, b: Holder) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_concrete_against_interface() {
+    let input = r#"
+interface Shape {
+  fn area(self) -> float64
+}
+
+struct Circle { r: int }
+
+impl Circle {
+  fn area(self) -> float64 { 0.0 }
+}
+
+fn test(c: Circle, s: Shape) {
+  let result = c == s;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_interface_through_alias() {
+    let input = r#"
+interface Shape {
+  fn area(self) -> float64
+}
+
+type ShapeAlias = Shape
+
+fn test(a: ShapeAlias, b: ShapeAlias) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_unknown_through_alias() {
+    let input = r#"
+type Any = Unknown
+
+fn test(a: Any, b: Any) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_slice_through_alias() {
+    let input = r#"
+type Bytes = Slice<int>
+
+fn test(a: Bytes, b: Bytes) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_function_through_alias() {
+    let input = r#"
+type Callback = fn() -> int
+
+fn test(a: Callback, b: Callback) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_struct_with_function_alias_field() {
+    let input = r#"
+type Callback = fn() -> int
+
+struct Holder {
+  on_done: Callback,
+}
+
+fn test(a: Holder, b: Holder) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_comparable_bound_rejects_slice() {
     let input = r#"
 fn requires_comparable<T: Comparable>(_x: T) {}

--- a/tests/ui/errors/snapshots/infer_not_comparable_concrete_against_interface.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_concrete_against_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+    ╭─[test.lis:13:21]
+ 12 │ fn test(c: Circle, s: Shape) {
+ 13 │   let result = c == s;
+    ·                     ┬
+    ·                     ╰── `Shape` cannot be compared with `==`
+ 14 │ }
+    ╰────
+  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_function_through_alias.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_function_through_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:16]
+ 4 │ fn test(a: Callback, b: Callback) {
+ 5 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Callback` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: The `==` and `!=` operators cannot be used on functions because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_interface.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:7:16]
+ 6 │ fn test(a: Shape, b: Shape) {
+ 7 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Shape` cannot be compared with `==`
+ 8 │ }
+   ╰────
+  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_interface_through_alias.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_interface_through_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+    ╭─[test.lis:9:16]
+  8 │ fn test(a: ShapeAlias, b: ShapeAlias) {
+  9 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `ShapeAlias` cannot be compared with `==`
+ 10 │ }
+    ╰────
+  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_slice_through_alias.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_slice_through_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:16]
+ 4 │ fn test(a: Bytes, b: Bytes) {
+ 5 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Bytes` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: The `==` and `!=` operators cannot be used on slices because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_struct_with_function_alias_field.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_struct_with_function_alias_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+    ╭─[test.lis:9:16]
+  8 │ fn test(a: Holder, b: Holder) {
+  9 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `Holder` cannot be compared with `==`
+ 10 │ }
+    ╰────
+  help: The `==` and `!=` operators cannot be used on a struct containing non-comparable fields because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_struct_with_interface_field.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_struct_with_interface_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+    ╭─[test.lis:11:16]
+ 10 │ fn test(a: Holder, b: Holder) {
+ 11 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `Holder` cannot be compared with `==`
+ 12 │ }
+    ╰────
+  help: The `==` and `!=` operators cannot be used on a struct containing non-comparable fields because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_unknown.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_unknown.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:3:16]
+ 2 │ fn test(a: Unknown, b: Unknown) {
+ 3 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Unknown` cannot be compared with `==`
+ 4 │ }
+   ╰────
+  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_unknown_through_alias.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_unknown_through_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:16]
+ 4 │ fn test(a: Any, b: Any) {
+ 5 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Any` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]


### PR DESCRIPTION
Comparing interface or `Unknown` values with `==` or `!=` is now a compile-time error. Lis was accepting these and Go as well it, but the comparison panicked at runtime when the dynamic value was non-comparable, e.g. a slice, map, or function.

```
  [error] Type mismatch
    ╭─[test.lis:9:16]
  8 │ fn test(a: ShapeAlias, b: ShapeAlias) {
  9 │   let result = a == b;
    ·                ┬
    ·                ╰── `ShapeAlias` cannot be compared with `==`
 10 │ }
    ╰────
  help: An interface value's comparability depends on its runtime type, so `==` and `!=` are not allowed here. Compare the concrete values instead · code: [infer.type_mismatch]
```