### PR TITLE
fix: track equals liveness per receiver type

### DIFF
--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -387,15 +387,13 @@ impl InferCtx<'_, '_> {
                 ));
             } else if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
                 && let Some(module) = store.module_for_qualified_name(id.as_str())
-                && id
-                    .as_str()
-                    .get(module.len() + 1..)
-                    .is_some_and(|rest| !rest.contains('.'))
+                && let Some(type_name) = id.as_str().get(module.len() + 1..)
+                && !type_name.contains('.')
             {
                 self.facts.mark_method_used_for_interface(
                     module.to_string(),
                     method_name.to_string(),
-                    Span::dummy(),
+                    type_name.to_string(),
                 );
             }
         }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -45,7 +45,7 @@ pub struct Facts {
     pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<Span>,
-    pub interface_satisfied_methods: HashMap<(String, String), Vec<Span>>,
+    pub interface_satisfied_methods: HashMap<(String, String), Vec<String>>,
 
     // Drained by passes::deferred via mem::take.
     pub generic_call_checks: Vec<GenericCallCheck>,
@@ -179,12 +179,12 @@ impl Facts {
         &mut self,
         module_id: String,
         method_name: String,
-        usage_span: Span,
+        impl_type_name: String,
     ) {
         self.interface_satisfied_methods
             .entry((module_id, method_name))
             .or_default()
-            .push(usage_span);
+            .push(impl_type_name);
     }
 
     pub fn absorb_local_facts(&mut self, local: LocalFacts) {
@@ -260,11 +260,11 @@ impl Facts {
             self.add_usage(usage_span, definition_span);
         }
 
-        for (key, spans) in interface_satisfied_methods {
+        for (key, impl_types) in interface_satisfied_methods {
             self.interface_satisfied_methods
                 .entry(key)
                 .or_default()
-                .extend(spans);
+                .extend(impl_types);
         }
     }
 }
@@ -485,14 +485,14 @@ mod tests {
     }
 
     #[test]
-    fn merge_concatenates_interface_method_spans() {
+    fn merge_concatenates_interface_method_impl_types() {
         let allocator = Arc::new(BindingIdAllocator::new());
         let mut a = Facts::new(allocator.clone());
         let mut b = Facts::new(allocator);
 
-        a.mark_method_used_for_interface("m".into(), "f".into(), span(0));
-        b.mark_method_used_for_interface("m".into(), "f".into(), span(1));
-        b.mark_method_used_for_interface("m".into(), "g".into(), span(2));
+        a.mark_method_used_for_interface("m".into(), "f".into(), "A".into());
+        b.mark_method_used_for_interface("m".into(), "f".into(), "B".into());
+        b.mark_method_used_for_interface("m".into(), "g".into(), "C".into());
 
         a.merge(b);
         assert_eq!(a.interface_satisfied_methods.len(), 2);

--- a/crates/semantics/src/passes/lints/ref_graph/extract.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/extract.rs
@@ -1,7 +1,8 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{
-    Annotation, Expression, ImportAlias, Pattern, SelectArm, SelectArmPattern, StructSpread,
+    Annotation, Binding, Expression, Generic, ImportAlias, Pattern, SelectArm, SelectArmPattern,
+    StructSpread,
 };
 use syntax::program::File;
 use syntax::program::{DefinitionBody, DotAccessKind, Module};
@@ -100,7 +101,8 @@ fn walk_expression(
                 && is_method_access(dot_access_kind)
                 && credits_local_method(&expression.get_type(), module)
             {
-                graph.add_reference(from, ModuleItemId::new(member));
+                let to = method_node(member, &expression.get_type());
+                graph.add_reference(from, to);
             }
         }
 
@@ -113,24 +115,16 @@ fn walk_expression(
             ..
         } => {
             let fn_ctx = ModuleItemId::new(name);
-            for g in generics {
-                for bound in &g.bounds {
-                    walk_annotation(module, bound, graph, alias_map, &fn_ctx);
-                }
-            }
-            for p in params {
-                walk_pattern(module, &p.pattern, graph, alias_map, Some(&fn_ctx));
-                walk_type_or_annotation(
-                    module,
-                    &p.ty,
-                    p.annotation.as_ref(),
-                    graph,
-                    alias_map,
-                    &fn_ctx,
-                );
-            }
-            walk_annotation(module, return_annotation, graph, alias_map, &fn_ctx);
-            walk_expression(module, body, graph, alias_map, Some(&fn_ctx));
+            walk_callable_body(
+                module,
+                generics,
+                params,
+                return_annotation,
+                body,
+                graph,
+                alias_map,
+                &fn_ctx,
+            );
         }
 
         Expression::Const {
@@ -252,7 +246,29 @@ fn walk_expression(
                 }
             }
             for m in methods {
-                walk_expression(module, m, graph, alias_map, ctx);
+                if let Expression::Function {
+                    name,
+                    generics,
+                    params,
+                    return_annotation,
+                    body,
+                    ..
+                } = m
+                {
+                    let method_ctx = ModuleItemId::method(name, receiver_name);
+                    walk_callable_body(
+                        module,
+                        generics,
+                        params,
+                        return_annotation,
+                        body,
+                        graph,
+                        alias_map,
+                        &method_ctx,
+                    );
+                } else {
+                    walk_expression(module, m, graph, alias_map, ctx);
+                }
             }
         }
 
@@ -349,7 +365,7 @@ fn walk_identifier(
         add_ref(graph, ctx, alias_map, module, first);
         if let Some(from) = ctx {
             let method_name = value.rsplit('.').next().unwrap_or("");
-            graph.add_reference(from, ModuleItemId::new(method_name));
+            graph.add_reference(from, ModuleItemId::method(method_name, first));
         }
     }
 }
@@ -372,7 +388,7 @@ fn walk_call(
             add_ref(graph, ctx, alias_map, module, first);
             if let Some(from) = ctx {
                 let method_name = value.rsplit('.').next().unwrap_or("");
-                graph.add_reference(from, ModuleItemId::new(method_name));
+                graph.add_reference(from, ModuleItemId::method(method_name, first));
             }
         }
     }
@@ -712,6 +728,46 @@ fn is_method_access(kind: &Option<DotAccessKind>) -> bool {
                 | DotAccessKind::StaticMethod { .. }
         )
     )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_callable_body(
+    module: &Module,
+    generics: &[Generic],
+    params: &[Binding],
+    return_annotation: &Annotation,
+    body: &Expression,
+    graph: &mut ReferenceGraph,
+    alias_map: &AliasMap,
+    fn_ctx: &ModuleItemId,
+) {
+    for g in generics {
+        for bound in &g.bounds {
+            walk_annotation(module, bound, graph, alias_map, fn_ctx);
+        }
+    }
+    for p in params {
+        walk_pattern(module, &p.pattern, graph, alias_map, Some(fn_ctx));
+        walk_type_or_annotation(
+            module,
+            &p.ty,
+            p.annotation.as_ref(),
+            graph,
+            alias_map,
+            fn_ctx,
+        );
+    }
+    walk_annotation(module, return_annotation, graph, alias_map, fn_ctx);
+    walk_expression(module, body, graph, alias_map, Some(fn_ctx));
+}
+
+/// The graph node for a `member` method call on `receiver_ty`, resolving the receiver to
+/// its unqualified type name so `equals` is keyed per receiver type.
+fn method_node(member: &str, receiver_ty: &Type) -> ModuleItemId {
+    match type_name(receiver_ty) {
+        Some(name) => ModuleItemId::method(member, &name),
+        None => ModuleItemId::new(member),
+    }
 }
 
 fn credits_local_method(receiver_ty: &Type, module: &Module) -> bool {

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -132,10 +132,16 @@ fn run_ref_lints(
         }
     }
 
-    for (method_module_id, method_name) in facts.interface_satisfied_methods.keys() {
-        if method_module_id == &module.id {
-            let method_id = ModuleItemId::new(method_name);
-            graph.mark_as_used(method_id);
+    for ((method_module_id, method_name), impl_types) in &facts.interface_satisfied_methods {
+        if method_module_id != &module.id {
+            continue;
+        }
+        if method_name == "equals" {
+            for type_name in impl_types {
+                graph.mark_as_used(ModuleItemId::equals_method(type_name));
+            }
+        } else {
+            graph.mark_as_used(ModuleItemId::new(method_name));
         }
     }
 
@@ -331,7 +337,11 @@ fn collect_items(
                         *visibility == Visibility::Public,
                     );
                 }
-                Expression::ImplBlock { methods, .. } => {
+                Expression::ImplBlock {
+                    methods,
+                    receiver_name,
+                    ..
+                } => {
                     for method in methods {
                         if let Expression::Function {
                             name,
@@ -340,7 +350,7 @@ fn collect_items(
                             ..
                         } = method
                         {
-                            let id = ModuleItemId::new(name);
+                            let id = ModuleItemId::method(name, receiver_name);
                             let is_entry = *visibility == Visibility::Public
                                 || is_upper(name)
                                 || matches!(name.as_str(), "string" | "goString" | "error");

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -12,6 +12,20 @@ impl ModuleItemId {
     pub fn new(name: &str) -> Self {
         Self { name: name.into() }
     }
+
+    pub fn equals_method(type_name: &str) -> Self {
+        Self {
+            name: format!("{type_name}#equals").into(),
+        }
+    }
+
+    pub fn method(method: &str, receiver: &str) -> Self {
+        if method == "equals" {
+            Self::equals_method(receiver)
+        } else {
+            Self::new(method)
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15487,3 +15487,141 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn equals_methods_are_tracked_per_receiver_type() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Inner { v: int }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    self.v == other.v
+  }
+}
+
+struct Other { v: int }
+
+impl Other {
+  fn equals(self, other: Other) -> bool {
+    self.v == other.v
+  }
+}
+
+fn main() {
+  let a = Inner { v: 1 }
+  let b = Inner { v: 2 }
+  let _ = a.equals(b)
+  let _o = Other { v: 3 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let unused_fns = result
+        .lints
+        .iter()
+        .filter(|l| l.code_str() == Some("lint.unused_function"))
+        .count();
+    assert_eq!(
+        unused_fns,
+        1,
+        "only the uncalled Other.equals should be flagged: {:?}",
+        result
+            .lints
+            .iter()
+            .filter_map(|l| l.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equals_method_satisfying_interface_is_kept() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+interface Eq<T> {
+  fn equals(self, other: T) -> bool
+}
+
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn check(_a: Eq<Point>) -> bool {
+  true
+}
+
+fn main() {
+  let p = Point { x: 1 }
+  let _ = check(p)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        !codes.contains(&"lint.unused_function"),
+        "Point.equals satisfies Eq and must not be flagged unused: {codes:?}"
+    );
+}
+
+#[test]
+fn equals_on_imported_type_does_not_keep_same_named_local_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "models.lis",
+        r#"
+pub struct Inner { pub x: int }
+
+impl Inner {
+  pub fn equals(self, _other: Inner) -> bool { true }
+}
+"#,
+    );
+    let source = r#"
+import "models"
+
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self, _other: Inner) -> bool { true }
+}
+
+fn main() {
+  let a = models.Inner { x: 1 }
+  let b = models.Inner { x: 2 }
+  let _ = a.equals(b)
+  let _ = Inner { x: 3 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "the local Inner.equals is unused: `a.equals(b)` dispatches to the imported \
+         models.Inner.equals, not the same-named local method: {codes:?}"
+    );
+}


### PR DESCRIPTION
The unused-function lint now tracks each type's `equals` method separately, so an `equals` that is never used is flagged even when another type's `equals` is used. Previously all `equals` methods shared one liveness node, so using any one of them kept every other `equals` alive.

```rs
struct Inner { v: int }
impl Inner {
  fn equals(self, other: Inner) -> bool { self.v == other.v }
}

struct Other { v: int }
impl Other {
  fn equals(self, other: Other) -> bool { self.v == other.v }
}

fn main() {
  let a = Inner { v: 1 }
  let b = Inner { v: 2 }
  let _ = a.equals(b) // keeps `Inner.equals` alive
  let _ = Other { v: 3 } // `Other.equals` is now flagged as unused
}
```
