### PR TITLE
feat: show parameter names in LSP signature help

### DIFF
--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -31,9 +31,16 @@ pub(crate) fn handle(items: &[Expression], offset: u32) -> Option<SignatureHelp>
         _ => "fn",
     };
 
-    let display_params = params.as_slice();
-
-    let param_strs: Vec<String> = display_params.iter().map(|p| p.to_string()).collect();
+    let param_strs: Vec<String> = params
+        .iter()
+        .enumerate()
+        .map(
+            |(i, ty)| match f.param_names.get(i).and_then(Option::as_ref) {
+                Some(name) => format!("{name}: {ty}"),
+                None => ty.to_string(),
+            },
+        )
+        .collect();
     let signature = format!("fn {func_name}({}) -> {return_type}", param_strs.join(", "));
 
     let raw_active = args

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -380,6 +380,115 @@ async fn signature_help_shows_function_params() {
 }
 
 #[tokio::test]
+async fn signature_help_shows_param_names() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn add(x: int, y: int) -> int { x + y }\nfn main() { add(1, 2) }",
+        )
+        .await;
+
+    let help = client.signature_help(TEST_URI, 1, 17).await;
+    let sig = &help.unwrap().signatures[0];
+    assert!(sig.label.contains("x: int"), "label was {}", sig.label);
+    assert!(sig.label.contains("y: int"), "label was {}", sig.label);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn signature_help_method_strips_receiver_name() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+struct Point { x: int, y: int }
+impl Point {
+  pub fn translate(self, dx: int, dy: int) -> int { self.x + dx + dy }
+}
+fn main() {
+  let p = Point { x: 1, y: 2 }
+  p.translate(1, 2)
+}";
+    client.open(TEST_URI, source).await;
+
+    let help = client.signature_help(TEST_URI, 6, 14).await;
+    let sig = &help.unwrap().signatures[0];
+    assert!(sig.label.contains("dx: int"), "label was {}", sig.label);
+    assert!(sig.label.contains("dy: int"), "label was {}", sig.label);
+    assert!(
+        !sig.label.contains("self"),
+        "receiver name leaked into label: {}",
+        sig.label
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn signature_help_generic_function_shows_param_names() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+fn pick<T>(first: T, second: T) -> T { first }
+fn main() {
+  let _ = pick(1, 2)
+}";
+    client.open(TEST_URI, source).await;
+
+    let help = client.signature_help(TEST_URI, 2, 15).await;
+    let sig = &help.unwrap().signatures[0];
+    assert!(sig.label.contains("first:"), "label was {}", sig.label);
+    assert!(sig.label.contains("second:"), "label was {}", sig.label);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn signature_help_interface_method_shows_param_names() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+interface Account {
+  fn withdraw(self, amount: int) -> int
+}
+fn process(a: Account) -> int {
+  a.withdraw(50)
+}";
+    client.open(TEST_URI, source).await;
+
+    let help = client.signature_help(TEST_URI, 4, 13).await;
+    let sig = &help.unwrap().signatures[0];
+    assert!(sig.label.contains("amount: int"), "label was {}", sig.label);
+    assert!(
+        !sig.label.contains("self"),
+        "receiver name leaked into label: {}",
+        sig.label
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn signature_help_inferred_closure_param_keeps_name() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+fn main() {
+  let inc = |x| -> int { x + 1 }
+  let _ = inc(5)
+}";
+    client.open(TEST_URI, source).await;
+
+    let help = client.signature_help(TEST_URI, 2, 14).await;
+    let sig = &help.unwrap().signatures[0];
+    assert!(sig.label.contains("x: int"), "label was {}", sig.label);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn signature_help_active_parameter() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -734,10 +734,7 @@ impl InferCtx<'_, '_> {
         };
 
         let f = Arc::make_mut(f);
-        let receiver_ty = f.params.remove(0);
-        if !f.param_mutability.is_empty() {
-            f.param_mutability.remove(0);
-        }
+        let receiver_ty = f.remove_receiver();
         let actual_ty = args.expression_ty;
 
         let receiver_coercion = self.unify_receiver_with_coercion(

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -171,8 +171,12 @@ impl InferCtx<'_, '_> {
 
         self.scopes.current_mut().fn_return_type = Some(return_ty.clone());
 
-        let base_fn_ty = Type::function(
+        let base_fn_ty = Type::function_with_names(
             new_params.iter().map(|p| p.ty.clone()).collect(),
+            new_params
+                .iter()
+                .map(|p| p.pattern.get_identifier())
+                .collect(),
             new_params.iter().map(|p| p.mutable).collect(),
             bounds,
             return_ty.clone().into(),
@@ -245,8 +249,12 @@ impl InferCtx<'_, '_> {
 
         self.scopes.current_mut().fn_return_type = Some(return_ty.clone());
 
-        let base_fn_ty = Type::function(
+        let base_fn_ty = Type::function_with_names(
             new_params.iter().map(|p| p.ty.clone()).collect(),
+            new_params
+                .iter()
+                .map(|p| p.pattern.get_identifier())
+                .collect(),
             vec![false; new_params.len()],
             vec![],
             return_ty.clone().into(),
@@ -635,10 +643,7 @@ impl InferCtx<'_, '_> {
                 && !f.params.is_empty()
             {
                 let f = std::sync::Arc::make_mut(f);
-                let receiver_param = f.params.remove(0);
-                if !f.param_mutability.is_empty() {
-                    f.param_mutability.remove(0);
-                }
+                let receiver_param = f.remove_receiver();
                 let receiver_ty_stripped = receiver_ty.strip_refs();
                 if receiver_param.is_ref() && !receiver_ty.is_ref() {
                     if let Some(inner) = receiver_param.inner() {

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -304,12 +304,7 @@ impl InferCtx<'_, '_> {
 
             // Strip bounds before comparing - bounds are checked separately via bounds_equivalent
             let strip_bounds = |ty: &Type| match ty {
-                Type::Function(f) => Type::function(
-                    f.params.clone(),
-                    f.param_mutability.clone(),
-                    vec![],
-                    f.return_type.clone(),
-                ),
+                Type::Function(f) => f.rebuild(f.params.clone(), vec![], f.return_type.clone()),
                 other => other.clone(),
             };
 
@@ -436,24 +431,7 @@ impl InferCtx<'_, '_> {
 
     fn remove_first_param(ty: &Type) -> Type {
         match ty {
-            Type::Function(f) => {
-                let new_params = if f.params.is_empty() {
-                    vec![]
-                } else {
-                    f.params[1..].to_vec()
-                };
-                let new_mutability = if f.param_mutability.is_empty() {
-                    vec![]
-                } else {
-                    f.param_mutability[1..].to_vec()
-                };
-                Type::function(
-                    new_params,
-                    new_mutability,
-                    f.bounds.clone(),
-                    f.return_type.clone(),
-                )
-            }
+            Type::Function(f) => f.without_receiver(),
             _ => ty.clone(),
         }
     }
@@ -501,9 +479,8 @@ fn covariant_return_adjustment(
         return None;
     }
 
-    Some(Type::function(
+    Some(impl_f.rebuild(
         impl_f.params.clone(),
-        impl_f.param_mutability.clone(),
         impl_f.bounds.clone(),
         iface_ret.clone(),
     ))

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -379,20 +379,7 @@ impl TaskState<'_> {
                 });
                 let fn_ty = if has_self_receiver {
                     match fn_ty {
-                        Type::Function(f) => {
-                            let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
-                            let param_mutability = if f.param_mutability.is_empty() {
-                                vec![]
-                            } else {
-                                f.param_mutability[1..].to_vec()
-                            };
-                            Type::function(
-                                f.params[1..].to_vec(),
-                                param_mutability,
-                                f.bounds,
-                                f.return_type,
-                            )
-                        }
+                        Type::Function(f) => f.without_receiver(),
                         other => other,
                     }
                 } else {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1043,7 +1043,13 @@ impl TaskState<'_> {
 
         let param_mutability: Vec<bool> = params.iter().map(|b| b.mutable).collect();
 
-        let base_fn_ty = Type::function(param_types, param_mutability, bounds, return_ty.into());
+        let base_fn_ty = Type::function_with_names(
+            param_types,
+            params.iter().map(|b| b.pattern.get_identifier()).collect(),
+            param_mutability,
+            bounds,
+            return_ty.into(),
+        );
 
         if generics.is_empty() {
             base_fn_ty
@@ -1136,9 +1142,8 @@ pub(super) fn wrap_with_impl_generics(
     match fn_ty {
         Type::Forall { vars, body } => {
             let new_body = match body.as_ref() {
-                Type::Function(f) => Type::function(
+                Type::Function(f) => f.rebuild(
                     f.params.clone(),
-                    f.param_mutability.clone(),
                     add_impl_bounds(&f.bounds),
                     f.return_type.clone(),
                 ),
@@ -1151,9 +1156,8 @@ pub(super) fn wrap_with_impl_generics(
         }
         Type::Function(f) => Type::Forall {
             vars: impl_vars,
-            body: Box::new(Type::function(
+            body: Box::new(f.rebuild(
                 f.params.clone(),
-                f.param_mutability.clone(),
                 add_impl_bounds(&f.bounds),
                 f.return_type.clone(),
             )),

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -153,9 +153,8 @@ impl TypeEnv {
                 if new_params.is_none() && new_return.is_none() && new_bounds.is_none() {
                     return None;
                 }
-                Some(Type::function(
+                Some(f.rebuild(
                     new_params.unwrap_or_else(|| f.params.clone()),
-                    f.param_mutability.clone(),
                     new_bounds.unwrap_or_else(|| f.bounds.clone()),
                     new_return.unwrap_or_else(|| f.return_type.clone()),
                 ))

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -499,13 +499,9 @@ impl Store {
                 underlying_ty,
             },
             Type::Function(f) => {
-                let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
-                Type::function(
-                    f.params.iter().map(|p| self.peel_alias_deep(p)).collect(),
-                    f.param_mutability,
-                    f.bounds,
-                    Box::new(self.peel_alias_deep(&f.return_type)),
-                )
+                let new_params = f.params.iter().map(|p| self.peel_alias_deep(p)).collect();
+                let new_return = Box::new(self.peel_alias_deep(&f.return_type));
+                f.rebuild(new_params, f.bounds.clone(), new_return)
             }
             other => other,
         }

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -228,9 +228,8 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
             params: params.iter().map(|p| substitute(p, map)).collect(),
             underlying_ty: underlying.as_ref().map(|u| Box::new(substitute(u, map))),
         },
-        Type::Function(f) => Type::function(
+        Type::Function(f) => f.rebuild(
             f.params.iter().map(|p| substitute(p, map)).collect(),
-            f.param_mutability.clone(),
             f.bounds
                 .iter()
                 .map(|b| Bound {
@@ -278,13 +277,63 @@ pub struct Bound {
     pub ty: Type,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FunctionType {
     pub params: Vec<Type>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub param_names: Vec<Option<EcoString>>,
     pub param_mutability: Vec<bool>,
     pub bounds: Vec<Bound>,
     pub return_type: Box<Type>,
+}
+
+impl PartialEq for FunctionType {
+    fn eq(&self, other: &Self) -> bool {
+        self.params == other.params
+            && self.param_mutability == other.param_mutability
+            && self.bounds == other.bounds
+            && self.return_type == other.return_type
+    }
+}
+
+impl FunctionType {
+    pub fn remove_receiver(&mut self) -> Type {
+        let receiver = self.params.remove(0);
+        if !self.param_mutability.is_empty() {
+            self.param_mutability.remove(0);
+        }
+        if !self.param_names.is_empty() {
+            self.param_names.remove(0);
+        }
+        receiver
+    }
+
+    pub fn without_receiver(&self) -> Type {
+        let mut stripped = self.clone();
+        if !stripped.params.is_empty() {
+            stripped.remove_receiver();
+        }
+        Type::Function(Arc::new(stripped))
+    }
+
+    pub fn rebuild(&self, params: Vec<Type>, bounds: Vec<Bound>, return_type: Box<Type>) -> Type {
+        debug_assert!(
+            self.param_names.is_empty() || self.param_names.len() == params.len(),
+            "rebuild changed arity: param_names would misalign with params"
+        );
+        debug_assert!(
+            self.param_mutability.is_empty() || self.param_mutability.len() == params.len(),
+            "rebuild changed arity: param_mutability would misalign with params"
+        );
+        Type::function_with_names(
+            params,
+            self.param_names.clone(),
+            self.param_mutability.clone(),
+            bounds,
+            return_type,
+        )
+    }
 }
 
 /// A unique handle identifying a type variable. The binding state (Unbound /
@@ -485,8 +534,19 @@ impl Type {
         bounds: Vec<Bound>,
         return_type: Box<Type>,
     ) -> Type {
+        Self::function_with_names(params, Vec::new(), param_mutability, bounds, return_type)
+    }
+
+    pub fn function_with_names(
+        params: Vec<Type>,
+        param_names: Vec<Option<EcoString>>,
+        param_mutability: Vec<bool>,
+        bounds: Vec<Bound>,
+        return_type: Box<Type>,
+    ) -> Type {
         Type::Function(Arc::new(FunctionType {
             params,
+            param_names,
             param_mutability,
             bounds,
             return_type,
@@ -1303,12 +1363,7 @@ impl Type {
                 }
                 let mut new_params = f.params.clone();
                 new_params[0] = new_first.clone();
-                Type::function(
-                    new_params,
-                    f.param_mutability.clone(),
-                    f.bounds.clone(),
-                    f.return_type.clone(),
-                )
+                f.rebuild(new_params, f.bounds.clone(), f.return_type.clone())
             }
             Type::Forall { vars, body } => Type::Forall {
                 vars: vars.clone(),
@@ -1432,7 +1487,21 @@ impl Type {
                 let mut new_mutability = vec![false];
                 new_mutability.extend(f.param_mutability);
 
-                Type::function(new_params, new_mutability, f.bounds, f.return_type)
+                let new_param_names = if f.param_names.is_empty() {
+                    Vec::new()
+                } else {
+                    let mut names = vec![None];
+                    names.extend(f.param_names);
+                    names
+                };
+
+                Type::function_with_names(
+                    new_params,
+                    new_param_names,
+                    new_mutability,
+                    f.bounds,
+                    f.return_type,
+                )
             }
             _ => unreachable!(
                 "with_receiver_placeholder called on non-function type: {:?}",
@@ -1652,6 +1721,33 @@ fn alpha_index(idx: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn function_equality_ignores_param_names() {
+        let named = Type::function_with_names(
+            vec![Type::int()],
+            vec![Some("width".into())],
+            vec![false],
+            vec![],
+            Box::new(Type::bool()),
+        );
+        let differently_named = Type::function_with_names(
+            vec![Type::int()],
+            vec![Some("height".into())],
+            vec![false],
+            vec![],
+            Box::new(Type::bool()),
+        );
+        let unnamed = Type::function(
+            vec![Type::int()],
+            vec![false],
+            vec![],
+            Box::new(Type::bool()),
+        );
+
+        assert_eq!(named, differently_named);
+        assert_eq!(named, unnamed);
+    }
 
     #[test]
     fn alpha_index_single() {


### PR DESCRIPTION
Adds param names to LSP signature help, which previously displayed parameter types only.

```rs
fn translate(self, dx: int, dy: int) -> int { ... }

point.translate(10, 20)
// signature help before:     fn translate(int, int) -> int
// signature help after:      fn translate(dx: int, dy: int) -> int
```
