### PR TITLE
refactor: finish migrating emit statements to structured IR

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -199,7 +199,7 @@ fn emit_lowered_tuple_return(
             .collect();
         return vec![multi_value_return(fields)];
     }
-    let mut setup = String::new();
+    let mut statements = Vec::new();
     let fields: Vec<String> = (0..arity)
         .map(|i| {
             let raw = format!("{}.{}", result_value, TUPLE_FIELDS[i]);
@@ -208,75 +208,82 @@ fn emit_lowered_tuple_return(
                 .filter(|t| planner.facts.is_nullable_option(t))
                 .map(|t| {
                     let inner = planner.go_type_string(&t.ok_type(), fx);
-                    planner.emit_option_projection(&mut setup, &raw, "unwrap", &inner, false, fx)
+                    planner.plan_option_projection(
+                        &mut statements,
+                        &raw,
+                        "unwrap",
+                        &inner,
+                        false,
+                        fx,
+                    )
                 })
                 .unwrap_or(raw)
         })
         .collect();
-    let mut statements = Vec::new();
-    if !setup.is_empty() {
-        statements.push(LoweredStatement::RawGo(setup));
-    }
     statements.push(multi_value_return(fields));
     statements
 }
 
 /// Wrap a lowered-callee `call_str` (Go-shaped return) into the Lisette
 /// tagged shape declared by `result_ty`.
-pub(crate) fn emit_callee_abi_wrapping(
+pub(crate) fn lower_callee_abi_wrapping(
     planner: &mut Planner,
-    output: &mut String,
     shape: &AbiShape,
     call_str: &str,
     result_ty: &Type,
     fx: &mut EmitEffects,
-) -> String {
+) -> (Vec<LoweredStatement>, String) {
     match shape {
-        AbiShape::PartialTuple => planner
-            .emit_partial_wrapping(
-                output,
+        AbiShape::PartialTuple => {
+            let (statements, outcome) = planner.lower_partial_wrapping(
                 call_str,
                 result_ty,
                 TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
                 fx,
-            )
-            .expect("wrapper produced no slot"),
-        AbiShape::CommaOk => planner
-            .emit_comma_ok_wrapping(
-                output,
-                call_str,
-                result_ty,
-                TupleReturnLayout::Packed,
-                WrapperTarget::FreshSlot,
-                fx,
-            )
-            .expect("wrapper produced no slot"),
-        AbiShape::NullableReturn => {
-            let raw_var = planner.hoist_tmp_value(output, "raw", call_str);
-            planner
-                .emit_nil_check_option_wrap(
-                    output,
-                    &raw_var,
-                    result_ty,
-                    WrapperTarget::FreshSlot,
-                    fx,
-                )
-                .expect("wrapper produced no slot")
+            );
+            (statements, outcome.expect("wrapper produced no slot"))
         }
-        AbiShape::ResultTuple | AbiShape::BareError => planner
-            .emit_result_wrapping(
-                output,
+        AbiShape::CommaOk => {
+            let (statements, outcome) = planner.lower_comma_ok_wrapping(
                 call_str,
                 result_ty,
                 TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
                 fx,
-            )
-            .expect("wrapper produced no slot"),
+            );
+            (statements, outcome.expect("wrapper produced no slot"))
+        }
+        AbiShape::NullableReturn => {
+            let mut statements = Vec::new();
+            let raw_var = planner.hoist_tmp_value_statement(&mut statements, "raw", call_str);
+            let (wrap, outcome) = planner.lower_nil_check_option_wrap(
+                &raw_var,
+                result_ty,
+                WrapperTarget::FreshSlot,
+                fx,
+            );
+            statements.extend(wrap);
+            (statements, outcome.expect("wrapper produced no slot"))
+        }
+        AbiShape::ResultTuple | AbiShape::BareError => {
+            let (statements, outcome) = planner.lower_result_wrapping(
+                call_str,
+                result_ty,
+                TupleReturnLayout::Packed,
+                WrapperTarget::FreshSlot,
+                fx,
+            );
+            (statements, outcome.expect("wrapper produced no slot"))
+        }
         AbiShape::Tuple { arity } => {
+            let mut statements = Vec::new();
             let temps = planner.create_temp_vars("ret", *arity);
-            write_line!(output, "{} := {}", temps.join(", "), call_str);
+            statements.push(LoweredStatement::RawGo(format!(
+                "{} := {}\n",
+                temps.join(", "),
+                call_str
+            )));
             let slot_tys = tuple_element_types(&planner.facts.peel_alias(result_ty));
             let wrapped: Vec<String> = temps
                 .iter()
@@ -286,20 +293,13 @@ pub(crate) fn emit_callee_abi_wrapping(
                         .get(i)
                         .filter(|slot_ty| planner.facts.is_nullable_option(slot_ty))
                         .map(|slot_ty| {
-                            planner
-                                .emit_nil_check_option_wrap(
-                                    output,
-                                    v,
-                                    slot_ty,
-                                    WrapperTarget::FreshSlot,
-                                    fx,
-                                )
-                                .expect("wrapper produced no slot")
+                            planner.plan_nil_check_option_wrap(&mut statements, v, slot_ty, fx)
                         })
                         .unwrap_or_else(|| v.clone())
                 })
                 .collect();
-            planner.emit_tuple_from_vars(output, &wrapped, result_ty, fx)
+            let tuple = planner.plan_tuple_from_vars(&mut statements, &wrapped, result_ty, fx);
+            (statements, tuple)
         }
     }
 }
@@ -554,8 +554,9 @@ pub(crate) fn emit_fn_arg_shape_adapter(
         None => planner.go_type_string(arg_ret, fx),
     };
 
-    let mut body = String::new();
-    let tagged = emit_callee_abi_wrapping(planner, &mut body, arg_shape, &inner_call, arg_ret, fx);
+    let (wrap_statements, tagged) =
+        lower_callee_abi_wrapping(planner, arg_shape, &inner_call, arg_ret, fx);
+    let mut body = Renderer.render_setup(&wrap_statements);
     match target_shape {
         Some(shape) => {
             render_lowered_result_return(planner, &mut body, &tagged, arg_ret, shape, fx)
@@ -595,9 +596,9 @@ pub(crate) fn lower_arg_to_tagged(
     let inner_call = format!("{}({})", arg_name, inner_arg_names.join(", "));
     let tagged_ret = planner.go_type_string(inner_ret, fx);
 
-    let mut body = String::new();
-    let result_var =
-        emit_callee_abi_wrapping(planner, &mut body, &shape, &inner_call, inner_ret, fx);
+    let (wrap_statements, result_var) =
+        lower_callee_abi_wrapping(planner, &shape, &inner_call, inner_ret, fx);
+    let mut body = Renderer.render_setup(&wrap_statements);
     write_line!(body, "return {}", result_var);
 
     let tagged_var = planner.fresh_var(Some("tagged"));
@@ -763,7 +764,10 @@ fn emit_nullable_slot_value(
         return match kind {
             Ok(()) => {
                 debug_assert_eq!(args.len(), 1, "Some(...) takes exactly one arg");
-                planner.emit_composite_value(output, &args[0], ExpressionContext::value(), fx)
+                let (setup, value) =
+                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                output.push_str(&Renderer.render_setup(&setup));
+                value
             }
             Err(()) => "nil".to_string(),
         };
@@ -771,7 +775,12 @@ fn emit_nullable_slot_value(
     if expression.is_none_literal() {
         return "nil".to_string();
     }
-    let value = planner.emit_value(output, expression, ExpressionContext::value(), fx);
+    let (setup, value) = planner.lower_value(expression, ExpressionContext::value(), fx);
+    output.push_str(&Renderer.render_setup(&setup));
     let inner = planner.go_type_string(&slot_ty.ok_type(), fx);
-    planner.emit_option_projection(output, &value, "unwrap", &inner, false, fx)
+    let mut statements = Vec::new();
+    let slot_var =
+        planner.plan_option_projection(&mut statements, &value, "unwrap", &inner, false, fx);
+    output.push_str(&Renderer.render_setup(&statements));
+    slot_var
 }

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -28,7 +28,7 @@ pub(crate) fn multi_value_return(values: Vec<String>) -> LoweredStatement {
 pub(crate) fn tag_check(condition: String, then_values: Vec<String>) -> LoweredStatement {
     LoweredStatement::If(IfPlan {
         directive: String::new(),
-        condition_setup: String::new(),
+        condition_setup: Vec::new(),
         condition,
         then_body: LoweredBlock {
             statements: vec![multi_value_return(then_values)],

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -5,7 +5,6 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::NativeCallContext;
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -224,20 +223,7 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn emit_call(
-        &mut self,
-        output: &mut String,
-        call_expression: &Expression,
-        call_ty: Option<&Type>,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let (setup, value) = self.lower_call(call_expression, call_ty, ctx, fx);
-        output.push_str(&Renderer.render_setup(&setup));
-        value
-    }
-
-    /// Structured form of `emit_call`: typed setup plus the value text.
+    /// Lower a call expression to typed setup plus the value text.
     pub(crate) fn lower_call(
         &mut self,
         call_expression: &Expression,

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -7,7 +7,6 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::calls::CallBoundary;
-use crate::calls::go_interop::wrappers::WrapperOutcome;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -41,19 +40,6 @@ impl GoCallStrategy {
 }
 
 impl Planner<'_> {
-    pub(crate) fn emit_go_wrapped_call(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        strategy: &GoCallStrategy,
-        result_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let (statements, value) = self.lower_go_wrapped_call(expression, strategy, result_ty, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        value
-    }
-
     /// Lower a Go-imported callee through its ABI bridge.
     pub(crate) fn lower_go_wrapped_call(
         &mut self,
@@ -84,68 +70,66 @@ impl Planner<'_> {
         }
     }
 
-    /// `emit_go_wrapped_call` writing into `target`. `None` for `Tuple`.
-    pub(crate) fn emit_go_wrapped_call_to(
+    /// `lower_go_wrapped_call` writing into `target`. `None` for `Tuple`.
+    pub(crate) fn lower_go_wrapped_call_to(
         &mut self,
-        output: &mut String,
         expression: &Expression,
         strategy: &GoCallStrategy,
         result_ty: &Type,
         target: WrapperTarget<'_>,
         fx: &mut EmitEffects,
-    ) -> Option<WrapperOutcome> {
-        match strategy {
-            GoCallStrategy::Tuple { .. } => None,
+    ) -> Option<Vec<LoweredStatement>> {
+        if matches!(strategy, GoCallStrategy::Tuple { .. }) {
+            return None;
+        }
+        let (mut statements, call_str) =
+            self.lower_call(expression, None, ExpressionContext::value(), fx);
+        let wrap = match strategy {
+            GoCallStrategy::Tuple { .. } => unreachable!("handled above"),
             GoCallStrategy::Result => {
-                let call_str =
-                    self.emit_call(output, expression, None, ExpressionContext::value(), fx);
                 fx.require_stdlib();
-                Some(self.emit_result_wrapping(
-                    output,
+                self.lower_result_wrapping(
                     &call_str,
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
                     fx,
-                ))
+                )
+                .0
             }
             GoCallStrategy::CommaOk => {
-                let call_str =
-                    self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                Some(self.emit_comma_ok_wrapping(
-                    output,
+                self.lower_comma_ok_wrapping(
                     &call_str,
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
                     fx,
-                ))
+                )
+                .0
             }
             GoCallStrategy::NullableReturn => {
-                let call_str =
-                    self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                let raw_var = self.hoist_tmp_value(output, "raw", &call_str);
-                Some(self.emit_nil_check_option_wrap(output, &raw_var, result_ty, target, fx))
+                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
+                self.lower_nil_check_option_wrap(&raw_var, result_ty, target, fx)
+                    .0
             }
             GoCallStrategy::Partial => {
                 fx.require_stdlib();
-                let call_str =
-                    self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                Some(self.emit_partial_wrapping(
-                    output,
+                self.lower_partial_wrapping(
                     &call_str,
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
                     fx,
-                ))
+                )
+                .0
             }
             GoCallStrategy::Sentinel { value } => {
-                let call_str =
-                    self.emit_call(output, expression, None, ExpressionContext::value(), fx);
-                Some(self.emit_sentinel_wrapping(output, &call_str, result_ty, *value, target, fx))
+                self.lower_sentinel_wrapping(&call_str, result_ty, *value, target, fx)
+                    .0
             }
-        }
+        };
+        statements.extend(wrap);
+        Some(statements)
     }
 
     fn has_go_hint(&self, receiver_expression: &Expression, member: &str, hint: &str) -> bool {
@@ -202,7 +186,8 @@ impl Planner<'_> {
         if has_array_return {
             ctx = ctx.with_raw_go_array_return();
         }
-        let call_str = self.emit_call(output, call_expression, None, ctx, fx);
+        let (setup, call_str) = self.lower_call(call_expression, None, ctx, fx);
+        output.push_str(&Renderer.render_setup(&setup));
 
         Some(call_str)
     }
@@ -226,6 +211,18 @@ impl Planner<'_> {
     ) -> String {
         let constructor = build_tuple_literal(vars, tuple_ty, fx);
         self.hoist_tmp_value(output, "tup", &constructor)
+    }
+
+    /// Structured counterpart of `emit_tuple_from_vars`.
+    pub(crate) fn plan_tuple_from_vars(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        vars: &[String],
+        tuple_ty: &Type,
+        fx: &mut EmitEffects,
+    ) -> String {
+        let constructor = build_tuple_literal(vars, tuple_ty, fx);
+        self.hoist_tmp_value_statement(statements, "tup", &constructor)
     }
 }
 

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -222,10 +222,11 @@ impl Planner<'_> {
         let opt_var = self.hoist_tmp_value_statement(statements, "opt", option_value);
         let slot_var = self.fresh_var(Some(slot_hint));
         self.declare(&slot_var);
-        statements.push(LoweredStatement::RawGo(format!(
-            "var {} {}\n",
-            slot_var, slot_ty
-        )));
+        statements.push(LoweredStatement::VarDecl {
+            name: slot_var.clone(),
+            go_type: slot_ty.to_string(),
+            value: None,
+        });
 
         fx.require_stdlib();
         let amp = if address { "&" } else { "" };

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,6 +1,5 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{
     TupleReturnLayout, WrapperOutcome, WrapperTarget, leaf_block,
@@ -52,21 +51,6 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
-    pub(crate) fn emit_sentinel_wrapping(
-        &mut self,
-        output: &mut String,
-        call_str: &str,
-        option_ty: &Type,
-        sentinel: i64,
-        target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
-    ) -> WrapperOutcome {
-        let (statements, outcome) =
-            self.lower_sentinel_wrapping(call_str, option_ty, sentinel, target, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        outcome
-    }
-
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.
     pub(crate) fn lower_sentinel_wrapping(
         &mut self,
@@ -87,21 +71,6 @@ impl Planner<'_> {
         let outcome =
             self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
         (statements, outcome)
-    }
-
-    pub(crate) fn emit_comma_ok_wrapping(
-        &mut self,
-        output: &mut String,
-        call_str: &str,
-        option_ty: &Type,
-        layout: TupleReturnLayout,
-        target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
-    ) -> WrapperOutcome {
-        let (statements, outcome) =
-            self.lower_comma_ok_wrapping(call_str, option_ty, layout, target, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        outcome
     }
 
     /// Wrap a comma-ok-returning call into a tagged `Option`. A `Flattened`
@@ -200,20 +169,6 @@ impl Planner<'_> {
         (statements, outcome)
     }
 
-    pub(crate) fn emit_nil_check_option_wrap(
-        &mut self,
-        output: &mut String,
-        raw_value: &str,
-        option_ty: &Type,
-        target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
-    ) -> WrapperOutcome {
-        let (statements, outcome) =
-            self.lower_nil_check_option_wrap(raw_value, option_ty, target, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        outcome
-    }
-
     /// Wrap a nilable Go value into a tagged `Option` via `OptionFromNilable`.
     pub(crate) fn lower_nil_check_option_wrap(
         &mut self,
@@ -253,28 +208,6 @@ impl Planner<'_> {
             self.lower_nil_check_option_wrap(&raw_var, option_ty, WrapperTarget::FreshSlot, fx);
         setup.extend(wrap_setup);
         (setup, outcome.expect("wrapper produced no slot"))
-    }
-
-    pub(crate) fn emit_option_projection(
-        &mut self,
-        output: &mut String,
-        option_value: &str,
-        slot_hint: &str,
-        slot_ty: &str,
-        address: bool,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let mut statements = Vec::new();
-        let slot_var = self.plan_option_projection(
-            &mut statements,
-            option_value,
-            slot_hint,
-            slot_ty,
-            address,
-            fx,
-        );
-        output.push_str(&Renderer.render_setup(&statements));
-        slot_var
     }
 
     pub(crate) fn plan_option_projection(

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -368,7 +368,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::Loop(LoopPlan {
             directive: String::new(),
-            prologue: String::new(),
+            prologue: Vec::new(),
             label: None,
             header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),
             body: loop_body,
@@ -461,7 +461,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::Loop(LoopPlan {
             directive: String::new(),
-            prologue: String::new(),
+            prologue: Vec::new(),
             label: None,
             header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),
             body: loop_body,

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -158,7 +158,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition,
             then_body: leaf_block(&sink, &some_wrapper),
             else_arm: ElseArm::Else {
@@ -238,7 +238,7 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("{}.Tag == {}", opt_var, OPTION_SOME_TAG),
             then_body: body,
             else_arm: ElseArm::None,
@@ -334,7 +334,7 @@ impl Planner<'_> {
                 };
                 let if_plan = IfPlan {
                     directive: String::new(),
-                    condition_setup: String::new(),
+                    condition_setup: Vec::new(),
                     condition,
                     then_body,
                     else_arm: ElseArm::Else {
@@ -430,7 +430,7 @@ impl Planner<'_> {
                 };
                 let if_plan = IfPlan {
                     directive: String::new(),
-                    condition_setup: String::new(),
+                    condition_setup: Vec::new(),
                     condition: format!("{}.Tag == {}", val_var, OPTION_SOME_TAG),
                     then_body,
                     else_arm,

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -191,21 +191,6 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
-    pub(crate) fn emit_partial_wrapping(
-        &mut self,
-        output: &mut String,
-        call_str: &str,
-        partial_ty: &Type,
-        layout: TupleReturnLayout,
-        target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
-    ) -> WrapperOutcome {
-        let (statements, outcome) =
-            self.lower_partial_wrapping(call_str, partial_ty, layout, target, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        outcome
-    }
-
     /// Lower a `(T, error)` Go return into a tagged `Partial`.
     pub(crate) fn lower_partial_wrapping(
         &mut self,
@@ -309,21 +294,6 @@ impl Planner<'_> {
         );
         setup.extend(wrap_setup);
         (setup, outcome.expect("wrapper produced no slot"))
-    }
-
-    pub(crate) fn emit_result_wrapping(
-        &mut self,
-        output: &mut String,
-        call_str: &str,
-        result_ty: &Type,
-        layout: TupleReturnLayout,
-        target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
-    ) -> WrapperOutcome {
-        let (statements, outcome) =
-            self.lower_result_wrapping(call_str, result_ty, layout, target, fx);
-        output.push_str(&Renderer.render_setup(&statements));
-        outcome
     }
 
     /// Lower a `(T, error)` Go return into a tagged `Result`.
@@ -543,7 +513,8 @@ impl Planner<'_> {
         expression: &Expression,
         fx: &mut EmitEffects,
     ) -> String {
-        let go_fn_str = self.emit_operand(output, expression, ExpressionContext::value(), fx);
+        let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+        let go_fn_str = Renderer.render_value(output, &plan);
 
         let is_go_module_fn = matches!(
             expression.unwrap_parens(),
@@ -611,7 +582,8 @@ impl Planner<'_> {
         let Some((return_type, param_strs, call_str)) =
             self.wrapper_call_parts(output, expression, fx)
         else {
-            return self.emit_operand(output, expression, ExpressionContext::value(), fx);
+            let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+            return Renderer.render_value(output, &plan);
         };
 
         let ret_ty_str = self.go_type_string(&return_type, fx);
@@ -644,58 +616,75 @@ impl Planner<'_> {
 
         let ret_ty_str = self.go_type_string(&return_type, fx);
 
-        let mut body = String::new();
+        let mut statements = Vec::new();
         let outcome = match strategy {
-            GoCallStrategy::Result => self.emit_result_wrapping(
-                &mut body,
-                &call_str,
-                &return_type,
-                TupleReturnLayout::Flattened,
-                WrapperTarget::Return,
-                fx,
-            ),
-            GoCallStrategy::CommaOk => self.emit_comma_ok_wrapping(
-                &mut body,
-                &call_str,
-                &return_type,
-                TupleReturnLayout::Flattened,
-                WrapperTarget::Return,
-                fx,
-            ),
+            GoCallStrategy::Result => {
+                let (wrap, outcome) = self.lower_result_wrapping(
+                    &call_str,
+                    &return_type,
+                    TupleReturnLayout::Flattened,
+                    WrapperTarget::Return,
+                    fx,
+                );
+                statements.extend(wrap);
+                outcome
+            }
+            GoCallStrategy::CommaOk => {
+                let (wrap, outcome) = self.lower_comma_ok_wrapping(
+                    &call_str,
+                    &return_type,
+                    TupleReturnLayout::Flattened,
+                    WrapperTarget::Return,
+                    fx,
+                );
+                statements.extend(wrap);
+                outcome
+            }
             GoCallStrategy::NullableReturn => {
-                let raw_var = self.hoist_tmp_value(&mut body, "raw", &call_str);
-                self.emit_nil_check_option_wrap(
-                    &mut body,
+                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
+                let (wrap, outcome) = self.lower_nil_check_option_wrap(
                     &raw_var,
                     &return_type,
                     WrapperTarget::Return,
                     fx,
-                )
+                );
+                statements.extend(wrap);
+                outcome
             }
             GoCallStrategy::Tuple { arity } => {
                 let temp_vars = self.create_temp_vars("ret", *arity);
-                write_line!(body, "{} := {}", temp_vars.join(", "), call_str);
-                let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars, &return_type, fx);
-                Some(tuple_str)
+                statements.push(LoweredStatement::RawGo(format!(
+                    "{} := {}\n",
+                    temp_vars.join(", "),
+                    call_str
+                )));
+                Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type, fx))
             }
-            GoCallStrategy::Partial => self.emit_partial_wrapping(
-                &mut body,
-                &call_str,
-                &return_type,
-                TupleReturnLayout::Flattened,
-                WrapperTarget::Return,
-                fx,
-            ),
-            GoCallStrategy::Sentinel { value } => self.emit_sentinel_wrapping(
-                &mut body,
-                &call_str,
-                &return_type,
-                *value,
-                WrapperTarget::Return,
-                fx,
-            ),
+            GoCallStrategy::Partial => {
+                let (wrap, outcome) = self.lower_partial_wrapping(
+                    &call_str,
+                    &return_type,
+                    TupleReturnLayout::Flattened,
+                    WrapperTarget::Return,
+                    fx,
+                );
+                statements.extend(wrap);
+                outcome
+            }
+            GoCallStrategy::Sentinel { value } => {
+                let (wrap, outcome) = self.lower_sentinel_wrapping(
+                    &call_str,
+                    &return_type,
+                    *value,
+                    WrapperTarget::Return,
+                    fx,
+                );
+                statements.extend(wrap);
+                outcome
+            }
         };
 
+        let mut body = Renderer.render_setup(&statements);
         if let Some(result_var) = outcome {
             write_line!(body, "return {}", result_var);
         }

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -223,7 +223,7 @@ impl Planner<'_> {
         let then_body = if let Some(check) = &nil_check {
             let inner = IfPlan {
                 directive: String::new(),
-                condition_setup: String::new(),
+                condition_setup: Vec::new(),
                 condition: check.clone(),
                 then_body: leaf_block(
                     &sink,
@@ -251,7 +251,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,
             else_arm,
@@ -359,7 +359,7 @@ impl Planner<'_> {
             };
             ElseArm::ElseIf(Box::new(IfPlan {
                 directive: String::new(),
-                condition_setup: String::new(),
+                condition_setup: Vec::new(),
                 condition: nil_condition,
                 then_body: leaf_block(&sink, &nil_err),
                 else_arm: ElseArm::Else {
@@ -380,7 +380,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,
             else_arm,
@@ -423,7 +423,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,
             else_arm,

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -82,17 +82,19 @@ impl Planner<'_> {
             WrapperTarget::FreshSlot => {
                 let var = self.fresh_var(Some(name_hint));
                 self.declare(&var);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "var {} {}\n",
-                    var, type_str
-                )));
+                statements.push(LoweredStatement::VarDecl {
+                    name: var.clone(),
+                    go_type: type_str.to_string(),
+                    value: None,
+                });
                 (ResolvedSink::Slot(var.clone()), Some(var))
             }
             WrapperTarget::Slot(name) => {
-                statements.push(LoweredStatement::RawGo(format!(
-                    "var {} {}\n",
-                    name, type_str
-                )));
+                statements.push(LoweredStatement::VarDecl {
+                    name: name.to_string(),
+                    go_type: type_str.to_string(),
+                    value: None,
+                });
                 self.declare(name);
                 let owned = name.to_string();
                 (ResolvedSink::Slot(owned.clone()), Some(owned))

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -396,6 +396,25 @@ impl Planner<'_> {
         )
     }
 
+    /// Pin the receiver stage to a temp when it reads a mutable operand,
+    /// carries no setup of its own, and a later argument (or the spread)
+    /// contains a call — so the receiver is captured before those args can
+    /// mutate it. A receiver that is itself a call already evaluates eagerly.
+    fn pin_receiver_if_mutated(
+        &mut self,
+        stage: &mut StagedExpression,
+        receiver: &Expression,
+        rest_has_call: bool,
+    ) {
+        if !matches!(receiver.unwrap_parens(), Expression::Call { .. })
+            && reads_mutable_operand(receiver)
+            && stage.setup.is_empty()
+            && rest_has_call
+        {
+            self.pin_staged(stage, "recv");
+        }
+    }
+
     fn stage_native_dot_access_call(
         &mut self,
         ctx: &NativeCallContext,
@@ -408,14 +427,9 @@ impl Planner<'_> {
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
         let mut receiver_stage = self.stage_operand(expression, ExpressionContext::value(), fx);
-        let receiver_is_call = matches!(expression.unwrap_parens(), Expression::Call { .. });
-        if !receiver_is_call
-            && reads_mutable_operand(expression)
-            && receiver_stage.setup.is_empty()
-            && (ctx.args.iter().any(contains_call) || ctx.spread.is_some_and(contains_call))
-        {
-            self.pin_staged(&mut receiver_stage, "recv");
-        }
+        let rest_has_call =
+            ctx.args.iter().any(contains_call) || ctx.spread.is_some_and(contains_call);
+        self.pin_receiver_if_mutated(&mut receiver_stage, expression, rest_has_call);
         if expression.get_type().is_ref() {
             receiver_stage.value = format!("*{}", receiver_stage.value);
         }
@@ -490,13 +504,10 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let mut stages = self.stage_native_method_args(ctx.function, ctx.args, fx);
-        if let Some(receiver) = ctx.args.first()
-            && !matches!(receiver.unwrap_parens(), Expression::Call { .. })
-            && reads_mutable_operand(receiver)
-            && stages[0].setup.is_empty()
-            && (ctx.args[1..].iter().any(contains_call) || ctx.spread.is_some_and(contains_call))
-        {
-            self.pin_staged(&mut stages[0], "recv");
+        if let Some(receiver) = ctx.args.first() {
+            let rest_has_call =
+                ctx.args[1..].iter().any(contains_call) || ctx.spread.is_some_and(contains_call);
+            self.pin_receiver_if_mutated(&mut stages[0], receiver, rest_has_call);
         }
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(0));
         self.sequence_with_spread_structured(stages, ctx.spread, false, "_arg", combine, fx)

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -632,8 +632,8 @@ impl<'a> Planner<'a> {
             return None;
         }
 
-        let mut setup = String::new();
-        let src_value = self.emit_value(&mut setup, spread, ExpressionContext::value(), fx);
+        let (src_setup, src_value) = self.lower_value(spread, ExpressionContext::value(), fx);
+        let mut setup = Renderer.render_setup(&src_setup);
         let src_var = self.hoist_tmp_value(&mut setup, "src", &src_value);
 
         let target_element_ret = match param_shape.as_ref() {

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -343,7 +343,7 @@ impl<'a> Planner<'a> {
         ctx: &CallArgsContext<'_>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
-        let mut stages: Vec<StagedExpression> = args
+        let stages: Vec<StagedExpression> = args
             .iter()
             .enumerate()
             .map(|(i, arg)| {
@@ -352,29 +352,12 @@ impl<'a> Planner<'a> {
             })
             .collect();
 
-        if let Some(spread) = ctx.spread
-            && let Some(adapter_stage) =
-                self.try_emit_variadic_spread_adapter(spread, ctx.generic_fn_param_types, fx)
-        {
-            stages.push(adapter_stage);
-            let spread_index = stages.len() - 1;
-            let (setup, mut values) = self.sequence_structured(stages, "_arg");
-            self.finalize_spread_stage(
-                &mut values,
-                spread_index,
-                ctx.wrap_spread_to_any,
-                ctx.combine_variadic.as_ref().cloned(),
-                fx,
-            );
-            return (setup, values);
-        }
-
-        self.sequence_with_spread_structured(
+        self.sequence_args_with_spread_adapter(
             stages,
             ctx.spread,
+            ctx.generic_fn_param_types,
             ctx.wrap_spread_to_any,
-            "_arg",
-            ctx.combine_variadic.as_ref().cloned(),
+            ctx.combine_variadic.clone(),
             fx,
         )
     }

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -151,18 +151,14 @@ impl Planner<'_> {
         }
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
 
-        let (setup, all_values) = if let Some(spread) = spread
-            && let Some(adapter_stage) =
-                self.try_emit_variadic_spread_adapter(spread, declared_params, fx)
-        {
-            all_stages.push(adapter_stage);
-            let spread_index = all_stages.len() - 1;
-            let (setup, mut all_values) = self.sequence_structured(all_stages, "_arg");
-            self.finalize_spread_stage(&mut all_values, spread_index, false, combine, fx);
-            (setup, all_values)
-        } else {
-            self.sequence_with_spread_structured(all_stages, spread, false, "_arg", combine, fx)
-        };
+        let (setup, all_values) = self.sequence_args_with_spread_adapter(
+            all_stages,
+            spread,
+            declared_params,
+            false,
+            combine,
+            fx,
+        );
         let receiver_arg = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
         (setup, receiver_arg, emitted_args)

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -1,50 +1,9 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
-use crate::write_line;
 use syntax::ast::Expression;
 
 impl Planner<'_> {
-    /// `if {`, `} else if {`, or `} else {` for the next link in a pattern
-    /// chain; enters a new scope after.
-    pub(crate) fn emit_branch_header(
-        &mut self,
-        output: &mut String,
-        condition: &str,
-        is_catchall: bool,
-        is_first: bool,
-    ) {
-        if is_first {
-            if is_catchall {
-                output.push_str("if true {\n");
-            } else {
-                write_line!(output, "if {} {{", condition);
-            }
-        } else {
-            self.exit_scope();
-            if is_catchall {
-                output.push_str("} else {\n");
-            } else {
-                write_line!(output, "}} else if {} {{", condition);
-            }
-        }
-        self.enter_scope();
-    }
-
-    pub(crate) fn emit_while_let_break_else(&mut self, output: &mut String) {
-        self.exit_scope();
-        output.push_str("} else {\n");
-        self.enter_scope();
-        if let Some(label) = self.current_loop_label() {
-            write_line!(output, "break {}", label);
-        } else {
-            output.push_str("break\n");
-        }
-        self.exit_scope();
-        output.push_str("}\n");
-        output.push_str("}\n");
-    }
-
     pub(crate) fn emit_block(
         &mut self,
         output: &mut String,

--- a/crates/emit/src/control_flow/branching.rs
+++ b/crates/emit/src/control_flow/branching.rs
@@ -56,27 +56,6 @@ impl Planner<'_> {
     }
 }
 
-impl Planner<'_> {
-    pub(crate) fn emit_labeled_loop(
-        &mut self,
-        output: &mut String,
-        header: &str,
-        body: &Expression,
-        needs_label: bool,
-        fx: &mut EmitEffects,
-    ) {
-        self.set_current_loop_label_if_needed(needs_label);
-        if let Some(label) = self.current_loop_label() {
-            write_line!(output, "{}:", label);
-        }
-        output.push_str(header);
-        self.enter_scope();
-        self.emit_block(output, body, fx);
-        self.exit_scope();
-        output.push_str("}\n");
-    }
-}
-
 pub(crate) fn wrap_if_struct_literal(condition: String) -> String {
     if condition.contains('{') {
         format!("({})", condition)

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,5 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::patterns::binding_decls::pattern_has_bindings;
@@ -90,7 +91,8 @@ impl Planner<'_> {
         self.enter_scope();
         let mut prologue = String::new();
         let range_var = if self.is_unmutated_identifier(iterable) {
-            self.emit_operand(&mut prologue, iterable, ExpressionContext::value(), fx)
+            let plan = self.plan_operand(iterable, ExpressionContext::value(), fx);
+            Renderer.render_value(&mut prologue, &plan)
         } else {
             self.emit_force_capture(&mut prologue, iterable, "_range", fx)
         };
@@ -127,8 +129,8 @@ impl Planner<'_> {
     ) -> (String, String, LoweredBlock) {
         self.enter_scope();
         let mut prologue = String::new();
-        let receiver_str =
-            self.emit_operand(&mut prologue, receiver, ExpressionContext::value(), fx);
+        let receiver_plan = self.plan_operand(receiver, ExpressionContext::value(), fx);
+        let receiver_str = Renderer.render_value(&mut prologue, &receiver_plan);
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
         let header = if loop_var == "_" {
             format!("for range {} {{\n", receiver_str)
@@ -151,7 +153,8 @@ impl Planner<'_> {
         self.enter_scope();
         let mut prologue = String::new();
         let receiver_var = if self.is_unmutated_identifier(receiver) {
-            self.emit_operand(&mut prologue, receiver, ExpressionContext::value(), fx)
+            let plan = self.plan_operand(receiver, ExpressionContext::value(), fx);
+            Renderer.render_value(&mut prologue, &plan)
         } else {
             self.emit_force_capture(&mut prologue, receiver, "_s", fx)
         };
@@ -180,7 +183,8 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> (String, String, bool) {
         let mut prologue = String::new();
-        let iter_raw = self.emit_operand(&mut prologue, iterable, ExpressionContext::value(), fx);
+        let iter_plan = self.plan_operand(iterable, ExpressionContext::value(), fx);
+        let iter_raw = Renderer.render_value(&mut prologue, &iter_plan);
         let iterable_ty = iterable.get_type();
         let iter_expression = if iterable_ty.is_ref() {
             format!("*{}", iter_raw)
@@ -310,25 +314,35 @@ impl Planner<'_> {
 
         self.scope.enter_use_region();
         let mut bindings = String::new();
-        self.emit_irrefutable_pattern_site(
-            &mut bindings,
+        let key_statements = self.lower_irrefutable_pattern_site(
             PatternSubject::for_value(key_var.clone()),
             first,
             None,
             first_ty,
             fx,
         );
+        Renderer.render_lowered_block(
+            &mut bindings,
+            &LoweredBlock {
+                statements: key_statements,
+            },
+        );
         if !bindings.is_empty() {
             self.scope.record_go_use(&key_var);
         }
         let after_key = bindings.len();
-        self.emit_irrefutable_pattern_site(
-            &mut bindings,
+        let value_statements = self.lower_irrefutable_pattern_site(
             PatternSubject::for_value(value_var.clone()),
             second,
             None,
             second_ty,
             fx,
+        );
+        Renderer.render_lowered_block(
+            &mut bindings,
+            &LoweredBlock {
+                statements: value_statements,
+            },
         );
         if bindings.len() > after_key {
             self.scope.record_go_use(&value_var);
@@ -380,13 +394,18 @@ impl Planner<'_> {
             };
             self.scope.enter_use_region();
             let mut bindings = String::new();
-            self.emit_irrefutable_pattern_site(
-                &mut bindings,
+            let binding_statements = self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(item_var.clone()),
                 &binding.pattern,
                 binding.typed_pattern.as_ref(),
                 &binding.ty,
                 fx,
+            );
+            Renderer.render_lowered_block(
+                &mut bindings,
+                &LoweredBlock {
+                    statements: binding_statements,
+                },
             );
             if !bindings.is_empty() {
                 self.scope.record_go_use(&item_var);
@@ -431,7 +450,10 @@ impl Planner<'_> {
 
         let mut prologue = String::new();
         let mut start_expression = match start {
-            Some(s) => self.emit_operand(&mut prologue, s, ExpressionContext::value(), fx),
+            Some(s) => {
+                let plan = self.plan_operand(s, ExpressionContext::value(), fx);
+                Renderer.render_value(&mut prologue, &plan)
+            }
             None => "0".to_string(),
         };
         let checkpoint = prologue.len();

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -2,12 +2,14 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
+use crate::expressions::emission::StagedExpression;
 use crate::is_order_sensitive;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
 use crate::plan::bodies::{LoopPlan, LoweredBlock, LoweredStatement};
 use crate::types::native::NativeGoType;
 use crate::types::shape::RangeShape;
+use crate::utils::observable_after_mutation;
 use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
 
@@ -79,6 +81,43 @@ impl Planner<'_> {
         })
     }
 
+    /// Plan `expr` as an operand, pushing its setup into `prologue` and
+    /// returning the value text.
+    fn capture_operand_into(
+        &mut self,
+        prologue: &mut Vec<LoweredStatement>,
+        expr: &Expression,
+        fx: &mut EmitEffects,
+    ) -> String {
+        let plan = self.plan_operand(expr, ExpressionContext::value(), fx);
+        let staged = StagedExpression::from_plan(plan, expr);
+        prologue.extend(staged.setup);
+        staged.value
+    }
+
+    /// `capture_operand_into`, hoisting to a fresh temp when `expr` is
+    /// observable after a mutation (mirrors `emit_force_capture`).
+    fn force_capture_into(
+        &mut self,
+        prologue: &mut Vec<LoweredStatement>,
+        expr: &Expression,
+        prefix: &str,
+        fx: &mut EmitEffects,
+    ) -> String {
+        if !observable_after_mutation(expr) {
+            return self.capture_operand_into(prologue, expr, fx);
+        }
+        let temp_var = self.fresh_var(Some(prefix));
+        self.declare(&temp_var);
+        let (setup, value) = self.lower_composite_value(expr, ExpressionContext::value(), fx);
+        prologue.extend(setup);
+        prologue.push(LoweredStatement::TempBind {
+            name: temp_var.clone(),
+            value,
+        });
+        temp_var
+    }
+
     /// `for i in stored_range`.
     fn lower_stored_range_for(
         &mut self,
@@ -87,14 +126,13 @@ impl Planner<'_> {
         range_shape: RangeShape,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
-        let mut prologue = String::new();
+        let mut prologue = Vec::new();
         let range_var = if self.is_unmutated_identifier(iterable) {
-            let plan = self.plan_operand(iterable, ExpressionContext::value(), fx);
-            Renderer.render_value(&mut prologue, &plan)
+            self.capture_operand_into(&mut prologue, iterable, fx)
         } else {
-            self.emit_force_capture(&mut prologue, iterable, "_range", fx)
+            self.force_capture_into(&mut prologue, iterable, "_range", fx)
         };
         let loop_var = self.bind_loop_pattern(&binding.pattern, Some("_i"));
         let header = match range_shape {
@@ -126,11 +164,10 @@ impl Planner<'_> {
         receiver: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
-        let mut prologue = String::new();
-        let receiver_plan = self.plan_operand(receiver, ExpressionContext::value(), fx);
-        let receiver_str = Renderer.render_value(&mut prologue, &receiver_plan);
+        let mut prologue = Vec::new();
+        let receiver_str = self.capture_operand_into(&mut prologue, receiver, fx);
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
         let header = if loop_var == "_" {
             format!("for range {} {{\n", receiver_str)
@@ -149,14 +186,13 @@ impl Planner<'_> {
         receiver: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
-        let mut prologue = String::new();
+        let mut prologue = Vec::new();
         let receiver_var = if self.is_unmutated_identifier(receiver) {
-            let plan = self.plan_operand(receiver, ExpressionContext::value(), fx);
-            Renderer.render_value(&mut prologue, &plan)
+            self.capture_operand_into(&mut prologue, receiver, fx)
         } else {
-            self.emit_force_capture(&mut prologue, receiver, "_s", fx)
+            self.force_capture_into(&mut prologue, receiver, "_s", fx)
         };
         let index_var = self.fresh_var(Some("_i"));
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
@@ -181,10 +217,9 @@ impl Planner<'_> {
         &mut self,
         iterable: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, bool) {
-        let mut prologue = String::new();
-        let iter_plan = self.plan_operand(iterable, ExpressionContext::value(), fx);
-        let iter_raw = Renderer.render_value(&mut prologue, &iter_plan);
+    ) -> (Vec<LoweredStatement>, String, bool) {
+        let mut prologue = Vec::new();
+        let iter_raw = self.capture_operand_into(&mut prologue, iterable, fx);
         let iterable_ty = iterable.get_type();
         let iter_expression = if iterable_ty.is_ref() {
             format!("*{}", iter_raw)
@@ -204,7 +239,7 @@ impl Planner<'_> {
         iterable: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
 
         self.enter_scope();
@@ -230,7 +265,7 @@ impl Planner<'_> {
         iterable: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let Pattern::Tuple { elements, .. } = &binding.pattern else {
             unreachable!("lower_map_tuple_for requires a tuple pattern");
         };
@@ -378,7 +413,7 @@ impl Planner<'_> {
         iterable: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
 
         self.enter_scope();
@@ -437,7 +472,7 @@ impl Planner<'_> {
         iterable: &Expression,
         body: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let Expression::Range {
             start,
             end,
@@ -448,23 +483,27 @@ impl Planner<'_> {
             unreachable!("lower_range_for requires a Range iterable");
         };
 
-        let mut prologue = String::new();
+        let mut prologue = Vec::new();
         let mut start_expression = match start {
-            Some(s) => {
-                let plan = self.plan_operand(s, ExpressionContext::value(), fx);
-                Renderer.render_value(&mut prologue, &plan)
-            }
+            Some(s) => self.capture_operand_into(&mut prologue, s, fx),
             None => "0".to_string(),
         };
         let checkpoint = prologue.len();
         let end_expression = end
             .as_ref()
-            .map(|e| self.emit_force_capture(&mut prologue, e, "_bound", fx));
+            .map(|e| self.force_capture_into(&mut prologue, e, "_bound", fx));
         if prologue.len() > checkpoint && start.as_ref().is_some_and(|s| is_order_sensitive(s)) {
+            // The end bound's capture inserted statements after the start value;
+            // hoist start into its own temp before them so it evaluates first.
             let var = self.fresh_var(Some("start"));
             self.declare(&var);
-            let statement = format!("{} := {}\n", var, start_expression);
-            prologue.insert_str(checkpoint, &statement);
+            prologue.insert(
+                checkpoint,
+                LoweredStatement::TempBind {
+                    name: var.clone(),
+                    value: start_expression,
+                },
+            );
             start_expression = var;
         }
 

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -105,10 +105,11 @@ impl Planner<'_> {
         } else {
             // Declared so the dead-path binding stays in scope for later references.
             let go_ty = self.go_type_string(inner_ty, fx);
-            statements.push(LoweredStatement::RawGo(format!(
-                "var {} {} = {}\n",
-                var_name, go_ty, zero
-            )));
+            statements.push(LoweredStatement::VarDecl {
+                name: var_name.to_string(),
+                go_type: go_ty,
+                value: Some(zero),
+            });
             self.declare(var_name);
         }
     }

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -492,12 +492,9 @@ impl Planner<'_> {
         if let Some(plan) = self.plan_call(expression)
             && let CalleePlan::GoInterop(strategy) = plan.callee
         {
-            let mut setup = String::new();
-            let result_var =
-                self.emit_go_wrapped_call(&mut setup, expression, &strategy, return_ty, fx);
-            if !setup.is_empty() {
-                statements.push(LoweredStatement::RawGo(setup));
-            }
+            let (setup, result_var) =
+                self.lower_go_wrapped_call(expression, &strategy, return_ty, fx);
+            statements.extend(setup);
             if let Some(shape) = lowered {
                 statements.extend(transition::emit_lowered_result_return(
                     self,

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -446,18 +446,13 @@ impl Planner<'_> {
             None
         } else {
             let receiver_var = self.fresh_var(Some("recv"));
-            let mut destructure = String::new();
-            self.emit_irrefutable_pattern_site(
-                &mut destructure,
+            body_statements.extend(self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(receiver_var.clone()),
                 effective_pattern,
                 inner_typed,
                 &ctx.element_ty,
                 fx,
-            );
-            if !destructure.is_empty() {
-                body_statements.push(LoweredStatement::RawGo(destructure));
-            }
+            ));
             Some(receiver_var)
         };
         let block = self.lower_block_to_place(ctx.body, ctx.place, fx);

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -261,7 +261,7 @@ impl Planner<'_> {
         let plan = if body_empty {
             IfPlan {
                 directive: String::new(),
-                condition_setup: String::new(),
+                condition_setup: Vec::new(),
                 condition: format!("!{}", ok_var),
                 then_body: else_block.expect("body_empty && has_else"),
                 else_arm: ElseArm::None,
@@ -276,7 +276,7 @@ impl Planner<'_> {
             };
             IfPlan {
                 directive: String::new(),
-                condition_setup: String::new(),
+                condition_setup: Vec::new(),
                 condition: ok_var.to_string(),
                 then_body: body_block,
                 else_arm,
@@ -356,7 +356,7 @@ impl Planner<'_> {
         };
         let if_plan = IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: ok_var,
             then_body: LoweredBlock {
                 statements: then_statements,
@@ -690,7 +690,7 @@ fn build_receive_arms_plan(
     match (some, none) {
         (Some(some), Some(none)) => Some(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: ok_var.to_string(),
             then_body: some,
             else_arm: ElseArm::Else {
@@ -700,14 +700,14 @@ fn build_receive_arms_plan(
         }),
         (Some(some), None) => Some(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: ok_var.to_string(),
             then_body: some,
             else_arm: ElseArm::None,
         }),
         (None, Some(none)) => Some(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("!{}", ok_var),
             then_body: none,
             else_arm: ElseArm::None,

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -8,6 +8,7 @@ use crate::abi::AbiShape;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::PatternSubject;
+use crate::plan::bodies::LoweredBlock;
 use crate::types::native::NativeGoType;
 use crate::utils::{group_params, receiver_name};
 use syntax::ast::{
@@ -190,14 +191,14 @@ impl Planner<'_> {
     ) -> String {
         let mut body_string = String::new();
         for (temp_name, pattern, typed, param_ty) in destructure_bindings {
-            self.emit_irrefutable_pattern_site(
-                &mut body_string,
+            let statements = self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(temp_name.clone()),
                 pattern,
                 *typed,
                 param_ty,
                 fx,
             );
+            Renderer.render_lowered_block(&mut body_string, &LoweredBlock { statements });
         }
         self.emit_function_body(&mut body_string, body, should_return, return_ctx, fx);
         body_string
@@ -374,14 +375,14 @@ impl Planner<'_> {
     ) {
         let should_return = !function_definition.return_type.is_unit();
         for (var_name, pattern, typed, param_ty) in deferred_patterns {
-            self.emit_irrefutable_pattern_site(
-                body,
+            let statements = self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(var_name),
                 &pattern,
                 typed.as_ref(),
                 &param_ty,
                 fx,
             );
+            Renderer.render_lowered_block(body, &LoweredBlock { statements });
         }
         self.emit_function_body(
             body,

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -62,13 +62,15 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> String {
         if !observable_after_mutation(expression) {
-            return self.emit_operand(output, expression, ExpressionContext::value(), fx);
+            let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+            return Renderer.render_value(output, &plan);
         }
 
         let temp_var = self.fresh_var(Some(prefix));
         self.declare(&temp_var);
-        let expression_string =
-            self.emit_composite_value(output, expression, ExpressionContext::value(), fx);
+        let (setup, expression_string) =
+            self.lower_composite_value(expression, ExpressionContext::value(), fx);
+        output.push_str(&Renderer.render_setup(&setup));
         write_line!(output, "{} := {}", temp_var, expression_string);
         temp_var
     }

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -289,4 +289,31 @@ impl Planner<'_> {
         }
         (setup, values)
     }
+
+    /// Sequence pre-built argument stages, routing a fn-shape-mismatched
+    /// variadic spread through `try_emit_variadic_spread_adapter` (which stages
+    /// the adapter as a sibling) and otherwise through the plain spread path.
+    /// `adapter_params` are the callee's declared params used to detect the
+    /// shape mismatch.
+    pub(crate) fn sequence_args_with_spread_adapter(
+        &mut self,
+        mut stages: Vec<StagedExpression>,
+        spread: Option<&Expression>,
+        adapter_params: Option<&[Type]>,
+        wrap_to_any: bool,
+        combine: Option<VariadicCombine>,
+        fx: &mut EmitEffects,
+    ) -> (Vec<LoweredStatement>, Vec<String>) {
+        if let Some(spread) = spread
+            && let Some(adapter_stage) =
+                self.try_emit_variadic_spread_adapter(spread, adapter_params, fx)
+        {
+            stages.push(adapter_stage);
+            let spread_index = stages.len() - 1;
+            let (setup, mut values) = self.sequence_structured(stages, "_arg");
+            self.finalize_spread_stage(&mut values, spread_index, wrap_to_any, combine, fx);
+            return (setup, values);
+        }
+        self.sequence_with_spread_structured(stages, spread, wrap_to_any, "_arg", combine, fx)
+    }
 }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -8,7 +8,7 @@ use crate::Planner;
 use crate::Renderer;
 use crate::abi::AbiShape;
 use crate::abi::coercion::{Coercion, CoercionDirection};
-use crate::abi::transition::{emit_callee_abi_wrapping, emit_lisette_callback_wrapper};
+use crate::abi::transition::{emit_lisette_callback_wrapper, lower_callee_abi_wrapping};
 use crate::calls::CallBoundary;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -34,18 +34,6 @@ impl Planner<'_> {
         write_line!(output, "var {} {}", result_var, self.go_type_string(ty, fx));
         self.declare(&result_var);
         result_var
-    }
-
-    pub(crate) fn emit_value(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let (setup, value) = self.lower_value(expression, ctx, fx);
-        output.push_str(&Renderer.render_setup(&setup));
-        value
     }
 
     pub(crate) fn lower_value(
@@ -176,30 +164,6 @@ impl Planner<'_> {
         self.fallible_tuple_return(&f.return_type)
     }
 
-    pub(crate) fn emit_composite_value(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let (setup, value) = self.lower_composite_value(expression, ctx, fx);
-        output.push_str(&Renderer.render_setup(&setup));
-        value
-    }
-
-    /// Emit a value-position expression: plan, then render.
-    pub(crate) fn emit_operand(
-        &mut self,
-        output: &mut String,
-        expression: &Expression,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> String {
-        let plan = self.plan_operand(expression, ctx, fx);
-        Renderer.render_value(output, &plan)
-    }
-
     /// Plan a value-position leaf expression (one `plan_operand` does not lower
     /// structurally) into a `ValuePlan`.
     pub(crate) fn plan_operand_leaf(
@@ -221,23 +185,23 @@ impl Planner<'_> {
                     self.maybe_lower_tagged_fn_ref(&mut buffer, expression, ty, raw, ctx, fx);
                 value_plan_from_statements(setup_from_string(buffer), value)
             }
-            Expression::Call { ty, .. } => {
-                let mut buffer = String::new();
-                let value = match self.classify_call(expression) {
-                    CallBoundary::GoWrapped(strategy) => {
-                        self.emit_go_wrapped_call(&mut buffer, expression, &strategy, ty, fx)
-                    }
-                    CallBoundary::LoweredCallee(shape) => {
-                        fx.require_stdlib();
-                        let call_str = self.emit_call(&mut buffer, expression, Some(ty), ctx, fx);
-                        emit_callee_abi_wrapping(self, &mut buffer, &shape, &call_str, ty, fx)
-                    }
-                    CallBoundary::Plain => {
-                        self.emit_call(&mut buffer, expression, Some(ty), ctx, fx)
-                    }
-                };
-                value_plan_from_statements(setup_from_string(buffer), value)
-            }
+            Expression::Call { ty, .. } => match self.classify_call(expression) {
+                CallBoundary::GoWrapped(strategy) => {
+                    let (setup, value) = self.lower_go_wrapped_call(expression, &strategy, ty, fx);
+                    value_plan_from_statements(setup, value)
+                }
+                CallBoundary::LoweredCallee(shape) => {
+                    fx.require_stdlib();
+                    let (mut setup, call_str) = self.lower_call(expression, Some(ty), ctx, fx);
+                    let (wrap, value) = lower_callee_abi_wrapping(self, &shape, &call_str, ty, fx);
+                    setup.extend(wrap);
+                    value_plan_from_statements(setup, value)
+                }
+                CallBoundary::Plain => {
+                    let (setup, value) = self.lower_call(expression, Some(ty), ctx, fx);
+                    value_plan_from_statements(setup, value)
+                }
+            },
             Expression::RawGo { text } => ValuePlan::Operand(text.clone()),
             Expression::Unit { .. } => ValuePlan::Operand("struct{}{}".to_string()),
             Expression::NoOp => ValuePlan::Operand(String::new()),

--- a/crates/emit/src/patterns/binding_decls.rs
+++ b/crates/emit/src/patterns/binding_decls.rs
@@ -10,7 +10,7 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::expressions::literals::{convert_escape_sequences, emit_raw_string};
 use crate::names::generics;
-use crate::write_line;
+use crate::plan::bodies::LoweredStatement;
 
 /// Generic vars paired with their concrete instantiation arguments; inputs
 /// to field-type substitution.
@@ -157,9 +157,9 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn emit_binding_declarations_with_type(
+    pub(crate) fn lower_binding_declarations_with_type(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         pattern: &Pattern,
         ty: &Type,
         typed: Option<&TypedPattern>,
@@ -167,15 +167,17 @@ impl Planner<'_> {
     ) {
         match pattern {
             Pattern::Identifier { identifier, .. } => {
-                self.declare_pattern_var(output, pattern, identifier, ty, fx);
+                self.declare_pattern_var(statements, pattern, identifier, ty, fx);
             }
             Pattern::Tuple { elements, .. } => {
-                self.emit_tuple_pattern_declarations(output, elements, ty, typed, fx);
+                self.lower_tuple_pattern_declarations(statements, elements, ty, typed, fx);
             }
             Pattern::Struct {
                 fields, identifier, ..
             } => {
-                self.emit_struct_pattern_declarations(output, fields, identifier, ty, typed, fx);
+                self.lower_struct_pattern_declarations(
+                    statements, fields, identifier, ty, typed, fx,
+                );
             }
             Pattern::EnumVariant {
                 fields,
@@ -183,12 +185,12 @@ impl Planner<'_> {
                 ty: pattern_ty,
                 ..
             } => {
-                self.emit_enum_variant_pattern_declarations(
-                    output, fields, identifier, pattern_ty, ty, typed, fx,
+                self.lower_enum_variant_pattern_declarations(
+                    statements, fields, identifier, pattern_ty, ty, typed, fx,
                 );
             }
             Pattern::Slice { prefix, rest, .. } => {
-                self.emit_slice_pattern_declarations(output, prefix, rest, ty, typed, fx);
+                self.lower_slice_pattern_declarations(statements, prefix, rest, ty, typed, fx);
             }
             Pattern::Or { patterns, .. } => {
                 let Some(first) = patterns.first() else {
@@ -198,15 +200,15 @@ impl Planner<'_> {
                     Some(TypedPattern::Or { alternatives }) => alternatives.first(),
                     _ => None,
                 };
-                self.emit_binding_declarations_with_type(output, first, ty, alt, fx);
+                self.lower_binding_declarations_with_type(statements, first, ty, alt, fx);
             }
             p @ Pattern::AsBinding {
                 pattern: inner,
                 name,
                 ..
             } => {
-                self.emit_binding_declarations_with_type(output, inner, ty, typed, fx);
-                self.declare_pattern_var(output, p, name, ty, fx);
+                self.lower_binding_declarations_with_type(statements, inner, ty, typed, fx);
+                self.declare_pattern_var(statements, p, name, ty, fx);
             }
             Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => {}
         }
@@ -215,7 +217,7 @@ impl Planner<'_> {
     /// Declare a `var X T` for an identifier pattern; binds `_` when unused.
     fn declare_pattern_var(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         pattern: &Pattern,
         lisette_name: &EcoString,
         resolved: &Type,
@@ -225,13 +227,13 @@ impl Planner<'_> {
             self.scope.bind(lisette_name, "_");
             return;
         };
-        self.declare_var_declaration(output, lisette_name, go_name, resolved, fx);
+        self.declare_var_declaration(statements, lisette_name, go_name, resolved, fx);
     }
 
     /// Freshen `go_name`, register the binding, emit `var X T`.
     fn declare_var_declaration(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         lisette_name: &EcoString,
         go_name: String,
         resolved: &Type,
@@ -245,13 +247,17 @@ impl Planner<'_> {
         let go_name = self.scope.bind(lisette_name, go_name);
         self.declare(&go_name);
         let go_ty = self.go_type_string(resolved, fx);
-        write_line!(output, "var {} {}", go_name, go_ty);
+        statements.push(LoweredStatement::VarDecl {
+            name: go_name,
+            go_type: go_ty,
+            value: None,
+        });
     }
 
     /// Recurse into tuple-pattern elements paired with their slot types.
-    fn emit_tuple_pattern_declarations(
+    fn lower_tuple_pattern_declarations(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         elements: &[Pattern],
         resolved: &Type,
         typed: Option<&TypedPattern>,
@@ -267,8 +273,8 @@ impl Planner<'_> {
             _ => return,
         };
         for (i, (element, element_ty)) in elements.iter().zip(types.iter()).enumerate() {
-            self.emit_binding_declarations_with_type(
-                output,
+            self.lower_binding_declarations_with_type(
+                statements,
                 element,
                 element_ty,
                 typed_elements.get(i),
@@ -279,9 +285,9 @@ impl Planner<'_> {
 
     /// Recurse into named struct-pattern fields (plain struct or enum's
     /// struct variant, resolved via the typed pattern or definitions table).
-    fn emit_struct_pattern_declarations(
+    fn lower_struct_pattern_declarations(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         fields: &[StructFieldPattern],
         identifier: &EcoString,
         resolved: &Type,
@@ -306,7 +312,7 @@ impl Planner<'_> {
                     return;
                 };
                 self.recurse_named_fields(
-                    output,
+                    statements,
                     fields,
                     struct_fields,
                     GenericArgs { generics, params },
@@ -331,7 +337,7 @@ impl Planner<'_> {
                     return;
                 };
                 self.recurse_named_fields(
-                    output,
+                    statements,
                     fields,
                     variant_fields,
                     GenericArgs { generics, params },
@@ -339,14 +345,14 @@ impl Planner<'_> {
                     fx,
                 );
             }
-            _ => self.emit_struct_pattern_fallback(output, fields, identifier, resolved, fx),
+            _ => self.lower_struct_pattern_fallback(statements, fields, identifier, resolved, fx),
         }
     }
 
     /// Untyped struct-pattern fallback via the definitions table.
-    fn emit_struct_pattern_fallback(
+    fn lower_struct_pattern_fallback(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         fields: &[StructFieldPattern],
         identifier: &EcoString,
         resolved: &Type,
@@ -362,7 +368,7 @@ impl Planner<'_> {
                 ..
             }) => {
                 self.recurse_named_fields(
-                    output,
+                    statements,
                     fields,
                     field_definitions,
                     GenericArgs { generics, params },
@@ -376,7 +382,7 @@ impl Planner<'_> {
                 let variant_name = unqualified_name(identifier);
                 if let Some(variant) = variants.iter().find(|v| v.name == variant_name) {
                     self.recurse_named_fields(
-                        output,
+                        statements,
                         fields,
                         variant_fields_slice(&variant.fields),
                         GenericArgs { generics, params },
@@ -392,9 +398,9 @@ impl Planner<'_> {
     /// Recurse into positional enum-variant fields (tuple-struct matches
     /// route through the struct definition).
     #[allow(clippy::too_many_arguments)]
-    fn emit_enum_variant_pattern_declarations(
+    fn lower_enum_variant_pattern_declarations(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         fields: &[Pattern],
         identifier: &EcoString,
         pattern_ty: &Type,
@@ -403,7 +409,7 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) {
         if self.is_tuple_struct_type(pattern_ty) {
-            self.emit_tuple_struct_variant_declarations(output, fields, resolved, typed, fx);
+            self.lower_tuple_struct_variant_declarations(statements, fields, resolved, typed, fx);
             return;
         }
 
@@ -429,7 +435,7 @@ impl Planner<'_> {
                 return;
             };
             self.recurse_positional_fields(
-                output,
+                statements,
                 fields,
                 variant_fields,
                 GenericArgs { generics, params },
@@ -456,7 +462,7 @@ impl Planner<'_> {
             return;
         };
         self.recurse_positional_fields(
-            output,
+            statements,
             fields,
             variant_fields_slice(&variant.fields),
             GenericArgs { generics, params },
@@ -466,9 +472,9 @@ impl Planner<'_> {
     }
 
     /// Newtype-tuple-struct match via the struct's own positional fields.
-    fn emit_tuple_struct_variant_declarations(
+    fn lower_tuple_struct_variant_declarations(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         fields: &[Pattern],
         resolved: &Type,
         typed: Option<&TypedPattern>,
@@ -495,7 +501,7 @@ impl Planner<'_> {
             _ => None,
         };
         self.recurse_positional_fields(
-            output,
+            statements,
             fields,
             field_definitions,
             GenericArgs { generics, params },
@@ -505,9 +511,9 @@ impl Planner<'_> {
     }
 
     /// Recurse into a slice pattern's prefix and bind any rest variable.
-    fn emit_slice_pattern_declarations(
+    fn lower_slice_pattern_declarations(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         prefix: &[Pattern],
         rest: &RestPattern,
         resolved: &Type,
@@ -533,13 +539,19 @@ impl Planner<'_> {
 
         for (i, element) in prefix.iter().enumerate() {
             let typed_child = typed_prefix.and_then(|tp| tp.get(i));
-            self.emit_binding_declarations_with_type(output, element, &element_ty, typed_child, fx);
+            self.lower_binding_declarations_with_type(
+                statements,
+                element,
+                &element_ty,
+                typed_child,
+                fx,
+            );
         }
 
         if let RestPattern::Bind { name, .. } = rest
             && let Some(go_name) = self.go_name_for_rest_binding(rest)
         {
-            self.declare_var_declaration(output, name, go_name, resolved, fx);
+            self.declare_var_declaration(statements, name, go_name, resolved, fx);
         }
     }
 
@@ -547,7 +559,7 @@ impl Planner<'_> {
     /// and recurse with the matching typed child.
     fn recurse_named_fields<F: FieldDef>(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         patterns: &[StructFieldPattern],
         definitions: &[F],
         generic_args: GenericArgs,
@@ -565,8 +577,8 @@ impl Planner<'_> {
                     .find(|(n, _)| n == &pattern.name)
                     .map(|(_, tp)| tp)
             });
-            self.emit_binding_declarations_with_type(
-                output,
+            self.lower_binding_declarations_with_type(
+                statements,
                 &pattern.value,
                 &field_ty,
                 typed_child,
@@ -578,7 +590,7 @@ impl Planner<'_> {
     /// Zip positional pattern slots with definition slots and recurse.
     fn recurse_positional_fields<F: FieldDef>(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         patterns: &[Pattern],
         definitions: &[F],
         generic_args: GenericArgs,
@@ -589,7 +601,13 @@ impl Planner<'_> {
         for (i, (pattern, definition)) in patterns.iter().zip(definitions.iter()).enumerate() {
             let field_ty = generics::resolve_field_type(generics, params, definition.ty());
             let typed_child = typed_fields.and_then(|tf| tf.get(i));
-            self.emit_binding_declarations_with_type(output, pattern, &field_ty, typed_child, fx);
+            self.lower_binding_declarations_with_type(
+                statements,
+                pattern,
+                &field_ty,
+                typed_child,
+                fx,
+            );
         }
     }
 }

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -1,16 +1,16 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
 use crate::patterns::decision_tree::{Check, PatternBinding, PatternInfo, render_condition};
-use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::bodies::LoweredStatement;
+use crate::plan::placement::simple_assign;
+use crate::plan::values::ValuePlan;
 use crate::state::bindings::{BindingValue, InlineExpr};
-use crate::write_line;
 
 /// Hoist a root type assertion as `asserted := subject.(T)` for irrefutable
 /// destructure paths (the pattern compiler has already verified the type).
 pub(crate) fn apply_root_assertion<'s>(
     planner: &mut Planner,
-    output: &mut String,
+    statements: &mut Vec<LoweredStatement>,
     info: &PatternInfo,
     subject: &'s str,
 ) -> std::borrow::Cow<'s, str> {
@@ -25,7 +25,7 @@ pub(crate) fn apply_root_assertion<'s>(
     };
     planner.scope.record_go_use(subject);
     let expression = format!("{}.({})", subject, go_type);
-    let var = planner.hoist_tmp_value(output, "asserted", &expression);
+    let var = planner.hoist_tmp_value_statement(statements, "asserted", &expression);
     std::borrow::Cow::Owned(var)
 }
 
@@ -33,7 +33,7 @@ pub(crate) fn apply_root_assertion<'s>(
 /// select arms, or-pattern let-else). Returns `(effective_subject, ok_var)`.
 pub(crate) fn apply_refutable_root_assertion<'s>(
     planner: &mut Planner,
-    output: &mut String,
+    statements: &mut Vec<LoweredStatement>,
     info: &PatternInfo,
     subject: &'s str,
 ) -> (std::borrow::Cow<'s, str>, Option<String>) {
@@ -53,14 +53,10 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
             };
             let ok = planner.fresh_var(Some("ok"));
             planner.declare(&ok);
-            write_line!(
-                output,
-                "{}, {} := {}.({})",
-                asserted_lhs,
-                ok,
-                subject,
-                go_type
-            );
+            statements.push(LoweredStatement::RawGo(format!(
+                "{}, {} := {}.({})\n",
+                asserted_lhs, ok, subject, go_type
+            )));
             let effective = if needs_asserted {
                 std::borrow::Cow::Owned(asserted_lhs)
             } else {
@@ -76,7 +72,10 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
                 .map(|t| {
                     let ok = planner.fresh_var(Some("ok"));
                     planner.declare(&ok);
-                    write_line!(output, "_, {} := {}.({})", ok, subject, t);
+                    statements.push(LoweredStatement::RawGo(format!(
+                        "_, {} := {}.({})\n",
+                        ok, subject, t
+                    )));
                     ok
                 })
                 .collect();
@@ -101,21 +100,6 @@ pub(crate) fn compose_refutable_condition(
         Some(ok) if condition == "true" => ok.to_string(),
         Some(ok) => format!("{} && {}", ok, condition),
     }
-}
-
-pub(crate) fn emit_tree_bindings_with_consumers(
-    planner: &mut Planner,
-    output: &mut String,
-    bindings: &[PatternBinding],
-    subject_var: &str,
-    consumers: &[&syntax::ast::Expression],
-) -> Vec<(String, Option<BindingValue>)> {
-    let mut statements = Vec::new();
-    let installed_inlines =
-        tree_binding_statements(planner, &mut statements, bindings, subject_var, consumers);
-    let block = LoweredBlock { statements };
-    Renderer.render_lowered_block(output, &block);
-    installed_inlines
 }
 
 /// Push one `name := subject.path` per binding. Inlined bindings produce no
@@ -153,23 +137,26 @@ pub(crate) fn tree_binding_statements(
         }
 
         planner.scope.record_go_use(subject_var);
-        let line = if planner.scope.has_binding_for_go_name(go_name) {
+        let name = if planner.scope.has_binding_for_go_name(go_name) {
             let fresh = planner.fresh_var(Some(&binding.lisette_name));
             planner.scope.bind(&binding.lisette_name, &fresh);
             planner.try_declare(&fresh);
-            format!("{} := {}\n", fresh, access_expression)
+            fresh
         } else {
             let name = planner.scope.bind(&binding.lisette_name, go_name.clone());
             if planner.try_declare(&name) {
-                format!("{} := {}\n", name, access_expression)
+                name
             } else {
                 let fresh = planner.fresh_var(Some(&binding.lisette_name));
                 planner.scope.bind(&binding.lisette_name, &fresh);
                 planner.try_declare(&fresh);
-                format!("{} := {}\n", fresh, access_expression)
+                fresh
             }
         };
-        statements.push(LoweredStatement::RawGo(line));
+        statements.push(LoweredStatement::TempBind {
+            name,
+            value: access_expression,
+        });
     }
     installed_inlines
 }
@@ -213,9 +200,6 @@ pub(crate) fn tree_assignment_statements(
         let name = registered_name.to_string();
         planner.scope.record_go_use(subject_var);
         let access_expression = binding.path.render(subject_var);
-        statements.push(LoweredStatement::RawGo(format!(
-            "{} = {}\n",
-            name, access_expression
-        )));
+        statements.push(simple_assign(&name, ValuePlan::Operand(access_expression)));
     }
 }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -156,7 +156,7 @@ impl Planner<'_> {
         );
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: format!("{} == nil", err_var),
             then_body,
             else_arm: ElseArm::Else {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -13,8 +13,7 @@ use crate::names::go_name;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::binding_emit::{
     apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
-    drop_inline_overlays, emit_tree_bindings_with_consumers, tree_assignment_statements,
-    tree_binding_statements,
+    drop_inline_overlays, tree_assignment_statements, tree_binding_statements,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan};
@@ -145,12 +144,8 @@ impl Planner<'_> {
         fx.extend(&info.effects);
 
         let mut body = Vec::new();
-        let mut assertion = String::new();
         self.scope.enter_use_region();
-        let effective = apply_root_assertion(self, &mut assertion, &info, resolved.var());
-        if !assertion.is_empty() {
-            body.push(LoweredStatement::RawGo(assertion));
-        }
+        let effective = apply_root_assertion(self, &mut body, &info, resolved.var());
         tree_binding_statements(self, &mut body, &info.bindings, &effective, &[]);
         let used = self.scope.exit_use_region();
         let body_block = LoweredBlock { statements: body };
@@ -276,28 +271,14 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, typed, &scrutinee_ty);
         fx.extend(&info.effects);
         let mut loop_body = subject_setup;
-        let mut assertion = String::new();
         let (effective, ok_var) =
-            apply_refutable_root_assertion(self, &mut assertion, &info, &subject_var);
-        if !assertion.is_empty() {
-            loop_body.push(LoweredStatement::RawGo(assertion));
-        }
+            apply_refutable_root_assertion(self, &mut loop_body, &info, &subject_var);
         let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
 
         self.enter_scope();
         let mut then_body: Vec<LoweredStatement> = Vec::new();
         if !matches!(pattern, Pattern::Or { .. }) {
-            let mut bindings = String::new();
-            emit_tree_bindings_with_consumers(
-                self,
-                &mut bindings,
-                &info.bindings,
-                &effective,
-                &[body],
-            );
-            if !bindings.is_empty() {
-                then_body.push(LoweredStatement::RawGo(bindings));
-            }
+            tree_binding_statements(self, &mut then_body, &info.bindings, &effective, &[body]);
         }
         then_body.extend(self.lower_block_as_body(body, fx).statements);
         self.exit_scope();
@@ -349,12 +330,8 @@ impl Planner<'_> {
         fx.extend(&info.effects);
 
         let mut statements = Vec::new();
-        let mut assert_buffer = String::new();
         let (effective_subject, assert_ok_var) =
-            apply_refutable_root_assertion(self, &mut assert_buffer, &info, subject_var);
-        if !assert_buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(assert_buffer));
-        }
+            apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if info.checks.is_empty() && assert_ok_var.is_none() {
             tree_binding_statements(
@@ -420,7 +397,7 @@ impl Planner<'_> {
         self.emit_binding_declarations_with_type(&mut declarations, pattern, binding_ty, typed, fx);
         let post_declaration_snapshot = self.scope.binding_snapshot();
 
-        let mut asserts = String::new();
+        let mut asserts = Vec::new();
         let alts =
             self.collect_let_else_alternatives(&mut asserts, patterns, subject_ty, subject_var, fx);
 
@@ -428,9 +405,7 @@ impl Planner<'_> {
         if !declarations.is_empty() {
             statements.push(LoweredStatement::RawGo(declarations));
         }
-        if !asserts.is_empty() {
-            statements.push(LoweredStatement::RawGo(asserts));
-        }
+        statements.extend(asserts);
 
         let chain_len = alts.irrefutable_index.unwrap_or(alts.collected.len());
 
@@ -497,7 +472,7 @@ impl Planner<'_> {
 
     fn collect_let_else_alternatives<'s>(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         patterns: &[Pattern],
         subject_ty: &Type,
         subject_var: &'s str,
@@ -512,7 +487,7 @@ impl Planner<'_> {
         }
         let hoisted: Vec<(Cow<'s, str>, Option<String>)> = collected
             .iter()
-            .map(|info| apply_refutable_root_assertion(self, output, info, subject_var))
+            .map(|info| apply_refutable_root_assertion(self, statements, info, subject_var))
             .collect();
         let irrefutable_index = collected
             .iter()
@@ -559,10 +534,19 @@ impl Planner<'_> {
             }
         }
 
+        let mut assert_statements = Vec::new();
         let hoisted: Vec<_> = alternatives
             .iter()
-            .map(|info| apply_refutable_root_assertion(self, output, info, subject_var))
+            .map(|info| {
+                apply_refutable_root_assertion(self, &mut assert_statements, info, subject_var)
+            })
             .collect();
+        Renderer.render_lowered_block(
+            output,
+            &LoweredBlock {
+                statements: assert_statements,
+            },
+        );
 
         for (i, info) in alternatives.iter().enumerate() {
             let (effective, ok_var) = &hoisted[i];
@@ -570,8 +554,20 @@ impl Planner<'_> {
 
             self.emit_branch_header(output, &condition, false, i == 0);
 
-            let overlays =
-                emit_tree_bindings_with_consumers(self, output, &info.bindings, effective, &[body]);
+            let mut binding_statements = Vec::new();
+            let overlays = tree_binding_statements(
+                self,
+                &mut binding_statements,
+                &info.bindings,
+                effective,
+                &[body],
+            );
+            Renderer.render_lowered_block(
+                output,
+                &LoweredBlock {
+                    statements: binding_statements,
+                },
+            );
             let block = self.lower_block_as_body(body, fx);
             Renderer.render_lowered_block(output, &block);
             drop_inline_overlays(self, &overlays);
@@ -628,12 +624,8 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
         fx.extend(&info.effects);
         let mut statements = Vec::new();
-        let mut asserts = String::new();
         let (effective, ok_var) =
-            apply_refutable_root_assertion(self, &mut asserts, &info, subject_var);
-        if !asserts.is_empty() {
-            statements.push(LoweredStatement::RawGo(asserts));
-        }
+            apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if info.checks.is_empty() && ok_var.is_none() {
             tree_binding_statements(self, &mut statements, &info.bindings, &effective, &[body]);

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -393,18 +393,14 @@ impl Planner<'_> {
             unreachable!("lower_let_else_or_pattern requires an Or pattern");
         };
         let pre_let_snapshot = self.scope.binding_snapshot();
-        let mut declarations = String::new();
-        self.emit_binding_declarations_with_type(&mut declarations, pattern, binding_ty, typed, fx);
+        let mut statements = Vec::new();
+        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty, typed, fx);
         let post_declaration_snapshot = self.scope.binding_snapshot();
 
         let mut asserts = Vec::new();
         let alts =
             self.collect_let_else_alternatives(&mut asserts, patterns, subject_ty, subject_var, fx);
 
-        let mut statements = Vec::new();
-        if !declarations.is_empty() {
-            statements.push(LoweredStatement::RawGo(declarations));
-        }
         statements.extend(asserts);
 
         let chain_len = alts.irrefutable_index.unwrap_or(alts.collected.len());

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -261,7 +261,7 @@ impl Planner<'_> {
             return LoweredBlock {
                 statements: vec![LoweredStatement::Loop(LoopPlan {
                     directive: String::new(),
-                    prologue: String::new(),
+                    prologue: Vec::new(),
                     label,
                     header: "for {\n".to_string(),
                     body: LoweredBlock {
@@ -307,7 +307,7 @@ impl Planner<'_> {
         LoweredBlock {
             statements: vec![LoweredStatement::Loop(LoopPlan {
                 directive: String::new(),
-                prologue: String::new(),
+                prologue: Vec::new(),
                 label,
                 header: "for {\n".to_string(),
                 body: LoweredBlock {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -6,7 +6,6 @@ use syntax::types::Type;
 
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::names::go_name;
@@ -247,24 +246,28 @@ impl Planner<'_> {
         if let Pattern::Or { patterns, .. } = pattern
             && pattern_has_bindings(pattern)
         {
-            let mut buffer = String::new();
-            if let Some(label) = &label {
-                write_line!(buffer, "{}:", label);
-            }
-            buffer.push_str("for {\n");
-            buffer.push_str(&Renderer.render_setup(&subject_setup));
-            self.emit_while_let_or_pattern(
-                &mut buffer,
+            let mut loop_body = subject_setup;
+            self.lower_while_let_or_pattern(
+                &mut loop_body,
                 patterns,
                 TypedSubject {
                     var: &subject_var,
                     ty: &scrutinee_ty,
                 },
                 body,
+                label.as_deref(),
                 fx,
             );
             return LoweredBlock {
-                statements: vec![LoweredStatement::RawGo(buffer)],
+                statements: vec![LoweredStatement::Loop(LoopPlan {
+                    directive: String::new(),
+                    prologue: String::new(),
+                    label,
+                    header: "for {\n".to_string(),
+                    body: LoweredBlock {
+                        statements: loop_body,
+                    },
+                })],
             };
         }
 
@@ -496,12 +499,16 @@ impl Planner<'_> {
         }
     }
 
-    fn emit_while_let_or_pattern(
+    /// Lower a binding or-pattern while-let body into `statements`: per-
+    /// alternative root assertions, then an `if/else if` chain whose terminal
+    /// `else` breaks the loop.
+    fn lower_while_let_or_pattern(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         patterns: &[Pattern],
         subject: TypedSubject,
         body: &Expression,
+        label: Option<&str>,
         fx: &mut EmitEffects,
     ) {
         let TypedSubject {
@@ -530,46 +537,34 @@ impl Planner<'_> {
             }
         }
 
-        let mut assert_statements = Vec::new();
         let hoisted: Vec<_> = alternatives
             .iter()
-            .map(|info| {
-                apply_refutable_root_assertion(self, &mut assert_statements, info, subject_var)
-            })
+            .map(|info| apply_refutable_root_assertion(self, statements, info, subject_var))
             .collect();
-        Renderer.render_lowered_block(
-            output,
-            &LoweredBlock {
-                statements: assert_statements,
-            },
-        );
 
+        let mut pieces: Vec<(String, LoweredBlock)> = Vec::with_capacity(alternatives.len());
         for (i, info) in alternatives.iter().enumerate() {
             let (effective, ok_var) = &hoisted[i];
             let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
 
-            self.emit_branch_header(output, &condition, false, i == 0);
-
-            let mut binding_statements = Vec::new();
-            let overlays = tree_binding_statements(
-                self,
-                &mut binding_statements,
-                &info.bindings,
-                effective,
-                &[body],
-            );
-            Renderer.render_lowered_block(
-                output,
-                &LoweredBlock {
-                    statements: binding_statements,
-                },
-            );
-            let block = self.lower_block_as_body(body, fx);
-            Renderer.render_lowered_block(output, &block);
+            self.enter_scope();
+            let mut branch = Vec::new();
+            let overlays =
+                tree_binding_statements(self, &mut branch, &info.bindings, effective, &[body]);
+            branch.extend(self.lower_block_as_body(body, fx).statements);
             drop_inline_overlays(self, &overlays);
+            self.exit_scope();
+
+            pieces.push((condition, LoweredBlock { statements: branch }));
         }
 
-        self.emit_while_let_break_else(output);
+        let terminal = LoweredBlock {
+            statements: vec![LoweredStatement::Break {
+                directive: String::new(),
+                label: label.map(str::to_string),
+            }],
+        };
+        statements.push(assemble_if_else_chain(pieces, terminal));
     }
 
     pub(crate) fn lower_select_receive_pattern_site(

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -288,7 +288,7 @@ impl Planner<'_> {
 
         loop_body.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition,
             then_body: LoweredBlock {
                 statements: then_body,
@@ -363,7 +363,7 @@ impl Planner<'_> {
         let else_lowered = self.lower_block_as_body(else_block, fx);
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: guard,
             then_body: else_lowered,
             else_arm: ElseArm::None,
@@ -644,7 +644,7 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::If(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition,
             then_body: LoweredBlock {
                 statements: then_body,
@@ -760,7 +760,7 @@ fn assemble_if_else_chain(
         let (condition, then_body) = pieces.pop().expect("len > 1");
         else_arm = ElseArm::ElseIf(Box::new(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition,
             then_body,
             else_arm,
@@ -769,7 +769,7 @@ fn assemble_if_else_chain(
     let (condition, then_body) = pieces.pop().expect("pieces is non-empty");
     LoweredStatement::If(IfPlan {
         directive: String::new(),
-        condition_setup: String::new(),
+        condition_setup: Vec::new(),
         condition,
         then_body,
         else_arm,

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -165,21 +165,6 @@ impl Planner<'_> {
         statements
     }
 
-    pub(crate) fn emit_irrefutable_pattern_site(
-        &mut self,
-        output: &mut String,
-        subject: PatternSubject<'_>,
-        pattern: &Pattern,
-        typed: Option<&TypedPattern>,
-        subject_ty: &Type,
-        fx: &mut EmitEffects,
-    ) {
-        let statements =
-            self.lower_irrefutable_pattern_site(subject, pattern, typed, subject_ty, fx);
-        let block = LoweredBlock { statements };
-        Renderer.render_lowered_block(output, &block);
-    }
-
     pub(crate) fn lower_let_else_pattern_site(
         &mut self,
         ap: AnnotatedPattern,

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -314,7 +314,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
             directive: String::new(),
-            prologue: String::new(),
+            prologue: Vec::new(),
             label: Some(label),
             header: "for {\n".to_string(),
             body: LoweredBlock { statements: body },

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -3,10 +3,10 @@ use syntax::types::Type;
 
 use crate::EmitEffects;
 use crate::Planner;
-use crate::Renderer;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
+use crate::expressions::emission::StagedExpression;
 use crate::patterns::binding_emit::drop_inline_overlays;
 use crate::patterns::decision_tree::{Decision, compile_expanded_arms, expand_or_patterns};
 use crate::patterns::emit_plan::{
@@ -545,7 +545,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         };
         IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: condition.to_string(),
             then_body,
             else_arm,
@@ -686,7 +686,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         match &first.condition {
             Some(condition) => statements.push(LoweredStatement::If(IfPlan {
                 directive: String::new(),
-                condition_setup: String::new(),
+                condition_setup: Vec::new(),
                 condition: condition.clone(),
                 then_body: body,
                 else_arm: ElseArm::None,
@@ -919,16 +919,18 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
     /// Lower an arm's guard to `(condition_setup, condition)` for an `IfPlan`,
     /// or `None` when the arm has no guard. The caller owns the scope and body.
-    fn lower_guard_condition(&mut self, arm_index: usize) -> Option<(String, String)> {
+    fn lower_guard_condition(
+        &mut self,
+        arm_index: usize,
+    ) -> Option<(Vec<LoweredStatement>, String)> {
         let guard_expression = self.arms[arm_index].guard.as_deref()?;
-        let mut condition_setup = String::new();
         let plan = self.planner.plan_operand(
             guard_expression,
             ExpressionContext::value().condition(),
             self.fx,
         );
-        let guard_str = Renderer.render_value(&mut condition_setup, &plan);
-        Some((condition_setup, wrap_if_struct_literal(guard_str)))
+        let staged = StagedExpression::from_plan(plan, guard_expression);
+        Some((staged.setup, wrap_if_struct_literal(staged.value)))
     }
 }
 
@@ -1047,7 +1049,7 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
     for branch in branches.into_iter().rev() {
         else_arm = ElseArm::ElseIf(Box::new(IfPlan {
             directive: String::new(),
-            condition_setup: String::new(),
+            condition_setup: Vec::new(),
             condition: branch.condition,
             then_body: branch.body,
             else_arm,
@@ -1055,7 +1057,7 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
     }
     IfPlan {
         directive: String::new(),
-        condition_setup: String::new(),
+        condition_setup: Vec::new(),
         condition: head.condition,
         then_body: head.body,
         else_arm,

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -3,6 +3,7 @@ use syntax::types::Type;
 
 use crate::EmitEffects;
 use crate::Planner;
+use crate::Renderer;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
@@ -921,12 +922,12 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn lower_guard_condition(&mut self, arm_index: usize) -> Option<(String, String)> {
         let guard_expression = self.arms[arm_index].guard.as_deref()?;
         let mut condition_setup = String::new();
-        let guard_str = self.planner.emit_operand(
-            &mut condition_setup,
+        let plan = self.planner.plan_operand(
             guard_expression,
             ExpressionContext::value().condition(),
             self.fx,
         );
+        let guard_str = Renderer.render_value(&mut condition_setup, &plan);
         Some((condition_setup, wrap_if_struct_literal(guard_str)))
     }
 }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -373,7 +373,9 @@ pub(crate) struct IfPlan {
     /// Empty unless debug; set only on the leading `if`, never on nested
     /// `else if`s.
     pub(crate) directive: String,
-    pub(crate) condition_setup: String,
+    /// Side-effecting setup hoisted before the `if` condition (temps from a
+    /// condition that lowered to statements).
+    pub(crate) condition_setup: Vec<LoweredStatement>,
     pub(crate) condition: String,
     pub(crate) then_body: LoweredBlock,
     pub(crate) else_arm: ElseArm,

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -363,7 +363,7 @@ pub(crate) struct WhileLetPlan {
 /// opening brace; `label` is the optional break/continue label.
 pub(crate) struct LoopPlan {
     pub(crate) directive: String,
-    pub(crate) prologue: String,
+    pub(crate) prologue: Vec<LoweredStatement>,
     pub(crate) label: Option<String>,
     pub(crate) header: String,
     pub(crate) body: LoweredBlock,

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -53,6 +53,12 @@ pub(crate) enum LoweredStatement {
         name: String,
         value: String,
     },
+    /// `var name go_type` (with `= value` when `value` is set).
+    VarDecl {
+        name: String,
+        go_type: String,
+        value: Option<String>,
+    },
     /// `name := <closure_open><body><closure_close>` (try-block IIFE,
     /// recover-block closure). `closure_open`/`close` are opaque Go text.
     ClosureBind {
@@ -145,10 +151,10 @@ pub(crate) struct LetPlan {
 }
 
 pub(crate) enum LetForm {
-    /// `!`-typed value. `declaration` is the optional `var X T` line so dead code
+    /// `!`-typed value. `declaration` is the optional `var X T` leaf so dead code
     /// can still reference the binding.
     Never {
-        declaration: Option<String>,
+        declaration: Option<Box<LoweredStatement>>,
         body: LoweredBlock,
     },
     /// `let x = value` (single identifier), including `let x = expr?`.
@@ -428,7 +434,9 @@ impl LoweredStatement {
             LoweredStatement::Select(plan) => plan.ends_with_diverge(),
             LoweredStatement::Switch(plan) => plan.ends_with_diverge(),
             LoweredStatement::WhileLet(plan) => plan.body.ends_with_diverge(),
-            LoweredStatement::TempBind { .. } | LoweredStatement::ClosureBind { .. } => false,
+            LoweredStatement::TempBind { .. }
+            | LoweredStatement::VarDecl { .. }
+            | LoweredStatement::ClosureBind { .. } => false,
             LoweredStatement::RawGo(_) => false,
             LoweredStatement::DivergingRawGo(_) | LoweredStatement::UnreachablePanic => true,
         }

--- a/crates/emit/src/plan/invariants.rs
+++ b/crates/emit/src/plan/invariants.rs
@@ -27,6 +27,7 @@ fn walk_statement(statement: &LoweredStatement, issues: &mut Vec<String>, path: 
         | LoweredStatement::Assign(_)
         | LoweredStatement::Expression(_)
         | LoweredStatement::TempBind { .. }
+        | LoweredStatement::VarDecl { .. }
         | LoweredStatement::RawGo(_)
         | LoweredStatement::DivergingRawGo(_)
         | LoweredStatement::UnreachablePanic => {}

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1,5 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
@@ -432,12 +433,8 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> (String, String) {
         let mut setup = String::new();
-        let value = self.emit_operand(
-            &mut setup,
-            condition,
-            ExpressionContext::value().condition(),
-            fx,
-        );
+        let plan = self.plan_operand(condition, ExpressionContext::value().condition(), fx);
+        let value = Renderer.render_value(&mut setup, &plan);
         (setup, value)
     }
 

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -490,7 +490,7 @@ impl Planner<'_> {
         self.exit_scope();
         LoopPlan {
             directive,
-            prologue: String::new(),
+            prologue: Vec::new(),
             label,
             header,
             body: lowered_body,

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -6,6 +6,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::branching::wrap_if_struct_literal;
 use crate::control_flow::propagation::plain_return;
 use crate::definitions::functions::is_go_never;
+use crate::expressions::emission::StagedExpression;
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
     LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan,
@@ -435,11 +436,10 @@ impl Planner<'_> {
         &mut self,
         condition: &Expression,
         fx: &mut EmitEffects,
-    ) -> (String, String) {
-        let mut setup = String::new();
+    ) -> (Vec<LoweredStatement>, String) {
         let plan = self.plan_operand(condition, ExpressionContext::value().condition(), fx);
-        let value = Renderer.render_value(&mut setup, &plan);
-        (setup, value)
+        let staged = StagedExpression::from_plan(plan, condition);
+        (staged.setup, staged.value)
     }
 
     fn lower_while(
@@ -455,7 +455,8 @@ impl Planner<'_> {
         let header = if !setup.is_empty() {
             // Condition produced setup statements (temps); they must re-run each
             // iteration, so move everything inside the loop.
-            format!("for {{\n{}if !({}) {{ break }}\n", setup, rendered)
+            let setup_text = Renderer.render_setup(&setup);
+            format!("for {{\n{}if !({}) {{ break }}\n", setup_text, rendered)
         } else if matches!(
             condition.unwrap_parens(),
             Expression::Literal {

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -25,9 +25,13 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> (String, LoweredStatement) {
         let result_var = self.fresh_var(None);
-        let declaration = format!("var {} {}\n", result_var, self.go_type_string(ty, fx));
+        let declaration = LoweredStatement::VarDecl {
+            name: result_var.clone(),
+            go_type: self.go_type_string(ty, fx),
+            value: None,
+        };
         self.declare(&result_var);
-        (result_var, LoweredStatement::RawGo(declaration))
+        (result_var, declaration)
     }
 
     /// Plan a value-position `if` as a fresh operand-temp variable: a `var V T`
@@ -470,7 +474,7 @@ impl Planner<'_> {
 
     /// Shared loop lowering once the header is known: set the label, lower
     /// the body in a fresh scope. Caller owns `push_loop`/`pop_loop`.
-    fn lower_loop_with_header(
+    pub(crate) fn lower_loop_with_header(
         &mut self,
         directive: String,
         header: String,

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -298,10 +298,7 @@ impl Planner<'_> {
         expression: &Expression,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let mut buffer = String::new();
-        let expression_string =
-            self.emit_operand(&mut buffer, expression, ExpressionContext::value(), fx);
-        let value = value_plan_from_statements(setup_from_string(buffer), expression_string);
+        let value = self.plan_operand(expression, ExpressionContext::value(), fx);
         vec![simple_assign(target_var, value)]
     }
 
@@ -354,19 +351,17 @@ impl Planner<'_> {
                 {
                     let (arg_setup, call_str) = {
                         let mut fe = FalliblePlanner::new(self, &fallible, fx);
-                        let mut arg_buffer = String::new();
-                        let arg = fe.planner.emit_composite_value(
-                            &mut arg_buffer,
+                        let (arg_setup, arg) = fe.planner.lower_composite_value(
                             &args[0],
                             ExpressionContext::value(),
                             fe.fx,
                         );
                         (
-                            arg_buffer,
+                            arg_setup,
                             fe.format_constructor_call(constructor_name, Some(&arg)),
                         )
                     };
-                    let value = value_plan_from_statements(setup_from_string(arg_setup), call_str);
+                    let value = value_plan_from_statements(arg_setup, call_str);
                     vec![simple_assign(target_var, value)]
                 } else {
                     let call_str = {

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -7,7 +7,8 @@ use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::is_go_never;
 use crate::expressions::emission::StagedExpression;
 use crate::plan::bodies::{
-    AssignForm, AssignPlan, BreakValueDisposition, BreakValuePlan, LoweredStatement, PlacePlan,
+    AssignForm, AssignPlan, BreakValueDisposition, BreakValuePlan, LoweredBlock, LoweredStatement,
+    PlacePlan,
 };
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{ValuePlan, setup_from_string, value_plan_from_statements};
@@ -51,7 +52,7 @@ pub(crate) fn is_unit_call(expression: &Expression) -> bool {
 }
 
 /// A `target = value` assignment with no lvalue capture.
-fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatement {
+pub(crate) fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatement {
     LoweredStatement::Assign(AssignPlan {
         directive: String::new(),
         form: AssignForm::Simple {
@@ -252,20 +253,17 @@ impl Planner<'_> {
         statements
     }
 
-    pub(crate) fn emit_assign(
+    pub(crate) fn lower_assign(
         &mut self,
-        output: &mut String,
         expression: &Expression,
         var: &str,
         target_ty: Option<&Type>,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Vec<LoweredStatement> {
         let ty = expression.get_type();
         let is_fallible = ty.is_result() || ty.is_option();
         if is_fallible {
-            let statements = self.lower_option_result_assignment(var, target_ty, expression, fx);
-            output.push_str(&Renderer.render_setup(&statements));
-            return;
+            return self.lower_option_result_assignment(var, target_ty, expression, fx);
         }
 
         if let Expression::Loop {
@@ -273,23 +271,25 @@ impl Planner<'_> {
         } = expression
         {
             self.push_loop(var);
-            self.emit_labeled_loop(output, "for {\n", body, *needs_label, fx);
+            let plan = self.lower_loop_with_header(
+                String::new(),
+                "for {\n".to_string(),
+                body,
+                *needs_label,
+                fx,
+            );
             self.pop_loop();
-            return;
+            return vec![LoweredStatement::Loop(plan)];
         }
 
         if let Expression::Block { items, .. } = expression
             && items.len() > 1
         {
-            output.push_str("{\n");
             let statements = self.lower_block_to_var(expression, var, target_ty, true, fx);
-            output.push_str(&Renderer.render_setup(&statements));
-            output.push_str("}\n");
-            return;
+            return vec![LoweredStatement::Block(LoweredBlock { statements })];
         }
 
-        let statements = self.lower_block_to_var(expression, var, target_ty, false, fx);
-        output.push_str(&Renderer.render_setup(&statements));
+        self.lower_block_to_var(expression, var, target_ty, false, fx)
     }
 
     fn lower_plain_assign(
@@ -644,18 +644,14 @@ impl Planner<'_> {
             }
             return result_var;
         }
-        if let Expression::Loop {
-            body, needs_label, ..
-        } = expression
-        {
-            let result_var = self.declare_result_var(output, ty, fx);
-            self.push_loop(result_var.clone());
-            self.emit_labeled_loop(output, "for {\n", body, *needs_label, fx);
-            self.pop_loop();
+        if let Expression::Loop { .. } = expression {
+            let (setup, result_var) = self.plan_loop_as_operand_temp(expression, ty, fx);
+            output.push_str(&Renderer.render_setup(&setup));
             return result_var;
         }
         let result_var = self.declare_result_var(output, ty, fx);
-        self.emit_assign(output, expression, &result_var, Some(ty), fx);
+        let statements = self.lower_assign(expression, &result_var, Some(ty), fx);
+        output.push_str(&Renderer.render_setup(&statements));
         result_var
     }
 

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -392,7 +392,7 @@ impl Renderer {
 
     fn render_if(&self, output: &mut String, plan: &IfPlan) {
         output.push_str(&plan.directive);
-        output.push_str(&plan.condition_setup);
+        output.push_str(&self.render_setup(&plan.condition_setup));
         write_line!(output, "if {} {{", plan.condition);
         self.render_lowered_block(output, &plan.then_body);
         self.render_else_arm(output, &plan.else_arm);
@@ -404,7 +404,7 @@ impl Renderer {
             ElseArm::ElseIf(plan) => {
                 if !plan.condition_setup.is_empty() {
                     output.push_str("} else {\n");
-                    output.push_str(&plan.condition_setup);
+                    output.push_str(&self.render_setup(&plan.condition_setup));
                     write_line!(output, "if {} {{", plan.condition);
                     self.render_lowered_block(output, &plan.then_body);
                     self.render_else_arm(output, &plan.else_arm);

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -381,7 +381,7 @@ impl Renderer {
 
     fn render_loop(&self, output: &mut String, plan: &LoopPlan) {
         output.push_str(&plan.directive);
-        output.push_str(&plan.prologue);
+        output.push_str(&self.render_setup(&plan.prologue));
         if let Some(label) = &plan.label {
             write_line!(output, "{}:", label);
         }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -185,6 +185,14 @@ impl Renderer {
             LoweredStatement::TempBind { name, value } => {
                 write_line!(output, "{} := {}", name, value);
             }
+            LoweredStatement::VarDecl {
+                name,
+                go_type,
+                value,
+            } => match value {
+                Some(value) => write_line!(output, "var {} {} = {}", name, go_type, value),
+                None => write_line!(output, "var {} {}", name, go_type),
+            },
             LoweredStatement::ClosureBind {
                 name,
                 closure_open,
@@ -236,14 +244,14 @@ impl Renderer {
     }
 
     /// Render a `LetPlan`. The `Never` form emits the optional `var X T`
-    /// declaration line first; every form then renders its body block.
+    /// declaration leaf first; every form then renders its body block.
     pub(crate) fn render_let_statement(&self, output: &mut String, plan: &LetPlan) {
         if let LetForm::Never {
             declaration: Some(declaration),
             ..
         } = &plan.form
         {
-            output.push_str(declaration);
+            self.render_statement(output, declaration);
         }
         self.render_lowered_block(output, plan.form.body());
     }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,5 +1,6 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::Renderer;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
@@ -266,9 +267,11 @@ impl Planner<'_> {
                 expression, member, ..
             } => {
                 let base_str = if let Some(inner) = expression.deref_inner() {
-                    self.emit_operand(output, inner, ExpressionContext::value(), fx)
+                    let plan = self.plan_operand(inner, ExpressionContext::value(), fx);
+                    Renderer.render_value(output, &plan)
                 } else {
-                    self.emit_operand(output, expression, ExpressionContext::value(), fx)
+                    let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+                    Renderer.render_value(output, &plan)
                 };
                 let expression_ty = expression.get_type();
                 self.format_dot_access_lvalue(&base_str, &expression_ty, member, fx)
@@ -277,13 +280,15 @@ impl Planner<'_> {
                 expression, index, ..
             } => {
                 let expression_string = if let Some(inner) = expression.deref_inner() {
-                    let inner_str =
-                        self.emit_operand(output, inner, ExpressionContext::value(), fx);
+                    let plan = self.plan_operand(inner, ExpressionContext::value(), fx);
+                    let inner_str = Renderer.render_value(output, &plan);
                     format!("(*{})", inner_str)
                 } else {
-                    self.emit_operand(output, expression, ExpressionContext::value(), fx)
+                    let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+                    Renderer.render_value(output, &plan)
                 };
-                let index_str = self.emit_operand(output, index, ExpressionContext::value(), fx);
+                let index_plan = self.plan_operand(index, ExpressionContext::value(), fx);
+                let index_str = Renderer.render_value(output, &index_plan);
                 format!("{}[{}]", expression_string, index_str)
             }
             Expression::Unary {
@@ -292,8 +297,8 @@ impl Planner<'_> {
                 ..
             } => self.emit_deref_lvalue(output, expression, false, fx),
             Expression::Call { .. } if expression.get_type().is_ref() => {
-                let call_str =
-                    self.emit_operand(output, expression, ExpressionContext::value(), fx);
+                let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+                let call_str = Renderer.render_value(output, &plan);
                 self.hoist_tmp_value(output, "ref", &call_str)
             }
             _ => "_".to_string(),
@@ -310,7 +315,8 @@ impl Planner<'_> {
         rhs_has_setup: bool,
         fx: &mut EmitEffects,
     ) -> String {
-        let pointee_string = self.emit_operand(output, pointee, ExpressionContext::value(), fx);
+        let pointee_plan = self.plan_operand(pointee, ExpressionContext::value(), fx);
+        let pointee_string = Renderer.render_value(output, &pointee_plan);
         let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
             || (rhs_has_setup && observable_after_mutation(pointee));
         if needs_capture {
@@ -377,7 +383,8 @@ impl Planner<'_> {
                     if rhs_has_setup {
                         self.emit_force_capture(output, inner, "ref", fx)
                     } else {
-                        self.emit_operand(output, inner, ExpressionContext::value(), fx)
+                        let plan = self.plan_operand(inner, ExpressionContext::value(), fx);
+                        Renderer.render_value(output, &plan)
                     }
                 } else if is_order_sensitive(base) {
                     self.emit_left_value_capturing(output, base, rhs_has_setup, fx)
@@ -426,7 +433,8 @@ impl Planner<'_> {
         if force_capture {
             self.emit_force_capture(output, expression, "base", fx)
         } else {
-            self.emit_operand(output, expression, ExpressionContext::value(), fx)
+            let plan = self.plan_operand(expression, ExpressionContext::value(), fx);
+            Renderer.render_value(output, &plan)
         }
     }
 
@@ -448,7 +456,8 @@ impl Planner<'_> {
         if needs_capture {
             self.emit_force_capture(output, index, "idx", fx)
         } else {
-            self.emit_operand(output, index, ExpressionContext::value(), fx)
+            let plan = self.plan_operand(index, ExpressionContext::value(), fx);
+            Renderer.render_value(output, &plan)
         }
     }
 }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -9,7 +9,6 @@ use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
 use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CalleePlan;
 use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
-use crate::plan::values::setup_from_string;
 use crate::types::native::NativeGoType;
 use crate::write_line;
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
@@ -362,12 +361,11 @@ impl Planner<'_> {
             return None;
         }
         let target = WrapperTarget::Slot(&go_identifier);
-        let mut buffer = String::new();
-        self.emit_go_wrapped_call_to(&mut buffer, value, &strategy, binding_ty, target, fx)?;
-        // `open_wrapper_slot` / `emit_simple_wrapper_value` already declared
+        let statements = self.lower_go_wrapped_call_to(value, &strategy, binding_ty, target, fx)?;
+        // `push_wrapper_slot` / `push_simple_wrapper_value` already declared
         // `go_identifier`; only the binding from the user-name still needs setup.
         self.scope.bind(identifier, go_identifier.as_ref());
-        Some(setup_from_string(buffer))
+        Some(statements)
     }
 
     fn lower_let_temp(
@@ -651,10 +649,9 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             })
             .collect();
 
-        let mut setup = String::new();
-        let call_str =
+        let (mut statements, call_str) =
             self.planner
-                .emit_call(&mut setup, self.value, None, ExpressionContext::value(), fx);
+                .lower_call(self.value, None, ExpressionContext::value(), fx);
 
         for (identifier, go_name) in planned.iter().flatten() {
             self.planner.scope.bind(*identifier, go_name);
@@ -662,10 +659,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
         }
 
         let op = if any_new { ":=" } else { "=" };
-        let mut statements = Vec::new();
-        if !setup.is_empty() {
-            statements.push(LoweredStatement::RawGo(setup));
-        }
         statements.push(LoweredStatement::RawGo(format!(
             "{} {} {}\n",
             go_vars.join(", "),

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -10,7 +10,6 @@ use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CalleePlan;
 use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
 use crate::types::native::NativeGoType;
-use crate::write_line;
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
 use syntax::types::{Type, peel_to_range_type};
 
@@ -229,10 +228,11 @@ impl Planner<'_> {
         let mut statements = Vec::new();
         if widens_to_interface {
             let var_ty = self.go_type_string(binding_ty, fx);
-            statements.push(LoweredStatement::RawGo(format!(
-                "var {} {}\n",
-                go_identifier, var_ty
-            )));
+            statements.push(LoweredStatement::VarDecl {
+                name: go_identifier.clone(),
+                go_type: var_ty,
+                value: None,
+            });
             self.declare(&go_identifier);
         }
         statements.extend(self.lower_propagate(inner, Some(&go_identifier), fx).0);
@@ -320,10 +320,11 @@ impl Planner<'_> {
             });
         } else if needs_explicit_type_declaration(self, value, binding_ty) {
             let var_ty = self.go_type_string(binding_ty, fx);
-            statements.push(LoweredStatement::RawGo(format!(
-                "var {} {} = {}\n",
-                go_identifier, var_ty, value_expression
-            )));
+            statements.push(LoweredStatement::VarDecl {
+                name: go_identifier,
+                go_type: var_ty,
+                value: Some(value_expression),
+            });
         } else {
             statements.push(LoweredStatement::TempBind {
                 name: go_identifier,
@@ -377,31 +378,24 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if !self.is_declared(name) {
-            let mut declaration = String::new();
-            self.emit_let_temp_var_declaration(&mut declaration, name, value, binding_ty, fx);
-            if !declaration.is_empty() {
-                statements.push(LoweredStatement::RawGo(declaration));
+            if let Some(declaration) = self.let_temp_var_declaration(name, value, binding_ty, fx) {
+                statements.push(declaration);
             }
             self.try_declare(name);
         }
-        let mut assignment = String::new();
-        self.emit_assign(&mut assignment, value, name, Some(binding_ty), fx);
-        if !assignment.is_empty() {
-            statements.push(LoweredStatement::RawGo(assignment));
-        }
+        statements.extend(self.lower_assign(value, name, Some(binding_ty), fx));
         statements
     }
 
-    fn emit_let_temp_var_declaration(
+    fn let_temp_var_declaration(
         &mut self,
-        output: &mut String,
         name: &str,
         value: &Expression,
         binding_ty: &Type,
         fx: &mut EmitEffects,
-    ) {
+    ) -> Option<LoweredStatement> {
         if name == "_" {
-            return;
+            return None;
         }
         let return_ctx = self.return_ctx();
         let resolved_ty = resolve_let_temp_declaration_ty(self, value, binding_ty);
@@ -426,7 +420,11 @@ impl Planner<'_> {
         } else {
             self.go_type_string(&resolved_ty, fx)
         };
-        write_line!(output, "var {} {}", name, var_ty);
+        Some(LoweredStatement::VarDecl {
+            name: name.to_string(),
+            go_type: var_ty,
+            value: None,
+        })
     }
 }
 
@@ -475,7 +473,11 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 let go_identifier = self.planner.scope.bind(identifier, &raw_go_name);
                 self.planner.try_declare(&go_identifier);
                 let var_ty = self.planner.go_type_string(&self.binding.ty, fx);
-                Some(format!("var {} {}\n", go_identifier, var_ty))
+                Some(Box::new(LoweredStatement::VarDecl {
+                    name: go_identifier,
+                    go_type: var_ty,
+                    value: None,
+                }))
             } else {
                 None
             };


### PR DESCRIPTION
Finishes collapsing the emit crate's string-buffer API into the structured lowered IR.
