### PR TITLE
refactor: reshape `lis run` onto build-then-exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
       - run: cargo build -p lisette --locked
       - run: cargo test -p tests --test e2e_smoke --locked -- --format terse
       - run: cargo test -p tests --test e2e_learn --locked -- --format terse
+      - run: cargo test -p tests --test e2e_run --locked -- --format terse
 
   stdlib-check:
     name: Stdlib check

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -13,6 +13,7 @@ pub enum Command {
         target: Option<String>,
         args: Vec<String>,
         debug: bool,
+        go_flags: Vec<String>,
     },
     Format {
         path: Option<String>,
@@ -65,6 +66,26 @@ pub enum ParseError {
         reason: String,
         hint: String,
     },
+}
+
+fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseError> {
+    match crate::shell_words::split(raw) {
+        Ok(tokens) => {
+            go_flags.extend(tokens);
+            Ok(())
+        }
+        Err(crate::shell_words::SplitError::UnterminatedQuote(quote)) => {
+            Err(ParseError::UnexpectedArgument {
+                message: format!("unterminated {} quote in `--go-flags`", quote),
+                reason: "the value passed to `--go-flags` has an unbalanced quote".to_string(),
+                hint: "Balance the quotes, e.g. `--go-flags \"-ldflags='-s -w'\"`".to_string(),
+            })
+        }
+    }
+}
+
+fn is_go_output_flag(token: &str) -> bool {
+    token == "-o" || token.starts_with("-o=")
 }
 
 fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
@@ -122,24 +143,48 @@ impl Command {
                 let mut target = None;
                 let mut args = Vec::new();
                 let mut debug = false;
+                let mut go_flags = Vec::new();
                 let mut found_separator = false;
 
-                for arg in arguments {
+                while let Some(arg) = arguments.next() {
                     if found_separator {
                         args.push(arg);
                     } else if arg == "--" {
                         found_separator = true;
                     } else if arg == "--debug" {
                         debug = true;
+                    } else if arg == "--go-flags" {
+                        let Some(value) = arguments.next() else {
+                            return Err(ParseError::MissingArgument {
+                                command: "run",
+                                argument: "--go-flags <flags>",
+                            });
+                        };
+                        extend_go_flags(&mut go_flags, &value)?;
+                    } else if let Some(value) = arg.strip_prefix("--go-flags=") {
+                        extend_go_flags(&mut go_flags, value)?;
+                    } else if arg.starts_with('-') {
+                        return Err(ParseError::UnknownFlag(arg));
                     } else {
                         target = Some(arg);
                     }
+                }
+
+                if let Some(flag) = go_flags.iter().find(|f| is_go_output_flag(f)) {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: format!("`{}` cannot be passed to `lis run` via `--go-flags`", flag),
+                        reason: "`run` executes the binary it links at an internal path, so it owns `-o`"
+                            .to_string(),
+                        hint: "Use `lis build --go-flags \"-o <path>\"` to choose the output location"
+                            .to_string(),
+                    });
                 }
 
                 Ok(Command::Run {
                     target,
                     args,
                     debug,
+                    go_flags,
                 })
             }
 
@@ -392,6 +437,105 @@ mod tests {
     fn check_rejects_both_filter_flags() {
         assert!(matches!(
             parse(&["lis", "check", "--errors-only", "--warnings-only"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    fn run_parts(parts: &[&str]) -> (Option<String>, Vec<String>, Vec<String>) {
+        let Ok(Command::Run {
+            target,
+            args,
+            go_flags,
+            ..
+        }) = parse(parts)
+        else {
+            panic!("expected Run command");
+        };
+        (target, args, go_flags)
+    }
+
+    #[test]
+    fn run_target_only() {
+        let (target, args, go_flags) = run_parts(&["lis", "run", "."]);
+        assert_eq!(target.as_deref(), Some("."));
+        assert!(args.is_empty());
+        assert!(go_flags.is_empty());
+    }
+
+    #[test]
+    fn run_go_flags_before_target() {
+        let (target, _, go_flags) = run_parts(&["lis", "run", "--go-flags", "-race", "."]);
+        assert_eq!(target.as_deref(), Some("."));
+        assert_eq!(go_flags, vec!["-race"]);
+    }
+
+    #[test]
+    fn run_go_flags_after_target() {
+        let (target, _, go_flags) = run_parts(&["lis", "run", ".", "--go-flags", "-race"]);
+        assert_eq!(target.as_deref(), Some("."));
+        assert_eq!(go_flags, vec!["-race"]);
+    }
+
+    #[test]
+    fn run_go_flags_equals_form() {
+        let (_, _, go_flags) = run_parts(&["lis", "run", "--go-flags=-trimpath"]);
+        assert_eq!(go_flags, vec!["-trimpath"]);
+    }
+
+    #[test]
+    fn run_go_flags_inner_quoted_value_stays_one_token() {
+        let (_, _, go_flags) =
+            run_parts(&["lis", "run", "--go-flags", "-trimpath -ldflags='-s -w'"]);
+        assert_eq!(go_flags, vec!["-trimpath", "-ldflags=-s -w"]);
+    }
+
+    #[test]
+    fn run_separator_routes_remaining_tokens_to_program_args() {
+        let (target, args, go_flags) = run_parts(&["lis", "run", ".", "--", "--go-flags", "-race"]);
+        assert_eq!(target.as_deref(), Some("."));
+        assert_eq!(args, vec!["--go-flags", "-race"]);
+        assert!(go_flags.is_empty());
+    }
+
+    #[test]
+    fn run_rejects_output_flag_separated_form() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags", "-o /tmp/x"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn run_rejects_output_flag_joined_form() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags", "-o=/tmp/x"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn run_rejects_unknown_flag() {
+        assert!(matches!(
+            parse(&["lis", "run", "--bogus"]),
+            Err(ParseError::UnknownFlag(_))
+        ));
+    }
+
+    #[test]
+    fn run_go_flags_requires_value() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags"]),
+            Err(ParseError::MissingArgument {
+                command: "run",
+                argument: "--go-flags <flags>",
+            })
+        ));
+    }
+
+    #[test]
+    fn run_go_flags_rejects_unterminated_quote() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags", "-ldflags='-s"]),
             Err(ParseError::UnexpectedArgument { .. })
         ));
     }

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -414,3 +414,168 @@ fn go_mod_tidy(path: &Path, target: Target) -> Result<(), String> {
 
     Ok(())
 }
+
+pub fn binary_name(go_module_name: &str, target: Target) -> String {
+    let stem = go_module_name.rsplit('/').next().unwrap_or(go_module_name);
+    with_exe_suffix(sanitize_binary_stem(stem), target)
+}
+
+pub fn run_binary_name(target: Target) -> String {
+    with_exe_suffix("lis-run".to_string(), target)
+}
+
+fn with_exe_suffix(stem: String, target: Target) -> String {
+    if target.goos == "windows" {
+        format!("{stem}.exe")
+    } else {
+        stem
+    }
+}
+
+/// Stem that keeps `target/bin/` invisible to Go tooling and is a usable
+/// filename on every host.
+pub fn sanitize_binary_stem(name: &str) -> String {
+    let mut stem: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    stem = stem.trim_start_matches(['.', '_']).to_string();
+
+    while stem.ends_with(".go") {
+        stem.truncate(stem.len() - ".go".len());
+    }
+
+    if stem.is_empty() || stem == "testdata" || stem == "vendor" || is_windows_reserved_name(&stem)
+    {
+        return "app".to_string();
+    }
+
+    stem
+}
+
+/// Reserved on Windows regardless of extension, keyed on the pre-dot segment
+/// (`con.txt` too); checked on every host so the name is host-independent.
+fn is_windows_reserved_name(stem: &str) -> bool {
+    let base = stem.split('.').next().unwrap_or(stem);
+    let lower = base.to_ascii_lowercase();
+    if matches!(lower.as_str(), "con" | "prn" | "aux" | "nul") {
+        return true;
+    }
+    let bytes = lower.as_bytes();
+    (lower.starts_with("com") || lower.starts_with("lpt"))
+        && bytes.len() == 4
+        && (b'1'..=b'9').contains(&bytes[3])
+}
+
+/// `go_flags` follow the default `-o` so a caller `-o` wins. `output_path` must
+/// be absolute, since `go build` runs with `build_dir` as cwd.
+pub fn build_binary(
+    build_dir: &Path,
+    output_path: &Path,
+    target: Target,
+    go_flags: &[String],
+) -> Result<(), GoCliError> {
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| GoCliError {
+            message: format!("Failed to create `{}`: {}", parent.display(), e),
+            hint: "Check directory permissions",
+        })?;
+    }
+
+    let mut cmd = go_command(target);
+    cmd.arg("build").arg("-o").arg(output_path);
+    for flag in go_flags {
+        cmd.arg(flag);
+    }
+    cmd.arg(".").current_dir(build_dir);
+
+    match cmd.status() {
+        Ok(status) if status.success() => Ok(()),
+        Ok(_) => Err(GoCliError {
+            message: "`go build` failed".to_string(),
+            hint: "Review the Go compiler output above",
+        }),
+        Err(e) => Err(GoCliError {
+            message: format!("Failed to execute `go build`: {}", e),
+            hint: "Check Go installation with `go version`",
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linux() -> Target {
+        Target::new("linux", "amd64")
+    }
+
+    fn windows() -> Target {
+        Target::new("windows", "amd64")
+    }
+
+    #[test]
+    fn binary_name_uses_last_module_segment() {
+        assert_eq!(binary_name("myproj", linux()), "myproj");
+        assert_eq!(binary_name("github.com/u/myproj", linux()), "myproj");
+    }
+
+    #[test]
+    fn binary_name_appends_exe_on_windows() {
+        assert_eq!(binary_name("myproj", windows()), "myproj.exe");
+        assert_eq!(run_binary_name(windows()), "lis-run.exe");
+        assert_eq!(run_binary_name(linux()), "lis-run");
+    }
+
+    #[test]
+    fn sanitize_replaces_illegal_chars() {
+        assert_eq!(sanitize_binary_stem("weird name!"), "weird_name_");
+    }
+
+    #[test]
+    fn sanitize_never_ends_in_go() {
+        assert_eq!(sanitize_binary_stem("foo.go"), "foo");
+        assert_eq!(sanitize_binary_stem("foo.go.go"), "foo");
+    }
+
+    #[test]
+    fn sanitize_strips_leading_reserved_prefixes() {
+        assert_eq!(sanitize_binary_stem(".hidden"), "hidden");
+        assert_eq!(sanitize_binary_stem("_x"), "x");
+    }
+
+    #[test]
+    fn sanitize_falls_back_for_empty_or_reserved() {
+        assert_eq!(sanitize_binary_stem("___"), "app");
+        assert_eq!(sanitize_binary_stem("testdata"), "app");
+        assert_eq!(sanitize_binary_stem("vendor"), "app");
+    }
+
+    #[test]
+    fn sanitize_avoids_windows_reserved_device_names() {
+        assert_eq!(sanitize_binary_stem("con"), "app");
+        assert_eq!(sanitize_binary_stem("CON"), "app");
+        assert_eq!(sanitize_binary_stem("NuL"), "app");
+        assert_eq!(sanitize_binary_stem("com1"), "app");
+        assert_eq!(sanitize_binary_stem("LPT9"), "app");
+        assert_eq!(sanitize_binary_stem("com0"), "com0");
+        assert_eq!(sanitize_binary_stem("com10"), "com10");
+        assert_eq!(sanitize_binary_stem("console"), "console");
+    }
+
+    #[test]
+    fn sanitize_avoids_dotted_windows_reserved_names() {
+        assert_eq!(sanitize_binary_stem("con.txt"), "app");
+        assert_eq!(sanitize_binary_stem("NUL.anything"), "app");
+        assert_eq!(sanitize_binary_stem("com1.foo"), "app");
+        assert_eq!(sanitize_binary_stem("foo.con"), "foo.con");
+        assert_eq!(sanitize_binary_stem("console.txt"), "console.txt");
+    }
+}

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -48,7 +48,7 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         run)
-            COMPREPLY=( $(compgen -W "--debug" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--debug --go-flags" -- "$cur") )
             return 0
             ;;
         format)
@@ -116,7 +116,9 @@ _lis() {
                     _arguments '--debug[Include line directives for stack traces]'
                     ;;
                 run)
-                    _arguments '--debug[Include line directives for stack traces]'
+                    _arguments \
+                        '--debug[Include line directives for stack traces]' \
+                        '--go-flags[Flags passed through to go build]:flags'
                     ;;
                 format)
                     _arguments '--check[Check formatting without modifying]'
@@ -164,6 +166,7 @@ complete -c lis -n __fish_use_subcommand -a version -d 'Print version informatio
 
 complete -c lis -n '__fish_seen_subcommand_from build' -l debug -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l debug -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'

--- a/crates/cli/src/handlers/new.rs
+++ b/crates/cli/src/handlers/new.rs
@@ -95,8 +95,7 @@ fn main() {
         r#"# {}
 
 ```bash
-lis build
-go run -C target .
+lis run
 ```
 "#,
         project_name

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -2,9 +2,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
-#[cfg(not(unix))]
-use std::path::PathBuf;
-#[cfg(not(unix))]
 use std::process::Command;
 
 use crate::cli_error;
@@ -13,136 +10,20 @@ use diagnostics::render::{self, Filter};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 use semantics::loader::MemoryLoader;
 
-fn run_with_invocation_cwd(
+fn build_and_exec(
     build_dir: &Path,
+    output_path: &Path,
     args: &[String],
+    go_flags: &[String],
     heading: &str,
     target: stdlib::Target,
 ) -> i32 {
-    #[cfg(unix)]
-    {
-        run_via_exec_wrapper(build_dir, args, heading, target)
-    }
-    #[cfg(not(unix))]
-    {
-        build_then_exec(build_dir, args, heading, target)
-    }
-}
-
-#[cfg(unix)]
-fn run_via_exec_wrapper(
-    build_dir: &Path,
-    args: &[String],
-    heading: &str,
-    target: stdlib::Target,
-) -> i32 {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to read current directory: {}", e),
-                "Check directory permissions"
-            );
-            return 1;
-        }
-    };
-    let cwd_str = cwd.to_string_lossy();
-    let quoted_cwd = match quote_for_go_exec(&cwd_str) {
-        Ok(q) => q,
-        Err(e) => {
-            cli_error!(
-                heading,
-                e,
-                "Run from a directory whose path does not contain both `'` and `\"`"
-            );
-            return 1;
-        }
-    };
-
-    let mut cmd = go_cli::go_command(target);
-    cmd.arg("-C")
-        .arg(build_dir)
-        .arg("run")
-        .arg(format!("-exec=env -C {}", quoted_cwd))
-        .arg(".")
-        .args(args);
-
-    match cmd.status() {
-        Ok(status) => status.code().unwrap_or(1),
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to execute `go run`: {}", e),
-                "Check Go installation with `go version`"
-            );
-            1
-        }
-    }
-}
-
-#[cfg(unix)]
-fn quote_for_go_exec(path: &str) -> Result<String, String> {
-    let has_single = path.contains('\'');
-    let has_double = path.contains('"');
-    match (has_single, has_double) {
-        (true, true) => Err(format!(
-            "Cannot pass cwd `{}` through `go run -exec`: contains both `'` and `\"`",
-            path
-        )),
-        (true, false) => Ok(format!("\"{}\"", path)),
-        _ => Ok(format!("'{}'", path)),
-    }
-}
-
-#[cfg(not(unix))]
-const RUN_BIN_NAME: &str = "lis-run.exe";
-
-#[cfg(not(unix))]
-fn build_then_exec(
-    build_dir: &Path,
-    args: &[String],
-    heading: &str,
-    target: stdlib::Target,
-) -> i32 {
-    let abs_build_dir = match build_dir.canonicalize() {
-        Ok(p) => p,
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to resolve `{}`: {}", build_dir.display(), e),
-                "Check that the directory exists"
-            );
-            return 1;
-        }
-    };
-    let binary_path: PathBuf = abs_build_dir.join(RUN_BIN_NAME);
-
-    let mut build_cmd = go_cli::go_command(target);
-    build_cmd
-        .arg("build")
-        .arg("-o")
-        .arg(&binary_path)
-        .arg(".")
-        .current_dir(&abs_build_dir);
-
-    match build_cmd.status() {
-        Ok(s) if s.success() => {}
-        Ok(s) => return s.code().unwrap_or(1),
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to execute `go build`: {}", e),
-                "Check Go installation with `go version`"
-            );
-            return 1;
-        }
+    if let Err(e) = go_cli::build_binary(build_dir, output_path, target, go_flags) {
+        cli_error!(heading, e.message, e.hint);
+        return 1;
     }
 
-    let mut cmd = Command::new(&binary_path);
-    cmd.args(args);
-
-    match cmd.status() {
+    match Command::new(output_path).args(args).status() {
         Ok(status) => status.code().unwrap_or(1),
         Err(e) => {
             cli_error!(
@@ -155,7 +36,7 @@ fn build_then_exec(
     }
 }
 
-pub fn run(target: Option<String>, args: Vec<String>, debug: bool) -> i32 {
+pub fn run(target: Option<String>, args: Vec<String>, debug: bool, go_flags: Vec<String>) -> i32 {
     if let Err(code) = crate::go_cli::require_go() {
         return code;
     }
@@ -163,13 +44,13 @@ pub fn run(target: Option<String>, args: Vec<String>, debug: bool) -> i32 {
     let target = target.unwrap_or_else(|| ".".to_string());
 
     if target.ends_with(".lis") {
-        run_standalone(&target, args, debug)
+        run_standalone(&target, args, debug, &go_flags)
     } else {
-        run_project(&target, args, debug)
+        run_project(&target, args, debug, &go_flags)
     }
 }
 
-fn run_project(path: &str, args: Vec<String>, debug: bool) -> i32 {
+fn run_project(path: &str, args: Vec<String>, debug: bool, go_flags: &[String]) -> i32 {
     let project_path = Path::new(path);
 
     let prep = match super::build::prepare_project_build(project_path) {
@@ -177,28 +58,39 @@ fn run_project(path: &str, args: Vec<String>, debug: bool) -> i32 {
         Err(code) => return code,
     };
 
-    // Held across the user program's lifetime so a concurrent `lis check`/
-    // `build`/`sync`/LSP cannot rewrite `target/` mid-`go run` compile.
+    // Held through the child's execution too: releasing sooner would let a concurrent
+    // `lis build`/`sync`/LSP relink `target/` under the running program.
     let _target_lock = match crate::lock::acquire_target_lock(&prep.target_dir) {
         Ok(f) => f,
         Err(code) => return code,
     };
 
-    let target_dir = prep.target_dir.clone();
+    let heading = "Failed to run project";
+    let target = stdlib::Target::host();
+    let binary_name = go_cli::binary_name(&prep.manifest.project.name, target);
+
     let build_result = super::build::build_locked(&prep, debug, true);
     if build_result != 0 {
         return build_result;
     }
 
-    run_with_invocation_cwd(
-        &target_dir,
-        &args,
-        "Failed to run project",
-        stdlib::Target::host(),
-    )
+    let build_dir = match prep.target_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            cli_error!(
+                heading,
+                format!("Failed to resolve `{}`: {}", prep.target_dir.display(), e),
+                "Check that the directory exists"
+            );
+            return 1;
+        }
+    };
+    let output_path = build_dir.join("bin").join(&binary_name);
+
+    build_and_exec(&build_dir, &output_path, &args, go_flags, heading, target)
 }
 
-fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
+fn run_standalone(file: &str, args: Vec<String>, debug: bool, go_flags: &[String]) -> i32 {
     let file_path = Path::new(file);
 
     if !file_path.exists() {
@@ -238,6 +130,19 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
         );
         return 1;
     }
+
+    // Absolute path required: a relative `TMPDIR` would break the `-o`/exec contract.
+    let temp_dir = match temp_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            cli_error!(
+                "Failed to run standalone file",
+                format!("Failed to resolve temporary directory: {}", e),
+                "Check permissions on temp directory"
+            );
+            return 1;
+        }
+    };
 
     let compile_config = CompileConfig {
         target_phase: CompilePhase::Emit,
@@ -314,5 +219,6 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool) -> i32 {
 
     go_cli::write_emit_manifest(&temp_dir, &emit.new_manifest);
 
-    run_with_invocation_cwd(&temp_dir, &args, "Failed to run standalone file", target)
+    let output_path = temp_dir.join(go_cli::run_binary_name(target));
+    build_and_exec(&temp_dir, &output_path, &args, go_flags, heading, target)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,6 +5,7 @@ mod handlers;
 mod lock;
 mod output;
 mod panic;
+mod shell_words;
 mod typedef_regen;
 mod workspace;
 
@@ -62,7 +63,8 @@ fn main() {
             target,
             args,
             debug,
-        } => handlers::run(target, args, debug),
+            go_flags,
+        } => handlers::run(target, args, debug, go_flags),
         Command::Format { path, check } => handlers::format(path, check),
         Command::Check {
             path,

--- a/crates/cli/src/shell_words.rs
+++ b/crates/cli/src/shell_words.rs
@@ -1,0 +1,126 @@
+//! POSIX-style word splitting for the `--go-flags` passthrough.
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SplitError {
+    UnterminatedQuote(char),
+}
+
+pub fn split(input: &str) -> Result<Vec<String>, SplitError> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_word = false;
+    let mut chars = input.chars();
+
+    while let Some(c) = chars.next() {
+        match c {
+            ' ' | '\t' | '\n' | '\r' => {
+                if in_word {
+                    words.push(std::mem::take(&mut current));
+                    in_word = false;
+                }
+            }
+            '\'' => {
+                in_word = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some(other) => current.push(other),
+                        None => return Err(SplitError::UnterminatedQuote('\'')),
+                    }
+                }
+            }
+            '"' => {
+                in_word = true;
+                loop {
+                    match chars.next() {
+                        Some('"') => break,
+                        Some('\\') => match chars.next() {
+                            Some(escaped @ ('"' | '\\' | '$' | '`')) => current.push(escaped),
+                            Some(other) => {
+                                current.push('\\');
+                                current.push(other);
+                            }
+                            None => return Err(SplitError::UnterminatedQuote('"')),
+                        },
+                        Some(other) => current.push(other),
+                        None => return Err(SplitError::UnterminatedQuote('"')),
+                    }
+                }
+            }
+            '\\' => {
+                in_word = true;
+                match chars.next() {
+                    Some(other) => current.push(other),
+                    None => current.push('\\'),
+                }
+            }
+            other => {
+                in_word = true;
+                current.push(other);
+            }
+        }
+    }
+
+    if in_word {
+        words.push(current);
+    }
+
+    Ok(words)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts(input: &str) -> Vec<String> {
+        split(input).expect("split should succeed")
+    }
+
+    #[test]
+    fn empty_input_yields_no_words() {
+        assert_eq!(parts(""), Vec::<String>::new());
+        assert_eq!(parts("   \t "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn splits_bare_words_on_whitespace() {
+        assert_eq!(parts("-race"), vec!["-race"]);
+        assert_eq!(parts("  a   b  "), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn single_quotes_group_a_value_with_spaces() {
+        assert_eq!(parts("-ldflags='-s -w'"), vec!["-ldflags=-s -w"]);
+        assert_eq!(parts("-gcflags='all=-N -l'"), vec!["-gcflags=all=-N -l"]);
+    }
+
+    #[test]
+    fn double_quotes_group_a_value_with_spaces() {
+        assert_eq!(parts("\"-s -w\""), vec!["-s -w"]);
+    }
+
+    #[test]
+    fn mixes_bare_and_quoted_words() {
+        assert_eq!(
+            parts("-trimpath -ldflags='-s -w'"),
+            vec!["-trimpath", "-ldflags=-s -w"]
+        );
+    }
+
+    #[test]
+    fn backslash_escapes_a_space() {
+        assert_eq!(parts("a\\ b"), vec!["a b"]);
+    }
+
+    #[test]
+    fn unterminated_quote_is_an_error() {
+        assert_eq!(
+            split("'unterminated"),
+            Err(SplitError::UnterminatedQuote('\''))
+        );
+        assert_eq!(
+            split("\"unterminated"),
+            Err(SplitError::UnterminatedQuote('"'))
+        );
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,6 +29,10 @@ name = "e2e_smoke"
 path = "e2e_smoke.rs"
 
 [[test]]
+name = "e2e_run"
+path = "e2e_run.rs"
+
+[[test]]
 name = "e2e_learn"
 path = "e2e_learn.rs"
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn go_available() -> bool {
+    Command::new("go").arg("version").output().is_ok()
+}
+
+fn repo() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn scaffold_marker_project(root: &Path) -> (PathBuf, PathBuf) {
+    let project = root.join("proj");
+    let invocation = root.join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"cwdprobe\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+import "go:os"
+
+fn main() {
+  match os.ReadFile("lis-run-cwd-marker") {
+    Ok(_) => fmt.Println("FOUND_MARKER"),
+    Err(_) => fmt.Println("NO_MARKER"),
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    fs::write(invocation.join("lis-run-cwd-marker"), "ok").unwrap();
+
+    (project, invocation)
+}
+
+fn lis_run(project: &Path, invocation: &Path, extra: &[&str]) -> std::process::Output {
+    let manifest = repo().join("Cargo.toml");
+    let mut cmd = Command::new("cargo");
+    cmd.args(["run", "--quiet", "--manifest-path"])
+        .arg(&manifest)
+        .args(["-p", "lisette", "--", "run"])
+        .arg(project)
+        .args(extra)
+        .current_dir(invocation)
+        .env("NO_COLOR", "1");
+    cmd.output().expect("failed to invoke lisette")
+}
+
+#[test]
+fn run_executes_binary_in_invocation_cwd() {
+    if !go_available() {
+        eprintln!("skipping run_executes_binary_in_invocation_cwd: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let (project, invocation) = scaffold_marker_project(scratch.path());
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("FOUND_MARKER"),
+        "program did not resolve a relative path against the invocation cwd:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_forwards_go_flags() {
+    if !go_available() {
+        eprintln!("skipping run_forwards_go_flags: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let (project, invocation) = scaffold_marker_project(scratch.path());
+
+    let output = lis_run(&project, &invocation, &["--go-flags", "-trimpath"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run --go-flags -trimpath failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("FOUND_MARKER"),
+        "program output unexpected with --go-flags:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Refactors `lis run` to compile a binary and execute it directly instead of shelling out to `go run`, which unifies the per-platform run paths and adds a `--go-flags` passthrough to `go build`.
