### PR TITLE
feat: lint for botched variable swaps

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -436,6 +436,15 @@ pub fn verbose_failure_propagation(span: &Span) -> LisetteDiagnostic {
         .with_help("Use `?` to propagate the failure concisely")
 }
 
+pub fn almost_swapped(span: &Span, first: &str, second: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Variables are not swapped")
+        .with_lint_code("almost_swapped")
+        .with_span_label(span, "does not swap the values")
+        .with_help(format!(
+            "`{first} = {second}` overwrites `{first}`, so the following `{second} = {first}` writes `{second}`'s own value back and the original `{first}` is lost. To swap them, save one value in a temporary variable first."
+        ))
+}
+
 pub fn self_assignment(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Self-assignment")
         .with_lint_code("self_assignment")

--- a/crates/semantics/src/passes/lints/ast_walk/checks/almost_swapped.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/almost_swapped.rs
@@ -1,0 +1,107 @@
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BindingId, Expression};
+use syntax::types::Type;
+
+pub fn check_almost_swapped(expression: &Expression, ctx: &NodeCtx) {
+    let (Expression::Block { items, .. }
+    | Expression::TryBlock { items, .. }
+    | Expression::RecoverBlock { items, .. }) = expression
+    else {
+        return;
+    };
+
+    let mut index = 0;
+    while index + 1 < items.len() {
+        if fire_if_swapped(&items[index], &items[index + 1], ctx) {
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn fire_if_swapped(first: &Expression, second: &Expression, ctx: &NodeCtx) -> bool {
+    let Some((first_target, first_value)) = plain_assignment(first) else {
+        return false;
+    };
+    let Some((second_target, second_value)) = plain_assignment(second) else {
+        return false;
+    };
+
+    let (Some(left), Some(right)) = (variable(first_target), variable(first_value)) else {
+        return false;
+    };
+    let (Some(second_to), Some(second_from)) = (variable(second_target), variable(second_value))
+    else {
+        return false;
+    };
+
+    // The second statement must reassign two distinct variables in the opposite
+    // direction: `a = b; b = a`.
+    if left.id != second_from.id || right.id != second_to.id || left.id == right.id {
+        return false;
+    }
+
+    // Both targets must be declared mutable, so the checker accepts both
+    // assignments rather than reporting an immutable-mutation error.
+    if !is_mutable(left.id, ctx) || !is_mutable(right.id, ctx) {
+        return false;
+    }
+
+    // Same type, so both assignments type-check; a mismatch or an `Error` operand
+    // fails this check and the checker owns the diagnostic.
+    if left.ty != right.ty {
+        return false;
+    }
+
+    let span = first.get_span().merge(second.get_span());
+    ctx.sink.push(diagnostics::lint::almost_swapped(
+        &span, left.name, right.name,
+    ));
+    true
+}
+
+struct Variable<'a> {
+    id: BindingId,
+    ty: &'a Type,
+    name: &'a str,
+}
+
+fn variable(expression: &Expression) -> Option<Variable<'_>> {
+    if let Expression::Identifier {
+        binding_id: Some(id),
+        ty,
+        value,
+        ..
+    } = expression
+    {
+        Some(Variable {
+            id: *id,
+            ty,
+            name: value.as_str(),
+        })
+    } else {
+        None
+    }
+}
+
+fn plain_assignment(item: &Expression) -> Option<(&Expression, &Expression)> {
+    if let Expression::Assignment {
+        target,
+        value,
+        compound_operator: None,
+        ..
+    } = item
+    {
+        Some((target.unwrap_parens(), value.unwrap_parens()))
+    } else {
+        None
+    }
+}
+
+fn is_mutable(id: BindingId, ctx: &NodeCtx) -> bool {
+    ctx.facts
+        .bindings
+        .get(&id)
+        .is_some_and(|binding| binding.kind.is_mutable())
+}

--- a/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,3 +1,4 @@
+mod almost_swapped;
 mod bad_bit_mask;
 mod bool_literal_comparison;
 mod collapsible_if;
@@ -66,6 +67,7 @@ mod unsigned_comparison;
 mod verbose_failure_propagation;
 mod waitgroup_add_in_task;
 
+pub use almost_swapped::check_almost_swapped;
 pub use bad_bit_mask::check_bad_bit_mask;
 pub use bool_literal_comparison::check_bool_literal_comparison;
 pub use collapsible_if::check_collapsible_if;

--- a/crates/semantics/src/passes/lints/ast_walk/mod.rs
+++ b/crates/semantics/src/passes/lints/ast_walk/mod.rs
@@ -19,7 +19,7 @@ use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
-    check_bad_bit_mask, check_bool_literal_comparison, check_collapsible_if,
+    check_almost_swapped, check_bad_bit_mask, check_bool_literal_comparison, check_collapsible_if,
     check_double_comparison, check_double_negation, check_dup_arg, check_duplicate_cutset,
     check_duplicate_logical_operand, check_empty_match_arm, check_equal_operands,
     check_excess_parens_on_condition, check_exit_after_defer, check_expression_naming,
@@ -88,6 +88,7 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_match_single_binding, &[Match]),
             (check_negated_equality, &[Unary]),
             (check_let_and_return, &[Block]),
+            (check_almost_swapped, &[Block, TryBlock, RecoverBlock]),
             (check_unnecessary_bool, &[If]),
             (check_unnecessary_range_loop, &[For]),
             (check_unnecessary_return, &[Function]),

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15205,6 +15205,157 @@ fn main() {
 }
 
 #[test]
+fn almost_swapped() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let mut a = 1
+  let mut b = 2
+  a = b
+  b = a
+  let _ = a + b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_mutable_params() {
+    assert_lint_snapshot!(
+        r#"
+fn swap(mut a: int, mut b: int) -> int {
+  a = b
+  b = a
+  a + b
+}
+
+fn main() {
+  let _ = swap(1, 2)
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_suppressed_by_allow() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(almost_swapped)]
+fn main() {
+  let mut a = 1
+  let mut b = 2
+  a = b
+  b = a
+  let _ = a + b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_in_try_block() {
+    assert_lint_snapshot!(
+        r#"
+fn risky() -> Result<int, string> {
+  Ok(1)
+}
+
+fn compute() -> Result<int, string> {
+  try {
+    let mut a = risky()?
+    let mut b = risky()?
+    a = b
+    b = a
+    a + b
+  }
+}
+
+fn main() {
+  let _ = compute()
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_third_variable_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = 1
+  let mut b = 2
+  let c = 3
+  a = b
+  b = c
+  let _ = a + b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_repeated_copy_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = 1
+  let b = 2
+  a = b
+  a = b
+  let _ = a + b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_compound_assignment_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = 1
+  let mut b = 2
+  a += b
+  b += a
+  let _ = a + b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_non_adjacent_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = 1
+  let mut b = 2
+  a = b
+  let _ = a
+  b = a
+  let _ = b
+}
+"#
+    );
+}
+
+#[test]
+fn almost_swapped_field_access_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct Point { x: int, y: int }
+
+fn main() {
+  let mut p = Point { x: 1, y: 2 }
+  p.x = p.y
+  p.y = p.x
+  let _ = p.x + p.y
+}
+"#
+    );
+}
+
+#[test]
 fn unnecessary_min_or_max_identical_min() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/almost_swapped.snap
+++ b/tests/ui/lint/snapshots/almost_swapped.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Variables are not swapped
+   ╭─[test.lis:5:3]
+ 4 │       let mut b = 2
+ 5 │ ╭─▶   a = b
+ 6 │ ├─▶   b = a
+   · ╰──── does not swap the values
+ 7 │       let _ = a + b
+   ╰────
+  help: `a = b` overwrites `a`, so the following `b = a` writes `b`'s own value back and the original `a` is lost. To swap them, save one value in a temporary variable first · code: [lint.almost_swapped]

--- a/tests/ui/lint/snapshots/almost_swapped_in_try_block.snap
+++ b/tests/ui/lint/snapshots/almost_swapped_in_try_block.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Variables are not swapped
+    ╭─[test.lis:10:5]
+  9 │         let mut b = risky()?
+ 10 │ ╭─▶     a = b
+ 11 │ ├─▶     b = a
+    · ╰──── does not swap the values
+ 12 │         a + b
+    ╰────
+  help: `a = b` overwrites `a`, so the following `b = a` writes `b`'s own value back and the original `a` is lost. To swap them, save one value in a temporary variable first · code: [lint.almost_swapped]

--- a/tests/ui/lint/snapshots/almost_swapped_mutable_params.snap
+++ b/tests/ui/lint/snapshots/almost_swapped_mutable_params.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  [warning] Variables are not swapped
+   ╭─[test.lis:3:3]
+ 2 │     fn swap(mut a: int, mut b: int) -> int {
+ 3 │ ╭─▶   a = b
+ 4 │ ├─▶   b = a
+   · ╰──── does not swap the values
+ 5 │       a + b
+   ╰────
+  help: `a = b` overwrites `a`, so the following `b = a` writes `b`'s own value back and the original `a` is lost. To swap them, save one value in a temporary variable first · code: [lint.almost_swapped]


### PR DESCRIPTION
Adds a diagnostic for an incorrect variable swap. Lisette has no swap sugar.

```
  [warning] Variables are not swapped
   ╭─[test.lis:5:3]
 4 │       let mut b = 2
 5 │ ╭─▶   a = b
 6 │ ├─▶   b = a
   · ╰──── does not swap the values
 7 │       let _ = a + b
   ╰────
  help: `a = b` overwrites `a`, so the following `b = a` writes `b`'s own value back and the original `a` is lost. To swap them, save one value in a temporary variable first · code: [lint.almost_swapped]
```