### PR TITLE
feat: lint for faulty bit masks and equal operands

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -312,6 +312,44 @@ pub fn double_comparison(span: &Span, combined: &str) -> LisetteDiagnostic {
         ))
 }
 
+pub fn bad_bit_mask(span: &Span, always_true: bool) -> LisetteDiagnostic {
+    let (result, clause) = if always_true {
+        ("true", "always satisfy")
+    } else {
+        ("false", "unable to satisfy")
+    };
+
+    LisetteDiagnostic::warn("Incompatible bit mask")
+        .with_lint_code("bad_bit_mask")
+        .with_span_label(span, format!("always `{result}`"))
+        .with_help(format!(
+            "The mask makes this value {clause} the comparison, so it is always `{result}`. Check the mask or the constant."
+        ))
+}
+
+pub fn ineffective_bit_mask(
+    span: &Span,
+    mask_operator: &str,
+    mask: i128,
+    constant: i128,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Ineffective bit mask")
+        .with_lint_code("ineffective_bit_mask")
+        .with_span_label(span, "mask has no effect")
+        .with_help(format!(
+            "`{mask_operator} {mask}` does not change the result of comparing with `{constant}`, so the mask can be removed."
+        ))
+}
+
+pub fn equal_operands(span: &Span, note: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Equal operands")
+        .with_lint_code("equal_operands")
+        .with_span_label(span, "identical operands")
+        .with_help(format!(
+            "Both operands are identical so the result {note}. Did you mean to use different operands?"
+        ))
+}
+
 pub fn non_negative_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic {
     let result = if always_true { "true" } else { "false" };
 

--- a/crates/semantics/src/passes/comparison.rs
+++ b/crates/semantics/src/passes/comparison.rs
@@ -1,7 +1,95 @@
 use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
+use syntax::types::SimpleKind;
 
 /// A value bound: `(value, inclusive)`, or `None` for an open side.
 pub(crate) type Bound = Option<(i128, bool)>;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MaskOp {
+    And,
+    Or,
+}
+
+/// A masked integer comparison, `operator` flipped so the masked side is left.
+pub(crate) struct MaskComparison {
+    pub(crate) mask_op: MaskOp,
+    pub(crate) mask: i128,
+    pub(crate) operator: BinaryOperator,
+    pub(crate) constant: i128,
+    pub(crate) kind: SimpleKind,
+}
+
+/// Decomposes a masked integer comparison; `None` unless `m` and `c` are in-range
+/// integer literals and `m != 0` (zero masks belong to `redundant_operation`).
+/// A negative `m` is valid only for the equality reasoning.
+pub(crate) fn mask_comparison(expression: &Expression) -> Option<MaskComparison> {
+    use BinaryOperator::*;
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        ..
+    } = expression
+    else {
+        return None;
+    };
+    if !matches!(
+        operator,
+        Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual
+    ) {
+        return None;
+    }
+
+    let left = left.unwrap_parens();
+    let right = right.unwrap_parens();
+    let (mask_expr, operator, constant) =
+        match (signed_integer_literal(left), signed_integer_literal(right)) {
+            (None, Some(constant)) => (left, *operator, constant),
+            (Some(constant), None) => (right, flip_comparison(*operator), constant),
+            _ => return None,
+        };
+
+    let Expression::Binary {
+        operator: bit_operator,
+        left: bit_left,
+        right: bit_right,
+        ..
+    } = mask_expr
+    else {
+        return None;
+    };
+    let mask_op = match bit_operator {
+        BitwiseAnd => MaskOp::And,
+        BitwiseOr => MaskOp::Or,
+        _ => return None,
+    };
+    let bit_left = bit_left.unwrap_parens();
+    let bit_right = bit_right.unwrap_parens();
+    let mask = match (
+        signed_integer_literal(bit_left),
+        signed_integer_literal(bit_right),
+    ) {
+        (None, Some(mask)) | (Some(mask), None) => mask,
+        _ => return None,
+    };
+
+    let kind = mask_expr.get_type().underlying_simple_kind()?;
+    if !kind.is_ordered() {
+        return None;
+    }
+    let (min, max) = kind.integer_range()?;
+    if mask == 0 || mask < min || mask > max || constant < min || constant > max {
+        return None;
+    }
+
+    Some(MaskComparison {
+        mask_op,
+        mask,
+        operator,
+        constant,
+        kind,
+    })
+}
 
 pub(crate) fn in_scope_comparison(a: &Expression, b: &Expression) -> bool {
     match (signed_integer_literal(a), signed_integer_literal(b)) {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/bad_bit_mask.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/bad_bit_mask.rs
@@ -1,0 +1,92 @@
+use crate::passes::comparison::{MaskComparison, MaskOp, mask_comparison};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
+
+pub fn check_bad_bit_mask(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::Binary { span, .. } = expression else {
+        return;
+    };
+    let Some(mask) = mask_comparison(expression) else {
+        return;
+    };
+    let Some(always_true) = constant_result(&mask) else {
+        return;
+    };
+    ctx.sink
+        .push(diagnostics::lint::bad_bit_mask(span, always_true));
+}
+
+fn constant_result(mask: &MaskComparison) -> Option<bool> {
+    use BinaryOperator::*;
+    match mask.operator {
+        Equal | NotEqual => equality_result(mask),
+        LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => relational_result(mask),
+        _ => None,
+    }
+}
+
+fn equality_result(mask: &MaskComparison) -> Option<bool> {
+    let reachable = match mask.mask_op {
+        MaskOp::And => (mask.constant & mask.mask) == mask.constant,
+        MaskOp::Or => (mask.constant | mask.mask) == mask.constant,
+    };
+    if reachable {
+        return None;
+    }
+    Some(matches!(mask.operator, BinaryOperator::NotEqual))
+}
+
+/// Skips cases already constant over the full type range, leaving those to
+/// `type_limit_comparison`/`unsigned_comparison`.
+fn relational_result(mask: &MaskComparison) -> Option<bool> {
+    let (low, high) = mask_range(mask)?;
+    let constant = relational_over(low, high, mask.operator, mask.constant)?;
+    let (type_low, type_high) = mask.kind.integer_range()?;
+    if relational_over(type_low, type_high, mask.operator, mask.constant).is_some() {
+        return None;
+    }
+    Some(constant)
+}
+
+/// `x & m` is `[0, m]` for any sign; `x | m` is `[m, max]` only for unsigned `x`
+/// (a negative `x` drops below `m`). Negative masks have no useful interval.
+fn mask_range(mask: &MaskComparison) -> Option<(i128, i128)> {
+    if mask.mask < 1 {
+        return None;
+    }
+    match mask.mask_op {
+        MaskOp::And => Some((0, mask.mask)),
+        MaskOp::Or => {
+            if !mask.kind.is_unsigned_int() {
+                return None;
+            }
+            let (_, max) = mask.kind.integer_range()?;
+            Some((mask.mask, max))
+        }
+    }
+}
+
+fn relational_over(
+    low: i128,
+    high: i128,
+    operator: BinaryOperator,
+    constant: i128,
+) -> Option<bool> {
+    let at_low = relational_holds(low, operator, constant);
+    if at_low == relational_holds(high, operator, constant) {
+        Some(at_low)
+    } else {
+        None
+    }
+}
+
+fn relational_holds(value: i128, operator: BinaryOperator, constant: i128) -> bool {
+    use BinaryOperator::*;
+    match operator {
+        LessThan => value < constant,
+        LessThanOrEqual => value <= constant,
+        GreaterThan => value > constant,
+        GreaterThanOrEqual => value >= constant,
+        _ => false,
+    }
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/equal_operands.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/equal_operands.rs
@@ -1,0 +1,59 @@
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
+use syntax::types::{SimpleKind, Type};
+
+use super::helpers::{expressions_equivalent, is_side_effect_free, signed_integer_literal};
+
+pub fn check_equal_operands(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    use BinaryOperator::*;
+    let note = match operator {
+        BitwiseAnd | BitwiseOr => "is that operand",
+        BitwiseXor | BitwiseAndNot | Subtraction => "is always `0`",
+        Division => "is always `1`, unless the operand is `0`, which panics",
+        Remainder => "is always `0`, unless the operand is `0`, which panics",
+        _ => return,
+    };
+    let bitwise = matches!(
+        operator,
+        BitwiseAnd | BitwiseOr | BitwiseXor | BitwiseAndNot
+    );
+
+    let left = left.unwrap_parens();
+    let right = right.unwrap_parens();
+    if !expressions_equivalent(left, right) {
+        return;
+    }
+    // Skip literal folds and side-effecting operands, which may differ per eval.
+    if signed_integer_literal(left).is_some() || !is_side_effect_free(left) {
+        return;
+    }
+    if !is_integer_operand(&left.get_type(), bitwise) {
+        return;
+    }
+
+    ctx.sink.push(diagnostics::lint::equal_operands(span, note));
+}
+
+/// Bitwise ops also accept a direct `uintptr` (per the checker's
+/// `is_integer_type`), but not a `uintptr` alias/newtype, so that exception is
+/// gated on `as_simple` rather than the underlying kind.
+fn is_integer_operand(ty: &Type, bitwise: bool) -> bool {
+    if ty
+        .underlying_simple_kind()
+        .is_some_and(|kind| kind.is_signed_int() || kind.is_unsigned_int())
+    {
+        return true;
+    }
+    bitwise && ty.as_simple() == Some(SimpleKind::Uintptr)
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/ineffective_bit_mask.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/ineffective_bit_mask.rs
@@ -1,0 +1,41 @@
+use crate::passes::comparison::{MaskComparison, MaskOp, mask_comparison};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression};
+
+pub fn check_ineffective_bit_mask(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::Binary { span, .. } = expression else {
+        return;
+    };
+    let Some(mask) = mask_comparison(expression) else {
+        return;
+    };
+    if mask.mask_op != MaskOp::Or || !is_ineffective(&mask) {
+        return;
+    }
+
+    ctx.sink.push(diagnostics::lint::ineffective_bit_mask(
+        span,
+        "|",
+        mask.mask,
+        mask.constant,
+    ));
+}
+
+/// A positive `x | m` sets only bits below a power-of-two boundary, so comparing
+/// it there gives the same answer as comparing `x` directly.
+fn is_ineffective(mask: &MaskComparison) -> bool {
+    use BinaryOperator::*;
+    if mask.mask < 1 {
+        return false;
+    }
+    let constant = mask.constant;
+    match mask.operator {
+        LessThan | GreaterThanOrEqual => is_power_of_two(constant) && mask.mask < constant,
+        LessThanOrEqual | GreaterThan => is_power_of_two(constant + 1) && mask.mask <= constant,
+        _ => false,
+    }
+}
+
+fn is_power_of_two(value: i128) -> bool {
+    value > 0 && value & (value - 1) == 0
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,3 +1,4 @@
+mod bad_bit_mask;
 mod bool_literal_comparison;
 mod collapsible_if;
 mod double_comparison;
@@ -6,12 +7,14 @@ mod dup_arg;
 mod duplicate_cutset;
 mod duplicate_logical_operand;
 mod empty_match_arm;
+mod equal_operands;
 mod excess_parens_on_condition;
 mod exit_after_defer;
 mod goos_goarch_comparison;
 mod helpers;
 mod identical_if_branches;
 mod identical_match_arms;
+mod ineffective_bit_mask;
 mod integer_division_to_zero;
 mod invisible_in_string;
 mod let_and_return;
@@ -60,6 +63,7 @@ mod unsigned_comparison;
 mod verbose_failure_propagation;
 mod waitgroup_add_in_task;
 
+pub use bad_bit_mask::check_bad_bit_mask;
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use collapsible_if::check_collapsible_if;
 pub use double_comparison::check_double_comparison;
@@ -68,11 +72,13 @@ pub use dup_arg::check_dup_arg;
 pub use duplicate_cutset::check_duplicate_cutset;
 pub use duplicate_logical_operand::check_duplicate_logical_operand;
 pub use empty_match_arm::check_empty_match_arm;
+pub use equal_operands::check_equal_operands;
 pub use excess_parens_on_condition::check_excess_parens_on_condition;
 pub use exit_after_defer::check_exit_after_defer;
 pub use goos_goarch_comparison::check_goos_goarch_comparison;
 pub use identical_if_branches::check_identical_if_branches;
 pub use identical_match_arms::check_identical_match_arms;
+pub use ineffective_bit_mask::check_ineffective_bit_mask;
 pub use integer_division_to_zero::check_integer_division_to_zero;
 pub use invisible_in_string::{
     check_invisible_in_string_expression, check_invisible_in_string_pattern,

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -19,11 +19,12 @@ use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
-    check_bool_literal_comparison, check_collapsible_if, check_double_comparison,
-    check_double_negation, check_dup_arg, check_duplicate_cutset, check_duplicate_logical_operand,
-    check_empty_match_arm, check_excess_parens_on_condition, check_exit_after_defer,
-    check_expression_naming, check_goos_goarch_comparison, check_identical_if_branches,
-    check_identical_match_arms, check_integer_division_to_zero,
+    check_bad_bit_mask, check_bool_literal_comparison, check_collapsible_if,
+    check_double_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
+    check_duplicate_logical_operand, check_empty_match_arm, check_equal_operands,
+    check_excess_parens_on_condition, check_exit_after_defer, check_expression_naming,
+    check_goos_goarch_comparison, check_identical_if_branches, check_identical_match_arms,
+    check_ineffective_bit_mask, check_integer_division_to_zero,
     check_invisible_in_string_expression, check_invisible_in_string_pattern, check_let_and_return,
     check_loop_runs_once, check_lost_cancel, check_lost_query_mutation, check_manual_bytes_equal,
     check_manual_compound_assignment, check_manual_equal_fold, check_manual_find,
@@ -52,6 +53,9 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_self_comparison, &[Binary]),
             (check_redundant_comparison, &[Binary]),
             (check_double_comparison, &[Binary]),
+            (check_bad_bit_mask, &[Binary]),
+            (check_ineffective_bit_mask, &[Binary]),
+            (check_equal_operands, &[Binary]),
             (check_unsigned_comparison, &[Binary]),
             (check_type_limit_comparison, &[Binary]),
             (check_non_negative_comparison, &[Binary]),

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3894,6 +3894,575 @@ fn main() {
 }
 
 #[test]
+fn bad_bit_mask_and_equality_impossible() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & 1 == 2
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_or_equality_impossible() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 1 == 0
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_literal_on_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = 2 == x & 1
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_or_relational_always_true() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: uint = 5
+  let _ = x | 1 > 0
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_and_relational_always_false() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & 7 > 100
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_satisfiable_equality_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & 1 == 1
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_mask_does_not_constrain_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & 7 < 4
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_signed_or_relational_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 1 > 0
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_defers_relational_to_unsigned_comparison() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let x: uint = 5
+  let _ = x | 1 >= 0
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Incompatible bit mask"),
+        "must leave the type-bound case to unsigned_comparison: {:?}",
+        result.lints
+    );
+    assert!(
+        result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Comparison is always true"),
+        "expected unsigned_comparison to own this comparison: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_less_than() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 1 < 8
+}
+"#
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_greater_than() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 3 > 7
+}
+"#
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_non_power_of_two_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 1 < 7
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_bitand() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_xor() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x ^ x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_subtraction() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x - x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_division() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x / x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_float_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 1.5
+  let _ = x - x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_distinct_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let a = 5
+  let b = 6
+  let _ = a - b
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_side_effecting_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn f() -> int { 1 }
+
+fn main() {
+  let _ = f() - f()
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_inequality_always_true() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & 1 != 2
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_alias() {
+    assert_lint_snapshot!(
+        r#"
+type Flags = int
+
+fn main() {
+  let a: Flags = 5
+  let _ = a & 1 == 2
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_named_newtype() {
+    assert_lint_snapshot!(
+        r#"
+struct Mask(int)
+
+fn main() {
+  let m = Mask(5)
+  let _ = m & 1 == 2
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_negative_mask() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & -2 == 1
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_negative_mask_relational_no_diagnostic() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x & -2 < 5
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_suppressed_by_allow() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(bad_bit_mask)]
+fn main() {
+  let x = 5
+  let _ = x & 1 == 2
+}
+"#
+    );
+}
+
+#[test]
+fn bad_bit_mask_uintptr_operand_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let p: uintptr = 5 as uintptr
+  let _ = p & 7 > 100
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the uintptr bitwise/orderability type error to still be reported: {:?}",
+        result.errors
+    );
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Incompatible bit mask"),
+        "must not flag a masked comparison on a non-orderable `uintptr`: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_less_than_or_equal() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 3 <= 7
+}
+"#
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_greater_than_or_equal() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | 1 >= 8
+}
+"#
+    );
+}
+
+#[test]
+fn ineffective_bit_mask_literal_on_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = 8 > x | 1
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_bitor() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x | x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_bitand_not() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x &^ x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_remainder() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x % x
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_alias() {
+    assert_lint_snapshot!(
+        r#"
+type MyInt = int
+
+fn main() {
+  let a: MyInt = 5
+  let _ = a - a
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_uintptr_bitand() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let p: uintptr = 5 as uintptr
+  let _ = p & p
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_uintptr_xor() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let p: uintptr = 5 as uintptr
+  let _ = p ^ p
+}
+"#
+    );
+}
+
+#[test]
+fn equal_operands_uintptr_arithmetic_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let p: uintptr = 5 as uintptr
+  let _ = p - p
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the uintptr arithmetic type error to still be reported: {:?}",
+        result.errors
+    );
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Equal operands"),
+        "must not flag arithmetic equal operands on a non-arithmetic `uintptr`: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn equal_operands_uintptr_alias_bitwise_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+type Handle = uintptr
+
+fn main() {
+  let h: Handle = 5 as Handle
+  let _ = h & h
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the uintptr-alias bitwise type error to still be reported: {:?}",
+        result.errors
+    );
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Equal operands"),
+        "must not flag bitwise equal operands on a `uintptr`-backed alias: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn equal_operands_uintptr_newtype_bitwise_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+struct Wrapped(uintptr)
+
+fn main() {
+  let w = Wrapped(5 as uintptr)
+  let _ = w & w
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the uintptr-newtype bitwise type error to still be reported: {:?}",
+        result.errors
+    );
+    assert!(
+        !result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Equal operands"),
+        "must not flag bitwise equal operands on a `uintptr`-backed newtype: {:?}",
+        result.lints
+    );
+}
+
+#[test]
 fn goos_comparison_invalid_equal() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/bad_bit_mask_alias.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:6:11]
+ 5 │   let a: Flags = 5
+ 6 │   let _ = a & 1 == 2
+   ·           ─────┬────
+   ·                ╰── always `false`
+ 7 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_and_equality_impossible.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_and_equality_impossible.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x & 1 == 2
+   ·           ─────┬────
+   ·                ╰── always `false`
+ 5 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_and_relational_always_false.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_and_relational_always_false.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x & 7 > 100
+   ·           ─────┬─────
+   ·                ╰── always `false`
+ 5 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_inequality_always_true.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_inequality_always_true.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x & 1 != 2
+   ·           ─────┬────
+   ·                ╰── always `true`
+ 5 │ }
+   ╰────
+  help: The mask makes this value always satisfy the comparison, so it is always `true`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_literal_on_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = 2 == x & 1
+   ·           ─────┬────
+   ·                ╰── always `false`
+ 5 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_named_newtype.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_named_newtype.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:6:11]
+ 5 │   let m = Mask(5)
+ 6 │   let _ = m & 1 == 2
+   ·           ─────┬────
+   ·                ╰── always `false`
+ 7 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_negative_mask.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_negative_mask.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x & -2 == 1
+   ·           ─────┬─────
+   ·                ╰── always `false`
+ 5 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_or_equality_impossible.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_or_equality_impossible.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | 1 == 0
+   ·           ─────┬────
+   ·                ╰── always `false`
+ 5 │ }
+   ╰────
+  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/bad_bit_mask_or_relational_always_true.snap
+++ b/tests/ui/lint/snapshots/bad_bit_mask_or_relational_always_true.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Incompatible bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x: uint = 5
+ 4 │   let _ = x | 1 > 0
+   ·           ────┬────
+   ·               ╰── always `true`
+ 5 │ }
+   ╰────
+  help: The mask makes this value always satisfy the comparison, so it is always `true`. Check the mask or the constant · code: [lint.bad_bit_mask]

--- a/tests/ui/lint/snapshots/equal_operands_alias.snap
+++ b/tests/ui/lint/snapshots/equal_operands_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:6:11]
+ 5 │   let a: MyInt = 5
+ 6 │   let _ = a - a
+   ·           ──┬──
+   ·             ╰── identical operands
+ 7 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_bitand.snap
+++ b/tests/ui/lint/snapshots/equal_operands_bitand.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x & x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is that operand. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_bitand_not.snap
+++ b/tests/ui/lint/snapshots/equal_operands_bitand_not.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x &^ x
+   ·           ───┬──
+   ·              ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_bitor.snap
+++ b/tests/ui/lint/snapshots/equal_operands_bitor.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is that operand. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_division.snap
+++ b/tests/ui/lint/snapshots/equal_operands_division.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x / x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `1`, unless the operand is `0`, which panics. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_remainder.snap
+++ b/tests/ui/lint/snapshots/equal_operands_remainder.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x % x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`, unless the operand is `0`, which panics. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_subtraction.snap
+++ b/tests/ui/lint/snapshots/equal_operands_subtraction.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x - x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_uintptr_bitand.snap
+++ b/tests/ui/lint/snapshots/equal_operands_uintptr_bitand.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let p: uintptr = 5 as uintptr
+ 4 │   let _ = p & p
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is that operand. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_uintptr_xor.snap
+++ b/tests/ui/lint/snapshots/equal_operands_uintptr_xor.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let p: uintptr = 5 as uintptr
+ 4 │   let _ = p ^ p
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/equal_operands_xor.snap
+++ b/tests/ui/lint/snapshots/equal_operands_xor.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Equal operands
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x ^ x
+   ·           ──┬──
+   ·             ╰── identical operands
+ 5 │ }
+   ╰────
+  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]

--- a/tests/ui/lint/snapshots/ineffective_bit_mask_greater_than.snap
+++ b/tests/ui/lint/snapshots/ineffective_bit_mask_greater_than.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Ineffective bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | 3 > 7
+   ·           ────┬────
+   ·               ╰── mask has no effect
+ 5 │ }
+   ╰────
+  help: `| 3` does not change the result of comparing with `7`, so the mask can be removed · code: [lint.ineffective_bit_mask]

--- a/tests/ui/lint/snapshots/ineffective_bit_mask_greater_than_or_equal.snap
+++ b/tests/ui/lint/snapshots/ineffective_bit_mask_greater_than_or_equal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Ineffective bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | 1 >= 8
+   ·           ─────┬────
+   ·                ╰── mask has no effect
+ 5 │ }
+   ╰────
+  help: `| 1` does not change the result of comparing with `8`, so the mask can be removed · code: [lint.ineffective_bit_mask]

--- a/tests/ui/lint/snapshots/ineffective_bit_mask_less_than.snap
+++ b/tests/ui/lint/snapshots/ineffective_bit_mask_less_than.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Ineffective bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | 1 < 8
+   ·           ────┬────
+   ·               ╰── mask has no effect
+ 5 │ }
+   ╰────
+  help: `| 1` does not change the result of comparing with `8`, so the mask can be removed · code: [lint.ineffective_bit_mask]

--- a/tests/ui/lint/snapshots/ineffective_bit_mask_less_than_or_equal.snap
+++ b/tests/ui/lint/snapshots/ineffective_bit_mask_less_than_or_equal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Ineffective bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = x | 3 <= 7
+   ·           ─────┬────
+   ·                ╰── mask has no effect
+ 5 │ }
+   ╰────
+  help: `| 3` does not change the result of comparing with `7`, so the mask can be removed · code: [lint.ineffective_bit_mask]

--- a/tests/ui/lint/snapshots/ineffective_bit_mask_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/ineffective_bit_mask_literal_on_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Ineffective bit mask
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5
+ 4 │   let _ = 8 > x | 1
+   ·           ────┬────
+   ·               ╰── mask has no effect
+ 5 │ }
+   ╰────
+  help: `| 1` does not change the result of comparing with `8`, so the mask can be removed · code: [lint.ineffective_bit_mask]


### PR DESCRIPTION
Adds three lints that flag integer bitwise and arithmetic expressions whose result is fixed, unaffected by the mask, or computed from two identical operands.

```
  [warning] Ineffective bit mask
   ╭─[test.lis:4:11]
 3 │   let x = 5
 4 │   let _ = 8 > x | 1
   ·           ────┬────
   ·               ╰── mask has no effect
 5 │ }
   ╰────
  help: `| 1` does not change the result of comparing with `8`, so the mask can be removed · code: [lint.ineffective_bit_mask]
```

```
  [warning] Incompatible bit mask
   ╭─[test.lis:6:11]
 5 │   let a: Flags = 5
 6 │   let _ = a & 1 == 2
   ·           ─────┬────
   ·                ╰── always `false`
 7 │ }
   ╰────
  help: The mask makes this value unable to satisfy the comparison, so it is always `false`. Check the mask or the constant · code: [lint.bad_bit_mask]
```

```
  [warning] Equal operands
   ╭─[test.lis:4:11]
 3 │   let p: uintptr = 5 as uintptr
 4 │   let _ = p ^ p
   ·           ──┬──
   ·             ╰── identical operands
 5 │ }
   ╰────
  help: Both operands are identical so the result is always `0`. Did you mean to use different operands? · code: [lint.equal_operands]
```