### PR TITLE
fix: stop generated imports from colliding with user names

### DIFF
--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -219,8 +219,9 @@ pub fn write_go_outputs(dir: &Path, files: &[OutputFile]) -> Result<EmitWriteRes
             });
         }
 
-        let mut imports: Vec<String> = file.imports.keys().cloned().collect();
+        let mut imports: Vec<String> = file.imports.iter().map(|(path, _)| path.clone()).collect();
         imports.sort();
+        imports.dedup();
         new_manifest.push(ManifestEntry {
             name: file.name.clone(),
             content_hash: hash,

--- a/crates/diagnostics/src/emit.rs
+++ b/crates/diagnostics/src/emit.rs
@@ -37,6 +37,17 @@ pub fn reserved_go_prefix(name: &str, prefix: &str, span: &Span) -> LisetteDiagn
         ))
 }
 
+pub fn reserved_go_qualifier(name: &str, span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Reserved Go name")
+        .with_emit_code("reserved_go_qualifier")
+        .with_span_primary_label(span, "reserved for generated imports")
+        .with_help(format!(
+            "`{}` is the qualifier of a Go package that generated code may \
+             import implicitly. Rename the type.",
+            name
+        ))
+}
+
 pub fn go_import_collision(alias: &str, paths: &[String]) -> LisetteDiagnostic {
     let mut sorted = paths.to_vec();
     sorted.sort();

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, emit as emit_diag};
-use syntax::ast::{Expression, ImportAlias, Pattern, Span, StructKind, Visibility};
+use syntax::ast::{Expression, ImportAlias, Pattern, Span, StructKind, VariantFields, Visibility};
 use syntax::program::File;
 
 use crate::Planner;
@@ -58,11 +58,13 @@ impl Planner<'_> {
                 name,
                 name_span,
                 visibility,
+                generics,
                 ..
             } => {
                 if self.facts.is_unused_definition(name_span) {
                     return;
                 }
+                self.check_reserved_qualifier_generics(generics, diagnostics);
                 let go = self.free_function_go_name(name, visibility);
                 self.check_reserved_prefix(&go, name_span, diagnostics);
                 package_block.entry(go).or_default().push(*name_span);
@@ -77,10 +79,15 @@ impl Planner<'_> {
                 package_block.entry(go).or_default().push(*identifier_span);
             }
             Expression::TypeAlias {
-                name, name_span, ..
+                name,
+                name_span,
+                generics,
+                ..
             } => {
                 let go = go_name::escape_keyword(name).into_owned();
                 self.check_reserved_prefix(&go, name_span, diagnostics);
+                self.check_reserved_qualifier(&go, name_span, diagnostics);
+                self.check_reserved_qualifier_generics(generics, diagnostics);
                 package_block.entry(go).or_default().push(*name_span);
             }
             Expression::Struct {
@@ -94,6 +101,8 @@ impl Planner<'_> {
             } => {
                 let type_go = go_name::escape_keyword(name).into_owned();
                 self.check_reserved_prefix(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier_generics(generics, diagnostics);
                 package_block
                     .entry(type_go.clone())
                     .or_default()
@@ -140,10 +149,13 @@ impl Planner<'_> {
                 variants,
                 attributes,
                 visibility,
+                generics,
                 ..
             } => {
                 let type_go = go_name::escape_keyword(name).into_owned();
                 self.check_reserved_prefix(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier_generics(generics, diagnostics);
 
                 if attributes
                     .iter()
@@ -221,7 +233,9 @@ impl Planner<'_> {
                 // Enum payload fields share the type's selector namespace. They
                 // are coalesced by Go name across variants, so each distinct
                 // name is recorded once (coalescing is intentional, not a
-                // collision); per-variant duplicates are out of scope here.
+                // collision). Within one variant, two fields landing on the
+                // same Go name would assign one struct field twice, so each
+                // struct variant's fields are also grouped on their own.
                 let qualified = self.facts.qualified_current(name);
                 if let Some(layout) = self.enum_layout(&qualified) {
                     let mut seen: HashSet<&str> = HashSet::default();
@@ -234,6 +248,16 @@ impl Planner<'_> {
                                     .push(variant.name_span);
                             }
                         }
+                        if let VariantFields::Struct(fields) = &variant.fields {
+                            let mut variant_fields: SpanMap = HashMap::default();
+                            for (field, layout_field) in fields.iter().zip(&layout_variant.fields) {
+                                variant_fields
+                                    .entry(layout_field.go_name.clone())
+                                    .or_default()
+                                    .push(field.name_span);
+                            }
+                            report_collisions(variant_fields, diagnostics);
+                        }
                     }
                 }
             }
@@ -242,10 +266,13 @@ impl Planner<'_> {
                 name_span,
                 method_signatures,
                 visibility,
+                generics,
                 ..
             } => {
                 let type_go = go_name::escape_keyword(name).into_owned();
                 self.check_reserved_prefix(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+                self.check_reserved_qualifier_generics(generics, diagnostics);
                 package_block
                     .entry(type_go.clone())
                     .or_default()
@@ -257,9 +284,11 @@ impl Planner<'_> {
                     if let Expression::Function {
                         name: method_name,
                         name_span: method_span,
+                        generics: method_generics,
                         ..
                     } = signature
                     {
+                        self.check_reserved_qualifier_generics(method_generics, diagnostics);
                         let method_go = if is_public || self.method_needs_export(method_name) {
                             go_name::snake_to_camel(method_name)
                         } else {
@@ -272,8 +301,10 @@ impl Planner<'_> {
             Expression::ImplBlock {
                 receiver_name,
                 methods,
+                generics,
                 ..
             } => {
+                self.check_reserved_qualifier_generics(generics, diagnostics);
                 let type_go = go_name::escape_keyword(receiver_name).into_owned();
                 let qualified_type = self.facts.qualified_current(receiver_name);
                 for method in methods {
@@ -282,6 +313,7 @@ impl Planner<'_> {
                         name_span,
                         visibility,
                         params,
+                        generics: method_generics,
                         ..
                     } = method
                     else {
@@ -290,6 +322,7 @@ impl Planner<'_> {
                     if self.facts.is_unused_definition(name_span) {
                         continue;
                     }
+                    self.check_reserved_qualifier_generics(method_generics, diagnostics);
                     let has_self = params.first().is_some_and(|binding| {
                         matches!(&binding.pattern, Pattern::Identifier { identifier, .. } if identifier == "self")
                     });
@@ -379,6 +412,22 @@ impl Planner<'_> {
                 go_name::ADAPTER_TYPE_PREFIX,
                 span,
             ));
+        }
+    }
+
+    fn check_reserved_qualifier(&self, go: &str, span: &Span, out: &mut Vec<LisetteDiagnostic>) {
+        if go_name::is_generated_import_qualifier(go) {
+            out.push(emit_diag::reserved_go_qualifier(go, span));
+        }
+    }
+
+    fn check_reserved_qualifier_generics(
+        &self,
+        generics: &[syntax::ast::Generic],
+        out: &mut Vec<LisetteDiagnostic>,
+    ) {
+        for generic in generics {
+            self.check_reserved_qualifier(&generic.name, &generic.span, out);
         }
     }
 }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -88,7 +88,7 @@ impl Planner<'_> {
             fx.require_fmt();
         }
         if has_json {
-            fx.require_go_import("encoding/json");
+            fx.require_json();
         }
 
         Some(result)

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -39,13 +39,14 @@ impl Planner<'_> {
             return ValuePlan::Operand(s);
         }
 
-        let (mut setup, expression_string) =
-            self.plan_coerced_expression(expression, receiver_coercion, ctx, fx);
         let expression_ty = expression.get_type();
 
-        if let Some(module) = expression_ty.as_import_namespace() {
-            self.require_module_import_fx(module, fx);
-        }
+        let (mut setup, expression_string) =
+            if let Some(module) = expression_ty.as_import_namespace() {
+                (Vec::new(), self.require_module_import_fx(module, fx))
+            } else {
+                self.plan_coerced_expression(expression, receiver_coercion, ctx, fx)
+            };
 
         if let Some(s) = self.try_emit_tuple_member_dot(
             &expression_string,

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -444,15 +444,6 @@ impl<'a> Planner<'a> {
         self.scope.is_go_const_binding(go_identifier)
     }
 
-    pub(crate) fn module_alias_for_type(&self, ty: &Type) -> Option<String> {
-        if let Type::Nominal { id, .. } = ty {
-            let module = self.facts.module_for_qualified_name(id)?;
-            self.module.module_alias(module).map(str::to_string)
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn maybe_line_directive(&self, span: &Span) -> String {
         if !self.facts.sourcemap_enabled() || span.is_dummy() {
             return String::new();

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -107,7 +107,7 @@ impl Planner<'_> {
                     comparable_seen = true;
                 }
                 ConstraintAtom::Ordered => {
-                    fx.require_go_import("cmp");
+                    fx.require_cmp();
                     named_bounds.push("cmp.Ordered".to_string());
                 }
                 ConstraintAtom::Named(ann) => {

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -266,6 +266,63 @@ pub(crate) fn escape_keyword(name: &str) -> Cow<'_, str> {
 /// identifiers with these names, so the emitter need not escape them.
 const PRELUDE_BUILTIN_NAMES: &[&str] = &["complex", "max", "min", "panic", "real"];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GeneratedPackage {
+    Prelude,
+    Fmt,
+    Errors,
+    Slices,
+    Strings,
+    Maps,
+    Json,
+    Cmp,
+}
+
+impl GeneratedPackage {
+    pub(crate) const ALL: &'static [GeneratedPackage] = &[
+        GeneratedPackage::Prelude,
+        GeneratedPackage::Fmt,
+        GeneratedPackage::Errors,
+        GeneratedPackage::Slices,
+        GeneratedPackage::Strings,
+        GeneratedPackage::Maps,
+        GeneratedPackage::Json,
+        GeneratedPackage::Cmp,
+    ];
+
+    pub(crate) fn path(self) -> &'static str {
+        match self {
+            GeneratedPackage::Prelude => PRELUDE_IMPORT_PATH,
+            GeneratedPackage::Fmt => "fmt",
+            GeneratedPackage::Errors => "errors",
+            GeneratedPackage::Slices => "slices",
+            GeneratedPackage::Strings => "strings",
+            GeneratedPackage::Maps => "maps",
+            GeneratedPackage::Json => "encoding/json",
+            GeneratedPackage::Cmp => "cmp",
+        }
+    }
+
+    pub(crate) fn qualifier(self) -> &'static str {
+        match self {
+            GeneratedPackage::Prelude => GO_STDLIB_PKG,
+            GeneratedPackage::Fmt => "fmt",
+            GeneratedPackage::Errors => "errors",
+            GeneratedPackage::Slices => "slices",
+            GeneratedPackage::Strings => "strings",
+            GeneratedPackage::Maps => "maps",
+            GeneratedPackage::Json => "json",
+            GeneratedPackage::Cmp => "cmp",
+        }
+    }
+}
+
+pub(crate) fn is_generated_import_qualifier(name: &str) -> bool {
+    GeneratedPackage::ALL
+        .iter()
+        .any(|package| package.qualifier() == name)
+}
+
 fn is_reserved_package_name(name: &str) -> bool {
     GO_KEYWORDS.contains(&name) || GO_BUILTINS.contains(&name)
 }
@@ -273,6 +330,7 @@ fn is_reserved_package_name(name: &str) -> bool {
 fn is_reserved_identifier(name: &str) -> bool {
     GO_KEYWORDS.contains(&name)
         || (GO_BUILTINS.contains(&name) && !PRELUDE_BUILTIN_NAMES.contains(&name))
+        || is_generated_import_qualifier(name)
 }
 
 pub(crate) fn escape_reserved(name: &str) -> Cow<'_, str> {

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -86,10 +86,19 @@ impl Planner<'_> {
         }
     }
 
-    /// Record the module import into `fx` and return its Go package qualifier.
+    /// Record the module import into `fx` and return the package qualifier
+    /// exactly as the import renders it: `format_import` sanitizes default
+    /// package names and prints explicit aliases verbatim, so references
+    /// must follow the same rule.
     pub(crate) fn require_module_import_fx(&self, module: &str, fx: &mut EmitEffects) -> String {
-        fx.require_go_import(self.go_import_path_for_module(module));
-        self.go_pkg_qualifier(module)
+        let path = self.go_import_path_for_module(module);
+        fx.require_go_import(path.clone());
+        let qualifier = self.go_pkg_qualifier(module);
+        if qualifier == go_name::go_package_name(&path) {
+            go_name::sanitize_package_name(&qualifier).into_owned()
+        } else {
+            qualifier
+        }
     }
 
     pub(crate) fn go_import_path_for_module(&self, module: &str) -> String {

--- a/crates/emit/src/output/imports.rs
+++ b/crates/emit/src/output/imports.rs
@@ -52,6 +52,9 @@ impl ImportPlan {
 pub struct ImportBuilder<'a> {
     go_package_names: &'a HashMap<String, String>,
     imports: HashMap<String, String>,
+    /// Generated imports of paths the source already imports under another
+    /// alias; emitted alongside (Go permits duplicate import paths).
+    generated_duplicates: Vec<(String, String)>,
     dropped_aliases: HashMap<String, String>,
     used_modules: HashSet<String>,
 }
@@ -61,6 +64,7 @@ impl<'a> ImportBuilder<'a> {
         Self {
             go_package_names,
             imports: HashMap::default(),
+            generated_duplicates: Vec::new(),
             dropped_aliases: HashMap::default(),
             used_modules: HashSet::default(),
         }
@@ -73,6 +77,7 @@ impl<'a> ImportBuilder<'a> {
         Self {
             go_package_names,
             imports: plan.imports.clone(),
+            generated_duplicates: Vec::new(),
             dropped_aliases: plan.dropped_aliases.clone(),
             used_modules: HashSet::default(),
         }
@@ -94,15 +99,26 @@ impl<'a> ImportBuilder<'a> {
         }
     }
 
-    pub fn require_stdlib(&mut self) {
-        let path = go_name::PRELUDE_IMPORT_PATH;
-        self.imports.insert(path.to_string(), "lisette".to_string());
+    /// Record a generated requirement. Generated code references the package
+    /// by its fixed canonical qualifier, so a source import of the same path
+    /// under another alias is preserved and a second, canonically named
+    /// import is added alongside it.
+    pub(crate) fn require_generated(&mut self, package: go_name::GeneratedPackage) {
+        let path = package.path();
+        let canonical = package.qualifier();
         self.used_modules.insert(path.to_string());
-    }
-
-    pub fn require_path(&mut self, path: &str) {
-        self.imports.insert(path.to_string(), path.to_string());
-        self.used_modules.insert(path.to_string());
+        match self.imports.get(path) {
+            Some(alias) if effective_package_name(path, alias) == canonical => {}
+            Some(_) => {
+                if !self.generated_duplicates.iter().any(|(p, _)| p == path) {
+                    self.generated_duplicates
+                        .push((path.to_string(), canonical.to_string()));
+                }
+            }
+            None => {
+                self.imports.insert(path.to_string(), canonical.to_string());
+            }
+        }
     }
 
     pub fn filter_unused_imports(&mut self) {
@@ -110,34 +126,38 @@ impl<'a> ImportBuilder<'a> {
             .retain(|path, alias| alias == "_" || self.used_modules.contains(path));
     }
 
-    pub fn build(self) -> (HashMap<String, String>, Vec<LisetteDiagnostic>) {
-        let diagnostics = self.detect_collisions();
-        (self.imports, diagnostics)
+    pub fn build(self) -> (Vec<(String, String)>, Vec<LisetteDiagnostic>) {
+        let mut entries: Vec<(String, String)> = self.imports.into_iter().collect();
+        entries.extend(self.generated_duplicates);
+        entries.sort();
+        entries.dedup();
+        let diagnostics = detect_collisions(&entries);
+        (entries, diagnostics)
     }
+}
 
-    fn detect_collisions(&self) -> Vec<LisetteDiagnostic> {
-        if self.imports.len() < 2 {
-            return Vec::new();
-        }
-        let mut groups: HashMap<String, Vec<&str>> = HashMap::default();
-        for (path, alias) in &self.imports {
-            if alias == "_" {
-                continue;
-            }
-            let effective = effective_package_name(path, alias);
-            let sanitized = go_name::sanitize_package_name(effective).into_owned();
-            groups.entry(sanitized).or_default().push(path.as_str());
-        }
-        let mut groups: Vec<_> = groups.into_iter().filter(|(_, p)| p.len() > 1).collect();
-        groups.sort_by(|a, b| a.0.cmp(&b.0));
-        groups
-            .into_iter()
-            .map(|(alias, paths)| {
-                let owned: Vec<String> = paths.into_iter().map(str::to_string).collect();
-                emit_diag::go_import_collision(&alias, &owned)
-            })
-            .collect()
+fn detect_collisions(entries: &[(String, String)]) -> Vec<LisetteDiagnostic> {
+    if entries.len() < 2 {
+        return Vec::new();
     }
+    let mut groups: HashMap<String, Vec<&str>> = HashMap::default();
+    for (path, alias) in entries {
+        if alias == "_" {
+            continue;
+        }
+        let effective = effective_package_name(path, alias);
+        let sanitized = go_name::sanitize_package_name(effective).into_owned();
+        groups.entry(sanitized).or_default().push(path.as_str());
+    }
+    let mut groups: Vec<_> = groups.into_iter().filter(|(_, p)| p.len() > 1).collect();
+    groups.sort_by(|a, b| a.0.cmp(&b.0));
+    groups
+        .into_iter()
+        .map(|(alias, paths)| {
+            let owned: Vec<String> = paths.into_iter().map(str::to_string).collect();
+            emit_diag::go_import_collision(&alias, &owned)
+        })
+        .collect()
 }
 
 fn effective_package_name<'a>(path: &'a str, alias: &'a str) -> &'a str {

--- a/crates/emit/src/output/mod.rs
+++ b/crates/emit/src/output/mod.rs
@@ -1,6 +1,5 @@
 pub mod imports;
 
-use rustc_hash::FxHashMap as HashMap;
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
 
@@ -12,7 +11,9 @@ use self::imports::format_import;
 pub struct OutputFile {
     pub name: String,
     pub source: String,
-    pub imports: HashMap<String, String>,
+    /// `(path, alias)` pairs; a path may appear twice when a generated
+    /// import coexists with a source alias of the same package.
+    pub imports: Vec<(String, String)>,
     pub package_name: String,
     pub diagnostics: Vec<LisetteDiagnostic>,
 }
@@ -32,19 +33,14 @@ impl OutputFile {
 
         output.collect(format!("package {}", self.package_name));
 
-        match self.imports.len() {
-            0 => {}
-            1 => {
-                let (path, alias) = self
-                    .imports
-                    .iter()
-                    .next()
-                    .expect("single-element collection must have first element");
+        match self.imports.as_slice() {
+            [] => {}
+            [(path, alias)] => {
                 output.collect(format!("import {}", format_import(path, alias)));
             }
-            _ => {
+            entries => {
                 output.collect("import (");
-                for (path, alias) in &self.imports {
+                for (path, alias) in entries {
                     output.collect(format_import(path, alias));
                 }
                 output.collect(")");

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1079,9 +1079,7 @@ fn collect_const_pattern_check(
             if qualifier.is_empty() || qualifier == planner.facts.current_module() {
                 const_name.to_string()
             } else {
-                collector
-                    .effects
-                    .require_go_import(planner.go_import_path_for_module(module));
+                let qualifier = planner.require_module_import_fx(module, &mut collector.effects);
                 format!("{}.{}", qualifier, const_name)
             }
         }
@@ -1187,8 +1185,12 @@ fn collect_tagged_enum_checks(
     variant: &EnumVariantData,
     collector: &mut PatternCollector,
 ) {
-    let alias = planner.module_alias_for_type(variant.ty);
     let enum_module = enum_module_of(planner, variant.ty);
+    let alias = if planner.facts.is_foreign_module(enum_module) {
+        Some(planner.require_module_import_fx(enum_module, &mut collector.effects))
+    } else {
+        None
+    };
     let resolved = go_name::variant(
         variant.identifier,
         variant.ty,
@@ -1197,7 +1199,7 @@ fn collect_tagged_enum_checks(
         alias.as_deref(),
     );
     if resolved.needs_stdlib {
-        collector.effects.needs_stdlib = true;
+        collector.effects.require_stdlib();
     }
     collector.checks.push(Check::EnumTag {
         path: path.clone(),
@@ -1341,8 +1343,12 @@ fn resolve_struct_child_path(
     }
     let enum_info = detect_enum_info(planner, ty, identifier, typed);
     if enum_info.is_some() {
-        let alias = planner.module_alias_for_type(ty);
         let enum_module = enum_module_of(planner, ty);
+        let alias = if planner.facts.is_foreign_module(enum_module) {
+            Some(planner.require_module_import_fx(enum_module, &mut collector.effects))
+        } else {
+            None
+        };
         let resolved = go_name::variant(
             identifier,
             ty,
@@ -1351,7 +1357,7 @@ fn resolve_struct_child_path(
             alias.as_deref(),
         );
         if resolved.needs_stdlib {
-            collector.effects.needs_stdlib = true;
+            collector.effects.require_stdlib();
         }
         collector.checks.push(Check::EnumTag {
             path: path.clone(),

--- a/crates/emit/src/patterns/emit_plan.rs
+++ b/crates/emit/src/patterns/emit_plan.rs
@@ -444,7 +444,7 @@ fn render_switch_expression(rendered_path: &str, kind: &SwitchKind) -> String {
 
 fn propagate_stdlib(ctx: &mut LoweringCtx, branches: &[SwitchBranch]) {
     if branches.iter().any(|b| b.needs_stdlib) {
-        ctx.effects.needs_stdlib = true;
+        ctx.effects.require_stdlib();
     }
 }
 

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -126,9 +126,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             &tree,
             single_catchall_has_collisions,
         );
-        if lowered.effects.needs_stdlib {
-            self.fx.require_stdlib();
-        }
+        self.fx.extend(&lowered.effects);
 
         let mut statements: Vec<LoweredStatement> = Vec::new();
         match lowered.plan {

--- a/crates/emit/src/state/effects.rs
+++ b/crates/emit/src/state/effects.rs
@@ -1,42 +1,66 @@
 use rustc_hash::FxHashSet as HashSet;
 
+use crate::names::go_name::GeneratedPackage;
 use crate::output::imports::ImportBuilder;
 use crate::types::go_type::GoType;
 
+#[derive(Debug, Clone, Copy, Default)]
+struct GeneratedImportSet(u8);
+
+impl GeneratedImportSet {
+    fn insert(&mut self, package: GeneratedPackage) {
+        self.0 |= 1 << package as u8;
+    }
+
+    fn union(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    fn iter(self) -> impl Iterator<Item = GeneratedPackage> {
+        GeneratedPackage::ALL
+            .iter()
+            .copied()
+            .filter(move |package| self.0 & (1 << *package as u8) != 0)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EmitEffects {
-    pub needs_stdlib: bool,
-    pub needs_fmt: bool,
-    pub needs_errors: bool,
-    pub needs_slices: bool,
-    pub needs_strings: bool,
-    pub needs_maps: bool,
+    generated: GeneratedImportSet,
     pub go_imports: Vec<String>,
 }
 
 impl EmitEffects {
     pub(crate) fn require_stdlib(&mut self) {
-        self.needs_stdlib = true;
+        self.generated.insert(GeneratedPackage::Prelude);
     }
 
     pub(crate) fn require_fmt(&mut self) {
-        self.needs_fmt = true;
+        self.generated.insert(GeneratedPackage::Fmt);
     }
 
     pub(crate) fn require_errors(&mut self) {
-        self.needs_errors = true;
+        self.generated.insert(GeneratedPackage::Errors);
     }
 
     pub(crate) fn require_slices(&mut self) {
-        self.needs_slices = true;
+        self.generated.insert(GeneratedPackage::Slices);
     }
 
     pub(crate) fn require_strings(&mut self) {
-        self.needs_strings = true;
+        self.generated.insert(GeneratedPackage::Strings);
     }
 
     pub(crate) fn require_maps(&mut self) {
-        self.needs_maps = true;
+        self.generated.insert(GeneratedPackage::Maps);
+    }
+
+    pub(crate) fn require_json(&mut self) {
+        self.generated.insert(GeneratedPackage::Json);
+    }
+
+    pub(crate) fn require_cmp(&mut self) {
+        self.generated.insert(GeneratedPackage::Cmp);
     }
 
     pub(crate) fn require_go_import(&mut self, path: impl Into<String>) {
@@ -44,36 +68,22 @@ impl EmitEffects {
     }
 
     pub(crate) fn merge_from_go_type(&mut self, go_type: &GoType) {
-        self.needs_stdlib |= go_type.needs_stdlib;
+        if go_type.needs_stdlib {
+            self.require_stdlib();
+        }
         self.go_imports.extend(go_type.go_imports.iter().cloned());
     }
 
     pub(crate) fn extend(&mut self, other: &EmitEffects) {
-        self.needs_stdlib |= other.needs_stdlib;
-        self.needs_fmt |= other.needs_fmt;
-        self.needs_errors |= other.needs_errors;
-        self.needs_slices |= other.needs_slices;
-        self.needs_strings |= other.needs_strings;
-        self.needs_maps |= other.needs_maps;
+        self.generated.union(other.generated);
         self.go_imports.extend(other.go_imports.iter().cloned());
     }
 
     pub(crate) fn drain_into(&self, builder: &mut ImportBuilder) {
         let modules: HashSet<String> = self.go_imports.iter().cloned().collect();
         builder.extend_with_modules(&modules);
-        if self.needs_stdlib {
-            builder.require_stdlib();
-        }
-        for (flag, path) in [
-            (self.needs_fmt, "fmt"),
-            (self.needs_errors, "errors"),
-            (self.needs_slices, "slices"),
-            (self.needs_strings, "strings"),
-            (self.needs_maps, "maps"),
-        ] {
-            if flag {
-                builder.require_path(path);
-            }
+        for package in self.generated.iter() {
+            builder.require_generated(package);
         }
     }
 }

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6538,3 +6538,337 @@ fn main() {
          parallel inference path; got:\n{go}"
     );
 }
+
+#[test]
+fn go_name_collision_enum_variant_fields_casing() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+enum Event {
+  Click { foo_bar: int, FooBar: int },
+}
+
+fn main() {
+  let _ = Event.Click { foo_bar: 1, FooBar: 2 }
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes.iter().any(|code| code == "emit.go_name_collision"),
+        "same-variant fields coalescing to one Go field must be rejected; got: {codes:?}"
+    );
+}
+
+#[test]
+fn enum_payload_coalescing_across_variants_not_flagged() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+enum E {
+  A { x: int },
+  B { x: int, y: string },
+}
+
+fn main() {
+  let _ = E.A { x: 1 }
+  let _ = E.B { x: 2, y: "s" }
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        !codes.iter().any(|code| code == "emit.go_name_collision"),
+        "cross-variant field coalescing is intentional; got: {codes:?}"
+    );
+}
+
+#[test]
+fn reserved_go_qualifier_rejects_type_named_after_generated_import() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+struct fmt {
+  x: int,
+}
+
+fn main() {
+  let _ = fmt { x: 1 }
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes
+            .iter()
+            .any(|code| code == "emit.reserved_go_qualifier"),
+        "type named after a generated import qualifier must be rejected; got: {codes:?}"
+    );
+}
+
+#[test]
+fn reserved_go_qualifier_rejects_type_parameter() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn pick<fmt>(x: fmt) -> fmt {
+  x
+}
+
+fn main() {
+  let _ = pick(1)
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes
+            .iter()
+            .any(|code| code == "emit.reserved_go_qualifier"),
+        "type parameter named after a generated import qualifier must be rejected; got: {codes:?}"
+    );
+}
+
+#[test]
+fn generated_fmt_import_coexists_with_private_fmt_function() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[display]
+struct Thing {
+  pub x: int,
+}
+
+fn fmt() -> int {
+  1
+}
+
+fn main() {
+  let _ = Thing { x: 1 }
+  let _ = fmt()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn prelude_alias_coexists_with_private_lisette_function() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn lisette() -> int {
+  1
+}
+
+fn main() {
+  let x = Some(1)
+  let _ = x
+  let _ = lisette()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn generated_import_qualifier_locals_renamed() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn show(fmt: int) -> string {
+  f"{fmt}"
+}
+
+fn main() {
+  let strings = 1
+  let ok = "abc".contains("a")
+  let _ = strings
+  let _ = ok
+  let _ = show(2)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn json_enum_coexists_with_private_json_function() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[json]
+enum Status {
+  Ready,
+}
+
+fn json() -> int {
+  1
+}
+
+fn main() {
+  let _ = Status.Ready
+  let _ = json()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn user_fmt_alias_preserved_alongside_generated_import() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import f "go:fmt"
+
+#[display]
+struct Thing {
+  pub x: int,
+}
+
+fn main() {
+  let _ = Thing { x: 1 }
+  let _ = f.Sprintf("x=%d", 1)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn user_json_alias_preserved_alongside_generated_import() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import js "go:encoding/json"
+
+#[json]
+enum Status {
+  Ready,
+}
+
+fn main() {
+  let s = Status.Ready
+  let _ = js.Valid([])
+  let _ = s
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn user_strings_alias_preserved_alongside_generated_import() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import s "go:strings"
+
+fn main() {
+  let _ = s.ToUpper("abc")
+  let _ = "abc".contains("a")
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn generated_fmt_requirement_reuses_unaliased_source_import() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println("direct")
+  let s = f"{1}"
+  let _ = s
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn builtin_named_module_qualifier_consistent_in_match() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "print",
+        "mod.lis",
+        r#"
+pub enum Level {
+  Low,
+  High,
+}
+
+pub const LIMIT = 9
+
+pub fn pick() -> Level {
+  Level.High
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "print"
+
+fn main() {
+  let level = print.pick()
+  match level {
+    Low => fmt.Println("low"),
+    High => fmt.Println("high"),
+  }
+  let x = 9
+  match x {
+    print.LIMIT => fmt.Println("limit"),
+    _ => fmt.Println("other"),
+  }
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}

--- a/tests/spec/build/snapshots/builtin_named_module_qualifier_consistent_in_match.snap
+++ b/tests/spec/build/snapshots/builtin_named_module_qualifier_consistent_in_match.snap
@@ -1,0 +1,54 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	print_ "github.com/user/myproject/print"
+)
+
+func main() {
+	level := print_.Pick()
+	if level.Tag == print_.LevelLow {
+		fmt.Println("low")
+	} else {
+		fmt.Println("high")
+	}
+	x := 9
+	if x == print_.LIMIT {
+		fmt.Println("limit")
+	} else {
+		fmt.Println("other")
+	}
+}
+
+
+// === print/mod.go ===
+package print_
+
+func MakeLevelLow() Level {
+	return Level{Tag: LevelLow}
+}
+
+func MakeLevelHigh() Level {
+	return Level{Tag: LevelHigh}
+}
+
+type LevelTag int
+
+const (
+	LevelLow LevelTag = iota
+	LevelHigh
+)
+
+type Level struct {
+	Tag LevelTag
+}
+
+const LIMIT int = 9
+
+func Pick() Level {
+	return MakeLevelHigh()
+}

--- a/tests/spec/build/snapshots/generated_fmt_import_coexists_with_private_fmt_function.snap
+++ b/tests/spec/build/snapshots/generated_fmt_import_coexists_with_private_fmt_function.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+type Thing struct {
+	X int
+}
+
+func (t Thing) String() string {
+	return fmt.Sprintf("Thing { x: %v }", t.X)
+}
+
+func (t Thing) to_string() string {
+	return t.String()
+}
+
+func fmt_() int {
+	return 1
+}
+
+func main() {
+	_ = Thing{X: 1}
+	_ = fmt_()
+}

--- a/tests/spec/build/snapshots/generated_fmt_requirement_reuses_unaliased_source_import.snap
+++ b/tests/spec/build/snapshots/generated_fmt_requirement_reuses_unaliased_source_import.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("direct")
+	s := fmt.Sprint(1)
+	_ = s
+}

--- a/tests/spec/build/snapshots/generated_import_qualifier_locals_renamed.snap
+++ b/tests/spec/build/snapshots/generated_import_qualifier_locals_renamed.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func show(fmt_ int) string {
+	return fmt.Sprint(fmt_)
+}
+
+func main() {
+	strings_ := 1
+	ok := strings.Contains("abc", "a")
+	_ = strings_
+	_ = ok
+	_ = show(2)
+}

--- a/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
+++ b/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
@@ -1,0 +1,56 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func MakeStatusReady() Status {
+	return Status{Tag: StatusReady}
+}
+
+type StatusTag int
+
+const (
+	StatusReady StatusTag = iota
+)
+
+type Status struct {
+	Tag StatusTag
+}
+
+func (s Status) MarshalJSON() ([]byte, error) {
+	switch s.Tag {
+	case StatusReady:
+		return json.Marshal("Ready")
+	default:
+		return nil, fmt.Errorf("unknown Status tag: %d", s.Tag)
+	}
+}
+
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return fmt.Errorf("invalid Status JSON: expected string")
+	}
+	switch name {
+	case "Ready":
+		s.Tag = StatusReady
+		return nil
+	default:
+		return fmt.Errorf("unknown Status variant: %s", name)
+	}
+}
+
+func json_() int {
+	return 1
+}
+
+func main() {
+	_ = MakeStatusReady()
+	_ = json_()
+}

--- a/tests/spec/build/snapshots/prelude_alias_coexists_with_private_lisette_function.snap
+++ b/tests/spec/build/snapshots/prelude_alias_coexists_with_private_lisette_function.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func lisette_() int {
+	return 1
+}
+
+func main() {
+	x := lisette.MakeOptionSome(1)
+	_ = x
+	_ = lisette_()
+}

--- a/tests/spec/build/snapshots/user_fmt_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_fmt_alias_preserved_alongside_generated_import.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	f "fmt"
+)
+
+type Thing struct {
+	X int
+}
+
+func (t Thing) String() string {
+	return fmt.Sprintf("Thing { x: %v }", t.X)
+}
+
+func (t Thing) to_string() string {
+	return t.String()
+}
+
+func main() {
+	_ = Thing{X: 1}
+	_ = f.Sprintf("x=%d", 1)
+}

--- a/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
@@ -1,0 +1,54 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"encoding/json"
+	js "encoding/json"
+	"fmt"
+)
+
+func MakeStatusReady() Status {
+	return Status{Tag: StatusReady}
+}
+
+type StatusTag int
+
+const (
+	StatusReady StatusTag = iota
+)
+
+type Status struct {
+	Tag StatusTag
+}
+
+func (s Status) MarshalJSON() ([]byte, error) {
+	switch s.Tag {
+	case StatusReady:
+		return json.Marshal("Ready")
+	default:
+		return nil, fmt.Errorf("unknown Status tag: %d", s.Tag)
+	}
+}
+
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return fmt.Errorf("invalid Status JSON: expected string")
+	}
+	switch name {
+	case "Ready":
+		s.Tag = StatusReady
+		return nil
+	default:
+		return fmt.Errorf("unknown Status variant: %s", name)
+	}
+}
+
+func main() {
+	s := MakeStatusReady()
+	_ = js.Valid(([]byte)(nil))
+	_ = s
+}

--- a/tests/spec/build/snapshots/user_strings_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_strings_alias_preserved_alongside_generated_import.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"strings"
+	s "strings"
+)
+
+func main() {
+	_ = s.ToUpper("abc")
+	_ = strings.Contains("abc", "a")
+}

--- a/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
@@ -36,13 +36,13 @@ func make_i() int {
 }
 
 func main() {
-	maps := make(map[int]map[string]Box)
+	maps_ := make(map[int]map[string]Box)
 	inner := make(map[string]Box)
 	inner["k"] = Box{x: 0}
-	maps[0] = inner
+	maps_[0] = inner
 	i := make_i()
-	entry := maps[i]["k"]
+	entry := maps_[i]["k"]
 	entry.x = 1
-	base_1 := maps[i]
+	base_1 := maps_[i]
 	base_1["k"] = entry
 }


### PR DESCRIPTION
The compiler could accept Lis source and emit Go that `go build` then rejected, because compiler-generated imports (`fmt`, `strings`, `lisette`, `encoding/json`, and others) were not being reconciled against user names. The qualifiers these imports rely on are now reserved.