### PR TITLE
fix: reject VarArgs in non-last parameter position

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3118,6 +3118,13 @@ pub fn control_flow_in_expression(keyword: &str, span: Span) -> LisetteDiagnosti
     ))
 }
 
+pub fn variadic_param_not_last(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Variadic parameter must be last")
+        .with_infer_code("variadic_param_not_last")
+        .with_span_label(&span, "a `VarArgs<T>` must be the last function parameter")
+        .with_help("Move this `VarArgs<T>` parameter to the end of the parameter list")
+}
+
 pub fn spread_on_non_variadic(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid spread argument")
         .with_infer_code("spread_on_non_variadic")

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3125,6 +3125,16 @@ pub fn variadic_param_not_last(span: Span) -> LisetteDiagnostic {
         .with_help("Move this `VarArgs<T>` parameter to the end of the parameter list")
 }
 
+pub fn variadic_type_not_allowed(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Variadic type not allowed here")
+        .with_infer_code("variadic_type_not_allowed")
+        .with_span_label(
+            &span,
+            "`VarArgs<T>` is only valid as a function's final parameter",
+        )
+        .with_help("Use `Slice<T>` to hold a collection of values")
+}
+
 pub fn spread_on_non_variadic(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid spread argument")
         .with_infer_code("spread_on_non_variadic")

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1077,7 +1077,7 @@ impl InferCtx<'_, '_> {
                     binding
                         .annotation
                         .as_ref()
-                        .map(|a| self.convert_to_type(store, a, pattern_span))
+                        .map(|a| self.convert_to_type_inner(store, a, pattern_span, true))
                         .unwrap_or_else(|| self.new_type_var())
                 });
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1039,6 +1039,20 @@ impl InferCtx<'_, '_> {
         handle_self_receiver: bool,
     ) -> Vec<Binding> {
         let store = self.store;
+
+        // `VarArgs<T>` must be the last function parameter
+        if let Some((_last, leading)) = params.split_last() {
+            for binding in leading {
+                if let Some(annotation @ Annotation::Constructor { name, .. }) = &binding.annotation
+                    && name == "VarArgs"
+                {
+                    self.sink.push(diagnostics::infer::variadic_param_not_last(
+                        annotation.get_span(),
+                    ));
+                }
+            }
+        }
+
         params
             .into_iter()
             .enumerate()

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -26,6 +26,16 @@ impl TaskState<'_> {
     }
 
     pub fn convert_to_type(&mut self, store: &Store, annotation: &Annotation, span: &Span) -> Type {
+        self.convert_to_type_inner(store, annotation, span, false)
+    }
+
+    pub(crate) fn convert_to_type_inner(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+        span: &Span,
+        variadic_allowed: bool,
+    ) -> Type {
         match annotation {
             Annotation::Unknown => self.new_type_var(),
 
@@ -34,9 +44,17 @@ impl TaskState<'_> {
                 return_type,
                 ..
             } => {
+                let last_param = params.len().wrapping_sub(1);
                 let new_params: Vec<Type> = params
                     .iter()
-                    .map(|param| self.convert_to_type(store, param, span))
+                    .enumerate()
+                    .map(|(index, param)| {
+                        if index == last_param {
+                            self.convert_to_type_inner(store, param, span, true)
+                        } else {
+                            self.convert_to_type(store, param, span)
+                        }
+                    })
                     .collect();
                 // For function type annotations, omitted return type means Unit (`()`),
                 // not a type variable. This ensures `fn(T)` is `fn(T) -> ()`.
@@ -60,6 +78,14 @@ impl TaskState<'_> {
                 params,
                 span: annotation_span,
             } => {
+                if type_name == "VarArgs" && !variadic_allowed {
+                    self.sink
+                        .push(diagnostics::infer::variadic_type_not_allowed(
+                            *annotation_span,
+                        ));
+                    return Type::Error;
+                }
+
                 // Unit is internal — `()` desugars to Constructor { name: "Unit" }.
                 // Return the interned unit type directly, unless a user-defined
                 // type named `Unit` exists in scope.

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1027,7 +1027,7 @@ impl TaskState<'_> {
                 binding
                     .annotation
                     .as_ref()
-                    .map(|a| self.convert_to_type(store, a, span))
+                    .map(|a| self.convert_to_type_inner(store, a, span, true))
                     .unwrap_or_else(|| self.new_type_var())
             })
             .collect();

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8502,6 +8502,30 @@ fn test(args: Slice<int>) {
 }
 
 #[test]
+fn infer_variadic_param_not_last() {
+    let input = r#"
+fn test(rest: VarArgs<int>, trailing: int) -> int {
+  trailing
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_param_not_last_method() {
+    let input = r#"
+struct Foo { n: int }
+
+impl Foo {
+  fn test(self, rest: VarArgs<int>, trailing: int) -> int {
+    trailing
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_spread_missing_required_positional_arg() {
     let input = r#"
 import url "go:net/url"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8526,6 +8526,44 @@ impl Foo {
 }
 
 #[test]
+fn infer_variadic_type_not_allowed_struct_field() {
+    let input = r#"
+struct Foo {
+  items: VarArgs<int>
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_type_not_allowed_type_alias() {
+    let input = r#"
+type Args = VarArgs<int>
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_type_not_allowed_return_type() {
+    let input = r#"
+fn test() -> VarArgs<int> {
+  []
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_type_not_allowed_nested() {
+    let input = r#"
+fn test(xs: Slice<VarArgs<int>>) {
+  let _ = xs
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_spread_missing_required_positional_arg() {
     let input = r#"
 import url "go:net/url"

--- a/tests/ui/errors/snapshots/infer_variadic_param_not_last.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_param_not_last.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic parameter must be last
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ fn test(rest: VarArgs<int>, trailing: int) -> int {
+   ·               ──────┬─────
+   ·                     ╰── a `VarArgs<T>` must be the last function parameter
+ 3 │   trailing
+   ╰────
+  help: Move this `VarArgs<T>` parameter to the end of the parameter list · code: [infer.variadic_param_not_last]

--- a/tests/ui/errors/snapshots/infer_variadic_param_not_last_method.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_param_not_last_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic parameter must be last
+   ╭─[test.lis:5:23]
+ 4 │ impl Foo {
+ 5 │   fn test(self, rest: VarArgs<int>, trailing: int) -> int {
+   ·                       ──────┬─────
+   ·                             ╰── a `VarArgs<T>` must be the last function parameter
+ 6 │     trailing
+   ╰────
+  help: Move this `VarArgs<T>` parameter to the end of the parameter list · code: [infer.variadic_param_not_last]

--- a/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_nested.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_nested.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic type not allowed here
+   ╭─[test.lis:2:19]
+ 1 │ 
+ 2 │ fn test(xs: Slice<VarArgs<int>>) {
+   ·                   ──────┬─────
+   ·                         ╰── `VarArgs<T>` is only valid as a function's final parameter
+ 3 │   let _ = xs
+   ╰────
+  help: Use `Slice<T>` to hold a collection of values · code: [infer.variadic_type_not_allowed]

--- a/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_return_type.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_return_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic type not allowed here
+   ╭─[test.lis:2:14]
+ 1 │ 
+ 2 │ fn test() -> VarArgs<int> {
+   ·              ──────┬─────
+   ·                    ╰── `VarArgs<T>` is only valid as a function's final parameter
+ 3 │   []
+   ╰────
+  help: Use `Slice<T>` to hold a collection of values · code: [infer.variadic_type_not_allowed]

--- a/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_struct_field.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic type not allowed here
+   ╭─[test.lis:3:10]
+ 2 │ struct Foo {
+ 3 │   items: VarArgs<int>
+   ·          ──────┬─────
+   ·                ╰── `VarArgs<T>` is only valid as a function's final parameter
+ 4 │ }
+   ╰────
+  help: Use `Slice<T>` to hold a collection of values · code: [infer.variadic_type_not_allowed]

--- a/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_type_alias.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_type_not_allowed_type_alias.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Variadic type not allowed here
+   ╭─[test.lis:2:13]
+ 1 │ 
+ 2 │ type Args = VarArgs<int>
+   ·             ──────┬─────
+   ·                   ╰── `VarArgs<T>` is only valid as a function's final parameter
+   ╰────
+  help: Use `Slice<T>` to hold a collection of values · code: [infer.variadic_type_not_allowed]


### PR DESCRIPTION
If the user creates a function with a `VarArgs<T>` in non-tail position the compiler
does not catch it before hitting `go fmt`.

```
ERROR: Failed to compile Lisette project to Go
 · reason: Go format failed: `gofmt` error: ./target/main.go:3:26: can only use ... with final parameter
```

This change adds a compile time check and enforces `VarArg<T>` to be in tail position.

```
  [error] Variadic parameter must be last
   ╭─[src/main.lis:3:29]
 2 │
 3 │ pub fn foo(s: string, vals: VarArgs<int>, a: int) {
   ·                             ──────┬─────
   ·                                   ╰── a `VarArgs<T>` must be the last parameter
 4 │   let _ = s
   ╰────
  help: Move this `VarArgs<T>` parameter to the end of the parameter list · code: [infer.variadic_param_not_last]
```


