### PR TITLE
fix: adjust diagnostics for `var`

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -250,7 +250,9 @@ pub fn const_disallows_composite(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Composite value in `const`")
         .with_infer_code("const_disallows_composite")
         .with_span_label(&span, "not allowed")
-        .with_help("`const` only accepts primitive values: `bool`, `int`, `float`, and `string`")
+        .with_help(
+            "`const` only accepts primitive values: `bool`, `int`, `float`, and `string`. Use a function that returns the value instead",
+        )
 }
 
 pub fn const_cycle(cycle: &[String], span: Span) -> LisetteDiagnostic {
@@ -1998,8 +2000,9 @@ pub fn variable_declaration_outside_typedef(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid variable declaration")
         .with_infer_code("variable_declaration_outside_typedef")
         .with_span_label(&span, "`var` is not allowed here")
-        .with_help("Use `let` to declare a variable: `let x: int = 0`.")
-        .with_note("`var` declarations are only allowed in `.d.lis` files.")
+        .with_help(
+            "Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite",
+        )
 }
 
 pub fn range_full_not_valid_expression(span: Span) -> LisetteDiagnostic {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -6852,7 +6852,7 @@ enum MyEnum { A, B }
 interface MyInterface { fn method(self: Self) -> int }
 type MyAlias = int
 const MY_CONST: int = 42
-var my_var: int = 0
+var my_var: int
 fn my_function() -> int { 1 }
 fn main() { 1 }",
         )

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -628,8 +628,16 @@ impl<'source> Parser<'source> {
         let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
         let name = self.read_identifier();
 
+        if self.advance_if(Equal) {
+            return self.recover_var_initializer(start);
+        }
+
         self.ensure(Colon);
         let annotation = self.parse_annotation();
+
+        if self.advance_if(Equal) {
+            return self.recover_var_initializer(start);
+        }
 
         Expression::VariableDeclaration {
             doc,
@@ -637,6 +645,16 @@ impl<'source> Parser<'source> {
             name_span,
             annotation,
             visibility: Visibility::Private,
+            ty: Type::uninferred(),
+            span: self.span_from_tokens(start),
+        }
+    }
+
+    fn recover_var_initializer(&mut self, start: Token<'source>) -> Expression {
+        self.parse_expression();
+        self.error_var_initializer(self.span_from_token(start));
+
+        Expression::Unit {
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1590,9 +1590,15 @@ impl<'source> Parser<'source> {
         let token = self.current_token();
         let keyword = token.text.to_string();
         let span = self.span_from_token(token);
-        let error = ParseError::new("Reserved keyword", span, "reserved keyword")
-            .with_parse_code("keyword_as_identifier")
-            .with_help(format!("Rename `{}`", keyword));
+        let error = if token.kind == Var {
+            ParseError::new("Syntax error", span, "expected `let`")
+                .with_parse_code("expected_let")
+                .with_help("Use `let` to declare a variable: `let x = 0`")
+        } else {
+            ParseError::new("Reserved keyword", span, "reserved keyword")
+                .with_parse_code("keyword_as_identifier")
+                .with_help(format!("Rename `{}`", keyword))
+        };
         self.errors.push(error);
         self.next();
         Expression::Identifier {

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -656,6 +656,19 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
+    fn error_var_initializer(&mut self, span: ast::Span) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new("Syntax error", span, "not allowed")
+            .with_parse_code("var_not_allowed")
+            .with_help(
+                "Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite",
+            );
+
+        self.errors.push(error);
+    }
+
     fn error_import_alias_after_path(&mut self, span: ast::Span, alias: &str, path: &str) {
         if self.too_many_errors() {
             return;
@@ -999,10 +1012,15 @@ impl<'source> Parser<'source> {
                 "use_unsupported",
                 "Use `import` instead of `use` for imports: `import \"module/path\"`",
             ),
+            "top_item" if token.kind == Let => (
+                "`let` is not allowed at the top level".to_string(),
+                "top_level_let",
+                "Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite",
+            ),
             "top_item" => (
                 "expected declaration".to_string(),
                 "expected_declaration",
-                "At the top level of a file, Lisette expects `fn`, `struct`, `enum`, `interface`, `import`, or `type`.",
+                "At the top level of a file, Lisette expects `fn`, `struct`, `enum`, `interface`, `impl`, `const`, `import`, or `type`.",
             ),
             _ => (
                 format!("unexpected {}", token_descriptor),

--- a/tests/_harness/wrap.rs
+++ b/tests/_harness/wrap.rs
@@ -79,6 +79,7 @@ fn needs_wrapping(source: &str) -> bool {
         "struct ",
         "enum ",
         "const ",
+        "var ",
         "impl ",
         "import ",
         "type ",

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3184,6 +3184,14 @@ const MAX_SIZE: int
 }
 
 #[test]
+fn infer_variable_declaration_outside_typedef() {
+    let input = r#"
+var count: int
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_valueless_const_missing_annotation_in_typedef() {
     let mut fs = MockFileSystem::new();
     fs.add_file("types", "consts.d.lis", "const MAX_SIZE");
@@ -4918,6 +4926,63 @@ trait Displayable {
 fn parse_expected_declaration() {
     let input = r#"
 123
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_top_level_var_with_initializer() {
+    let input = r#"
+struct Config {
+  gravity: float,
+  count: int,
+}
+
+var conf = Config {
+  gravity: 0.03,
+  count: 6,
+}
+"#;
+
+    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
+    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+
+    assert!(
+        parse_result.errors.len() == 1,
+        "Expected exactly 1 error for top-level var with initializer, got {}: {:?}",
+        parse_result.errors.len(),
+        parse_result
+            .errors
+            .iter()
+            .map(|e| &e.message)
+            .collect::<Vec<_>>()
+    );
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_top_level_var_annotated_with_initializer() {
+    let input = r#"
+var count: int = 6
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_top_level_let() {
+    let input = r#"
+let x = 1
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_var_in_function_body() {
+    let input = r#"
+fn test() {
+  var x = 1
+}
 "#;
     assert_parse_error_snapshot!(input);
 }

--- a/tests/ui/errors/snapshots/infer_const_disallows_list_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_list_literal.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    ·               ─────┬────
    ·                    ╰── not allowed
    ╰────
-  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string`. Use a function that returns the value instead · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_const_disallows_struct_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_struct_literal.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    ·                ──────────┬─────────
    ·                          ╰── not allowed
    ╰────
-  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string`. Use a function that returns the value instead · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_const_disallows_tuple_literal.snap
+++ b/tests/ui/errors/snapshots/infer_const_disallows_tuple_literal.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    ·              ───┬──
    ·                 ╰── not allowed
    ╰────
-  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string` · code: [infer.const_disallows_composite]
+  help: `const` only accepts primitive values: `bool`, `int`, `float`, and `string`. Use a function that returns the value instead · code: [infer.const_disallows_composite]

--- a/tests/ui/errors/snapshots/infer_variable_declaration_outside_typedef.snap
+++ b/tests/ui/errors/snapshots/infer_variable_declaration_outside_typedef.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid variable declaration
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ var count: int
+   · ───────┬──────
+   ·        ╰── `var` is not allowed here
+   ╰────
+  help: Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite · code: [infer.variable_declaration_outside_typedef]

--- a/tests/ui/errors/snapshots/parse_expected_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_expected_declaration.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    · ─┬─
    ·  ╰── expected declaration
    ╰────
-  help: At the top level of a file, Lisette expects `fn`, `struct`, `enum`, `interface`, `import`, or `type` · code: [parse.expected_declaration]
+  help: At the top level of a file, Lisette expects `fn`, `struct`, `enum`, `interface`, `impl`, `const`, `import`, or `type` · code: [parse.expected_declaration]

--- a/tests/ui/errors/snapshots/parse_top_level_let.snap
+++ b/tests/ui/errors/snapshots/parse_top_level_let.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ let x = 1
+   · ─┬─
+   ·  ╰── `let` is not allowed at the top level
+   ╰────
+  help: Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite · code: [parse.top_level_let]

--- a/tests/ui/errors/snapshots/parse_top_level_var_annotated_with_initializer.snap
+++ b/tests/ui/errors/snapshots/parse_top_level_var_annotated_with_initializer.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ var count: int = 6
+   · ─┬─
+   ·  ╰── not allowed
+   ╰────
+  help: Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite · code: [parse.var_not_allowed]

--- a/tests/ui/errors/snapshots/parse_top_level_var_with_initializer.snap
+++ b/tests/ui/errors/snapshots/parse_top_level_var_with_initializer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:7:1]
+ 6 │ 
+ 7 │ var conf = Config {
+   · ─┬─
+   ·  ╰── not allowed
+ 8 │   gravity: 0.03,
+   ╰────
+  help: Use `const` for a primitive, or a function that returns the value e.g. `fn origin() -> Point { ... }` for a composite · code: [parse.var_not_allowed]

--- a/tests/ui/errors/snapshots/parse_var_in_function_body.snap
+++ b/tests/ui/errors/snapshots/parse_var_in_function_body.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:3]
+ 2 │ fn test() {
+ 3 │   var x = 1
+   ·   ─┬─
+   ·    ╰── expected `let`
+ 4 │ }
+   ╰────
+  help: Use `let` to declare a variable: `let x = 0` · code: [parse.expected_let]


### PR DESCRIPTION
Improves the diagnostics a user hits when reaching for a Go-style global `var`. 

Motivated by #678