### PR TITLE
fix: reject unrepresentable receiver method bounds

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2777,6 +2777,34 @@ pub fn impl_on_foreign_type(type_name: &str, module_name: &str, span: Span) -> L
         ))
 }
 
+pub fn impl_bound_conflicts_with_type(
+    interface: &str,
+    type_name: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Conflicting impl bound")
+        .with_infer_code("impl_bound_conflicts_with_type")
+        .with_span_label(&span, "this bound cannot strengthen the receiver type")
+        .with_help(format!(
+            "`{type_name}` already bounds this parameter with a different `{interface}` instantiation. A receiver method would embed `{interface}` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration."
+        ))
+}
+
+pub fn conflicting_impl_interface_instantiations(
+    interface: &str,
+    type_name: &str,
+    span: Span,
+    earlier: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Conflicting interface bounds")
+        .with_infer_code("conflicting_impl_interface_instantiations")
+        .with_span_label(&span, "one impl instantiates it differently here")
+        .with_span_label(&earlier, "one impl instantiates it here")
+        .with_help(format!(
+            "Two impls instantiate `{interface}` differently for the same parameter of `{type_name}`. A receiver method folds its bound onto the type, so Go would embed `{interface}` twice. Use one instantiation, or split `{type_name}` into separate types."
+        ))
+}
+
 pub fn impl_on_type_alias(_type_name: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot implement methods on type alias")
         .with_infer_code("impl_on_type_alias")

--- a/crates/emit/src/analyze/constraint_collector.rs
+++ b/crates/emit/src/analyze/constraint_collector.rs
@@ -88,6 +88,7 @@ impl Planner<'_> {
         for file in files {
             for item in &file.items {
                 let Expression::ImplBlock {
+                    annotation,
                     receiver_name,
                     generics: impl_generics,
                     methods,
@@ -100,6 +101,7 @@ impl Planner<'_> {
                 for method in methods {
                     let Expression::Function {
                         generics: method_generics,
+                        name_span: method_name_span,
                         ..
                     } = method
                     else {
@@ -113,14 +115,13 @@ impl Planner<'_> {
                     );
                     match layout {
                         ImplMethodLayout::Receiver { method_key } => {
-                            for impl_g in impl_generics {
-                                for bound in &impl_g.bounds {
-                                    table.add_explicit(
-                                        &receiver_key,
-                                        impl_g.name.as_str(),
-                                        classify_bound_annotation(bound),
-                                    );
-                                }
+                            if !self.facts.is_unused_definition(method_name_span) {
+                                self.hoist_impl_bounds_onto_receiver(
+                                    &receiver_key,
+                                    annotation,
+                                    impl_generics,
+                                    table,
+                                );
                             }
                             table.ensure_seeded(&method_key, method_generics);
                         }
@@ -132,6 +133,47 @@ impl Planner<'_> {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    fn hoist_impl_bounds_onto_receiver(
+        &self,
+        receiver_key: &str,
+        receiver_annotation: &Annotation,
+        impl_generics: &[Generic],
+        table: &mut GenericConstraintTable,
+    ) {
+        if impl_generics.is_empty() {
+            return;
+        }
+        let type_generics = match self.facts.definition(receiver_key).map(|d| &d.body) {
+            Some(
+                DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. },
+            ) => generics,
+            _ => return,
+        };
+        let Annotation::Constructor {
+            params: receiver_args,
+            ..
+        } = receiver_annotation
+        else {
+            return;
+        };
+        for impl_g in impl_generics {
+            let position = receiver_args.iter().position(|arg| {
+                matches!(arg, Annotation::Constructor { name, params, .. }
+                    if params.is_empty() && name == &impl_g.name)
+            });
+            let Some(type_param) = position.and_then(|p| type_generics.get(p)) else {
+                continue;
+            };
+            for bound in &impl_g.bounds {
+                table.add_explicit(
+                    receiver_key,
+                    type_param.name.as_str(),
+                    classify_bound_annotation(bound),
+                );
             }
         }
     }

--- a/crates/emit/src/names/constraints.rs
+++ b/crates/emit/src/names/constraints.rs
@@ -29,6 +29,14 @@ impl ParamConstraintSet {
         if self.explicit.contains(&atom) {
             return false;
         }
+        if let ConstraintAtom::Named(new_ann) = &atom
+            && self.explicit.iter().any(|existing| {
+                matches!(existing, ConstraintAtom::Named(existing_ann)
+                    if annotations_equivalent(existing_ann, new_ann))
+            })
+        {
+            return false;
+        }
         self.explicit.push(atom);
         true
     }
@@ -115,6 +123,55 @@ pub(crate) fn classify_builtin_name(name: &str) -> Option<ConstraintAtom> {
     }
 }
 
+fn annotations_equivalent(a: &Annotation, b: &Annotation) -> bool {
+    match (a, b) {
+        (
+            Annotation::Constructor {
+                name: a_name,
+                params: a_params,
+                ..
+            },
+            Annotation::Constructor {
+                name: b_name,
+                params: b_params,
+                ..
+            },
+        ) => a_name == b_name && annotation_lists_equivalent(a_params, b_params),
+        (
+            Annotation::Function {
+                params: a_params,
+                return_type: a_return,
+                ..
+            },
+            Annotation::Function {
+                params: b_params,
+                return_type: b_return,
+                ..
+            },
+        ) => {
+            annotation_lists_equivalent(a_params, b_params)
+                && annotations_equivalent(a_return, b_return)
+        }
+        (
+            Annotation::Tuple {
+                elements: a_elements,
+                ..
+            },
+            Annotation::Tuple {
+                elements: b_elements,
+                ..
+            },
+        ) => annotation_lists_equivalent(a_elements, b_elements),
+        (Annotation::Unknown, Annotation::Unknown) => true,
+        (Annotation::Opaque { .. }, Annotation::Opaque { .. }) => true,
+        _ => false,
+    }
+}
+
+fn annotation_lists_equivalent(a: &[Annotation], b: &[Annotation]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| annotations_equivalent(x, y))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +231,40 @@ mod tests {
         let mut s = set("T");
         assert!(s.add_explicit(ConstraintAtom::Comparable));
         assert!(!s.add_explicit(ConstraintAtom::Comparable));
+    }
+
+    #[test]
+    fn add_explicit_keeps_distinct_named_instantiations() {
+        let parent = |arg: &str| {
+            ConstraintAtom::Named(Annotation::Constructor {
+                name: "Parent".into(),
+                params: vec![ctor(arg)],
+                span: Span::dummy(),
+            })
+        };
+        let mut s = set("T");
+        assert!(s.add_explicit(parent("int")));
+        assert!(s.add_explicit(parent("string")));
+        assert_eq!(s.explicit.len(), 2);
+    }
+
+    #[test]
+    fn add_explicit_collapses_same_named_instantiation_across_spans() {
+        let parent_int = |span| {
+            ConstraintAtom::Named(Annotation::Constructor {
+                name: "Parent".into(),
+                params: vec![Annotation::Constructor {
+                    name: "int".into(),
+                    params: vec![],
+                    span,
+                }],
+                span,
+            })
+        };
+        let mut s = set("T");
+        assert!(s.add_explicit(parent_int(Span::new(0, 0, 1))));
+        assert!(!s.add_explicit(parent_int(Span::new(0, 5, 1))));
+        assert_eq!(s.explicit.len(), 1);
     }
 
     #[test]

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -4,7 +4,7 @@ use crate::checker::infer::InferCtx;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
 use syntax::program::DefinitionBody;
-use syntax::types::{CompoundKind, Type, substitute};
+use syntax::types::{CompoundKind, Type, build_substitution_map, substitute};
 
 pub(crate) fn check_not_comparable(
     env: &TypeEnv,
@@ -99,6 +99,44 @@ pub(crate) fn check_not_comparable(
 fn is_interface_or_unknown(store: &Store, ty: &Type) -> bool {
     let resolved = store.deep_resolve_alias(ty);
     resolved.is_unknown() || store.is_interface(&resolved)
+}
+
+pub(crate) fn bounds_conflict(store: &Store, type_bounds: &[Type], impl_bound: &Type) -> bool {
+    let impl_bound = store.deep_resolve_alias(impl_bound);
+    let Some(impl_base) = impl_bound.get_qualified_id().map(str::to_string) else {
+        return false;
+    };
+    type_bounds
+        .iter()
+        .any(|tb| closure_conflicts(store, tb, &impl_base, &impl_bound))
+}
+
+fn closure_conflicts(store: &Store, start: &Type, target_base: &str, target: &Type) -> bool {
+    let mut stack = vec![store.deep_resolve_alias(start)];
+    let mut seen: Vec<Type> = Vec::new();
+    while let Some(current) = stack.pop() {
+        if current.get_qualified_id() == Some(target_base) && current != *target {
+            return true;
+        }
+        if seen.contains(&current) {
+            continue;
+        }
+        seen.push(current.clone());
+        let Some(id) = current.get_qualified_id() else {
+            continue;
+        };
+        let Some(interface) = store.get_interface(id) else {
+            continue;
+        };
+        let map = build_substitution_map(
+            &interface.generics,
+            current.get_type_params().unwrap_or_default(),
+        );
+        for parent in &interface.parents {
+            stack.push(store.deep_resolve_alias(&substitute(parent, &map)));
+        }
+    }
+    false
 }
 
 impl InferCtx<'_, '_> {

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -125,6 +125,10 @@ pub struct TaskState<'s> {
     /// Lets `convert_to_type` admit bound-only markers (e.g. `Comparable`)
     /// without flagging them as misuse in value positions.
     pub bound_position_depth: u32,
+    /// Interface bounds seen per receiver type parameter, keyed by (receiver qualified name,
+    /// parameter position), so `check_conflicting_cross_impl_bounds` can reject two impls
+    /// that instantiate one interface differently on the same parameter.
+    pub impl_param_interface_bounds: HashMap<(EcoString, usize), Vec<(Type, Span)>>,
 }
 
 impl<'s> TaskState<'s> {
@@ -145,6 +149,7 @@ impl<'s> TaskState<'s> {
             ufcs_shared: None,
             typed_files: Vec::new(),
             bound_position_depth: 0,
+            impl_param_interface_bounds: HashMap::default(),
         }
     }
 

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -1,0 +1,312 @@
+use rustc_hash::FxHashMap as HashMap;
+
+use syntax::EcoString;
+use syntax::ast::{Annotation, Generic, Span};
+use syntax::program::DefinitionBody;
+use syntax::types::{Symbol, Type, substitute, unqualified_name};
+
+use super::TaskState;
+use crate::checker::infer::expressions::comparison::bounds_conflict;
+use crate::store::Store;
+
+/// An impl bound resolved into the type's namespace: type-generic position, span, type.
+type ImplBound = (usize, Span, Type);
+
+/// Impl bounds and the receiver type's own bounds, both indexed by type-generic position.
+type BoundsByPosition = (Vec<ImplBound>, Vec<Vec<Type>>);
+
+impl TaskState<'_> {
+    /// Reject an impl whose bound instantiates an interface the receiver type already bounds
+    /// with different arguments. Returns whether a conflict was reported.
+    pub(super) fn check_conflicting_impl_bounds(
+        &mut self,
+        store: &Store,
+        receiver_annotation: &Annotation,
+        receiver_qualified: &Symbol,
+        impl_generics: &[Generic],
+    ) -> bool {
+        let Some((impl_bounds, type_bounds)) = self.resolve_impl_bounds_by_position(
+            store,
+            receiver_annotation,
+            receiver_qualified,
+            impl_generics,
+        ) else {
+            return false;
+        };
+
+        let type_label = unqualified_name(receiver_qualified.as_str());
+        let mut found = false;
+        for (position, span, impl_bound) in &impl_bounds {
+            let Some(type_bounds_here) = type_bounds.get(*position) else {
+                continue;
+            };
+            if bounds_conflict(store, type_bounds_here, impl_bound) {
+                found = true;
+                let interface = impl_bound
+                    .get_qualified_id()
+                    .map(unqualified_name)
+                    .unwrap_or("");
+                self.sink
+                    .push(diagnostics::infer::impl_bound_conflicts_with_type(
+                        interface, type_label, *span,
+                    ));
+            }
+        }
+        found
+    }
+
+    /// Reject two conditional impls that instantiate the same interface differently on one
+    /// receiver type parameter, which the receiver-hoisting emit cannot represent.
+    pub(super) fn check_conflicting_cross_impl_bounds(
+        &mut self,
+        store: &Store,
+        receiver_annotation: &Annotation,
+        receiver_qualified: &Symbol,
+        impl_generics: &[Generic],
+    ) {
+        let Some((impl_bounds, _type_bounds)) = self.resolve_impl_bounds_by_position(
+            store,
+            receiver_annotation,
+            receiver_qualified,
+            impl_generics,
+        ) else {
+            return;
+        };
+
+        let type_label = unqualified_name(receiver_qualified.as_str());
+        for (position, span, impl_bound) in &impl_bounds {
+            let key: (EcoString, usize) = (receiver_qualified.as_str().into(), *position);
+            let recorded = self.impl_param_interface_bounds.get(&key);
+            // Re-registration guard: this exact bound (same source span) was already seen.
+            if recorded.is_some_and(|seen| seen.iter().any(|(_, prev)| prev == span)) {
+                continue;
+            }
+            let earlier = recorded.and_then(|seen| {
+                seen.iter()
+                    .find(|(ty, _)| bounds_conflict(store, std::slice::from_ref(ty), impl_bound))
+                    .map(|(_, prev)| *prev)
+            });
+            if let Some(earlier) = earlier {
+                let interface = impl_bound
+                    .get_qualified_id()
+                    .map(unqualified_name)
+                    .unwrap_or("");
+                self.sink.push(
+                    diagnostics::infer::conflicting_impl_interface_instantiations(
+                        interface, type_label, *span, earlier,
+                    ),
+                );
+            }
+            self.impl_param_interface_bounds
+                .entry(key)
+                .or_default()
+                .push((impl_bound.clone(), *span));
+        }
+    }
+
+    /// Resolve an impl block's bounds and its receiver type's bounds, both keyed by the
+    /// receiver type's generic position, with impl parameters alpha-renamed into the type's
+    /// namespace. `None` when there is nothing to compare.
+    fn resolve_impl_bounds_by_position(
+        &mut self,
+        store: &Store,
+        receiver_annotation: &Annotation,
+        receiver_qualified: &Symbol,
+        impl_generics: &[Generic],
+    ) -> Option<BoundsByPosition> {
+        if impl_generics.is_empty() {
+            return None;
+        }
+        let type_generics = match store
+            .get_definition(receiver_qualified.as_str())
+            .map(|d| &d.body)
+        {
+            Some(
+                DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. },
+            ) => generics.clone(),
+            _ => return None,
+        };
+        if type_generics.is_empty() {
+            return None;
+        }
+        let Annotation::Constructor {
+            params: receiver_args,
+            ..
+        } = receiver_annotation
+        else {
+            return None;
+        };
+        // An impl variable instantiates the type generic at its position in the receiver, so
+        // rename impl variables to those generic names to put both sides in one namespace.
+        let position_of = |name: &EcoString| {
+            receiver_args.iter().position(|arg| {
+                matches!(arg, Annotation::Constructor { name: n, params, .. }
+                    if params.is_empty() && n == name)
+            })
+        };
+        let alpha: HashMap<EcoString, Type> = impl_generics
+            .iter()
+            .filter_map(|ig| {
+                let position = position_of(&ig.name)?;
+                let type_param = type_generics.get(position)?.name.clone();
+                Some((ig.name.clone(), Type::Parameter(type_param)))
+            })
+            .collect();
+
+        self.scopes.push();
+        self.put_in_scope(&type_generics);
+        self.put_in_scope(impl_generics);
+        let before = self.sink.len();
+
+        let type_bounds: Vec<Vec<Type>> = type_generics
+            .iter()
+            .map(|generic| {
+                generic
+                    .bounds
+                    .iter()
+                    .filter_map(|bound| {
+                        self.resolve_type_bound(store, bound, &generic.span, receiver_qualified)
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let mut impl_bounds: Vec<ImplBound> = Vec::new();
+        for impl_generic in impl_generics {
+            let Some(position) = position_of(&impl_generic.name) else {
+                continue;
+            };
+            for bound in &impl_generic.bounds {
+                if let Some(resolved) =
+                    self.resolve_type_bound(store, bound, &impl_generic.span, receiver_qualified)
+                {
+                    impl_bounds.push((position, bound.get_span(), substitute(&resolved, &alpha)));
+                }
+            }
+        }
+
+        // Drop any noise resolution pushed for unresolvable bounds; conflict diagnostics are
+        // reported by the caller, outside this window.
+        self.sink.truncate(before);
+        self.scopes.pop();
+
+        Some((impl_bounds, type_bounds))
+    }
+
+    /// Resolve a type generic's bound annotation to a type, type arguments preserved so
+    /// `Parent<string>` and `Parent<int>` stay distinct.
+    fn resolve_type_bound(
+        &mut self,
+        store: &Store,
+        bound: &Annotation,
+        span: &Span,
+        type_qualified: &Symbol,
+    ) -> Option<Type> {
+        let bound_ty = self.register_bound_annotation(store, bound, span);
+        let id = match store.deep_resolve_alias(&bound_ty).get_qualified_id() {
+            Some(id) => id.to_string(),
+            None => self.resolve_type_bound_id(store, bound, span, type_qualified)?,
+        };
+        let type_module = store.module_for_qualified_name(type_qualified.as_str())?;
+        // Arguments come from the annotation, so they survive even when
+        // `register_bound_annotation` drops them or cannot resolve the bound.
+        let params = match bound {
+            Annotation::Constructor { params, .. } => params
+                .iter()
+                .map(|param| self.resolve_bound_arg(store, param, span, type_module))
+                .collect(),
+            _ => Vec::new(),
+        };
+        Some(Type::Nominal {
+            id: id.into(),
+            params,
+            underlying_ty: None,
+        })
+    }
+
+    /// Resolve a bound's type argument to a type. `convert_to_type` handles primitives,
+    /// builtins, and in-scope parameters; an out-of-scope user type is resolved against the
+    /// store instead so it carries the same `Nominal` the method side does.
+    fn resolve_bound_arg(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+        span: &Span,
+        type_module: &str,
+    ) -> Type {
+        let ty = self.convert_to_type(store, annotation, span);
+        if !matches!(ty, Type::Error) {
+            return ty;
+        }
+        let Annotation::Constructor { name, params, .. } = annotation else {
+            return ty;
+        };
+        let Some(id) = resolve_definition_id(store, type_module, name) else {
+            return ty;
+        };
+        let params = params
+            .iter()
+            .map(|param| self.resolve_bound_arg(store, param, span, type_module))
+            .collect();
+        Type::Nominal {
+            id: id.into(),
+            params,
+            underlying_ty: None,
+        }
+    }
+
+    /// Resolve a user interface bound's qualified id when it is out of scope: a bare name
+    /// against the type's own module, or an `alias.Name` against the aliased module.
+    fn resolve_type_bound_id(
+        &mut self,
+        store: &Store,
+        bound: &Annotation,
+        _span: &Span,
+        type_qualified: &Symbol,
+    ) -> Option<String> {
+        let Annotation::Constructor { name, .. } = bound else {
+            return None;
+        };
+        let type_module = store.module_for_qualified_name(type_qualified.as_str())?;
+        let (bound_module, bound_name) = match name.split_once('.') {
+            Some((alias, type_name)) => (
+                import_module_for_alias(store, type_module, alias)?,
+                type_name,
+            ),
+            None => (type_module.to_string(), name.as_str()),
+        };
+        let candidate = Symbol::from_parts(&bound_module, bound_name);
+        matches!(
+            store.get_definition(candidate.as_str()).map(|d| &d.body),
+            Some(DefinitionBody::Interface { .. })
+        )
+        .then(|| candidate.to_string())
+    }
+}
+
+/// Resolve a type name (any definition kind) to its qualified id out of file context:
+/// a bare name against `type_module`, or an `alias.Name` against the aliased module.
+fn resolve_definition_id(store: &Store, type_module: &str, name: &str) -> Option<String> {
+    let (module, bare) = match name.split_once('.') {
+        Some((alias, type_name)) => (
+            import_module_for_alias(store, type_module, alias)?,
+            type_name,
+        ),
+        None => (type_module.to_string(), name),
+    };
+    let candidate = Symbol::from_parts(&module, bare);
+    store
+        .get_definition(candidate.as_str())
+        .map(|_| candidate.to_string())
+}
+
+/// The module id that `alias` imports within `module`, or `None`.
+fn import_module_for_alias(store: &Store, module: &str, alias: &str) -> Option<String> {
+    let module = store.get_module(module)?;
+    module.files.values().find_map(|file| {
+        file.imports().into_iter().find_map(|import| {
+            (import.effective_alias(&store.go_package_names).as_deref() == Some(alias))
+                .then(|| import.name.to_string())
+        })
+    })
+}

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -177,6 +177,14 @@ impl TaskState<'_> {
             return;
         }
 
+        self.check_conflicting_impl_bounds(&*store, annotation, &receiver_qualified_name, generics);
+        self.check_conflicting_cross_impl_bounds(
+            &*store,
+            annotation,
+            &receiver_qualified_name,
+            generics,
+        );
+
         let mut impl_bounds: Vec<syntax::types::Bound> = Vec::new();
         for g in generics {
             for b in &g.bounds {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1,6 +1,7 @@
 mod builtins;
 mod convert;
 mod display;
+mod impl_bounds;
 mod iterate;
 mod methods;
 mod types;

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -104,3 +104,55 @@ fn run_forwards_go_flags() {
         "program output unexpected with --go-flags:\nstdout: {stdout}\nstderr: {stderr}"
     );
 }
+
+#[test]
+fn run_unused_stronger_bound_does_not_constrain_type() {
+    if !go_available() {
+        eprintln!("skipping run_unused_stronger_bound_does_not_constrain_type: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"unusedstronger\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+struct Point { x: int }
+
+struct Box<T: Comparable> { value: T }
+
+impl<T: Ordered> Box<T> {
+  fn less(self, _other: Box<T>) -> bool { true }
+}
+
+fn main() {
+  let _ = Box { value: Point { x: 1 } }
+  fmt.Println("ok")
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed (unused stronger bound likely hoisted into the type):\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("ok"),
+        "program did not run:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}

--- a/tests/spec/emit/snapshots/conditional_impl_renamed_param_keeps_receiver_bound.snap
+++ b/tests/spec/emit/snapshots/conditional_impl_renamed_param_keeps_receiver_bound.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Box<T> { value: T }
+  
+  impl<U: Ordered> Box<U> {
+    fn less(self, other: Box<U>) -> bool {
+      self.value < other.value
+    }
+  }
+  
+  fn main() {
+    let a = Box { value: 1 }
+    let b = Box { value: 2 }
+    let _ = a.less(b)
+  }
+---
+package main
+
+import "cmp"
+
+type Box[T cmp.Ordered] struct {
+	value T
+}
+
+func (b Box[U]) less(other Box[U]) bool {
+	return b.value < other.value
+}
+
+func main() {
+	a := Box[int]{value: 1}
+	b := Box[int]{value: 2}
+	_ = a.less(b)
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -3909,3 +3909,23 @@ fn zero() {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/anon", ANON_STRUCT_TYPEDEF)]);
 }
+
+#[test]
+fn conditional_impl_renamed_param_keeps_receiver_bound() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl<U: Ordered> Box<U> {
+  fn less(self, other: Box<U>) -> bool {
+    self.value < other.value
+  }
+}
+
+fn main() {
+  let a = Box { value: 1 }
+  let b = Box { value: 2 }
+  let _ = a.less(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8767,3 +8767,111 @@ fn main() {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn impl_conflicting_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T: Parent<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn less(self, _other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_inherited_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+interface Child<T> {
+  embed Parent<T>
+  fn c(self)
+}
+
+struct Box<T: Child<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn less(self, _other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_type_variable_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T: Parent<T>> { value: T }
+
+impl<T: Parent<string>> Box<T> {
+  fn label(self) -> string {
+    self.value.p()
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_cross_impl_interface_instantiations_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<T: Parent<string>> Box<T> {
+  fn as_string(self) -> string { self.value.p() }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_cross_impl_renamed_params_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<U: Parent<int>> Box<U> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<V: Parent<string>> Box<V> {
+  fn as_string(self) -> string { self.value.p() }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_redundant_same_interface_instantiation_accepted() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int_again(self) -> int { self.value.p() }
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    result.assert_no_errors();
+}

--- a/tests/ui/errors/snapshots/impl_conflicting_bound_rejected.snap
+++ b/tests/ui/errors/snapshots/impl_conflicting_bound_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+   ╭─[test.lis:6:9]
+ 5 │ 
+ 6 │ impl<T: Parent<int>> Box<T> {
+   ·         ─────┬─────
+   ·              ╰── this bound cannot strengthen the receiver type
+ 7 │   fn less(self, _other: Box<T>) -> bool {
+   ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]

--- a/tests/ui/errors/snapshots/impl_conflicting_cross_impl_interface_instantiations_rejected.snap
+++ b/tests/ui/errors/snapshots/impl_conflicting_cross_impl_interface_instantiations_rejected.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting interface bounds
+    ╭─[test.lis:6:9]
+  5 │ 
+  6 │ impl<T: Parent<int>> Box<T> {
+    ·         ─────┬─────
+    ·              ╰── one impl instantiates it here
+  7 │   fn as_int(self) -> int { self.value.p() }
+  8 │ }
+  9 │ 
+ 10 │ impl<T: Parent<string>> Box<T> {
+    ·         ───────┬──────
+    ·                ╰── one impl instantiates it differently here
+ 11 │   fn as_string(self) -> string { self.value.p() }
+    ╰────
+  help: Two impls instantiate `Parent` differently for the same parameter of `Box`. A receiver method folds its bound onto the type, so Go would embed `Parent` twice. Use one instantiation, or split `Box` into separate types · code: [infer.conflicting_impl_interface_instantiations]

--- a/tests/ui/errors/snapshots/impl_conflicting_cross_impl_renamed_params_rejected.snap
+++ b/tests/ui/errors/snapshots/impl_conflicting_cross_impl_renamed_params_rejected.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting interface bounds
+    ╭─[test.lis:6:9]
+  5 │ 
+  6 │ impl<U: Parent<int>> Box<U> {
+    ·         ─────┬─────
+    ·              ╰── one impl instantiates it here
+  7 │   fn as_int(self) -> int { self.value.p() }
+  8 │ }
+  9 │ 
+ 10 │ impl<V: Parent<string>> Box<V> {
+    ·         ───────┬──────
+    ·                ╰── one impl instantiates it differently here
+ 11 │   fn as_string(self) -> string { self.value.p() }
+    ╰────
+  help: Two impls instantiate `Parent` differently for the same parameter of `Box`. A receiver method folds its bound onto the type, so Go would embed `Parent` twice. Use one instantiation, or split `Box` into separate types · code: [infer.conflicting_impl_interface_instantiations]

--- a/tests/ui/errors/snapshots/impl_conflicting_inherited_bound_rejected.snap
+++ b/tests/ui/errors/snapshots/impl_conflicting_inherited_bound_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+    ╭─[test.lis:11:9]
+ 10 │ 
+ 11 │ impl<T: Parent<int>> Box<T> {
+    ·         ─────┬─────
+    ·              ╰── this bound cannot strengthen the receiver type
+ 12 │   fn less(self, _other: Box<T>) -> bool {
+    ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]

--- a/tests/ui/errors/snapshots/impl_conflicting_type_variable_bound_rejected.snap
+++ b/tests/ui/errors/snapshots/impl_conflicting_type_variable_bound_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+   ╭─[test.lis:6:9]
+ 5 │ 
+ 6 │ impl<T: Parent<string>> Box<T> {
+   ·         ───────┬──────
+   ·                ╰── this bound cannot strengthen the receiver type
+ 7 │   fn label(self) -> string {
+   ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]


### PR DESCRIPTION
Lis now rejects generic receiver method bounds that Go cannot represent, at compile time, rather than accepting them and failing later at `go build` time. An impl whose bound instantiates an interface differently than the receiver type's own bound (or than another `impl` on the same type) embeds that interface twice in Go, which no type argument can satisfy.