### PR TITLE
feat: go-to-definition for go stdlib symbols

### DIFF
--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -2,8 +2,13 @@ mod project_manifest;
 mod typedef_locator;
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use stdlib::Target;
+
+/// Disambiguates temp files so concurrent analyses writing the same typedef do
+/// not share a temp path.
+static TYPEDEF_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub use project_manifest::{
     GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
@@ -60,10 +65,11 @@ pub fn ensure_stdlib_typedef_on_disk(
 }
 
 /// Write `content` to `path` via a temp file + rename, so a concurrent reader
-/// never observes a partial write. The temp name carries the pid so a separate
-/// process writing the same global typedef uses a distinct temp file.
+/// never observes a partial write. The temp name carries the pid and a counter
+/// so concurrent writers (across processes or analyses) use distinct temp files.
 fn atomic_write(path: &Path, content: &str) -> Option<()> {
-    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    let counter = TYPEDEF_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), counter));
     std::fs::write(&tmp, content).ok()?;
     if std::fs::rename(&tmp, path).is_err() {
         let _ = std::fs::remove_file(&tmp);

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -57,7 +57,13 @@ pub fn ensure_stdlib_typedef_on_disk(
     target: Target,
 ) -> Option<PathBuf> {
     let path = stdlib_typedef_dir(target)?.join(format!("{go_pkg}.d.lis"));
-    if std::fs::read_to_string(&path).ok().as_deref() != Some(source) {
+    let needs_write = match std::fs::read_to_string(&path) {
+        Ok(existing) => existing != source,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        // Present but unreadable (e.g. permissions): don't rewrite on every call.
+        Err(_) => return None,
+    };
+    if needs_write {
         std::fs::create_dir_all(path.parent()?).ok()?;
         atomic_write(&path, source)?;
     }

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -2,6 +2,7 @@ mod project_manifest;
 mod typedef_locator;
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 pub use stdlib::Target;
@@ -9,6 +10,14 @@ use stdlib::{GO_STD_CONTENT_HASH, get_go_stdlib_packages, get_go_stdlib_typedef}
 
 /// Disambiguates temp dirs so concurrent stdlib extractions do not share a path.
 static STDLIB_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Test-only override for the home dir stdlib typedefs extract under.
+static STDLIB_TYPEDEF_HOME: OnceLock<PathBuf> = OnceLock::new();
+
+#[doc(hidden)]
+pub fn set_stdlib_typedef_home(home: PathBuf) {
+    let _ = STDLIB_TYPEDEF_HOME.set(home);
+}
 
 pub use project_manifest::{
     GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
@@ -42,16 +51,15 @@ pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
 /// existence proves the contents are current, and distinct versions or embedded
 /// stdlibs get distinct dirs.
 fn stdlib_typedef_version_dir() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    Some(
-        PathBuf::from(home)
-            .join(".lisette/cache/stdlib-typedefs")
-            .join(format!(
-                "lis@v{}-{:016x}",
-                env!("CARGO_PKG_VERSION"),
-                GO_STD_CONTENT_HASH
-            )),
-    )
+    let home = match STDLIB_TYPEDEF_HOME.get() {
+        Some(home) => home.clone(),
+        None => PathBuf::from(std::env::var_os("HOME")?),
+    };
+    Some(home.join(".lisette/cache/stdlib-typedefs").join(format!(
+        "lis@v{}-{:016x}",
+        env!("CARGO_PKG_VERSION"),
+        GO_STD_CONTENT_HASH
+    )))
 }
 
 /// Deterministic on-disk path for a stdlib package's typedef. Pure path
@@ -81,6 +89,7 @@ pub fn ensure_stdlib_extracted(target: Target) {
     if std::fs::create_dir_all(&version_dir).is_err() {
         return;
     }
+    clear_stale_temp_dirs(&version_dir, target);
 
     // Build in a temp dir, then atomically rename into place. The temp name
     // carries the pid and a counter so concurrent extractions don't collide.
@@ -103,15 +112,33 @@ pub fn ensure_stdlib_extracted(target: Target) {
 }
 
 /// Write every embedded stdlib typedef for `target` into `target_tmp`. Returns
-/// `None` on the first error so a partial set is never renamed into place.
+/// `None` on the first I/O error so a partial set is never renamed into place.
 fn extract_all(target_tmp: &Path, target: Target) -> Option<()> {
     for pkg in get_go_stdlib_packages(target) {
-        let source = get_go_stdlib_typedef(pkg, target)?;
+        let Some(source) = get_go_stdlib_typedef(pkg, target) else {
+            continue;
+        };
         let path = target_tmp.join(format!("{pkg}.d.lis"));
         std::fs::create_dir_all(path.parent()?).ok()?;
         std::fs::write(&path, source).ok()?;
     }
     Some(())
+}
+
+fn clear_stale_temp_dirs(version_dir: &Path, target: Target) {
+    let prefix = format!("{}.tmp.", target.cache_segment());
+    let Ok(entries) = std::fs::read_dir(version_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with(&prefix))
+        {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 /// Remove sibling `lis@v*` dirs from other compiler versions or embedded stdlibs.
@@ -188,5 +215,30 @@ impl GoPackage<'_> {
         } else {
             module_dir.join(relative).join(&filename)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_stale_temp_dirs_removes_only_this_targets_temps() {
+        let version_dir = tempfile::tempdir().unwrap();
+        let root = version_dir.path();
+
+        let stale = root.join("darwin_arm64.tmp.999.0");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("fmt.d.lis"), "x").unwrap();
+        let completed = root.join("darwin_arm64");
+        std::fs::create_dir_all(&completed).unwrap();
+        let other_target_tmp = root.join("linux_amd64.tmp.1.0");
+        std::fs::create_dir_all(&other_target_tmp).unwrap();
+
+        clear_stale_temp_dirs(root, Target::new("darwin", "arm64"));
+
+        assert!(!stale.exists(), "this target's stale temp is removed");
+        assert!(completed.exists(), "the completed target dir is kept");
+        assert!(other_target_tmp.exists(), "another target's temp is kept");
     }
 }

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -32,38 +32,38 @@ pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
         .join(format!("lis@v{}", lis_version))
 }
 
-/// Directory holding materialized Go stdlib typedefs. Global (stdlib is the same
-/// for every project) and keyed by target + stdlib content hash, so a compiler
-/// upgrade or stdlib change lands in a fresh directory rather than reusing stale
-/// files.
+/// Directory holding materialized Go stdlib typedefs, one per target. Global
+/// because stdlib is the same for every project.
 fn stdlib_typedef_dir(target: Target) -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(
         PathBuf::from(home)
             .join(".lisette/typedefs/go-std")
-            .join(target.cache_segment())
-            .join(format!("{:016x}", stdlib::GO_STD_CONTENT_HASH)),
+            .join(target.cache_segment()),
     )
 }
 
 /// Materialize an embedded Go stdlib typedef to disk so the editor can open it as
-/// a regular file, and return its path. Idempotent: the content is keyed by
-/// stdlib hash, so an existing file is always current and is left untouched.
-pub fn ensure_stdlib_typedef_on_disk(go_pkg: &str, source: &str, target: Target) -> Option<PathBuf> {
+/// a regular file, and return its path. Rewrites only when the on-disk content
+/// differs (first materialization or after a compiler/stdlib upgrade).
+pub fn ensure_stdlib_typedef_on_disk(
+    go_pkg: &str,
+    source: &str,
+    target: Target,
+) -> Option<PathBuf> {
     let path = stdlib_typedef_dir(target)?.join(format!("{go_pkg}.d.lis"));
-    if !path.exists() {
+    if std::fs::read_to_string(&path).ok().as_deref() != Some(source) {
         std::fs::create_dir_all(path.parent()?).ok()?;
         atomic_write(&path, source)?;
     }
     Some(path)
 }
 
-/// Write `content` to `path` via a temp file + rename so a concurrent reader
-/// never observes a partially written typedef.
+/// Write `content` to `path` via a temp file + rename, so a concurrent reader
+/// never observes a partial write. The temp name carries the pid so a separate
+/// process writing the same global typedef uses a distinct temp file.
 fn atomic_write(path: &Path, content: &str) -> Option<()> {
-    let mut tmp = path.as_os_str().to_owned();
-    tmp.push(".tmp");
-    let tmp = PathBuf::from(tmp);
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
     std::fs::write(&tmp, content).ok()?;
     if std::fs::rename(&tmp, path).is_err() {
         let _ = std::fs::remove_file(&tmp);

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -4,11 +4,11 @@ mod typedef_locator;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use stdlib::Target;
+pub use stdlib::Target;
+use stdlib::{GO_STD_CONTENT_HASH, get_go_stdlib_packages, get_go_stdlib_typedef};
 
-/// Disambiguates temp files so concurrent analyses writing the same typedef do
-/// not share a temp path.
-static TYPEDEF_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// Disambiguates temp dirs so concurrent stdlib extractions do not share a path.
+static STDLIB_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub use project_manifest::{
     GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
@@ -37,51 +37,108 @@ pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
         .join(format!("lis@v{}", lis_version))
 }
 
-/// Directory holding materialized Go stdlib typedefs, one per target. Global
-/// because stdlib is the same for every project.
-fn stdlib_typedef_dir(target: Target) -> Option<PathBuf> {
+/// Version dir for the materialized stdlib typedefs, under `~/.lisette/cache`.
+/// The name encodes the compiler version and stdlib content hash, so its
+/// existence proves the contents are current, and distinct versions or embedded
+/// stdlibs get distinct dirs.
+fn stdlib_typedef_version_dir() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(
         PathBuf::from(home)
-            .join(".lisette/typedefs/go-std")
-            .join(target.cache_segment()),
+            .join(".lisette/cache/stdlib-typedefs")
+            .join(format!(
+                "lis@v{}-{:016x}",
+                env!("CARGO_PKG_VERSION"),
+                GO_STD_CONTENT_HASH
+            )),
     )
 }
 
-/// Materialize an embedded Go stdlib typedef to disk so the editor can open it as
-/// a regular file, and return its path. Rewrites only when the on-disk content
-/// differs (first materialization or after a compiler/stdlib upgrade).
-pub fn ensure_stdlib_typedef_on_disk(
-    go_pkg: &str,
-    source: &str,
-    target: Target,
-) -> Option<PathBuf> {
-    let path = stdlib_typedef_dir(target)?.join(format!("{go_pkg}.d.lis"));
-    let needs_write = match std::fs::read_to_string(&path) {
-        Ok(existing) => existing != source,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
-        // Present but unreadable (e.g. permissions): don't rewrite on every call.
-        Err(_) => return None,
-    };
-    if needs_write {
-        std::fs::create_dir_all(path.parent()?).ok()?;
-        atomic_write(&path, source)?;
-    }
-    Some(path)
+/// Deterministic on-disk path for a stdlib package's typedef. Pure path
+/// construction; the files are written by [`ensure_stdlib_extracted`].
+pub fn stdlib_typedef_path(target: Target, go_pkg: &str) -> Option<PathBuf> {
+    Some(
+        stdlib_typedef_version_dir()?
+            .join(target.cache_segment())
+            .join(format!("{go_pkg}.d.lis")),
+    )
 }
 
-/// Write `content` to `path` via a temp file + rename, so a concurrent reader
-/// never observes a partial write. The temp name carries the pid and a counter
-/// so concurrent writers (across processes or analyses) use distinct temp files.
-fn atomic_write(path: &Path, content: &str) -> Option<()> {
-    let counter = TYPEDEF_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), counter));
-    std::fs::write(&tmp, content).ok()?;
-    if std::fs::rename(&tmp, path).is_err() {
-        let _ = std::fs::remove_file(&tmp);
-        return None;
+/// Materialize the whole embedded Go stdlib for `target` so the editor can open
+/// typedefs as regular files. Runs once, at LSP startup.
+///
+/// All-or-nothing: written to a temp dir then atomically renamed, so the target
+/// dir exists only when complete and one existence check gates the work. Sibling
+/// `lis@v*` dirs from other versions are pruned.
+pub fn ensure_stdlib_extracted(target: Target) {
+    let Some(version_dir) = stdlib_typedef_version_dir() else {
+        return;
+    };
+    let target_dir = version_dir.join(target.cache_segment());
+    if target_dir.exists() {
+        return;
+    }
+    if std::fs::create_dir_all(&version_dir).is_err() {
+        return;
+    }
+
+    // Build in a temp dir, then atomically rename into place. The temp name
+    // carries the pid and a counter so concurrent extractions don't collide.
+    let counter = STDLIB_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = version_dir.join(format!(
+        "{}.tmp.{}.{}",
+        target.cache_segment(),
+        std::process::id(),
+        counter
+    ));
+    if extract_all(&tmp, target).is_none() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return;
+    }
+    if std::fs::rename(&tmp, &target_dir).is_err() {
+        // Another extraction won the race, or the rename failed; drop our temp.
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+    prune_stale_version_dirs(&version_dir);
+}
+
+/// Write every embedded stdlib typedef for `target` into `target_tmp`. Returns
+/// `None` on the first error so a partial set is never renamed into place.
+fn extract_all(target_tmp: &Path, target: Target) -> Option<()> {
+    for pkg in get_go_stdlib_packages(target) {
+        let source = get_go_stdlib_typedef(pkg, target)?;
+        let path = target_tmp.join(format!("{pkg}.d.lis"));
+        std::fs::create_dir_all(path.parent()?).ok()?;
+        std::fs::write(&path, source).ok()?;
     }
     Some(())
+}
+
+/// Remove sibling `lis@v*` dirs from other compiler versions or embedded stdlibs.
+///
+/// Caveat: if another `lis` version's LSP is running, this removes its dir; its
+/// go-to-definition then declines until it restarts. Acceptable, normal lisette
+/// users don't run multiple versions simultaneously.
+fn prune_stale_version_dirs(current: &Path) {
+    let Some(parent) = current.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == current {
+            continue;
+        }
+        let is_version_dir = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("lis@v"));
+        if is_version_dir {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -32,6 +32,46 @@ pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
         .join(format!("lis@v{}", lis_version))
 }
 
+/// Directory holding materialized Go stdlib typedefs. Global (stdlib is the same
+/// for every project) and keyed by target + stdlib content hash, so a compiler
+/// upgrade or stdlib change lands in a fresh directory rather than reusing stale
+/// files.
+fn stdlib_typedef_dir(target: Target) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".lisette/typedefs/go-std")
+            .join(target.cache_segment())
+            .join(format!("{:016x}", stdlib::GO_STD_CONTENT_HASH)),
+    )
+}
+
+/// Materialize an embedded Go stdlib typedef to disk so the editor can open it as
+/// a regular file, and return its path. Idempotent: the content is keyed by
+/// stdlib hash, so an existing file is always current and is left untouched.
+pub fn ensure_stdlib_typedef_on_disk(go_pkg: &str, source: &str, target: Target) -> Option<PathBuf> {
+    let path = stdlib_typedef_dir(target)?.join(format!("{go_pkg}.d.lis"));
+    if !path.exists() {
+        std::fs::create_dir_all(path.parent()?).ok()?;
+        atomic_write(&path, source)?;
+    }
+    Some(path)
+}
+
+/// Write `content` to `path` via a temp file + rename so a concurrent reader
+/// never observes a partially written typedef.
+fn atomic_write(path: &Path, content: &str) -> Option<()> {
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    std::fs::write(&tmp, content).ok()?;
+    if std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return None;
+    }
+    Some(())
+}
+
 #[derive(Clone, Copy)]
 pub struct GoModule<'a> {
     /// Module path, e.g. `github.com/gorilla/mux`.

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -194,9 +194,17 @@ impl TypedefLocator {
             DeclarationStatus::Stdlib => {
                 let source = stdlib::get_go_stdlib_typedef(package_path, self.target)
                     .expect("Stdlib classification implies an embedded typedef");
+                // Materialize the embedded source so go-to-definition can navigate
+                // to it; fall back to a non-navigable origin if the disk write
+                // fails (e.g. no HOME).
+                let origin =
+                    match crate::ensure_stdlib_typedef_on_disk(package_path, source, self.target) {
+                        Some(path) => TypedefOrigin::Cache(path),
+                        None => TypedefOrigin::Stdlib,
+                    };
                 return TypedefLocatorResult::Found {
                     content: Cow::Borrowed(source),
-                    origin: TypedefOrigin::Stdlib,
+                    origin,
                 };
             }
             DeclarationStatus::UnknownStdlib => return TypedefLocatorResult::UnknownStdlib,

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -194,14 +194,12 @@ impl TypedefLocator {
             DeclarationStatus::Stdlib => {
                 let source = stdlib::get_go_stdlib_typedef(package_path, self.target)
                     .expect("Stdlib classification implies an embedded typedef");
-                // Materialize the embedded source so go-to-definition can navigate
-                // to it; fall back to a non-navigable origin if the disk write
-                // fails (e.g. no HOME).
-                let origin =
-                    match crate::ensure_stdlib_typedef_on_disk(package_path, source, self.target) {
-                        Some(path) => TypedefOrigin::Cache(path),
-                        None => TypedefOrigin::Stdlib,
-                    };
+                // Record the path the editor will navigate to; the files are
+                // written by the LSP at startup. No HOME -> non-navigable.
+                let origin = match crate::stdlib_typedef_path(self.target, package_path) {
+                    Some(path) => TypedefOrigin::Cache(path),
+                    None => TypedefOrigin::Stdlib,
+                };
                 return TypedefLocatorResult::Found {
                     content: Cow::Borrowed(source),
                     origin,

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,6 +25,7 @@ rustc-hash.workspace = true
 
 [dev-dependencies]
 bytes = "1"
+deps = { package = "lisette-deps", path = "../deps" }
 futures = "0.3"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -407,9 +407,8 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        // Stdlib go: typedefs are loaded from cache without registering a File,
-        // so their definitions carry Span::dummy(). Refuse to navigate rather
-        // than jump to (0,0) of whatever happens to be at file_id 0.
+        // Refuse to navigate to genuinely dummy spans (e.g. synthesised definitions
+        // with no source location) to avoid jumping to offset 0 of a random file.
         if definition_span.is_dummy() {
             return Ok(None);
         }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -61,6 +61,11 @@ impl LanguageServer for Backend {
             *self.project_config.write().await = Some(config);
         }
 
+        // Materialize the stdlib typedefs so the editor can open them. Off the
+        // async executor since the first run for a version writes the full stdlib.
+        let _ = tokio::task::spawn_blocking(|| deps::ensure_stdlib_extracted(deps::Target::host()))
+            .await;
+
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
@@ -419,6 +424,14 @@ impl LanguageServer for Backend {
             if end > target_file.source.len() {
                 return Ok(None);
             }
+        }
+
+        // The typedef file may be absent (cache cleared, or pruned by another lis
+        // version); decline instead of returning a dangling Location.
+        if let Some(path) = snapshot.typedef_path(definition_span.file_id)
+            && !path.exists()
+        {
+            return Ok(None);
         }
 
         let Some(target_uri) = snapshot.get_uri(definition_span.file_id) else {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -407,8 +407,8 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        // Refuse to navigate to genuinely dummy spans (e.g. synthesised definitions
-        // with no source location) to avoid jumping to offset 0 of a random file.
+        // A dummy span (zero length) would resolve to offset 0 of file_id 0;
+        // refuse rather than jump there.
         if definition_span.is_dummy() {
             return Ok(None);
         }

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -98,6 +98,11 @@ impl AnalysisSnapshot {
         self.id_to_uri.get(&file_id)
     }
 
+    /// On-disk path of a `go:` typedef file, if `file_id` names one.
+    pub(crate) fn typedef_path(&self, file_id: u32) -> Option<&std::path::Path> {
+        self.result.typedef_paths.get(&file_id).map(|p| p.as_path())
+    }
+
     pub(crate) fn get_line_index(&self, file_id: u32) -> Option<&LineIndex> {
         self.line_indexes.get(&file_id)
     }

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -921,9 +921,10 @@ async fn goto_definition_on_stdlib_go_function_navigates_to_typedef() {
     // Stdlib go: typedefs are materialized to disk on demand, so F12 navigates
     // into the generated `.d.lis` file just like a third-party dependency.
     let response = client.goto_definition(TEST_URI, 3, 6).await;
-    let location =
-        definition_location(&response.expect("F12 on stdlib go: function should return a location"))
-            .expect("response should contain a location");
+    let location = definition_location(
+        &response.expect("F12 on stdlib go: function should return a location"),
+    )
+    .expect("response should contain a location");
     let path = location.uri.path();
     assert!(
         path.contains("go-std") && path.ends_with(".d.lis"),

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -911,20 +911,23 @@ async fn goto_definition_on_literal_returns_none() {
 }
 
 #[tokio::test]
-async fn goto_definition_on_stdlib_go_function_returns_none() {
+async fn goto_definition_on_stdlib_go_function_navigates_to_typedef() {
     let mut client = TestClient::new().await;
     client.initialize().await;
 
     let source = "import \"go:fmt\"\n\nfn main() {\n  fmt.Println(\"hello\")\n}";
     client.open(TEST_URI, source).await;
 
-    // Stdlib go: typedefs are embedded in the binary; no on-disk file exists.
-    // The handler must return None rather than navigate to (0,0) of the entry file.
+    // Stdlib go: typedefs are materialized to disk on demand, so F12 navigates
+    // into the generated `.d.lis` file just like a third-party dependency.
     let response = client.goto_definition(TEST_URI, 3, 6).await;
+    let location =
+        definition_location(&response.expect("F12 on stdlib go: function should return a location"))
+            .expect("response should contain a location");
+    let path = location.uri.path();
     assert!(
-        response.is_none(),
-        "stdlib go: F12 should return None, got {:?}",
-        response
+        path.contains("go-std") && path.ends_with(".d.lis"),
+        "stdlib go: F12 should land in a materialized typedef, got {path}"
     );
 
     client.shutdown().await;
@@ -9573,7 +9576,7 @@ fn main() {
 }
 
 #[tokio::test]
-async fn goto_definition_stdlib_member_returns_none() {
+async fn goto_definition_stdlib_member_navigates_to_typedef() {
     let mut client = TestClient::new().await;
     client.initialize().await;
     client
@@ -9583,13 +9586,18 @@ async fn goto_definition_stdlib_member_returns_none() {
         )
         .await;
 
-    // Cursor on "Println" in "fmt.Println" (line 2, col 6)
+    // Cursor on "Println" in "fmt.Println" (line 2, col 6).
+    // Stdlib typedefs are materialized to disk, so this navigates into the
+    // generated `.d.lis` file.
     let response = client.goto_definition(TEST_URI, 2, 6).await;
-    // Stdlib definitions are embedded — no file to jump to.
-    // Should return None rather than a bogus location.
+    let location = definition_location(
+        &response.expect("goto_definition on stdlib member should return a location"),
+    )
+    .expect("response should contain a location");
+    let path = location.uri.path();
     assert!(
-        response.is_none(),
-        "goto_definition on stdlib member should return None, not a bogus location"
+        path.contains("go-std") && path.ends_with(".d.lis"),
+        "stdlib member F12 should land in a materialized typedef, got {path}"
     );
 
     client.shutdown().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1,7 +1,8 @@
 mod lsp_harness;
 
 use lsp_harness::{
-    TestClient, completion_labels, definition_location, hover_content, symbol_names,
+    TestClient, completion_labels, definition_location, definition_target_text, hover_content,
+    symbol_names,
 };
 use tower_lsp::lsp_types::*;
 
@@ -918,17 +919,21 @@ async fn goto_definition_on_stdlib_go_function_navigates_to_typedef() {
     let source = "import \"go:fmt\"\n\nfn main() {\n  fmt.Println(\"hello\")\n}";
     client.open(TEST_URI, source).await;
 
-    // Stdlib go: typedefs are materialized to disk on demand, so F12 navigates
-    // into the generated `.d.lis` file just like a third-party dependency.
+    // Stdlib go: typedefs are materialized to disk on demand, so go-to-definition
+    // navigates into the generated `.d.lis` file just like a third-party dependency.
     let response = client.goto_definition(TEST_URI, 3, 6).await;
     let location = definition_location(
-        &response.expect("F12 on stdlib go: function should return a location"),
+        &response.expect("go-to-definition on stdlib go: function should return a location"),
     )
     .expect("response should contain a location");
     let path = location.uri.path();
     assert!(
         path.contains("go-std") && path.ends_with(".d.lis"),
-        "stdlib go: F12 should land in a materialized typedef, got {path}"
+        "should land in a materialized typedef, got {path}"
+    );
+    assert!(
+        definition_target_text(&location).starts_with("Println"),
+        "should land on the `Println` definition"
     );
 
     client.shutdown().await;
@@ -978,7 +983,7 @@ async fn goto_definition_on_third_party_go_function_navigates_to_cache() {
     // Cursor on `DoStuff`.
     let response = client.goto_definition(&main_uri, 3, 14).await;
     let location = definition_location(
-        &response.expect("F12 on third-party go: function should return a location"),
+        &response.expect("go-to-definition on third-party go: function should return a location"),
     )
     .expect("response should contain a location");
 
@@ -9592,13 +9597,17 @@ async fn goto_definition_stdlib_member_navigates_to_typedef() {
     // generated `.d.lis` file.
     let response = client.goto_definition(TEST_URI, 2, 6).await;
     let location = definition_location(
-        &response.expect("goto_definition on stdlib member should return a location"),
+        &response.expect("go-to-definition on stdlib member should return a location"),
     )
     .expect("response should contain a location");
     let path = location.uri.path();
     assert!(
         path.contains("go-std") && path.ends_with(".d.lis"),
-        "stdlib member F12 should land in a materialized typedef, got {path}"
+        "should land in a materialized typedef, got {path}"
+    );
+    assert!(
+        definition_target_text(&location).starts_with("Println"),
+        "should land on the `Println` definition"
     );
 
     client.shutdown().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -919,8 +919,8 @@ async fn goto_definition_on_stdlib_go_function_navigates_to_typedef() {
     let source = "import \"go:fmt\"\n\nfn main() {\n  fmt.Println(\"hello\")\n}";
     client.open(TEST_URI, source).await;
 
-    // Stdlib go: typedefs are materialized to disk on demand, so go-to-definition
-    // navigates into the generated `.d.lis` file just like a third-party dependency.
+    // The LSP materializes the whole stdlib typedef set to disk at startup, so
+    // go-to-definition navigates into the generated `.d.lis` file.
     let response = client.goto_definition(TEST_URI, 3, 6).await;
     let location = definition_location(
         &response.expect("go-to-definition on stdlib go: function should return a location"),
@@ -928,7 +928,7 @@ async fn goto_definition_on_stdlib_go_function_navigates_to_typedef() {
     .expect("response should contain a location");
     let path = location.uri.path();
     assert!(
-        path.contains("go-std") && path.ends_with(".d.lis"),
+        path.contains("stdlib-typedefs") && path.ends_with(".d.lis"),
         "should land in a materialized typedef, got {path}"
     );
     assert!(
@@ -9592,9 +9592,9 @@ async fn goto_definition_stdlib_member_navigates_to_typedef() {
         )
         .await;
 
-    // Cursor on "Println" in "fmt.Println" (line 2, col 6).
-    // Stdlib typedefs are materialized to disk, so this navigates into the
-    // generated `.d.lis` file.
+    // Cursor on "Println" in "fmt.Println" (line 2, col 6). The LSP materializes
+    // the stdlib typedefs at startup, so this navigates into the generated
+    // `.d.lis` file.
     let response = client.goto_definition(TEST_URI, 2, 6).await;
     let location = definition_location(
         &response.expect("go-to-definition on stdlib member should return a location"),
@@ -9602,7 +9602,7 @@ async fn goto_definition_stdlib_member_navigates_to_typedef() {
     .expect("response should contain a location");
     let path = location.uri.path();
     assert!(
-        path.contains("go-std") && path.ends_with(".d.lis"),
+        path.contains("stdlib-typedefs") && path.ends_with(".d.lis"),
         "should land in a materialized typedef, got {path}"
     );
     assert!(

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -346,6 +346,22 @@ pub fn definition_location(response: &GotoDefinitionResponse) -> Option<Location
     }
 }
 
+/// Reads the file a definition `Location` points to and returns the text from
+/// the range start to end of line, so a test can assert the jump landed on the
+/// expected symbol rather than merely on some file.
+pub fn definition_target_text(location: &Location) -> String {
+    let path = location
+        .uri
+        .to_file_path()
+        .expect("location uri should be a file path");
+    let source = std::fs::read_to_string(&path).expect("definition file should be readable");
+    let line = source
+        .lines()
+        .nth(location.range.start.line as usize)
+        .expect("range line should exist");
+    line[location.range.start.character as usize..].to_string()
+}
+
 pub fn completion_labels(response: &CompletionResponse) -> Vec<String> {
     match response {
         CompletionResponse::Array(items) => items.iter().map(|i| i.label.clone()).collect(),

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -62,9 +62,22 @@ pub struct TestClient {
     buffered: Vec<Value>,
 }
 
+fn init_test_stdlib_home() {
+    static HOME: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    HOME.get_or_init(|| {
+        let dir =
+            std::env::temp_dir().join(format!("lisette-lsp-test-home-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create test home dir");
+        deps::set_stdlib_typedef_home(dir.clone());
+        dir
+    });
+}
+
 impl TestClient {
     /// Spawn a new LSP server and return a connected client.
     pub async fn new() -> Self {
+        init_test_stdlib_home();
+
         let (client, server) = tokio::io::duplex(64 * 1024);
         let (server_read, server_write) = tokio::io::split(server);
         let (client_read, client_write) = tokio::io::split(client);

--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -167,8 +167,8 @@ fn register_cached_go_module(
             .insert(module_id.to_string(), pkg_name);
     }
 
-    // Register the typedef File and materialize it so go-to-definition can
-    // navigate, mirroring the `typedef_paths` entry the locator records.
+    // Register the typedef File and its on-disk path so go-to-definition can
+    // navigate. The files are written by the LSP at startup.
     let owned_file_id;
     let mut file_ids: &[u32] = &[];
     if let (Some(go_pkg), Some(source)) = (go_pkg, source) {
@@ -178,7 +178,7 @@ fn register_cached_go_module(
             module_id,
             File::new_cached(module_id, &filename, &filename, source, file_id),
         );
-        if let Some(path) = deps::ensure_stdlib_typedef_on_disk(go_pkg, source, target) {
+        if let Some(path) = deps::stdlib_typedef_path(target, go_pkg) {
             store.typedef_paths.insert(file_id, path);
         }
         owned_file_id = [file_id];

--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -9,6 +9,7 @@ use super::types::CachedDefinition;
 use super::{COMPILER_VERSION_HASH, GO_STDLIB_HASH};
 use crate::checker::registration::extract_package_directive;
 use crate::store::Store;
+use syntax::program::File;
 
 #[derive(Serialize, Deserialize)]
 pub struct GoStdlibCache {
@@ -154,8 +155,10 @@ fn register_cached_go_module(
     store.add_module(module_id);
     store.mark_visited(module_id);
 
-    if let Some(go_pkg) = module_id.strip_prefix("go:")
-        && let Some(source) = get_go_stdlib_typedef(go_pkg, target)
+    let go_pkg = module_id.strip_prefix("go:");
+    let source = go_pkg.and_then(|go_pkg| get_go_stdlib_typedef(go_pkg, target));
+
+    if let Some(source) = source
         && let Some(pkg_name) = extract_package_directive(source)
         && module_id.rsplit('/').next() != Some(pkg_name.as_str())
     {
@@ -164,10 +167,25 @@ fn register_cached_go_module(
             .insert(module_id.to_string(), pkg_name);
     }
 
-    // Go modules don't need files registered — they're internal and filtered out
-    // of diagnostic rendering. We use an empty file_ids slice for span restoration
-    // (all spans will get file_id 0, which is fine for Go stdlib).
-    let file_ids: &[u32] = &[];
+    // Register the typedef as a file so its definitions' byte-offset spans
+    // resolve, and materialize it to disk so go-to-definition can navigate
+    // there. This fast cache path bypasses the locator, so it mirrors the
+    // `typedef_paths` entry the locator records on the slow path.
+    let owned_file_id;
+    let mut file_ids: &[u32] = &[];
+    if let (Some(go_pkg), Some(source)) = (go_pkg, source) {
+        let file_id = store.new_file_id();
+        let filename = format!("{}.d.lis", go_pkg.replace('/', "_"));
+        store.store_file(
+            module_id,
+            File::new_cached(module_id, &filename, &filename, source, file_id),
+        );
+        if let Some(path) = deps::ensure_stdlib_typedef_on_disk(go_pkg, source, target) {
+            store.typedef_paths.insert(file_id, path);
+        }
+        owned_file_id = [file_id];
+        file_ids = &owned_file_id;
+    }
 
     let module = store.get_module_mut(module_id).unwrap();
     for (qualified_name, cached_definition) in &cached.definitions {

--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -167,10 +167,8 @@ fn register_cached_go_module(
             .insert(module_id.to_string(), pkg_name);
     }
 
-    // Register the typedef as a file so its definitions' byte-offset spans
-    // resolve, and materialize it to disk so go-to-definition can navigate
-    // there. This fast cache path bypasses the locator, so it mirrors the
-    // `typedef_paths` entry the locator records on the slow path.
+    // Register the typedef File and materialize it so go-to-definition can
+    // navigate, mirroring the `typedef_paths` entry the locator records.
     let owned_file_id;
     let mut file_ids: &[u32] = &[];
     if let (Some(go_pkg), Some(source)) = (go_pkg, source) {


### PR DESCRIPTION
This change allows the user to navigate to stdlib definitions with lsp goto-def.

Currently the lsp goto-def does not work with stdlib symbols like `fmt.Println` as stdlib typedefs are embedded in the compiler binary, so from the lsp's point of view there is no file on disk to jump to. Third-party deps work because their typedefs get generated to disk, for example during `lis add <pkg>`.

This change writes the stdlib typedef to disk **on demand** at `$HOME/.lisette/typedefs/go-std/<target>/<pkg>.d.lis` and records it in `typedef_paths`. The lsp goto-def then resolves stdlib symbols through the same mechanism already used for third-party packages, so no new lsp handling is required.

This matches how most other lsp servers expose stdlib sources.