### PR TITLE
refactor!: rename `--debug` to `--sourcemap`

### DIFF
--- a/crates/benchmark/benches/emit.rs
+++ b/crates/benchmark/benches/emit.rs
@@ -27,7 +27,7 @@ fn bench_small(c: &mut Criterion) {
             Planner::emit(
                 black_box(&emit_input),
                 black_box("bench"),
-                EmitOptions { debug: false },
+                EmitOptions { sourcemap: false },
             )
         });
     });
@@ -51,7 +51,7 @@ fn bench_stress(c: &mut Criterion, n_modules: usize) {
             Planner::emit(
                 black_box(&emit_input),
                 black_box("bench"),
-                EmitOptions { debug: false },
+                EmitOptions { sourcemap: false },
             )
         });
     });

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -7,16 +7,16 @@ pub enum Command {
     },
     Build {
         path: Option<String>,
-        debug: bool,
+        sourcemap: bool,
     },
     Emit {
         path: Option<String>,
-        debug: bool,
+        sourcemap: bool,
     },
     Run {
         target: Option<String>,
         args: Vec<String>,
-        debug: bool,
+        sourcemap: bool,
         go_flags: Vec<String>,
     },
     Format {
@@ -72,19 +72,19 @@ pub enum ParseError {
     },
 }
 
-fn parse_path_and_debug(
+fn parse_path_and_sourcemap(
     arguments: impl Iterator<Item = String>,
 ) -> Result<(Option<String>, bool), ParseError> {
     let mut path = None;
-    let mut debug = false;
+    let mut sourcemap = false;
     for arg in arguments {
         match arg.as_str() {
-            "--debug" => debug = true,
+            "--sourcemap" => sourcemap = true,
             s if s.starts_with('-') => return Err(ParseError::UnknownFlag(s.to_string())),
             s => path = Some(s.to_string()),
         }
     }
-    Ok((path, debug))
+    Ok((path, sourcemap))
 }
 
 fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseError> {
@@ -142,19 +142,19 @@ impl Command {
             },
 
             "build" | "b" => {
-                let (path, debug) = parse_path_and_debug(arguments)?;
-                Ok(Command::Build { path, debug })
+                let (path, sourcemap) = parse_path_and_sourcemap(arguments)?;
+                Ok(Command::Build { path, sourcemap })
             }
 
             "emit" | "e" => {
-                let (path, debug) = parse_path_and_debug(arguments)?;
-                Ok(Command::Emit { path, debug })
+                let (path, sourcemap) = parse_path_and_sourcemap(arguments)?;
+                Ok(Command::Emit { path, sourcemap })
             }
 
             "run" | "r" => {
                 let mut target = None;
                 let mut args = Vec::new();
-                let mut debug = false;
+                let mut sourcemap = false;
                 let mut go_flags = Vec::new();
                 let mut found_separator = false;
 
@@ -163,8 +163,8 @@ impl Command {
                         args.push(arg);
                     } else if arg == "--" {
                         found_separator = true;
-                    } else if arg == "--debug" {
-                        debug = true;
+                    } else if arg == "--sourcemap" {
+                        sourcemap = true;
                     } else if arg == "--go-flags" {
                         let Some(value) = arguments.next() else {
                             return Err(ParseError::MissingArgument {
@@ -195,7 +195,7 @@ impl Command {
                 Ok(Command::Run {
                     target,
                     args,
-                    debug,
+                    sourcemap,
                     go_flags,
                 })
             }
@@ -553,12 +553,13 @@ mod tests {
     }
 
     #[test]
-    fn emit_parses_path_and_debug() {
-        let Ok(Command::Emit { path, debug }) = parse(&["lis", "emit", "src", "--debug"]) else {
+    fn emit_parses_path_and_sourcemap() {
+        let Ok(Command::Emit { path, sourcemap }) = parse(&["lis", "emit", "src", "--sourcemap"])
+        else {
             panic!("expected Emit command");
         };
         assert_eq!(path.as_deref(), Some("src"));
-        assert!(debug);
+        assert!(sourcemap);
     }
 
     #[test]

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -11,15 +11,15 @@ use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 
-pub fn emit(path: Option<String>, debug: bool) -> i32 {
-    compile_project(path, debug, false, "Emit")
+pub fn emit(path: Option<String>, sourcemap: bool) -> i32 {
+    compile_project(path, sourcemap, false, "Emit")
 }
 
-pub fn build(path: Option<String>, debug: bool, quiet: bool) -> i32 {
-    compile_project(path, debug, quiet, "Build")
+pub fn build(path: Option<String>, sourcemap: bool, quiet: bool) -> i32 {
+    compile_project(path, sourcemap, quiet, "Build")
 }
 
-fn compile_project(path: Option<String>, debug: bool, quiet: bool, label: &str) -> i32 {
+fn compile_project(path: Option<String>, sourcemap: bool, quiet: bool, label: &str) -> i32 {
     let project_root = path.unwrap_or_else(|| ".".to_string());
     let project_path = Path::new(&project_root);
 
@@ -33,7 +33,7 @@ fn compile_project(path: Option<String>, debug: bool, quiet: bool, label: &str) 
         Err(code) => return code,
     };
 
-    build_locked(&prep, debug, quiet, label)
+    build_locked(&prep, sourcemap, quiet, label)
 }
 
 pub(super) fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
@@ -80,7 +80,7 @@ pub(super) struct BuildPrep {
     pub locator: deps::TypedefLocator,
 }
 
-pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &str) -> i32 {
+pub(super) fn build_locked(prep: &BuildPrep, sourcemap: bool, quiet: bool, label: &str) -> i32 {
     let start = Instant::now();
 
     if let Err(e) =
@@ -147,7 +147,7 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &s
         go_module: go_module_name.to_string(),
         standalone_mode: false,
         load_siblings: true,
-        debug,
+        sourcemap,
         project_root: Some(prep.project_path.clone()),
         locator: locator.clone(),
     };
@@ -189,7 +189,7 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &s
 
     let heading = "Failed to compile Lisette project to Go";
 
-    if debug
+    if sourcemap
         && let Err(e) = semantics::cache::apply_emit_stamps(
             &prep.project_path,
             &result
@@ -201,7 +201,7 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &s
     {
         cli_error!(
             heading,
-            format!("Failed to invalidate emit stamps before debug write: {e}"),
+            format!("Failed to invalidate emit stamps before sourcemap write: {e}"),
             "Check file permissions on `target/cache`, or delete the directory and retry"
         );
         return 1;
@@ -267,7 +267,7 @@ pub(super) fn build_locked(prep: &BuildPrep, debug: bool, quiet: bool, label: &s
         return 1;
     }
 
-    if !debug
+    if !sourcemap
         && let Err(e) = semantics::cache::apply_emit_stamps(
             &prep.project_path,
             &result

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -207,7 +207,7 @@ fn compile_single_file(
         go_module: "main".to_string(),
         standalone_mode: !load_siblings,
         load_siblings,
-        debug: false,
+        sourcemap: false,
         project_root: locator.project_root().map(|p| p.to_path_buf()),
         locator,
     };

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -44,15 +44,15 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         build)
-            COMPREPLY=( $(compgen -W "--debug" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--sourcemap" -- "$cur") )
             return 0
             ;;
         emit)
-            COMPREPLY=( $(compgen -W "--debug" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--sourcemap" -- "$cur") )
             return 0
             ;;
         run)
-            COMPREPLY=( $(compgen -W "--debug --go-flags" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--sourcemap --go-flags" -- "$cur") )
             return 0
             ;;
         format)
@@ -119,14 +119,14 @@ _lis() {
         args)
             case "$words[1]" in
                 build)
-                    _arguments '--debug[Include line directives for stack traces]'
+                    _arguments '--sourcemap[Include line directives for stack traces]'
                     ;;
                 emit)
-                    _arguments '--debug[Include line directives for stack traces]'
+                    _arguments '--sourcemap[Include line directives for stack traces]'
                     ;;
                 run)
                     _arguments \
-                        '--debug[Include line directives for stack traces]' \
+                        '--sourcemap[Include line directives for stack traces]' \
                         '--go-flags[Flags passed through to go build]:flags'
                     ;;
                 format)
@@ -175,9 +175,9 @@ complete -c lis -n __fish_use_subcommand -a learn -d 'Create a new sample projec
 complete -c lis -n __fish_use_subcommand -a complete -d 'Shell completion scripts'
 complete -c lis -n __fish_use_subcommand -a lsp -d 'Start the language server'
 
-complete -c lis -n '__fish_seen_subcommand_from build' -l debug -d 'Include line directives for stack traces'
-complete -c lis -n '__fish_seen_subcommand_from emit' -l debug -d 'Include line directives for stack traces'
-complete -c lis -n '__fish_seen_subcommand_from run' -l debug -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from build' -l sourcemap -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from emit' -l sourcemap -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from run' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -77,12 +77,12 @@ Arguments:
     [path]     Path to project dir (default: current dir)
 
 Options:
-    `--debug`    Include `//line` directives in generated Go code for stack traces
+    `--sourcemap`    Include `//line` directives in generated Go code for stack traces
 
 Examples:
     `lis build`                          Build project in current dir
     `lis build` {path/to/project/dir:g}      Build project in specific dir
-    `lis build` {--debug:g}                  Build with source mapping directives",
+    `lis build` {--sourcemap:g}              Build with source mapping directives",
         ),
 
         "emit" | "e" => print_help(
@@ -94,12 +94,12 @@ Arguments:
     [path]     Path to project dir (default: current dir)
 
 Options:
-    `--debug`    Include `//line` directives in generated Go code for stack traces
+    `--sourcemap`    Include `//line` directives in generated Go code for stack traces
 
 Examples:
     `lis emit`                          Emit Go for project in current dir
     `lis emit` {path/to/project/dir:g}      Emit Go for project in specific dir
-    `lis emit` {--debug:g}                  Emit with source mapping directives",
+    `lis emit` {--sourcemap:g}              Emit with source mapping directives",
         ),
 
         "run" | "r" => print_help(
@@ -112,7 +112,7 @@ Arguments:
     [args]      Arguments to pass to the program (after --)
 
 Options:
-    `--debug`     Include `//line` directives in generated Go code for stack traces
+    `--sourcemap`    Include `//line` directives in generated Go code for stack traces
 
 Examples:
     `lis run`                            Run project in current dir

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -36,7 +36,12 @@ fn build_and_exec(
     }
 }
 
-pub fn run(target: Option<String>, args: Vec<String>, debug: bool, go_flags: Vec<String>) -> i32 {
+pub fn run(
+    target: Option<String>,
+    args: Vec<String>,
+    sourcemap: bool,
+    go_flags: Vec<String>,
+) -> i32 {
     if let Err(code) = crate::go_cli::require_go() {
         return code;
     }
@@ -44,13 +49,13 @@ pub fn run(target: Option<String>, args: Vec<String>, debug: bool, go_flags: Vec
     let target = target.unwrap_or_else(|| ".".to_string());
 
     if target.ends_with(".lis") {
-        run_standalone(&target, args, debug, &go_flags)
+        run_standalone(&target, args, sourcemap, &go_flags)
     } else {
-        run_project(&target, args, debug, &go_flags)
+        run_project(&target, args, sourcemap, &go_flags)
     }
 }
 
-fn run_project(path: &str, args: Vec<String>, debug: bool, go_flags: &[String]) -> i32 {
+fn run_project(path: &str, args: Vec<String>, sourcemap: bool, go_flags: &[String]) -> i32 {
     let project_path = Path::new(path);
 
     let prep = match super::build::prepare_project_build(project_path) {
@@ -69,7 +74,7 @@ fn run_project(path: &str, args: Vec<String>, debug: bool, go_flags: &[String]) 
     let target = stdlib::Target::host();
     let binary_name = go_cli::binary_name(&prep.manifest.project.name, target);
 
-    let build_result = super::build::build_locked(&prep, debug, true, "Build");
+    let build_result = super::build::build_locked(&prep, sourcemap, true, "Build");
     if build_result != 0 {
         return build_result;
     }
@@ -90,7 +95,7 @@ fn run_project(path: &str, args: Vec<String>, debug: bool, go_flags: &[String]) 
     build_and_exec(&build_dir, &output_path, &args, go_flags, heading, target)
 }
 
-fn run_standalone(file: &str, args: Vec<String>, debug: bool, go_flags: &[String]) -> i32 {
+fn run_standalone(file: &str, args: Vec<String>, sourcemap: bool, go_flags: &[String]) -> i32 {
     let file_path = Path::new(file);
 
     if !file_path.exists() {
@@ -149,7 +154,7 @@ fn run_standalone(file: &str, args: Vec<String>, debug: bool, go_flags: &[String
         go_module: "lis-standalone".to_string(),
         standalone_mode: true,
         load_siblings: false,
-        debug,
+        sourcemap,
         project_root: None,
         locator: deps::TypedefLocator::default(),
     };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -58,14 +58,14 @@ fn main() {
 
     let exit_code = match command {
         Command::New { name } => handlers::new_project(&name),
-        Command::Build { path, debug } => handlers::build(path, debug, false),
-        Command::Emit { path, debug } => handlers::emit(path, debug),
+        Command::Build { path, sourcemap } => handlers::build(path, sourcemap, false),
+        Command::Emit { path, sourcemap } => handlers::emit(path, sourcemap),
         Command::Run {
             target,
             args,
-            debug,
+            sourcemap,
             go_flags,
-        } => handlers::run(target, args, debug, go_flags),
+        } => handlers::run(target, args, sourcemap, go_flags),
         Command::Format { path, check } => handlers::format(path, check),
         Command::Check {
             path,

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -25,7 +25,7 @@ pub struct CompileConfig {
     pub go_module: String,
     pub standalone_mode: bool,
     pub load_siblings: bool,
-    pub debug: bool,
+    pub sourcemap: bool,
     pub project_root: Option<PathBuf>,
     pub locator: TypedefLocator,
 }
@@ -70,7 +70,7 @@ pub fn compile(
         };
     }
 
-    let disable_cache = config.debug && config.target_phase == CompilePhase::Emit;
+    let disable_cache = config.sourcemap && config.target_phase == CompilePhase::Emit;
 
     let analyze_output = analyze(AnalyzeInput {
         config: SemanticConfig {
@@ -133,7 +133,7 @@ pub fn compile(
         &semantic_result.into_emit_input(),
         &config.go_module,
         EmitOptions {
-            debug: config.debug,
+            sourcemap: config.sourcemap,
         },
     );
 
@@ -180,7 +180,7 @@ mod tests {
             go_module: "test".to_string(),
             standalone_mode: false,
             load_siblings: true,
-            debug: false,
+            sourcemap: false,
             project_root: Some(project_dir.to_path_buf()),
             locator,
         };

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -213,8 +213,8 @@ impl<'a> EmitFacts<'a> {
         self.globals.go_call_strategies.get(qualified_name)
     }
 
-    pub(crate) fn debug_enabled(&self) -> bool {
-        self.options.debug
+    pub(crate) fn sourcemap_enabled(&self) -> bool {
+        self.options.sourcemap
     }
 
     pub(crate) fn line_index(&self, file_id: u32) -> Option<&LineIndex> {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -54,7 +54,7 @@ use syntax::types::{Symbol, Type};
 
 #[derive(Clone, Debug, Default)]
 pub struct EmitOptions {
-    pub debug: bool,
+    pub sourcemap: bool,
 }
 
 #[derive(Default)]
@@ -223,7 +223,7 @@ impl<'a> Planner<'a> {
 
 impl<'a> Planner<'a> {
     pub fn emit(analysis: &'a EmitInput, go_module: &str, options: EmitOptions) -> Vec<OutputFile> {
-        let line_indexes: Arc<HashMap<u32, LineIndex>> = Arc::new(if options.debug {
+        let line_indexes: Arc<HashMap<u32, LineIndex>> = Arc::new(if options.sourcemap {
             analysis
                 .files
                 .iter()
@@ -270,7 +270,7 @@ impl<'a> Planner<'a> {
     }
 
     pub fn new_for_tests(config: &TestEmitConfig<'a>, source: Option<&str>) -> Self {
-        let (debug, line_indexes) = match source {
+        let (sourcemap, line_indexes) = match source {
             Some(src) => (
                 true,
                 Arc::new(HashMap::from_iter([(
@@ -290,7 +290,7 @@ impl<'a> Planner<'a> {
             go_module_ids: config.go_module_ids,
             entry_module: config.module_id.to_string(),
             go_module: config.go_module.to_string(),
-            options: EmitOptions { debug },
+            options: EmitOptions { sourcemap },
             line_indexes,
             globals,
             generic_base: Arc::new(OnceLock::new()),
@@ -454,7 +454,7 @@ impl<'a> Planner<'a> {
     }
 
     pub(crate) fn maybe_line_directive(&self, span: &Span) -> String {
-        if !self.facts.debug_enabled() || span.is_dummy() {
+        if !self.facts.sourcemap_enabled() || span.is_dummy() {
             return String::new();
         }
 

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -370,7 +370,7 @@ pub(crate) struct LoopPlan {
 }
 
 pub(crate) struct IfPlan {
-    /// Empty unless debug; set only on the leading `if`, never on nested
+    /// Empty unless sourcemap; set only on the leading `if`, never on nested
     /// `else if`s.
     pub(crate) directive: String,
     /// Side-effecting setup hoisted before the `if` condition (temps from a

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -58,7 +58,7 @@ pub struct AnalyzeInput<'a> {
     /// hash so a project rename invalidates Go outputs.
     pub go_module: String,
     /// When true, `analyze` skips both cache load and save. Set by the CLI for
-    /// `--debug` Emit so cwd-decorated Go files are not reused across cwds.
+    /// `--sourcemap` Emit so cwd-decorated Go files are not reused across cwds.
     pub disable_cache: bool,
 }
 

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -119,7 +119,7 @@ pub struct EmitStamp {
     pub artifact_hash: u64,
 }
 
-/// Hash over the non-debug Go-artifact inputs for one module.
+/// Hash over the non-sourcemap Go-artifact inputs for one module.
 pub fn compute_emit_artifact_hash(source_hash: u64, go_module: &str) -> u64 {
     let mut hasher = FnvHasher::new();
     source_hash.hash(&mut hasher);
@@ -392,7 +392,7 @@ fn cached_file_display_path(project_root: &Path, module_id: &str, bare_name: &st
 
 /// Set or clear the `emit_stamp` for each module's cache file. Missing files
 /// are skipped; undecodable (e.g. pre-bump) files are unlinked and skipped;
-/// other read errors propagate so the debug pre-write clear can hard-fail
+/// other read errors propagate so the sourcemap pre-write clear can hard-fail
 /// rather than leave a stale stamp over freshly-overwritten Go.
 pub fn apply_emit_stamps(
     project_root: &Path,
@@ -772,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    fn try_load_cache_rejects_after_debug_invalidation() {
+    fn try_load_cache_rejects_after_sourcemap_invalidation() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("target").join("cache")).unwrap();

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -12,7 +12,7 @@ pub struct File {
     /// Stable bare filename (e.g. `greet.lis`); identity key for caching and
     /// LSP path reconstruction.
     pub name: String,
-    /// Cwd-relative path for diagnostics and `--debug` directives; equals
+    /// Cwd-relative path for diagnostics and `--sourcemap` directives; equals
     /// `name` for synthetic/test loaders that have no notion of cwd.
     pub display_path: String,
     pub source: String,

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -189,7 +189,7 @@ fn emit_and_write(
     let files = Planner::emit(
         &result.into_emit_input(),
         &module,
-        EmitOptions { debug: false },
+        EmitOptions { sourcemap: false },
     );
     let dir = work.join("emitted");
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -94,7 +94,7 @@ pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLoc
 pub fn compile_project_files(
     fs: MockFileSystem,
     go_module: &str,
-    debug: bool,
+    sourcemap: bool,
 ) -> Vec<emit::OutputFile> {
     let main_source = fs
         .scan_folder(ENTRY_MODULE_ID)
@@ -137,7 +137,7 @@ pub fn compile_project_files(
     Planner::emit(
         &analysis.into_emit_input(),
         go_module,
-        EmitOptions { debug },
+        EmitOptions { sourcemap },
     )
 }
 

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -3,7 +3,7 @@ use syntax::program::File;
 
 use super::pipeline::TestPipeline;
 
-pub fn emit_with_debug_info(raw_source: &str) -> EmitResult {
+pub fn emit_with_sourcemap(raw_source: &str) -> EmitResult {
     emit_inner(raw_source, Some(raw_source), &[])
 }
 
@@ -17,7 +17,7 @@ pub fn emit_with_go_typedefs(raw_source: &str, typedefs: &[(&str, &str)]) -> Emi
 
 fn emit_inner(
     raw_source: &str,
-    source_for_debug: Option<&str>,
+    source_for_sourcemap: Option<&str>,
     extra_go_typedefs: &[(&str, &str)],
 ) -> EmitResult {
     let mut pipeline = TestPipeline::new(raw_source).wrapped();
@@ -37,7 +37,7 @@ fn emit_inner(
         module_id: result.module_id.clone(),
         name: "test.lis".to_string(),
         display_path: "src/test.lis".to_string(),
-        source: source_for_debug.unwrap_or("").to_string(),
+        source: source_for_sourcemap.unwrap_or("").to_string(),
         items: result.ast,
     };
 
@@ -51,7 +51,7 @@ fn emit_inner(
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
     };
-    let mut emitter = Planner::new_for_tests(&config, source_for_debug);
+    let mut emitter = Planner::new_for_tests(&config, source_for_sourcemap);
     let emitted_files = emitter.emit_files(&[&file], &result.module_id);
 
     EmitResult {

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -10,7 +10,7 @@ pub mod pipeline;
 pub mod wrap;
 
 pub use builders::*;
-pub use emit::emit_with_debug_info;
+pub use emit::emit_with_sourcemap;
 pub use filesystem::MockFileSystem;
 pub use formatting::snapshot_description;
 pub use infer::{InferResult, infer, infer_module, infer_with_go_typedefs};

--- a/tests/spec/emit/line_directives.rs
+++ b/tests/spec/emit/line_directives.rs
@@ -1,9 +1,9 @@
-use crate::_harness::emit_with_debug_info;
+use crate::_harness::emit_with_sourcemap;
 
 #[test]
 fn emits_line_directive_for_function_definition() {
     let input = "fn foo() -> int { 42 }";
-    let result = emit_with_debug_info(input);
+    let result = emit_with_sourcemap(input);
     let go_code = result.go_code();
     assert!(
         go_code.contains("//line src/test.lis:1"),
@@ -20,7 +20,7 @@ fn main() {
   let y = 2
 }
 "#;
-    let result = emit_with_debug_info(input);
+    let result = emit_with_sourcemap(input);
     let go_code = result.go_code();
     assert!(
         go_code.contains("//line src/test.lis:3"),
@@ -41,7 +41,7 @@ fn main() {
   let f = || 42
 }
 "#;
-    let result = emit_with_debug_info(input);
+    let result = emit_with_sourcemap(input);
     let go_code = result.go_code();
     assert!(
         go_code.contains("//line src/test.lis:3"),
@@ -53,7 +53,7 @@ fn main() {
 #[test]
 fn line_directive_includes_column() {
     let input = "fn main() { let x = 1 }";
-    let result = emit_with_debug_info(input);
+    let result = emit_with_sourcemap(input);
     let go_code = result.go_code();
     assert!(
         go_code.contains("//line src/test.lis:1:13"),


### PR DESCRIPTION
Renames the source-mapping flag from `--debug` to `--sourcemap` on `emit`, `build`, and `run`. When set, the generated Go carries `//line` directives so that panics and stack traces point at `.lis` source instead of `target/*.go`.
