### PR TITLE
fix: correct UFCS lowering and generic type args

### DIFF
--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -16,61 +16,75 @@ use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
 
 impl Planner<'_> {
-    fn infer_ufcs_return_only_type_args(
+    fn ufcs_type_args(
         &mut self,
         function: &Expression,
         qualified_name: &str,
         member: &str,
         receiver_ty: &Type,
+        type_args: &[Annotation],
         fx: &mut EmitEffects,
     ) -> Option<String> {
         let method_key = format!("{}.{}", qualified_name, member);
         let definition_ty = self.facts.definition(method_key.as_str())?.ty().clone();
 
+        // A method with no type parameters lowers to a non-generic free function.
         let Type::Forall { vars, body } = &definition_ty else {
             return None;
         };
         let Type::Function(f) = body.as_ref() else {
             return None;
         };
-        let generic_params = &f.params;
+
+        let mut receiver_mapping: HashMap<String, Type> = HashMap::default();
+        if let Some(self_param) = f.params.first() {
+            extract_type_mapping(&self_param.strip_refs(), receiver_ty, &mut receiver_mapping);
+        }
+
+        if !type_args.is_empty() {
+            let impl_count = vars.len().saturating_sub(type_args.len());
+            let mut go_type_strs = Vec::with_capacity(vars.len());
+            for (index, var) in vars.iter().enumerate() {
+                let go_type = if index < impl_count {
+                    self.go_type_string(receiver_mapping.get(var.as_str())?, fx)
+                } else {
+                    self.annotation_to_go_type(type_args.get(index - impl_count)?, fx)
+                };
+                go_type_strs.push(go_type);
+            }
+            return (!go_type_strs.is_empty()).then(|| format!("[{}]", go_type_strs.join(", ")));
+        }
 
         let all_inferable = vars.iter().all(|var| {
             let param_ty = Type::Parameter(var.clone());
-            generic_params.iter().any(|pt| pt.contains_type(&param_ty))
+            f.params.iter().any(|pt| pt.contains_type(&param_ty))
         });
         if all_inferable {
             return None;
         }
 
-        let instantiated_ty = function.get_type();
-        let mut mapping: HashMap<String, Type> = HashMap::default();
-        extract_type_mapping(body, &instantiated_ty, &mut mapping);
-
-        let mut go_type_strs = Vec::new();
-        if let Type::Nominal { params, .. } = receiver_ty {
-            for param in params {
-                go_type_strs.push(self.go_type_string(param, fx));
-            }
-        }
-        let base_generics_count = if let Type::Nominal { params, .. } = receiver_ty {
-            params.len()
-        } else {
-            0
-        };
-        for var in vars.iter().skip(base_generics_count) {
-            if let Some(resolved) = mapping.get(var.as_str()) {
-                go_type_strs.push(self.go_type_string(resolved, fx));
+        let mut inferred_mapping: HashMap<String, Type> = HashMap::default();
+        if let Type::Function(inst) = function.get_type() {
+            let self_curried = inst.params.len() + 1 == f.params.len();
+            let declared = if self_curried {
+                &f.params[1..]
             } else {
-                return None;
+                &f.params[..]
+            };
+            for (decl, conc) in declared.iter().zip(inst.params.iter()) {
+                extract_type_mapping(decl, conc, &mut inferred_mapping);
             }
+            extract_type_mapping(&f.return_type, &inst.return_type, &mut inferred_mapping);
         }
 
-        if go_type_strs.is_empty() {
-            return None;
+        let mut go_type_strs = Vec::with_capacity(vars.len());
+        for var in vars {
+            let resolved = receiver_mapping
+                .get(var.as_str())
+                .or_else(|| inferred_mapping.get(var.as_str()))?;
+            go_type_strs.push(self.go_type_string(resolved, fx));
         }
-
-        Some(format!("[{}]", go_type_strs.join(", ")))
+        (!go_type_strs.is_empty()).then(|| format!("[{}]", go_type_strs.join(", ")))
     }
 
     pub(super) fn lower_ufcs_call(
@@ -91,7 +105,7 @@ impl Planner<'_> {
             unreachable!("lower_ufcs_call called on non-DotAccess");
         };
 
-        let receiver_ty = receiver.get_type().strip_refs().clone();
+        let receiver_ty = self.facts.peel_alias(&receiver.get_type().strip_refs());
         let Type::Nominal {
             id: qualified_name, ..
         } = &receiver_ty
@@ -115,10 +129,10 @@ impl Planner<'_> {
 
         let fn_name = self.build_ufcs_qualified_call(
             function,
-            type_args,
             &receiver_ty,
             qualified_name,
             member,
+            type_args,
             fx,
         );
         (setup, format!("{}({})", fn_name, new_args.join(", ")))
@@ -186,18 +200,15 @@ impl Planner<'_> {
     fn build_ufcs_qualified_call(
         &mut self,
         function: &Expression,
-        type_args: &[Annotation],
         receiver_ty: &Type,
         qualified_name: &str,
         member: &str,
+        type_args: &[Annotation],
         fx: &mut EmitEffects,
     ) -> String {
-        let type_args_string = if !type_args.is_empty() {
-            self.format_type_args_with_receiver(receiver_ty, type_args, fx)
-        } else {
-            self.infer_ufcs_return_only_type_args(function, qualified_name, member, receiver_ty, fx)
-                .unwrap_or_default()
-        };
+        let type_args_string = self
+            .ufcs_type_args(function, qualified_name, member, receiver_ty, type_args, fx)
+            .unwrap_or_default();
 
         let method_key = format!("{}.{}", qualified_name, member);
         let is_public = self

--- a/crates/semantics/src/call_classification.rs
+++ b/crates/semantics/src/call_classification.rs
@@ -2,14 +2,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::Expression;
 use syntax::program::{DefinitionBody, Module};
-use syntax::types::{Symbol, Type};
+use syntax::types::{Symbol, Type, type_args_match_params};
 
-/// Determines if a method type requires UFCS emission based on its signature.
-///
-/// A method is UFCS when:
-/// - It has extra type parameters beyond the base type's generics (e.g., `Option<T>.map<U>`)
-/// - It has no Forall but the base type is generic (specialized impl block)
-/// - Its receiver has concrete type constructor parameters (e.g., `impl Option<int>`)
 pub fn is_ufcs_method_type(method_ty: &Type, base_generics_count: usize) -> bool {
     let Type::Forall { vars, body } = method_ty else {
         return base_generics_count > 0;
@@ -25,12 +19,9 @@ pub fn is_ufcs_method_type(method_ty: &Type, base_generics_count: usize) -> bool
             params: receiver_params,
             ..
         } = receiver_param.strip_refs()
+        && !type_args_match_params(&receiver_params, vars.iter())
     {
-        for param in receiver_params {
-            if matches!(param, Type::Nominal { .. }) {
-                return true;
-            }
-        }
+        return true;
     }
 
     false
@@ -40,7 +31,7 @@ pub fn is_ufcs_method_type(method_ty: &Type, base_generics_count: usize) -> bool
 ///
 /// Three conditions (any one suffices):
 /// 1. Extra type params: method's Forall vars exceed base type's generics count
-/// 2. Specialized receiver: receiver's type constructor params contain concrete types
+/// 2. Partial receiver: receiver is not the impl's own type parameters in order
 /// 3. Mixed impl blocks: type has both bounded and unbounded impl blocks
 pub fn compute_module_ufcs(module: &Module, module_id: &str) -> Vec<(String, String)> {
     let mut ufcs = Vec::new();

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -853,8 +853,12 @@ impl InferCtx<'_, '_> {
         }
 
         if !self.scopes.is_callee_context()
-            && let Type::Forall { vars, .. } = method_ty
-            && vars.len() > self.get_receiver_generics_count(deref_ty)
+            && (matches!(deref_ty, Type::Nominal { id, .. }
+                    if self.is_ufcs_method(id.as_str(), args.member_name))
+                || matches!(store.deep_resolve_alias(deref_ty), Type::Nominal { id, .. }
+                    if self.is_ufcs_method(id.as_str(), args.member_name))
+                || matches!(method_ty, Type::Forall { vars, .. }
+                    if vars.len() > self.get_receiver_generics_count(deref_ty)))
         {
             self.sink
                 .push(diagnostics::infer::taking_value_of_ufcs_method(*args.span));

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1,3 +1,4 @@
+use ecow::EcoString;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::checker::EnvResolve;
@@ -443,6 +444,11 @@ impl InferCtx<'_, '_> {
                 });
         }
 
+        if type_args.is_empty() && self.callee_has_phantom_type_param(&callee_expression) {
+            self.sink
+                .push(diagnostics::infer::cannot_infer_type_argument(span));
+        }
+
         // Use expected_ty for generic containers (Option, Result) when it has
         // interface type parameters. This ensures coercion like `Option<Printable>`
         // from `Some(Text{...})` gets the correct type for codegen.
@@ -474,11 +480,14 @@ impl InferCtx<'_, '_> {
         expression: &Expression,
         type_args: &[Annotation],
     ) -> Type {
-        let store = self.store;
         if type_args.is_empty() {
             return expression.get_type();
         }
+        self.declared_callee_type(expression)
+    }
 
+    fn declared_callee_type(&self, expression: &Expression) -> Type {
+        let store = self.store;
         match expression {
             Expression::Identifier { value, .. } => self
                 .lookup_type(store, value)
@@ -520,25 +529,23 @@ impl InferCtx<'_, '_> {
     }
 
     fn is_generic_callee(&self, expression: &Expression) -> bool {
-        let store = self.store;
-        match expression {
-            Expression::Identifier { value, .. } => self
-                .lookup_type(store, value)
-                .map(|ty| matches!(ty, Type::Forall { .. }))
-                .unwrap_or(false),
-            Expression::DotAccess {
-                expression: receiver,
-                member,
-                ..
-            } => {
-                let receiver_ty = receiver.get_type().resolve_in(&self.env);
-                self.get_all_methods(store, &receiver_ty.strip_refs())
-                    .get(member)
-                    .map(|ty| matches!(ty, Type::Forall { .. }))
-                    .unwrap_or(false)
-            }
-            _ => false,
-        }
+        matches!(self.declared_callee_type(expression), Type::Forall { .. })
+    }
+
+    fn callee_has_phantom_type_param(&self, expression: &Expression) -> bool {
+        let Type::Forall { vars, body } = self.declared_callee_type(expression) else {
+            return false;
+        };
+        let Type::Function(f) = body.as_ref() else {
+            return false;
+        };
+        vars.iter().any(|var| {
+            let param = Type::Parameter(var.clone());
+            let in_signature = f.params.iter().any(|pt| pt.contains_type(&param))
+                || f.return_type.contains_type(&param);
+            let is_bounded = f.bounds.iter().any(|bound| bound.param_name == *var);
+            !in_signature && !is_bounded
+        })
     }
 
     fn instantiate_callee_type(
@@ -565,19 +572,17 @@ impl InferCtx<'_, '_> {
             return (instantiated.resolve_in(&self.env), vec![]);
         }
 
-        // For DotAccess method calls, accept type args that provide only the
-        // method-own generics (excluding receiver/impl generics).
-        let receiver_generics_count =
-            if let Expression::DotAccess { expression, .. } = callee_expression {
-                let receiver_ty = expression
-                    .get_type()
-                    .resolve_in(&self.env)
-                    .strip_refs()
-                    .clone();
-                self.get_receiver_generics_count(&receiver_ty)
-            } else {
-                0
-            };
+        let declared_param_count = match body.as_ref() {
+            Type::Function(f) => f.params.len(),
+            _ => 0,
+        };
+        let is_receiver_method = matches!(callee_expression, Expression::DotAccess { .. })
+            && declared_param_count > callee_expression.get_type().param_count();
+        let receiver_generics_count = if is_receiver_method {
+            receiver_inferred_prefix_count(body, vars)
+        } else {
+            0
+        };
 
         let method_only_count = vars.len().saturating_sub(receiver_generics_count);
         let is_full_arity = type_args.len() == vars.len();
@@ -1113,18 +1118,18 @@ impl InferCtx<'_, '_> {
                 ..
             } => {
                 let receiver_ty = receiver.get_type().resolve_in(&self.env).strip_refs();
+                let peeled = store.deep_resolve_alias(&receiver_ty);
 
-                // UFCS method: receiver.method() where method is a free function
-                if let Type::Nominal { id, .. } = &receiver_ty
-                    && self
-                        .effective_ufcs_methods()
-                        .contains(&(id.to_string(), member.to_string()))
-                {
+                let ufcs_methods = self.effective_ufcs_methods();
+                let is_ufcs_member = |ty: &Type| {
+                    matches!(ty, Type::Nominal { id, .. }
+                        if ufcs_methods.contains(&(id.to_string(), member.to_string())))
+                };
+                if is_ufcs_member(&receiver_ty) || is_ufcs_member(&peeled) {
                     return CallKind::UfcsMethod;
                 }
 
                 // Native method: receiver.method() on Slice/Map/Channel/etc.
-                let peeled = store.deep_resolve_alias(&receiver_ty);
                 if let Some(kind) = NativeTypeKind::from_type(&peeled) {
                     return CallKind::NativeMethod(kind);
                 }
@@ -1476,6 +1481,19 @@ impl InferCtx<'_, '_> {
                 .is_some_and(|n| n == "Range")
         })
     }
+}
+
+fn receiver_inferred_prefix_count(body: &Type, vars: &[EcoString]) -> usize {
+    let Type::Function(f) = body else {
+        return 0;
+    };
+    let Some(self_param) = f.params.first() else {
+        return 0;
+    };
+    let self_ty = self_param.strip_refs();
+    vars.iter()
+        .take_while(|var| self_ty.contains_type(&Type::Parameter((*var).clone())))
+        .count()
 }
 
 fn callee_label(expr: &Expression) -> String {

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -233,19 +233,23 @@ impl InferCtx<'_, '_> {
         let mut missing: Vec<(String, Type)> = Vec::new();
         let mut incompatible: Vec<(String, Type, Type)> = Vec::new();
 
-        let struct_generics: Option<Vec<String>> =
-            if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env) {
-                store
-                    .get_definition(&id)
-                    .and_then(|definition| match &definition.body {
-                        DefinitionBody::Struct { generics, .. } if !generics.is_empty() => {
-                            Some(generics.iter().map(|g| g.name.to_string()).collect())
-                        }
-                        _ => None,
-                    })
-            } else {
-                None
-            };
+        let resolved_receiver = store.deep_resolve_alias(&ty.strip_refs().resolve_in(&self.env));
+        let receiver_id = match &resolved_receiver {
+            Type::Nominal { id, .. } => Some(id.clone()),
+            _ => None,
+        };
+        let receiver_generics: Vec<String> = receiver_id
+            .as_ref()
+            .and_then(|id| {
+                let generics = match &store.get_definition(id)?.body {
+                    DefinitionBody::Struct { generics, .. }
+                    | DefinitionBody::Enum { generics, .. }
+                    | DefinitionBody::TypeAlias { generics, .. } => generics,
+                    _ => return None,
+                };
+                Some(generics.iter().map(|g| g.name.to_string()).collect())
+            })
+            .unwrap_or_default();
 
         for (method_name, method_ty) in &interface.methods {
             if method_name.as_str() == "equals" && self.is_native_container(ty) {
@@ -257,23 +261,23 @@ impl InferCtx<'_, '_> {
                 continue;
             };
 
-            // A method on a generic struct that is NOT wrapped in Forall came from a
-            // specialized impl block. The emitter emits these as UFCS (standalone functions)
-            // because Go's receiver syntax shadows type parameter names. UFCS methods cannot
-            // satisfy Go interfaces, so reject them here.
-            if let Some(ref generics) = struct_generics
-                && !matches!(symbol_method, Type::Forall { .. })
+            if let Some(ref id) = receiver_id
+                && self.is_ufcs_method(id.as_str(), method_name.as_str())
             {
-                let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
-                self.sink.push(
-                    diagnostics::infer::specialized_impl_cannot_satisfy_interface(
-                        &type_name,
-                        &interface.name,
-                        method_name,
-                        generics,
-                        *span,
-                    ),
-                );
+                if !receiver_generics.is_empty() {
+                    let type_name = resolved_receiver
+                        .get_name()
+                        .map_or_else(|| resolved_receiver.to_string(), str::to_owned);
+                    self.sink.push(
+                        diagnostics::infer::specialized_impl_cannot_satisfy_interface(
+                            &type_name,
+                            &interface.name,
+                            method_name,
+                            &receiver_generics,
+                            *span,
+                        ),
+                    );
+                }
                 missing.push((method_name.to_string(), method_ty.clone()));
                 continue;
             }

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -156,6 +156,11 @@ impl<'s> TaskState<'s> {
         self.ufcs_shared.as_deref().unwrap_or(&self.ufcs_methods)
     }
 
+    fn is_ufcs_method(&self, type_id: &str, method: &str) -> bool {
+        self.effective_ufcs_methods()
+            .contains(&(type_id.to_string(), method.to_string()))
+    }
+
     pub fn new_type_var(&mut self) -> Type {
         let id = self.env.fresh(None);
         Type::Var { id, hint: None }

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -4,7 +4,9 @@ use syntax::ast::{
     Visibility as SyntacticVisibility,
 };
 use syntax::program::{Definition, DefinitionBody, Interface, Visibility};
-use syntax::types::{Symbol, Type, build_substitution_map, substitute, unqualified_name};
+use syntax::types::{
+    Symbol, Type, build_substitution_map, substitute, type_args_match_params, unqualified_name,
+};
 
 use super::{extract_attribute_flags, has_recursive_instantiation, wrap_with_impl_generics};
 use crate::checker::TaskState;
@@ -646,13 +648,6 @@ impl TaskState<'_> {
             _ => return false,
         };
 
-        if params.len() != generics.len() {
-            return false;
-        }
-
-        params
-            .iter()
-            .zip(generics.iter())
-            .all(|(param, generic)| matches!(param, Type::Parameter(name) if *name == generic.name))
+        type_args_match_params(params, generics.iter().map(|generic| &generic.name))
     }
 }

--- a/crates/semantics/src/promotion.rs
+++ b/crates/semantics/src/promotion.rs
@@ -6,6 +6,7 @@ use syntax::ast::{Generic, Visibility};
 use syntax::program::{DefinitionBody, MethodSignatures};
 use syntax::types::{CompoundKind, Symbol, Type, build_substitution_map, substitute};
 
+use crate::call_classification::is_ufcs_method_type;
 use crate::store::Store;
 
 #[derive(Clone, Debug)]
@@ -382,70 +383,19 @@ fn instantiate_method(store: &Store, container: &Type, method_ty: &Type) -> Opti
     let Some(id) = container.get_qualified_id() else {
         return Some(method_ty.clone());
     };
-    let args = container.get_type_params().unwrap_or_default();
     let arity = declaring_generics(store, id).len();
+    if is_ufcs_method_type(method_ty, arity) {
+        return None;
+    }
+    let args = container.get_type_params().unwrap_or_default();
     if args.is_empty() || arity == 0 {
         return Some(method_ty.clone());
     }
-    if let Type::Forall { vars, body } = method_ty
-        && args.len() == arity
-        && vars.len() >= arity
-    {
-        let (impl_vars, method_vars) = vars.split_at(arity);
-        if receiver_is_simple(body, id, impl_vars) {
-            let map: HashMap<EcoString, Type> = impl_vars
-                .iter()
-                .cloned()
-                .zip(args.iter().cloned())
-                .collect();
-            let new_body = substitute(body, &map);
-            return Some(if method_vars.is_empty() {
-                new_body
-            } else {
-                Type::Forall {
-                    vars: method_vars.to_vec(),
-                    body: Box::new(new_body),
-                }
-            });
-        }
-    }
-    // Anything else is a specialized impl (`impl Container<int>`): it promotes
-    // only when its concrete receiver is exactly this instantiation, so a method
-    // declared for one instantiation never leaks onto another through promotion.
-    let receiver = method_receiver(method_ty)?;
-    (receiver.strip_refs() == *container).then(|| method_ty.clone())
-}
-
-/// The receiver (first parameter) of a method type, peeling any `Forall`.
-fn method_receiver(method_ty: &Type) -> Option<&Type> {
-    let body = match method_ty {
-        Type::Forall { body, .. } => body.as_ref(),
-        other => other,
+    let Type::Forall { vars, body } = method_ty else {
+        return Some(method_ty.clone());
     };
-    match body {
-        Type::Function(f) => f.params.first(),
-        _ => None,
-    }
-}
-
-/// The method's receiver is `Container<v0, .., vk>` with the impl vars bare and
-/// in order, i.e. an unspecialized `impl<v..> Container<v..>`.
-fn receiver_is_simple(body: &Type, container_id: &str, impl_vars: &[EcoString]) -> bool {
-    let Type::Function(f) = body else {
-        return false;
-    };
-    let Some(receiver) = f.params.first() else {
-        return false;
-    };
-    let Type::Nominal { id, params, .. } = receiver.strip_refs() else {
-        return false;
-    };
-    id.as_str() == container_id
-        && params.len() == impl_vars.len()
-        && params
-            .iter()
-            .zip(impl_vars)
-            .all(|(p, v)| matches!(p, Type::Parameter(name) if name == v))
+    let map: HashMap<EcoString, Type> = vars.iter().cloned().zip(args.iter().cloned()).collect();
+    Some(substitute(body, &map))
 }
 
 #[cfg(test)]
@@ -1046,7 +996,7 @@ mod tests {
     }
 
     #[test]
-    fn specialized_impl_promotes_onto_matching_instantiation() {
+    fn specialized_impl_method_not_promoted_onto_matching_instantiation() {
         let mut b = Builder::new();
         b.generic_struct(
             "Box",
@@ -1063,8 +1013,9 @@ mod tests {
             )],
             vec![],
         );
-        let member = found(resolve_selector(&b.store, &nominal("Outer"), "only_int"));
-        assert_eq!(member.depth, 1);
-        assert_eq!(method_return(&member), Type::int());
+        assert!(matches!(
+            resolve_selector(&b.store, &nominal("Outer"), "only_int"),
+            Resolution::NotFound
+        ));
     }
 }

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -202,6 +202,17 @@ pub fn build_substitution_map(generics: &[Generic], type_args: &[Type]) -> Subst
         .collect()
 }
 
+pub fn type_args_match_params<'a>(
+    args: &[Type],
+    params: impl ExactSizeIterator<Item = &'a EcoString>,
+) -> bool {
+    args.len() == params.len()
+        && args
+            .iter()
+            .zip(params)
+            .all(|(arg, param)| matches!(arg, Type::Parameter(name) if name == param))
+}
+
 pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
     if map.is_empty() {
         return ty.clone();

--- a/tests/e2e_suite/skip.txt
+++ b/tests/e2e_suite/skip.txt
@@ -37,6 +37,9 @@ try_block_panic_tail_option_context         # intentional: explicit panic in try
 try_block_panic_tail_result_context         # intentional: explicit panic in try-block tail
 try_block_user_never_tail_result_context    # intentional: tail calls Never-returning fn
 ufcs_call_return_only_type_args             # intentional: explicit panic in test body
+specialized_impl_return_only_type_args      # intentional: explicit panic in test body
+partial_impl_repeated_return_only_type_args # intentional: explicit panic in test body
+partial_impl_primitive_receiver_return_only_type_args  # intentional: explicit panic in test body
 
 # --- eval-order (panic is the assertion mechanism) ---
 index_access_eval_order_captured            # eval-order: out-of-range index proves capture

--- a/tests/spec/emit/snapshots/alias_partial_impl_ufcs_call.snap
+++ b/tests/spec/emit/snapshots/alias_partial_impl_ufcs_call.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<T> Pair<T, T> {\n  fn first(self) -> T { self.a }\n}\n\ntype IntPair = Pair<int, int>\n\nfn test() -> int {\n  let p: IntPair = Pair { a: 1, b: 2 };\n  p.first()\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_first[T any](self Pair[T, T]) T {
+	return self.a
+}
+
+type IntPair = Pair[int, int]
+
+func test() int {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_first(p)
+}

--- a/tests/spec/emit/snapshots/alias_specialized_impl_ufcs_call.snap
+++ b/tests/spec/emit/snapshots/alias_specialized_impl_ufcs_call.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Box<T> { value: T }\n\nimpl Box<int> {\n  fn only_int(self) -> int { self.value }\n}\n\ntype IntBox = Box<int>\n\nfn test() -> int {\n  let b: IntBox = Box { value: 7 };\n  b.only_int()\n}\n"
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func Box_only_int(self Box[int]) int {
+	return self.value
+}
+
+type IntBox = Box[int]
+
+func test() int {
+	b := Box[int]{value: 7}
+	return Box_only_int(b)
+}

--- a/tests/spec/emit/snapshots/full_arity_type_args_with_nonreceiver_impl_generic.snap
+++ b/tests/spec/emit/snapshots/full_arity_type_args_with_nonreceiver_impl_generic.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<X, T> Pair<T, T> {\n  fn pick(self, x: X) -> X { x }\n}\n\nfn test() -> bool {\n  let p = Pair { a: 1, b: 2 };\n  p.pick<bool, int>(true)\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_pick[X any, T any](_ Pair[T, T], x X) X {
+	return x
+}
+
+func test() bool {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_pick[bool, int](p, true)
+}

--- a/tests/spec/emit/snapshots/multi_impl_generic_method_only_type_arg.snap
+++ b/tests/spec/emit/snapshots/multi_impl_generic_method_only_type_arg.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<A, B> Pair<A, B> {\n  fn snd<U>(self, u: U) -> U { u }\n}\n\nfn test() -> bool {\n  let p: Pair<int, string> = Pair { a: 1, b: \"x\" };\n  p.snd<bool>(true)\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_snd[A any, B any, U any](_ Pair[A, B], u U) U {
+	return u
+}
+
+func test() bool {
+	p := Pair[int, string]{
+		a: 1,
+		b: "x",
+	}
+	return Pair_snd[int, string, bool](p, true)
+}

--- a/tests/spec/emit/snapshots/partial_impl_method_only_explicit_type_arg.snap
+++ b/tests/spec/emit/snapshots/partial_impl_method_only_explicit_type_arg.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<T> Pair<T, T> {\n  fn keep<U>(self, x: U) -> U { x }\n}\n\nfn test() -> string {\n  let p = Pair { a: 1, b: 2 };\n  p.keep<string>(\"ok\")\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_keep[T any, U any](_ Pair[T, T], x U) U {
+	return x
+}
+
+func test() string {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_keep[int, string](p, "ok")
+}

--- a/tests/spec/emit/snapshots/partial_impl_nominal_arg_uses_ufcs.snap
+++ b/tests/spec/emit/snapshots/partial_impl_nominal_arg_uses_ufcs.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct User {\n  name: string,\n}\n\nstruct Pair<A, B> {\n  a: A,\n  b: B,\n}\n\nimpl<B> Pair<User, B> {\n  fn left(self) -> User {\n    self.a\n  }\n}\n\nfn test() -> string {\n  let p = Pair { a: User { name: \"x\" }, b: 1 };\n  p.left().name\n}\n"
+---
+package main
+
+type User struct {
+	name string
+}
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_left[B any](self Pair[User, B]) User {
+	return self.a
+}
+
+func test() string {
+	p := Pair[User, int]{
+		a: User{name: "x"},
+		b: 1,
+	}
+	return Pair_left(p).name
+}

--- a/tests/spec/emit/snapshots/partial_impl_phantom_type_arg.snap
+++ b/tests/spec/emit/snapshots/partial_impl_phantom_type_arg.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<T> Pair<T, T> {\n  fn tag<U>(self) -> int { 1 }\n}\n\nfn test() -> int {\n  let p = Pair { a: 1, b: 2 };\n  p.tag<string>()\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_tag[T any, U any](_ Pair[T, T]) int {
+	return 1
+}
+
+func test() int {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_tag[int, string](p)
+}

--- a/tests/spec/emit/snapshots/partial_impl_primitive_arg_uses_ufcs.snap
+++ b/tests/spec/emit/snapshots/partial_impl_primitive_arg_uses_ufcs.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> {\n  a: A,\n  b: B,\n}\n\nimpl<B> Pair<int, B> {\n  fn left(self) -> int {\n    self.a\n  }\n}\n\nfn test() -> int {\n  let p = Pair { a: 1, b: \"x\" };\n  p.left()\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_left[B any](self Pair[int, B]) int {
+	return self.a
+}
+
+func test() int {
+	p := Pair[int, string]{
+		a: 1,
+		b: "x",
+	}
+	return Pair_left(p)
+}

--- a/tests/spec/emit/snapshots/partial_impl_primitive_receiver_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/partial_impl_primitive_receiver_return_only_type_args.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<B> Pair<int, B> {\n  fn make<U>(self) -> U { panic(\"boom\") }\n}\n\nfn test() {\n  let p: Pair<int, bool> = Pair { a: 1, b: true };\n  let x: string = p.make();\n  let _ = x;\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_make[B any, U any](_ Pair[int, B]) U {
+	panic("boom")
+}
+
+func test() {
+	p := Pair[int, bool]{
+		a: 1,
+		b: true,
+	}
+	x := Pair_make[bool, string](p)
+	_ = x
+}

--- a/tests/spec/emit/snapshots/partial_impl_repeated_explicit_type_args.snap
+++ b/tests/spec/emit/snapshots/partial_impl_repeated_explicit_type_args.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<T> Pair<T, T> {\n  fn keep<U>(self, x: U) -> U { x }\n}\n\nfn test() -> string {\n  let p = Pair { a: 1, b: 2 };\n  p.keep<int, string>(\"ok\")\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_keep[T any, U any](_ Pair[T, T], x U) U {
+	return x
+}
+
+func test() string {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_keep[int, string](p, "ok")
+}

--- a/tests/spec/emit/snapshots/partial_impl_repeated_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/partial_impl_repeated_return_only_type_args.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> { a: A, b: B }\n\nimpl<T> Pair<T, T> {\n  fn make<U>(self) -> U { panic(\"boom\") }\n}\n\nfn test() {\n  let p = Pair { a: 1, b: 2 };\n  let x: string = p.make();\n  let _ = x;\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_make[T any, U any](_ Pair[T, T]) U {
+	panic("boom")
+}
+
+func test() {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	x := Pair_make[int, string](p)
+	_ = x
+}

--- a/tests/spec/emit/snapshots/partial_impl_repeated_type_var_uses_ufcs.snap
+++ b/tests/spec/emit/snapshots/partial_impl_repeated_type_var_uses_ufcs.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Pair<A, B> {\n  a: A,\n  b: B,\n}\n\nimpl<T> Pair<T, T> {\n  fn first(self) -> T {\n    self.a\n  }\n}\n\nfn test() -> int {\n  let p = Pair { a: 1, b: 2 };\n  p.first()\n}\n"
+---
+package main
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func Pair_first[T any](self Pair[T, T]) T {
+	return self.a
+}
+
+func test() int {
+	p := Pair[int, int]{
+		a: 1,
+		b: 2,
+	}
+	return Pair_first(p)
+}

--- a/tests/spec/emit/snapshots/specialized_impl_explicit_type_args.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_explicit_type_args.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Box<T> { value: T }\n\nimpl Box<int> {\n  fn keep<U>(self, x: U) -> U { x }\n}\n\nfn test() -> string {\n  let b = Box { value: 1 };\n  b.keep<string>(\"ok\")\n}\n"
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func Box_keep[U any](_ Box[int], x U) U {
+	return x
+}
+
+func test() string {
+	b := Box[int]{value: 1}
+	return Box_keep[string](b, "ok")
+}

--- a/tests/spec/emit/snapshots/specialized_impl_phantom_type_arg.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_phantom_type_arg.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Box<T> { value: T }\n\nimpl Box<int> {\n  fn tag<U>(self) -> int { 1 }\n}\n\nfn test() -> int {\n  let b = Box { value: 1 };\n  b.tag<string>()\n}\n"
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func Box_tag[U any](_ Box[int]) int {
+	return 1
+}
+
+func test() int {
+	b := Box[int]{value: 1}
+	return Box_tag[string](b)
+}

--- a/tests/spec/emit/snapshots/specialized_impl_return_only_type_args.snap
+++ b/tests/spec/emit/snapshots/specialized_impl_return_only_type_args.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Box<T> { value: T }\n\nimpl Box<int> {\n  fn make<U>(self) -> U { panic(\"boom\") }\n}\n\nfn test() {\n  let b = Box { value: 1 };\n  let x: string = b.make();\n  let _ = x;\n}\n"
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func Box_make[U any](_ Box[int]) U {
+	panic("boom")
+}
+
+func test() {
+	b := Box[int]{value: 1}
+	x := Box_make[string](b)
+	_ = x
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2552,6 +2552,287 @@ fn test() -> int {
 }
 
 #[test]
+fn partial_impl_repeated_type_var_uses_ufcs() {
+    let input = r#"
+struct Pair<A, B> {
+  a: A,
+  b: B,
+}
+
+impl<T> Pair<T, T> {
+  fn first(self) -> T {
+    self.a
+  }
+}
+
+fn test() -> int {
+  let p = Pair { a: 1, b: 2 };
+  p.first()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_primitive_arg_uses_ufcs() {
+    let input = r#"
+struct Pair<A, B> {
+  a: A,
+  b: B,
+}
+
+impl<B> Pair<int, B> {
+  fn left(self) -> int {
+    self.a
+  }
+}
+
+fn test() -> int {
+  let p = Pair { a: 1, b: "x" };
+  p.left()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_nominal_arg_uses_ufcs() {
+    let input = r#"
+struct User {
+  name: string,
+}
+
+struct Pair<A, B> {
+  a: A,
+  b: B,
+}
+
+impl<B> Pair<User, B> {
+  fn left(self) -> User {
+    self.a
+  }
+}
+
+fn test() -> string {
+  let p = Pair { a: User { name: "x" }, b: 1 };
+  p.left().name
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn specialized_impl_explicit_type_args() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl Box<int> {
+  fn keep<U>(self, x: U) -> U { x }
+}
+
+fn test() -> string {
+  let b = Box { value: 1 };
+  b.keep<string>("ok")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_repeated_explicit_type_args() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn keep<U>(self, x: U) -> U { x }
+}
+
+fn test() -> string {
+  let p = Pair { a: 1, b: 2 };
+  p.keep<int, string>("ok")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn specialized_impl_return_only_type_args() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl Box<int> {
+  fn make<U>(self) -> U { panic("boom") }
+}
+
+fn test() {
+  let b = Box { value: 1 };
+  let x: string = b.make();
+  let _ = x;
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_repeated_return_only_type_args() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn make<U>(self) -> U { panic("boom") }
+}
+
+fn test() {
+  let p = Pair { a: 1, b: 2 };
+  let x: string = p.make();
+  let _ = x;
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_primitive_receiver_return_only_type_args() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<B> Pair<int, B> {
+  fn make<U>(self) -> U { panic("boom") }
+}
+
+fn test() {
+  let p: Pair<int, bool> = Pair { a: 1, b: true };
+  let x: string = p.make();
+  let _ = x;
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_partial_impl_ufcs_call() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn first(self) -> T { self.a }
+}
+
+type IntPair = Pair<int, int>
+
+fn test() -> int {
+  let p: IntPair = Pair { a: 1, b: 2 };
+  p.first()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_specialized_impl_ufcs_call() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl Box<int> {
+  fn only_int(self) -> int { self.value }
+}
+
+type IntBox = Box<int>
+
+fn test() -> int {
+  let b: IntBox = Box { value: 7 };
+  b.only_int()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn specialized_impl_phantom_type_arg() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl Box<int> {
+  fn tag<U>(self) -> int { 1 }
+}
+
+fn test() -> int {
+  let b = Box { value: 1 };
+  b.tag<string>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_phantom_type_arg() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn tag<U>(self) -> int { 1 }
+}
+
+fn test() -> int {
+  let p = Pair { a: 1, b: 2 };
+  p.tag<string>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_impl_method_only_explicit_type_arg() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn keep<U>(self, x: U) -> U { x }
+}
+
+fn test() -> string {
+  let p = Pair { a: 1, b: 2 };
+  p.keep<string>("ok")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn full_arity_type_args_with_nonreceiver_impl_generic() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<X, T> Pair<T, T> {
+  fn pick(self, x: X) -> X { x }
+}
+
+fn test() -> bool {
+  let p = Pair { a: 1, b: 2 };
+  p.pick<bool, int>(true)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn multi_impl_generic_method_only_type_arg() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<A, B> Pair<A, B> {
+  fn snd<U>(self, u: U) -> U { u }
+}
+
+fn test() -> bool {
+  let p: Pair<int, string> = Pair { a: 1, b: "x" };
+  p.snd<bool>(true)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn enum_variant_named_string() {
     let input = r#"
 enum ASTNode {

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1703,7 +1703,7 @@ fn main() {
 }
 
 #[test]
-fn constrained_generic_impl_receiver_match_accepted() {
+fn partial_impl_receiver_cannot_satisfy_interface() {
     infer(
         r#"
 interface Same { fn same(self) -> int }
@@ -1716,7 +1716,110 @@ fn main() {
 }
 "#,
     )
-    .assert_no_errors();
+    .assert_infer_code("specialized_impl_cannot_satisfy_interface");
+}
+
+#[test]
+fn partial_impl_on_enum_cannot_satisfy_interface() {
+    infer(
+        r#"
+interface Same { fn same(self) -> int }
+enum Pair<A, B> { Both(A, B) }
+impl<T> Pair<T, T> { fn same(self) -> int { 1 } }
+fn want(s: Same) -> int { s.same() }
+fn main() {
+  let p: Pair<int, int> = Pair.Both(1, 2)
+  let _ = want(p)
+}
+"#,
+    )
+    .assert_infer_code("specialized_impl_cannot_satisfy_interface");
+}
+
+#[test]
+fn generic_method_on_nongeneric_receiver_cannot_satisfy_interface() {
+    infer(
+        r#"
+interface IntId { fn id(self, x: int) -> int }
+struct S {}
+impl S { fn id<T>(self, x: T) -> T { x } }
+fn want(i: IntId) -> int { i.id(1) }
+fn main() {
+  let _ = want(S {})
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn alias_partial_impl_method_value_rejected() {
+    infer(
+        r#"
+struct Pair<A, B> { a: A, b: B }
+impl<T> Pair<T, T> { fn first(self) -> T { self.a } }
+type IntPair = Pair<int, int>
+fn main() {
+  let p: IntPair = Pair { a: 1, b: 2 }
+  let f = p.first
+  let _ = f()
+}
+"#,
+    )
+    .assert_infer_code("taking_value_of_ufcs_method");
+}
+
+#[test]
+fn alias_specialized_impl_method_value_rejected() {
+    infer(
+        r#"
+struct Box<T> { value: T }
+impl Box<int> { fn only_int(self) -> int { self.value } }
+type IntBox = Box<int>
+fn main() {
+  let b: IntBox = Box { value: 1 }
+  let f = b.only_int
+  let _ = f()
+}
+"#,
+    )
+    .assert_infer_code("taking_value_of_ufcs_method");
+}
+
+#[test]
+fn alias_partial_impl_cannot_satisfy_interface() {
+    infer(
+        r#"
+interface Same { fn same(self) -> int }
+struct Pair<A, B> { a: A, b: B }
+impl<T> Pair<T, T> { fn same(self) -> int { 1 } }
+type IntPair = Pair<int, int>
+fn want(s: Same) -> int { s.same() }
+fn main() {
+  let p: IntPair = Pair { a: 1, b: 2 }
+  let _ = want(p)
+}
+"#,
+    )
+    .assert_infer_code("specialized_impl_cannot_satisfy_interface");
+}
+
+#[test]
+fn alias_specialized_impl_cannot_satisfy_interface() {
+    infer(
+        r#"
+interface OnlyInt { fn only_int(self) -> int }
+struct Box<T> { value: T }
+impl Box<int> { fn only_int(self) -> int { self.value } }
+type IntBox = Box<int>
+fn want(x: OnlyInt) -> int { x.only_int() }
+fn main() {
+  let b: IntBox = Box { value: 1 }
+  let _ = want(b)
+}
+"#,
+    )
+    .assert_infer_code("specialized_impl_cannot_satisfy_interface");
 }
 
 #[test]
@@ -3589,6 +3692,78 @@ fn ufcs_method_with_method_only_type_args() {
         "#,
     )
     .assert_no_errors();
+}
+
+#[test]
+fn partial_impl_method_only_type_args_accepted() {
+    infer(
+        r#"
+struct Pair<A, B> { a: A, b: B }
+impl<T> Pair<T, T> { fn keep<U>(self, x: U) -> U { x } }
+fn main() {
+  let p = Pair { a: 1, b: 2 }
+  let _ = p.keep<string>("ok")
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn phantom_type_param_method_call_without_type_args_rejected() {
+    infer(
+        r#"
+struct Box<T> { value: T }
+impl Box<int> { fn tag<U>(self) -> int { 1 } }
+fn main() {
+  let b = Box { value: 1 }
+  let _ = b.tag()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn partial_impl_phantom_type_param_method_call_without_type_args_rejected() {
+    infer(
+        r#"
+struct Pair<A, B> { a: A, b: B }
+impl<T> Pair<T, T> { fn tag<U>(self) -> int { 1 } }
+fn main() {
+  let p = Pair { a: 1, b: 2 }
+  let _ = p.tag()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn phantom_type_param_function_call_without_type_args_rejected() {
+    infer(
+        r#"
+fn weird<T>() -> int { 1 }
+fn main() {
+  let _ = weird()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn phantom_type_param_static_method_call_without_type_args_rejected() {
+    infer(
+        r#"
+struct Box {}
+impl Box { fn weird<T>() -> int { 1 } }
+fn main() {
+  let _ = Box.weird()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
 }
 
 #[test]
@@ -6193,7 +6368,7 @@ fn main() {}
 }
 
 #[test]
-fn specialized_impl_method_promoted_onto_matching_instantiation() {
+fn specialized_impl_method_not_promoted_onto_matching_instantiation() {
     infer(
         r#"
 pub struct Box<T> { pub value: T }
@@ -6203,7 +6378,53 @@ fn use_it(o: Outer) -> int { o.only_int() }
 fn main() {}
 "#,
     )
-    .assert_no_errors();
+    .assert_infer_code("member_not_found");
+}
+
+#[test]
+fn embedded_specialized_impl_method_cannot_satisfy_interface() {
+    infer(
+        r#"
+interface OnlyInt { fn only_int(self) -> int }
+pub struct Box<T> { pub value: T }
+impl Box<int> { pub fn only_int(self) -> int { self.value } }
+struct Outer { embed Box<int> }
+fn want(x: OnlyInt) -> int { x.only_int() }
+fn main() {
+  let o = Outer { Box: Box { value: 1 } }
+  let _ = want(o)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn generic_method_with_extra_type_params_not_promoted() {
+    infer(
+        r#"
+struct Box<T> { value: T }
+impl<T> Box<T> { fn mapped<U>(self, f: fn(T) -> U) -> U { f(self.value) } }
+struct Outer { embed Box<int> }
+fn use_it(o: Outer) -> int { o.mapped(|x| x + 1) }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("member_not_found");
+}
+
+#[test]
+fn generic_method_on_nongeneric_embedded_receiver_not_promoted() {
+    infer(
+        r#"
+struct S {}
+impl S { fn id<T>(self, x: T) -> T { x } }
+struct Outer { embed S }
+fn use_it(o: Outer) -> int { o.id(1) }
+fn main() {}
+"#,
+    )
+    .assert_infer_code("member_not_found");
 }
 
 #[test]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1040,6 +1040,84 @@ fn main() {
 }
 
 #[test]
+fn infer_phantom_type_param_imported_function_call_rejected() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub fn weird<T>() -> int { 1 }
+"#,
+    );
+
+    let source = r#"
+import "util"
+
+fn main() {
+  let _ = util.weird()
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn infer_imported_function_shortened_type_args_rejected() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub fn choose<T, U>(x: T) -> U { panic("boom") }
+"#,
+    );
+
+    let source = r#"
+import "util"
+
+fn main() {
+  let y: string = util.choose<string>(1)
+  let _ = y
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn infer_cross_module_static_method_shortened_type_args_rejected() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub struct Box {}
+impl Box { pub fn choose<T, U>(x: T) -> U { panic("boom") } }
+"#,
+    );
+
+    let source = r#"
+import "util"
+
+fn main() {
+  let y: string = util.Box.choose<string>(1)
+  let _ = y
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
 fn infer_struct_enum_variant_as_bare_value_cross_module() {
     let mut fs = MockFileSystem::new();
 
@@ -5239,6 +5317,23 @@ fn infer_taking_value_of_ufcs_method() {
 fn test() {
   let opt: Option<int> = Some(42);
   let f = opt.map;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_taking_value_of_partial_impl_method() {
+    let input = r#"
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn first(self) -> T { self.a }
+}
+
+fn test() {
+  let p: Pair<int, int> = Pair { a: 1, b: 2 };
+  let f = p.first;
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_cross_module_static_method_shortened_type_args_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_cross_module_static_method_shortened_type_args_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Wrong type argument count
+   ╭─[main.lis:5:34]
+ 4 │ fn main() {
+ 5 │   let y: string = util.Box.choose<string>(1)
+   ·                                  ────┬───
+   ·                                      ╰── expected `<T, U>`, found `<string>`
+ 6 │   let _ = y
+   ╰────
+  help: This type expects 2 type parameters but received 1 type parameter · code: [infer.type_arg_count_mismatch]

--- a/tests/ui/errors/snapshots/infer_imported_function_shortened_type_args_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_imported_function_shortened_type_args_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Wrong type argument count
+   ╭─[main.lis:5:30]
+ 4 │ fn main() {
+ 5 │   let y: string = util.choose<string>(1)
+   ·                              ────┬───
+   ·                                  ╰── expected `<T, U>`, found `<string>`
+ 6 │   let _ = y
+   ╰────
+  help: This type expects 2 type parameters but received 1 type parameter · code: [infer.type_arg_count_mismatch]

--- a/tests/ui/errors/snapshots/infer_phantom_type_param_imported_function_call_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_phantom_type_param_imported_function_call_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Missing type argument
+   ╭─[main.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let _ = util.weird()
+   ·           ──────┬─────
+   ·                 ╰── expected type argument
+ 6 │ }
+   ╰────
+  help: Supply a type argument for the call, e.g. `Channel.new<int>()` · code: [infer.missing_type_argument]

--- a/tests/ui/errors/snapshots/infer_taking_value_of_partial_impl_method.snap
+++ b/tests/ui/errors/snapshots/infer_taking_value_of_partial_impl_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid method value
+    ╭─[test.lis:10:11]
+  9 │   let p: Pair<int, int> = Pair { a: 1, b: 2 };
+ 10 │   let f = p.first;
+    ·           ───┬───
+    ·              ╰── taking value not allowed
+ 11 │ }
+    ╰────
+  help: This method cannot be taken as a value. Call the method directly: `obj.method(...)` · code: [infer.taking_value_of_ufcs_method]


### PR DESCRIPTION
Methods declared on a partially instantiated generic `impl`, such as `impl<T> Pair<T, T>` or `impl<B> Pair<int, B>`, were compiling to invalid Go or silently dropped the type restriction in the `impl`. They now compile to sound Go.

```rs
struct Pair<A, B> { a: A, b: B }

impl<T> Pair<T, T> {
  fn first(self) -> T { self.a }
}

fn main() {
  let p: Pair<int, int> = Pair { a: 1, b: 2 }
  let _ = p.first()
}
```

This pass also corrects the Go type args generated for generic calls, and reports a call whose type args cannot be inferred at check time, instead of letting it fail later in `go build`.
