### PR TITLE
ci: cache the go build output for e2e suite

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Install Go.
     required: false
     default: 'false'
+  go-cache:
+    description: Let setup-go cache GOMODCACHE/GOCACHE.
+    required: false
+    default: 'true'
   cache:
     description: Restore the Swatinem/rust-cache
     required: false
@@ -27,7 +31,7 @@ runs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
       with:
         go-version-file: go-version
-        cache: true
+        cache: ${{ inputs.go-cache }}
         cache-dependency-path: '**/go.sum'
     - if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # ratchet:Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,20 @@ jobs:
         with:
           just: 'true'
           go: 'true'
+          go-cache: 'false'
+      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        id: go-build-cache
+        with:
+          path: ~/.cache/go-build
+          key: go-build-e2e-suite-${{ runner.os }}-${{ hashFiles('go-version', 'Cargo.lock', 'crates/**', 'tests/**', 'prelude/**') }}
+          restore-keys: |
+            go-build-e2e-suite-${{ runner.os }}-
       - run: just test-e2e-suite
+      - if: github.ref == 'refs/heads/main' && steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.go-build-cache.outputs.cache-primary-key }}
 
   embed-diff:
     name: Embed differential


### PR DESCRIPTION
Persists Go's build cache for the e2e suite so it recompiles only the generated pkgs that changed instead of all of them every run.
