### PR TITLE
feat: add `equals` method for slices and maps

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1059,8 +1059,23 @@ pub fn not_comparable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic 
         .with_infer_code("type_mismatch")
         .with_span_label(&span, format!("`{}` cannot be compared with `==`", ty))
         .with_help(format!(
-            "The `==` and `!=` operators cannot be used on {} because they are not comparable in Go",
-            reason
+            "The `==` and `!=` operators cannot be used on {reason} because they are not comparable in Go"
+        ))
+}
+
+pub fn not_comparable_use_equals(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid comparison")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("`{}` cannot be compared with `==`", ty))
+        .with_help(format!("Use `.equals()` to compare {reason}"))
+}
+
+pub fn not_comparable_no_equals(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid comparison")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("`{}` cannot be compared with `==`", ty))
+        .with_help(format!(
+            "`.equals()` will not help either, because {reason} cannot be compared"
         ))
 }
 
@@ -1072,6 +1087,15 @@ pub fn not_comparable_interface(ty: &Type, span: Span) -> LisetteDiagnostic {
             "An interface value's comparability depends on its runtime type, so `==` and `!=` \
              are not allowed here. Compare the concrete values instead",
         )
+}
+
+pub fn not_equatable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid comparison")
+        .with_infer_code("not_equatable")
+        .with_span_label(&span, "cannot be compared")
+        .with_help(format!(
+            "`{ty}` cannot be compared because {reason} cannot be compared"
+        ))
 }
 
 pub fn not_orderable_bound(span: Span) -> LisetteDiagnostic {

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -11,7 +11,7 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::types::native::NativeGoType;
 use crate::utils::{contains_call, reads_mutable_operand};
 use syntax::ast::Expression;
-use syntax::types::peel_to_range_type;
+use syntax::types::{Type, peel_to_range_type};
 
 #[derive(Clone, Copy)]
 pub(super) enum InlineImport {
@@ -338,6 +338,18 @@ impl Planner<'_> {
             return self.lower_string_substring(expression, ctx.args, fx);
         }
 
+        if ctx.method == "equals"
+            && matches!(ctx.native_type, NativeGoType::Slice | NativeGoType::Map)
+        {
+            let receiver_ty = self.facts.peel_alias(&expression.get_type().strip_refs());
+            if receiver_ty.is_slice() || receiver_ty.is_map() {
+                let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
+                let body =
+                    self.render_container_equality(&receiver, &emitted_args[0], &receiver_ty, fx);
+                return (setup, body);
+            }
+        }
+
         let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
 
         if let Some(inlined) = apply_inline_lookup(
@@ -455,6 +467,27 @@ impl Planner<'_> {
             && ctx.args.len() >= 2
         {
             return self.lower_string_substring(&ctx.args[0], &ctx.args[1..], fx);
+        }
+
+        if ctx.method == "equals"
+            && matches!(ctx.native_type, NativeGoType::Slice | NativeGoType::Map)
+            && let Some(receiver_expr) = ctx.args.first()
+        {
+            let receiver_ty = self
+                .facts
+                .peel_alias(&receiver_expr.get_type().strip_refs());
+            if receiver_ty.is_slice() || receiver_ty.is_map() {
+                let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
+                if emitted_args.len() >= 2 {
+                    let body = self.render_container_equality(
+                        &emitted_args[0],
+                        &emitted_args[1],
+                        &receiver_ty,
+                        fx,
+                    );
+                    return (setup, body);
+                }
+            }
         }
 
         let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
@@ -578,6 +611,53 @@ impl Planner<'_> {
             setup,
             format_substring_call(&deref(&values[0]), start.as_deref(), end.as_deref()),
         )
+    }
+
+    fn render_container_equality(
+        &mut self,
+        lhs: &str,
+        rhs: &str,
+        ty: &Type,
+        fx: &mut EmitEffects,
+    ) -> String {
+        let peeled = self.facts.peel_alias(&ty.strip_refs());
+        if peeled.is_slice() {
+            fx.require_slices();
+            return match peeled.inner() {
+                Some(elem) if self.is_container(&elem) => {
+                    let eq = self.container_equality_closure(&elem, fx);
+                    format!("slices.EqualFunc({lhs}, {rhs}, {eq})")
+                }
+                _ => format!("slices.Equal({lhs}, {rhs})"),
+            };
+        }
+        if peeled.is_map() {
+            fx.require_maps();
+            let value = peeled
+                .as_compound()
+                .and_then(|(_, args)| args.get(1).cloned());
+            return match value {
+                Some(value) if self.is_container(&value) => {
+                    let eq = self.container_equality_closure(&value, fx);
+                    format!("maps.EqualFunc({lhs}, {rhs}, {eq})")
+                }
+                _ => format!("maps.Equal({lhs}, {rhs})"),
+            };
+        }
+        unreachable!("`.equals()` gate guarantees a slice or map receiver")
+    }
+
+    fn container_equality_closure(&mut self, ty: &Type, fx: &mut EmitEffects) -> String {
+        let go_ty = self.go_type_string(ty, fx);
+        let a = self.fresh_var(Some("a"));
+        let b = self.fresh_var(Some("b"));
+        let body = self.render_container_equality(&a, &b, ty, fx);
+        format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
+    }
+
+    fn is_container(&self, ty: &Type) -> bool {
+        let peeled = self.facts.peel_alias(&ty.strip_refs());
+        peeled.is_slice() || peeled.is_map()
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -1,0 +1,208 @@
+use crate::checker::EnvResolve;
+use crate::checker::TypeEnv;
+use crate::checker::infer::InferCtx;
+use crate::store::Store;
+use syntax::ast::{Expression, Span};
+use syntax::program::DefinitionBody;
+use syntax::types::{CompoundKind, Type, substitute};
+
+pub(crate) fn check_not_comparable(
+    env: &TypeEnv,
+    store: &Store,
+    ty: &Type,
+) -> Option<&'static str> {
+    let resolved = store.deep_resolve_alias(ty);
+    let ty = &resolved;
+
+    if matches!(ty, Type::Function(_)) {
+        return Some("functions");
+    }
+
+    if ty.has_name("Slice") {
+        return Some("slices");
+    }
+    if ty.has_name("Map") {
+        return Some("maps");
+    }
+
+    if ty.has_name("Ref") || ty.has_name("Channel") {
+        return None;
+    }
+
+    if matches!(ty, Type::Var { .. }) {
+        return None;
+    }
+
+    if ty.is_unknown() {
+        return Some("interface values");
+    }
+
+    if let Some(underlying) = ty.get_underlying() {
+        return check_not_comparable(env, store, underlying);
+    }
+
+    if matches!(ty, Type::Parameter(_)) {
+        return Some("type parameters");
+    }
+
+    if let Some(name) = ty.get_qualified_id()
+        && let Some(definition) = store.get_definition(name)
+    {
+        let type_args = ty.get_type_params().unwrap_or_default();
+        let generics = match &definition.body {
+            DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
+                generics.as_slice()
+            }
+            _ => &[],
+        };
+        let sub_map = generics
+            .iter()
+            .map(|g| g.name.clone())
+            .zip(type_args.iter().cloned())
+            .collect();
+
+        match &definition.body {
+            DefinitionBody::Struct { fields, .. } => {
+                for f in fields {
+                    let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
+                    if check_not_comparable(env, store, &field_ty).is_some() {
+                        return Some("a struct containing non-comparable fields");
+                    }
+                }
+            }
+            DefinitionBody::Enum { variants, .. } => {
+                for v in variants {
+                    for f in v.fields.iter() {
+                        let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
+                        if check_not_comparable(env, store, &field_ty).is_some() {
+                            return Some("an enum containing non-comparable fields");
+                        }
+                    }
+                }
+            }
+            DefinitionBody::Interface { .. } => return Some("interface values"),
+            _ => {}
+        }
+    }
+
+    if let Type::Tuple(elems) = ty {
+        for e in elems {
+            if check_not_comparable(env, store, &e.resolve_in(env)).is_some() {
+                return Some("a tuple containing non-comparable elements");
+            }
+        }
+    }
+
+    None
+}
+
+fn is_interface_or_unknown(store: &Store, ty: &Type) -> bool {
+    let resolved = store.deep_resolve_alias(ty);
+    resolved.is_unknown() || store.is_interface(&resolved)
+}
+
+impl InferCtx<'_, '_> {
+    pub(super) fn ensure_comparable(
+        &mut self,
+        ty: &Type,
+        span: &Span,
+        operands_match: bool,
+    ) -> bool {
+        let store = self.store;
+        let resolved = ty.resolve_in(&self.env);
+        if resolved.is_error() {
+            return true;
+        }
+        if let Type::Parameter(name) = &resolved
+            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+        {
+            return true;
+        }
+        let Some(reason) = check_not_comparable(&self.env, store, &resolved) else {
+            return true;
+        };
+        if is_interface_or_unknown(store, &resolved) {
+            self.sink.push(diagnostics::infer::not_comparable_interface(
+                &resolved, *span,
+            ));
+        } else if operands_match && let Some(element) = self.container_equals_element(&resolved) {
+            match self.not_equatable_reason(&element) {
+                Some(element_reason) => self.sink.push(
+                    diagnostics::infer::not_comparable_no_equals(&resolved, element_reason, *span),
+                ),
+                None => self
+                    .sink
+                    .push(diagnostics::infer::not_comparable_use_equals(
+                        &resolved, reason, *span,
+                    )),
+            }
+        } else {
+            self.sink
+                .push(diagnostics::infer::not_comparable(&resolved, reason, *span));
+        }
+        false
+    }
+
+    pub(super) fn not_equatable_reason(&self, ty: &Type) -> Option<&'static str> {
+        let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
+
+        if let Type::Parameter(name) = &resolved
+            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+        {
+            return None;
+        }
+        // `?` returns `None` (equatable) when the type is comparable.
+        let reason = check_not_comparable(&self.env, self.store, &resolved)?;
+
+        match resolved.as_compound() {
+            Some((CompoundKind::Slice, args)) => self.not_equatable_reason(args.first()?),
+            Some((CompoundKind::Map, args)) => self.not_equatable_reason(args.get(1)?),
+            _ => Some(reason),
+        }
+    }
+
+    pub(super) fn gate_container_equals(&mut self, receiver_ty: &Type, span: Span) {
+        let receiver = self.store.deep_resolve_alias(receiver_ty);
+        let element = match receiver.as_compound() {
+            Some((CompoundKind::Slice, args)) => args.first().cloned(),
+            Some((CompoundKind::Map, args)) => args.get(1).cloned(),
+            _ => return,
+        };
+        if let Some(element) = element
+            && let Some(reason) = self.not_equatable_reason(&element)
+        {
+            self.sink
+                .push(diagnostics::infer::not_equatable(&receiver, reason, span));
+        }
+    }
+
+    /// A container's `equals` lowers to a free function, not a Go method, so it cannot satisfy an interface or bound.
+    pub(in crate::checker::infer) fn is_native_container(&self, ty: &Type) -> bool {
+        let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
+        resolved.is_slice() || resolved.is_map()
+    }
+
+    fn container_equals_element(&self, ty: &Type) -> Option<Type> {
+        let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
+        match resolved.as_compound() {
+            Some((CompoundKind::Slice, args)) => args.first().cloned(),
+            Some((CompoundKind::Map, args)) => args.get(1).cloned(),
+            _ => None,
+        }
+    }
+
+    /// Gates `Slice.equals(a, b)`, which parses as one identifier (not a dot access) so `infer_dot_access` never sees it.
+    pub(super) fn check_native_equals_ufcs(&mut self, callee: &Expression, args: &[Expression]) {
+        let Expression::Identifier { value, .. } = callee.unwrap_parens() else {
+            return;
+        };
+        if value.as_str() != "Slice.equals" && value.as_str() != "Map.equals" {
+            return;
+        }
+        let Some(receiver) = args.first() else {
+            return;
+        };
+        let receiver_ty = receiver.get_type().resolve_in(&self.env).strip_refs();
+        self.gate_container_equals(&receiver_ty, receiver.get_span());
+    }
+}

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -256,6 +256,9 @@ impl InferCtx<'_, '_> {
             {
                 self.sink.push(diagnostics::infer::ref_slice_append(span));
             }
+            if member.as_str() == "equals" && self.scopes.is_callee_context() {
+                self.gate_container_equals(&args.deref_ty, args.expression.get_span());
+            }
             if !self.scopes.is_callee_context()
                 && matches!(
                     expression.get_type().resolve_in(&self.env),

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -429,6 +429,7 @@ impl InferCtx<'_, '_> {
             resolved.is_unit() || resolved.is_ignored() || expected_was_variable
         };
         self.check_native_mutating_call(&callee_expression, result_unused, &span);
+        self.check_native_equals_ufcs(&callee_expression, &new_args);
 
         if self.is_generic_callee(&callee_expression)
             && type_args.is_empty()

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -1,4 +1,5 @@
 pub mod bindings;
+pub mod comparison;
 pub mod control_flow;
 pub mod definitions;
 pub mod dot_access;

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -1,105 +1,12 @@
 use crate::checker::EnvResolve;
-use crate::checker::TypeEnv;
 use crate::store::Store;
 use syntax::ast::{BinaryOperator, Expression, Literal, Span, UnaryOperator};
-use syntax::program::DefinitionBody;
-use syntax::types::{SimpleKind, Type, substitute};
+use syntax::types::{SimpleKind, Type};
 
 use BinaryOperator::*;
 use UnaryOperator::*;
 
 use crate::checker::infer::InferCtx;
-
-/// Returns the first non-comparable shape per Go's `comparable` rules, or `None` if comparable.
-pub(crate) fn check_not_comparable(
-    env: &TypeEnv,
-    store: &Store,
-    ty: &Type,
-) -> Option<&'static str> {
-    let resolved = store.deep_resolve_alias(ty);
-    let ty = &resolved;
-
-    if matches!(ty, Type::Function(_)) {
-        return Some("functions");
-    }
-
-    if ty.has_name("Slice") {
-        return Some("slices");
-    }
-    if ty.has_name("Map") {
-        return Some("maps");
-    }
-
-    if ty.has_name("Ref") || ty.has_name("Channel") {
-        return None;
-    }
-
-    if matches!(ty, Type::Var { .. }) {
-        return None;
-    }
-
-    if ty.is_unknown() {
-        return Some("interface values");
-    }
-
-    if let Some(underlying) = ty.get_underlying() {
-        return check_not_comparable(env, store, underlying);
-    }
-
-    if matches!(ty, Type::Parameter(_)) {
-        return Some("type parameters (Go requires the `comparable` constraint)");
-    }
-
-    if let Some(name) = ty.get_qualified_id()
-        && let Some(definition) = store.get_definition(name)
-    {
-        let type_args = ty.get_type_params().unwrap_or_default();
-        let generics = match &definition.body {
-            DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
-                generics.as_slice()
-            }
-            _ => &[],
-        };
-        let sub_map = generics
-            .iter()
-            .map(|g| g.name.clone())
-            .zip(type_args.iter().cloned())
-            .collect();
-
-        match &definition.body {
-            DefinitionBody::Struct { fields, .. } => {
-                for f in fields {
-                    let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
-                    if check_not_comparable(env, store, &field_ty).is_some() {
-                        return Some("a struct containing non-comparable fields");
-                    }
-                }
-            }
-            DefinitionBody::Enum { variants, .. } => {
-                for v in variants {
-                    for f in v.fields.iter() {
-                        let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
-                        if check_not_comparable(env, store, &field_ty).is_some() {
-                            return Some("an enum containing non-comparable fields");
-                        }
-                    }
-                }
-            }
-            DefinitionBody::Interface { .. } => return Some("interface values"),
-            _ => {}
-        }
-    }
-
-    if let Type::Tuple(elems) = ty {
-        for e in elems {
-            if check_not_comparable(env, store, &e.resolve_in(env)).is_some() {
-                return Some("a tuple containing non-comparable elements");
-            }
-        }
-    }
-
-    None
-}
 
 impl InferCtx<'_, '_> {
     pub(super) fn infer_unary(
@@ -445,8 +352,10 @@ impl InferCtx<'_, '_> {
                         );
                     }
                 }
-                if self.ensure_comparable(left_operand_ty, left_span) {
-                    self.ensure_comparable(right_operand_ty, right_span);
+                let operands_match =
+                    left_operand_ty.resolve_in(&self.env) == right_operand_ty.resolve_in(&self.env);
+                if self.ensure_comparable(left_operand_ty, left_span, operands_match) {
+                    self.ensure_comparable(right_operand_ty, right_span, operands_match);
                 }
                 self.type_bool()
             }
@@ -695,31 +604,6 @@ impl InferCtx<'_, '_> {
             self.sink
                 .push(diagnostics::infer::not_orderable(&resolved_ty, *span));
         }
-    }
-
-    fn ensure_comparable(&mut self, ty: &Type, span: &Span) -> bool {
-        let store = self.store;
-        let resolved = ty.resolve_in(&self.env);
-        if resolved.is_error() {
-            return true;
-        }
-        if let Type::Parameter(name) = &resolved
-            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
-        {
-            return true;
-        }
-        let Some(reason) = check_not_comparable(&self.env, store, &resolved) else {
-            return true;
-        };
-        if is_interface_or_unknown(store, &resolved) {
-            self.sink.push(diagnostics::infer::not_comparable_interface(
-                &resolved, *span,
-            ));
-        } else {
-            self.sink
-                .push(diagnostics::infer::not_comparable(&resolved, reason, *span));
-        }
-        false
     }
 
     fn unify_binary_operands(
@@ -1075,11 +959,6 @@ fn literal_can_adapt_to(kind: &LiteralKind, target: &Type) -> bool {
         LiteralKind::Boolean => named_backed_by(SimpleKind::Bool),
         LiteralKind::None => false,
     }
-}
-
-fn is_interface_or_unknown(store: &Store, ty: &Type) -> bool {
-    let resolved = store.deep_resolve_alias(ty);
-    resolved.is_unknown() || store.is_interface(&resolved)
 }
 
 fn is_nominal_defined_type(ty: &Type, store: &Store) -> bool {

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -248,6 +248,10 @@ impl InferCtx<'_, '_> {
             };
 
         for (method_name, method_ty) in &interface.methods {
+            if method_name.as_str() == "equals" && self.is_native_container(ty) {
+                missing.push((method_name.to_string(), method_ty.clone()));
+                continue;
+            }
             let Some(symbol_method) = symbol_methods.get(method_name.as_str()) else {
                 missing.push((method_name.to_string(), method_ty.clone()));
                 continue;

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -628,7 +628,7 @@ impl InferCtx<'_, '_> {
                     .push(diagnostics::infer::not_orderable_bound(*span));
             }
             BuiltinBound::Comparable => {
-                if super::expressions::operators::check_not_comparable(
+                if super::expressions::comparison::check_not_comparable(
                     &self.env,
                     store,
                     resolved_generic,

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -310,6 +310,9 @@ impl<T> Slice<T> {
   /// Returns `true` if the slice contains `value`.
   fn contains(self, value: T) -> bool
 
+  /// Returns `true` if this slice is element-wise equal to `other`.
+  fn equals(self, other: Slice<T>) -> bool
+
   /// Reduces the slice to a single value by applying `f` to each element
   /// with an accumulator, starting from `accumulator`.
   fn fold<U>(self, accumulator: U, f: fn(U, T) -> U) -> U
@@ -378,6 +381,9 @@ impl<K, V> Map<K, V> {
 
   /// Returns a shallow copy of the map.
   fn clone(self) -> Map<K, V>
+
+  /// Returns `true` if this map has the same keys and values as `other`.
+  fn equals(self, other: Map<K, V>) -> bool
 }
 
 /// A reference (pointer) to a value of type `T`. Equivalent to Go's `*T`.

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -334,6 +334,86 @@ fn test(s: Slice<int>, v: int) -> bool {
 }
 
 #[test]
+fn slice_equals() {
+    let input = r#"
+fn test(a: Slice<int>, b: Slice<int>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_equals_negated() {
+    let input = r#"
+fn test(a: Slice<int>, b: Slice<int>) -> bool {
+  !a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nested_slice_equals() {
+    let input = r#"
+fn test(a: Slice<Slice<int>>, b: Slice<Slice<int>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_equals_comparable_generic() {
+    let input = r#"
+fn test<T: Comparable>(a: Slice<T>, b: Slice<T>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_equals_ufcs() {
+    let input = r#"
+fn test(a: Slice<int>, b: Slice<int>) -> bool {
+  Slice.equals(a, b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_equals() {
+    let input = r#"
+fn test(a: Map<string, int>, b: Map<string, int>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_of_slice_equals() {
+    let input = r#"
+fn test(a: Map<string, Slice<int>>, b: Map<string, Slice<int>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_of_map_equals() {
+    let input = r#"
+fn test(a: Slice<Map<string, int>>, b: Slice<Map<string, int>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_fold() {
     let input = r#"
 fn test(s: Slice<int>) -> int {

--- a/tests/spec/emit/snapshots/map_equals.snap
+++ b/tests/spec/emit/snapshots/map_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Map<string, int>, b: Map<string, int>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "maps"
+
+func test(a, b map[string]int) bool {
+	return maps.Equal(a, b)
+}

--- a/tests/spec/emit/snapshots/map_of_slice_equals.snap
+++ b/tests/spec/emit/snapshots/map_of_slice_equals.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Map<string, Slice<int>>, b: Map<string, Slice<int>>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import (
+	"maps"
+	"slices"
+)
+
+func test(a, b map[string][]int) bool {
+	return maps.EqualFunc(a, b, func(a_1 []int, b_2 []int) bool { return slices.Equal(a_1, b_2) })
+}

--- a/tests/spec/emit/snapshots/nested_slice_equals.snap
+++ b/tests/spec/emit/snapshots/nested_slice_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Slice<Slice<int>>, b: Slice<Slice<int>>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+func test(a, b [][]int) bool {
+	return slices.EqualFunc(a, b, func(a_1 []int, b_2 []int) bool { return slices.Equal(a_1, b_2) })
+}

--- a/tests/spec/emit/snapshots/slice_equals.snap
+++ b/tests/spec/emit/snapshots/slice_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+func test(a, b []int) bool {
+	return slices.Equal(a, b)
+}

--- a/tests/spec/emit/snapshots/slice_equals_comparable_generic.snap
+++ b/tests/spec/emit/snapshots/slice_equals_comparable_generic.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test<T: Comparable>(a: Slice<T>, b: Slice<T>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+func test[T comparable](a, b []T) bool {
+	return slices.Equal(a, b)
+}

--- a/tests/spec/emit/snapshots/slice_equals_negated.snap
+++ b/tests/spec/emit/snapshots/slice_equals_negated.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  !a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+func test(a, b []int) bool {
+	return !slices.Equal(a, b)
+}

--- a/tests/spec/emit/snapshots/slice_equals_ufcs.snap
+++ b/tests/spec/emit/snapshots/slice_equals_ufcs.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  Slice.equals(a, b)\n}\n"
+---
+package main
+
+import "slices"
+
+func test(a, b []int) bool {
+	return slices.Equal(a, b)
+}

--- a/tests/spec/emit/snapshots/slice_of_map_equals.snap
+++ b/tests/spec/emit/snapshots/slice_of_map_equals.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/prelude.rs
+description: "\nfn test(a: Slice<Map<string, int>>, b: Slice<Map<string, int>>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import (
+	"maps"
+	"slices"
+)
+
+func test(a, b []map[string]int) bool {
+	return slices.EqualFunc(a, b, func(a_1 map[string]int, b_2 map[string]int) bool { return maps.Equal(a_1, b_2) })
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6072,6 +6072,123 @@ fn test() {
 }
 
 #[test]
+fn infer_not_comparable_map() {
+    let input = r#"
+fn test(a: Map<string, int>, b: Map<string, int>) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_slice_of_functions() {
+    let input = r#"
+fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) -> bool {
+  a == b
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_map_of_functions() {
+    let input = r#"
+fn test(a: Map<string, fn() -> int>, b: Map<string, fn() -> int>) -> bool {
+  a == b
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_slice_of_noncomparable_structs() {
+    let input = r#"
+struct Holder {
+  items: Slice<int>,
+}
+
+fn test(a: Slice<Holder>, b: Slice<Holder>) -> bool {
+  a == b
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_container_fails_interface_bound() {
+    let input = r#"
+interface Equatable<T> {
+  fn equals(self, other: T) -> bool
+}
+
+fn same<T: Equatable<T>>(x: T, y: T) -> bool {
+  x.equals(y)
+}
+
+fn main() {
+  let x = [1, 2]
+  let _ = same(x, x)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_rejects_function_element() {
+    let input = r#"
+fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
+  let result = a.equals(b);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_rejects_noncomparable_struct_element() {
+    let input = r#"
+struct Holder {
+  items: Slice<int>,
+}
+
+fn test(a: Slice<Holder>, b: Slice<Holder>) {
+  let result = a.equals(b);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_rejects_unbounded_generic_element() {
+    let input = r#"
+fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_rejects_map_function_value() {
+    let input = r#"
+fn test(a: Map<string, fn() -> int>, b: Map<string, fn() -> int>) {
+  let result = a.equals(b);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_equals_ufcs_rejects_function_element() {
+    let input = r#"
+fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
+  let result = Slice.equals(a, b);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_not_comparable_function() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_equals_container_fails_interface_bound.snap
+++ b/tests/ui/errors/snapshots/infer_equals_container_fails_interface_bound.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Interface not implemented
+    ╭─[test.lis:12:16]
+ 11 │   let x = [1, 2]
+ 12 │   let _ = same(x, x)
+    ·                ┬
+    ·                ╰── `Slice` does not implement `Equatable`
+ 13 │ }
+    ╰────
+  help: Missing methods:
+          From `Equatable`
+            - equals: fn (T) -> bool
+        code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_equals_rejects_function_element.snap
+++ b/tests/ui/errors/snapshots/infer_equals_rejects_function_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:16]
+ 2 │ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
+ 3 │   let result = a.equals(b);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Slice<fn () -> int>` cannot be compared because functions cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_equals_rejects_map_function_value.snap
+++ b/tests/ui/errors/snapshots/infer_equals_rejects_map_function_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:16]
+ 2 │ fn test(a: Map<string, fn() -> int>, b: Map<string, fn() -> int>) {
+ 3 │   let result = a.equals(b);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Map<string, fn () -> int>` cannot be compared because functions cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_equals_rejects_noncomparable_struct_element.snap
+++ b/tests/ui/errors/snapshots/infer_equals_rejects_noncomparable_struct_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:7:16]
+ 6 │ fn test(a: Slice<Holder>, b: Slice<Holder>) {
+ 7 │   let result = a.equals(b);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 8 │ }
+   ╰────
+  help: `Slice<Holder>` cannot be compared because a struct containing non-comparable fields cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_equals_rejects_unbounded_generic_element.snap
+++ b/tests/ui/errors/snapshots/infer_equals_rejects_unbounded_generic_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:3]
+ 2 │ fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
+ 3 │   a.equals(b)
+   ·   ┬
+   ·   ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Slice<T>` cannot be compared because type parameters cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_equals_ufcs_rejects_function_element.snap
+++ b/tests/ui/errors/snapshots/infer_equals_ufcs_rejects_function_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:29]
+ 2 │ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
+ 3 │   let result = Slice.equals(a, b);
+   ·                             ┬
+   ·                             ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Slice<fn () -> int>` cannot be compared because functions cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_not_comparable_map.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_map.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:16]
+ 2 │ fn test(a: Map<string, int>, b: Map<string, int>) {
+ 3 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Map<string, int>` cannot be compared with `==`
+ 4 │ }
+   ╰────
+  help: Use `.equals()` to compare maps · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_map_of_functions.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_map_of_functions.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:3]
+ 2 │ fn test(a: Map<string, fn() -> int>, b: Map<string, fn() -> int>) -> bool {
+ 3 │   a == b
+   ·   ┬
+   ·   ╰── `Map<string, fn () -> int>` cannot be compared with `==`
+ 4 │ }
+   ╰────
+  help: `.equals()` will not help either, because functions cannot be compared · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_slice.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_slice.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Type mismatch
+  [error] Invalid comparison
    ╭─[test.lis:5:16]
  4 │   let b = [1, 2, 3];
  5 │   let result = a == b;
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                ╰── `Slice<int>` cannot be compared with `==`
  6 │ }
    ╰────
-  help: The `==` and `!=` operators cannot be used on slices because they are not comparable in Go · code: [infer.type_mismatch]
+  help: Use `.equals()` to compare slices · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_slice_of_functions.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_slice_of_functions.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:3:3]
+ 2 │ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) -> bool {
+ 3 │   a == b
+   ·   ┬
+   ·   ╰── `Slice<fn () -> int>` cannot be compared with `==`
+ 4 │ }
+   ╰────
+  help: `.equals()` will not help either, because functions cannot be compared · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_slice_of_noncomparable_structs.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_slice_of_noncomparable_structs.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:7:3]
+ 6 │ fn test(a: Slice<Holder>, b: Slice<Holder>) -> bool {
+ 7 │   a == b
+   ·   ┬
+   ·   ╰── `Slice<Holder>` cannot be compared with `==`
+ 8 │ }
+   ╰────
+  help: `.equals()` will not help either, because a struct containing non-comparable fields cannot be compared · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_slice_through_alias.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_slice_through_alias.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Type mismatch
+  [error] Invalid comparison
    ╭─[test.lis:5:16]
  4 │ fn test(a: Bytes, b: Bytes) {
  5 │   let result = a == b;
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                ╰── `Bytes` cannot be compared with `==`
  6 │ }
    ╰────
-  help: The `==` and `!=` operators cannot be used on slices because they are not comparable in Go · code: [infer.type_mismatch]
+  help: Use `.equals()` to compare slices · code: [infer.type_mismatch]


### PR DESCRIPTION
Adds an `equals` method to `Slice<T>` and `Map<K, V>` for element-wise comparison.