### PR TITLE
feat: lint for min/max clamp mistakes

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2410,6 +2410,15 @@ pub fn cast_nan_to_int(span: &Span, target: &str) -> LisetteDiagnostic {
         )
 }
 
+pub fn min_max(span: &Span, constant: i128) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Clamp always returns a constant")
+        .with_infer_code("min_max")
+        .with_span_label(span, format!("always `{constant}`"))
+        .with_help(format!(
+            "This clamp always returns `{constant}` regardless of its variable operand. Did you swap `min` and `max`?"
+        ))
+}
+
 pub fn deferred_lock(span: Span, locked: &str, unlock: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("Deferred `{locked}` instead of `{unlock}`"))
         .with_infer_code("deferred_lock")

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -411,6 +411,15 @@ pub fn redundant_operation(span: &Span, always: Option<&str>) -> LisetteDiagnost
     }
 }
 
+pub fn unnecessary_min_or_max(span: &Span, op: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::info(format!("Unnecessary `{op}` call"))
+        .with_lint_code("unnecessary_min_or_max")
+        .with_span_label(span, "always returns the same operand")
+        .with_help(format!(
+            "This `{op}` always evaluates to one of its operands, so it has no effect. Simplify it to that operand."
+        ))
+}
+
 pub fn integer_division_to_zero(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Integer division is always `0`")
         .with_lint_code("integer_division_to_zero")

--- a/crates/semantics/src/passes/checks/min_max.rs
+++ b/crates/semantics/src/passes/checks/min_max.rs
@@ -1,0 +1,68 @@
+use crate::passes::comparison::{MinMaxOp, prelude_min_max, signed_integer_literal};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::Expression;
+use syntax::types::SimpleKind;
+
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let span = expression.get_span();
+    if ctx.claimed_spans.borrow().contains(&span) {
+        return;
+    }
+
+    let Some(outer) = prelude_min_max(expression) else {
+        return;
+    };
+
+    // Integers only: a float clamp can yield NaN, which Go's `min`/`max`
+    // propagate, so the result is not constant.
+    let Some(kind) = expression.get_type().as_simple() else {
+        return;
+    };
+    if kind.integer_range().is_none() {
+        return;
+    }
+
+    let (outer_constant, nested) = match (
+        in_range_literal(outer.left, kind),
+        in_range_literal(outer.right, kind),
+    ) {
+        (Some(constant), None) => (constant, outer.right),
+        (None, Some(constant)) => (constant, outer.left),
+        _ => return,
+    };
+
+    let nested = nested.unwrap_parens();
+    let Some(inner) = prelude_min_max(nested) else {
+        return;
+    };
+    if inner.op == outer.op {
+        return;
+    }
+
+    let inner_constant = match (
+        in_range_literal(inner.left, kind),
+        in_range_literal(inner.right, kind),
+    ) {
+        (Some(constant), None) | (None, Some(constant)) => constant,
+        _ => return,
+    };
+
+    let always_constant = match outer.op {
+        MinMaxOp::Min => outer_constant <= inner_constant,
+        MinMaxOp::Max => outer_constant >= inner_constant,
+    };
+    if !always_constant {
+        return;
+    }
+
+    ctx.claimed_spans.borrow_mut().insert(nested.get_span());
+    ctx.sink
+        .push(diagnostics::infer::min_max(&span, outer_constant));
+}
+
+// In range for `kind`, so the lint never fires on a literal the checker rejects.
+fn in_range_literal(expression: &Expression, kind: SimpleKind) -> Option<i128> {
+    let value = signed_integer_literal(expression.unwrap_parens())?;
+    let (min, max) = kind.integer_range()?;
+    (min <= value && value <= max).then_some(value)
+}

--- a/crates/semantics/src/passes/checks/mod.rs
+++ b/crates/semantics/src/passes/checks/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod interpolation_stringer;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
 pub(crate) mod json_serializable_fields;
+pub(crate) mod min_max;
 pub(crate) mod nan_comparison;
 pub(crate) mod native_value_usage;
 pub(crate) mod newtype;

--- a/crates/semantics/src/passes/checks/node_walk.rs
+++ b/crates/semantics/src/passes/checks/node_walk.rs
@@ -8,7 +8,7 @@ use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
 use super::{
     cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop,
     empty_range, enum_variant_value, impossible_comparison, index_out_of_bounds,
-    irrefutable_patterns, nan_comparison, newtype, oversized_shift, predeclared_shadowing,
+    irrefutable_patterns, min_max, nan_comparison, newtype, oversized_shift, predeclared_shadowing,
     pub_type_export, receivers, repeated_if_condition, stringer_signature, temp_producing,
     unchanging_loop_condition,
 };
@@ -17,6 +17,7 @@ static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
     CheckTable::new(
         &[
             (nan_comparison::check, &[Binary]),
+            (min_max::check, &[Call]),
             (cast_nan_to_int::check, &[Cast]),
             (impossible_comparison::check, &[Binary]),
             (empty_range::check, &[Range]),

--- a/crates/semantics/src/passes/comparison.rs
+++ b/crates/semantics/src/passes/comparison.rs
@@ -245,6 +245,51 @@ pub(crate) fn expressions_equivalent(a: &Expression, b: &Expression) -> bool {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MinMaxOp {
+    Min,
+    Max,
+}
+
+pub(crate) struct MinMaxCall<'a> {
+    pub(crate) op: MinMaxOp,
+    pub(crate) left: &'a Expression,
+    pub(crate) right: &'a Expression,
+}
+
+pub(crate) fn prelude_min_max(expression: &Expression) -> Option<MinMaxCall<'_>> {
+    let Expression::Call {
+        expression: callee,
+        args,
+        spread,
+        ..
+    } = expression
+    else {
+        return None;
+    };
+    if spread.is_some() || args.len() != 2 {
+        return None;
+    }
+    let Expression::Identifier {
+        binding_id: None,
+        qualified: Some(qualified),
+        ..
+    } = callee.unwrap_parens()
+    else {
+        return None;
+    };
+    let op = match qualified.as_str() {
+        "prelude.min" => MinMaxOp::Min,
+        "prelude.max" => MinMaxOp::Max,
+        _ => return None,
+    };
+    Some(MinMaxCall {
+        op,
+        left: &args[0],
+        right: &args[1],
+    })
+}
+
 /// The more restrictive of two bounds; `first_wins(a, b)` is true when `a`'s
 /// value is tighter. At equal values the bound stays inclusive only if both were.
 pub(crate) fn tighter(a: Bound, b: Bound, first_wins: impl Fn(i128, i128) -> bool) -> Bound {

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -58,6 +58,7 @@ mod single_arm_select;
 mod type_limit_comparison;
 mod uninterpolated_fstring;
 mod unnecessary_bool;
+mod unnecessary_min_or_max;
 mod unnecessary_range_loop;
 mod unnecessary_raw_string;
 mod unnecessary_return;
@@ -126,6 +127,7 @@ pub use single_arm_select::check_single_arm_select;
 pub use type_limit_comparison::check_type_limit_comparison;
 pub use uninterpolated_fstring::check_uninterpolated_fstring;
 pub use unnecessary_bool::check_unnecessary_bool;
+pub use unnecessary_min_or_max::check_unnecessary_min_or_max;
 pub use unnecessary_range_loop::check_unnecessary_range_loop;
 pub use unnecessary_raw_string::{
     check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,

--- a/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
@@ -1,0 +1,84 @@
+use crate::passes::comparison::{MinMaxOp, prelude_min_max};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::Expression;
+use syntax::types::SimpleKind;
+
+use super::helpers::{expressions_equivalent, is_side_effect_free, signed_integer_literal};
+
+pub fn check_unnecessary_min_or_max(expression: &Expression, ctx: &NodeCtx) {
+    let Some(call) = prelude_min_max(expression) else {
+        return;
+    };
+
+    if expression.get_type().is_error() {
+        return;
+    }
+
+    let op = match call.op {
+        MinMaxOp::Min => "min",
+        MinMaxOp::Max => "max",
+    };
+
+    if expressions_equivalent(call.left, call.right) && is_side_effect_free(call.left) {
+        ctx.sink.push(diagnostics::lint::unnecessary_min_or_max(
+            &expression.get_span(),
+            op,
+        ));
+        return;
+    }
+
+    let Some((value_operand, literal)) = split_one_literal(call.left, call.right) else {
+        return;
+    };
+    let Some(kind) = value_operand.get_type().as_simple() else {
+        return;
+    };
+    let no_op_bound = match call.op {
+        MinMaxOp::Min => max_bound(kind),
+        MinMaxOp::Max => min_bound(kind),
+    };
+    if no_op_bound == Some(literal) {
+        ctx.sink.push(diagnostics::lint::unnecessary_min_or_max(
+            &expression.get_span(),
+            op,
+        ));
+    }
+}
+
+fn split_one_literal<'a>(a: &'a Expression, b: &'a Expression) -> Option<(&'a Expression, i128)> {
+    match (
+        signed_integer_literal(a.unwrap_parens()),
+        signed_integer_literal(b.unwrap_parens()),
+    ) {
+        (None, Some(value)) => Some((a, value)),
+        (Some(value), None) => Some((b, value)),
+        _ => None,
+    }
+}
+
+fn min_bound(kind: SimpleKind) -> Option<i128> {
+    use SimpleKind::*;
+    Some(match kind {
+        Int8 => i8::MIN as i128,
+        Int16 => i16::MIN as i128,
+        Int32 | Rune => i32::MIN as i128,
+        Int64 => i64::MIN as i128,
+        Uint8 | Byte | Uint16 | Uint32 | Uint64 | Uint | Uintptr => 0,
+        _ => return None,
+    })
+}
+
+fn max_bound(kind: SimpleKind) -> Option<i128> {
+    use SimpleKind::*;
+    Some(match kind {
+        Int8 => i8::MAX as i128,
+        Int16 => i16::MAX as i128,
+        Int32 | Rune => i32::MAX as i128,
+        Int64 => i64::MAX as i128,
+        Uint8 | Byte => u8::MAX as i128,
+        Uint16 => u16::MAX as i128,
+        Uint32 => u32::MAX as i128,
+        Uint64 => u64::MAX as i128,
+        _ => return None,
+    })
+}

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -39,9 +39,10 @@ use checks::{
     check_regexp_in_loop, check_replaceable_with_zero_fill, check_rest_only_slice_pattern,
     check_self_assignment, check_self_comparison, check_single_arm_select,
     check_type_limit_comparison, check_uninterpolated_fstring, check_unnecessary_bool,
-    check_unnecessary_range_loop, check_unnecessary_raw_string_expression,
-    check_unnecessary_raw_string_pattern, check_unnecessary_return, check_unsigned_comparison,
-    check_verbose_failure_propagation, check_waitgroup_add_in_task,
+    check_unnecessary_min_or_max, check_unnecessary_range_loop,
+    check_unnecessary_raw_string_expression, check_unnecessary_raw_string_pattern,
+    check_unnecessary_return, check_unsigned_comparison, check_verbose_failure_propagation,
+    check_waitgroup_add_in_task,
 };
 
 static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
@@ -72,6 +73,7 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_redundant_sprintf, &[Call]),
             (check_manual_equal_fold, &[Binary]),
             (check_manual_find, &[Call]),
+            (check_unnecessary_min_or_max, &[Call]),
             (check_manual_is_empty, &[Binary]),
             (check_bool_literal_comparison, &[Binary]),
             (check_identical_if_branches, &[If]),

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15082,3 +15082,257 @@ fn main() {
         result.lints
     );
 }
+
+#[test]
+fn min_max_min_over_max() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(max(x, 5), 1)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_max_over_min() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = max(min(x, 1), 5)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_equal_bounds() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(max(x, 5), 5)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_float_integer_literals_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let g: float64 = 1.5
+  let _ = min(max(g, 5), 1)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_literal_on_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(1, max(5, x))
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_valid_clamp_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = max(min(x, 5), 1)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_inner_clamp_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(max(x, 1), 5)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_same_op_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(min(x, 5), 1)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_float_literal_bounds_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let g: float64 = 1.5
+  let _ = min(max(g, 5.0), 1.0)
+}
+"#
+    );
+}
+
+#[test]
+fn min_max_shadowed_min_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let min = |a: int, b: int| a + b
+  let x: int = 3
+  let _ = min(max(x, 5), 1)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_identical_min() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = min(x, x)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_identical_max() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int = 3
+  let _ = max(x, x)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_uint8_floor() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let b: uint8 = 5
+  let _ = max(b, 0)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_uint8_ceil() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let b: uint8 = 5
+  let _ = min(b, 255)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_int8_floor() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let c: int8 = 5
+  let _ = max(c, -128)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_identical_string() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let s: string = "a"
+  let _ = min(s, s)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_side_effect_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn f() -> int { 3 }
+fn main() {
+  let _ = min(f(), f())
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_distinct_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let a: int = 1
+  let b: int = 2
+  let _ = min(a, b)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_signed_floor_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let a: int = 1
+  let _ = max(a, 0)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_below_ceil_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let b: uint8 = 5
+  let _ = min(b, 254)
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_min_or_max_shadowed_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let min = |a: int, b: int| a + b
+  let _ = min(7, 7)
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/min_max_equal_bounds.snap
+++ b/tests/ui/lint/snapshots/min_max_equal_bounds.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Clamp always returns a constant
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = min(max(x, 5), 5)
+   ·           ────────┬────────
+   ·                   ╰── always `5`
+ 5 │ }
+   ╰────
+  help: This clamp always returns `5` regardless of its variable operand. Did you swap `min` and `max`? · code: [infer.min_max]

--- a/tests/ui/lint/snapshots/min_max_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/min_max_literal_on_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Clamp always returns a constant
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = min(1, max(5, x))
+   ·           ────────┬────────
+   ·                   ╰── always `1`
+ 5 │ }
+   ╰────
+  help: This clamp always returns `1` regardless of its variable operand. Did you swap `min` and `max`? · code: [infer.min_max]

--- a/tests/ui/lint/snapshots/min_max_max_over_min.snap
+++ b/tests/ui/lint/snapshots/min_max_max_over_min.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Clamp always returns a constant
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = max(min(x, 1), 5)
+   ·           ────────┬────────
+   ·                   ╰── always `5`
+ 5 │ }
+   ╰────
+  help: This clamp always returns `5` regardless of its variable operand. Did you swap `min` and `max`? · code: [infer.min_max]

--- a/tests/ui/lint/snapshots/min_max_min_over_max.snap
+++ b/tests/ui/lint/snapshots/min_max_min_over_max.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [error] Clamp always returns a constant
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = min(max(x, 5), 1)
+   ·           ────────┬────────
+   ·                   ╰── always `1`
+ 5 │ }
+   ╰────
+  help: This clamp always returns `1` regardless of its variable operand. Did you swap `min` and `max`? · code: [infer.min_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_max.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_max.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `max` call
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = max(x, x)
+   ·           ────┬────
+   ·               ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `max` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_min.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_min.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `min` call
+   ╭─[test.lis:4:11]
+ 3 │   let x: int = 3
+ 4 │   let _ = min(x, x)
+   ·           ────┬────
+   ·               ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `min` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_string.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_identical_string.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `min` call
+   ╭─[test.lis:4:11]
+ 3 │   let s: string = "a"
+ 4 │   let _ = min(s, s)
+   ·           ────┬────
+   ·               ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `min` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_int8_floor.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_int8_floor.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `max` call
+   ╭─[test.lis:4:11]
+ 3 │   let c: int8 = 5
+ 4 │   let _ = max(c, -128)
+   ·           ──────┬─────
+   ·                 ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `max` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_uint8_ceil.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_uint8_ceil.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `min` call
+   ╭─[test.lis:4:11]
+ 3 │   let b: uint8 = 5
+ 4 │   let _ = min(b, 255)
+   ·           ─────┬─────
+   ·                ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `min` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]

--- a/tests/ui/lint/snapshots/unnecessary_min_or_max_uint8_floor.snap
+++ b/tests/ui/lint/snapshots/unnecessary_min_or_max_uint8_floor.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [info] Unnecessary `max` call
+   ╭─[test.lis:4:11]
+ 3 │   let b: uint8 = 5
+ 4 │   let _ = max(b, 0)
+   ·           ────┬────
+   ·               ╰── always returns the same operand
+ 5 │ }
+   ╰────
+  help: This `max` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]


### PR DESCRIPTION
Adds two diagnostics for misuse of the `min` and `max` builtins, i.e. a crossed-bound clamp that is constant regardless of its variable operand, and a `min` or `max` call that always returns one of its operands.

```
  [error] Clamp always returns a constant
   ╭─[test.lis:4:11]
 3 │   let x: int = 3
 4 │   let _ = min(max(x, 5), 1)
   ·           ────────┬────────
   ·                   ╰── always `1`
 5 │ }
   ╰────
  help: This clamp always returns `1` regardless of its variable operand. Did you swap `min` and `max`? · code: [infer.min_max]
```

```
  [info] Unnecessary `min` call
   ╭─[test.lis:4:11]
 3 │   let x: int = 3
 4 │   let _ = min(x, x)
   ·           ────┬────
   ·               ╰── always returns the same operand
 5 │ }
   ╰────
  help: This `min` always evaluates to one of its operands, so it has no effect. Simplify it to that operand · code: [lint.unnecessary_min_or_max]
```

