### PR TITLE
ci: run on main to warm the pull request cache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,3 +31,5 @@ runs:
         cache-dependency-path: '**/go.sum'
     - if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # ratchet:Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -20,7 +22,7 @@ env:
 jobs:
   pr-title:
     name: PR title
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
@@ -165,7 +167,7 @@ jobs:
 
   ide-extension-version-check:
     name: IDE extension version check
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6


### PR DESCRIPTION
CI now runs on `push` to main in addition to PRs, and `Swatinem/rust-cache` saves only on `refs/heads/main`. PRs then restore the dep cache from main instead of rcompiling deps cold on their first run.
