### PR TITLE
feat: add LSP inlay type hints for `let` bindings

### DIFF
--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,0 +1,60 @@
+use syntax::ast::{Expression, Pattern, Span};
+use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel};
+
+use crate::position::LineIndex;
+
+/// Type hints for `let` bindings that lack an explicit annotation, within the
+/// requested byte range.
+pub(crate) fn collect(
+    items: &[Expression],
+    range: (u32, u32),
+    line_index: &LineIndex,
+) -> Vec<InlayHint> {
+    let mut hints = Vec::new();
+    for item in items {
+        walk(item, range, line_index, &mut hints);
+    }
+    hints
+}
+
+fn walk(
+    expression: &Expression,
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    if !overlaps(expression.get_span(), range) {
+        return;
+    }
+
+    if let Expression::Let { binding, .. } = expression
+        && binding.annotation.is_none()
+        && let Pattern::Identifier {
+            span: name_span, ..
+        } = &binding.pattern
+        && !binding.ty.is_type_var()
+        && !binding.ty.is_error()
+    {
+        let at = name_span.byte_offset + name_span.byte_length;
+        if at >= range.0 && at < range.1 {
+            hints.push(InlayHint {
+                position: line_index.offset_to_position(at),
+                label: InlayHintLabel::String(format!(": {}", binding.ty)),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: None,
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            });
+        }
+    }
+
+    for child in expression.children() {
+        walk(child, range, line_index, hints);
+    }
+}
+
+fn overlaps(span: Span, range: (u32, u32)) -> bool {
+    span.byte_offset < range.1 && span.byte_offset + span.byte_length > range.0
+}

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -3,6 +3,7 @@ mod completion;
 mod definition;
 mod document;
 mod hover;
+mod inlay_hints;
 mod loader;
 mod paths;
 mod position;
@@ -73,6 +74,7 @@ impl LanguageServer for Backend {
                 )),
                 document_formatting_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
+                inlay_hint_provider: Some(OneOf::Left(true)),
                 definition_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
@@ -235,6 +237,37 @@ impl LanguageServer for Backend {
             }),
             range: Some(line_index.span_to_range(span)),
         }))
+    }
+
+    async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
+        let uri = &params.text_document.uri;
+
+        let Some(snapshot) = self.get_snapshot(uri).await else {
+            return Ok(None);
+        };
+        let Some(file_id) = snapshot.get_file_id(uri) else {
+            return Ok(None);
+        };
+        let Some(file) = snapshot.files().get(&file_id) else {
+            return Ok(None);
+        };
+        let Some(line_index) = snapshot.get_line_index(file_id) else {
+            return Ok(None);
+        };
+
+        let eof = file.source.len() as u32;
+        let start = line_index
+            .position_to_offset(params.range.start)
+            .unwrap_or(eof);
+        let end = line_index
+            .position_to_offset(params.range.end)
+            .unwrap_or(eof);
+
+        Ok(Some(inlay_hints::collect(
+            &file.items,
+            (start, end),
+            line_index,
+        )))
     }
 
     async fn goto_definition(

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1,8 +1,8 @@
 mod lsp_harness;
 
 use lsp_harness::{
-    TestClient, completion_labels, definition_location, definition_target_text, hover_content,
-    symbol_names,
+    TestClient, completion_labels, definition_location, definition_target_text, doc_end,
+    hover_content, inlay_hint_triples, symbol_names,
 };
 use tower_lsp::lsp_types::*;
 
@@ -21,6 +21,7 @@ async fn initialize_returns_capabilities() {
     assert!(result.capabilities.rename_provider.is_some());
     assert!(result.capabilities.document_formatting_provider.is_some());
     assert!(result.capabilities.document_symbol_provider.is_some());
+    assert!(result.capabilities.inlay_hint_provider.is_some());
 
     client.shutdown().await;
 }
@@ -1993,6 +1994,7 @@ async fn stress_test_input(source: &str) -> bool {
     let _sig = client.signature_help(TEST_URI, 0, 0).await;
     let _fmt = client.formatting(TEST_URI).await;
     let _sym = client.document_symbol(TEST_URI).await;
+    let _inlay = client.inlay_hint(TEST_URI, (0, 0), doc_end(source)).await;
 
     client.change(TEST_URI, "fn main() { 1 }", 2).await;
     let hover = client.hover(TEST_URI, 0, 4).await;
@@ -3698,6 +3700,9 @@ async fn stress_test_all_positions(source: &str) -> bool {
             let _sig = client.signature_help(TEST_URI, line, col).await;
             let _refs = client.references(TEST_URI, line, col, true).await;
             let _rename = client.prepare_rename(TEST_URI, line, col).await;
+            let _inlay = client
+                .inlay_hint(TEST_URI, (line, col), doc_end(source))
+                .await;
         }
     }
 
@@ -6034,9 +6039,11 @@ async fn stress_all_handlers_at_eof() {
     let _sig = client.signature_help(TEST_URI, 0, eof_col).await;
     let _refs = client.references(TEST_URI, 0, eof_col, true).await;
     let _rename = client.prepare_rename(TEST_URI, 0, eof_col).await;
+    let _inlay = client.inlay_hint(TEST_URI, (0, 0), (0, eof_col)).await;
 
     let _hover_past = client.hover(TEST_URI, 0, eof_col + 10).await;
     let _hover_line_past = client.hover(TEST_URI, 5, 0).await;
+    let _inlay_past = client.inlay_hint(TEST_URI, (5, 0), (6, 0)).await;
 
     client.shutdown().await;
 }
@@ -7053,6 +7060,7 @@ async fn stress_all_handlers_past_end_of_source() {
     let _ = client.signature_help(TEST_URI, 999, 999).await;
     let _ = client.prepare_rename(TEST_URI, 999, 999).await;
     let _ = client.rename(TEST_URI, 999, 999, "foo").await;
+    let _ = client.inlay_hint(TEST_URI, (999, 999), (1000, 0)).await;
 
     // Still alive
     let hover = client.hover(TEST_URI, 0, 4).await;
@@ -8313,6 +8321,16 @@ fn main() {
 
     let syms = client.document_symbol(TEST_URI).await;
     assert!(syms.is_some(), "document symbols should work via fallback");
+
+    let inlay = client.inlay_hint(TEST_URI, (0, 0), (5, 1)).await;
+    assert!(
+        inlay.is_some(),
+        "inlay hints should work via last_valid_snapshot during lex error"
+    );
+    assert!(
+        inlay_hint_triples(&inlay.unwrap()).contains(&(3, 7, ": Point".to_string())),
+        "fallback inlay hints should reflect the last valid snapshot"
+    );
 
     let _ = client.formatting(TEST_URI).await;
 
@@ -11567,6 +11585,147 @@ fn use_rw(rw: ReadWriter) { rw. }";
     assert!(
         labels.iter().any(|l| l == "read"),
         "should include inherited method 'read', got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_shows_let_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { let x = 42; x }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 17, ": int".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_renders_collection_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { let xs = [1, 2, 3]; xs.length() }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 18, ": Slice<int>".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_skips_annotated_let() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { let x: int = 42; x }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert!(
+        hints.is_empty(),
+        "annotated let should have no hint: {hints:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_skips_destructuring_let() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { let (a, b) = (1, 2); a + b }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert!(
+        hints.is_empty(),
+        "destructuring let is out of v1 scope: {hints:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_respects_requested_range() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn main() {\n    let a = 1\n    let b = 2\n    a + b\n}",
+        )
+        .await;
+
+    let hints = client.inlay_hint(TEST_URI, (2, 0), (3, 0)).await.unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(2, 9, ": int".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_range_end_is_exclusive() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "fn main() { let x = 42; x }").await;
+
+    let at_boundary = client.inlay_hint(TEST_URI, (0, 0), (0, 17)).await.unwrap();
+    assert!(
+        at_boundary.is_empty(),
+        "insertion point at the exclusive range end must not be returned: {at_boundary:?}"
+    );
+
+    let past_boundary = client.inlay_hint(TEST_URI, (0, 0), (0, 18)).await.unwrap();
+    assert_eq!(
+        inlay_hint_triples(&past_boundary),
+        vec![(0, 17, ": int".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_range_past_eof_is_empty() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(TEST_URI, "fn main() { let x = 42; x }").await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (999, 999), (1000, 0))
+        .await
+        .unwrap();
+
+    assert!(
+        hints.is_empty(),
+        "a range entirely past EOF must not scan the whole file: {hints:?}"
     );
 
     client.shutdown().await;

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -275,6 +275,25 @@ impl TestClient {
         .await
     }
 
+    pub async fn inlay_hint(
+        &mut self,
+        uri: &str,
+        start: (u32, u32),
+        end: (u32, u32),
+    ) -> Option<Vec<InlayHint>> {
+        self.request(
+            "textDocument/inlayHint",
+            json!({
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": start.0, "character": start.1},
+                    "end": {"line": end.0, "character": end.1}
+                }
+            }),
+        )
+        .await
+    }
+
     pub async fn prepare_rename(
         &mut self,
         uri: &str,
@@ -380,6 +399,28 @@ pub fn completion_labels(response: &CompletionResponse) -> Vec<String> {
         CompletionResponse::Array(items) => items.iter().map(|i| i.label.clone()).collect(),
         CompletionResponse::List(list) => list.items.iter().map(|i| i.label.clone()).collect(),
     }
+}
+
+pub fn doc_end(content: &str) -> (u32, u32) {
+    let line = content.matches('\n').count() as u32;
+    let last_line = content.rsplit('\n').next().unwrap_or("");
+    let character = last_line.chars().map(|c| c.len_utf16() as u32).sum();
+    (line, character)
+}
+
+pub fn inlay_hint_triples(hints: &[InlayHint]) -> Vec<(u32, u32, String)> {
+    hints
+        .iter()
+        .map(|h| {
+            let label = match &h.label {
+                InlayHintLabel::String(s) => s.clone(),
+                InlayHintLabel::LabelParts(parts) => {
+                    parts.iter().map(|p| p.value.clone()).collect()
+                }
+            };
+            (h.position.line, h.position.character, label)
+        })
+        .collect()
 }
 
 pub fn symbol_names(response: &DocumentSymbolResponse) -> Vec<String> {


### PR DESCRIPTION
Adds to the LSP inlay type hints so that a `let` binding written without a type annotation now shows its inferred type inline, after the variable name, if the user has enabled inlay hints editor-side.