### PR TITLE
feat: deep equality for slices and maps of equatable types

### DIFF
--- a/crates/diagnostics/src/result.rs
+++ b/crates/diagnostics/src/result.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ParseError;
-use syntax::program::{Definition, EmitInput, File, ModuleInfo, MutationInfo, UnusedInfo};
+use syntax::program::{
+    Definition, EmitInput, File, ModuleInfo, MutationInfo, UnusedInfo, UsableEquals,
+};
 use syntax::types::Symbol;
 
 use crate::LisetteDiagnostic;
@@ -19,6 +21,7 @@ pub struct SemanticResult {
     pub mutations: MutationInfo,
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
+    pub usable_equals: UsableEquals,
     /// File ID -> on-disk path of the `.d.lis` typedef. Populated for third-party
     /// go: typedefs read from `target/.lisette/typedefs/...`; absent for embedded
     /// stdlib typedefs.
@@ -40,6 +43,7 @@ impl SemanticResult {
             mutations: MutationInfo::default(),
             cached_modules: HashSet::default(),
             ufcs_methods: HashSet::default(),
+            usable_equals: UsableEquals::default(),
             typedef_paths: HashMap::default(),
             go_package_names: HashMap::default(),
             go_module_ids: HashSet::default(),
@@ -60,6 +64,7 @@ impl SemanticResult {
             mutations: self.mutations,
             cached_modules: self.cached_modules,
             ufcs_methods: self.ufcs_methods,
+            usable_equals: self.usable_equals,
             go_package_names: self.go_package_names,
             go_module_ids: self.go_module_ids,
         }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -5,7 +5,9 @@ use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{BindingId, Pattern, RestPattern, Span};
-use syntax::program::{Definition, DefinitionBody, ModuleId, MutationInfo, UnusedInfo};
+use syntax::program::{
+    Definition, DefinitionBody, ModuleId, MutationInfo, UnusedInfo, UsableEquals,
+};
 use syntax::types::{Symbol, Type};
 
 use crate::classify_go_return_type;
@@ -19,6 +21,7 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) unused: &'a UnusedInfo,
     pub(crate) mutations: &'a MutationInfo,
     pub(crate) ufcs_methods: &'a HashSet<(String, String)>,
+    pub(crate) usable_equals: &'a UsableEquals,
     pub(crate) go_package_names: &'a HashMap<String, String>,
     pub(crate) go_module_ids: &'a HashSet<String>,
     pub(crate) entry_module: ModuleId,
@@ -35,6 +38,7 @@ pub(crate) struct EmitFacts<'a> {
     unused: &'a UnusedInfo,
     mutations: &'a MutationInfo,
     ufcs_methods: &'a HashSet<(String, String)>,
+    usable_equals: &'a UsableEquals,
     go_package_names: &'a HashMap<String, String>,
     go_module_ids: &'a HashSet<String>,
     entry_module: ModuleId,
@@ -53,6 +57,7 @@ impl<'a> EmitFacts<'a> {
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
+            usable_equals: config.usable_equals,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
             entry_module: config.entry_module,
@@ -144,6 +149,10 @@ impl<'a> EmitFacts<'a> {
     pub(crate) fn is_ufcs_method(&self, qualified_type: &str, method: &str) -> bool {
         self.ufcs_methods
             .contains(&(qualified_type.to_string(), method.to_string()))
+    }
+
+    pub(crate) fn usable_equals_from(&self, id: &str) -> bool {
+        self.usable_equals.usable_from(id, &self.current_module)
     }
 
     pub(crate) fn current_module(&self) -> &str {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -106,6 +106,14 @@ impl Planner<'_> {
             || matches!(method_name, "string" | "goString" | "error")
     }
 
+    pub(crate) fn type_has_equals(&self, ty: &Type) -> bool {
+        let peeled = self.facts.peel_alias(ty);
+        let Some(id) = peeled.get_qualified_id() else {
+            return false;
+        };
+        self.facts.usable_equals_from(id)
+    }
+
     pub(crate) fn has_field(&self, struct_ty: &Type, field_name: &str) -> bool {
         let Type::Nominal { id, .. } = struct_ty.strip_refs() else {
             return false;

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -344,8 +344,7 @@ impl Planner<'_> {
             let receiver_ty = self.facts.peel_alias(&expression.get_type().strip_refs());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
-                let body =
-                    self.render_container_equality(&receiver, &emitted_args[0], &receiver_ty, fx);
+                let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty, fx);
                 return (setup, body);
             }
         }
@@ -479,12 +478,8 @@ impl Planner<'_> {
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
                 if emitted_args.len() >= 2 {
-                    let body = self.render_container_equality(
-                        &emitted_args[0],
-                        &emitted_args[1],
-                        &receiver_ty,
-                        fx,
-                    );
+                    let body =
+                        self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty, fx);
                     return (setup, body);
                 }
             }
@@ -613,19 +608,22 @@ impl Planner<'_> {
         )
     }
 
-    fn render_container_equality(
+    pub(crate) fn render_equality(
         &mut self,
         lhs: &str,
         rhs: &str,
         ty: &Type,
         fx: &mut EmitEffects,
     ) -> String {
-        let peeled = self.facts.peel_alias(&ty.strip_refs());
+        let peeled = self.facts.peel_alias(ty);
+        if peeled.is_ref() {
+            return format!("{lhs} == {rhs}");
+        }
         if peeled.is_slice() {
             fx.require_slices();
             return match peeled.inner() {
-                Some(elem) if self.is_container(&elem) => {
-                    let eq = self.container_equality_closure(&elem, fx);
+                Some(elem) if self.needs_custom_equality(&elem) => {
+                    let eq = self.equality_closure(&elem, fx);
                     format!("slices.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("slices.Equal({lhs}, {rhs})"),
@@ -637,26 +635,33 @@ impl Planner<'_> {
                 .as_compound()
                 .and_then(|(_, args)| args.get(1).cloned());
             return match value {
-                Some(value) if self.is_container(&value) => {
-                    let eq = self.container_equality_closure(&value, fx);
+                Some(value) if self.needs_custom_equality(&value) => {
+                    let eq = self.equality_closure(&value, fx);
                     format!("maps.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("maps.Equal({lhs}, {rhs})"),
             };
         }
-        unreachable!("`.equals()` gate guarantees a slice or map receiver")
+        if self.type_has_equals(&peeled) {
+            return format!("{lhs}.{}({rhs})", self.equals_method_go_name());
+        }
+        format!("{lhs} == {rhs}")
     }
 
-    fn container_equality_closure(&mut self, ty: &Type, fx: &mut EmitEffects) -> String {
+    fn equality_closure(&mut self, ty: &Type, fx: &mut EmitEffects) -> String {
         let go_ty = self.go_type_string(ty, fx);
         let a = self.fresh_var(Some("a"));
         let b = self.fresh_var(Some("b"));
-        let body = self.render_container_equality(&a, &b, ty, fx);
+        let body = self.render_equality(&a, &b, ty, fx);
         format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
     }
 
+    fn needs_custom_equality(&self, ty: &Type) -> bool {
+        self.is_container(ty) || self.type_has_equals(ty)
+    }
+
     fn is_container(&self, ty: &Type) -> bool {
-        let peeled = self.facts.peel_alias(&ty.strip_refs());
+        let peeled = self.facts.peel_alias(ty);
         peeled.is_slice() || peeled.is_map()
     }
 }

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -235,10 +235,18 @@ impl Planner<'_> {
     }
 
     pub(crate) fn to_string_method_go_name(&self) -> String {
-        if self.method_needs_export("to_string") {
-            go_name::snake_to_camel("to_string")
+        self.method_go_name("to_string")
+    }
+
+    pub(crate) fn equals_method_go_name(&self) -> String {
+        self.method_go_name("equals")
+    }
+
+    fn method_go_name(&self, method: &str) -> String {
+        if self.method_needs_export(method) {
+            go_name::snake_to_camel(method)
         } else {
-            go_name::escape_keyword("to_string").into_owned()
+            go_name::escape_keyword(method).into_owned()
         }
     }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -48,7 +48,7 @@ use state::module_state::{FunctionEmissionState, ModuleState};
 use state::scope::ScopeState;
 use syntax::ast::Span;
 use syntax::program::{
-    Definition, DefinitionBody, EmitInput, File, ModuleId, MutationInfo, UnusedInfo,
+    Definition, DefinitionBody, EmitInput, File, ModuleId, MutationInfo, UnusedInfo, UsableEquals,
 };
 use syntax::types::{Symbol, Type};
 
@@ -193,6 +193,7 @@ pub struct TestEmitConfig<'a> {
     pub unused: &'a UnusedInfo,
     pub mutations: &'a MutationInfo,
     pub ufcs_methods: &'a HashSet<(String, String)>,
+    pub usable_equals: &'a UsableEquals,
     pub go_package_names: &'a HashMap<String, String>,
     pub go_module_ids: &'a HashSet<String>,
 }
@@ -286,6 +287,7 @@ impl<'a> Planner<'a> {
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
+            usable_equals: config.usable_equals,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
             entry_module: config.module_id.to_string(),
@@ -536,6 +538,7 @@ fn emit_module<'a>(
         unused: &analysis.unused,
         mutations: &analysis.mutations,
         ufcs_methods: &analysis.ufcs_methods,
+        usable_equals: &analysis.usable_equals,
         go_package_names: &analysis.go_package_names,
         go_module_ids: &analysis.go_module_ids,
         entry_module: analysis.entry_module_id.to_string(),

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -377,6 +377,8 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
             }
         }
 
+        checker.record_usable_equals(&mut store);
+
         let module_files: Vec<(String, Vec<File>)> = to_infer
             .iter()
             .map(|module_id| {
@@ -572,6 +574,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         mutations,
         cached_modules,
         ufcs_methods,
+        usable_equals: store.usable_equals,
         typedef_paths: store.typedef_paths,
         go_package_names: store.go_package_names,
         go_module_ids,

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -101,21 +101,58 @@ fn is_interface_or_unknown(store: &Store, ty: &Type) -> bool {
     resolved.is_unknown() || store.is_interface(&resolved)
 }
 
-pub(crate) fn bounds_conflict(store: &Store, type_bounds: &[Type], impl_bound: &Type) -> bool {
-    let impl_bound = store.deep_resolve_alias(impl_bound);
-    let Some(impl_base) = impl_bound.get_qualified_id().map(str::to_string) else {
+pub(crate) fn type_has_usable_equals(store: &Store, ty: &Type, current_module: &str) -> bool {
+    let resolved = store.deep_resolve_alias(ty);
+    let Some(qualified) = resolved.get_qualified_id() else {
         return false;
     };
-    type_bounds
-        .iter()
-        .any(|tb| closure_conflicts(store, tb, &impl_base, &impl_bound))
+    store.usable_equals.usable_from(qualified, current_module)
 }
 
-fn closure_conflicts(store: &Store, start: &Type, target_base: &str, target: &Type) -> bool {
+fn type_has_callable_bound_mismatched_equals(
+    store: &Store,
+    ty: &Type,
+    current_module: &str,
+) -> bool {
+    let Some(id) = ty.get_qualified_id() else {
+        return false;
+    };
+    if !store.equals_bound_mismatch.contains(id) {
+        return false;
+    }
+    let method_key = format!("{id}.equals");
+    store.get_definition(&method_key).is_some_and(|method| {
+        method.visibility.is_public() || store.module_for_qualified_name(id) == Some(current_module)
+    })
+}
+
+pub(crate) fn bound_implied(store: &Store, type_bounds: &[Type], method_bound: &Type) -> bool {
+    use super::super::unify::BuiltinBound;
+    let builtin = |ty: &Type| {
+        ty.get_qualified_id()
+            .and_then(BuiltinBound::from_qualified_id)
+    };
+    if let Some(method) = builtin(method_bound)
+        && type_bounds
+            .iter()
+            .any(|tb| builtin(tb).is_some_and(|tb| tb.satisfies(method)))
+    {
+        return true;
+    }
+    type_bounds
+        .iter()
+        .any(|tb| bound_satisfies(store, tb, method_bound))
+}
+
+fn interface_closure_any(
+    store: &Store,
+    start: &Type,
+    mut predicate: impl FnMut(&Type) -> bool,
+) -> bool {
     let mut stack = vec![store.deep_resolve_alias(start)];
     let mut seen: Vec<Type> = Vec::new();
     while let Some(current) = stack.pop() {
-        if current.get_qualified_id() == Some(target_base) && current != *target {
+        if predicate(&current) {
             return true;
         }
         if seen.contains(&current) {
@@ -137,6 +174,27 @@ fn closure_conflicts(store: &Store, start: &Type, target_base: &str, target: &Ty
         }
     }
     false
+}
+
+fn bound_satisfies(store: &Store, start: &Type, target: &Type) -> bool {
+    let target = store.deep_resolve_alias(target);
+    interface_closure_any(store, start, |current| current == &target)
+}
+
+pub(crate) fn bounds_conflict(store: &Store, type_bounds: &[Type], impl_bound: &Type) -> bool {
+    let impl_bound = store.deep_resolve_alias(impl_bound);
+    let Some(impl_base) = impl_bound.get_qualified_id().map(str::to_string) else {
+        return false;
+    };
+    type_bounds
+        .iter()
+        .any(|tb| closure_conflicts(store, tb, &impl_base, &impl_bound))
+}
+
+fn closure_conflicts(store: &Store, start: &Type, target_base: &str, target: &Type) -> bool {
+    interface_closure_any(store, start, |current| {
+        current.get_qualified_id() == Some(target_base) && current != target
+    })
 }
 
 impl InferCtx<'_, '_> {
@@ -183,32 +241,54 @@ impl InferCtx<'_, '_> {
 
     pub(super) fn not_equatable_reason(&self, ty: &Type) -> Option<&'static str> {
         let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
+        let current_module = self.cursor.module_id.as_str();
 
         if let Type::Parameter(name) = &resolved
             && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
         {
             return None;
         }
-        // `?` returns `None` (equatable) when the type is comparable.
-        let reason = check_not_comparable(&self.env, self.store, &resolved)?;
+        if type_has_usable_equals(self.store, &resolved, current_module) {
+            return None;
+        }
+
+        let Some(reason) = check_not_comparable(&self.env, self.store, &resolved) else {
+            return type_has_callable_bound_mismatched_equals(
+                self.store,
+                &resolved,
+                current_module,
+            )
+            .then_some("a type whose `equals` requires stricter bounds");
+        };
 
         match resolved.as_compound() {
             Some((CompoundKind::Slice, args)) => self.not_equatable_reason(args.first()?),
-            Some((CompoundKind::Map, args)) => self.not_equatable_reason(args.get(1)?),
+            Some((CompoundKind::Map, args)) => {
+                if self.map_key_not_comparable(args.first()?) {
+                    return Some("a map with a non-comparable key");
+                }
+                self.not_equatable_reason(args.get(1)?)
+            }
             _ => Some(reason),
         }
     }
 
+    fn map_key_not_comparable(&self, key: &Type) -> bool {
+        let resolved = self.store.deep_resolve_alias(&key.resolve_in(&self.env));
+        if let Type::Parameter(name) = &resolved
+            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+        {
+            return false;
+        }
+        check_not_comparable(&self.env, self.store, &resolved).is_some()
+    }
+
     pub(super) fn gate_container_equals(&mut self, receiver_ty: &Type, span: Span) {
         let receiver = self.store.deep_resolve_alias(receiver_ty);
-        let element = match receiver.as_compound() {
-            Some((CompoundKind::Slice, args)) => args.first().cloned(),
-            Some((CompoundKind::Map, args)) => args.get(1).cloned(),
-            _ => return,
-        };
-        if let Some(element) = element
-            && let Some(reason) = self.not_equatable_reason(&element)
-        {
+        if !receiver.is_slice() && !receiver.is_map() {
+            return;
+        }
+        if let Some(reason) = self.not_equatable_reason(&receiver) {
             self.sink
                 .push(diagnostics::infer::not_equatable(&receiver, reason, span));
         }

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -1,0 +1,180 @@
+use rustc_hash::FxHashMap as HashMap;
+
+use syntax::EcoString;
+use syntax::program::DefinitionBody;
+use syntax::types::{Symbol, Type, substitute};
+
+use super::TaskState;
+use crate::checker::infer::expressions::comparison::bound_implied;
+use crate::store::Store;
+
+/// A usable `equals`'s visibility (`None` public, `Some(module)` private), else `None`.
+fn usable_equals_entry(store: &Store, id: &str) -> Option<Option<String>> {
+    if store.equals_bound_mismatch.contains(id) {
+        return None;
+    }
+    let definition = store.get_definition(id)?;
+    let (methods, generics_len) = match &definition.body {
+        DefinitionBody::Struct {
+            methods, generics, ..
+        }
+        | DefinitionBody::Enum {
+            methods, generics, ..
+        } => (methods, generics.len()),
+        _ => return None,
+    };
+    methods
+        .get("equals")?
+        .equals_receiver_vars(id, generics_len)?;
+    let method_key = format!("{id}.equals");
+    let method = store.get_definition(&method_key)?;
+    if method.visibility.is_public() {
+        Some(None)
+    } else {
+        Some(store.module_for_qualified_name(id).map(str::to_string))
+    }
+}
+
+impl TaskState<'_> {
+    /// Build the usable-`equals` verdict Go emission consumes, on the merged store.
+    pub fn record_usable_equals(&mut self, store: &mut Store) {
+        let module_ids: Vec<String> = store.modules.keys().cloned().collect();
+        for module_id in &module_ids {
+            self.record_bound_mismatched_equals(store, module_id);
+        }
+
+        let ids: Vec<Symbol> = store
+            .modules
+            .values()
+            .flat_map(|module| module.definitions.iter())
+            .filter_map(|(qualified, definition)| match &definition.body {
+                DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. }
+                    if methods.contains_key("equals") =>
+                {
+                    Some(qualified.clone())
+                }
+                _ => None,
+            })
+            .collect();
+
+        for id in ids {
+            if let Some(visibility) = usable_equals_entry(store, id.as_str()) {
+                store.usable_equals.insert(id.to_string(), visibility);
+            }
+        }
+    }
+
+    /// Record one module's bound-mismatched `equals` types into the verdict's negative set.
+    fn record_bound_mismatched_equals(&mut self, store: &mut Store, module_id: &str) {
+        let candidates: Vec<(Symbol, Vec<EcoString>)> = {
+            let module = store.get_module(module_id).expect("module must exist");
+            module
+                .definitions
+                .iter()
+                .filter_map(|(qualified, definition)| {
+                    let (methods, arity) = match &definition.body {
+                        DefinitionBody::Struct {
+                            methods, generics, ..
+                        }
+                        | DefinitionBody::Enum {
+                            methods, generics, ..
+                        } => (methods, generics.len()),
+                        _ => return None,
+                    };
+                    let method_ty = methods.get("equals")?;
+                    let vars = method_ty.equals_receiver_vars(qualified.as_str(), arity)?;
+                    Some((qualified.clone(), vars))
+                })
+                .collect()
+        };
+        let mut mismatched = Vec::new();
+        for (qualified, vars) in &candidates {
+            if self.equals_bounds_mismatch(store, qualified, vars) {
+                mismatched.push(qualified.to_string());
+            }
+        }
+        store.equals_bound_mismatch.extend(mismatched);
+    }
+
+    /// Whether the `equals` carries generic bounds the type does not imply, comparing by
+    /// position (`vars[i]` is the method's variable in slot `i`).
+    fn equals_bounds_mismatch(
+        &mut self,
+        store: &Store,
+        qualified: &Symbol,
+        vars: &[EcoString],
+    ) -> bool {
+        let Some(definition) = store.get_definition(qualified.as_str()) else {
+            return false;
+        };
+        let (generics, method_ty) = match &definition.body {
+            DefinitionBody::Struct {
+                generics, methods, ..
+            }
+            | DefinitionBody::Enum {
+                generics, methods, ..
+            } => {
+                let Some(method) = methods.get("equals") else {
+                    return false;
+                };
+                (generics.clone(), method.clone())
+            }
+            _ => return false,
+        };
+        if generics.is_empty() {
+            return false;
+        }
+        let method_bounds = method_bounds_by_var(store, &method_ty);
+        let empty: Vec<Type> = Vec::new();
+        // Rename the method's variables to the type's, so an alpha-equivalent bound matches.
+        let alpha: HashMap<EcoString, Type> = vars
+            .iter()
+            .zip(&generics)
+            .map(|(var, generic)| (var.clone(), Type::Parameter(generic.name.clone())))
+            .collect();
+
+        self.scopes.push();
+        self.put_in_scope(&generics);
+        let before = self.sink.len();
+        let mut mismatch = false;
+        for (position, generic) in generics.iter().enumerate() {
+            let mut type_bounds: Vec<Type> = Vec::new();
+            for bound in &generic.bounds {
+                if let Some(ty) = self.resolve_type_bound(store, bound, &generic.span, qualified) {
+                    type_bounds.push(ty);
+                }
+            }
+            let method_set = method_bounds.get(&vars[position]).unwrap_or(&empty);
+            if !method_set
+                .iter()
+                .all(|mb| bound_implied(store, &type_bounds, &substitute(mb, &alpha)))
+            {
+                mismatch = true;
+                break;
+            }
+        }
+        self.sink.truncate(before);
+        self.scopes.pop();
+        mismatch
+    }
+}
+
+/// The bounds a method type carries, keyed by its type-variable name.
+fn method_bounds_by_var(store: &Store, method_ty: &Type) -> HashMap<EcoString, Vec<Type>> {
+    let func = match method_ty {
+        Type::Forall { body, .. } => body.as_ref(),
+        other => other,
+    };
+    let mut map: HashMap<EcoString, Vec<Type>> = HashMap::default();
+    if let Type::Function(f) = func {
+        for bound in &f.bounds {
+            let resolved = store.deep_resolve_alias(&bound.ty);
+            if resolved.get_qualified_id().is_some() {
+                map.entry(bound.param_name.clone())
+                    .or_default()
+                    .push(resolved);
+            }
+        }
+    }
+    map
+}

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -195,7 +195,7 @@ impl TaskState<'_> {
 
     /// Resolve a type generic's bound annotation to a type, type arguments preserved so
     /// `Parent<string>` and `Parent<int>` stay distinct.
-    fn resolve_type_bound(
+    pub(super) fn resolve_type_bound(
         &mut self,
         store: &Store,
         bound: &Annotation,

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1,6 +1,7 @@
 mod builtins;
 mod convert;
 mod display;
+mod equality;
 mod impl_bounds;
 mod iterate;
 mod methods;

--- a/crates/semantics/src/passes/lints/ref_graph/extract.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/extract.rs
@@ -5,8 +5,8 @@ use syntax::ast::{
     StructSpread,
 };
 use syntax::program::File;
-use syntax::program::{DefinitionBody, DotAccessKind, Module};
-use syntax::types::{Symbol, Type, unqualified_name};
+use syntax::program::{DefinitionBody, DotAccessKind, Module, UsableEquals};
+use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 use super::reference_graph::{EnumVariantId, ModuleItemId, ReferenceGraph, StructFieldId};
 
@@ -103,6 +103,12 @@ fn walk_expression(
             {
                 let to = method_node(member, &expression.get_type());
                 graph.add_reference(from, to);
+            }
+            if let Some(from) = ctx
+                && member == "equals"
+                && is_container_receiver(&expression.get_type())
+            {
+                graph.record_equals_dispatch(from.clone(), expression.get_type());
             }
         }
 
@@ -390,6 +396,13 @@ fn walk_call(
                 let method_name = value.rsplit('.').next().unwrap_or("");
                 graph.add_reference(from, ModuleItemId::method(method_name, first));
             }
+        }
+        if let Some(from) = ctx
+            && (value.as_str() == "Slice.equals" || value.as_str() == "Map.equals")
+            && let Some(receiver) = args.first()
+            && is_container_receiver(&receiver.get_type())
+        {
+            graph.record_equals_dispatch(from.clone(), receiver.get_type());
         }
     }
     walk_expression(module, callee, graph, alias_map, ctx);
@@ -783,6 +796,52 @@ fn credits_local_method(receiver_ty: &Type, module: &Module) -> bool {
         Type::Nominal { id, .. } => id.as_str().starts_with(&format!("{}.", module.id)),
         _ => false,
     }
+}
+
+pub(super) fn equals_targets(
+    ty: &Type,
+    module: &Module,
+    usable: &UsableEquals,
+    out: &mut Vec<ModuleItemId>,
+) {
+    let mut current = ty.clone();
+    while let Some(next) = current.get_underlying().cloned() {
+        current = next;
+    }
+    match &current {
+        Type::Compound {
+            kind: CompoundKind::Slice,
+            args,
+        } => {
+            if let Some(element) = args.first() {
+                equals_targets(element, module, usable, out);
+            }
+        }
+        Type::Compound {
+            kind: CompoundKind::Map,
+            args,
+        } => {
+            if let Some(value) = args.get(1) {
+                equals_targets(value, module, usable, out);
+            }
+        }
+        Type::Nominal { id, .. } => {
+            if id.as_str().starts_with(&format!("{}.", module.id))
+                && usable.usable_from(id.as_str(), &module.id)
+            {
+                out.push(ModuleItemId::equals_method(unqualified_name(id)));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_container_receiver(receiver_ty: &Type) -> bool {
+    let mut current = receiver_ty.strip_refs();
+    while let Some(next) = current.get_underlying().cloned() {
+        current = next;
+    }
+    current.is_slice() || current.is_map()
 }
 
 fn type_name(ty: &Type) -> Option<String> {

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -14,11 +14,12 @@ use diagnostics::LocalSink;
 use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
+use syntax::program::UsableEquals;
 use syntax::program::{File, FileImport};
 
 use super::Lint as LintEnum;
 use super::from_facts::LintConfig;
-use extract::{AliasMap, extract_references, is_upper};
+use extract::{AliasMap, equals_targets, extract_references, is_upper};
 use reference_graph::{
     EnumVariantId, EnumVariantInfo, ItemKind, ModuleItemId, ReferenceGraph, StructFieldId,
     StructFieldInfo,
@@ -38,6 +39,7 @@ pub(crate) fn run(
 ) -> (Vec<LisetteDiagnostic>, UnusedInfo) {
     let store = analysis.store;
     let go_package_names = &store.go_package_names;
+    let usable_equals = &store.usable_equals;
     let config = LintConfig::default();
 
     let mut modules: Vec<&Module> = store
@@ -53,7 +55,15 @@ pub(crate) fn run(
     if modules.len() < PARALLEL_THRESHOLD {
         let sink = LocalSink::new();
         for module in &modules {
-            apply_ref_lints(module, go_package_names, &config, facts, &mut unused, &sink);
+            apply_ref_lints(
+                module,
+                go_package_names,
+                usable_equals,
+                &config,
+                facts,
+                &mut unused,
+                &sink,
+            );
         }
         return (sink.take(), unused);
     }
@@ -67,6 +77,7 @@ pub(crate) fn run(
             apply_ref_lints(
                 module,
                 go_package_names,
+                usable_equals,
                 &config,
                 facts,
                 &mut local_unused,
@@ -87,12 +98,20 @@ pub(crate) fn run(
 fn apply_ref_lints(
     module: &Module,
     go_package_names: &HashMap<String, String>,
+    usable_equals: &UsableEquals,
     config: &LintConfig,
     facts: &Facts,
     unused: &mut UnusedInfo,
     sink: &LocalSink,
 ) {
-    let result = run_ref_lints(module, &module.files, go_package_names, config, facts);
+    let result = run_ref_lints(
+        module,
+        &module.files,
+        go_package_names,
+        usable_equals,
+        config,
+        facts,
+    );
     if !result.unused_import_aliases.is_empty() {
         unused.imports_by_module.insert(
             module.id.clone().into(),
@@ -115,6 +134,7 @@ fn run_ref_lints(
     module: &Module,
     files: &HashMap<u32, File>,
     go_package_names: &HashMap<String, String>,
+    usable_equals: &UsableEquals,
     config: &LintConfig,
     facts: &Facts,
 ) -> RefLintResult {
@@ -129,6 +149,14 @@ fn run_ref_lints(
     for file in files.values() {
         for item in &file.items {
             extract_references(module, item, &mut graph, &alias_map);
+        }
+    }
+
+    for (from, receiver_ty) in graph.take_equals_dispatch() {
+        let mut targets = Vec::new();
+        equals_targets(&receiver_ty, module, usable_equals, &mut targets);
+        for to in targets {
+            graph.add_reference(&from, to);
         }
     }
 

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -2,6 +2,7 @@ use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::Span;
+use syntax::types::Type;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModuleItemId {
@@ -85,6 +86,9 @@ pub struct ReferenceGraph {
     used_struct_fields: HashSet<StructFieldId>,
     enum_variants: HashMap<EnumVariantId, EnumVariantInfo>,
     used_enum_variants: HashSet<EnumVariantId>,
+    /// Container `.equals()` receivers whose element `equals` is credited after the walk,
+    /// once the usable-equality verdict can filter them.
+    pending_equals_dispatch: Vec<(ModuleItemId, Type)>,
 }
 
 impl ReferenceGraph {
@@ -113,6 +117,14 @@ impl ReferenceGraph {
 
     pub fn add_reference(&mut self, from: &ModuleItemId, to: ModuleItemId) {
         self.edges.entry(from.clone()).or_default().insert(to);
+    }
+
+    pub fn record_equals_dispatch(&mut self, from: ModuleItemId, receiver_ty: Type) {
+        self.pending_equals_dispatch.push((from, receiver_ty));
+    }
+
+    pub fn take_equals_dispatch(&mut self) -> Vec<(ModuleItemId, Type)> {
+        std::mem::take(&mut self.pending_equals_dispatch)
     }
 
     /// Mark an item as used by adding it to entrypoints.

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -7,7 +7,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{EnumVariant, Expression, Literal, StructFieldDefinition};
 use syntax::program::{
-    Definition, DefinitionBody, File, Interface, MethodSignatures, Module, ModuleId,
+    Definition, DefinitionBody, File, Interface, MethodSignatures, Module, ModuleId, UsableEquals,
 };
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
@@ -110,6 +110,9 @@ pub struct Store {
     /// file IDs to the actual cache path so go-to-definition can navigate there.
     pub typedef_paths: HashMap<u32, PathBuf>,
     visited_modules: HashSet<String>,
+    /// Types whose `equals` carries bounds the type does not imply; excluded from `usable_equals`.
+    pub equals_bound_mismatch: HashSet<String>,
+    pub usable_equals: UsableEquals,
     /// File ID counter. Starts at 2 because 0 is reserved for entry, 1 for prelude.
     next_file_id: AtomicU32,
     /// Closed-domain index, keyed by the type's qualified name (the `id` in
@@ -144,6 +147,8 @@ impl Store {
             go_package_names: Default::default(),
             typedef_paths: Default::default(),
             visited_modules: Default::default(),
+            equals_bound_mismatch: Default::default(),
+            usable_equals: Default::default(),
             next_file_id: AtomicU32::new(2), // 0 = entrypoint, 1 = prelude
             closed_domains: Default::default(),
         }
@@ -261,6 +266,8 @@ impl Store {
             go_package_names: self.go_package_names.clone(),
             typedef_paths: HashMap::default(),
             visited_modules: HashSet::default(),
+            equals_bound_mismatch: HashSet::default(),
+            usable_equals: UsableEquals::default(),
             next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
             closed_domains: HashMap::default(),
         }

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -67,6 +67,29 @@ impl UnusedInfo {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct UsableEquals {
+    by_id: HashMap<String, Option<String>>,
+}
+
+impl UsableEquals {
+    pub fn insert(&mut self, id: String, private_to_module: Option<String>) {
+        self.by_id.insert(id, private_to_module);
+    }
+
+    pub fn usable_from(&self, id: &str, current_module: &str) -> bool {
+        Self::entry_usable_from(self.by_id.get(id), current_module)
+    }
+
+    pub fn entry_usable_from(entry: Option<&Option<String>>, current_module: &str) -> bool {
+        match entry {
+            Some(None) => true,
+            Some(Some(module)) => module == current_module,
+            None => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct MutationInfo {
     bindings: HashSet<AstBindingId>,
 }
@@ -90,6 +113,7 @@ pub struct EmitInput {
     pub mutations: MutationInfo,
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
+    pub usable_equals: UsableEquals,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
 }

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -7,7 +7,7 @@ mod resolution;
 pub use definition::{
     Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute, Visibility,
 };
-pub use emit_input::{EmitInput, MutationInfo, UnusedInfo};
+pub use emit_input::{EmitInput, MutationInfo, UnusedInfo, UsableEquals};
 pub use file::{File, FileImport};
 pub use module::{Module, ModuleId, ModuleInfo};
 pub use resolution::{CallKind, DotAccessKind, NativeTypeKind, ReceiverCoercion};

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -800,6 +800,57 @@ impl Type {
         )
     }
 
+    pub fn is_equals_signature(&self) -> bool {
+        let func = match self {
+            Type::Forall { body, .. } => body.as_ref(),
+            other => other,
+        };
+        matches!(
+            func,
+            Type::Function(f)
+                if f.params.len() == 2
+                    && matches!(f.return_type.as_ref(), Type::Simple(SimpleKind::Bool))
+                    && f.params[0] == f.params[1]
+                    && !f.params[0].is_ref()
+        )
+    }
+
+    pub fn equals_receiver_vars(&self, owner_id: &str, arity: usize) -> Option<Vec<EcoString>> {
+        if !self.is_equals_signature() {
+            return None;
+        }
+        let (quantified, func): (&[EcoString], &Type) = match self {
+            Type::Forall { vars, body } => (vars, body.as_ref()),
+            other => (&[], other),
+        };
+        if quantified.len() != arity {
+            return None;
+        }
+        let Type::Function(f) = func else {
+            return None;
+        };
+        let Type::Nominal { id, params, .. } = &f.params[0] else {
+            return None;
+        };
+        if id.as_str() != owner_id || params.len() != arity {
+            return None;
+        }
+        let mut vars = Vec::with_capacity(arity);
+        for param in params {
+            let Type::Parameter(name) = param else {
+                return None;
+            };
+            if vars.contains(name) {
+                return None;
+            }
+            vars.push(name.clone());
+        }
+        if !quantified.iter().all(|v| vars.contains(v)) {
+            return None;
+        }
+        Some(vars)
+    }
+
     pub fn has_name(&self, name: &str) -> bool {
         match self {
             Type::Nominal { id, .. } => id.last_segment() == name,

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -48,6 +48,7 @@ fn emit_inner(
         unused: &result.unused,
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
+        usable_equals: &result.usable_equals,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
     };

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -81,6 +81,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     checker.put_imported_modules_in_scope(&store, &imports);
 
     checker.register_types_and_values(&mut store, &ast, &Visibility::Private);
+    checker.record_usable_equals(&mut store);
 
     let mut typed_ast = vec![];
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -8,7 +8,7 @@ use syntax::{
     desugar,
     lex::Lexer,
     parse::Parser,
-    program::{Definition, File, FileImport, MutationInfo, UnusedInfo, Visibility},
+    program::{Definition, File, FileImport, MutationInfo, UnusedInfo, UsableEquals, Visibility},
     types::Symbol,
 };
 
@@ -104,6 +104,7 @@ impl CompiledTest {
             unused,
             mutations,
             ufcs_methods,
+            usable_equals,
             go_package_names,
             go_module_ids,
         ) = {
@@ -177,6 +178,8 @@ impl CompiledTest {
                     semantics::call_classification::compute_module_ufcs(module, TEST_MODULE_ID);
                 checker.ufcs_methods.extend(ufcs_entries);
             }
+
+            checker.record_usable_equals(&mut store);
 
             let mut typed_ast = vec![];
 
@@ -267,6 +270,7 @@ impl CompiledTest {
             }
 
             let ufcs_methods = std::mem::take(&mut checker.ufcs_methods);
+            let usable_equals = std::mem::take(&mut store.usable_equals);
             let go_package_names = store.go_package_names.clone();
             let go_module_ids: HashSet<String> = store
                 .modules
@@ -281,6 +285,7 @@ impl CompiledTest {
                 unused,
                 mutations,
                 ufcs_methods,
+                usable_equals,
                 go_package_names,
                 go_module_ids,
             )
@@ -294,6 +299,7 @@ impl CompiledTest {
             unused,
             mutations,
             ufcs_methods,
+            usable_equals,
             go_package_names,
             go_module_ids,
         }
@@ -308,6 +314,7 @@ pub struct InferenceResult {
     pub unused: UnusedInfo,
     pub mutations: MutationInfo,
     pub ufcs_methods: HashSet<(String, String)>,
+    pub usable_equals: UsableEquals,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
 }

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -61,6 +61,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         unused: &result.unused,
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
+        usable_equals: &result.usable_equals,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
     };

--- a/tests/spec/emit/snapshots/map_equals_dispatches_to_value_equals.snap
+++ b/tests/spec/emit/snapshots/map_equals_dispatches_to_value_equals.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Point { x: int }
+  
+  impl Point {
+    fn equals(self, other: Point) -> bool {
+      self.x == other.x
+    }
+  }
+  
+  fn test(a: Map<string, Point>, b: Map<string, Point>) -> bool {
+    a.equals(b)
+  }
+---
+package main
+
+import "maps"
+
+type Point struct {
+	x int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func test(a, b map[string]Point) bool {
+	return maps.EqualFunc(a, b, func(a_1 Point, b_2 Point) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/slice_equals_dispatches_to_element_equals.snap
+++ b/tests/spec/emit/snapshots/slice_equals_dispatches_to_element_equals.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Point { x: int }
+  
+  impl Point {
+    fn equals(self, other: Point) -> bool {
+      self.x == other.x
+    }
+  }
+  
+  fn test(a: Slice<Point>, b: Slice<Point>) -> bool {
+    a.equals(b)
+  }
+---
+package main
+
+import "slices"
+
+type Point struct {
+	x int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func test(a, b []Point) bool {
+	return slices.EqualFunc(a, b, func(a_1 Point, b_2 Point) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -3929,3 +3929,39 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn slice_equals_dispatches_to_element_equals() {
+    let input = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn test(a: Slice<Point>, b: Slice<Point>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_equals_dispatches_to_value_equals() {
+    let input = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn test(a: Map<string, Point>, b: Map<string, Point>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6296,6 +6296,36 @@ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
 }
 
 #[test]
+fn container_equals_map_non_comparable_key_rejected() {
+    let input = r#"
+struct Key { tags: Slice<int> }
+
+fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn container_equals_element_with_bound_mismatched_equals_rejected() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+fn test(a: Slice<Box<Slice<int>>>, b: Slice<Box<Slice<int>>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_not_comparable_function() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/container_equals_element_with_bound_mismatched_equals_rejected.snap
+++ b/tests/ui/errors/snapshots/container_equals_element_with_bound_mismatched_equals_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+    ╭─[test.lis:11:3]
+ 10 │ fn test(a: Slice<Box<Slice<int>>>, b: Slice<Box<Slice<int>>>) -> bool {
+ 11 │   a.equals(b)
+    ·   ┬
+    ·   ╰── cannot be compared
+ 12 │ }
+    ╰────
+  help: `Slice<Box<Slice<int>>>` cannot be compared because a struct containing non-comparable fields cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/container_equals_map_non_comparable_key_rejected.snap
+++ b/tests/ui/errors/snapshots/container_equals_map_non_comparable_key_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:5:3]
+ 4 │ fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
+ 5 │   a.equals(b)
+   ·   ┬
+   ·   ╰── cannot be compared
+ 6 │ }
+   ╰────
+  help: `Map<Key, int>` cannot be compared because a map with a non-comparable key cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15541,6 +15541,146 @@ fn main() {
 }
 
 #[test]
+fn container_equals_keeps_usable_element_equals_alive() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn main() {
+  let a: Slice<Point> = []
+  let b: Slice<Point> = []
+  let _ = a.equals(b)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        !codes.contains(&"lint.unused_function"),
+        "Slice<Point>.equals dispatches to Point.equals, which must be kept alive: {codes:?}"
+    );
+}
+
+#[test]
+fn container_equals_does_not_keep_wrong_signature_equals_alive() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Point { x: int, y: int }
+
+impl Point {
+  fn equals(self) -> bool {
+    self.x == self.y
+  }
+}
+
+fn main() {
+  let a: Slice<Point> = []
+  let b: Slice<Point> = []
+  let _ = a.equals(b)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "Point.equals has the wrong signature, so Slice<Point>.equals never calls it: {codes:?}"
+    );
+}
+
+#[test]
+fn ufcs_container_equals_keeps_element_equals_alive() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn main() {
+  let a: Slice<Point> = []
+  let b: Slice<Point> = []
+  let _ = Slice.equals(a, b)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        !codes.contains(&"lint.unused_function"),
+        "Slice.equals(a, b) dispatches to Point.equals, which must be kept alive: {codes:?}"
+    );
+}
+
+#[test]
+fn container_equals_does_not_credit_nested_type_argument_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+struct Box<T> { value: T }
+
+impl<T> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+
+fn main() {
+  let a: Slice<Box<Point>> = []
+  let b: Slice<Box<Point>> = []
+  let _ = a.equals(b)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "Box.equals does not call Point.equals, so Point.equals is unused: {codes:?}"
+    );
+}
+
+#[test]
 fn equals_method_satisfying_interface_is_kept() {
     let mut fs = MockFileSystem::new();
     let source = r#"


### PR DESCRIPTION
`Slice<T>.equals` and `Map<K, V>.equals` now compare elements with a user-defined `equals` method when one is available, so containers of types that are not Go-comparable can still be compared.

```rs
struct Point { x: int, y: int }

impl Point {
  fn equals(self, other: Point) -> bool {
    self.x == other.x && self.y == other.y
  }
}

fn main() {
  let a = [Point { x: 1, y: 2 }]
  let b = [Point { x: 1, y: 2 }]
  let _ = a.equals(b)
}
```