### PR TITLE
refactor: replace text-scanned liveness with structural tracking

### DIFF
--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -308,6 +308,7 @@ impl Planner<'_> {
             key_var, value_var, iter_expression
         );
 
+        self.scope.enter_use_region();
         let mut bindings = String::new();
         self.emit_irrefutable_pattern_site(
             &mut bindings,
@@ -317,6 +318,10 @@ impl Planner<'_> {
             first_ty,
             fx,
         );
+        if !bindings.is_empty() {
+            self.scope.record_go_use(&key_var);
+        }
+        let after_key = bindings.len();
         self.emit_irrefutable_pattern_site(
             &mut bindings,
             PatternSubject::for_value(value_var.clone()),
@@ -325,18 +330,25 @@ impl Planner<'_> {
             second_ty,
             fx,
         );
+        if bindings.len() > after_key {
+            self.scope.record_go_use(&value_var);
+        }
         let lowered_body = self.lower_block_as_body(body, fx);
+        let used = self.scope.exit_use_region();
 
         let mut inner = vec![LoweredStatement::RawGo(bindings)];
         inner.extend(lowered_body.statements);
         let body_block = LoweredBlock { statements: inner };
 
+        let references_value = used.contains(&value_var);
+        let references_key = used.contains(&key_var);
+
         // Discard guards: value first, then key (insertion order matters).
         let mut statements = Vec::new();
-        if !body_block.references_var(&value_var) {
+        if !references_value {
             statements.push(LoweredStatement::RawGo(format!("_ = {}\n", value_var)));
         }
-        if !body_block.references_var(&key_var) {
+        if !references_key {
             statements.push(LoweredStatement::RawGo(format!("_ = {}\n", key_var)));
         }
         statements.extend(body_block.statements);
@@ -366,6 +378,7 @@ impl Planner<'_> {
             } else {
                 format!("for _, {} := range {} {{\n", item_var, iter_expression)
             };
+            self.scope.enter_use_region();
             let mut bindings = String::new();
             self.emit_irrefutable_pattern_site(
                 &mut bindings,
@@ -375,14 +388,20 @@ impl Planner<'_> {
                 &binding.ty,
                 fx,
             );
+            if !bindings.is_empty() {
+                self.scope.record_go_use(&item_var);
+            }
             let lowered_body = self.lower_block_as_body(body, fx);
+            let used = self.scope.exit_use_region();
 
             let mut inner = vec![LoweredStatement::RawGo(bindings)];
             inner.extend(lowered_body.statements);
             let body_block = LoweredBlock { statements: inner };
 
+            let references_item = used.contains(&item_var);
+
             let mut statements = Vec::new();
-            if !body_block.references_var(&item_var) {
+            if !references_item {
                 statements.push(LoweredStatement::RawGo(format!("_ = {}\n", item_var)));
             }
             statements.extend(body_block.statements);

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -103,9 +103,7 @@ impl Planner<'_> {
         if self.is_declared(var_name) {
             statements.push(simple_assign(var_name.to_string(), zero));
         } else {
-            // Kept as `RawGo`: a `var name ty = value` declaration reuse (`ConstPlan`)
-            // would drop `name`/`ty` from `references_var`, flipping queries on
-            // this dead-path binding.
+            // Declared so the dead-path binding stays in scope for later references.
             let go_ty = self.go_type_string(inner_ty, fx);
             statements.push(LoweredStatement::RawGo(format!(
                 "var {} {} = {}\n",

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -318,6 +318,7 @@ impl Planner<'_> {
     ) -> SelectArmPlan {
         let ok_var = self.fresh_ok_var();
         let receive_vars = format!("{}, {}", receiver_var, ok_var);
+        self.scope.enter_use_region();
         let body_statements = if let Some((pattern, typed)) = inner_pattern {
             self.lower_select_receive_pattern_site(
                 TypedSubject {
@@ -334,11 +335,13 @@ impl Planner<'_> {
             self.lower_block_to_place(ctx.body, ctx.place, fx)
                 .statements
         };
+        let used = self.scope.exit_use_region();
         let body_holder = LoweredBlock {
             statements: body_statements,
         };
         let mut then_statements: Vec<LoweredStatement> = Vec::new();
-        if !body_holder.references_var(receiver_var) {
+        let references_receiver = used.contains(receiver_var);
+        if !references_receiver {
             then_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", receiver_var)));
         }
         then_statements.extend(body_holder.statements);
@@ -569,6 +572,7 @@ impl Planner<'_> {
 
         let ok_var = self.fresh_ok_var();
 
+        self.scope.enter_use_region();
         let some_block = self.lower_receive_some_arm(
             some_arm,
             match_arms,
@@ -582,11 +586,17 @@ impl Planner<'_> {
         let none_block = self
             .capture_scoped_block(|this| sites::lower_none_arm_body(this, match_arms, place, fx));
 
+        let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
+        if arms_plan.is_some() {
+            self.scope.record_go_use(&ok_var);
+        }
+        let used = self.scope.exit_use_region();
+
         // Compose the receive-arms body as a structured `if ok { ... } else
         // { ... }` plan so usage of `case_var` and `ok_var` can be checked
         // structurally before deciding whether to emit per-var discards.
         let body_block = LoweredBlock {
-            statements: match build_receive_arms_plan(&ok_var, some_block, none_block) {
+            statements: match arms_plan {
                 Some(plan) => vec![LoweredStatement::If(plan)],
                 None => Vec::new(),
             },
@@ -597,10 +607,12 @@ impl Planner<'_> {
         // Per-var discards (emitted when the body does not reference the var)
         // precede the structured body inside the `case x, ok := <-ch:` arm.
         let mut body_statements: Vec<LoweredStatement> = Vec::new();
-        if !body_block.references_var(&ok_var) {
+        let references_ok = used.contains(&ok_var);
+        if !references_ok {
             body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", ok_var)));
         }
-        if case_var != "_" && !body_block.references_var(&case_var) {
+        let references_case = used.contains(&case_var);
+        if case_var != "_" && !references_case {
             body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", case_var)));
         }
         body_statements.extend(body_block.statements);

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -28,7 +28,19 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> String {
         if let Some(BindingValue::InlineExpr(expr)) = self.scope.resolve_identifier_binding(value) {
-            return expr.as_str().to_string();
+            let text = expr.as_str().to_string();
+            let refs = expr.refs().to_vec();
+            for go_name in &refs {
+                self.scope.record_go_use(go_name);
+            }
+            return text;
+        }
+        let bound_go_name = self
+            .scope
+            .resolve_binding_go_name(value)
+            .map(str::to_string);
+        if let Some(go_name) = &bound_go_name {
+            self.scope.record_go_use(go_name);
         }
         match self.classify_identifier(value, ty, ctx, fx) {
             IdentifierKind::UnitValue => "struct{}{}".to_string(),

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -91,22 +91,8 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
-        let needs_string_bridge = (expression.get_type().is_unit()
-            && matches!(
-                expression.unwrap_parens(),
-                Expression::Call { .. } | Expression::Block { .. }
-            ))
-            || self.classify_go_fn_value(expression).is_some()
-            || self.is_go_array_return_value(expression);
-
-        if needs_string_bridge {
-            let mut setup = String::new();
-            let value = self.emit_composite_value(&mut setup, expression, ctx, fx);
-            return StagedExpression::new(setup, value, expression);
-        }
-
-        let plan = self.plan_operand(expression, ctx, fx);
-        StagedExpression::from_plan(plan, expression)
+        let (setup, value) = self.lower_composite_value(expression, ctx, fx);
+        StagedExpression::from_typed_setup(setup, value, expression)
     }
 
     /// Suppresses the Go-fn identity short-circuit when the formal param

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -81,8 +81,19 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
-        let staged = self.stage_composite(expression, ctx, fx);
-        (staged.setup, staged.value)
+        if expression.get_type().is_unit()
+            && matches!(
+                expression.unwrap_parens(),
+                Expression::Call { .. } | Expression::Block { .. }
+            )
+        {
+            let (mut setup, call_str) = self.lower_value(expression, ctx, fx);
+            if !call_str.is_empty() {
+                setup.push(LoweredStatement::RawGo(format!("{call_str}\n")));
+            }
+            return (setup, "struct{}{}".to_string());
+        }
+        self.lower_value(expression, ctx, fx)
     }
 
     /// Wrap a captured tagged-shape prelude fn ref into a lowered-ABI closure
@@ -172,19 +183,9 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> String {
-        if expression.get_type().is_unit()
-            && matches!(
-                expression.unwrap_parens(),
-                Expression::Call { .. } | Expression::Block { .. }
-            )
-        {
-            let call_str = self.emit_value(output, expression, ctx, fx);
-            if !call_str.is_empty() {
-                write_line!(output, "{call_str}");
-            }
-            return "struct{}{}".to_string();
-        }
-        self.emit_value(output, expression, ctx, fx)
+        let (setup, value) = self.lower_composite_value(expression, ctx, fx);
+        output.push_str(&Renderer.render_setup(&setup));
+        value
     }
 
     /// Emit a value-position expression: plan, then render.

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -23,6 +23,7 @@ pub(crate) fn apply_root_assertion<'s>(
     let [go_type] = assertion.go_types.as_slice() else {
         unreachable!("multi-type root assertions only reach match destructure paths")
     };
+    planner.scope.record_go_use(subject);
     let expression = format!("{}.({})", subject, go_type);
     let var = planner.hoist_tmp_value(output, "asserted", &expression);
     std::borrow::Cow::Owned(var)
@@ -39,6 +40,7 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
     let Some(assertion) = info.root_assertion.as_ref() else {
         return (std::borrow::Cow::Borrowed(subject), None);
     };
+    planner.scope.record_go_use(subject);
     let needs_asserted = info.requires_asserted_subject();
     match assertion.go_types.as_slice() {
         [go_type] => {
@@ -142,13 +144,15 @@ pub(crate) fn tree_binding_statements(
                 .resolve_identifier_binding(&binding.lisette_name)
                 .cloned();
             let safe_text = binding.path.render_composable(subject_var);
-            planner
-                .scope
-                .bind_inline_expr(&binding.lisette_name, InlineExpr::new(safe_text));
+            planner.scope.bind_inline_expr(
+                &binding.lisette_name,
+                InlineExpr::with_refs(safe_text, vec![subject_var.to_string()]),
+            );
             installed_inlines.push((binding.lisette_name.clone(), previous));
             continue;
         }
 
+        planner.scope.record_go_use(subject_var);
         let line = if planner.scope.has_binding_for_go_name(go_name) {
             let fresh = planner.fresh_var(Some(&binding.lisette_name));
             planner.scope.bind(&binding.lisette_name, &fresh);
@@ -207,6 +211,7 @@ pub(crate) fn tree_assignment_statements(
             continue;
         };
         let name = registered_name.to_string();
+        planner.scope.record_go_use(subject_var);
         let access_expression = binding.path.render(subject_var);
         statements.push(LoweredStatement::RawGo(format!(
             "{} = {}\n",

--- a/crates/emit/src/patterns/emit_plan.rs
+++ b/crates/emit/src/patterns/emit_plan.rs
@@ -14,6 +14,7 @@ pub(crate) struct EmitBinding {
     pub go_name: Option<String>,
     pub rendered_access: String,
     pub composable_access: String,
+    pub subject: String,
 }
 
 #[derive(Debug)]
@@ -62,6 +63,8 @@ pub(crate) enum EmitDecision {
     },
     IfElse {
         condition: String,
+        /// Subject the condition reads, for liveness recording.
+        subject: Option<String>,
         then_branch: Box<EmitDecision>,
         else_branch: Option<Box<EmitDecision>>,
     },
@@ -71,11 +74,15 @@ pub(crate) enum EmitDecision {
     },
     Switch {
         expr: String,
+        /// Subject the switch projects from, for liveness recording.
+        subject: String,
         cases: Vec<EmitCase>,
         default: Option<Box<EmitDecision>>,
     },
     TypeSwitch {
         base: String,
+        /// Subject the switch projects from, for liveness recording.
+        subject: String,
         cases: Vec<EmitCase>,
         default: Option<Box<EmitDecision>>,
     },
@@ -91,6 +98,8 @@ pub(crate) enum EmitDecision {
 pub(crate) struct EmitChainTest {
     /// `None` marks a catchall test (empty `checks` in the source).
     pub condition: Option<String>,
+    /// Subject the condition reads (`None` for catchalls).
+    pub subject: Option<String>,
     pub decision: Box<EmitDecision>,
 }
 
@@ -269,14 +278,18 @@ pub(crate) fn lower_decision(ctx: &mut LoweringCtx, decision: &Decision) -> Emit
 }
 
 fn lower_chain_test(ctx: &mut LoweringCtx, test: &ChainTest) -> EmitChainTest {
-    let condition = if test.checks.is_empty() {
-        None
+    let (condition, subject) = if test.checks.is_empty() {
+        (None, None)
     } else {
-        Some(render_condition(&test.checks, &ctx.current_subject))
+        (
+            Some(render_condition(&test.checks, &ctx.current_subject)),
+            Some(ctx.current_subject.clone()),
+        )
     };
     let decision = Box::new(lower_decision(ctx, &test.decision));
     EmitChainTest {
         condition,
+        subject,
         decision,
     }
 }
@@ -289,6 +302,7 @@ fn lower_bindings(ctx: &mut LoweringCtx, bindings: &[PatternBinding]) -> Vec<Emi
             go_name: b.go_name.clone(),
             rendered_access: b.path.render(&ctx.current_subject),
             composable_access: b.path.render_composable(&ctx.current_subject),
+            subject: ctx.current_subject.clone(),
         })
         .collect()
 }
@@ -321,11 +335,13 @@ fn lower_type_switch(
     branches: &[SwitchBranch],
     fallback: &Option<Box<Decision>>,
 ) -> EmitDecision {
+    let subject = ctx.current_subject.clone();
     ctx.with_subject(base.clone(), |ctx| {
         let (cases, default) =
             lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
         EmitDecision::TypeSwitch {
             base,
+            subject,
             cases,
             default,
         }
@@ -349,6 +365,7 @@ fn lower_bool_switch(
         .expect("Bool shape requires a false-labeled branch");
     EmitDecision::IfElse {
         condition: wrap_if_struct_literal(rendered_path),
+        subject: Some(ctx.current_subject.clone()),
         then_branch: Box::new(lower_decision(ctx, &true_branch.decision)),
         else_branch: Some(Box::new(lower_decision(ctx, &false_branch.decision))),
     }
@@ -365,6 +382,7 @@ fn lower_binary_switch(
     let expr = render_switch_expression(rendered_path, kind);
     EmitDecision::IfElse {
         condition: format!("{} == {}", expr, first.case_label),
+        subject: Some(ctx.current_subject.clone()),
         then_branch: Box::new(lower_decision(ctx, &first.decision)),
         else_branch: Some(Box::new(lower_decision(ctx, &second.decision))),
     }
@@ -392,6 +410,7 @@ fn lower_single_arm_switch(
     };
     EmitDecision::IfElse {
         condition: format!("{} == {}", expr, branch.case_label),
+        subject: Some(ctx.current_subject.clone()),
         then_branch: Box::new(lower_decision(ctx, &branch.decision)),
         else_branch,
     }
@@ -409,6 +428,7 @@ fn lower_multi_switch(
         lower_cases_with_default_lift(ctx, branches, fallback, /*lift=*/ true);
     EmitDecision::Switch {
         expr,
+        subject: ctx.current_subject.clone(),
         cases,
         default,
     }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -47,8 +47,10 @@ impl Planner<'_> {
         let (subject_var, declaration) =
             self.lower_match_subject_var(&mut statements, subject, arms, fx);
 
+        self.scope.enter_use_region();
         let block = self.lower_match_tree(arms, subject_var.clone(), subject_ty, place, fx);
-        let used = block.references_var(&subject_var);
+        let used_set = self.scope.exit_use_region();
+        let used = used_set.contains(&subject_var);
 
         match declaration {
             SubjectDeclaration::PlainDiscard { var } => {
@@ -178,14 +180,17 @@ impl Planner<'_> {
             self.declare(&go_name);
             (go_name, value.to_string())
         });
+        self.scope.enter_use_region();
         let body_block = self.lower_block_to_place(body, place, fx);
+        let used = self.scope.exit_use_region();
         let mut statements = Vec::new();
         if let Some((go_name, value)) = &bound {
             statements.push(LoweredStatement::TempBind {
                 name: go_name.clone(),
                 value: value.clone(),
             });
-            if !body_block.references_var(go_name) {
+            let references = used.contains(go_name);
+            if !references {
                 statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
             }
         }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -77,9 +77,9 @@ impl ResolvedSubject {
         }
     }
 
-    fn emit_declaration(self, output: &mut String, body: &LoweredBlock) {
+    fn emit_declaration(self, output: &mut String, references: bool) {
         if let ResolvedSubject::Composite { var, expression } = self {
-            if body.references_var(&var) {
+            if references {
                 write_line!(output, "{} := {}", var, expression);
             } else {
                 write_line!(output, "_ = {}", expression);
@@ -146,15 +146,18 @@ impl Planner<'_> {
 
         let mut body = Vec::new();
         let mut assertion = String::new();
+        self.scope.enter_use_region();
         let effective = apply_root_assertion(self, &mut assertion, &info, resolved.var());
         if !assertion.is_empty() {
             body.push(LoweredStatement::RawGo(assertion));
         }
         tree_binding_statements(self, &mut body, &info.bindings, &effective, &[]);
+        let used = self.scope.exit_use_region();
         let body_block = LoweredBlock { statements: body };
 
+        let references = used.contains(resolved.var());
         let mut declaration = String::new();
-        resolved.emit_declaration(&mut declaration, &body_block);
+        resolved.emit_declaration(&mut declaration, references);
         if !declaration.is_empty() {
             statements.push(LoweredStatement::RawGo(declaration));
         }
@@ -197,15 +200,18 @@ impl Planner<'_> {
             ty: &value_ty,
         };
 
+        self.scope.enter_use_region();
         let body = if matches!(ap.pattern, Pattern::Or { .. }) {
             self.lower_let_else_or_pattern(ap, binding_ty, subject, else_block, fx)
         } else {
             self.lower_let_else_single_pattern(ap, subject, else_block, fx)
         };
+        let used = self.scope.exit_use_region();
         let body_block = LoweredBlock { statements: body };
 
+        let references = used.contains(resolved.var());
         let mut declaration = String::new();
-        resolved.emit_declaration(&mut declaration, &body_block);
+        resolved.emit_declaration(&mut declaration, references);
         if !declaration.is_empty() {
             statements.push(LoweredStatement::RawGo(declaration));
         }
@@ -381,6 +387,7 @@ impl Planner<'_> {
             guard_parts.push(format!("!{}", ok));
         }
         if !info.checks.is_empty() {
+            self.scope.record_go_use(effective_subject.as_ref());
             let negated = match info.checks.as_slice() {
                 [check] => check.render_negated(&effective_subject),
                 _ => format!("!({})", render_condition(&info.checks, &effective_subject)),
@@ -460,6 +467,9 @@ impl Planner<'_> {
         let mut pieces: Vec<(String, LoweredBlock)> = Vec::with_capacity(chain_len);
         for (i, info) in alts.collected.iter().take(chain_len).enumerate() {
             let (effective, ok_var) = &alts.hoisted[i];
+            if !info.checks.is_empty() {
+                self.scope.record_go_use(effective.as_ref());
+            }
             let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
             let mut assigns = Vec::new();
             tree_assignment_statements(self, &mut assigns, &info.bindings, effective);
@@ -647,6 +657,9 @@ impl Planner<'_> {
             return statements;
         }
 
+        if !info.checks.is_empty() {
+            self.scope.record_go_use(effective.as_ref());
+        }
         let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
         let mut then_body = Vec::new();
         let overlays =

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -240,6 +240,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let mut branches: Vec<ChainBranch> = Vec::with_capacity(regular.len());
         let mut last_diverges = false;
         for test in regular {
+            if let Some(subject) = &test.subject {
+                self.planner.scope.record_go_use(subject);
+            }
             let condition = test.condition.as_deref().unwrap_or("true").to_string();
             let walk_ctx = if matches!(test.decision.as_ref(), EmitDecision::Guard { .. }) {
                 &guard_ctx
@@ -356,9 +359,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             } => self.walk_guard(statements, *arm_index, bindings, success, failure, ctx),
             EmitDecision::IfElse {
                 condition,
+                subject,
                 then_branch,
                 else_branch,
             } => {
+                if let Some(subject) = subject {
+                    self.planner.scope.record_go_use(subject);
+                }
                 let plan =
                     self.lower_if_else_block(condition, then_branch, else_branch.as_deref(), ctx);
                 let body_diverges = capture_diverge(vec![LoweredStatement::If(plan)], statements);
@@ -373,10 +380,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             }
             EmitDecision::Switch {
                 expr,
+                subject,
                 cases,
                 default,
-                ..
             } => {
+                self.planner.scope.record_go_use(subject);
                 let plan = self.lower_value_switch(expr, cases, default.as_deref(), ctx.arm_place);
                 let body_diverges =
                     capture_diverge(vec![LoweredStatement::Switch(plan)], statements);
@@ -384,9 +392,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             }
             EmitDecision::TypeSwitch {
                 base,
+                subject,
                 cases,
                 default,
             } => {
+                self.planner.scope.record_go_use(subject);
                 let plan = self.lower_type_switch(base, cases, default.as_deref(), ctx.arm_place);
                 let body_diverges =
                     capture_diverge(vec![LoweredStatement::Switch(plan)], statements);
@@ -568,15 +578,14 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         default: Option<&EmitDecision>,
         place: &PlacePlan,
     ) -> SwitchStatementPlan {
+        self.planner.scope.enter_use_region();
         let case_plans = self.lower_switch_cases(cases, place);
         let default_block = self.lower_switch_default(default, place);
+        let used = self.planner.scope.exit_use_region();
 
         // Keep the `base :=` type-switch binding only when a case references it;
         // Go rejects an unused `:= base` assignment otherwise.
-        let references_base = case_plans.iter().any(|case| case.references_var(base))
-            || default_block
-                .as_ref()
-                .is_some_and(|body| body.references_var(base));
+        let references_base = used.contains(base);
         let binding = references_base.then(|| base.to_string());
 
         SwitchStatementPlan {
@@ -670,6 +679,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         self.planner.exit_scope();
 
         let body = LoweredBlock { statements: body };
+        if let Some(subject) = &first.subject {
+            self.planner.scope.record_go_use(subject);
+        }
         match &first.condition {
             Some(condition) => statements.push(LoweredStatement::If(IfPlan {
                 directive: String::new(),
@@ -820,6 +832,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             if self.try_inline_binding(
                 &binding.lisette_name,
                 &binding.composable_access,
+                &binding.subject,
                 consumers,
                 &failure_trees,
             ) {
@@ -827,6 +840,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 continue;
             }
 
+            self.planner.scope.record_go_use(&binding.subject);
             if self.planner.scope.has_binding_for_go_name(go_name) {
                 let fresh = self.planner.fresh_var(Some(&binding.lisette_name));
                 self.planner.scope.bind(&binding.lisette_name, &fresh);
@@ -867,6 +881,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         &mut self,
         lisette_name: &str,
         composable_access: &str,
+        subject: &str,
         consumers: &[&Expression],
         failure_trees: &[&Expression],
     ) -> bool {
@@ -881,9 +896,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         {
             return false;
         }
-        self.planner
-            .scope
-            .bind_inline_expr(lisette_name, InlineExpr::new(composable_access));
+        self.planner.scope.bind_inline_expr(
+            lisette_name,
+            InlineExpr::with_refs(composable_access, vec![subject.to_string()]),
+        );
         true
     }
 

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -2,7 +2,6 @@
 //! consumes. `RawGo` is a transitional node holding pre-rendered Go.
 
 use crate::plan::values::ValuePlan;
-use crate::utils::output_references_var;
 use syntax::types::Type;
 
 /// Destination for a lowered block's tail. The enclosing function's return
@@ -285,35 +284,10 @@ pub(crate) struct SwitchCasePlan {
 }
 
 impl SwitchStatementPlan {
-    fn references_var(&self, var: &str) -> bool {
-        let kind_references = match &self.kind {
-            SwitchKind::Value { subject } => output_references_var(subject, var),
-            SwitchKind::Type { subject, binding } => {
-                output_references_var(subject, var)
-                    || binding
-                        .as_deref()
-                        .is_some_and(|binding| output_references_var(binding, var))
-            }
-        };
-        kind_references
-            || self.cases.iter().any(|case| case.references_var(var))
-            || self
-                .default
-                .as_ref()
-                .is_some_and(|body| body.references_var(var))
-            || self.postlude.iter().any(|s| s.references_var(var))
-    }
-
     fn ends_with_diverge(&self) -> bool {
         self.postlude
             .last()
             .is_some_and(LoweredStatement::ends_with_diverge)
-    }
-}
-
-impl SwitchCasePlan {
-    pub(crate) fn references_var(&self, var: &str) -> bool {
-        output_references_var(&self.labels, var) || self.body.references_var(var)
     }
 }
 
@@ -351,12 +325,6 @@ pub(crate) enum SelectArmPlan {
 }
 
 impl SelectStatementPlan {
-    fn references_var(&self, var: &str) -> bool {
-        self.setup.iter().any(|s| s.references_var(var))
-            || self.arms.iter().any(|arm| arm.references_var(var))
-            || self.postlude.iter().any(|s| s.references_var(var))
-    }
-
     fn ends_with_diverge(&self) -> bool {
         self.postlude
             .last()
@@ -376,24 +344,6 @@ impl SelectArmPlan {
             | SelectArmPlan::Send { body, .. }
             | SelectArmPlan::Default { body } => body,
         }
-    }
-
-    fn references_var(&self, var: &str) -> bool {
-        let header_references = match self {
-            SelectArmPlan::Receive {
-                receive_vars,
-                channel,
-                ..
-            } => {
-                receive_vars
-                    .as_deref()
-                    .is_some_and(|vars| output_references_var(vars, var))
-                    || output_references_var(channel, var)
-            }
-            SelectArmPlan::Send { operation, .. } => output_references_var(operation, var),
-            SelectArmPlan::Default { .. } => false,
-        };
-        header_references || self.body().references_var(var)
     }
 }
 
@@ -447,15 +397,6 @@ impl LoweredBlock {
     pub(crate) fn is_empty(&self) -> bool {
         self.statements.is_empty()
     }
-
-    /// Whether `var` appears as a standalone identifier in the rendered
-    /// block.
-    #[allow(dead_code)]
-    pub(crate) fn references_var(&self, var: &str) -> bool {
-        self.statements
-            .iter()
-            .any(|statement| statement.references_var(var))
-    }
 }
 
 impl LoweredStatement {
@@ -496,114 +437,6 @@ impl LoweredStatement {
     pub(crate) fn blocks_fallthrough(&self) -> bool {
         !matches!(self, LoweredStatement::WhileLet(_)) && self.ends_with_diverge()
     }
-
-    pub(crate) fn references_var(&self, var: &str) -> bool {
-        match self {
-            LoweredStatement::If(plan) => plan.references_var(var),
-            LoweredStatement::Loop(plan) => plan.references_var(var),
-            LoweredStatement::Block(body) => body.references_var(var),
-            LoweredStatement::Break { label, .. } | LoweredStatement::Continue { label, .. } => {
-                label.as_deref() == Some(var)
-            }
-            LoweredStatement::Const(plan) => plan.value.references_var(var),
-            LoweredStatement::Return(plan) => match &plan.form {
-                ReturnForm::Plain { value } => value.references_var(var),
-                ReturnForm::Unit { side_effect } => {
-                    side_effect.as_ref().is_some_and(|b| b.references_var(var))
-                }
-                ReturnForm::Multi { values } => {
-                    values.iter().any(|v| output_references_var(v, var))
-                }
-                ReturnForm::LoweredAbi { body } | ReturnForm::Wrapped { body } => {
-                    body.references_var(var)
-                }
-            },
-            LoweredStatement::BreakValue(plan) => {
-                if plan.value.references_var(var) {
-                    return true;
-                }
-                match &plan.disposition {
-                    BreakValueDisposition::UnitCallIntoResult { result_var }
-                    | BreakValueDisposition::AssignToResult { result_var } => result_var == var,
-                    BreakValueDisposition::Diverged | BreakValueDisposition::Discard => false,
-                }
-            }
-            LoweredStatement::Let(plan) => {
-                let declaration_ref = match &plan.form {
-                    LetForm::Never { declaration, .. } => declaration
-                        .as_ref()
-                        .is_some_and(|s| output_references_var(s, var)),
-                    _ => false,
-                };
-                declaration_ref || plan.form.body().references_var(var)
-            }
-            LoweredStatement::Assign(plan) => match &plan.form {
-                AssignForm::Compound {
-                    target_capture,
-                    target_str,
-                    kind,
-                } => {
-                    if target_capture.iter().any(|s| s.references_var(var)) {
-                        return true;
-                    }
-                    if output_references_var(target_str, var) {
-                        return true;
-                    }
-                    match kind {
-                        CompoundKind::Increment | CompoundKind::Decrement => false,
-                        CompoundKind::OpAssign { rhs, .. } => rhs.references_var(var),
-                    }
-                }
-                AssignForm::Simple {
-                    target_capture,
-                    target_str,
-                    value,
-                } => {
-                    target_capture.iter().any(|s| s.references_var(var))
-                        || output_references_var(target_str, var)
-                        || value.references_var(var)
-                }
-                AssignForm::NilClear {
-                    target_capture,
-                    target_str,
-                } => {
-                    target_capture.iter().any(|s| s.references_var(var))
-                        || output_references_var(target_str, var)
-                }
-                AssignForm::Discard { body } | AssignForm::NeverTyped { body } => {
-                    body.references_var(var)
-                }
-            },
-            LoweredStatement::Expression(plan) => match &plan.form {
-                ExpressionStatementForm::Async { value } => value.references_var(var),
-                ExpressionStatementForm::AsyncBlock { body, .. } => body.references_var(var),
-                ExpressionStatementForm::Propagate { body }
-                | ExpressionStatementForm::Discard { body } => body.references_var(var),
-            },
-            LoweredStatement::Match(plan) => plan.body.references_var(var),
-            LoweredStatement::Select(plan) => plan.references_var(var),
-            LoweredStatement::Switch(plan) => plan.references_var(var),
-            LoweredStatement::WhileLet(plan) => plan.body.references_var(var),
-            LoweredStatement::TempBind { name, value } => {
-                output_references_var(name, var) || output_references_var(value, var)
-            }
-            LoweredStatement::ClosureBind {
-                name,
-                closure_open,
-                body,
-                closure_close,
-            } => {
-                output_references_var(name, var)
-                    || output_references_var(closure_open, var)
-                    || body.references_var(var)
-                    || output_references_var(closure_close, var)
-            }
-            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
-                output_references_var(code, var)
-            }
-            LoweredStatement::UnreachablePanic => false,
-        }
-    }
 }
 
 impl IfPlan {
@@ -617,26 +450,5 @@ impl IfPlan {
             ElseArm::ElseIf(_) => false,
             ElseArm::Else { body, .. } => body.ends_with_diverge(),
         }
-    }
-
-    #[allow(dead_code)]
-    fn references_var(&self, var: &str) -> bool {
-        output_references_var(&self.condition_setup, var)
-            || output_references_var(&self.condition, var)
-            || self.then_body.references_var(var)
-            || match &self.else_arm {
-                ElseArm::None => false,
-                ElseArm::ElseIf(plan) => plan.references_var(var),
-                ElseArm::Else { body, .. } => body.references_var(var),
-            }
-    }
-}
-
-impl LoopPlan {
-    #[allow(dead_code)]
-    fn references_var(&self, var: &str) -> bool {
-        output_references_var(&self.prologue, var)
-            || output_references_var(&self.header, var)
-            || self.body.references_var(var)
     }
 }

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -3,7 +3,6 @@ use crate::Planner;
 use crate::calls::CallBoundary;
 use crate::context::expression::ExpressionContext;
 use crate::plan::bodies::LoweredStatement;
-use crate::utils::output_references_var;
 use syntax::ast::Expression;
 
 pub(crate) enum ValuePlan {
@@ -56,23 +55,6 @@ impl ValuePlan {
         match self {
             ValuePlan::Operand(value) | ValuePlan::Composite { value, .. } => Some(value),
             ValuePlan::Paren(_) | ValuePlan::Cast { .. } | ValuePlan::Unary { .. } => None,
-        }
-    }
-
-    /// Whether `var` appears as a standalone identifier in the value text or
-    /// any setup statement.
-    pub(crate) fn references_var(&self, var: &str) -> bool {
-        match self {
-            ValuePlan::Operand(value) => output_references_var(value, var),
-            ValuePlan::Composite { setup, value } => {
-                output_references_var(value, var)
-                    || setup.iter().any(|statement| statement.references_var(var))
-            }
-            ValuePlan::Paren(inner) => inner.references_var(var),
-            ValuePlan::Cast { go_type, inner } => {
-                output_references_var(go_type, var) || inner.references_var(var)
-            }
-            ValuePlan::Unary { inner, .. } => inner.references_var(var),
         }
     }
 }

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -3,15 +3,26 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::escape_reserved;
 
 #[derive(Clone, Debug)]
-pub(crate) struct InlineExpr(String);
+pub(crate) struct InlineExpr {
+    text: String,
+    /// Emitter vars the text references, recorded as uses on substitution.
+    refs: Vec<String>,
+}
 
 impl InlineExpr {
-    pub(crate) fn new(text: impl Into<String>) -> Self {
-        Self(text.into())
+    pub(crate) fn with_refs(text: impl Into<String>, refs: Vec<String>) -> Self {
+        Self {
+            text: text.into(),
+            refs,
+        }
     }
 
     pub(crate) fn as_str(&self) -> &str {
-        &self.0
+        &self.text
+    }
+
+    pub(crate) fn refs(&self) -> &[String] {
+        &self.refs
     }
 }
 

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -17,6 +17,8 @@ pub(crate) struct ScopeState {
     return_ctx_stack: Vec<Rc<ReturnContext>>,
     assign_targets: HashSet<String>,
     go_const_bindings: Vec<HashSet<String>>,
+    /// Go identifiers referenced during lowering, for structural liveness.
+    use_frames: Vec<HashSet<String>>,
 }
 
 pub(crate) struct BindingSnapshot {
@@ -39,6 +41,26 @@ impl ScopeState {
             return_ctx_stack: Vec::new(),
             assign_targets: HashSet::default(),
             go_const_bindings: vec![HashSet::default()],
+            use_frames: Vec::new(),
+        }
+    }
+
+    pub(crate) fn enter_use_region(&mut self) {
+        self.use_frames.push(HashSet::default());
+    }
+
+    /// Pop and return the region's uses, merging them into the enclosing region.
+    pub(crate) fn exit_use_region(&mut self) -> HashSet<String> {
+        let frame = self.use_frames.pop().unwrap_or_default();
+        if let Some(parent) = self.use_frames.last_mut() {
+            parent.extend(frame.iter().cloned());
+        }
+        frame
+    }
+
+    pub(crate) fn record_go_use(&mut self, go_name: &str) {
+        if let Some(frame) = self.use_frames.last_mut() {
+            frame.insert(go_name.to_string());
         }
     }
 

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use syntax::ast::{Expression, FormatStringPart, Literal, UnaryOperator};
 use syntax::program::DotAccessKind;
 
@@ -20,73 +19,6 @@ pub(crate) fn receiver_name(type_name: &str) -> String {
         .unwrap_or('x')
         .to_lowercase()
         .to_string()
-}
-
-/// Whether `var` appears as a standalone identifier in emitted Go,
-/// ignoring string-literal contents.
-pub(crate) fn output_references_var(output: &str, var: &str) -> bool {
-    let masked = mask_go_string_literals(output);
-    let bytes = masked.as_bytes();
-    masked
-        .match_indices(var)
-        .any(|(abs, _)| is_at_token_boundary(bytes, abs, var.len()))
-}
-
-fn is_at_token_boundary(bytes: &[u8], pos: usize, token_len: usize) -> bool {
-    let before_ok = pos == 0 || {
-        let c = bytes[pos - 1];
-        !c.is_ascii_alphanumeric() && c != b'_'
-    };
-    let after = pos + token_len;
-    let after_ok = after >= bytes.len() || {
-        let c = bytes[after];
-        !c.is_ascii_alphanumeric() && c != b'_'
-    };
-    before_ok && after_ok
-}
-
-/// Replace Go string/rune/raw-string contents with spaces, preserving byte
-/// positions. Borrows when no quote is present.
-pub(crate) fn mask_go_string_literals(go_text: &str) -> Cow<'_, str> {
-    if !go_text.bytes().any(|b| matches!(b, b'"' | b'\'' | b'`')) {
-        return Cow::Borrowed(go_text);
-    }
-    let bytes = go_text.as_bytes();
-    let mut out = String::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            quote @ (b'"' | b'\'') => i = mask_literal(bytes, i, quote, true, &mut out),
-            b'`' => i = mask_literal(bytes, i, b'`', false, &mut out),
-            _ => {
-                let start = i;
-                while i < bytes.len() && !matches!(bytes[i], b'"' | b'\'' | b'`') {
-                    i += 1;
-                }
-                out.push_str(&go_text[start..i]);
-            }
-        }
-    }
-    Cow::Owned(out)
-}
-
-fn mask_literal(bytes: &[u8], start: usize, quote: u8, escapes: bool, out: &mut String) -> usize {
-    out.push(quote as char);
-    let mut i = start + 1;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if escapes && b == b'\\' && i + 1 < bytes.len() {
-            out.push_str("  ");
-            i += 2;
-        } else if b == quote {
-            out.push(quote as char);
-            return i + 1;
-        } else {
-            out.push(' ');
-            i += 1;
-        }
-    }
-    i
 }
 
 /// Group consecutive parameters with the same Go type: `a int, b int` → `a, b int`.


### PR DESCRIPTION
Codegen used to decide whether a generated variable was used by re-scanning the emitted Go as text, which was fragile. That check now runs structurally as the code is built.
