### PR TITLE
feat: warn on use of deprecated Go APIs

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -860,6 +860,13 @@ pub fn waitgroup_add_in_task(span: &Span) -> LisetteDiagnostic {
         )
 }
 
+pub fn deprecated_api(span: &Span, message: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Use of deprecated API")
+        .with_lint_code("deprecated")
+        .with_span_label(span, "deprecated")
+        .with_help(message)
+}
+
 pub fn exit_after_defer(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("`os.Exit` skips `defer`")
         .with_lint_code("exit_after_defer")

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -190,10 +190,13 @@ impl TaskState<'_> {
         let mut static_methods: Vec<(String, Type)> = Vec::new();
 
         for function in functions {
-            let fn_attrs = if let Expression::Function { attributes, .. } = function {
-                attributes.as_slice()
+            let (fn_attrs, fn_doc) = if let Expression::Function {
+                attributes, doc, ..
+            } = function
+            {
+                (attributes.as_slice(), doc.clone())
             } else {
-                &[]
+                (&[][..], None)
             };
             let fn_visibility = if let Expression::Function { visibility, .. } = function
                 && (*visibility == SyntacticVisibility::Public || self.is_d_lis(&*store))
@@ -282,7 +285,7 @@ impl TaskState<'_> {
                     ty: method_ty,
                     name: None,
                     name_span: Some(fn_sig.name_span),
-                    doc: None,
+                    doc: fn_doc,
                     body: DefinitionBody::Value {
                         allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
                         go_hints,
@@ -324,14 +327,25 @@ impl TaskState<'_> {
 
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
-        let mut method_defs: Vec<(EcoString, Type, Vec<String>, Vec<String>)> = Vec::new();
+        struct MethodDef {
+            name: EcoString,
+            ty: Type,
+            go_hints: Vec<String>,
+            allowed_lints: Vec<String>,
+            name_span: Span,
+            doc: Option<String>,
+        }
+        let mut method_defs: Vec<MethodDef> = Vec::new();
         let methods = fn_expressions
             .iter()
             .map(|fe| {
-                let fn_attrs = if let Expression::Function { attributes, .. } = fe {
-                    attributes.as_slice()
+                let (fn_attrs, fn_doc) = if let Expression::Function {
+                    attributes, doc, ..
+                } = fe
+                {
+                    (attributes.as_slice(), doc.clone())
                 } else {
-                    &[]
+                    (&[][..], None)
                 };
                 let method_sig = fe.to_function_signature();
                 let fn_ty = self.extract_signature_parts(
@@ -382,12 +396,14 @@ impl TaskState<'_> {
                         fn_ty,
                     )
                 } else {
-                    method_defs.push((
-                        method_sig.name.clone(),
-                        fn_ty.clone(),
+                    method_defs.push(MethodDef {
+                        name: method_sig.name.clone(),
+                        ty: fn_ty.clone(),
                         go_hints,
-                        extract_attribute_flags(fn_attrs, "allow"),
-                    ));
+                        allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
+                        name_span: method_sig.name_span,
+                        doc: fn_doc,
+                    });
                     (method_sig.name, fn_ty)
                 }
             })
@@ -434,19 +450,19 @@ impl TaskState<'_> {
         // Register interface methods as Definition::Value entries so the emitter
         // can look up their go_hints (e.g., comma_ok) by qualified name.
         // Methods inherit the interface's visibility — a `pub interface`'s methods are implicitly public.
-        for (method_name, method_ty, go_hints, allowed_lints) in method_defs {
-            let method_qualified_name = format!("{}.{}.{}", module_id, interface_name, method_name);
+        for method in method_defs {
+            let method_qualified_name = format!("{}.{}.{}", module_id, interface_name, method.name);
             module.definitions.insert(
                 method_qualified_name.into(),
                 Definition {
                     visibility: visibility.clone(),
-                    ty: method_ty,
+                    ty: method.ty,
                     name: None,
-                    name_span: None, // Interface method signatures; span tracked in Interface definition
-                    doc: None,
+                    name_span: Some(method.name_span),
+                    doc: method.doc,
                     body: DefinitionBody::Value {
-                        allowed_lints,
-                        go_hints,
+                        allowed_lints: method.allowed_lints,
+                        go_hints: method.go_hints,
                         go_name: None,
                         const_value: None,
                     },

--- a/crates/semantics/src/passes/lints/ast_walk/deprecation.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/deprecation.rs
@@ -1,0 +1,80 @@
+use diagnostics::LocalSink;
+use rustc_hash::FxHashMap as HashMap;
+use syntax::ast::Span;
+use syntax::types::Type;
+
+use crate::facts::Usage;
+use crate::store::Store;
+
+pub(super) fn build_index(store: &Store) -> HashMap<Span, String> {
+    let mut index = HashMap::default();
+    for module in store.modules.values() {
+        for definition in module.definitions.values() {
+            if !is_function_type(&definition.ty) {
+                continue;
+            }
+            let Some(name_span) = definition.name_span() else {
+                continue;
+            };
+            let Some(doc) = definition.doc() else {
+                continue;
+            };
+            if let Some(message) = deprecation_message(doc) {
+                index.insert(name_span, message);
+            }
+        }
+    }
+    index
+}
+
+fn is_function_type(ty: &Type) -> bool {
+    match ty {
+        Type::Function(_) => true,
+        Type::Forall { body, .. } => is_function_type(body),
+        _ => false,
+    }
+}
+
+pub(super) fn sweep(usages: &[&Usage], index: &HashMap<Span, String>, sink: &LocalSink) {
+    for usage in usages {
+        if let Some(message) = index.get(&usage.definition_span) {
+            sink.push(diagnostics::lint::deprecated_api(
+                &usage.usage_span,
+                message,
+            ));
+        }
+    }
+}
+
+fn deprecation_message(doc: &str) -> Option<String> {
+    if !doc.contains("Deprecated:") {
+        return None;
+    }
+
+    let mut paragraph = doc
+        .lines()
+        .map(str::trim)
+        .skip_while(|line| !line.starts_with("Deprecated:"))
+        .take_while(|line| !line.is_empty());
+
+    let mut message = paragraph
+        .next()?
+        .trim_start_matches("Deprecated:")
+        .trim()
+        .to_string();
+    for line in paragraph {
+        message.push(' ');
+        message.push_str(line);
+    }
+
+    if message.is_empty() {
+        return None;
+    }
+
+    let mut chars = message.chars();
+    let capitalized = match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => message,
+    };
+    Some(capitalized)
+}

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -1,17 +1,20 @@
 pub(crate) mod attributes;
 pub(crate) mod casing;
 mod checks;
+mod deprecation;
 mod suppression;
 
 use std::sync::{Arc, LazyLock};
 
 use crate::context::AnalysisContext;
-use crate::facts::Facts;
+use crate::facts::{Facts, Usage};
 use crate::passes::PARALLEL_THRESHOLD;
 use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
 use crate::store::Store;
 use diagnostics::{LisetteDiagnostic, LocalSink};
 use rayon::prelude::*;
+use rustc_hash::FxHashMap as HashMap;
+use syntax::ast::Span;
 use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
@@ -124,6 +127,17 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
 pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts) -> Vec<LisetteDiagnostic> {
     let store = analysis.store;
 
+    let deprecated = deprecation::build_index(store);
+    let mut usages_by_file: HashMap<u32, Vec<&Usage>> = HashMap::default();
+    if !deprecated.is_empty() {
+        for usage in &facts.usages {
+            usages_by_file
+                .entry(usage.usage_span.file_id)
+                .or_default()
+                .push(usage);
+        }
+    }
+
     let mut modules: Vec<&Module> = store
         .modules
         .values()
@@ -135,7 +149,7 @@ pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts) -> Vec<LisetteDiagn
     if modules.len() < PARALLEL_THRESHOLD {
         let sink = LocalSink::new();
         for module in &modules {
-            run_module(module, store, facts, &sink);
+            run_module(module, store, facts, &sink, &deprecated, &usages_by_file);
         }
         return sink.take();
     }
@@ -144,15 +158,29 @@ pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts) -> Vec<LisetteDiagn
         .par_iter()
         .map(|module| {
             let local_sink = LocalSink::new();
-            run_module(module, store, facts, &local_sink);
+            run_module(
+                module,
+                store,
+                facts,
+                &local_sink,
+                &deprecated,
+                &usages_by_file,
+            );
             local_sink
         })
         .collect();
     LocalSink::merge(worker_sinks)
 }
 
-fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
-    for file in module.files.values() {
+fn run_module(
+    module: &Module,
+    store: &Store,
+    facts: &Facts,
+    sink: &LocalSink,
+    deprecated: &HashMap<Span, String>,
+    usages_by_file: &HashMap<u32, Vec<&Usage>>,
+) {
+    for (file_id, file) in &module.files {
         let file_sink = LocalSink::new();
         let ctx = NodeCtx {
             store,
@@ -165,6 +193,10 @@ fn run_module(module: &Module, store: &Store, facts: &Facts, sink: &LocalSink) {
             claimed_spans: Default::default(),
         };
         walk_nodes(&file.items, &ctx, &LINT_CHECKS);
+
+        if let Some(usages) = usages_by_file.get(file_id) {
+            deprecation::sweep(usages, deprecated, &file_sink);
+        }
 
         let produced = file_sink.take();
         if produced.is_empty() {

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9892,6 +9892,179 @@ fn main() {
 }
 
 #[test]
+fn deprecated_function() {
+    assert_lint_snapshot!(
+        r#"
+/// Deprecated: use the new API instead.
+fn legacy() -> int {
+  42
+}
+
+fn main() {
+  let _ = legacy()
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_method() {
+    assert_lint_snapshot!(
+        r#"
+struct Cache {}
+
+impl Cache {
+  /// Deprecated: use the new method instead.
+  fn warm(self) -> int {
+    1
+  }
+}
+
+fn main() {
+  let c = Cache {}
+  let _ = c.warm()
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_function_value() {
+    assert_lint_snapshot!(
+        r#"
+/// Deprecated: use the new API instead.
+fn legacy() -> int {
+  42
+}
+
+fn main() {
+  let f = legacy
+  let _ = f()
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_promoted_method() {
+    assert_lint_snapshot!(
+        r#"
+pub struct Logger {
+  pub prefix: string,
+}
+
+impl Logger {
+  /// Deprecated: use the new method instead.
+  pub fn old_log(self) -> string {
+    self.prefix
+  }
+}
+
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+
+fn main() {
+  let s = Server { Logger: Logger { prefix: "[api]" }, port: 8080 }
+  let _ = s.old_log()
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_interface_method() {
+    assert_lint_snapshot!(
+        r#"
+interface Store {
+  /// Deprecated: use `fetch` instead.
+  fn old_get(self) -> int
+}
+
+struct Db {}
+
+impl Db {
+  fn old_get(self) -> int {
+    1
+  }
+}
+
+fn read(s: Store) -> int {
+  s.old_get()
+}
+
+fn main() {
+  let _ = read(Db {})
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_go_stdlib_function() {
+    assert_lint_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let _ = strings.Title("hello world")
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_type_use_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+/// Deprecated: use NewType instead.
+pub struct OldType {
+  pub x: int,
+}
+
+fn make() -> OldType {
+  OldType { x: 1 }
+}
+
+fn main() {
+  let _ = make()
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_non_deprecated_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let _ = strings.ToLower("HELLO")
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_allow_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+/// Deprecated: use the new API instead.
+fn legacy() -> int {
+  42
+}
+
+#[allow(deprecated)]
+fn main() {
+  let _ = legacy()
+}
+"#
+    );
+}
+
+#[test]
 fn exit_after_defer() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/deprecated_function.snap
+++ b/tests/ui/lint/snapshots/deprecated_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+   ╭─[test.lis:8:11]
+ 7 │ fn main() {
+ 8 │   let _ = legacy()
+   ·           ───┬──
+   ·              ╰── deprecated
+ 9 │ }
+   ╰────
+  help: Use the new API instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_function_value.snap
+++ b/tests/ui/lint/snapshots/deprecated_function_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+   ╭─[test.lis:8:11]
+ 7 │ fn main() {
+ 8 │   let f = legacy
+   ·           ───┬──
+   ·              ╰── deprecated
+ 9 │   let _ = f()
+   ╰────
+  help: Use the new API instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_go_stdlib_function.snap
+++ b/tests/ui/lint/snapshots/deprecated_go_stdlib_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let _ = strings.Title("hello world")
+   ·           ──────┬──────
+   ·                 ╰── deprecated
+ 6 │ }
+   ╰────
+  help: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_interface_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_interface_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+    ╭─[test.lis:16:3]
+ 15 │ fn read(s: Store) -> int {
+ 16 │   s.old_get()
+    ·   ────┬────
+    ·       ╰── deprecated
+ 17 │ }
+    ╰────
+  help: Use `fetch` instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+    ╭─[test.lis:13:11]
+ 12 │   let c = Cache {}
+ 13 │   let _ = c.warm()
+    ·           ───┬──
+    ·              ╰── deprecated
+ 14 │ }
+    ╰────
+  help: Use the new method instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_promoted_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_promoted_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Use of deprecated API
+    ╭─[test.lis:20:11]
+ 19 │   let s = Server { Logger: Logger { prefix: "[api]" }, port: 8080 }
+ 20 │   let _ = s.old_log()
+    ·           ────┬────
+    ·               ╰── deprecated
+ 21 │ }
+    ╰────
+  help: Use the new method instead · code: [lint.deprecated]


### PR DESCRIPTION
Adds a warning when using a Go function or method marked `// Deprecated:`, surfacing the deprecation note as the help text. Covers stdlib and user-defined functions, methods, promoted methods, interface methods, and function values.

```
  [warning] Use of deprecated API
   ╭─[test.lis:5:11]
 4 │ fn main() {
 5 │   let _ = strings.Title("hello world")
   ·           ──────┬──────
   ·                 ╰── deprecated
 6 │ }
   ╰────
  help: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead · code: [lint.deprecated]
```