### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.4.3](https://github.com/ivov/lisette/compare/lisette-v0.4.2...lisette-v0.4.3) - 2026-06-17
+
+- feat: enable cgo for third-party go packages [#760](https://github.com/ivov/lisette/pull/760) [`f097c20`](https://github.com/ivov/lisette/commit/f097c203034e6c872333b7f3b2472338c7710521)
+- fix: fall back to constructor heuristic on inconclusive nil analysis [#761](https://github.com/ivov/lisette/pull/761) [`50ab4e0`](https://github.com/ivov/lisette/commit/50ab4e0a9a8a161dbf0ff99d321a4af75b3dd951)
+- feat: lint for an operand and its own negation [#759](https://github.com/ivov/lisette/pull/759) [`c2d91fb`](https://github.com/ivov/lisette/commit/c2d91fb31fde359c903957f90de7912d8cbea3e0)
+- feat: recognize and validate `#[test]` functions [#758](https://github.com/ivov/lisette/pull/758) [`ad379b2`](https://github.com/ivov/lisette/commit/ad379b22b35066919b21a7ee3690eaf5ec68bd30)
+- fix: take recursive-enum constructor fields by value [#751](https://github.com/ivov/lisette/pull/751) [`1de2f4e`](https://github.com/ivov/lisette/commit/1de2f4e328ed9cadcb38870c2353f86812fb3b91)
+- refactor: drop the string-setup path from emit [#757](https://github.com/ivov/lisette/pull/757) [`d30936d`](https://github.com/ivov/lisette/commit/d30936d321d1e3a1c023746c2b26d903d8b2cc99)
+- feat: discover `.test.lis` files and isolate them from production [#756](https://github.com/ivov/lisette/pull/756) [`8d4390b`](https://github.com/ivov/lisette/commit/8d4390bda1213e97ce5c95ad7d88e6675c10bbdd)
+- feat: lints for slice membership and emptiness checks [#755](https://github.com/ivov/lisette/pull/755) [`519f424`](https://github.com/ivov/lisette/commit/519f4240462da8785f1e4debd9f424eb8f19105c)
+- feat: lints for unnecessary eager and lazy evaluation [#754](https://github.com/ivov/lisette/pull/754) [`0bd336e`](https://github.com/ivov/lisette/commit/0bd336e8b72538a3f26a48114817de5ee599c97b)
+- chore: update fuzz lockfile [#750](https://github.com/ivov/lisette/pull/750) [`33d6fbe`](https://github.com/ivov/lisette/commit/33d6fbed44e1f02f227ba19e96b9f94dc47851f8)
+- refactor: extract the post-inference passes into their own crate [#749](https://github.com/ivov/lisette/pull/749) [`4c41014`](https://github.com/ivov/lisette/commit/4c4101446e3b51e96bb33424f08f0718335acf70)
+- feat: go-to-definition for prelude symbols [#748](https://github.com/ivov/lisette/pull/748) [`a56fd02`](https://github.com/ivov/lisette/commit/a56fd02e688736ed5972c9028da1f98d7996e0e6)
+- refactor: decouple inference from the post-inference passes [#747](https://github.com/ivov/lisette/pull/747) [`ac3a457`](https://github.com/ivov/lisette/commit/ac3a45707a00990e71806ce3204c9b08f1f47f1a)
+- feat: inlay hint additons [#742](https://github.com/ivov/lisette/pull/742) [`ebd6ef2`](https://github.com/ivov/lisette/commit/ebd6ef22e5351ca4c01c687bfe67ca5b7bb8af36)
+- feat: introduce `#[equality]` attribute [#746](https://github.com/ivov/lisette/pull/746) [`3a273a3`](https://github.com/ivov/lisette/commit/3a273a38efaf2efb33d604718d53f6d31cea7447)
+- fix: reject VarArgs in non-last parameter position [#743](https://github.com/ivov/lisette/pull/743) [`ab535ad`](https://github.com/ivov/lisette/commit/ab535ad7d221f200c88856c4c7e0d843e75fab1e)
+- feat: lints for needless question mark and manual option zip [#744](https://github.com/ivov/lisette/pull/744) [`4a40051`](https://github.com/ivov/lisette/commit/4a400510c1c37ed9653aa886e537a55ddef453a7)
+
 ## [0.4.2](https://github.com/ivov/lisette/compare/lisette-v0.4.1...lisette-v0.4.2) - 2026-06-15
 
 - refactor: rename info summary count label to advisories [#741](https://github.com/ivov/lisette/pull/741) [`410b75e`](https://github.com/ivov/lisette/commit/410b75e059082b98833dcca537dee16f94688e06)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bincode",
  "ecow",
@@ -624,11 +624,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.4.2"
+version = "0.4.3"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,15 +20,15 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.4.2", path = "../semantics" }
-passes = { package = "lisette-passes", version = "0.4.2", path = "../passes" }
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.2", path = "../diagnostics" }
-format = { package = "lisette-format", version = "0.4.2", path = "../format" }
-emit = { package = "lisette-emit", version = "0.4.2", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "0.4.2", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.4.2", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "0.4.2", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "0.4.3", path = "../semantics" }
+passes = { package = "lisette-passes", version = "0.4.3", path = "../passes" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.3", path = "../diagnostics" }
+format = { package = "lisette-format", version = "0.4.3", path = "../format" }
+emit = { package = "lisette-emit", version = "0.4.3", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "0.4.3", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.4.3", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "0.4.3", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "0.4.2", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "0.4.3", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.2", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.3", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "0.4.2", path = "../semantics" }
-passes = { package = "lisette-passes", version = "0.4.2", path = "../passes" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.2", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "0.4.2", path = "../deps" }
-format = { package = "lisette-format", version = "0.4.2", path = "../format" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "0.4.3", path = "../semantics" }
+passes = { package = "lisette-passes", version = "0.4.3", path = "../passes" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.3", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "0.4.3", path = "../deps" }
+format = { package = "lisette-format", version = "0.4.3", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "0.4.2", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.2", path = "../diagnostics" }
+semantics = { package = "lisette-semantics", version = "0.4.3", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.3", path = "../diagnostics" }
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "0.4.2", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "0.4.2", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "0.4.2", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "0.4.2", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "0.4.3", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "0.4.3", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "0.4.3", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "0.4.3", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.4.3 (upcoming)

- feat: enable cgo for third-party go packages [#760](https://github.com/ivov/lisette/pull/760) [`f097c20`](https://github.com/ivov/lisette/commit/f097c203034e6c872333b7f3b2472338c7710521)
- fix: fall back to constructor heuristic on inconclusive nil analysis [#761](https://github.com/ivov/lisette/pull/761) [`50ab4e0`](https://github.com/ivov/lisette/commit/50ab4e0a9a8a161dbf0ff99d321a4af75b3dd951)
- feat: lint for an operand and its own negation [#759](https://github.com/ivov/lisette/pull/759) [`c2d91fb`](https://github.com/ivov/lisette/commit/c2d91fb31fde359c903957f90de7912d8cbea3e0)
- feat: recognize and validate `#[test]` functions [#758](https://github.com/ivov/lisette/pull/758) [`ad379b2`](https://github.com/ivov/lisette/commit/ad379b22b35066919b21a7ee3690eaf5ec68bd30)
- fix: take recursive-enum constructor fields by value [#751](https://github.com/ivov/lisette/pull/751) [`1de2f4e`](https://github.com/ivov/lisette/commit/1de2f4e328ed9cadcb38870c2353f86812fb3b91)
- refactor: drop the string-setup path from emit [#757](https://github.com/ivov/lisette/pull/757) [`d30936d`](https://github.com/ivov/lisette/commit/d30936d321d1e3a1c023746c2b26d903d8b2cc99)
- feat: discover `.test.lis` files and isolate them from production [#756](https://github.com/ivov/lisette/pull/756) [`8d4390b`](https://github.com/ivov/lisette/commit/8d4390bda1213e97ce5c95ad7d88e6675c10bbdd)
- feat: lints for slice membership and emptiness checks [#755](https://github.com/ivov/lisette/pull/755) [`519f424`](https://github.com/ivov/lisette/commit/519f4240462da8785f1e4debd9f424eb8f19105c)
- feat: lints for unnecessary eager and lazy evaluation [#754](https://github.com/ivov/lisette/pull/754) [`0bd336e`](https://github.com/ivov/lisette/commit/0bd336e8b72538a3f26a48114817de5ee599c97b)
- chore: update fuzz lockfile [#750](https://github.com/ivov/lisette/pull/750) [`33d6fbe`](https://github.com/ivov/lisette/commit/33d6fbed44e1f02f227ba19e96b9f94dc47851f8)
- refactor: extract the post-inference passes into their own crate [#749](https://github.com/ivov/lisette/pull/749) [`4c41014`](https://github.com/ivov/lisette/commit/4c4101446e3b51e96bb33424f08f0718335acf70)
- feat: go-to-definition for prelude symbols [#748](https://github.com/ivov/lisette/pull/748) [`a56fd02`](https://github.com/ivov/lisette/commit/a56fd02e688736ed5972c9028da1f98d7996e0e6)
- refactor: decouple inference from the post-inference passes [#747](https://github.com/ivov/lisette/pull/747) [`ac3a457`](https://github.com/ivov/lisette/commit/ac3a45707a00990e71806ce3204c9b08f1f47f1a)
- feat: inlay hint additons [#742](https://github.com/ivov/lisette/pull/742) [`ebd6ef2`](https://github.com/ivov/lisette/commit/ebd6ef22e5351ca4c01c687bfe67ca5b7bb8af36)
- feat: introduce `#[equality]` attribute [#746](https://github.com/ivov/lisette/pull/746) [`3a273a3`](https://github.com/ivov/lisette/commit/3a273a38efaf2efb33d604718d53f6d31cea7447)
- fix: reject VarArgs in non-last parameter position [#743](https://github.com/ivov/lisette/pull/743) [`ab535ad`](https://github.com/ivov/lisette/commit/ab535ad7d221f200c88856c4c7e0d843e75fab1e)
- feat: lints for needless question mark and manual option zip [#744](https://github.com/ivov/lisette/pull/744) [`4a40051`](https://github.com/ivov/lisette/commit/4a400510c1c37ed9653aa886e537a55ddef453a7)
