### PR TITLE
feat: inlay hints for parameter names at call sites

### DIFF
--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,10 +1,10 @@
 use syntax::ast::{Expression, Pattern, Span};
+use syntax::types::{CompoundKind, Type};
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel};
 
 use crate::position::LineIndex;
 
-/// Type hints for `let` bindings that lack an explicit annotation, within the
-/// requested byte range.
+/// `let`-binding type hints and call-site parameter-name hints in the range.
 pub(crate) fn collect(
     items: &[Expression],
     range: (u32, u32),
@@ -50,8 +50,69 @@ fn walk(
         }
     }
 
+    if let Expression::Call {
+        expression: callee,
+        args,
+        ..
+    } = expression
+    {
+        collect_parameter_hints(callee, args, range, line_index, hints);
+    }
+
     for child in expression.children() {
         walk(child, range, line_index, hints);
+    }
+}
+
+/// Parameter-name hints before each argument that maps to a named parameter.
+fn collect_parameter_hints(
+    callee: &Expression,
+    args: &[Expression],
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    let callee_ty = callee.get_type();
+    let func = match &callee_ty {
+        Type::Forall { body, .. } => body.as_ref(),
+        other => other,
+    };
+    let Type::Function(f) = func else { return };
+
+    let fixed_param_count = match f.params.last() {
+        Some(Type::Compound {
+            kind: CompoundKind::VarArgs,
+            ..
+        }) => f.params.len() - 1,
+        _ => f.params.len(),
+    };
+
+    for (arg, name) in args
+        .iter()
+        .zip(f.param_names.iter())
+        .take(fixed_param_count)
+    {
+        let Some(name) = name else { continue };
+
+        if let Expression::Identifier { value, .. } = arg.unwrap_parens()
+            && value.as_str() == name.as_str()
+        {
+            continue;
+        }
+
+        let at = arg.get_span().byte_offset;
+        if at >= range.0 && at < range.1 {
+            hints.push(InlayHint {
+                position: line_index.offset_to_position(at),
+                label: InlayHintLabel::String(format!("{name}:")),
+                kind: Some(InlayHintKind::PARAMETER),
+                text_edits: None,
+                tooltip: None,
+                padding_left: None,
+                padding_right: Some(true),
+                data: None,
+            });
+        }
     }
 }
 

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -11720,6 +11720,95 @@ async fn inlay_hint_shows_let_type() {
 }
 
 #[tokio::test]
+async fn inlay_hint_shows_parameter_names() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn add(x: int, y: int) -> int { x + y }\nfn main() { add(1, 2) }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(1, 16, "x:".to_string()), (1, 19, "y:".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_suppresses_matching_argument_name() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source =
+        "fn add(x: int, y: int) -> int { x + y }\nfn wrap(x: int, y: int) -> int { add(x, y) }";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(inlay_hint_triples(&hints), vec![]);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_method_call_omits_receiver() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+struct Point { x: int, y: int }
+impl Point {
+  fn translate(self, dx: int, dy: int) -> int { self.x + dx + dy }
+}
+fn run(p: Point) -> int {
+  p.translate(10, 20)
+}";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(5, 14, "dx:".to_string()), (5, 18, "dy:".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_variadic_only_labels_fixed_params() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "\
+fn log_all(prefix: string, vals: VarArgs<int>) -> int { prefix.length() }
+fn main() {
+  let _ = log_all(\"tag\", 1, 2, 3)
+}";
+    client.open(TEST_URI, source).await;
+
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(2, 18, "prefix:".to_string())]
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn inlay_hint_renders_collection_type() {
     let mut client = TestClient::new().await;
     client.initialize().await;


### PR DESCRIPTION
Adds parameter-name inlay hints for LSP at callsites.