### PR TITLE
perf: stop cloning function bodies during emit

### DIFF
--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -17,7 +17,7 @@ impl Planner<'_> {
                 } = item
                 {
                     for method in method_signatures {
-                        let func = method.to_function_definition();
+                        let func = method.function_definition_view();
                         self.module
                             .record_exported_method_name(func.name.to_string());
                     }
@@ -201,7 +201,7 @@ fn is_display_to_string(method: &Expression) -> bool {
     if !matches!(method, Expression::Function { .. }) {
         return false;
     }
-    let func = method.to_function_definition();
+    let func = method.function_definition_view();
     func.name.as_str() == "to_string"
         && func.params.len() == 1
         && matches!(

--- a/crates/emit/src/analyze/constraint_collector.rs
+++ b/crates/emit/src/analyze/constraint_collector.rs
@@ -146,6 +146,7 @@ impl Planner<'_> {
         let Expression::Function {
             name: method_name,
             generics: method_generics,
+            params,
             visibility,
             ..
         } = method
@@ -153,8 +154,7 @@ impl Planner<'_> {
             unreachable!("callers filter to Function expressions");
         };
 
-        let function = method.to_function_definition();
-        let has_self = function.params.first().is_some_and(|p| {
+        let has_self = params.first().is_some_and(|p| {
             matches!(p.pattern, Pattern::Identifier { ref identifier, .. } if identifier == "self")
         });
         let is_ufcs = self.facts.is_ufcs_method(receiver_key, method_name);

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -11,7 +11,7 @@ use crate::patterns::sites::PatternSubject;
 use crate::types::native::NativeGoType;
 use crate::utils::{group_params, receiver_name};
 use syntax::ast::{
-    Annotation, Binding, Expression, FunctionDefinition, Generic, Pattern, Span, TypedPattern,
+    Annotation, Binding, Expression, FunctionDefinitionView, Generic, Pattern, Span, TypedPattern,
 };
 use syntax::types::Type;
 
@@ -218,12 +218,12 @@ impl Planner<'_> {
 
     pub(crate) fn emit_function(
         &mut self,
-        function_definition: &FunctionDefinition,
+        function_definition: FunctionDefinitionView<'_>,
         receiver: Option<(String, Type)>,
         is_public: bool,
         fx: &mut EmitEffects,
     ) -> String {
-        if matches!(*function_definition.body, Expression::NoOp) {
+        if matches!(function_definition.body, Expression::NoOp) {
             return String::new();
         }
 
@@ -231,10 +231,17 @@ impl Planner<'_> {
         let return_ctx = self.return_context_for_type(function_definition.return_type.clone());
         let return_shape = return_ctx.lowered_shape();
 
-        let (function_definition, receiver) =
-            change_go_builtin_methods(function_definition, receiver);
+        let (native_override, receiver) = change_go_builtin_methods(function_definition, receiver);
+        let function_definition = match &native_override {
+            Some((name, params)) => FunctionDefinitionView {
+                name,
+                params,
+                ..function_definition
+            },
+            None => function_definition,
+        };
         let (params_to_process, receiver_override) =
-            self.extract_receiver(&function_definition, receiver.is_some(), fx);
+            self.extract_receiver(function_definition, receiver.is_some(), fx);
 
         let mut parts = vec!["func".to_string()];
 
@@ -244,10 +251,10 @@ impl Planner<'_> {
             parts.push(part);
         }
 
-        parts.push(self.pick_go_function_name(&function_definition, receiver.is_some(), is_public));
+        parts.push(self.pick_go_function_name(function_definition, receiver.is_some(), is_public));
 
         let generics_str = self.build_generics_string(
-            &function_definition,
+            function_definition,
             params_to_process,
             receiver.as_ref(),
             fx,
@@ -259,11 +266,11 @@ impl Planner<'_> {
         let mut body = String::new();
         let signature = self.with_absorbed_ref_generics(
             params_to_process,
-            &function_definition.generics,
+            function_definition.generics,
             fx,
             |this, fx| {
                 let (params_string, return_ty, deferred_patterns) = this.build_signature_tail(
-                    &function_definition,
+                    function_definition,
                     params_to_process,
                     return_shape.as_ref(),
                     fx,
@@ -275,7 +282,7 @@ impl Planner<'_> {
                 let signature = parts.join(" ");
                 this.emit_function_body_with_deferred_patterns(
                     &mut body,
-                    &function_definition,
+                    function_definition,
                     deferred_patterns,
                     &return_ctx,
                     fx,
@@ -294,30 +301,30 @@ impl Planner<'_> {
 
     fn pick_go_function_name(
         &self,
-        function_definition: &FunctionDefinition,
+        function_definition: FunctionDefinitionView<'_>,
         has_receiver: bool,
         is_public: bool,
     ) -> String {
         if is_public {
-            go_name::snake_to_camel(&function_definition.name)
+            go_name::snake_to_camel(function_definition.name)
         } else if has_receiver {
-            go_name::escape_keyword(&function_definition.name).into_owned()
+            go_name::escape_keyword(function_definition.name).into_owned()
         } else if let Some(remapped) = self.module.escape_remap(function_definition.name.as_str()) {
             remapped.to_string()
         } else {
-            go_name::escape_reserved(&function_definition.name).into_owned()
+            go_name::escape_reserved(function_definition.name).into_owned()
         }
     }
 
     fn build_generics_string(
         &mut self,
-        function_definition: &FunctionDefinition,
+        function_definition: FunctionDefinitionView<'_>,
         _params_to_process: &[Binding],
         receiver: Option<&(String, Type)>,
         fx: &mut EmitEffects,
     ) -> String {
-        let symbol = self.symbol_for_function(&function_definition.name, receiver);
-        self.generics_to_string_for_symbol(&symbol, &function_definition.generics, fx)
+        let symbol = self.symbol_for_function(function_definition.name, receiver);
+        self.generics_to_string_for_symbol(&symbol, function_definition.generics, fx)
     }
 
     fn symbol_for_function(
@@ -339,7 +346,7 @@ impl Planner<'_> {
 
     fn build_signature_tail(
         &mut self,
-        function_definition: &FunctionDefinition,
+        function_definition: FunctionDefinitionView<'_>,
         params_to_process: &[Binding],
         return_shape: Option<&AbiShape>,
         fx: &mut EmitEffects,
@@ -349,9 +356,9 @@ impl Planner<'_> {
         let return_ty = if function_definition.return_type.is_unit() {
             String::new()
         } else if let Some(shape) = return_shape {
-            self.render_lowered_return_ty(shape, &function_definition.return_type, fx)
+            self.render_lowered_return_ty(shape, function_definition.return_type, fx)
         } else {
-            self.go_type_string(&function_definition.return_type, fx)
+            self.go_type_string(function_definition.return_type, fx)
         };
 
         (params_string, return_ty, deferred_patterns)
@@ -360,7 +367,7 @@ impl Planner<'_> {
     fn emit_function_body_with_deferred_patterns(
         &mut self,
         body: &mut String,
-        function_definition: &FunctionDefinition,
+        function_definition: FunctionDefinitionView<'_>,
         deferred_patterns: Vec<DeferredParamDestructure>,
         return_ctx: &ReturnContext,
         fx: &mut EmitEffects,
@@ -378,7 +385,7 @@ impl Planner<'_> {
         }
         self.emit_function_body(
             body,
-            &function_definition.body,
+            function_definition.body,
             should_return,
             return_ctx,
             fx,
@@ -507,11 +514,11 @@ impl Planner<'_> {
 
     fn extract_receiver<'a>(
         &mut self,
-        function_definition: &'a FunctionDefinition,
+        function_definition: FunctionDefinitionView<'a>,
         has_receiver: bool,
         fx: &mut EmitEffects,
     ) -> (&'a [Binding], Option<Type>) {
-        let default = (&function_definition.params[..], None);
+        let default = (function_definition.params, None);
 
         if !has_receiver || function_definition.params.is_empty() {
             return default;
@@ -542,28 +549,23 @@ pub(crate) fn is_go_never(expression: &Expression) -> bool {
     }
 }
 
-fn change_go_builtin_methods<'a>(
-    function_definition: &'a FunctionDefinition,
+/// Renamed definition parts for methods on native Go receiver types; the
+/// caller rebinds its view to borrow these.
+type NativeMethodOverride = (ecow::EcoString, Vec<Binding>);
+
+fn change_go_builtin_methods(
+    function_definition: FunctionDefinitionView<'_>,
     receiver: Option<(String, Type)>,
-) -> (
-    std::borrow::Cow<'a, FunctionDefinition>,
-    Option<(String, Type)>,
-) {
-    use std::borrow::Cow;
+) -> (Option<NativeMethodOverride>, Option<(String, Type)>) {
     let Some((receiver_name, receiver_type)) = receiver else {
-        return (Cow::Borrowed(function_definition), None);
+        return (None, None);
     };
 
     let Some(native) = NativeGoType::from_type(&receiver_type) else {
-        return (
-            Cow::Borrowed(function_definition),
-            Some((receiver_name, receiver_type)),
-        );
+        return (None, Some((receiver_name, receiver_type)));
     };
 
-    let mut new_function_definition = function_definition.clone();
-    new_function_definition.name =
-        format!("{}.{}", native.lisette_name(), function_definition.name).into();
+    let name = format!("{}.{}", native.lisette_name(), function_definition.name).into();
 
     let self_binding = Binding {
         pattern: Pattern::Identifier {
@@ -576,6 +578,8 @@ fn change_go_builtin_methods<'a>(
         mutable: false,
     };
 
-    new_function_definition.params.insert(0, self_binding);
-    (Cow::Owned(new_function_definition), None)
+    let mut params = Vec::with_capacity(function_definition.params.len() + 1);
+    params.push(self_binding);
+    params.extend(function_definition.params.iter().cloned());
+    (Some((name, params)), None)
 }

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -2,7 +2,7 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name;
-use syntax::ast::{Expression, Generic, Pattern, Visibility};
+use syntax::ast::{Expression, FunctionDefinitionView, Generic, Pattern, Visibility};
 use syntax::types::Type;
 
 struct ImplContext<'a> {
@@ -57,7 +57,7 @@ impl Planner<'_> {
 
         self.scope.reset_for_top_level();
 
-        let function = method.to_function_definition();
+        let function = method.function_definition_view();
         let is_public = matches!(visibility, Visibility::Public);
 
         let has_self = function.params.first().is_some_and(|p| {
@@ -65,25 +65,28 @@ impl Planner<'_> {
         });
         let is_ufcs = self
             .facts
-            .is_ufcs_method(&ctx.qualified_type, &function.name);
-        let should_export = is_public || self.method_needs_export(&function.name);
+            .is_ufcs_method(&ctx.qualified_type, function.name);
+        let should_export = is_public || self.method_needs_export(function.name);
         let is_free_function = !has_self || is_ufcs;
 
         let code = if is_free_function {
-            let mut free_function = function.clone();
             let method_name = if should_export {
-                go_name::snake_to_camel(&function.name)
+                go_name::snake_to_camel(function.name)
             } else {
                 function.name.to_string()
             };
-            free_function.name = format!("{}_{}", ctx.receiver_name, method_name).into();
+            let free_name = format!("{}_{}", ctx.receiver_name, method_name).into();
             let mut combined_generics = ctx.generics.to_vec();
-            combined_generics.extend(free_function.generics.iter().cloned());
-            free_function.generics = combined_generics;
-            self.emit_function(&free_function, None, false, fx)
+            combined_generics.extend(function.generics.iter().cloned());
+            let free_function = FunctionDefinitionView {
+                name: &free_name,
+                generics: &combined_generics,
+                ..function
+            };
+            self.emit_function(free_function, None, false, fx)
         } else {
             self.emit_function(
-                &function,
+                function,
                 Some((ctx.receiver_name.to_string(), ctx.ty.clone())),
                 should_export,
                 fx,

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -50,7 +50,7 @@ impl Planner<'_> {
         is_public: bool,
         fx: &mut EmitEffects,
     ) -> String {
-        let func = item.to_function_definition();
+        let func = item.function_definition_view();
         let ty = item.get_type();
         let all_args = ty
             .get_function_params()
@@ -70,16 +70,16 @@ impl Planner<'_> {
             .expect("interface method must have return type")
             .clone();
         let qualified_id = self.facts.qualified_current(interface_name);
-        let hints = self.go_interface_method_hints(&qualified_id, &func.name);
+        let hints = self.go_interface_method_hints(&qualified_id, func.name);
         let return_type = match self.classify_with_go_hints(&raw_return_ty, &hints) {
             Some(shape) => self.render_lowered_return_ty(&shape, &raw_return_ty, fx),
             None => self.go_type_string(&raw_return_ty, fx),
         };
 
-        let method_name = if is_public || self.method_needs_export(&func.name) {
-            go_name::snake_to_camel(&func.name)
+        let method_name = if is_public || self.method_needs_export(func.name) {
+            go_name::snake_to_camel(func.name)
         } else {
-            go_name::escape_keyword(&func.name).into_owned()
+            go_name::escape_keyword(func.name).into_owned()
         };
 
         if return_type == "struct{}" {

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -15,10 +15,10 @@ impl Planner<'_> {
                     return String::new();
                 }
                 let is_public = matches!(visibility, Visibility::Public);
-                let function = item.to_function_definition();
+                let function = item.function_definition_view();
                 let doc_comment = emit_doc(doc);
 
-                let code = self.emit_function(&function, None, is_public, fx);
+                let code = self.emit_function(function, None, is_public, fx);
                 format!("{}{}", doc_comment, code)
             }
             Expression::Struct {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -440,6 +440,16 @@ pub struct FunctionDefinition {
     pub ty: Type,
 }
 
+#[derive(Clone, Copy)]
+pub struct FunctionDefinitionView<'a> {
+    pub name: &'a EcoString,
+    pub name_span: Span,
+    pub generics: &'a [Generic],
+    pub params: &'a [Binding],
+    pub body: &'a Expression,
+    pub return_type: &'a Type,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum VariantFields {
     Unit,
@@ -1188,29 +1198,25 @@ impl Expression {
         }
     }
 
-    pub fn to_function_definition(&self) -> FunctionDefinition {
+    pub fn function_definition_view(&self) -> FunctionDefinitionView<'_> {
         match self {
             Expression::Function {
                 name,
                 name_span,
                 generics,
                 params,
-                return_annotation,
                 return_type,
                 body,
-                ty,
                 ..
-            } => FunctionDefinition {
-                name: name.clone(),
+            } => FunctionDefinitionView {
+                name,
                 name_span: *name_span,
-                generics: generics.clone(),
-                params: params.clone(),
-                body: body.clone(),
-                return_type: return_type.clone(),
-                annotation: return_annotation.clone(),
-                ty: ty.clone(),
+                generics,
+                params,
+                body,
+                return_type,
             },
-            _ => panic!("to_function_definition called on non-Function expression"),
+            _ => panic!("function_definition_view called on non-Function expression"),
         }
     }
 


### PR DESCRIPTION
Emit used to build an owned `FunctionDefinition` for every fn, impl method, and interface signature it rendered, deep-cloning the full body expression tree each time. These definitions are now read through a borrowed `FunctionDefinitionView`, so emit no longer copies.
