### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.4.1](https://github.com/ivov/lisette/compare/lisette-v0.4.0...lisette-v0.4.1) - 2026-06-14
+
+- test: render remaining emit snapshot descriptions as yaml blocks [#725](https://github.com/ivov/lisette/pull/725) [`414e81b`](https://github.com/ivov/lisette/commit/414e81ba162c568c06cb660b7549c9ba2fe4acc9)
+- fix: correct UFCS lowering and generic type args [#724](https://github.com/ivov/lisette/pull/724) [`2ce2570`](https://github.com/ivov/lisette/commit/2ce25702968f5046418715ffb9848521fdc2d472)
+- feat: lint for float comparison hazards and NaN casts [#723](https://github.com/ivov/lisette/pull/723) [`6a316fe`](https://github.com/ivov/lisette/commit/6a316fe2181eef8e00b9446d2b20325785e79482)
+- feat: add LSP inlay type hints for `let` bindings [#722](https://github.com/ivov/lisette/pull/722) [`c61d141`](https://github.com/ivov/lisette/commit/c61d141660f0070cba0c35b8d31654d94c255b7b)
+- feat: lint for faulty bit masks and equal operands [#721](https://github.com/ivov/lisette/pull/721) [`b23d692`](https://github.com/ivov/lisette/commit/b23d692127e85ae24071e468ff549ff8f3e6eca6)
+- refactor: tighten bindgen for maintainability [#720](https://github.com/ivov/lisette/pull/720) [`efde06b`](https://github.com/ivov/lisette/commit/efde06b5b8731acc923f493fa2af0204c8cffcfb)
+- ci: stop requiring zed extension version bump on grammar change [#718](https://github.com/ivov/lisette/pull/718) [`13a3231`](https://github.com/ivov/lisette/commit/13a3231cd245c3e1c531b8bc3dc077c69261829d)
+- refactor: rework cli styling [#717](https://github.com/ivov/lisette/pull/717) [`27d427e`](https://github.com/ivov/lisette/commit/27d427ea21c5885c956460d41e5e31ede0673528)
+- chore: rebuild playground [#716](https://github.com/ivov/lisette/pull/716) [`66677a1`](https://github.com/ivov/lisette/commit/66677a1d4fd88d9a20a0dc816b628d83b8abafda)
+- feat: add `equals` method for slices and maps [#715](https://github.com/ivov/lisette/pull/715) [`2c69536`](https://github.com/ivov/lisette/commit/2c69536dafdd22f9514133edf5983bdaff080e33)
+- feat: flag impossible, redundant, and combinable comparisons [#712](https://github.com/ivov/lisette/pull/712) [`8fbcb7f`](https://github.com/ivov/lisette/commit/8fbcb7fd50677637ca3558cb07ed691d3c77ff2a)
+
 ## [0.4.0](https://github.com/ivov/lisette/compare/lisette-v0.3.4...lisette-v0.4.0) - 2026-06-13
 
 - feat: advise against recompiling a regexp in a loop [#710](https://github.com/ivov/lisette/pull/710) [`b88540d`](https://github.com/ivov/lisette/commit/b88540d712bc493d764484ca3f86f152a3889d23)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "ecow",
@@ -610,11 +610,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,14 +20,14 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.4.0", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.0", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.4.0", path = "../format" }
-emit = { package = "lisette-emit", version = "0.4.0", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.4.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.4.0", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.4.0", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.4.1", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.1", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.4.1", path = "../format" }
+emit = { package = "lisette-emit", version = "0.4.1", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.4.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.4.1", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.4.1", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.4.0", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.4.1", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.0", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.1", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.4.0", path = "../semantics" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.0", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.4.0", path = "../deps" }
-format = { package = "lisette-format", version = "0.4.0", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.4.1", path = "../semantics" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.1", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.4.1", path = "../deps" }
+format = { package = "lisette-format", version = "0.4.1", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.0", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.0", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.4.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.4.0", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.4.1", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.1", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.4.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.4.1", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.4.1 (upcoming)

- test: render remaining emit snapshot descriptions as yaml blocks [#725](https://github.com/ivov/lisette/pull/725) [`414e81b`](https://github.com/ivov/lisette/commit/414e81ba162c568c06cb660b7549c9ba2fe4acc9)
- fix: correct UFCS lowering and generic type args [#724](https://github.com/ivov/lisette/pull/724) [`2ce2570`](https://github.com/ivov/lisette/commit/2ce25702968f5046418715ffb9848521fdc2d472)
- feat: lint for float comparison hazards and NaN casts [#723](https://github.com/ivov/lisette/pull/723) [`6a316fe`](https://github.com/ivov/lisette/commit/6a316fe2181eef8e00b9446d2b20325785e79482)
- feat: add LSP inlay type hints for `let` bindings [#722](https://github.com/ivov/lisette/pull/722) [`c61d141`](https://github.com/ivov/lisette/commit/c61d141660f0070cba0c35b8d31654d94c255b7b)
- feat: lint for faulty bit masks and equal operands [#721](https://github.com/ivov/lisette/pull/721) [`b23d692`](https://github.com/ivov/lisette/commit/b23d692127e85ae24071e468ff549ff8f3e6eca6)
- refactor: tighten bindgen for maintainability [#720](https://github.com/ivov/lisette/pull/720) [`efde06b`](https://github.com/ivov/lisette/commit/efde06b5b8731acc923f493fa2af0204c8cffcfb)
- ci: stop requiring zed extension version bump on grammar change [#718](https://github.com/ivov/lisette/pull/718) [`13a3231`](https://github.com/ivov/lisette/commit/13a3231cd245c3e1c531b8bc3dc077c69261829d)
- refactor: rework cli styling [#717](https://github.com/ivov/lisette/pull/717) [`27d427e`](https://github.com/ivov/lisette/commit/27d427ea21c5885c956460d41e5e31ede0673528)
- chore: rebuild playground [#716](https://github.com/ivov/lisette/pull/716) [`66677a1`](https://github.com/ivov/lisette/commit/66677a1d4fd88d9a20a0dc816b628d83b8abafda)
- feat: add `equals` method for slices and maps [#715](https://github.com/ivov/lisette/pull/715) [`2c69536`](https://github.com/ivov/lisette/commit/2c69536dafdd22f9514133edf5983bdaff080e33)
- feat: flag impossible, redundant, and combinable comparisons [#712](https://github.com/ivov/lisette/pull/712) [`8fbcb7f`](https://github.com/ivov/lisette/commit/8fbcb7fd50677637ca3558cb07ed691d3c77ff2a)
