### PR TITLE
feat: inlay hint additons

### DIFF
--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Annotation, Expression, Pattern, Span, TypedPattern};
+use syntax::ast::{Annotation, Expression, Span};
 use syntax::program::{Definition, DefinitionBody};
 
 use crate::analysis::find_module_by_alias;
@@ -7,6 +7,7 @@ use crate::definition::{
     resolve_match_pattern_definition,
 };
 use crate::offset_in_span;
+use crate::patterns::get_pattern_element_type;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
 use crate::type_name;
@@ -146,172 +147,6 @@ pub(crate) fn get_hover_type_and_span(
     expression: &Expression,
     offset: u32,
 ) -> (syntax::types::Type, Span) {
-    fn get_pattern_element_type(
-        pattern: &Pattern,
-        typed_pattern: Option<&TypedPattern>,
-        fallback_ty: &syntax::types::Type,
-        offset: u32,
-    ) -> Option<(syntax::types::Type, Span)> {
-        let span = pattern.get_span();
-        if offset < span.byte_offset || offset >= span.byte_offset + span.byte_length {
-            return None;
-        }
-
-        match (pattern, typed_pattern) {
-            (Pattern::Identifier { .. }, _) => Some((fallback_ty.clone(), span)),
-
-            (
-                Pattern::Tuple { elements, .. },
-                Some(TypedPattern::Tuple {
-                    elements: typed_elements,
-                    ..
-                }),
-            ) => elements.iter().enumerate().find_map(|(i, elem)| {
-                get_pattern_element_type(elem, typed_elements.get(i), fallback_ty, offset)
-            }),
-
-            (Pattern::Tuple { elements, .. }, _) => {
-                let type_elements = match fallback_ty {
-                    syntax::types::Type::Tuple(elems) => elems,
-                    _ => return None,
-                };
-                elements.iter().enumerate().find_map(|(i, elem)| {
-                    let elem_ty = type_elements.get(i)?;
-                    get_pattern_element_type(elem, None, elem_ty, offset)
-                })
-            }
-
-            (
-                Pattern::EnumVariant { fields, .. },
-                Some(TypedPattern::EnumVariant {
-                    fields: typed_fields,
-                    field_types,
-                    ..
-                }),
-            ) => fields
-                .iter()
-                .enumerate()
-                .find_map(|(i, field)| {
-                    let field_ty = field_types.get(i).unwrap_or(fallback_ty);
-                    get_pattern_element_type(field, typed_fields.get(i), field_ty, offset)
-                })
-                .or_else(|| Some((fallback_ty.clone(), span))),
-
-            (
-                Pattern::EnumVariant { fields, .. },
-                Some(TypedPattern::EnumStructVariant { variant_fields, .. }),
-            ) => fields
-                .iter()
-                .enumerate()
-                .find_map(|(i, field)| {
-                    let field_ty = variant_fields.get(i).map(|f| &f.ty).unwrap_or(fallback_ty);
-                    get_pattern_element_type(field, None, field_ty, offset)
-                })
-                .or_else(|| Some((fallback_ty.clone(), span))),
-
-            (Pattern::EnumVariant { .. }, _) => Some((fallback_ty.clone(), span)),
-
-            (Pattern::Struct { fields, .. }, Some(typed)) => {
-                let (field_defs, pattern_fields): (Vec<_>, _) = match typed {
-                    TypedPattern::Struct {
-                        struct_fields,
-                        pattern_fields,
-                        ..
-                    } => (
-                        struct_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
-                        pattern_fields,
-                    ),
-                    TypedPattern::EnumStructVariant {
-                        variant_fields,
-                        pattern_fields,
-                        ..
-                    } => (
-                        variant_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
-                        pattern_fields,
-                    ),
-                    _ => return None,
-                };
-
-                fields.iter().find_map(|field| {
-                    let field_ty = field_defs
-                        .iter()
-                        .find(|(name, _)| *name == &field.name)
-                        .map(|(_, ty)| *ty)
-                        .unwrap_or(fallback_ty);
-                    let typed_field = pattern_fields
-                        .iter()
-                        .find(|(name, _)| name == &field.name)
-                        .map(|(_, tp)| tp);
-                    get_pattern_element_type(&field.value, typed_field, field_ty, offset)
-                })
-            }
-
-            (
-                Pattern::Slice {
-                    prefix,
-                    rest,
-                    element_ty,
-                    ..
-                },
-                typed,
-            ) => {
-                let elem_type = match typed {
-                    Some(TypedPattern::Slice { element_type, .. }) => element_type,
-                    _ => element_ty,
-                };
-
-                prefix
-                    .iter()
-                    .find_map(|elem| get_pattern_element_type(elem, None, elem_type, offset))
-                    .or_else(|| {
-                        if let syntax::ast::RestPattern::Bind { span, .. } = rest
-                            && offset >= span.byte_offset
-                            && offset < span.byte_offset + span.byte_length
-                        {
-                            let slice_ty = syntax::types::Type::compound(
-                                syntax::types::CompoundKind::Slice,
-                                vec![elem_type.clone()],
-                            );
-                            Some((slice_ty, *span))
-                        } else {
-                            None
-                        }
-                    })
-            }
-
-            (Pattern::Or { patterns, .. }, Some(TypedPattern::Or { alternatives, .. })) => {
-                patterns.iter().enumerate().find_map(|(i, alt)| {
-                    get_pattern_element_type(alt, alternatives.get(i), fallback_ty, offset)
-                })
-            }
-
-            (
-                Pattern::AsBinding {
-                    pattern: inner,
-                    name,
-                    ..
-                },
-                _,
-            ) => {
-                get_pattern_element_type(inner, typed_pattern, fallback_ty, offset).or_else(|| {
-                    let binding_ty = inner.get_type().unwrap_or_else(|| fallback_ty.clone());
-                    let name_span = Span::new(
-                        span.file_id,
-                        span.byte_offset + span.byte_length - name.len() as u32,
-                        name.len() as u32,
-                    );
-                    Some((binding_ty, name_span))
-                })
-            }
-
-            (Pattern::Literal { .. }, _) | (Pattern::WildCard { .. }, _) => {
-                Some((fallback_ty.clone(), span))
-            }
-
-            _ => None,
-        }
-    }
-
     fn get_binding_type(
         binding: &syntax::ast::Binding,
         offset: u32,

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,10 +1,11 @@
-use syntax::ast::{Expression, Pattern, Span};
-use syntax::types::{CompoundKind, Type};
+use syntax::ast::{Annotation, Binding, Expression, Pattern, RestPattern, Span, TypedPattern};
+use syntax::types::Type;
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel};
 
+use crate::patterns::get_pattern_element_type;
 use crate::position::LineIndex;
 
-/// `let`-binding type hints and call-site parameter-name hints in the range.
+/// Inlay hints for `items` within the range.
 pub(crate) fn collect(
     items: &[Expression],
     range: (u32, u32),
@@ -27,40 +28,213 @@ fn walk(
         return;
     }
 
-    if let Expression::Let { binding, .. } = expression
-        && binding.annotation.is_none()
-        && let Pattern::Identifier {
-            span: name_span, ..
-        } = &binding.pattern
-        && !binding.ty.is_type_var()
-        && !binding.ty.is_error()
-    {
-        let at = name_span.byte_offset + name_span.byte_length;
-        if at >= range.0 && at < range.1 {
-            hints.push(InlayHint {
-                position: line_index.offset_to_position(at),
-                label: InlayHintLabel::String(format!(": {}", binding.ty)),
-                kind: Some(InlayHintKind::TYPE),
-                text_edits: None,
-                tooltip: None,
-                padding_left: None,
-                padding_right: None,
-                data: None,
-            });
+    match expression {
+        Expression::Let { binding, .. } | Expression::For { binding, .. } => {
+            binding_type_hint(binding, range, line_index, hints);
         }
-    }
 
-    if let Expression::Call {
-        expression: callee,
-        args,
-        ..
-    } = expression
-    {
-        collect_parameter_hints(callee, args, range, line_index, hints);
+        Expression::Match { subject, arms, .. } => {
+            let fallback = subject.get_type();
+            for arm in arms {
+                pattern_hints(
+                    &arm.pattern,
+                    arm.typed_pattern.as_ref(),
+                    &fallback,
+                    range,
+                    line_index,
+                    hints,
+                );
+            }
+        }
+
+        Expression::IfLet {
+            pattern,
+            scrutinee,
+            typed_pattern,
+            ..
+        }
+        | Expression::WhileLet {
+            pattern,
+            scrutinee,
+            typed_pattern,
+            ..
+        } => {
+            pattern_hints(
+                pattern,
+                typed_pattern.as_ref(),
+                &scrutinee.get_type(),
+                range,
+                line_index,
+                hints,
+            );
+        }
+
+        Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } => collect_parameter_hints(callee, args, range, line_index, hints),
+
+        Expression::Lambda {
+            params,
+            return_annotation,
+            body,
+            ty,
+            ..
+        } => lambda_hints(
+            params,
+            return_annotation,
+            body,
+            ty,
+            range,
+            line_index,
+            hints,
+        ),
+
+        _ => {}
     }
 
     for child in expression.children() {
         walk(child, range, line_index, hints);
+    }
+}
+
+fn binding_type_hint(
+    binding: &Binding,
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    if binding.annotation.is_some() {
+        return;
+    }
+    // Identifier patterns only; destructuring is handled via the pattern path.
+    let Pattern::Identifier { span, .. } = &binding.pattern else {
+        return;
+    };
+    let at = span.byte_offset + span.byte_length;
+    push_type_hint(at, &binding.ty, range, line_index, hints);
+}
+
+fn pattern_hints(
+    pattern: &Pattern,
+    typed_pattern: Option<&TypedPattern>,
+    fallback: &Type,
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    let mut spans = Vec::new();
+    collect_identifier_spans(pattern, &mut spans);
+    for span in spans {
+        if let Some((ty, name_span)) =
+            get_pattern_element_type(pattern, typed_pattern, fallback, span.byte_offset)
+        {
+            let at = name_span.byte_offset + name_span.byte_length;
+            push_type_hint(at, &ty, range, line_index, hints);
+        }
+    }
+}
+
+fn collect_identifier_spans(pattern: &Pattern, out: &mut Vec<Span>) {
+    match pattern {
+        Pattern::Identifier { span, .. } => out.push(*span),
+        Pattern::Tuple { elements, .. }
+        | Pattern::EnumVariant {
+            fields: elements, ..
+        } => elements
+            .iter()
+            .for_each(|p| collect_identifier_spans(p, out)),
+        Pattern::Struct { fields, .. } => fields
+            .iter()
+            .for_each(|f| collect_identifier_spans(&f.value, out)),
+        Pattern::Slice { prefix, rest, .. } => {
+            prefix.iter().for_each(|p| collect_identifier_spans(p, out));
+            if let RestPattern::Bind { span, .. } = rest {
+                out.push(*span);
+            }
+        }
+        // Alternatives are distinct occurrences (same names, different spans).
+        Pattern::Or { patterns, .. } => patterns
+            .iter()
+            .for_each(|p| collect_identifier_spans(p, out)),
+        Pattern::AsBinding {
+            pattern,
+            name,
+            span,
+        } => {
+            collect_identifier_spans(pattern, out);
+            let name_len = name.len() as u32;
+            out.push(Span::new(
+                span.file_id,
+                span.byte_offset + span.byte_length - name_len,
+                name_len,
+            ));
+        }
+        Pattern::Literal { .. } | Pattern::WildCard { .. } | Pattern::Unit { .. } => {}
+    }
+}
+
+/// `: T` hints for a lambda's un-annotated params, plus `-> T` when the return is omitted.
+fn lambda_hints(
+    params: &[Binding],
+    return_annotation: &Annotation,
+    body: &Expression,
+    ty: &Type,
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    for param in params {
+        binding_type_hint(param, range, line_index, hints);
+    }
+
+    // Skip a curried lambda's return; the inner lambda's own hints convey the shape.
+    if matches!(return_annotation, Annotation::Unknown)
+        && !matches!(body, Expression::Lambda { .. })
+        && let Some(ret) = ty.get_function_ret()
+        && !ret.is_unit()
+        && !ret.is_type_var()
+        && !ret.is_error()
+    {
+        let at = leftmost_offset(body);
+        if at >= range.0 && at < range.1 {
+            hints.push(InlayHint {
+                position: line_index.offset_to_position(at),
+                label: InlayHintLabel::String(format!("-> {ret}")),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: None,
+                tooltip: None,
+                // No left padding: the body is already preceded by a source space.
+                padding_left: None,
+                padding_right: Some(true),
+                data: None,
+            });
+        }
+    }
+}
+
+fn push_type_hint(
+    at: u32,
+    ty: &Type,
+    range: (u32, u32),
+    line_index: &LineIndex,
+    hints: &mut Vec<InlayHint>,
+) {
+    if ty.is_type_var() || ty.is_error() {
+        return;
+    }
+    if at >= range.0 && at < range.1 {
+        hints.push(InlayHint {
+            position: line_index.offset_to_position(at),
+            label: InlayHintLabel::String(format!(": {ty}")),
+            kind: Some(InlayHintKind::TYPE),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        });
     }
 }
 
@@ -79,19 +253,9 @@ fn collect_parameter_hints(
     };
     let Type::Function(f) = func else { return };
 
-    let fixed_param_count = match f.params.last() {
-        Some(Type::Compound {
-            kind: CompoundKind::VarArgs,
-            ..
-        }) => f.params.len() - 1,
-        _ => f.params.len(),
-    };
-
-    for (arg, name) in args
-        .iter()
-        .zip(f.param_names.iter())
-        .take(fixed_param_count)
-    {
+    // Zipping against `param_names` stops at the last param, so a trailing variadic labels
+    // only its first argument.
+    for (arg, name) in args.iter().zip(f.param_names.iter()) {
         let Some(name) = name else { continue };
 
         if let Expression::Identifier { value, .. } = arg.unwrap_parens()
@@ -100,7 +264,7 @@ fn collect_parameter_hints(
             continue;
         }
 
-        let at = arg.get_span().byte_offset;
+        let at = leftmost_offset(arg);
         if at >= range.0 && at < range.1 {
             hints.push(InlayHint {
                 position: line_index.offset_to_position(at),
@@ -118,4 +282,14 @@ fn collect_parameter_hints(
 
 fn overlaps(span: Span, range: (u32, u32)) -> bool {
     span.byte_offset < range.1 && span.byte_offset + span.byte_length > range.0
+}
+
+/// Leftmost source offset of an expression. Postfix nodes (`x[i]`, `x.*`, `x?`) carry a
+/// span that starts at the operator, so take the min across the whole subtree.
+fn leftmost_offset(expr: &Expression) -> u32 {
+    let mut min = expr.get_span().byte_offset;
+    for child in expr.children() {
+        min = min.min(leftmost_offset(child));
+    }
+    min
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -6,6 +6,7 @@ mod hover;
 mod inlay_hints;
 mod loader;
 mod paths;
+mod patterns;
 mod position;
 mod project;
 mod signature_help;

--- a/crates/lsp/src/patterns.rs
+++ b/crates/lsp/src/patterns.rs
@@ -1,0 +1,163 @@
+//! Pattern-to-type resolution shared by hover and inlay hints.
+
+use syntax::ast::{Pattern, RestPattern, Span, TypedPattern};
+use syntax::types::{CompoundKind, Type};
+
+/// Resolve the type and span of the pattern element at `offset`.
+pub(crate) fn get_pattern_element_type(
+    pattern: &Pattern,
+    typed_pattern: Option<&TypedPattern>,
+    fallback_ty: &Type,
+    offset: u32,
+) -> Option<(Type, Span)> {
+    let span = pattern.get_span();
+    if offset < span.byte_offset || offset >= span.byte_offset + span.byte_length {
+        return None;
+    }
+
+    match (pattern, typed_pattern) {
+        (Pattern::Identifier { .. }, _) => Some((fallback_ty.clone(), span)),
+
+        (Pattern::Tuple { elements, .. }, typed) => {
+            // Element types come from decomposing the tuple type; the typed sub-pattern
+            // only carries deeper structure.
+            let typed_elements = match typed {
+                Some(TypedPattern::Tuple { elements, .. }) => Some(elements),
+                _ => None,
+            };
+            let type_elements = match fallback_ty {
+                Type::Tuple(elems) => elems,
+                _ => return None,
+            };
+            elements.iter().enumerate().find_map(|(i, elem)| {
+                let elem_ty = type_elements.get(i)?;
+                let typed_elem = typed_elements.and_then(|te| te.get(i));
+                get_pattern_element_type(elem, typed_elem, elem_ty, offset)
+            })
+        }
+
+        (
+            Pattern::EnumVariant { fields, .. },
+            Some(TypedPattern::EnumVariant {
+                fields: typed_fields,
+                field_types,
+                ..
+            }),
+        ) => fields
+            .iter()
+            .enumerate()
+            .find_map(|(i, field)| {
+                let field_ty = field_types.get(i).unwrap_or(fallback_ty);
+                get_pattern_element_type(field, typed_fields.get(i), field_ty, offset)
+            })
+            .or_else(|| Some((fallback_ty.clone(), span))),
+
+        (
+            Pattern::EnumVariant { fields, .. },
+            Some(TypedPattern::EnumStructVariant { variant_fields, .. }),
+        ) => fields
+            .iter()
+            .enumerate()
+            .find_map(|(i, field)| {
+                let field_ty = variant_fields.get(i).map(|f| &f.ty).unwrap_or(fallback_ty);
+                get_pattern_element_type(field, None, field_ty, offset)
+            })
+            .or_else(|| Some((fallback_ty.clone(), span))),
+
+        (Pattern::EnumVariant { .. }, _) => Some((fallback_ty.clone(), span)),
+
+        (Pattern::Struct { fields, .. }, Some(typed)) => {
+            let (field_defs, pattern_fields): (Vec<_>, _) = match typed {
+                TypedPattern::Struct {
+                    struct_fields,
+                    pattern_fields,
+                    ..
+                } => (
+                    struct_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
+                    pattern_fields,
+                ),
+                TypedPattern::EnumStructVariant {
+                    variant_fields,
+                    pattern_fields,
+                    ..
+                } => (
+                    variant_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
+                    pattern_fields,
+                ),
+                _ => return None,
+            };
+
+            fields.iter().find_map(|field| {
+                let field_ty = field_defs
+                    .iter()
+                    .find(|(name, _)| *name == &field.name)
+                    .map(|(_, ty)| *ty)
+                    .unwrap_or(fallback_ty);
+                let typed_field = pattern_fields
+                    .iter()
+                    .find(|(name, _)| name == &field.name)
+                    .map(|(_, tp)| tp);
+                get_pattern_element_type(&field.value, typed_field, field_ty, offset)
+            })
+        }
+
+        (
+            Pattern::Slice {
+                prefix,
+                rest,
+                element_ty,
+                ..
+            },
+            typed,
+        ) => {
+            let elem_type = match typed {
+                Some(TypedPattern::Slice { element_type, .. }) => element_type,
+                _ => element_ty,
+            };
+
+            prefix
+                .iter()
+                .find_map(|elem| get_pattern_element_type(elem, None, elem_type, offset))
+                .or_else(|| {
+                    if let RestPattern::Bind { span, .. } = rest
+                        && offset >= span.byte_offset
+                        && offset < span.byte_offset + span.byte_length
+                    {
+                        let slice_ty = Type::compound(CompoundKind::Slice, vec![elem_type.clone()]);
+                        Some((slice_ty, *span))
+                    } else {
+                        None
+                    }
+                })
+        }
+
+        (Pattern::Or { patterns, .. }, Some(TypedPattern::Or { alternatives, .. })) => {
+            patterns.iter().enumerate().find_map(|(i, alt)| {
+                get_pattern_element_type(alt, alternatives.get(i), fallback_ty, offset)
+            })
+        }
+
+        (
+            Pattern::AsBinding {
+                pattern: inner,
+                name,
+                ..
+            },
+            _,
+        ) => get_pattern_element_type(inner, typed_pattern, fallback_ty, offset).or_else(|| {
+            let binding_ty = inner.get_type().unwrap_or_else(|| fallback_ty.clone());
+            let name_span = Span::new(
+                span.file_id,
+                span.byte_offset + span.byte_length - name.len() as u32,
+                name.len() as u32,
+            );
+            Some((binding_ty, name_span))
+        }),
+
+        (Pattern::Literal { .. }, _) | (Pattern::WildCard { .. }, _) => {
+            Some((fallback_ty.clone(), span))
+        }
+
+        _ => None,
+    }
+}

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -11785,7 +11785,7 @@ fn run(p: Point) -> int {
 }
 
 #[tokio::test]
-async fn inlay_hint_variadic_only_labels_fixed_params() {
+async fn inlay_hint_variadic_labels_first_arg_only() {
     let mut client = TestClient::new().await;
     client.initialize().await;
     let source = "\
@@ -11800,9 +11800,10 @@ fn main() {
         .await
         .unwrap();
 
+    // The fixed `prefix` is labeled, and the variadic `vals` labels only its first arg.
     assert_eq!(
         inlay_hint_triples(&hints),
-        vec![(2, 18, "prefix:".to_string())]
+        vec![(2, 18, "prefix:".to_string()), (2, 25, "vals:".to_string())]
     );
 
     client.shutdown().await;
@@ -11926,5 +11927,235 @@ async fn inlay_hint_range_past_eof_is_empty() {
         "a range entirely past EOF must not scan the whole file: {hints:?}"
     );
 
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_for_loop_variable() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { for i in 0..3 { i } }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 17, ": int".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_match_tuple_binding() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn pick(p: (int, string)) -> int { match p { (a, b) => a } }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![
+            (0, 47, ": int".to_string()),
+            (0, 50, ": string".to_string())
+        ]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_match_enum_payload() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source =
+        "fn m(o: Option<int>) -> int { match o { Option.Some(n) => n, Option.None => 0 } }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 53, ": int".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_if_let_binding() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn u(o: Option<int>) -> int { if let Some(x) = o { x } else { 0 } }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 43, ": int".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_while_let_binding() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn drain(o: Option<int>) -> int { let mut c: Option<int> = o; while let Some(x) = c { c = Option.None } 0 }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 78, ": int".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_lambda_param_and_return() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { (|x| x + 1)(5) }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![
+            (0, 24, "x:".to_string()),
+            (0, 15, ": int".to_string()),
+            (0, 17, "-> int".to_string())
+        ]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_lambda_skips_annotated_param() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { (|x: int| x + 1)(5) }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(0, 29, "x:".to_string()), (0, 22, "-> int".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_curried_lambda_skips_outer_return() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source = "fn main() { ((|x| |y| x + y)(1))(2) }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![
+            (0, 33, "y:".to_string()),
+            (0, 29, "x:".to_string()),
+            (0, 16, ": int".to_string()),
+            (0, 20, ": int".to_string()),
+            (0, 22, "-> int".to_string())
+        ]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn hover_match_tuple_binding_shows_element_type() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    // A tuple pattern in a match arm carries a typed pattern; `a` must resolve to its
+    // element type `int`, not the whole `(int, string)`.
+    let source = "fn pick(p: (int, string)) -> int { match p { (a, b) => a } }";
+    client.open(TEST_URI, source).await;
+
+    let hover = client.hover(TEST_URI, 0, 46).await;
+    let content = hover_content(&hover.unwrap());
+    assert!(content.contains("int"));
+    assert!(!content.contains("string"));
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_parameter_position_for_index_arg() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    // Regression: param-name hints anchor at the start of `items[..]`, not the `[`.
+    let source = "fn add(x: int, y: int) -> int { x + y }\nfn s(items: Slice<int>) -> int { add(items[0], items[1]) }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![(1, 37, "x:".to_string()), (1, 47, "y:".to_string())]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_match_slice_prefix_and_rest() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    let source =
+        "fn head(items: Slice<int>) -> int { match items { [] => 0, [first, ..rest] => first } }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    // `first` binds the element type; `rest` binds the remaining slice.
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![
+            (0, 65, ": int".to_string()),
+            (0, 73, ": Slice<int>".to_string())
+        ]
+    );
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn inlay_hint_lambda_return_over_index_body() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    // The `-> int` return hint anchors at the body's left edge (`ys`), not the `[`.
+    let source =
+        "fn ap(f: fn(Slice<int>) -> int) -> int { f([1, 2]) }\nfn d() -> int { ap(|ys| ys[0]) }";
+    client.open(TEST_URI, source).await;
+    let hints = client
+        .inlay_hint(TEST_URI, (0, 0), doc_end(source))
+        .await
+        .unwrap();
+    assert_eq!(
+        inlay_hint_triples(&hints),
+        vec![
+            (1, 19, "f:".to_string()),
+            (1, 22, ": Slice<int>".to_string()),
+            (1, 24, "-> int".to_string())
+        ]
+    );
     client.shutdown().await;
 }


### PR DESCRIPTION
Hey!

I started working on inlay hints a few days ago, then noticed the support had already landed in main.

You are too fast :) 

So, started fresh on top of main, kept everything already shipped mostly as-is, and just added what was not yet covered in the main branch.

Additions:

- for-loop variable type hints
- pattern-binding hints in `match` / `if let` / `while let`
- lambda parameter type + return hints
- variadic parameters label their first argument name, ie. is not repeating

Also made a shared `patterns.rs` resolver (lifted out of hover, now used by hover + inlay hints)

This pr also should include a fix for the issue reported here: https://github.com/ivov/lisette/discussions/719
