### PR TITLE
feat: add `lis emit` to CLI

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -9,6 +9,10 @@ pub enum Command {
         path: Option<String>,
         debug: bool,
     },
+    Emit {
+        path: Option<String>,
+        debug: bool,
+    },
     Run {
         target: Option<String>,
         args: Vec<String>,
@@ -68,6 +72,21 @@ pub enum ParseError {
     },
 }
 
+fn parse_path_and_debug(
+    arguments: impl Iterator<Item = String>,
+) -> Result<(Option<String>, bool), ParseError> {
+    let mut path = None;
+    let mut debug = false;
+    for arg in arguments {
+        match arg.as_str() {
+            "--debug" => debug = true,
+            s if s.starts_with('-') => return Err(ParseError::UnknownFlag(s.to_string())),
+            s => path = Some(s.to_string()),
+        }
+    }
+    Ok((path, debug))
+}
+
 fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseError> {
     match crate::shell_words::split(raw) {
         Ok(tokens) => {
@@ -123,20 +142,13 @@ impl Command {
             },
 
             "build" | "b" => {
-                let mut path = None;
-                let mut debug = false;
-
-                for arg in arguments {
-                    match arg.as_str() {
-                        "--debug" => debug = true,
-                        s if s.starts_with('-') => {
-                            return Err(ParseError::UnknownFlag(s.to_string()));
-                        }
-                        s => path = Some(s.to_string()),
-                    }
-                }
-
+                let (path, debug) = parse_path_and_debug(arguments)?;
                 Ok(Command::Build { path, debug })
+            }
+
+            "emit" | "e" => {
+                let (path, debug) = parse_path_and_debug(arguments)?;
+                Ok(Command::Emit { path, debug })
             }
 
             "run" | "r" => {
@@ -374,8 +386,8 @@ impl Command {
 
     pub fn suggest(typo: &str) -> Option<String> {
         const COMMANDS: &[&str] = &[
-            "new", "build", "run", "format", "check", "help", "version", "add", "sync", "learn",
-            "doc", "complete", "lsp", "bindgen",
+            "new", "build", "emit", "run", "format", "check", "help", "version", "add", "sync",
+            "learn", "doc", "complete", "lsp", "bindgen",
         ];
         let candidates: Vec<String> = COMMANDS.iter().map(|s| s.to_string()).collect();
         diagnostics::infer::find_similar_name(typo, &candidates)
@@ -537,6 +549,23 @@ mod tests {
         assert!(matches!(
             parse(&["lis", "run", "--go-flags", "-ldflags='-s"]),
             Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn emit_parses_path_and_debug() {
+        let Ok(Command::Emit { path, debug }) = parse(&["lis", "emit", "src", "--debug"]) else {
+            panic!("expected Emit command");
+        };
+        assert_eq!(path.as_deref(), Some("src"));
+        assert!(debug);
+    }
+
+    #[test]
+    fn emit_rejects_unknown_flag() {
+        assert!(matches!(
+            parse(&["lis", "emit", "--bogus"]),
+            Err(ParseError::UnknownFlag(_))
         ));
     }
 

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -11,7 +11,15 @@ use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 
+pub fn emit(path: Option<String>, debug: bool) -> i32 {
+    compile_project(path, debug, false, "Emit")
+}
+
 pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
+    compile_project(path, debug, quiet, "Build")
+}
+
+fn compile_project(path: Option<String>, debug: bool, quiet: bool, label: &str) -> i32 {
     let project_root = path.unwrap_or_else(|| ".".to_string());
     let project_path = Path::new(&project_root);
 
@@ -25,7 +33,7 @@ pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
         Err(code) => return code,
     };
 
-    build_locked(&prep, debug, quiet)
+    build_locked(&prep, debug, quiet, label)
 }
 
 pub(super) fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
@@ -72,7 +80,7 @@ pub(super) struct BuildPrep {
     pub locator: deps::TypedefLocator,
 }
 
-pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
+pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &str) -> i32 {
     let start = Instant::now();
 
     if let Err(e) =
@@ -277,7 +285,8 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool) -> i32 {
 
     if !quiet {
         eprintln!(
-            "  ✓ Build completed {}",
+            "  ✓ {} completed {}",
+            label,
             crate::output::format_elapsed(start.elapsed())
         );
     }

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -36,7 +36,7 @@ fn bash_completions() -> &'static str {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="new build run format check add sync learn doc help complete version"
+    commands="new run build emit check format add sync version help doc learn complete lsp"
 
     case "$prev" in
         lis)
@@ -44,6 +44,10 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         build)
+            COMPREPLY=( $(compgen -W "--debug" -- "$cur") )
+            return 0
+            ;;
+        emit)
             COMPREPLY=( $(compgen -W "--debug" -- "$cur") )
             return 0
             ;;
@@ -89,17 +93,19 @@ _lis() {
     local -a commands
     commands=(
         'new:Create a new project'
-        'build:Compile a project'
         'run:Compile and run a project'
-        'format:Format a file or project'
-        'check:Validate a file or project'
+        'build:Compile a project to Go'
+        'emit:Emit Go code into target/'
+        'check:Lint and typecheck a project'
+        'format:Format a project'
         'add:Add a third-party Go dependency'
-        'sync:Reconcile project manifest with imports'
-        'learn:Generate a sample project'
-        'doc:Explore prelude and Go stdlib'
-        'help:Print help message'
-        'complete:Generate shell completions'
-        'version:Print version information'
+        'sync:Tidy project manifest'
+        'version:Print compiler version'
+        'help:Show help for a command'
+        'doc:Browse symbols and packages'
+        'learn:Create a new sample project'
+        'complete:Shell completion scripts'
+        'lsp:Start the language server'
     )
 
     _arguments -C \
@@ -113,6 +119,9 @@ _lis() {
         args)
             case "$words[1]" in
                 build)
+                    _arguments '--debug[Include line directives for stack traces]'
+                    ;;
+                emit)
                     _arguments '--debug[Include line directives for stack traces]'
                     ;;
                 run)
@@ -152,19 +161,22 @@ fn fish_completions() -> &'static str {
 complete -c lis -f
 
 complete -c lis -n __fish_use_subcommand -a new -d 'Create a new project'
-complete -c lis -n __fish_use_subcommand -a build -d 'Compile a project'
 complete -c lis -n __fish_use_subcommand -a run -d 'Compile and run a project'
-complete -c lis -n __fish_use_subcommand -a format -d 'Format a file or project'
-complete -c lis -n __fish_use_subcommand -a check -d 'Validate a file or project'
+complete -c lis -n __fish_use_subcommand -a build -d 'Compile a project to Go'
+complete -c lis -n __fish_use_subcommand -a emit -d 'Emit Go code into target/'
+complete -c lis -n __fish_use_subcommand -a check -d 'Lint and typecheck a project'
+complete -c lis -n __fish_use_subcommand -a format -d 'Format a project'
 complete -c lis -n __fish_use_subcommand -a add -d 'Add a third-party Go dependency'
-complete -c lis -n __fish_use_subcommand -a sync -d 'Reconcile project manifest with imports'
-complete -c lis -n __fish_use_subcommand -a learn -d 'Generate a sample project'
-complete -c lis -n __fish_use_subcommand -a doc -d 'Explore prelude and Go stdlib'
-complete -c lis -n __fish_use_subcommand -a help -d 'Print help message'
-complete -c lis -n __fish_use_subcommand -a complete -d 'Generate shell completions'
-complete -c lis -n __fish_use_subcommand -a version -d 'Print version information'
+complete -c lis -n __fish_use_subcommand -a sync -d 'Tidy project manifest'
+complete -c lis -n __fish_use_subcommand -a version -d 'Print compiler version'
+complete -c lis -n __fish_use_subcommand -a help -d 'Show help for a command'
+complete -c lis -n __fish_use_subcommand -a doc -d 'Browse symbols and packages'
+complete -c lis -n __fish_use_subcommand -a learn -d 'Create a new sample project'
+complete -c lis -n __fish_use_subcommand -a complete -d 'Shell completion scripts'
+complete -c lis -n __fish_use_subcommand -a lsp -d 'Start the language server'
 
 complete -c lis -n '__fish_seen_subcommand_from build' -l debug -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from emit' -l debug -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l debug -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
@@ -173,6 +185,6 @@ complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show
 complete -c lis -n '__fish_seen_subcommand_from check' -l output -r -a unix -d 'Machine-readable output'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'
 complete -c lis -n '__fish_seen_subcommand_from complete' -a 'bash zsh fish' -d 'Shell type'
-complete -c lis -n '__fish_seen_subcommand_from help' -a 'new build run format check add sync learn doc help complete version' -d 'Command'
+complete -c lis -n '__fish_seen_subcommand_from help' -a 'new run build emit check format add sync version help doc learn complete lsp' -d 'Command'
 "#
 }

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -13,12 +13,13 @@ Usage:
 
 Commands:
     `new`        Create a new project
-    `build`, `b`   Compile a project to Go
     `run`, `r`     Compile and run a project
+    `build`, `b`   Compile a project to Go
+    `emit`, `e`    Emit Go code into `target/`
+    `check`, `c`   Lint and typecheck a project
     `format`, `f`  Format a project
-    `check`, `c`   Validate a project
     `add`        Add a third-party Go dependency
-    `sync`       Reconcile project manifest
+    `sync`       Tidy project manifest
 
 Extras:
     `version`    Print compiler version
@@ -40,7 +41,7 @@ Usage:
     `lis help` <command>
 
 Commands:
-    `new`, `build`, `run`, `format`, `check`, `add`, `sync`, `doc`
+    `new`, `build`, `emit`, `run`, `format`, `check`, `add`, `sync`, `doc`
 
 Extras:
     `version`, `help`, `learn`, `complete`, `lsp`",
@@ -73,7 +74,7 @@ Arguments:
 Compile a Lisette project.
 
 Arguments:
-    [path]    Path to project dir (default: current dir)
+    [path]     Path to project dir (default: current dir)
 
 Options:
     `--debug`    Include `//line` directives in generated Go code for stack traces
@@ -84,17 +85,34 @@ Examples:
     `lis build` {--debug:g}                  Build with source mapping directives",
         ),
 
+        "emit" | "e" => print_help(
+            "`lis emit` [path] [options]
+
+Generate Go code from a Lisette project into the `target/` dir.
+
+Arguments:
+    [path]     Path to project dir (default: current dir)
+
+Options:
+    `--debug`    Include `//line` directives in generated Go code for stack traces
+
+Examples:
+    `lis emit`                          Emit Go for project in current dir
+    `lis emit` {path/to/project/dir:g}      Emit Go for project in specific dir
+    `lis emit` {--debug:g}                  Emit with source mapping directives",
+        ),
+
         "run" | "r" => print_help(
             "`lis run` [target:g] [options] [-- args...]
 
 Compile and execute a Lisette file or project.
 
 Arguments:
-    [target:g]         Project dir or `.lis` file (default: current dir)
-    [args]           Arguments to pass to the program (after --)
+    [target:g]    Project dir or `.lis` file (default: current dir)
+    [args]      Arguments to pass to the program (after --)
 
 Options:
-    `--debug`    Include `//line` directives in generated Go code for stack traces
+    `--debug`     Include `//line` directives in generated Go code for stack traces
 
 Examples:
     `lis run`                            Run project in current dir
@@ -109,10 +127,10 @@ Examples:
 Format Lisette source files.
 
 Arguments:
-    [path]      Path to file or dir (default: current dir)
+    [path]       Path to file or dir (default: current dir)
 
 Options:
-    [--check]     Check if files are formatted without modifying them
+    [--check]    Check if files are formatted without modifying them
 
 Examples:
     `lis format`                   Format project in current dir
@@ -126,7 +144,7 @@ Examples:
 Find errors and warnings in Lisette source files.
 
 Arguments:
-    [path]    Path to file or dir (default: current dir)
+    [path]             Path to file or dir (default: current dir)
 
 Options:
     `--errors-only`      Show only errors
@@ -178,7 +196,7 @@ Start the Lisette language server over stdio, for use by editor extensions.",
 Generate `.d.lis` type definition bindings for a Go package.
 
 Arguments:
-    <package>    Go package path (e.g., `fmt`, `net/http`)
+    <package>              Go package path (e.g., `fmt`, `net/http`)
 
 Options:
     `-o`, `--output` <path>    Output file path (default: <package>`.d.lis`)
@@ -224,8 +242,8 @@ matching, error handling, closures, Go interop, and concurrency.",
 Browse symbols and packages.
 
 Arguments:
-    [query]              Symbol or package to look up (omit to list all in stdlib)
-    `-s`, `--search` <term>  Search across symbols and packages
+    [query]                Symbol or package to look up (omit to list all in stdlib)
+    `-s`, `--search` <term>    Search across symbols and packages
 
 Examples:
     `lis doc`                          List all prelude types and functions

--- a/crates/cli/src/handlers/mod.rs
+++ b/crates/cli/src/handlers/mod.rs
@@ -14,7 +14,7 @@ mod sync;
 
 pub use add::add;
 pub use bindgen::bindgen;
-pub use build::build;
+pub use build::{build, emit};
 pub use check::check;
 pub use completions::completions;
 pub use doc::{doc, doc_search};

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -69,7 +69,7 @@ fn run_project(path: &str, args: Vec<String>, debug: bool, go_flags: &[String]) 
     let target = stdlib::Target::host();
     let binary_name = go_cli::binary_name(&prep.manifest.project.name, target);
 
-    let build_result = super::build::build_locked(&prep, debug, true);
+    let build_result = super::build::build_locked(&prep, debug, true, "Build");
     if build_result != 0 {
         return build_result;
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
     let exit_code = match command {
         Command::New { name } => handlers::new_project(&name),
         Command::Build { path, debug } => handlers::build(path, debug, false),
+        Command::Emit { path, debug } => handlers::emit(path, debug),
         Command::Run {
             target,
             args,

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -155,12 +155,13 @@ Usage:
 
 Commands:
     new        Create a new project
-    build, b   Compile a project to Go
     run, r     Compile and run a project
+    build, b   Compile a project to Go
+    emit, e    Emit Go code into target/
+    check, c   Lint and typecheck a project
     format, f  Format a project
-    check, c   Validate a project
     add        Add a third-party Go dependency
-    sync       Reconcile project manifest
+    sync       Tidy project manifest
 
 Extras:
     version    Print compiler version


### PR DESCRIPTION
Adds `lis emit` to the CLI, to emit Go source from a Lisette project into the `target/` dir. 

Currently `lis emit` and `lis build` are synonyms. An upcoming breaking change will arrange `lis` verbs as a phase ladder.

| verb | effect | artifact |
|---|---|---|
| `lis emit` | write Go source | `target/*.go` |
| `lis build` | `lis emit` then `go build` | `target/bin/{name}` binary |
| `lis run` | `lis build` then run binary | `target/bin/{name}` binary + execution |
