### PR TITLE
feat: allow suppressing more lints via `#[allow]`

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -438,6 +438,10 @@ impl LisetteDiagnostic {
         self.code.as_deref()
     }
 
+    pub fn lint_name(&self) -> Option<&str> {
+        self.code.as_deref()?.strip_prefix("lint.")
+    }
+
     pub fn primary_offset(&self) -> usize {
         self.labels.first().map(|l| l.offset()).unwrap_or(0)
     }

--- a/crates/semantics/src/passes/lints/ast_walk/checks/exit_after_defer.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/exit_after_defer.rs
@@ -1,19 +1,11 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{Attribute, AttributeArg, Expression};
-
-const LINT_NAME: &str = "exit_after_defer";
+use syntax::ast::Expression;
 
 pub fn check_exit_after_defer(expression: &Expression, ctx: &NodeCtx) {
-    let Expression::Function {
-        attributes, body, ..
-    } = expression
-    else {
-        return;
+    let body = match expression {
+        Expression::Function { body, .. } | Expression::Lambda { body, .. } => body,
+        _ => return,
     };
-
-    if is_allowed(attributes) {
-        return;
-    }
 
     scan(body, false, ctx);
 }
@@ -60,14 +52,4 @@ fn is_os_exit(callee: &Expression) -> bool {
         return false;
     };
     member.as_str() == "Exit" && receiver.get_type().as_import_namespace() == Some("go:os")
-}
-
-fn is_allowed(attributes: &[Attribute]) -> bool {
-    attributes.iter().any(|attribute| {
-        attribute.name == "allow"
-            && attribute
-                .args
-                .iter()
-                .any(|arg| matches!(arg, AttributeArg::Flag(flag) if flag == LINT_NAME))
-    })
 }

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod attributes;
 pub(crate) mod casing;
 mod checks;
+mod suppression;
 
 use std::sync::{Arc, LazyLock};
 
@@ -90,7 +91,7 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_dup_arg, &[Call]),
             (check_duplicate_cutset, &[Call]),
             (check_waitgroup_add_in_task, &[Function, Lambda]),
-            (check_exit_after_defer, &[Function]),
+            (check_exit_after_defer, &[Function, Lambda]),
             (check_struct_attributes, &[Struct]),
             (check_attributes, &[Function]),
             (check_enum_attributes, &[Enum]),
@@ -153,6 +154,7 @@ pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts) -> Vec<LisetteDiagn
 
 fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
     for file in module.files.values() {
+        let file_sink = LocalSink::new();
         let ctx = NodeCtx {
             store,
             facts,
@@ -160,9 +162,16 @@ fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
             module_id: &module.id,
             source: &file.source,
             is_d_lis: file.is_d_lis(),
-            sink,
+            sink: &file_sink,
             claimed_spans: Default::default(),
         };
         walk_nodes(&file.items, &ctx, &LINT_CHECKS);
+
+        let produced = file_sink.take();
+        if produced.is_empty() {
+            continue;
+        }
+        let allows = suppression::collect_declaration_allows(&file.items);
+        sink.extend(suppression::filter_allowed(produced, &allows));
     }
 }

--- a/crates/semantics/src/passes/lints/ast_walk/suppression.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/suppression.rs
@@ -1,0 +1,61 @@
+use crate::passes::walk::visit_ast;
+use diagnostics::LisetteDiagnostic;
+use syntax::ast::{AttributeArg, Expression, Span};
+
+/// Every declaration carrying `#[allow(...)]`, as (span, allowed lint names); a
+/// diagnostic whose location falls inside such a span is suppressed.
+pub(super) fn collect_declaration_allows(items: &[Expression]) -> Vec<(Span, Vec<String>)> {
+    let mut out = Vec::new();
+    visit_ast(
+        items,
+        &mut |expression| {
+            let flags = allow_flags(expression);
+            if !flags.is_empty() {
+                out.push((expression.get_span(), flags));
+            }
+        },
+        &mut |_| {},
+    );
+    out
+}
+
+fn allow_flags(expression: &Expression) -> Vec<String> {
+    let Expression::Function { attributes, .. } = expression else {
+        return Vec::new();
+    };
+    attributes
+        .iter()
+        .filter(|attribute| attribute.name == "allow")
+        .flat_map(|attribute| {
+            attribute.args.iter().filter_map(|arg| match arg {
+                AttributeArg::Flag(name) => Some(name.clone()),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+pub(super) fn filter_allowed(
+    diagnostics: Vec<LisetteDiagnostic>,
+    allows: &[(Span, Vec<String>)],
+) -> Vec<LisetteDiagnostic> {
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| !is_allowed(diagnostic, allows))
+        .collect()
+}
+
+fn is_allowed(diagnostic: &LisetteDiagnostic, allows: &[(Span, Vec<String>)]) -> bool {
+    let Some(lint_name) = diagnostic.lint_name() else {
+        return false;
+    };
+    let Some(point) = diagnostic.location_offset() else {
+        return false;
+    };
+    let point = point as u32;
+    allows.iter().any(|(span, flags)| {
+        span.byte_offset <= point
+            && point < span.end()
+            && flags.iter().any(|flag| flag == lint_name)
+    })
+}

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -131,16 +131,33 @@ type User struct {
 
 ## Lint suppression
 
-Use `#[allow]` on a function to suppress an unused expression lint on its call sites. 
+`#[allow(lint)]` on a function silences that lint.
 
-Lint rules currently suppressible: `unused_result`, `unused_option`, `unused_literal`, `unused_value`.
+For most lints, place the attribute on the function whose code is flagged:
 
-```rust
+```rs
+#[allow(match_on_bool)]
+fn describe(ready: bool) -> string {
+  match ready {
+    true => "go",
+    false => "wait",
+  }
+}
+```
+
+For the unused-value of lints (namely `unused_result`, `unused_option`, `unused_literal`, and `unused_value`), place `#[allow]` on the function whose result is ignored, so every call to it stops warning.
+
+```rs
 import "go:os"
 
 #[allow(unused_result)]
-fn warm_cache(path: string) {
-  os.ReadFile(path)  // preload file, ignore contents
+fn warm_cache(path: string) -> Result<Slice<byte>, error> {
+  os.ReadFile(path)
+}
+
+fn main() {
+  warm_cache("/config")
+  warm_cache("/data")
 }
 ```
 

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -10033,6 +10033,86 @@ fn main() {
 }
 
 #[test]
+fn exit_after_defer_in_lambda() {
+    assert_lint_snapshot!(
+        r#"
+import "go:os"
+
+fn cleanup() {}
+
+fn main() {
+  let f = || {
+    defer cleanup()
+    os.Exit(1)
+  }
+  f()
+}
+"#
+    );
+}
+
+#[test]
+fn exit_after_defer_in_lambda_allow_on_enclosing_function_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:os"
+
+fn cleanup() {}
+
+#[allow(exit_after_defer)]
+fn main() {
+  let f = || {
+    defer cleanup()
+    os.Exit(1)
+  }
+  f()
+}
+"#
+    );
+}
+
+#[test]
+fn allow_suppresses_ast_walk_lint() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(self_comparison)]
+fn main() {
+  let x = 1
+  let _ = x == x
+}
+"#
+    );
+}
+
+#[test]
+fn allow_suppresses_nested_ast_walk_lint() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(self_comparison)]
+fn main() {
+  let x = 1
+  if x > 0 {
+    let _ = x == x
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn allow_is_lint_specific() {
+    assert_lint_snapshot!(
+        r#"
+#[allow(self_comparison)]
+fn main() {
+  let flag = true
+  let _ = !!flag
+}
+"#
+    );
+}
+
+#[test]
 fn unnecessary_range_loop_read() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/allow_is_lint_specific.snap
+++ b/tests/ui/lint/snapshots/allow_is_lint_specific.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Double boolean negation
+   ╭─[test.lis:5:11]
+ 4 │   let flag = true
+ 5 │   let _ = !!flag
+   ·           ─┬
+   ·            ╰── accidental double negation
+ 6 │ }
+   ╰────
+  help: Remove one of the negation operators · code: [lint.double_bool_negation]

--- a/tests/ui/lint/snapshots/exit_after_defer_in_lambda.snap
+++ b/tests/ui/lint/snapshots/exit_after_defer_in_lambda.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] `os.Exit` skips `defer`
+    ╭─[test.lis:9:5]
+  8 │     defer cleanup()
+  9 │     os.Exit(1)
+    ·     ─────┬────
+    ·          ╰── exits before the `defer` above can run
+ 10 │   }
+    ╰────
+  help: `os.Exit` will terminate the process without running deferred calls. Run the cleanup before exiting instead of deferring it · code: [lint.exit_after_defer]


### PR DESCRIPTION
Extends `#[allow(...)]` to suppress any lint, not just the `unused_*` family. Placing `#[allow(<lint>)]` on a function now silences that lint anywhere in the function body, including inside closures.

```rs
#[allow(match_on_bool)]
fn describe(ready: bool) -> string {
  match ready {
    true => "go",
    false => "wait",
  }
}
```
