### PR TITLE
test: render remaining emit snapshot descriptions as yaml blocks

### DIFF
--- a/tests/spec/emit/snapshots/map_equals.snap
+++ b/tests/spec/emit/snapshots/map_equals.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Map<string, int>, b: Map<string, int>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Map<string, int>, b: Map<string, int>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/map_of_slice_equals.snap
+++ b/tests/spec/emit/snapshots/map_of_slice_equals.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Map<string, Slice<int>>, b: Map<string, Slice<int>>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Map<string, Slice<int>>, b: Map<string, Slice<int>>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/nested_slice_equals.snap
+++ b/tests/spec/emit/snapshots/nested_slice_equals.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Slice<Slice<int>>, b: Slice<Slice<int>>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Slice<Slice<int>>, b: Slice<Slice<int>>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/promoted_method_expression_pointer_receiver.snap
+++ b/tests/spec/emit/snapshots/promoted_method_expression_pointer_receiver.snap
@@ -1,6 +1,20 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "\nstruct Base { pub id: int }\n\nimpl Base {\n  pub fn bump(self: Ref<Base>) { self.id += 1 }\n}\n\nstruct Outer { embed Base }\n\nfn main() {\n  let g = Outer.bump\n  let mut o = Outer { Base: Base { id: 1 } }\n  g(&o)\n}\n"
+description: |
+  
+  struct Base { pub id: int }
+  
+  impl Base {
+    pub fn bump(self: Ref<Base>) { self.id += 1 }
+  }
+  
+  struct Outer { embed Base }
+  
+  fn main() {
+    let g = Outer.bump
+    let mut o = Outer { Base: Base { id: 1 } }
+    g(&o)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/promoted_method_expression_value_receiver.snap
+++ b/tests/spec/emit/snapshots/promoted_method_expression_value_receiver.snap
@@ -1,6 +1,20 @@
 ---
 source: tests/spec/emit/expressions.rs
-description: "\nstruct Base { pub id: int }\n\nimpl Base {\n  pub fn describe(self) -> string { \"base\" }\n}\n\nstruct Mid { embed Base }\nstruct Top { embed Mid }\n\nfn main() {\n  let f = Top.describe\n  let _ = f(Top { Mid: Mid { Base: Base { id: 1 } } })\n}\n"
+description: |
+  
+  struct Base { pub id: int }
+  
+  impl Base {
+    pub fn describe(self) -> string { "base" }
+  }
+  
+  struct Mid { embed Base }
+  struct Top { embed Mid }
+  
+  fn main() {
+    let f = Top.describe
+    let _ = f(Top { Mid: Mid { Base: Base { id: 1 } } })
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/slice_equals.snap
+++ b/tests/spec/emit/snapshots/slice_equals.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Slice<int>, b: Slice<int>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/slice_equals_comparable_generic.snap
+++ b/tests/spec/emit/snapshots/slice_equals_comparable_generic.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test<T: Comparable>(a: Slice<T>, b: Slice<T>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test<T: Comparable>(a: Slice<T>, b: Slice<T>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/slice_equals_negated.snap
+++ b/tests/spec/emit/snapshots/slice_equals_negated.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  !a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Slice<int>, b: Slice<int>) -> bool {
+    !a.equals(b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/slice_equals_ufcs.snap
+++ b/tests/spec/emit/snapshots/slice_equals_ufcs.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Slice<int>, b: Slice<int>) -> bool {\n  Slice.equals(a, b)\n}\n"
+description: |
+  
+  fn test(a: Slice<int>, b: Slice<int>) -> bool {
+    Slice.equals(a, b)
+  }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/slice_of_map_equals.snap
+++ b/tests/spec/emit/snapshots/slice_of_map_equals.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/spec/emit/prelude.rs
-description: "\nfn test(a: Slice<Map<string, int>>, b: Slice<Map<string, int>>) -> bool {\n  a.equals(b)\n}\n"
+description: |
+  
+  fn test(a: Slice<Map<string, int>>, b: Slice<Map<string, int>>) -> bool {
+    a.equals(b)
+  }
 ---
 package main
 


### PR DESCRIPTION
Regenerates the 10 emit snapshots created after #691 so that their descriptions use YAML literal blocks, matching the rest of the suite.