### PR TITLE
feat: support method expressions on promoted methods

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -940,17 +940,6 @@ pub fn member_not_found(
     diagnostic
 }
 
-pub fn promoted_method_expression(member: &str, span: Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Unsupported method expression")
-        .with_infer_code("promoted_method_expression")
-        .with_span_label(&span, format!("`{}` is a promoted method", member))
-        .with_help(format!(
-            "A method expression on a promoted method is not supported. Call it on a \
-             value (`v.{}(...)`) or reach it through the embedded field.",
-            member
-        ))
-}
-
 pub fn ambiguous_selector(
     ty: &Type,
     member: &str,

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -181,6 +181,23 @@ impl Planner<'_> {
         is_pointer_receiver: bool,
         fx: &mut EmitEffects,
     ) -> Option<String> {
+        if let Expression::Identifier { value, .. } = expression {
+            let go_method = if is_exported {
+                go_name::snake_to_camel(member)
+            } else {
+                go_name::escape_keyword(member).into_owned()
+            };
+            let type_name = self
+                .resolve_alias_type_name(value)
+                .unwrap_or_else(|| value.to_string());
+            let type_args = self.method_expression_type_args(result_ty, fx);
+            return Some(if is_pointer_receiver {
+                format!("(*{}{}).{}", type_name, type_args, go_method)
+            } else {
+                format!("{}{}.{}", type_name, type_args, go_method)
+            });
+        }
+
         let Expression::DotAccess {
             expression: inner_expression,
             member: type_name,
@@ -211,28 +228,7 @@ impl Planner<'_> {
 
         let pkg = self.require_module_import_fx(module_name, fx);
         let go_type_name = go_name::snake_to_camel(type_name);
-
-        // Extract type args from the receiver parameter
-        let type_args = if let Type::Function(f) = result_ty.unwrap_forall()
-            && let Some(first_param) = f.params.first()
-        {
-            let receiver_ty = first_param.strip_refs();
-            if let Type::Nominal {
-                params: receiver_params,
-                ..
-            } = receiver_ty
-            {
-                if receiver_params.is_empty() {
-                    String::new()
-                } else {
-                    self.format_type_args(&receiver_params, fx)
-                }
-            } else {
-                String::new()
-            }
-        } else {
-            String::new()
-        };
+        let type_args = self.method_expression_type_args(result_ty, fx);
 
         let method_expression = if is_pointer_receiver {
             format!("(*{}.{}{}).{}", pkg, go_type_name, type_args, go_method)
@@ -241,6 +237,27 @@ impl Planner<'_> {
         };
 
         Some(method_expression)
+    }
+
+    fn method_expression_type_args(&mut self, result_ty: &Type, fx: &mut EmitEffects) -> String {
+        let Type::Function(f) = result_ty.unwrap_forall() else {
+            return String::new();
+        };
+        let Some(first_param) = f.params.first() else {
+            return String::new();
+        };
+        let Type::Nominal {
+            params: receiver_params,
+            ..
+        } = first_param.strip_refs()
+        else {
+            return String::new();
+        };
+        if receiver_params.is_empty() {
+            String::new()
+        } else {
+            self.format_type_args(&receiver_params, fx)
+        }
     }
 
     /// Cross-module static method access (`shapes.Point.new` →

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::checker::EnvResolve;
 use ecow::EcoString;
 use syntax::ast::{Expression, Span, StructKind};
@@ -701,19 +703,10 @@ impl InferCtx<'_, '_> {
             .get(args.member_name)
             .cloned()?;
 
-        // Promoted method expressions (`Type.M`) are not lowered yet; reject
-        // cleanly rather than mis-resolve (own ones resolve via the qualified path).
         if self.is_type_level_receiver(args.expression)
             && self.method_is_promoted(&args.deref_ty, args.member_name)
         {
-            self.sink
-                .push(diagnostics::infer::promoted_method_expression(
-                    args.member_name,
-                    *args.span,
-                ));
-            self.unify(args.expected_ty, &Type::Error, args.span);
-            let kind = DotAccessKind::InstanceMethod { is_exported: false };
-            return Some((args.build_dot_access(Type::Error, Some(kind), None), kind));
+            return self.as_promoted_method_expression(args, &method_ty);
         }
 
         self.check_instance_method_access(&args.deref_ty, &method_ty, args);
@@ -737,7 +730,7 @@ impl InferCtx<'_, '_> {
             unreachable!();
         };
 
-        let f = std::sync::Arc::make_mut(f);
+        let f = Arc::make_mut(f);
         let receiver_ty = f.params.remove(0);
         if !f.param_mutability.is_empty() {
             f.param_mutability.remove(0);
@@ -758,6 +751,59 @@ impl InferCtx<'_, '_> {
             args.build_dot_access(method_ty, Some(kind), receiver_coercion),
             kind,
         ))
+    }
+
+    fn as_promoted_method_expression(
+        &mut self,
+        args: &DotAccessResolutionArgs,
+        method_ty: &Type,
+    ) -> Option<(Expression, DotAccessKind)> {
+        let Resolution::Found(member) =
+            promotion::resolve_selector(self.store, &args.deref_ty, args.member_name)
+        else {
+            return None;
+        };
+
+        self.check_instance_method_access(&args.deref_ty, method_ty, args);
+
+        let (method_ty, _) = self.instantiate(method_ty);
+        let Type::Function(f) = &method_ty else {
+            return None;
+        };
+        let is_pointer_receiver = f
+            .params
+            .first()
+            .is_some_and(|param| param.resolve_in(&self.env).is_ref());
+
+        let is_exported =
+            self.promoted_method_is_exported(&member.declaring_type, args.member_name);
+        if !is_exported {
+            self.sink
+                .push(diagnostics::infer::private_method_expression(*args.span));
+        }
+
+        let kind = DotAccessKind::InstanceMethodValue {
+            is_exported,
+            is_pointer_receiver,
+        };
+
+        self.unify(args.expected_ty, &method_ty, args.span);
+        Some((args.build_dot_access(method_ty, Some(kind), None), kind))
+    }
+
+    fn promoted_method_is_exported(&self, declaring_type: &Symbol, member_name: &str) -> bool {
+        let store = self.store;
+        let type_module = store
+            .module_for_qualified_name(declaring_type)
+            .unwrap_or(declaring_type.as_str());
+        if type_module != self.cursor.module_id {
+            return true;
+        }
+        let method_key = declaring_type.with_segment(member_name);
+        store
+            .get_definition(&method_key)
+            .map(|d| d.visibility().is_public())
+            .unwrap_or(false)
     }
 
     /// Check cross-module visibility, record usage for find-references,

--- a/tests/_embed_harness/mod.rs
+++ b/tests/_embed_harness/mod.rs
@@ -19,4 +19,8 @@ use scenario::NodeId;
 pub struct PrintedQuestion {
     pub root: NodeId,
     pub member: String,
+    /// Also exercise the `Root.member` method-expression form. Set only for a
+    /// public, value-receiver method on a non-generic root and declaring type,
+    /// where `Root.member` is valid and `g(r)` needs no addressing.
+    pub method_expression: bool,
 }

--- a/tests/_embed_harness/render_go.rs
+++ b/tests/_embed_harness/render_go.rs
@@ -203,6 +203,10 @@ fn render_main(scenario: &Scenario, printed: &[PrintedQuestion], out: &mut Strin
         out.push_str(&format!("\t\tfmt.Println(r.{}())\n", question.member));
         out.push_str(&format!("\t\tf := r.{}\n", question.member));
         out.push_str("\t\tfmt.Println(f())\n");
+        if question.method_expression {
+            out.push_str(&format!("\t\tg := {root}.{}\n", question.member));
+            out.push_str("\t\tfmt.Println(g(r))\n");
+        }
         out.push_str("\t}\n");
     }
     out.push_str("}\n");
@@ -244,6 +248,7 @@ mod tests {
         let printed = [PrintedQuestion {
             root: 0,
             member: "M".into(),
+            method_expression: true,
         }];
         assert_snap(
             "go_run_direct",

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -109,6 +109,11 @@ pub fn render_lis_run(scenario: &Scenario, printed: &[PrintedQuestion]) -> Strin
         out.push_str(&format!("  fmt.Println(r{i}.{}())\n", question.member));
         out.push_str(&format!("  let f{i} = r{i}.{}\n", question.member));
         out.push_str(&format!("  fmt.Println(f{i}())\n"));
+        if question.method_expression {
+            let root = scenario.node_name(question.root);
+            out.push_str(&format!("  let g{i} = {root}.{}\n", question.member));
+            out.push_str(&format!("  fmt.Println(g{i}(r{i}))\n"));
+        }
     }
     out.push_str("}\n");
     out
@@ -182,10 +187,12 @@ fn render_node(scenario: &Scenario, node: &Node, out: &mut String) {
             render_impl(scenario, node, methods, out);
         }
         NodeKind::Interface { methods, embeds } => {
+            // Public so a public-method implementer does not trip the
+            // private-interface/public-impl visibility rule.
             if embeds.is_empty() && methods.is_empty() {
-                out.push_str(&format!("interface {}{generics} {{}}\n", node.name));
+                out.push_str(&format!("pub interface {}{generics} {{}}\n", node.name));
             } else {
-                out.push_str(&format!("interface {}{generics} {{\n", node.name));
+                out.push_str(&format!("pub interface {}{generics} {{\n", node.name));
                 for embed in embeds {
                     out.push_str(&format!(
                         "  embed {}\n",
@@ -226,11 +233,15 @@ fn render_impl(scenario: &Scenario, node: &Node, methods: &[Method], out: &mut S
             Receiver::Value => "self".to_string(),
             Receiver::Pointer => format!("self: Ref<{owner}{generics}>"),
         };
+        let visibility = match method.visibility {
+            Visibility::Public => "pub ",
+            Visibility::Private => "",
+        };
         let extra = lis_parameters(scenario, &method.signature.parameters);
         match &method.signature.return_type {
             MemberType::Basic(BasicType::String) => {
                 out.push_str(&format!(
-                    "  fn {}({receiver}{extra}) -> string {{\n    \"{}.{}\"\n  }}\n",
+                    "  {visibility}fn {}({receiver}{extra}) -> string {{\n    \"{}.{}\"\n  }}\n",
                     method.name, owner, method.name,
                 ));
             }
@@ -370,6 +381,7 @@ mod tests {
         let printed = [PrintedQuestion {
             root: 0,
             member: "M".into(),
+            method_expression: true,
         }];
         assert_snap("lis_run_direct", render_lis_run(&scenario, &printed));
     }
@@ -416,6 +428,7 @@ mod tests {
                     vec![PrintedQuestion {
                         root: n.id,
                         member: "M".into(),
+                        method_expression: false,
                     }]
                 })
                 .unwrap_or_default();

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -13,7 +13,9 @@ use super::go_answerer::{GoAnswer, GoAnswers};
 use super::lisette_answer::{LisetteAnswer, LisetteAnswers};
 use super::render_go::{GoMode, render_go};
 use super::render_lis::render_lis_run;
-use super::scenario::{EdgeKind, MemberType, NodeId, NodeKind, Question, Scenario};
+use super::scenario::{
+    EdgeKind, MemberType, NodeId, NodeKind, Question, Receiver, Scenario, Visibility,
+};
 
 const ENTRY_FILE_ID: u32 = 0;
 const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
@@ -92,10 +94,35 @@ fn runnable_questions(
             printed.push(PrintedQuestion {
                 root: *root,
                 member: member.clone(),
+                method_expression: runs_as_method_expression(scenario, *root, expected, member),
             });
         }
     }
     printed
+}
+
+/// Whether the `Root.member` method-expression form is safe to render and run:
+/// a public value-receiver method whose root and declaring type are non-generic,
+/// so `Root.member` needs no type arguments and `g(r)` needs no addressing.
+fn runs_as_method_expression(
+    scenario: &Scenario,
+    root: NodeId,
+    expected: &GoAnswer,
+    member: &str,
+) -> bool {
+    if !scenario.node(root).type_params.is_empty() {
+        return false;
+    }
+    scenario.nodes.iter().any(|node| {
+        node.name == expected.declaring_type
+            && node.type_params.is_empty()
+            && matches!(&node.kind, NodeKind::Struct { methods, .. }
+            if methods.iter().any(|method| {
+                method.name == member
+                    && matches!(method.receiver, Receiver::Value)
+                    && matches!(method.visibility, Visibility::Public)
+            }))
+    })
 }
 
 /// A promoted (depth > 0) method runs only with no pointer indirection and a

--- a/tests/_embed_harness/snapshots/go_run_direct.snap
+++ b/tests/_embed_harness/snapshots/go_run_direct.snap
@@ -17,5 +17,7 @@ func main() {
 		fmt.Println(r.M())
 		f := r.M
 		fmt.Println(f())
+		g := N0.M
+		fmt.Println(g(r))
 	}
 }

--- a/tests/_embed_harness/snapshots/lis_declarations_diamond.snap
+++ b/tests/_embed_harness/snapshots/lis_declarations_diamond.snap
@@ -3,7 +3,7 @@ source: tests/_embed_harness/render_lis.rs
 ---
 struct N0 {}
 impl N0 {
-  fn M(self) -> string {
+  pub fn M(self) -> string {
     "N0.M"
   }
 }

--- a/tests/_embed_harness/snapshots/lis_declarations_interface.snap
+++ b/tests/_embed_harness/snapshots/lis_declarations_interface.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/_embed_harness/render_lis.rs
 ---
-interface N0 {
+pub interface N0 {
   fn Speak(self) -> string
 }
 
 struct N1 {}
 impl N1 {
-  fn Speak(self) -> string {
+  pub fn Speak(self) -> string {
     "N1.Speak"
   }
 }

--- a/tests/_embed_harness/snapshots/lis_questions_satisfaction.snap
+++ b/tests/_embed_harness/snapshots/lis_questions_satisfaction.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/_embed_harness/render_lis.rs
 ---
-interface N0 {
+pub interface N0 {
   fn Speak(self) -> string
 }
 
 struct N1 {}
 impl N1 {
-  fn Speak(self) -> string {
+  pub fn Speak(self) -> string {
     "N1.Speak"
   }
 }

--- a/tests/_embed_harness/snapshots/lis_questions_value_embed.snap
+++ b/tests/_embed_harness/snapshots/lis_questions_value_embed.snap
@@ -3,7 +3,7 @@ source: tests/_embed_harness/render_lis.rs
 ---
 struct N0 {}
 impl N0 {
-  fn M(self) -> string {
+  pub fn M(self) -> string {
     "N0.M"
   }
 }

--- a/tests/_embed_harness/snapshots/lis_run_direct.snap
+++ b/tests/_embed_harness/snapshots/lis_run_direct.snap
@@ -5,7 +5,7 @@ import "go:fmt"
 
 struct N0 {}
 impl N0 {
-  fn M(self) -> string {
+  pub fn M(self) -> string {
     "N0.M"
   }
 }
@@ -15,4 +15,6 @@ fn main() {
   fmt.Println(r0.M())
   let f0 = r0.M
   fmt.Println(f0())
+  let g0 = N0.M
+  fmt.Println(g0(r0))
 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2718,6 +2718,46 @@ fn main() {
 }
 
 #[test]
+fn promoted_method_expression_value_receiver() {
+    let input = r#"
+struct Base { pub id: int }
+
+impl Base {
+  pub fn describe(self) -> string { "base" }
+}
+
+struct Mid { embed Base }
+struct Top { embed Mid }
+
+fn main() {
+  let f = Top.describe
+  let _ = f(Top { Mid: Mid { Base: Base { id: 1 } } })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn promoted_method_expression_pointer_receiver() {
+    let input = r#"
+struct Base { pub id: int }
+
+impl Base {
+  pub fn bump(self: Ref<Base>) { self.id += 1 }
+}
+
+struct Outer { embed Base }
+
+fn main() {
+  let g = Outer.bump
+  let mut o = Outer { Base: Base { id: 1 } }
+  g(&o)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn cast_in_statement_position_uses_discard() {
     let input = r#"
 fn main() {

--- a/tests/spec/emit/snapshots/promoted_method_expression_pointer_receiver.snap
+++ b/tests/spec/emit/snapshots/promoted_method_expression_pointer_receiver.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "\nstruct Base { pub id: int }\n\nimpl Base {\n  pub fn bump(self: Ref<Base>) { self.id += 1 }\n}\n\nstruct Outer { embed Base }\n\nfn main() {\n  let g = Outer.bump\n  let mut o = Outer { Base: Base { id: 1 } }\n  g(&o)\n}\n"
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+func (b *Base) Bump() {
+	b.Id++
+}
+
+type Outer struct {
+	Base
+}
+
+func main() {
+	g := (*Outer).Bump
+	o := Outer{Base: Base{Id: 1}}
+	g(&o)
+}

--- a/tests/spec/emit/snapshots/promoted_method_expression_value_receiver.snap
+++ b/tests/spec/emit/snapshots/promoted_method_expression_value_receiver.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/expressions.rs
+description: "\nstruct Base { pub id: int }\n\nimpl Base {\n  pub fn describe(self) -> string { \"base\" }\n}\n\nstruct Mid { embed Base }\nstruct Top { embed Mid }\n\nfn main() {\n  let f = Top.describe\n  let _ = f(Top { Mid: Mid { Base: Base { id: 1 } } })\n}\n"
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+func (b Base) Describe() string {
+	return "base"
+}
+
+type Mid struct {
+	Base
+}
+
+type Top struct {
+	Mid
+}
+
+func main() {
+	f := Top.Describe
+	_ = f(Top{Mid: Mid{Base: Base{Id: 1}}})
+}

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -7122,7 +7122,24 @@ fn main() {}
 }
 
 #[test]
-fn promoted_method_expression_is_rejected() {
+fn promoted_method_expression_resolves() {
+    infer(
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+struct Outer { embed Base }
+fn use_it(o: Outer) -> string {
+  let f = Outer.describe
+  f(o)
+}
+fn main() {}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_private_method_expression_is_rejected() {
     infer(
         r#"
 struct Base { pub id: int }
@@ -7134,7 +7151,62 @@ fn use_it() {
 fn main() {}
 "#,
     )
-    .assert_infer_code("promoted_method_expression");
+    .assert_infer_code("private_method_expression");
+}
+
+#[test]
+fn cross_module_promoted_private_method_expression_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "lib",
+        "lib.lis",
+        r#"
+pub struct Base { pub id: int }
+impl Base { fn secret(self) -> string { "s" } }
+pub struct Outer { embed Base }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "lib"
+
+fn use_it() {
+  let _ = lib.Outer.secret
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_resolve_code("private_method_access");
+}
+
+#[test]
+fn cross_module_promoted_public_method_expression_resolves() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "lib",
+        "lib.lis",
+        r#"
+pub struct Base { pub id: int }
+impl Base { pub fn describe(self) -> string { "b" } }
+pub struct Outer { embed Base }
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "lib"
+
+fn use_it(o: lib.Outer) -> string {
+  let f = lib.Outer.describe
+  f(o)
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
 }
 
 #[test]


### PR DESCRIPTION
Adds support for method expressions on promoted methods, so a method reached through an embedded field can be taken as a value via `Type.method`.

```rs
struct Base { pub id: int }
impl Base { pub fn describe(self) -> string { "base" } }
struct Outer { embed Base }

fn main() {
  let f = Outer.describe
  let _ = f(Outer { Base: Base { id: 1 } })
}
```

These previously hard-errored. Pointer-receiver promoted methods lower to `(*Outer).method`, and a private promoted method is still rejected, matching the rule for non-promoted method expressions.
