### PR TITLE
feat!: make `lis build` produce a binary

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -8,6 +8,7 @@ pub enum Command {
     Build {
         path: Option<String>,
         sourcemap: bool,
+        go_flags: Vec<String>,
     },
     Emit {
         path: Option<String>,
@@ -103,10 +104,6 @@ fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseErr
     }
 }
 
-fn is_go_output_flag(token: &str) -> bool {
-    token == "-o" || token.starts_with("-o=")
-}
-
 fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
     match value {
         "unix" => Ok(OutputFormat::Unix),
@@ -142,8 +139,35 @@ impl Command {
             },
 
             "build" | "b" => {
-                let (path, sourcemap) = parse_path_and_sourcemap(arguments)?;
-                Ok(Command::Build { path, sourcemap })
+                let mut path = None;
+                let mut sourcemap = false;
+                let mut go_flags = Vec::new();
+
+                while let Some(arg) = arguments.next() {
+                    if arg == "--sourcemap" {
+                        sourcemap = true;
+                    } else if arg == "--go-flags" {
+                        let Some(value) = arguments.next() else {
+                            return Err(ParseError::MissingArgument {
+                                command: "build",
+                                argument: "--go-flags <flags>",
+                            });
+                        };
+                        extend_go_flags(&mut go_flags, &value)?;
+                    } else if let Some(value) = arg.strip_prefix("--go-flags=") {
+                        extend_go_flags(&mut go_flags, value)?;
+                    } else if arg.starts_with('-') {
+                        return Err(ParseError::UnknownFlag(arg));
+                    } else {
+                        path = Some(arg);
+                    }
+                }
+
+                Ok(Command::Build {
+                    path,
+                    sourcemap,
+                    go_flags,
+                })
             }
 
             "emit" | "e" => {
@@ -182,7 +206,10 @@ impl Command {
                     }
                 }
 
-                if let Some(flag) = go_flags.iter().find(|f| is_go_output_flag(f)) {
+                if let Some(flag) = go_flags
+                    .iter()
+                    .find(|f| crate::go_cli::is_go_output_flag(f))
+                {
                     return Err(ParseError::UnexpectedArgument {
                         message: format!("`{}` cannot be passed to `lis run` via `--go-flags`", flag),
                         reason: "`run` executes the binary it links at an internal path, so it owns `-o`"
@@ -526,6 +553,22 @@ mod tests {
     }
 
     #[test]
+    fn run_rejects_output_flag_double_dash_separated_form() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags", "--o /tmp/x"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn run_rejects_output_flag_double_dash_joined_form() {
+        assert!(matches!(
+            parse(&["lis", "run", "--go-flags", "--o=/tmp/x"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
     fn run_rejects_unknown_flag() {
         assert!(matches!(
             parse(&["lis", "run", "--bogus"]),
@@ -567,6 +610,61 @@ mod tests {
         assert!(matches!(
             parse(&["lis", "emit", "--bogus"]),
             Err(ParseError::UnknownFlag(_))
+        ));
+    }
+
+    #[test]
+    fn build_parses_go_flags_before_target() {
+        let Ok(Command::Build { path, go_flags, .. }) =
+            parse(&["lis", "build", "--go-flags", "-trimpath", "."])
+        else {
+            panic!("expected Build command");
+        };
+        assert_eq!(path.as_deref(), Some("."));
+        assert_eq!(go_flags, vec!["-trimpath"]);
+    }
+
+    #[test]
+    fn build_parses_go_flags_equals_form() {
+        let Ok(Command::Build { go_flags, .. }) = parse(&["lis", "build", "--go-flags=-race"])
+        else {
+            panic!("expected Build command");
+        };
+        assert_eq!(go_flags, vec!["-race"]);
+    }
+
+    #[test]
+    fn build_allows_output_flag() {
+        let Ok(Command::Build { go_flags, .. }) =
+            parse(&["lis", "build", "--go-flags", "-o dist/app"])
+        else {
+            panic!("expected Build command");
+        };
+        assert_eq!(go_flags, vec!["-o", "dist/app"]);
+    }
+
+    #[test]
+    fn build_parses_sourcemap_and_go_flags() {
+        let Ok(Command::Build {
+            sourcemap,
+            go_flags,
+            ..
+        }) = parse(&["lis", "build", "--sourcemap", "--go-flags", "-trimpath"])
+        else {
+            panic!("expected Build command");
+        };
+        assert!(sourcemap);
+        assert_eq!(go_flags, vec!["-trimpath"]);
+    }
+
+    #[test]
+    fn build_go_flags_requires_value() {
+        assert!(matches!(
+            parse(&["lis", "build", "--go-flags"]),
+            Err(ParseError::MissingArgument {
+                command: "build",
+                argument: "--go-flags <flags>",
+            })
         ));
     }
 

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -474,6 +474,10 @@ fn is_windows_reserved_name(stem: &str) -> bool {
         && (b'1'..=b'9').contains(&bytes[3])
 }
 
+pub fn is_go_output_flag(token: &str) -> bool {
+    matches!(token, "-o" | "--o") || token.starts_with("-o=") || token.starts_with("--o=")
+}
+
 /// `go_flags` follow the default `-o` so a caller `-o` wins. `output_path` must
 /// be absolute, since `go build` runs with `build_dir` as cwd.
 pub fn build_binary(
@@ -525,6 +529,17 @@ mod tests {
     fn binary_name_uses_last_module_segment() {
         assert_eq!(binary_name("myproj", linux()), "myproj");
         assert_eq!(binary_name("github.com/u/myproj", linux()), "myproj");
+    }
+
+    #[test]
+    fn is_go_output_flag_catches_every_go_spelling() {
+        assert!(is_go_output_flag("-o"));
+        assert!(is_go_output_flag("--o"));
+        assert!(is_go_output_flag("-o=dist/app"));
+        assert!(is_go_output_flag("--o=dist/app"));
+        assert!(!is_go_output_flag("-trimpath"));
+        assert!(!is_go_output_flag("-ofoo"));
+        assert!(!is_go_output_flag("--output"));
     }
 
     #[test]

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -12,14 +12,42 @@ use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 
 pub fn emit(path: Option<String>, sourcemap: bool) -> i32 {
-    compile_project(path, sourcemap, false, "Emit")
+    with_locked_project(path, |prep| build_locked(prep, sourcemap, false, "Emit"))
 }
 
-pub fn build(path: Option<String>, sourcemap: bool, quiet: bool) -> i32 {
-    compile_project(path, sourcemap, quiet, "Build")
+pub fn build(path: Option<String>, sourcemap: bool, go_flags: Vec<String>) -> i32 {
+    with_locked_project(path, |prep| {
+        let emit_code = build_locked(prep, sourcemap, false, "Emit");
+        if emit_code != 0 {
+            return emit_code;
+        }
+
+        let target = stdlib::Target::host();
+        let output_path =
+            match link_project_binary(prep, &go_flags, target, "Failed to build project") {
+                Ok(p) => p,
+                Err(code) => return code,
+            };
+
+        let user_chose_output = go_flags.iter().any(|f| go_cli::is_go_output_flag(f));
+        if user_chose_output {
+            eprintln!("  ✓ Binary built");
+        } else {
+            let shown = lisette::fs::relative_to_cwd(&output_path)
+                .unwrap_or_else(|| output_path.display().to_string());
+            if crate::output::use_color() {
+                use owo_colors::OwoColorize;
+                eprintln!("  ✓ Binary at {}", shown.bright_magenta());
+            } else {
+                eprintln!("  ✓ Binary at `{}`", shown);
+            }
+        }
+
+        0
+    })
 }
 
-fn compile_project(path: Option<String>, sourcemap: bool, quiet: bool, label: &str) -> i32 {
+fn with_locked_project(path: Option<String>, f: impl FnOnce(&BuildPrep) -> i32) -> i32 {
     let project_root = path.unwrap_or_else(|| ".".to_string());
     let project_path = Path::new(&project_root);
 
@@ -33,7 +61,36 @@ fn compile_project(path: Option<String>, sourcemap: bool, quiet: bool, label: &s
         Err(code) => return code,
     };
 
-    build_locked(&prep, sourcemap, quiet, label)
+    f(&prep)
+}
+
+pub(super) fn link_project_binary(
+    prep: &BuildPrep,
+    go_flags: &[String],
+    target: stdlib::Target,
+    heading: &str,
+) -> Result<PathBuf, i32> {
+    let build_dir = match prep.target_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            cli_error!(
+                heading,
+                format!("Failed to resolve `{}`: {}", prep.target_dir.display(), e),
+                "Check that the directory exists"
+            );
+            return Err(1);
+        }
+    };
+
+    let binary_name = go_cli::binary_name(&prep.manifest.project.name, target);
+    let output_path = build_dir.join("bin").join(&binary_name);
+
+    if let Err(e) = go_cli::build_binary(&build_dir, &output_path, target, go_flags) {
+        cli_error!(heading, e.message, e.hint);
+        return Err(1);
+    }
+
+    Ok(output_path)
 }
 
 pub(super) fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -44,7 +44,7 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         build)
-            COMPREPLY=( $(compgen -W "--sourcemap" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--sourcemap --go-flags" -- "$cur") )
             return 0
             ;;
         emit)
@@ -119,7 +119,9 @@ _lis() {
         args)
             case "$words[1]" in
                 build)
-                    _arguments '--sourcemap[Include line directives for stack traces]'
+                    _arguments \
+                        '--sourcemap[Include line directives for stack traces]' \
+                        '--go-flags[Flags passed through to go build]:flags'
                     ;;
                 emit)
                     _arguments '--sourcemap[Include line directives for stack traces]'
@@ -176,6 +178,7 @@ complete -c lis -n __fish_use_subcommand -a complete -d 'Shell completion script
 complete -c lis -n __fish_use_subcommand -a lsp -d 'Start the language server'
 
 complete -c lis -n '__fish_seen_subcommand_from build' -l sourcemap -d 'Include line directives for stack traces'
+complete -c lis -n '__fish_seen_subcommand_from build' -l go-flags -r -d 'Flags passed through to go build'
 complete -c lis -n '__fish_seen_subcommand_from emit' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -71,18 +71,21 @@ Arguments:
         "build" | "b" => print_help(
             "`lis build` [path] [options]
 
-Compile a Lisette project.
+Compile a Lisette project to a binary at `target/bin/<project-name>`
 
 Arguments:
     [path]     Path to project dir (default: current dir)
 
 Options:
-    `--sourcemap`    Include `//line` directives in generated Go code for stack traces
+    `--sourcemap`           Include `//line` directives in generated Go code for stack traces
+    `--go-flags` <flags>    Flags passed through to `go build` (e.g. `-trimpath`, `-ldflags`)
 
 Examples:
-    `lis build`                          Build project in current dir
-    `lis build` {path/to/project/dir:g}      Build project in specific dir
-    `lis build` {--sourcemap:g}              Build with source mapping directives",
+    `lis build`                                  Build project in current dir
+    `lis build` {path/to/project/dir:g}              Build project in specific dir
+    `lis build` {--sourcemap:g}                      Build with source mapping directives
+    `lis build` {--go-flags \"-trimpath\":g}           Pass extra flags to the Go compiler
+    `lis build` {--go-flags \"-ldflags='-s -w'\":g}    Quote flag values that contain spaces",
         ),
 
         "emit" | "e" => print_help(
@@ -109,10 +112,11 @@ Compile and execute a Lisette file or project.
 
 Arguments:
     [target:g]    Project dir or `.lis` file (default: current dir)
-    [args]      Arguments to pass to the program (after --)
+    [args]      Arguments to pass to the program (after {--})
 
 Options:
-    `--sourcemap`    Include `//line` directives in generated Go code for stack traces
+    `--sourcemap`           Include `//line` directives in generated Go code for stack traces
+    `--go-flags` <flags>    Flags passed through to `go build` (e.g. `-race`, `-ldflags`)
 
 Examples:
     `lis run`                            Run project in current dir

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -10,19 +10,7 @@ use diagnostics::render::{self, Filter};
 use lisette::pipeline::{CompileConfig, CompilePhase, compile};
 use semantics::loader::MemoryLoader;
 
-fn build_and_exec(
-    build_dir: &Path,
-    output_path: &Path,
-    args: &[String],
-    go_flags: &[String],
-    heading: &str,
-    target: stdlib::Target,
-) -> i32 {
-    if let Err(e) = go_cli::build_binary(build_dir, output_path, target, go_flags) {
-        cli_error!(heading, e.message, e.hint);
-        return 1;
-    }
-
+fn exec_binary(output_path: &Path, args: &[String], heading: &str) -> i32 {
     match Command::new(output_path).args(args).status() {
         Ok(status) => status.code().unwrap_or(1),
         Err(e) => {
@@ -72,27 +60,18 @@ fn run_project(path: &str, args: Vec<String>, sourcemap: bool, go_flags: &[Strin
 
     let heading = "Failed to run project";
     let target = stdlib::Target::host();
-    let binary_name = go_cli::binary_name(&prep.manifest.project.name, target);
 
     let build_result = super::build::build_locked(&prep, sourcemap, true, "Build");
     if build_result != 0 {
         return build_result;
     }
 
-    let build_dir = match prep.target_dir.canonicalize() {
+    let output_path = match super::build::link_project_binary(&prep, go_flags, target, heading) {
         Ok(p) => p,
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to resolve `{}`: {}", prep.target_dir.display(), e),
-                "Check that the directory exists"
-            );
-            return 1;
-        }
+        Err(code) => return code,
     };
-    let output_path = build_dir.join("bin").join(&binary_name);
 
-    build_and_exec(&build_dir, &output_path, &args, go_flags, heading, target)
+    exec_binary(&output_path, &args, heading)
 }
 
 fn run_standalone(file: &str, args: Vec<String>, sourcemap: bool, go_flags: &[String]) -> i32 {
@@ -225,5 +204,9 @@ fn run_standalone(file: &str, args: Vec<String>, sourcemap: bool, go_flags: &[St
     go_cli::write_emit_manifest(&temp_dir, &emit.new_manifest);
 
     let output_path = temp_dir.join(go_cli::run_binary_name(target));
-    build_and_exec(&temp_dir, &output_path, &args, go_flags, heading, target)
+    if let Err(e) = go_cli::build_binary(&temp_dir, &output_path, target, go_flags) {
+        cli_error!(heading, e.message, e.hint);
+        return 1;
+    }
+    exec_binary(&output_path, &args, heading)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -58,7 +58,11 @@ fn main() {
 
     let exit_code = match command {
         Command::New { name } => handlers::new_project(&name),
-        Command::Build { path, sourcemap } => handlers::build(path, sourcemap, false),
+        Command::Build {
+            path,
+            sourcemap,
+            go_flags,
+        } => handlers::build(path, sourcemap, go_flags),
         Command::Emit { path, sourcemap } => handlers::emit(path, sourcemap),
         Command::Run {
             target,


### PR DESCRIPTION
`lis build` now produces a binary at `target/bin/<project-name>` instead of stopping at generated Go source. 

This completes `lis` verb reorganization:

verb | effect | artifact
-- | -- | --
`lis emit` | write Go source | `target/*.go`
`lis build` | `lis emit` then `go build` | `target/bin/{name}` binary
`lis run` | `lis build` then run binary | `target/bin/{name}` binary + execution

`--go-flags` is also exposed on `build` and passed through to `go build`. On `run` it stays rejected for output-changing flags such as `-o`, because `run` must execute the artifact it links.

Motivated by https://github.com/ivov/lisette/discussions/636