### PR TITLE
feat: introduce `#[equality]` attribute

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -98,6 +98,78 @@ pub fn display_specialized_to_string(attribute_span: &Span) -> LisetteDiagnostic
         )
 }
 
+pub fn equality_not_a_struct_or_enum(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` not on a struct or enum")
+        .with_attribute_code("equality_not_a_struct_or_enum")
+        .with_span_label(attribute_span, "not on a struct or enum")
+        .with_help("Only a struct or enum can be marked `#[equality]`")
+}
+
+pub fn equality_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` in a typedef")
+        .with_attribute_code("equality_in_typedef")
+        .with_span_label(attribute_span, "disallowed in a `.d.lis` typedef")
+        .with_help("Only structs or enums in `.lis` source can be marked `#[equality]`")
+}
+
+pub fn equality_with_arguments(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` takes no arguments")
+        .with_attribute_code("equality_with_arguments")
+        .with_span_label(attribute_span, "remove the arguments")
+        .with_help("Write `#[equality]` with no arguments")
+}
+
+pub fn equality_on_tuple_struct(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` on a tuple struct")
+        .with_attribute_code("equality_on_tuple_struct")
+        .with_span_label(
+            attribute_span,
+            "tuple structs and newtypes are not supported",
+        )
+        .with_help("Give the type named fields, or hand-write an `equals` method")
+}
+
+pub fn equality_bounded_equals(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` conflicts with a bounded `equals`")
+        .with_attribute_code("equality_bounded_equals")
+        .with_span_label(attribute_span, "would synthesize an `equals` of its own")
+        .with_help(
+            "A hand-written `equals` must carry the same generic bounds as the type, or it strengthens the type for every instantiation. Match the type's bounds, or remove `#[equality]`.",
+        )
+}
+
+pub fn equality_specialized_equals(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` conflicts with a specialized `equals`")
+        .with_attribute_code("equality_specialized_equals")
+        .with_span_label(attribute_span, "would synthesize an `equals` of its own")
+        .with_help(
+            "`#[equality]` needs a plain `fn equals(self, other: Self) -> bool` over the whole type. An `equals` over a partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`), or one with extra type parameters (`fn equals<U>`, `impl<T, U> Box<T>`), is emitted as a free function and cannot satisfy `#[equality]`. Write `equals` in that form, or remove `#[equality]`.",
+        )
+}
+
+pub fn equality_conflicting_equals(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[equality]` conflicts with your `equals`")
+        .with_attribute_code("equality_conflicting_equals")
+        .with_span_label(attribute_span, "would synthesize an `equals` of its own")
+        .with_help(
+            "`#[equality]` needs a plain `fn equals(self, other: Self) -> bool`. Write `equals` in that form, or remove `#[equality]`.",
+        )
+}
+
+pub fn cannot_derive_equality(
+    type_name: &str,
+    field_name: &str,
+    field_span: &Span,
+    reason: &str,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot derive equality")
+        .with_attribute_code("cannot_derive_equality")
+        .with_span_label(field_span, format!("`{field_name}` cannot be compared"))
+        .with_help(format!(
+            "`#[equality]` cannot compare {reason}. Give `{type_name}` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field"
+        ))
+}
+
 pub fn iterate_variants_conflict(
     attribute_span: &Span,
     existing_span: Option<&Span>,

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1098,6 +1098,22 @@ pub fn not_equatable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn not_comparable_value_use_equals(ty: &Type, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid comparison")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("`{ty}` cannot be compared with `==`"))
+        .with_help(format!("Use `.equals()` to compare `{ty}`"))
+}
+
+pub fn not_comparable_derive_equality(ty: &Type, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid comparison")
+        .with_infer_code("type_mismatch")
+        .with_span_label(&span, format!("`{ty}` cannot be compared with `==`"))
+        .with_help(format!(
+            "Mark `{ty}` with `#[equality]` to compare it with `.equals()`"
+        ))
+}
+
 pub fn not_orderable_bound(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Bound not satisfied")
         .with_infer_code("not_orderable_bound")

--- a/crates/diagnostics/src/result.rs
+++ b/crates/diagnostics/src/result.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ParseError;
 use syntax::program::{
-    Definition, EmitInput, File, ModuleInfo, MutationInfo, UnusedInfo, UsableEquals,
+    Definition, EmitInput, EqualityIndex, File, ModuleInfo, MutationInfo, UnusedInfo,
 };
 use syntax::types::Symbol;
 
@@ -21,7 +21,7 @@ pub struct SemanticResult {
     pub mutations: MutationInfo,
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
-    pub usable_equals: UsableEquals,
+    pub equality_index: EqualityIndex,
     /// File ID -> on-disk path of the `.d.lis` typedef. Populated for third-party
     /// go: typedefs read from `target/.lisette/typedefs/...`; absent for embedded
     /// stdlib typedefs.
@@ -43,7 +43,7 @@ impl SemanticResult {
             mutations: MutationInfo::default(),
             cached_modules: HashSet::default(),
             ufcs_methods: HashSet::default(),
-            usable_equals: UsableEquals::default(),
+            equality_index: EqualityIndex::default(),
             typedef_paths: HashMap::default(),
             go_package_names: HashMap::default(),
             go_module_ids: HashSet::default(),
@@ -64,7 +64,7 @@ impl SemanticResult {
             mutations: self.mutations,
             cached_modules: self.cached_modules,
             ufcs_methods: self.ufcs_methods,
-            usable_equals: self.usable_equals,
+            equality_index: self.equality_index,
             go_package_names: self.go_package_names,
             go_module_ids: self.go_module_ids,
         }

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -142,6 +142,12 @@ impl Planner<'_> {
                         .or_default()
                         .push(*name_span);
                 }
+                if self.should_synthesize_equals(name) {
+                    members
+                        .entry(self.equals_method_go_name())
+                        .or_default()
+                        .push(*name_span);
+                }
             }
             Expression::Enum {
                 name,
@@ -217,6 +223,12 @@ impl Planner<'_> {
                 if self.should_synthesize_to_string(name, attributes) {
                     members
                         .entry(self.to_string_method_go_name())
+                        .or_default()
+                        .push(*name_span);
+                }
+                if self.should_synthesize_equals(name) {
+                    members
+                        .entry(self.equals_method_go_name())
                         .or_default()
                         .push(*name_span);
                 }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -6,7 +6,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{BindingId, Pattern, RestPattern, Span};
 use syntax::program::{
-    Definition, DefinitionBody, ModuleId, MutationInfo, UnusedInfo, UsableEquals,
+    Definition, DefinitionBody, EqualityIndex, ModuleId, MutationInfo, UnusedInfo,
 };
 use syntax::types::{Symbol, Type};
 
@@ -21,7 +21,7 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) unused: &'a UnusedInfo,
     pub(crate) mutations: &'a MutationInfo,
     pub(crate) ufcs_methods: &'a HashSet<(String, String)>,
-    pub(crate) usable_equals: &'a UsableEquals,
+    pub(crate) equality_index: &'a EqualityIndex,
     pub(crate) go_package_names: &'a HashMap<String, String>,
     pub(crate) go_module_ids: &'a HashSet<String>,
     pub(crate) entry_module: ModuleId,
@@ -38,7 +38,7 @@ pub(crate) struct EmitFacts<'a> {
     unused: &'a UnusedInfo,
     mutations: &'a MutationInfo,
     ufcs_methods: &'a HashSet<(String, String)>,
-    usable_equals: &'a UsableEquals,
+    equality_index: &'a EqualityIndex,
     go_package_names: &'a HashMap<String, String>,
     go_module_ids: &'a HashSet<String>,
     entry_module: ModuleId,
@@ -57,7 +57,7 @@ impl<'a> EmitFacts<'a> {
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
-            usable_equals: config.usable_equals,
+            equality_index: config.equality_index,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
             entry_module: config.entry_module,
@@ -152,7 +152,11 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn usable_equals_from(&self, id: &str) -> bool {
-        self.usable_equals.usable_from(id, &self.current_module)
+        self.equality_index.usable_from(id, &self.current_module)
+    }
+
+    pub(crate) fn synthesizes_equals(&self, id: &str) -> bool {
+        self.equality_index.is_synthesized(id)
     }
 
     pub(crate) fn current_module(&self) -> &str {

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -4,6 +4,7 @@ use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_MET
 use crate::definitions::structs::should_synthesize_stringer;
 use crate::names::generics::receiver_generics_string;
 use crate::names::go_name;
+use crate::utils::receiver_name;
 use syntax::ast::{Attribute, Generic};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
@@ -84,6 +85,7 @@ impl Planner<'_> {
             result.push_str(&layout.emit_variants_function(&fn_name));
         }
         self.append_to_string_method(&mut result, name, &receiver_generics, attributes);
+        self.append_enum_equals_method(&mut result, name, &enum_id, &receiver_generics, fx);
         if needs_fmt {
             fx.require_fmt();
         }
@@ -92,6 +94,76 @@ impl Planner<'_> {
         }
 
         Some(result)
+    }
+
+    fn append_enum_equals_method(
+        &mut self,
+        out: &mut String,
+        name: &str,
+        enum_id: &str,
+        receiver_generics: &str,
+        fx: &mut EmitEffects,
+    ) {
+        if !self.should_synthesize_equals(name) {
+            return;
+        }
+        let Some(Definition {
+            body:
+                DefinitionBody::Enum {
+                    variants: sem_variants,
+                    ..
+                },
+            ..
+        }) = self.facts.definition(enum_id)
+        else {
+            return;
+        };
+        let sem_variants = sem_variants.clone();
+        let layout = self.enum_layout(enum_id).expect("enum layout should exist");
+
+        let receiver = receiver_name(name);
+        let go_type_name = go_name::escape_keyword(name);
+        let receiver_type = format!("{go_type_name}{receiver_generics}");
+        let go_method = self.equals_method_go_name();
+
+        let mut cases: Vec<String> = Vec::new();
+        for (sem_variant, layout_variant) in sem_variants.iter().zip(layout.variants.iter()) {
+            if sem_variant.fields.is_empty() {
+                continue;
+            }
+            let comparisons: Vec<String> = sem_variant
+                .fields
+                .iter()
+                .zip(layout_variant.fields.iter())
+                .map(|(sem_field, layout_field)| {
+                    let lhs = format!("{receiver}.{}", layout_field.go_name);
+                    let rhs = format!("other.{}", layout_field.go_name);
+                    self.render_equality(&lhs, &rhs, &sem_field.ty, fx)
+                })
+                .collect();
+            cases.push(format!(
+                "case {}:\nreturn {}",
+                layout_variant.tag_constant,
+                comparisons.join(" && ")
+            ));
+        }
+
+        out.push_str("\n\n");
+        if cases.is_empty() {
+            out.push_str(&format!(
+                "func ({receiver} {receiver_type}) {go_method}(other {receiver_type}) bool {{\nreturn {receiver}.Tag == other.Tag\n}}"
+            ));
+            return;
+        }
+        let mut method = format!(
+            "func ({receiver} {receiver_type}) {go_method}(other {receiver_type}) bool {{\nif {receiver}.Tag != other.Tag {{\nreturn false\n}}\nswitch {receiver}.Tag {{\n"
+        );
+        for case in &cases {
+            method.push_str(case);
+            method.push('\n');
+        }
+        method.push_str("default:\nreturn true\n}\n}");
+        out.push_str(&method);
     }
 
     /// Export-aware Go name for an `#[iterate]` enum's synthesized `variants`

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -54,10 +54,10 @@ impl Planner<'_> {
         if self.facts.is_unused_definition(name_span) {
             return None;
         }
+        let function = method.function_definition_view();
 
         self.scope.reset_for_top_level();
 
-        let function = method.function_definition_view();
         let is_public = matches!(visibility, Visibility::Public);
 
         let has_self = function.params.first().is_some_and(|p| {

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -72,6 +72,14 @@ impl Planner<'_> {
             definition
         };
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
+        self.append_equals_method(
+            &mut result,
+            name,
+            &receiver_generics,
+            fields,
+            struct_attrs,
+            fx,
+        );
         result
     }
 
@@ -221,6 +229,11 @@ impl Planner<'_> {
         attributes.iter().any(|a| a.name == "display") && !self.module.has_user_to_string(name)
     }
 
+    pub(crate) fn should_synthesize_equals(&self, name: &str) -> bool {
+        let qualified = self.facts.qualified_current(name);
+        self.facts.synthesizes_equals(qualified.as_str())
+    }
+
     pub(crate) fn is_pointer_backed_newtype(&self, name: &str) -> bool {
         let qualified = self.facts.qualified_current(name);
         self.facts
@@ -262,6 +275,42 @@ impl Planner<'_> {
             out.push_str("\n\n");
             out.push_str(&emit_to_string_method(name, receiver_generics, &go_method));
         }
+    }
+
+    pub(crate) fn append_equals_method(
+        &mut self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        fields: &[StructFieldDefinition],
+        attributes: &[Attribute],
+        fx: &mut EmitEffects,
+    ) {
+        if !self.should_synthesize_equals(name) {
+            return;
+        }
+        let receiver = receiver_name(name);
+        let comparisons: Vec<String> = fields
+            .iter()
+            .map(|f| {
+                let go_field = struct_field_go_name(f, attributes);
+                let lhs = format!("{receiver}.{go_field}");
+                let rhs = format!("other.{go_field}");
+                self.render_equality(&lhs, &rhs, &f.ty, fx)
+            })
+            .collect();
+        let body = if comparisons.is_empty() {
+            "true".to_string()
+        } else {
+            comparisons.join(" && ")
+        };
+        let go_method = self.equals_method_go_name();
+        let go_type_name = go_name::escape_keyword(name);
+        let receiver_type = format!("{go_type_name}{receiver_generics}");
+        out.push_str("\n\n");
+        out.push_str(&format!(
+            "func ({receiver} {receiver_type}) {go_method}(other {receiver_type}) bool {{\nreturn {body}\n}}"
+        ));
     }
 
     /// Single stringer to synthesize for structs: `String` by default,

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -48,7 +48,7 @@ use state::module_state::{FunctionEmissionState, ModuleState};
 use state::scope::ScopeState;
 use syntax::ast::Span;
 use syntax::program::{
-    Definition, DefinitionBody, EmitInput, File, ModuleId, MutationInfo, UnusedInfo, UsableEquals,
+    Definition, DefinitionBody, EmitInput, EqualityIndex, File, ModuleId, MutationInfo, UnusedInfo,
 };
 use syntax::types::{Symbol, Type};
 
@@ -193,7 +193,7 @@ pub struct TestEmitConfig<'a> {
     pub unused: &'a UnusedInfo,
     pub mutations: &'a MutationInfo,
     pub ufcs_methods: &'a HashSet<(String, String)>,
-    pub usable_equals: &'a UsableEquals,
+    pub equality_index: &'a EqualityIndex,
     pub go_package_names: &'a HashMap<String, String>,
     pub go_module_ids: &'a HashSet<String>,
 }
@@ -287,7 +287,7 @@ impl<'a> Planner<'a> {
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
-            usable_equals: config.usable_equals,
+            equality_index: config.equality_index,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
             entry_module: config.module_id.to_string(),
@@ -538,7 +538,7 @@ fn emit_module<'a>(
         unused: &analysis.unused,
         mutations: &analysis.mutations,
         ufcs_methods: &analysis.ufcs_methods,
-        usable_equals: &analysis.usable_equals,
+        equality_index: &analysis.equality_index,
         go_package_names: &analysis.go_package_names,
         go_module_ids: &analysis.go_module_ids,
         entry_module: analysis.entry_module_id.to_string(),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -605,6 +605,7 @@ mod attribute_completion_tests {
         let labels = labels_at("#[|\nstruct Point { x: int }").unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(labels.contains(&"display".to_string()));
+        assert!(labels.contains(&"equality".to_string()));
         assert!(labels.contains(&"tag".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
         assert!(!labels.contains(&"allow".to_string()));
@@ -615,6 +616,7 @@ mod attribute_completion_tests {
         let labels = labels_at("#[|\nenum Direction { North, South }").unwrap();
         assert!(labels.contains(&"iterate".to_string()));
         assert!(labels.contains(&"display".to_string()));
+        assert!(labels.contains(&"equality".to_string()));
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"xml".to_string()));
         assert!(!labels.contains(&"tag".to_string()));
@@ -627,6 +629,7 @@ mod attribute_completion_tests {
         assert!(labels.contains(&"json".to_string()));
         assert!(labels.contains(&"tag".to_string()));
         assert!(!labels.contains(&"display".to_string()));
+        assert!(!labels.contains(&"equality".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
         assert!(!labels.contains(&"allow".to_string()));
     }

--- a/crates/semantics/src/analyze.rs
+++ b/crates/semantics/src/analyze.rs
@@ -377,7 +377,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
             }
         }
 
-        checker.record_usable_equals(&mut store);
+        checker.finalize_equality(&mut store);
 
         let module_files: Vec<(String, Vec<File>)> = to_infer
             .iter()
@@ -574,7 +574,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         mutations,
         cached_modules,
         ufcs_methods,
-        usable_equals: store.usable_equals,
+        equality_index: store.equality_index,
         typedef_paths: store.typedef_paths,
         go_package_names: store.go_package_names,
         go_module_ids,

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -1,9 +1,10 @@
 use crate::checker::EnvResolve;
 use crate::checker::TypeEnv;
 use crate::checker::infer::InferCtx;
+use crate::checker::scopes::Scopes;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::program::DefinitionBody;
+use syntax::program::{DefinitionBody, EqualityUnusableReason};
 use syntax::types::{CompoundKind, Type, build_substitution_map, substitute};
 
 pub(crate) fn check_not_comparable(
@@ -106,24 +107,75 @@ pub(crate) fn type_has_usable_equals(store: &Store, ty: &Type, current_module: &
     let Some(qualified) = resolved.get_qualified_id() else {
         return false;
     };
-    store.usable_equals.usable_from(qualified, current_module)
+    store.equality_index.usable_from(qualified, current_module)
 }
 
-fn type_has_callable_bound_mismatched_equals(
+fn callable_unusable_equals_reason(
     store: &Store,
     ty: &Type,
     current_module: &str,
-) -> bool {
-    let Some(id) = ty.get_qualified_id() else {
-        return false;
+) -> Option<&'static str> {
+    let id = ty.get_qualified_id()?;
+    match store
+        .equality_index
+        .unusable_reason_from(id, current_module)?
+    {
+        EqualityUnusableReason::BoundMismatch => {
+            Some("a type whose `equals` requires stricter bounds")
+        }
+        EqualityUnusableReason::UfcsLowered => Some("a type whose `equals` is not a method"),
+    }
+}
+
+pub(crate) fn check_not_equatable(
+    env: &TypeEnv,
+    store: &Store,
+    ty: &Type,
+    current_module: &str,
+    comparable_param: &dyn Fn(&str) -> bool,
+) -> Option<&'static str> {
+    let resolved = store.deep_resolve_alias(&ty.resolve_in(env));
+
+    if let Type::Parameter(name) = &resolved
+        && comparable_param(name)
+    {
+        return None;
+    }
+    if type_has_usable_equals(store, &resolved, current_module) {
+        return None;
+    }
+
+    let Some(reason) = check_not_comparable(env, store, &resolved) else {
+        return callable_unusable_equals_reason(store, &resolved, current_module);
     };
-    if !store.equals_bound_mismatch.contains(id) {
+
+    match resolved.as_compound() {
+        Some((CompoundKind::Slice, args)) => {
+            check_not_equatable(env, store, args.first()?, current_module, comparable_param)
+        }
+        Some((CompoundKind::Map, args)) => {
+            if map_key_not_comparable(env, store, args.first()?, comparable_param) {
+                return Some("a map with a non-comparable key");
+            }
+            check_not_equatable(env, store, args.get(1)?, current_module, comparable_param)
+        }
+        _ => Some(reason),
+    }
+}
+
+fn map_key_not_comparable(
+    env: &TypeEnv,
+    store: &Store,
+    key: &Type,
+    comparable_param: &dyn Fn(&str) -> bool,
+) -> bool {
+    let resolved = store.deep_resolve_alias(&key.resolve_in(env));
+    if let Type::Parameter(name) = &resolved
+        && comparable_param(name)
+    {
         return false;
     }
-    let method_key = format!("{id}.equals");
-    store.get_definition(&method_key).is_some_and(|method| {
-        method.visibility.is_public() || store.module_for_qualified_name(id) == Some(current_module)
-    })
+    check_not_comparable(env, store, &resolved).is_some()
 }
 
 pub(crate) fn bound_implied(store: &Store, type_bounds: &[Type], method_bound: &Type) -> bool {
@@ -197,6 +249,24 @@ fn closure_conflicts(store: &Store, start: &Type, target_base: &str, target: &Ty
     })
 }
 
+pub(crate) fn param_is_comparable(scopes: &Scopes, env: &TypeEnv, param_name: &str) -> bool {
+    let mut found = false;
+    scopes.for_each_bound_on_param(param_name, |bound_ty| {
+        if found {
+            return;
+        }
+        if let Some(declared) = bound_ty
+            .resolve_in(env)
+            .get_qualified_id()
+            .and_then(super::super::unify::BuiltinBound::from_qualified_id)
+            && declared.satisfies(super::super::unify::BuiltinBound::Comparable)
+        {
+            found = true;
+        }
+    });
+    found
+}
+
 impl InferCtx<'_, '_> {
     pub(super) fn ensure_comparable(
         &mut self,
@@ -232,6 +302,21 @@ impl InferCtx<'_, '_> {
                         &resolved, reason, *span,
                     )),
             }
+        } else if operands_match
+            && type_has_usable_equals(store, &resolved, self.cursor.module_id.as_str())
+        {
+            self.sink
+                .push(diagnostics::infer::not_comparable_value_use_equals(
+                    &resolved, *span,
+                ));
+        } else if operands_match
+            && self.is_struct_or_enum(&resolved)
+            && self.is_equality_derivable(&resolved)
+        {
+            self.sink
+                .push(diagnostics::infer::not_comparable_derive_equality(
+                    &resolved, *span,
+                ));
         } else {
             self.sink
                 .push(diagnostics::infer::not_comparable(&resolved, reason, *span));
@@ -240,47 +325,78 @@ impl InferCtx<'_, '_> {
     }
 
     pub(super) fn not_equatable_reason(&self, ty: &Type) -> Option<&'static str> {
-        let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
-        let current_module = self.cursor.module_id.as_str();
-
-        if let Type::Parameter(name) = &resolved
-            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
-        {
-            return None;
-        }
-        if type_has_usable_equals(self.store, &resolved, current_module) {
-            return None;
-        }
-
-        let Some(reason) = check_not_comparable(&self.env, self.store, &resolved) else {
-            return type_has_callable_bound_mismatched_equals(
-                self.store,
-                &resolved,
-                current_module,
-            )
-            .then_some("a type whose `equals` requires stricter bounds");
-        };
-
-        match resolved.as_compound() {
-            Some((CompoundKind::Slice, args)) => self.not_equatable_reason(args.first()?),
-            Some((CompoundKind::Map, args)) => {
-                if self.map_key_not_comparable(args.first()?) {
-                    return Some("a map with a non-comparable key");
-                }
-                self.not_equatable_reason(args.get(1)?)
-            }
-            _ => Some(reason),
-        }
+        check_not_equatable(
+            &self.env,
+            self.store,
+            ty,
+            self.cursor.module_id.as_str(),
+            &|name| {
+                self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+            },
+        )
     }
 
-    fn map_key_not_comparable(&self, key: &Type) -> bool {
-        let resolved = self.store.deep_resolve_alias(&key.resolve_in(&self.env));
-        if let Type::Parameter(name) = &resolved
-            && self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
-        {
+    fn is_struct_or_enum(&self, ty: &Type) -> bool {
+        let resolved = self.store.deep_resolve_alias(ty);
+        let Some(name) = resolved.get_qualified_id() else {
             return false;
-        }
-        check_not_comparable(&self.env, self.store, &resolved).is_some()
+        };
+        matches!(
+            self.store.get_definition(name).map(|d| &d.body),
+            Some(DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. })
+        )
+    }
+
+    /// Whether the `==` diagnostic may suggest `#[equality]` for this struct or enum.
+    fn is_equality_derivable(&self, ty: &Type) -> bool {
+        let resolved = self.store.deep_resolve_alias(ty);
+        let Some(name) = resolved.get_qualified_id() else {
+            return false;
+        };
+        let Some(definition) = self.store.get_definition(name) else {
+            return false;
+        };
+        let type_args = resolved.get_type_params().unwrap_or_default();
+        let (generics, field_types): (&[syntax::ast::Generic], Vec<Type>) = match &definition.body {
+            DefinitionBody::Struct {
+                kind: syntax::ast::StructKind::Tuple,
+                ..
+            } => return false,
+            DefinitionBody::Struct {
+                generics, fields, ..
+            } => (generics, fields.iter().map(|f| f.ty.clone()).collect()),
+            DefinitionBody::Enum {
+                generics, variants, ..
+            } => (
+                generics,
+                variants
+                    .iter()
+                    .flat_map(|v| v.fields.iter().map(|f| f.ty.clone()))
+                    .collect(),
+            ),
+            _ => return false,
+        };
+        let sub_map = generics
+            .iter()
+            .map(|g| g.name.clone())
+            .zip(type_args.iter().cloned())
+            .collect();
+        field_types.iter().all(|field_ty| {
+            let substituted = substitute(&field_ty.resolve_in(&self.env), &sub_map);
+            check_not_equatable(
+                &self.env,
+                self.store,
+                &substituted,
+                self.cursor.module_id.as_str(),
+                &|name| {
+                    self.parameter_satisfies_bound(
+                        name,
+                        super::super::unify::BuiltinBound::Comparable,
+                    )
+                },
+            )
+            .is_none()
+        })
     }
 
     pub(super) fn gate_container_equals(&mut self, receiver_ty: &Type, span: Span) {

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -1,71 +1,69 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::EcoString;
-use syntax::program::DefinitionBody;
+use syntax::ast::{Attribute, Expression, Generic, Span, VariantFields};
+use syntax::program::{Definition, DefinitionBody, EqualityUnusableReason};
 use syntax::types::{Symbol, Type, substitute};
 
-use super::TaskState;
-use crate::checker::infer::expressions::comparison::bound_implied;
+use super::{TaskState, wrap_with_impl_generics};
+use crate::checker::infer::expressions::comparison::{
+    bound_implied, check_not_equatable, param_is_comparable,
+};
 use crate::store::Store;
 
-/// A usable `equals`'s visibility (`None` public, `Some(module)` private), else `None`.
-fn usable_equals_entry(store: &Store, id: &str) -> Option<Option<String>> {
-    if store.equals_bound_mismatch.contains(id) {
-        return None;
-    }
-    let definition = store.get_definition(id)?;
-    let (methods, generics_len) = match &definition.body {
-        DefinitionBody::Struct {
-            methods, generics, ..
-        }
-        | DefinitionBody::Enum {
-            methods, generics, ..
-        } => (methods, generics.len()),
-        _ => return None,
-    };
-    methods
-        .get("equals")?
-        .equals_receiver_vars(id, generics_len)?;
+fn equals_visibility(store: &Store, id: &str) -> Option<String> {
     let method_key = format!("{id}.equals");
-    let method = store.get_definition(&method_key)?;
-    if method.visibility.is_public() {
-        Some(None)
-    } else {
-        Some(store.module_for_qualified_name(id).map(str::to_string))
+    match store.get_definition(&method_key) {
+        Some(method) if method.visibility.is_public() => None,
+        _ => store.module_for_qualified_name(id).map(str::to_string),
     }
 }
 
+/// How a hand-written `equals` on a `#[equality]` type bears on synthesis.
+enum UserEquals {
+    /// No `equals`: gate the fields and synthesize.
+    None,
+    /// A valid full-type override (its type variables, for the bound comparison).
+    ValidReceiver(Vec<EcoString>),
+    /// A partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`) or extra
+    /// generics: does not cover every instantiation, so it cannot derive equality.
+    Specialized,
+    /// Wrong shape: cannot be the derived method and would collide with one.
+    Conflict,
+}
+
 impl TaskState<'_> {
-    /// Build the usable-`equals` verdict Go emission consumes, on the merged store.
-    pub fn record_usable_equals(&mut self, store: &mut Store) {
-        let module_ids: Vec<String> = store.modules.keys().cloned().collect();
-        for module_id in &module_ids {
-            self.record_bound_mismatched_equals(store, module_id);
+    pub fn register_equality(&mut self, store: &mut Store, items: &[Expression]) {
+        let module_id = self.cursor.module_id.clone();
+        let is_d_lis = self.is_d_lis(store);
+        let mut candidates = Vec::new();
+        for item in items {
+            collect_equality_candidates(item, is_d_lis, &mut candidates);
         }
-
-        let ids: Vec<Symbol> = store
-            .modules
-            .values()
-            .flat_map(|module| module.definitions.iter())
-            .filter_map(|(qualified, definition)| match &definition.body {
-                DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. }
-                    if methods.contains_key("equals") =>
-                {
-                    Some(qualified.clone())
-                }
-                _ => None,
-            })
-            .collect();
-
-        for id in ids {
-            if let Some(visibility) = usable_equals_entry(store, id.as_str()) {
-                store.usable_equals.insert(id.to_string(), visibility);
-            }
+        for candidate in candidates {
+            self.process_equality_candidate(store, &module_id, candidate);
         }
     }
 
-    /// Record one module's bound-mismatched `equals` types into the verdict's negative set.
-    fn record_bound_mismatched_equals(&mut self, store: &mut Store, module_id: &str) {
+    pub(super) fn register_module_equality(&mut self, store: &mut Store, module_id: &str) {
+        let candidates = {
+            let module = store.get_module(module_id).expect("module must exist");
+            let mut candidates = Vec::new();
+            for file in module.files.values().chain(module.typedefs.values()) {
+                let is_d_lis = file.is_d_lis();
+                for item in &file.items {
+                    collect_equality_candidates(item, is_d_lis, &mut candidates);
+                }
+            }
+            candidates
+        };
+
+        for candidate in candidates {
+            self.process_equality_candidate(store, module_id, candidate);
+        }
+    }
+
+    fn collect_bound_mismatched_equals(&mut self, store: &Store, module_id: &str) -> Vec<String> {
         let candidates: Vec<(Symbol, Vec<EcoString>)> = {
             let module = store.get_module(module_id).expect("module must exist");
             module
@@ -93,11 +91,260 @@ impl TaskState<'_> {
                 mismatched.push(qualified.to_string());
             }
         }
-        store.equals_bound_mismatch.extend(mismatched);
+        mismatched
     }
 
-    /// Whether the `equals` carries generic bounds the type does not imply, comparing by
-    /// position (`vars[i]` is the method's variable in slot `i`).
+    fn process_equality_candidate(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        candidate: EqualityCandidate,
+    ) {
+        let EqualityCandidate {
+            attribute_span,
+            kind,
+        } = candidate;
+        let TypeCandidate {
+            name,
+            is_d_lis,
+            has_args,
+        } = match kind {
+            CandidateKind::Misplaced => {
+                self.sink
+                    .push(diagnostics::attribute::equality_not_a_struct_or_enum(
+                        &attribute_span,
+                    ));
+                return;
+            }
+            CandidateKind::Type(type_candidate) => type_candidate,
+        };
+
+        if has_args {
+            self.sink
+                .push(diagnostics::attribute::equality_with_arguments(
+                    &attribute_span,
+                ));
+            return;
+        }
+        if is_d_lis {
+            self.sink
+                .push(diagnostics::attribute::equality_in_typedef(&attribute_span));
+            return;
+        }
+
+        let qualified = Symbol::from_parts(module_id, &name);
+        if is_tuple_struct(store, &qualified) {
+            self.sink
+                .push(diagnostics::attribute::equality_on_tuple_struct(
+                    &attribute_span,
+                ));
+            return;
+        }
+
+        match user_equals(store, &qualified) {
+            UserEquals::ValidReceiver(vars) => {
+                if self.is_ufcs_method(qualified.as_str(), "equals") {
+                    self.sink
+                        .push(diagnostics::attribute::equality_specialized_equals(
+                            &attribute_span,
+                        ));
+                    return;
+                }
+                if self.equals_bounds_mismatch(store, &qualified, &vars)
+                    && !store.bound_conflict_types.contains(qualified.as_str())
+                {
+                    self.sink
+                        .push(diagnostics::attribute::equality_bounded_equals(
+                            &attribute_span,
+                        ));
+                }
+                return;
+            }
+            UserEquals::Conflict => {
+                self.sink
+                    .push(diagnostics::attribute::equality_conflicting_equals(
+                        &attribute_span,
+                    ));
+                return;
+            }
+            UserEquals::Specialized => {
+                self.sink
+                    .push(diagnostics::attribute::equality_specialized_equals(
+                        &attribute_span,
+                    ));
+                return;
+            }
+            UserEquals::None => {}
+        }
+
+        if has_hidden_user_equals(store, &qualified) {
+            self.sink
+                .push(diagnostics::attribute::equality_conflicting_equals(
+                    &attribute_span,
+                ));
+            return;
+        }
+
+        self.synthesize_equals(store, module_id, &qualified);
+        self.facts.equality_derivations.push(qualified.to_string());
+    }
+
+    /// Build the equality verdict and gate derivations. Run once after registration + UFCS.
+    pub fn finalize_equality(&mut self, store: &mut Store) {
+        self.record_equality_index(store);
+        self.validate_equality_derivations(store);
+    }
+
+    fn validate_equality_derivations(&mut self, store: &Store) {
+        let derivations = std::mem::take(&mut self.facts.equality_derivations);
+        for id in &derivations {
+            let qualified = Symbol::from_raw(id.as_str());
+            let module_id = store
+                .module_for_qualified_name(id)
+                .map(str::to_string)
+                .unwrap_or_default();
+            let name = syntax::types::unqualified_name(id).to_string();
+            self.gate_equality_derivation(store, &name, &qualified, &module_id);
+        }
+    }
+
+    fn gate_equality_derivation(
+        &mut self,
+        store: &Store,
+        type_name: &str,
+        qualified: &Symbol,
+        module_id: &str,
+    ) {
+        let Some(definition) = store.get_definition(qualified.as_str()) else {
+            return;
+        };
+        let (generics, fields): (Vec<Generic>, Vec<(EcoString, Span, Type)>) = match &definition
+            .body
+        {
+            DefinitionBody::Struct {
+                generics, fields, ..
+            } => (
+                generics.clone(),
+                fields
+                    .iter()
+                    .map(|f| (f.name.clone(), f.name_span, f.ty.clone()))
+                    .collect(),
+            ),
+            DefinitionBody::Enum {
+                generics, variants, ..
+            } => {
+                let mut specs: Vec<(EcoString, Span, Type)> = Vec::new();
+                for variant in variants {
+                    match &variant.fields {
+                        VariantFields::Tuple(fields) => {
+                            for field in fields {
+                                specs.push((
+                                    variant.name.clone(),
+                                    variant.name_span,
+                                    field.ty.clone(),
+                                ));
+                            }
+                        }
+                        VariantFields::Struct(fields) => {
+                            for field in fields {
+                                specs.push((field.name.clone(), field.name_span, field.ty.clone()));
+                            }
+                        }
+                        VariantFields::Unit => {}
+                    }
+                }
+                (generics.clone(), specs)
+            }
+            _ => return,
+        };
+
+        self.scopes.push();
+        self.put_in_scope(&generics);
+        let before = self.sink.len();
+        for g in &generics {
+            let qualified_g = self.qualify_name(&g.name);
+            for bound in &g.bounds {
+                let bound_ty = self.register_bound_annotation(store, bound, &g.span);
+                self.scopes
+                    .current_mut()
+                    .trait_bounds
+                    .get_or_insert_with(HashMap::default)
+                    .entry(qualified_g.clone())
+                    .or_default()
+                    .push(bound_ty);
+            }
+        }
+        self.sink.truncate(before);
+
+        for (field_name, field_span, field_ty) in &fields {
+            let reason = check_not_equatable(&self.env, store, field_ty, module_id, &|name| {
+                param_is_comparable(&self.scopes, &self.env, name)
+            });
+            if let Some(reason) = reason {
+                self.sink
+                    .push(diagnostics::attribute::cannot_derive_equality(
+                        type_name, field_name, field_span, reason,
+                    ));
+            }
+        }
+
+        self.scopes.pop();
+    }
+
+    fn record_equality_index(&mut self, store: &mut Store) {
+        let module_ids: Vec<String> = store.modules.keys().cloned().collect();
+        let bound_mismatch: HashSet<String> = module_ids
+            .iter()
+            .flat_map(|module_id| self.collect_bound_mismatched_equals(store, module_id))
+            .collect();
+        let synthesized: HashSet<String> =
+            self.facts.equality_derivations.iter().cloned().collect();
+
+        let ids: Vec<Symbol> = store
+            .modules
+            .values()
+            .flat_map(|module| module.definitions.iter())
+            .filter_map(|(qualified, definition)| match &definition.body {
+                DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. }
+                    if methods.contains_key("equals") =>
+                {
+                    Some(qualified.clone())
+                }
+                _ => None,
+            })
+            .collect();
+
+        for id in ids {
+            let id_str = id.as_str();
+            let visibility = equals_visibility(store, id_str);
+            let classification = user_equals(store, &id);
+            if bound_mismatch.contains(id_str) {
+                store.equality_index.insert_unusable(
+                    id.to_string(),
+                    EqualityUnusableReason::BoundMismatch,
+                    visibility,
+                );
+            } else if self.is_ufcs_method(id_str, "equals")
+                && matches!(
+                    classification,
+                    UserEquals::ValidReceiver(_) | UserEquals::Specialized
+                )
+            {
+                store.equality_index.insert_unusable(
+                    id.to_string(),
+                    EqualityUnusableReason::UfcsLowered,
+                    visibility,
+                );
+            } else if matches!(classification, UserEquals::ValidReceiver(_)) {
+                store.equality_index.insert_method(
+                    id.to_string(),
+                    visibility,
+                    synthesized.contains(id_str),
+                );
+            }
+        }
+    }
+
     fn equals_bounds_mismatch(
         &mut self,
         store: &Store,
@@ -126,7 +373,6 @@ impl TaskState<'_> {
         }
         let method_bounds = method_bounds_by_var(store, &method_ty);
         let empty: Vec<Type> = Vec::new();
-        // Rename the method's variables to the type's, so an alpha-equivalent bound matches.
         let alpha: HashMap<EcoString, Type> = vars
             .iter()
             .zip(&generics)
@@ -157,6 +403,87 @@ impl TaskState<'_> {
         self.scopes.pop();
         mismatch
     }
+
+    fn type_generic_bounds(
+        &mut self,
+        store: &Store,
+        qualified: &Symbol,
+        generics: &[Generic],
+    ) -> Vec<syntax::types::Bound> {
+        self.scopes.push();
+        self.put_in_scope(generics);
+        let before = self.sink.len();
+        let mut bounds = Vec::new();
+        for generic in generics {
+            for bound in &generic.bounds {
+                if let Some(bound_ty) =
+                    self.resolve_type_bound(store, bound, &generic.span, qualified)
+                {
+                    bounds.push(syntax::types::Bound {
+                        param_name: generic.name.clone(),
+                        generic: Type::Parameter(generic.name.clone()),
+                        ty: bound_ty,
+                    });
+                }
+            }
+        }
+        self.sink.truncate(before);
+        self.scopes.pop();
+        bounds
+    }
+
+    fn synthesize_equals(&mut self, store: &mut Store, module_id: &str, qualified: &Symbol) {
+        let Some(scheme) = store.get_type(qualified.as_str()).cloned() else {
+            return;
+        };
+        let Some(definition) = store.get_definition(qualified.as_str()) else {
+            return;
+        };
+        let Some(generics) = type_generics(definition) else {
+            return;
+        };
+        let visibility = definition.visibility().clone();
+        let name_span = definition.name_span();
+
+        let receiver_ty = match scheme {
+            Type::Forall { body, .. } => *body,
+            other => other,
+        };
+        let fn_ty = Type::function(
+            vec![receiver_ty.clone(), receiver_ty],
+            vec![false, false],
+            Default::default(),
+            Box::new(Type::bool()),
+        );
+        let impl_bounds = self.type_generic_bounds(store, qualified, &generics);
+        let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
+
+        let equals_key = qualified.with_segment("equals");
+        let module = store.get_module_mut(module_id).expect("module must exist");
+        if let Some(methods) = module
+            .definitions
+            .get_mut(qualified.as_str())
+            .and_then(Definition::methods_mut)
+        {
+            methods.insert("equals".into(), method_ty.clone());
+        }
+        module
+            .definitions
+            .entry(equals_key)
+            .or_insert_with(|| Definition {
+                visibility,
+                ty: method_ty,
+                name: None,
+                name_span,
+                doc: None,
+                body: DefinitionBody::Value {
+                    allowed_lints: vec![],
+                    go_hints: vec![],
+                    go_name: None,
+                    const_value: None,
+                },
+            });
+    }
 }
 
 /// The bounds a method type carries, keyed by its type-variable name.
@@ -177,4 +504,152 @@ fn method_bounds_by_var(store: &Store, method_ty: &Type) -> HashMap<EcoString, V
         }
     }
     map
+}
+
+fn is_tuple_struct(store: &Store, qualified: &Symbol) -> bool {
+    matches!(
+        store.get_definition(qualified.as_str()).map(|d| &d.body),
+        Some(DefinitionBody::Struct {
+            kind: syntax::ast::StructKind::Tuple,
+            ..
+        })
+    )
+}
+
+fn has_hidden_user_equals(store: &Store, qualified: &Symbol) -> bool {
+    let in_method_set = matches!(
+        store.get_definition(qualified.as_str()).map(|d| &d.body),
+        Some(DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. })
+            if methods.contains_key("equals")
+    );
+    if in_method_set {
+        return false;
+    }
+    let equals_key = qualified.with_segment("equals");
+    store
+        .get_definition(equals_key.as_str())
+        .is_some_and(|d| d.name_span().is_some())
+}
+
+fn user_equals(store: &Store, qualified: &Symbol) -> UserEquals {
+    let Some(definition) = store.get_definition(qualified.as_str()) else {
+        return UserEquals::None;
+    };
+    let (methods, generics_len) = match &definition.body {
+        DefinitionBody::Struct {
+            methods, generics, ..
+        }
+        | DefinitionBody::Enum {
+            methods, generics, ..
+        } => (methods, generics.len()),
+        _ => return UserEquals::None,
+    };
+    let Some(method_ty) = methods.get("equals") else {
+        return UserEquals::None;
+    };
+    if let Some(vars) = method_ty.equals_receiver_vars(qualified.as_str(), generics_len) {
+        UserEquals::ValidReceiver(vars)
+    } else if method_ty.is_equals_signature() {
+        UserEquals::Specialized
+    } else {
+        UserEquals::Conflict
+    }
+}
+
+fn type_generics(definition: &Definition) -> Option<Vec<Generic>> {
+    match &definition.body {
+        DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
+            Some(generics.clone())
+        }
+        _ => None,
+    }
+}
+
+struct EqualityCandidate {
+    attribute_span: Span,
+    kind: CandidateKind,
+}
+
+enum CandidateKind {
+    Type(TypeCandidate),
+    Misplaced,
+}
+
+struct TypeCandidate {
+    name: String,
+    is_d_lis: bool,
+    has_args: bool,
+}
+
+fn equality_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
+    attributes.iter().find(|a| a.name == "equality")
+}
+
+fn misplaced_candidate(attribute: &Attribute) -> EqualityCandidate {
+    EqualityCandidate {
+        attribute_span: attribute.span,
+        kind: CandidateKind::Misplaced,
+    }
+}
+
+fn collect_method_attributes(methods: &[Expression], out: &mut Vec<EqualityCandidate>) {
+    for method in methods {
+        if let Expression::Function { attributes, .. } = method {
+            out.extend(equality_attribute(attributes).map(misplaced_candidate));
+        }
+    }
+}
+
+fn collect_equality_candidates(
+    item: &Expression,
+    is_d_lis: bool,
+    out: &mut Vec<EqualityCandidate>,
+) {
+    match item {
+        Expression::Struct {
+            attributes,
+            name,
+            fields,
+            ..
+        } => {
+            if let Some(attribute) = equality_attribute(attributes) {
+                out.push(EqualityCandidate {
+                    attribute_span: attribute.span,
+                    kind: CandidateKind::Type(TypeCandidate {
+                        name: name.to_string(),
+                        is_d_lis,
+                        has_args: !attribute.args.is_empty(),
+                    }),
+                });
+            }
+            for field in fields {
+                out.extend(equality_attribute(&field.attributes).map(misplaced_candidate));
+            }
+        }
+        Expression::Enum {
+            attributes, name, ..
+        } => {
+            if let Some(attribute) = equality_attribute(attributes) {
+                out.push(EqualityCandidate {
+                    attribute_span: attribute.span,
+                    kind: CandidateKind::Type(TypeCandidate {
+                        name: name.to_string(),
+                        is_d_lis,
+                        has_args: !attribute.args.is_empty(),
+                    }),
+                });
+            }
+        }
+        Expression::Function { attributes, .. } => {
+            out.extend(equality_attribute(attributes).map(misplaced_candidate));
+        }
+        Expression::TypeAlias { attributes, .. } => {
+            out.extend(equality_attribute(attributes).map(misplaced_candidate));
+        }
+        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
+        Expression::Interface {
+            method_signatures, ..
+        } => collect_method_attributes(method_signatures, out),
+        _ => {}
+    }
 }

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -177,7 +177,17 @@ impl TaskState<'_> {
             return;
         }
 
-        self.check_conflicting_impl_bounds(&*store, annotation, &receiver_qualified_name, generics);
+        if self.check_conflicting_impl_bounds(
+            &*store,
+            annotation,
+            &receiver_qualified_name,
+            generics,
+        ) {
+            store
+                .bound_conflict_types
+                .insert(receiver_qualified_name.to_string());
+        }
+
         self.check_conflicting_cross_impl_bounds(
             &*store,
             annotation,

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -229,6 +229,8 @@ impl TaskState<'_> {
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = crate::call_classification::compute_module_ufcs(module, id);
         self.ufcs_methods.extend(ufcs_entries);
+
+        self.register_module_equality(store, id);
     }
 
     /// Register a Go module (stdlib or third-party). Unlike regular modules,
@@ -335,6 +337,7 @@ impl TaskState<'_> {
                         .items,
                 );
                 this.register_types_and_values(store, &items, &Visibility::Public);
+                this.register_equality(store, &items);
             },
         );
     }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -46,6 +46,7 @@ pub struct Facts {
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<Span>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<String>>,
+    pub equality_derivations: Vec<String>,
 
     // Drained by passes::deferred via mem::take.
     pub generic_call_checks: Vec<GenericCallCheck>,
@@ -100,6 +101,7 @@ impl Facts {
             usages: Vec::new(),
             usage_set: HashSet::default(),
             interface_satisfied_methods: HashMap::default(),
+            equality_derivations: Vec::new(),
         }
     }
 
@@ -228,7 +230,9 @@ impl Facts {
             usages,
             usage_set: _,
             interface_satisfied_methods,
+            equality_derivations,
         } = other;
+        self.equality_derivations.extend(equality_derivations);
 
         self.bindings.extend(bindings);
         self.dead_code.extend(dead_code);

--- a/crates/semantics/src/passes/lints/ref_graph/extract.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/extract.rs
@@ -1,11 +1,11 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{
-    Annotation, Binding, Expression, Generic, ImportAlias, Pattern, SelectArm, SelectArmPattern,
-    StructSpread,
+    Annotation, Attribute, Binding, Expression, Generic, ImportAlias, Pattern, SelectArm,
+    SelectArmPattern, StructSpread,
 };
 use syntax::program::File;
-use syntax::program::{DefinitionBody, DotAccessKind, Module, UsableEquals};
+use syntax::program::{DefinitionBody, DotAccessKind, EqualityIndex, Module};
 use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 use super::reference_graph::{EnumVariantId, ModuleItemId, ReferenceGraph, StructFieldId};
@@ -146,11 +146,21 @@ fn walk_expression(
             walk_expression(module, expression, graph, alias_map, Some(&const_ctx));
         }
 
-        Expression::Enum { name, variants, .. } => {
+        Expression::Enum {
+            name,
+            variants,
+            attributes,
+            ..
+        } => {
             let enum_ctx = ModuleItemId::new(name);
+            let owner = format!("{}.{}", module.id, name);
+            let has_equality = has_equality_attr(attributes);
             for v in variants {
                 for f in &v.fields {
                     walk_annotation(module, &f.annotation, graph, alias_map, &enum_ctx);
+                    if has_equality {
+                        graph.record_equals_root(owner.clone(), f.ty.clone());
+                    }
                 }
             }
         }
@@ -159,6 +169,7 @@ fn walk_expression(
             name,
             generics,
             fields,
+            attributes,
             ..
         } => {
             let struct_ctx = ModuleItemId::new(name);
@@ -167,8 +178,13 @@ fn walk_expression(
                     walk_annotation(module, bound, graph, alias_map, &struct_ctx);
                 }
             }
+            let owner = format!("{}.{}", module.id, name);
+            let has_equality = has_equality_attr(attributes);
             for f in fields {
                 walk_annotation(module, &f.annotation, graph, alias_map, &struct_ctx);
+                if has_equality {
+                    graph.record_equals_root(owner.clone(), f.ty.clone());
+                }
             }
         }
 
@@ -798,10 +814,14 @@ fn credits_local_method(receiver_ty: &Type, module: &Module) -> bool {
     }
 }
 
+fn has_equality_attr(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|a| a.name == "equality")
+}
+
 pub(super) fn equals_targets(
     ty: &Type,
     module: &Module,
-    usable: &UsableEquals,
+    index: &EqualityIndex,
     out: &mut Vec<ModuleItemId>,
 ) {
     let mut current = ty.clone();
@@ -814,7 +834,7 @@ pub(super) fn equals_targets(
             args,
         } => {
             if let Some(element) = args.first() {
-                equals_targets(element, module, usable, out);
+                equals_targets(element, module, index, out);
             }
         }
         Type::Compound {
@@ -822,12 +842,12 @@ pub(super) fn equals_targets(
             args,
         } => {
             if let Some(value) = args.get(1) {
-                equals_targets(value, module, usable, out);
+                equals_targets(value, module, index, out);
             }
         }
         Type::Nominal { id, .. } => {
             if id.as_str().starts_with(&format!("{}.", module.id))
-                && usable.usable_from(id.as_str(), &module.id)
+                && index.usable_from(id.as_str(), &module.id)
             {
                 out.push(ModuleItemId::equals_method(unqualified_name(id)));
             }

--- a/crates/semantics/src/passes/lints/ref_graph/mod.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/mod.rs
@@ -12,9 +12,9 @@ use crate::passes::PARALLEL_THRESHOLD;
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
+use syntax::program::EqualityIndex;
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
-use syntax::program::UsableEquals;
 use syntax::program::{File, FileImport};
 
 use super::Lint as LintEnum;
@@ -39,7 +39,7 @@ pub(crate) fn run(
 ) -> (Vec<LisetteDiagnostic>, UnusedInfo) {
     let store = analysis.store;
     let go_package_names = &store.go_package_names;
-    let usable_equals = &store.usable_equals;
+    let equality_index = &store.equality_index;
     let config = LintConfig::default();
 
     let mut modules: Vec<&Module> = store
@@ -58,7 +58,7 @@ pub(crate) fn run(
             apply_ref_lints(
                 module,
                 go_package_names,
-                usable_equals,
+                equality_index,
                 &config,
                 facts,
                 &mut unused,
@@ -77,7 +77,7 @@ pub(crate) fn run(
             apply_ref_lints(
                 module,
                 go_package_names,
-                usable_equals,
+                equality_index,
                 &config,
                 facts,
                 &mut local_unused,
@@ -98,7 +98,7 @@ pub(crate) fn run(
 fn apply_ref_lints(
     module: &Module,
     go_package_names: &HashMap<String, String>,
-    usable_equals: &UsableEquals,
+    equality_index: &EqualityIndex,
     config: &LintConfig,
     facts: &Facts,
     unused: &mut UnusedInfo,
@@ -108,7 +108,7 @@ fn apply_ref_lints(
         module,
         &module.files,
         go_package_names,
-        usable_equals,
+        equality_index,
         config,
         facts,
     );
@@ -134,7 +134,7 @@ fn run_ref_lints(
     module: &Module,
     files: &HashMap<u32, File>,
     go_package_names: &HashMap<String, String>,
-    usable_equals: &UsableEquals,
+    equality_index: &EqualityIndex,
     config: &LintConfig,
     facts: &Facts,
 ) -> RefLintResult {
@@ -143,7 +143,13 @@ fn run_ref_lints(
     let mut unused_definition_spans = Vec::new();
     let mut graph = ReferenceGraph::new();
 
-    collect_items(files, go_package_names, &mut graph);
+    collect_items(
+        files,
+        &module.id,
+        go_package_names,
+        equality_index,
+        &mut graph,
+    );
 
     let alias_map = AliasMap::build(files, go_package_names);
     for file in files.values() {
@@ -154,9 +160,20 @@ fn run_ref_lints(
 
     for (from, receiver_ty) in graph.take_equals_dispatch() {
         let mut targets = Vec::new();
-        equals_targets(&receiver_ty, module, usable_equals, &mut targets);
+        equals_targets(&receiver_ty, module, equality_index, &mut targets);
         for to in targets {
             graph.add_reference(&from, to);
+        }
+    }
+
+    for (owner, field_ty) in graph.take_equals_roots() {
+        if !equality_index.is_synthesized(&owner) {
+            continue;
+        }
+        let mut targets = Vec::new();
+        equals_targets(&field_ty, module, equality_index, &mut targets);
+        for to in targets {
+            graph.mark_as_used(to);
         }
     }
 
@@ -212,7 +229,9 @@ fn run_ref_lints(
 
 fn collect_items(
     files: &HashMap<u32, File>,
+    module_id: &str,
     go_package_names: &HashMap<String, String>,
+    equality_index: &EqualityIndex,
     graph: &mut ReferenceGraph,
 ) {
     for file in files.values() {
@@ -318,6 +337,8 @@ fn collect_items(
                     });
 
                     let has_display_attr = attributes.iter().any(|a| a.name == "display");
+                    let synthesizes_equals =
+                        equality_index.is_synthesized(&format!("{module_id}.{name}"));
 
                     for struct_field in fields {
                         let field_id = StructFieldId::new(name, &struct_field.name);
@@ -331,6 +352,7 @@ fn collect_items(
                                 parent_is_public: is_public,
                                 parent_has_serialization_attr: has_serialization_attr,
                                 parent_has_display_attr: has_display_attr,
+                                parent_synthesizes_equals: synthesizes_equals,
                                 has_tag_attribute,
                                 embedded: struct_field.embedded,
                             },

--- a/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/semantics/src/passes/lints/ref_graph/reference_graph.rs
@@ -51,6 +51,7 @@ pub struct StructFieldInfo {
     pub parent_is_public: bool,
     pub parent_has_serialization_attr: bool,
     pub parent_has_display_attr: bool,
+    pub parent_synthesizes_equals: bool,
     pub has_tag_attribute: bool,
     pub embedded: bool,
 }
@@ -86,9 +87,8 @@ pub struct ReferenceGraph {
     used_struct_fields: HashSet<StructFieldId>,
     enum_variants: HashMap<EnumVariantId, EnumVariantInfo>,
     used_enum_variants: HashSet<EnumVariantId>,
-    /// Container `.equals()` receivers whose element `equals` is credited after the walk,
-    /// once the usable-equality verdict can filter them.
     pending_equals_dispatch: Vec<(ModuleItemId, Type)>,
+    pending_equals_roots: Vec<(String, Type)>,
 }
 
 impl ReferenceGraph {
@@ -125,6 +125,14 @@ impl ReferenceGraph {
 
     pub fn take_equals_dispatch(&mut self) -> Vec<(ModuleItemId, Type)> {
         std::mem::take(&mut self.pending_equals_dispatch)
+    }
+
+    pub fn record_equals_root(&mut self, owner: String, field_ty: Type) {
+        self.pending_equals_roots.push((owner, field_ty));
+    }
+
+    pub fn take_equals_roots(&mut self) -> Vec<(String, Type)> {
+        std::mem::take(&mut self.pending_equals_roots)
     }
 
     /// Mark an item as used by adding it to entrypoints.
@@ -191,6 +199,7 @@ impl ReferenceGraph {
                     && !info.parent_is_public
                     && !info.parent_has_serialization_attr
                     && !info.parent_has_display_attr
+                    && !info.parent_synthesizes_equals
                     && !info.has_tag_attribute
                     && !info.embedded
                     && !self.used_struct_fields.contains(*id)

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -7,7 +7,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{EnumVariant, Expression, Literal, StructFieldDefinition};
 use syntax::program::{
-    Definition, DefinitionBody, File, Interface, MethodSignatures, Module, ModuleId, UsableEquals,
+    Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, ModuleId,
 };
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
@@ -110,14 +110,13 @@ pub struct Store {
     /// file IDs to the actual cache path so go-to-definition can navigate there.
     pub typedef_paths: HashMap<u32, PathBuf>,
     visited_modules: HashSet<String>,
-    /// Types whose `equals` carries bounds the type does not imply; excluded from `usable_equals`.
-    pub equals_bound_mismatch: HashSet<String>,
-    pub usable_equals: UsableEquals,
     /// File ID counter. Starts at 2 because 0 is reserved for entry, 1 for prelude.
     next_file_id: AtomicU32,
     /// Closed-domain index, keyed by the type's qualified name (the `id` in
     /// `Type::Nominal`). Built once after registration by `build_closed_domains`.
     pub closed_domains: HashMap<Symbol, ClosedDomain>,
+    pub bound_conflict_types: HashSet<String>,
+    pub equality_index: EqualityIndex,
 }
 
 impl Default for Store {
@@ -147,10 +146,10 @@ impl Store {
             go_package_names: Default::default(),
             typedef_paths: Default::default(),
             visited_modules: Default::default(),
-            equals_bound_mismatch: Default::default(),
-            usable_equals: Default::default(),
             next_file_id: AtomicU32::new(2), // 0 = entrypoint, 1 = prelude
             closed_domains: Default::default(),
+            bound_conflict_types: Default::default(),
+            equality_index: Default::default(),
         }
     }
 
@@ -266,10 +265,10 @@ impl Store {
             go_package_names: self.go_package_names.clone(),
             typedef_paths: HashMap::default(),
             visited_modules: HashSet::default(),
-            equals_bound_mismatch: HashSet::default(),
-            usable_equals: UsableEquals::default(),
             next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
             closed_domains: HashMap::default(),
+            bound_conflict_types: HashSet::default(),
+            equality_index: EqualityIndex::default(),
         }
     }
 

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -99,6 +99,11 @@ pub const ATTRIBUTES: &[AttributeInfo] = &[
         detail: "derive `to_string`",
         targets: &[Struct, Enum],
     },
+    AttributeInfo {
+        name: "equality",
+        detail: "derive `equals`",
+        targets: &[Struct, Enum],
+    },
 ];
 
 /// `go` is accepted but absent from [`ATTRIBUTES`] (the Go-interop rail).

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -67,25 +67,96 @@ impl UnusedInfo {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct UsableEquals {
-    by_id: HashMap<String, Option<String>>,
+pub struct EqualityIndex {
+    by_id: HashMap<String, EqualityInfo>,
 }
 
-impl UsableEquals {
-    pub fn insert(&mut self, id: String, private_to_module: Option<String>) {
-        self.by_id.insert(id, private_to_module);
+#[derive(Debug, Clone)]
+pub enum EqualityInfo {
+    Method {
+        private_to_module: Option<String>,
+        synthesized: bool,
+    },
+    Unusable {
+        reason: EqualityUnusableReason,
+        private_to_module: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EqualityUnusableReason {
+    UfcsLowered,
+    BoundMismatch,
+}
+
+fn visible_from(private_to_module: &Option<String>, current_module: &str) -> bool {
+    match private_to_module {
+        None => true,
+        Some(module) => module == current_module,
+    }
+}
+
+impl EqualityIndex {
+    pub fn insert_method(
+        &mut self,
+        id: String,
+        private_to_module: Option<String>,
+        synthesized: bool,
+    ) {
+        self.by_id.insert(
+            id,
+            EqualityInfo::Method {
+                private_to_module,
+                synthesized,
+            },
+        );
+    }
+
+    pub fn insert_unusable(
+        &mut self,
+        id: String,
+        reason: EqualityUnusableReason,
+        private_to_module: Option<String>,
+    ) {
+        self.by_id.insert(
+            id,
+            EqualityInfo::Unusable {
+                reason,
+                private_to_module,
+            },
+        );
     }
 
     pub fn usable_from(&self, id: &str, current_module: &str) -> bool {
-        Self::entry_usable_from(self.by_id.get(id), current_module)
+        matches!(
+            self.by_id.get(id),
+            Some(EqualityInfo::Method { private_to_module, .. })
+                if visible_from(private_to_module, current_module)
+        )
     }
 
-    pub fn entry_usable_from(entry: Option<&Option<String>>, current_module: &str) -> bool {
-        match entry {
-            Some(None) => true,
-            Some(Some(module)) => module == current_module,
-            None => false,
+    pub fn unusable_reason_from(
+        &self,
+        id: &str,
+        current_module: &str,
+    ) -> Option<EqualityUnusableReason> {
+        match self.by_id.get(id) {
+            Some(EqualityInfo::Unusable {
+                reason,
+                private_to_module,
+            }) if visible_from(private_to_module, current_module) => Some(*reason),
+            _ => None,
         }
+    }
+
+    pub fn is_synthesized(&self, id: &str) -> bool {
+        matches!(
+            self.by_id.get(id),
+            Some(EqualityInfo::Method {
+                synthesized: true,
+                ..
+            })
+        )
     }
 }
 
@@ -113,7 +184,7 @@ pub struct EmitInput {
     pub mutations: MutationInfo,
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
-    pub usable_equals: UsableEquals,
+    pub equality_index: EqualityIndex,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
 }

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -7,7 +7,9 @@ mod resolution;
 pub use definition::{
     Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute, Visibility,
 };
-pub use emit_input::{EmitInput, MutationInfo, UnusedInfo, UsableEquals};
+pub use emit_input::{
+    EmitInput, EqualityIndex, EqualityInfo, EqualityUnusableReason, MutationInfo, UnusedInfo,
+};
 pub use file::{File, FileImport};
 pub use module::{Module, ModuleId, ModuleInfo};
 pub use resolution::{CallKind, DotAccessKind, NativeTypeKind, ReceiverCoercion};

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -218,6 +218,85 @@ fn render(value: Display) -> string {
 render(Point { x: 1, y: 2 }) // `Point` satisfies `Display`
 ```
 
+## Equality
+
+`==` and `!=` work on natively comparable types: primitives and any struct, enum, and tuple whose components are all comparable.
+
+```rs
+struct User {
+  name: string,
+  age: int,
+}
+
+let u1 = User { name: "Alice", age: 30 }
+let u2 = User { name: "Alice", age: 30 }
+
+u1 == u2 // true
+```
+
+Other types are not natively comparable: slice and map and any struct, enum, and tuple that contains a slice or map, plus any function and interface value.
+
+```rs
+struct Order {
+  id: int,
+  tags: Slice<string>, // not natively comparable
+}
+
+let o1 = Order { id: 1, tags: ["a"] }
+let o2 = Order { id: 1, tags: ["a"] }
+
+o1 == o2 // compile error: comparison of non-comparables
+```
+
+For maps and slices, use the built-in `equals()` method:
+
+```rs
+let a = [1, 2, 3]
+let b = [1, 2, 3]
+let ok = a.equals(b) // true, element-wise
+```
+
+To enable comparison on types that are not natively comparable and do not have a built-in `equals()` method, mark them with the `#[equality]` attribute. This will auto-generate an `equals()` method to compare the type structurally.
+
+```rs
+#[equality]
+struct Order {
+  id: int,
+  tags: Slice<string>,
+}
+
+let a = Order { id: 1, tags: ["a"] }
+let b = Order { id: 1, tags: ["a"] }
+
+a.equals(b) // true
+```
+
+The auto-generated `equals()` method compares by this rule: 
+
+- `==` for comparable fields
+- `.equals()` for slice and map fields
+- the field type's own `equals` for nested `#[equality]` types
+
+If you need a custom comparator, write an `equals` method yourself:
+
+```rs
+struct Fraction {
+  numerator: int,
+  denominator: int,
+}
+
+impl Fraction {
+  fn equals(self, other: Fraction) -> bool {
+    self.numerator * other.denominator == other.numerator * self.denominator
+  }
+}
+
+let a = Fraction { numerator: 1, denominator: 2 }
+let b = Fraction { numerator: 2, denominator: 4 }
+
+a.equals(b) // true
+```
+
 <br>
 
 <table><tr>

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -48,7 +48,7 @@ fn emit_inner(
         unused: &result.unused,
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
-        usable_equals: &result.usable_equals,
+        equality_index: &result.equality_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
     };

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -68,6 +68,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         checker.put_prelude_in_scope(&store);
 
         let order = std::mem::take(&mut graph_result.order);
+        let mut to_infer: Vec<String> = Vec::new();
         for module_id in order {
             if let Some(go_pkg) = module_id.strip_prefix("go:") {
                 if let Some(typedef) = get_go_stdlib_typedef(go_pkg, Target::host()) {
@@ -86,12 +87,20 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
 
             let prev_module_id = checker.cursor.module_id.clone();
             checker.cursor.module_id = module_id.to_string();
-
             store.store_module(&module_id, files);
             checker.register_module(&mut store, &module_id);
-            let module_files = checker.take_module_files(&mut store, &module_id);
-            InferCtx::new(&mut checker, &store).infer_module(&module_id, module_files);
+            checker.cursor.module_id = prev_module_id;
 
+            to_infer.push(module_id);
+        }
+
+        checker.finalize_equality(&mut store);
+
+        for module_id in &to_infer {
+            let prev_module_id = checker.cursor.module_id.clone();
+            checker.cursor.module_id = module_id.to_string();
+            let module_files = checker.take_module_files(&mut store, module_id);
+            InferCtx::new(&mut checker, &store).infer_module(module_id, module_files);
             checker.cursor.module_id = prev_module_id;
         }
 
@@ -258,6 +267,10 @@ impl InferResult {
 
     pub fn assert_infer_code(self, code: &str) -> Self {
         self.assert_code(&format!("infer.{}", code))
+    }
+
+    pub fn assert_attribute_code(self, code: &str) -> Self {
+        self.assert_code(&format!("attribute.{}", code))
     }
 
     fn assert_code(self, expected_code: &str) -> Self {

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -81,7 +81,8 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     checker.put_imported_modules_in_scope(&store, &imports);
 
     checker.register_types_and_values(&mut store, &ast, &Visibility::Private);
-    checker.record_usable_equals(&mut store);
+    checker.register_equality(&mut store, &ast);
+    checker.finalize_equality(&mut store);
 
     let mut typed_ast = vec![];
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -8,7 +8,7 @@ use syntax::{
     desugar,
     lex::Lexer,
     parse::Parser,
-    program::{Definition, File, FileImport, MutationInfo, UnusedInfo, UsableEquals, Visibility},
+    program::{Definition, EqualityIndex, File, FileImport, MutationInfo, UnusedInfo, Visibility},
     types::Symbol,
 };
 
@@ -104,7 +104,7 @@ impl CompiledTest {
             unused,
             mutations,
             ufcs_methods,
-            usable_equals,
+            equality_index,
             go_package_names,
             go_module_ids,
         ) = {
@@ -157,7 +157,6 @@ impl CompiledTest {
             checker.register_types_and_values(&mut store, &self.ast, &Visibility::Local);
             InferCtx::new(&mut checker, &store).check_const_cycles(&[self.ast.as_slice()]);
 
-            // Store AST in module so compute_module_ufcs can scan impl blocks (condition 3)
             let test_file_id = store.new_file_id();
             store.store_file(
                 TEST_MODULE_ID,
@@ -179,7 +178,8 @@ impl CompiledTest {
                 checker.ufcs_methods.extend(ufcs_entries);
             }
 
-            checker.record_usable_equals(&mut store);
+            checker.register_equality(&mut store, &self.ast);
+            checker.finalize_equality(&mut store);
 
             let mut typed_ast = vec![];
 
@@ -270,7 +270,7 @@ impl CompiledTest {
             }
 
             let ufcs_methods = std::mem::take(&mut checker.ufcs_methods);
-            let usable_equals = std::mem::take(&mut store.usable_equals);
+            let equality_index = std::mem::take(&mut store.equality_index);
             let go_package_names = store.go_package_names.clone();
             let go_module_ids: HashSet<String> = store
                 .modules
@@ -285,7 +285,7 @@ impl CompiledTest {
                 unused,
                 mutations,
                 ufcs_methods,
-                usable_equals,
+                equality_index,
                 go_package_names,
                 go_module_ids,
             )
@@ -299,7 +299,7 @@ impl CompiledTest {
             unused,
             mutations,
             ufcs_methods,
-            usable_equals,
+            equality_index,
             go_package_names,
             go_module_ids,
         }
@@ -314,7 +314,7 @@ pub struct InferenceResult {
     pub unused: UnusedInfo,
     pub mutations: MutationInfo,
     pub ufcs_methods: HashSet<(String, String)>,
-    pub usable_equals: UsableEquals,
+    pub equality_index: EqualityIndex,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
 }

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -57,6 +57,210 @@ fn lis_run(project: &Path, invocation: &Path, extra: &[&str]) -> std::process::O
     cmd.output().expect("failed to invoke lisette")
 }
 
+fn lis(project: &Path, subcommand: &str) -> std::process::Output {
+    let manifest = repo().join("Cargo.toml");
+    Command::new("cargo")
+        .args(["run", "--quiet", "--manifest-path"])
+        .arg(&manifest)
+        .args(["-p", "lisette", "--", subcommand])
+        .arg(project)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to invoke lisette")
+}
+
+const BOUND_MISMATCHED_BOX: &str = r#"
+pub struct Box<T: Comparable> { pub items: Slice<T> }
+
+impl<T: Ordered> Box<T> {
+  pub fn equals(self, other: Box<T>) -> bool {
+    self.items.equals(other.items)
+  }
+}
+"#;
+
+const WRAP_OVER_BOX: &str = r#"
+import "box"
+
+#[equality]
+pub struct Wrap { pub box: box.Box<int> }
+"#;
+
+fn assert_rejected_at_check(output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected a checker rejection:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("Cannot derive equality"),
+        "expected `Cannot derive equality` at check, got:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !combined.contains("invalid operation"),
+        "reached Go build instead of rejecting at check:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn parallel_equality_field_rejects_bound_mismatched_dependency() {
+    if !go_available() {
+        eprintln!(
+            "skipping parallel_equality_field_rejects_bound_mismatched_dependency: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/box")).unwrap();
+    fs::create_dir_all(project.join("src/wrap")).unwrap();
+    for pad in ["a", "b", "c"] {
+        fs::create_dir_all(project.join("src").join(pad)).unwrap();
+        fs::write(
+            project.join("src").join(pad).join(format!("{pad}.lis")),
+            "pub fn ping() -> int { 1 }\n",
+        )
+        .unwrap();
+    }
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/eqpar\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/box/box.lis"), BOUND_MISMATCHED_BOX).unwrap();
+    fs::write(project.join("src/wrap/wrap.lis"), WRAP_OVER_BOX).unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "wrap"
+import "box"
+import "a"
+import "b"
+import "c"
+
+fn main() {
+  let _ = a.ping()
+  let _ = b.ping()
+  let _ = c.ping()
+  let x = wrap.Wrap { box: box.Box { items: [1] } }
+  let y = wrap.Wrap { box: box.Box { items: [1] } }
+  let _ok = x.equals(y)
+}
+"#,
+    )
+    .unwrap();
+
+    assert_rejected_at_check(&lis(&project, "check"));
+}
+
+#[test]
+fn cached_equality_field_rejects_bound_mismatched_dependency() {
+    if !go_available() {
+        eprintln!(
+            "skipping cached_equality_field_rejects_bound_mismatched_dependency: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/box")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/eqcache\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/box/box.lis"), BOUND_MISMATCHED_BOX).unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"box\"\n\nfn main() {\n  let _b = box.Box { items: [1] }\n}\n",
+    )
+    .unwrap();
+
+    let first = lis(&project, "run");
+    assert!(
+        first.status.success(),
+        "first run should cache `box`:\nstderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    fs::create_dir_all(project.join("src/wrap")).unwrap();
+    fs::write(project.join("src/wrap/wrap.lis"), WRAP_OVER_BOX).unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "box"
+import "wrap"
+
+fn main() {
+  let x = wrap.Wrap { box: box.Box { items: [1] } }
+  let y = wrap.Wrap { box: box.Box { items: [1] } }
+  let _ok = x.equals(y)
+}
+"#,
+    )
+    .unwrap();
+
+    assert_rejected_at_check(&lis(&project, "check"));
+}
+
+#[test]
+fn imported_weaker_interface_bound_equals_accepted() {
+    if !go_available() {
+        eprintln!("skipping imported_weaker_interface_bound_equals_accepted: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/iface")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/iface_bound\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/iface/iface.lis"),
+        r#"pub interface Parent {
+  fn p(self)
+}
+
+pub interface Child {
+  embed Parent
+
+  fn c(self)
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "iface"
+
+#[equality]
+struct Box<T: iface.Child> { value: T }
+
+impl<T: iface.Parent> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+
+fn main() {}
+"#,
+    )
+    .unwrap();
+
+    let output = lis(&project, "check");
+    assert!(
+        output.status.success(),
+        "imported weaker interface bound should be accepted:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn run_executes_binary_in_invocation_cwd() {
     if !go_available() {
@@ -102,6 +306,258 @@ fn run_forwards_go_flags() {
     assert!(
         stdout.contains("FOUND_MARKER"),
         "program output unexpected with --go-flags:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_unused_equality_type_keeps_nested_user_equals() {
+    if !go_available() {
+        eprintln!("skipping run_unused_equality_type_keeps_nested_user_equals: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"eqprune\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+struct Inner { x: int }
+
+fn same(a: int, b: int) -> bool { a == b }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    same(self.x, other.x)
+  }
+}
+
+#[equality]
+struct Outer { inner: Inner }
+
+fn main() {
+  fmt.Println("OK")
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed (nested user equals or its helper likely pruned):\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("OK"),
+        "program did not run:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_used_equality_dispatches_to_nested_equals_with_helper() {
+    if !go_available() {
+        eprintln!(
+            "skipping run_used_equality_dispatches_to_nested_equals_with_helper: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"eqhelper\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+struct Inner { x: int }
+
+fn same(a: int, b: int) -> bool { a == b }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    same(self.x, other.x)
+  }
+}
+
+#[equality]
+struct Outer { inner: Inner }
+
+fn main() {
+  let a = Outer { inner: Inner { x: 1 } }
+  let b = Outer { inner: Inner { x: 1 } }
+  fmt.Println(a.equals(b))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("true"),
+        "expected `true`:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_equality_matching_parametrized_interface_bound_builds() {
+    if !go_available() {
+        eprintln!(
+            "skipping run_equality_matching_parametrized_interface_bound_builds: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"eqparam\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+struct Holder { tag: string }
+
+impl Holder {
+  fn p(self) -> string {
+    self.tag
+  }
+}
+
+#[equality]
+struct Box<T: Parent<string>> { value: T }
+
+impl<T: Parent<string>> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value.p() == other.value.p()
+  }
+}
+
+fn main() {
+  let a = Box { value: Holder { tag: "x" } }
+  let b = Box { value: Holder { tag: "y" } }
+  fmt.Println(a.equals(b))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("false"),
+        "expected `false`:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_equality_user_type_parametrized_bound_builds() {
+    if !go_available() {
+        eprintln!("skipping run_equality_user_type_parametrized_bound_builds: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"equserarg\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+struct Key { v: int }
+
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+struct Leaf { k: Key }
+
+impl Leaf {
+  fn p(self) -> Key {
+    self.k
+  }
+}
+
+#[equality]
+struct Box<T: Parent<Key>> { value: T }
+
+impl<T: Parent<Key>> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value.p().v == other.value.p().v
+  }
+}
+
+fn main() {
+  let a = Box { value: Leaf { k: Key { v: 1 } } }
+  let b = Box { value: Leaf { k: Key { v: 2 } } }
+  fmt.Println(a.equals(b))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("false"),
+        "expected `false`:\nstdout: {stdout}\nstderr: {stderr}"
     );
 }
 

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -61,7 +61,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         unused: &result.unused,
         mutations: &result.mutations,
         ufcs_methods: &result.ufcs_methods,
-        usable_equals: &result.usable_equals,
+        equality_index: &result.equality_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
     };

--- a/tests/spec/emit/snapshots/equality_empty_struct.snap
+++ b/tests/spec/emit/snapshots/equality_empty_struct.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Blank {}\n"
+---
+package main
+
+type Blank struct{}
+
+func (b Blank) equals(other Blank) bool {
+	return true
+}

--- a/tests/spec/emit/snapshots/equality_enum_mixed_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_mixed_variants.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nenum Message {\n  Quit,\n  Move { x: int, y: int },\n  Write(string),\n}\n"
+---
+package main
+
+func MakeMessageQuit() Message {
+	return Message{Tag: MessageQuit}
+}
+
+func MakeMessageMove(arg0 int, arg1 int) Message {
+	return Message{Tag: MessageMove, X: arg0, Y: arg1}
+}
+
+func MakeMessageWrite(arg0 string) Message {
+	return Message{Tag: MessageWrite, Write: arg0}
+}
+
+type MessageTag int
+
+const (
+	MessageQuit MessageTag = iota
+	MessageMove
+	MessageWrite
+)
+
+type Message struct {
+	Tag   MessageTag
+	X     int
+	Y     int
+	Write string
+}
+
+func (m Message) equals(other Message) bool {
+	if m.Tag != other.Tag {
+		return false
+	}
+	switch m.Tag {
+	case MessageMove:
+		return m.X == other.X && m.Y == other.Y
+	case MessageWrite:
+		return m.Write == other.Write
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_enum_payload_generic_synthesized_equality.snap
+++ b/tests/spec/emit/snapshots/equality_enum_payload_generic_synthesized_equality.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { items: Slice<T> }\n\n#[equality]\nenum Wrap { Wrapped(Box<int>) }\n"
+---
+package main
+
+import "slices"
+
+func MakeWrapWrapped(arg0 Box[int]) Wrap {
+	return Wrap{Tag: WrapWrapped, Wrapped: arg0}
+}
+
+type Box[T comparable] struct {
+	items []T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return slices.Equal(b.items, other.items)
+}
+
+type WrapTag int
+
+const (
+	WrapWrapped WrapTag = iota
+)
+
+type Wrap struct {
+	Tag     WrapTag
+	Wrapped Box[int]
+}
+
+func (w Wrap) equals(other Wrap) bool {
+	if w.Tag != other.Tag {
+		return false
+	}
+	switch w.Tag {
+	case WrapWrapped:
+		return w.Wrapped.equals(other.Wrapped)
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_enum_payload_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_payload_variants.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nenum Shape {\n  Circle(float64),\n  Rectangle(float64, float64),\n}\n"
+---
+package main
+
+func MakeShapeCircle(arg0 float64) Shape {
+	return Shape{Tag: ShapeCircle, Circle: arg0}
+}
+
+func MakeShapeRectangle(arg0 float64, arg1 float64) Shape {
+	return Shape{Tag: ShapeRectangle, Rectangle0: arg0, Rectangle1: arg1}
+}
+
+type ShapeTag int
+
+const (
+	ShapeCircle ShapeTag = iota
+	ShapeRectangle
+)
+
+type Shape struct {
+	Tag        ShapeTag
+	Circle     float64
+	Rectangle0 float64
+	Rectangle1 float64
+}
+
+func (s Shape) equals(other Shape) bool {
+	if s.Tag != other.Tag {
+		return false
+	}
+	switch s.Tag {
+	case ShapeCircle:
+		return s.Circle == other.Circle
+	case ShapeRectangle:
+		return s.Rectangle0 == other.Rectangle0 && s.Rectangle1 == other.Rectangle1
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_enum_slice_payload.snap
+++ b/tests/spec/emit/snapshots/equality_enum_slice_payload.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nenum Event {\n  Tags(Slice<string>),\n  Empty,\n}\n"
+---
+package main
+
+import "slices"
+
+func MakeEventTags(arg0 []string) Event {
+	return Event{Tag: EventTags, Tags: arg0}
+}
+
+func MakeEventEmpty() Event {
+	return Event{Tag: EventEmpty}
+}
+
+type EventTag int
+
+const (
+	EventTags EventTag = iota
+	EventEmpty
+)
+
+type Event struct {
+	Tag  EventTag
+	Tags []string
+}
+
+func (e Event) equals(other Event) bool {
+	if e.Tag != other.Tag {
+		return false
+	}
+	switch e.Tag {
+	case EventTags:
+		return slices.Equal(e.Tags, other.Tags)
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_enum_unit_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_unit_variants.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nenum Color { Red, Green, Blue }\n"
+---
+package main
+
+func MakeColorRed() Color {
+	return Color{Tag: ColorRed}
+}
+
+func MakeColorGreen() Color {
+	return Color{Tag: ColorGreen}
+}
+
+func MakeColorBlue() Color {
+	return Color{Tag: ColorBlue}
+}
+
+type ColorTag int
+
+const (
+	ColorRed ColorTag = iota
+	ColorGreen
+	ColorBlue
+)
+
+type Color struct {
+	Tag ColorTag
+}
+
+func (c Color) equals(other Color) bool {
+	return c.Tag == other.Tag
+}

--- a/tests/spec/emit/snapshots/equality_field_private_cross_module_equals_uses_native.snap
+++ b/tests/spec/emit/snapshots/equality_field_private_cross_module_equals_uses_native.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Foo { x: int }\n\nimpl Foo {\n  fn equals(self, other: int) -> bool {\n    false\n  }\n}\n\n#[equality]\nstruct Wrap { foo: Foo }\n"
+---
+package main
+
+type Foo struct {
+	x int
+}
+
+func (f Foo) equals(_ int) bool {
+	return false
+}
+
+type Wrap struct {
+	foo Foo
+}
+
+func (w Wrap) equals(other Wrap) bool {
+	return w.foo == other.foo
+}

--- a/tests/spec/emit/snapshots/equality_generic_struct_comparable.snap
+++ b/tests/spec/emit/snapshots/equality_generic_struct_comparable.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { value: T }\n"
+---
+package main
+
+type Box[T comparable] struct {
+	value T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return b.value == other.value
+}

--- a/tests/spec/emit/snapshots/equality_map_of_equality_struct_dispatches_equals.snap
+++ b/tests/spec/emit/snapshots/equality_map_of_equality_struct_dispatches_equals.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Order { id: int, tags: Slice<string> }\n\nfn test(a: Map<string, Order>, b: Map<string, Order>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import (
+	"maps"
+	"slices"
+)
+
+type Order struct {
+	id   int
+	tags []string
+}
+
+func (o Order) equals(other Order) bool {
+	return o.id == other.id && slices.Equal(o.tags, other.tags)
+}
+
+func test(a, b map[string]Order) bool {
+	return maps.EqualFunc(a, b, func(a_1 Order, b_2 Order) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/equality_matching_bound_generic_equals.snap
+++ b/tests/spec/emit/snapshots/equality_matching_bound_generic_equals.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { value: T }\n\nimpl<T: Comparable> Box<T> {\n  fn equals(self, other: Box<T>) -> bool {\n    self.value == other.value\n  }\n}\n"
+---
+package main
+
+type Box[T comparable] struct {
+	value T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return b.value == other.value
+}

--- a/tests/spec/emit/snapshots/equality_nested_generic_synthesized_equality.snap
+++ b/tests/spec/emit/snapshots/equality_nested_generic_synthesized_equality.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { items: Slice<T> }\n\n#[equality]\nstruct Wrap { box: Box<int> }\n"
+---
+package main
+
+import "slices"
+
+type Box[T comparable] struct {
+	items []T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return slices.Equal(b.items, other.items)
+}
+
+type Wrap struct {
+	box Box[int]
+}
+
+func (w Wrap) equals(other Wrap) bool {
+	return w.box.equals(other.box)
+}

--- a/tests/spec/emit/snapshots/equality_renamed_generic_param_equals.snap
+++ b/tests/spec/emit/snapshots/equality_renamed_generic_param_equals.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { value: T }\n\nimpl<U: Comparable> Box<U> {\n  fn equals(self, other: Box<U>) -> bool {\n    self.value == other.value\n  }\n}\n"
+---
+package main
+
+type Box[T comparable] struct {
+	value T
+}
+
+func (b Box[U]) equals(other Box[U]) bool {
+	return b.value == other.value
+}

--- a/tests/spec/emit/snapshots/equality_slice_of_equality_struct_dispatches_equals.snap
+++ b/tests/spec/emit/snapshots/equality_slice_of_equality_struct_dispatches_equals.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Order { id: int, tags: Slice<string> }\n\nfn test(a: Slice<Order>, b: Slice<Order>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+type Order struct {
+	id   int
+	tags []string
+}
+
+func (o Order) equals(other Order) bool {
+	return o.id == other.id && slices.Equal(o.tags, other.tags)
+}
+
+func test(a, b []Order) bool {
+	return slices.EqualFunc(a, b, func(a_1 Order, b_2 Order) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/equality_slice_of_generic_synthesized_equality.snap
+++ b/tests/spec/emit/snapshots/equality_slice_of_generic_synthesized_equality.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Comparable> { items: Slice<T> }\n\nfn test(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+type Box[T comparable] struct {
+	items []T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return slices.Equal(b.items, other.items)
+}
+
+func test(a, b []Box[int]) bool {
+	return slices.EqualFunc(a, b, func(a_1 Box[int], b_2 Box[int]) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/equality_struct_comparable_fields.snap
+++ b/tests/spec/emit/snapshots/equality_struct_comparable_fields.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Point { x: int, y: int }\n"
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x && p.y == other.y
+}

--- a/tests/spec/emit/snapshots/equality_struct_map_field.snap
+++ b/tests/spec/emit/snapshots/equality_struct_map_field.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Counts { name: string, totals: Map<string, int> }\n"
+---
+package main
+
+import "maps"
+
+type Counts struct {
+	name   string
+	totals map[string]int
+}
+
+func (c Counts) equals(other Counts) bool {
+	return c.name == other.name && maps.Equal(c.totals, other.totals)
+}

--- a/tests/spec/emit/snapshots/equality_struct_nested_equality_field.snap
+++ b/tests/spec/emit/snapshots/equality_struct_nested_equality_field.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Inner { items: Slice<int> }\n\n#[equality]\nstruct Outer { name: string, inner: Inner }\n"
+---
+package main
+
+import "slices"
+
+type Inner struct {
+	items []int
+}
+
+func (i Inner) equals(other Inner) bool {
+	return slices.Equal(i.items, other.items)
+}
+
+type Outer struct {
+	name  string
+	inner Inner
+}
+
+func (o Outer) equals(other Outer) bool {
+	return o.name == other.name && o.inner.equals(other.inner)
+}

--- a/tests/spec/emit/snapshots/equality_struct_ref_field_compares_by_identity.snap
+++ b/tests/spec/emit/snapshots/equality_struct_ref_field_compares_by_identity.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Node { value: int, next: Ref<Node> }\n"
+---
+package main
+
+type Node struct {
+	value int
+	next  *Node
+}
+
+func (n Node) equals(other Node) bool {
+	return n.value == other.value && n.next == other.next
+}

--- a/tests/spec/emit/snapshots/equality_struct_synthesizes_equals.snap
+++ b/tests/spec/emit/snapshots/equality_struct_synthesizes_equals.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Order { id: int, tags: Slice<string> }\n"
+---
+package main
+
+import "slices"
+
+type Order struct {
+	id   int
+	tags []string
+}
+
+func (o Order) equals(other Order) bool {
+	return o.id == other.id && slices.Equal(o.tags, other.tags)
+}

--- a/tests/spec/emit/snapshots/equality_synthesized_keeps_nested_slice_user_equals_live.snap
+++ b/tests/spec/emit/snapshots/equality_synthesized_keeps_nested_slice_user_equals_live.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Inner { x: int }\n\nimpl Inner {\n  fn equals(self, other: Inner) -> bool {\n    self.x == other.x\n  }\n}\n\n#[equality]\nstruct Outer { items: Slice<Inner> }\n"
+---
+package main
+
+import "slices"
+
+type Inner struct {
+	x int
+}
+
+func (i Inner) equals(other Inner) bool {
+	return i.x == other.x
+}
+
+type Outer struct {
+	items []Inner
+}
+
+func (o Outer) equals(other Outer) bool {
+	return slices.EqualFunc(o.items, other.items, func(a_1 Inner, b_2 Inner) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/equality_synthesized_keeps_nested_user_equals_live.snap
+++ b/tests/spec/emit/snapshots/equality_synthesized_keeps_nested_user_equals_live.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Inner { x: int }\n\nimpl Inner {\n  fn equals(self, other: Inner) -> bool {\n    self.x == other.x\n  }\n}\n\n#[equality]\nstruct Outer { inner: Inner }\n"
+---
+package main
+
+type Inner struct {
+	x int
+}
+
+func (i Inner) equals(other Inner) bool {
+	return i.x == other.x
+}
+
+type Outer struct {
+	inner Inner
+}
+
+func (o Outer) equals(other Outer) bool {
+	return o.inner.equals(other.inner)
+}

--- a/tests/spec/emit/snapshots/equality_user_equals_over_function_field.snap
+++ b/tests/spec/emit/snapshots/equality_user_equals_over_function_field.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Handler { run: fn(int) -> int }\n\nimpl Handler {\n  fn equals(self, other: Handler) -> bool {\n    true\n  }\n}\n"
+---
+package main
+
+type Handler struct {
+	run func(int) int
+}
+
+func (h Handler) equals(_ Handler) bool {
+	return true
+}

--- a/tests/spec/emit/snapshots/equality_user_equals_suppresses_synthesis.snap
+++ b/tests/spec/emit/snapshots/equality_user_equals_suppresses_synthesis.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Caseless { value: string }\n\nimpl Caseless {\n  fn equals(self, other: Caseless) -> bool {\n    self.value == other.value\n  }\n}\n"
+---
+package main
+
+type Caseless struct {
+	value string
+}
+
+func (c Caseless) equals(other Caseless) bool {
+	return c.value == other.value
+}

--- a/tests/spec/emit/snapshots/equality_weaker_interface_method_bound_is_usable.snap
+++ b/tests/spec/emit/snapshots/equality_weaker_interface_method_bound_is_usable.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+description: "\ninterface Parent {\n  fn p(self)\n}\n\ninterface Child {\n  embed Parent\n\n  fn c(self)\n}\n\n#[equality]\nstruct Box<T: Child> { value: T }\n\nimpl<T: Parent> Box<T> {\n  fn equals(self, other: Box<T>) -> bool {\n    true\n  }\n}\n"
+---
+package main
+
+type Parent interface {
+	p()
+}
+
+type Child interface {
+	Parent
+	c()
+}
+
+type Box[T interface {
+	Child
+	Parent
+}] struct {
+	value T
+}
+
+func (b Box[T]) equals(_ Box[T]) bool {
+	return true
+}

--- a/tests/spec/emit/snapshots/equality_weaker_method_bound_is_usable.snap
+++ b/tests/spec/emit/snapshots/equality_weaker_method_bound_is_usable.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/types.rs
+description: "\n#[equality]\nstruct Box<T: Ordered> { value: T }\n\nimpl<T: Comparable> Box<T> {\n  fn equals(self, other: Box<T>) -> bool {\n    self.value == other.value\n  }\n}\n"
+---
+package main
+
+import "cmp"
+
+type Box[T interface {
+	cmp.Ordered
+	comparable
+}] struct {
+	value T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return b.value == other.value
+}

--- a/tests/spec/emit/snapshots/map_equals_keeps_user_equals_live.snap
+++ b/tests/spec/emit/snapshots/map_equals_keeps_user_equals_live.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Point { x: int }\n\nimpl Point {\n  fn equals(self, other: Point) -> bool {\n    self.x == other.x\n  }\n}\n\nfn test(a: Map<string, Point>, b: Map<string, Point>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "maps"
+
+type Point struct {
+	x int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func test(a, b map[string]Point) bool {
+	return maps.EqualFunc(a, b, func(a_1 Point, b_2 Point) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/snapshots/slice_equals_keeps_user_equals_live.snap
+++ b/tests/spec/emit/snapshots/slice_equals_keeps_user_equals_live.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Point { x: int }\n\nimpl Point {\n  fn equals(self, other: Point) -> bool {\n    self.x == other.x\n  }\n}\n\nfn test(a: Slice<Point>, b: Slice<Point>) -> bool {\n  a.equals(b)\n}\n"
+---
+package main
+
+import "slices"
+
+type Point struct {
+	x int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func test(a, b []Point) bool {
+	return slices.EqualFunc(a, b, func(a_1 Point, b_2 Point) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -189,6 +189,368 @@ impl Point {
 }
 
 #[test]
+fn equality_struct_comparable_fields() {
+    let input = r#"
+#[equality]
+struct Point { x: int, y: int }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_struct_synthesizes_equals() {
+    let input = r#"
+#[equality]
+struct Order { id: int, tags: Slice<string> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_struct_ref_field_compares_by_identity() {
+    let input = r#"
+#[equality]
+struct Node { value: int, next: Ref<Node> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_struct_map_field() {
+    let input = r#"
+#[equality]
+struct Counts { name: string, totals: Map<string, int> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_struct_nested_equality_field() {
+    let input = r#"
+#[equality]
+struct Inner { items: Slice<int> }
+
+#[equality]
+struct Outer { name: string, inner: Inner }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_slice_of_equality_struct_dispatches_equals() {
+    let input = r#"
+#[equality]
+struct Order { id: int, tags: Slice<string> }
+
+fn test(a: Slice<Order>, b: Slice<Order>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_map_of_equality_struct_dispatches_equals() {
+    let input = r#"
+#[equality]
+struct Order { id: int, tags: Slice<string> }
+
+fn test(a: Map<string, Order>, b: Map<string, Order>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_empty_struct() {
+    let input = r#"
+#[equality]
+struct Blank {}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_generic_struct_comparable() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_user_equals_suppresses_synthesis() {
+    let input = r#"
+#[equality]
+struct Caseless { value: string }
+
+impl Caseless {
+  fn equals(self, other: Caseless) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_unit_variants() {
+    let input = r#"
+#[equality]
+enum Color { Red, Green, Blue }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_payload_variants() {
+    let input = r#"
+#[equality]
+enum Shape {
+  Circle(float64),
+  Rectangle(float64, float64),
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_mixed_variants() {
+    let input = r#"
+#[equality]
+enum Message {
+  Quit,
+  Move { x: int, y: int },
+  Write(string),
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_slice_payload() {
+    let input = r#"
+#[equality]
+enum Event {
+  Tags(Slice<string>),
+  Empty,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_user_equals_over_function_field() {
+    let input = r#"
+#[equality]
+struct Handler { run: fn(int) -> int }
+
+impl Handler {
+  fn equals(self, other: Handler) -> bool {
+    true
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_matching_bound_generic_equals() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_weaker_method_bound_is_usable() {
+    let input = r#"
+#[equality]
+struct Box<T: Ordered> { value: T }
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_weaker_interface_method_bound_is_usable() {
+    let input = r#"
+interface Parent {
+  fn p(self)
+}
+
+interface Child {
+  embed Parent
+
+  fn c(self)
+}
+
+#[equality]
+struct Box<T: Child> { value: T }
+
+impl<T: Parent> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_field_private_cross_module_equals_uses_native() {
+    let input = r#"
+struct Foo { x: int }
+
+impl Foo {
+  fn equals(self, other: int) -> bool {
+    false
+  }
+}
+
+#[equality]
+struct Wrap { foo: Foo }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_slice_of_generic_synthesized_equality() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { items: Slice<T> }
+
+fn test(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_nested_generic_synthesized_equality() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { items: Slice<T> }
+
+#[equality]
+struct Wrap { box: Box<int> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_payload_generic_synthesized_equality() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { items: Slice<T> }
+
+#[equality]
+enum Wrap { Wrapped(Box<int>) }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_renamed_generic_param_equals() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+impl<U: Comparable> Box<U> {
+  fn equals(self, other: Box<U>) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_equals_keeps_user_equals_live() {
+    let input = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn test(a: Slice<Point>, b: Slice<Point>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_equals_keeps_user_equals_live() {
+    let input = r#"
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn test(a: Map<string, Point>, b: Map<string, Point>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_synthesized_keeps_nested_user_equals_live() {
+    let input = r#"
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    self.x == other.x
+  }
+}
+
+#[equality]
+struct Outer { inner: Inner }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_synthesized_keeps_nested_slice_user_equals_live() {
+    let input = r#"
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    self.x == other.x
+  }
+}
+
+#[equality]
+struct Outer { items: Slice<Inner> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn display_satisfies_display_interface() {
     let input = r#"
 interface Display {
@@ -3925,42 +4287,6 @@ fn main() {
   let a = Box { value: 1 }
   let b = Box { value: 2 }
   let _ = a.less(b)
-}
-"#;
-    assert_emit_snapshot!(input);
-}
-
-#[test]
-fn slice_equals_dispatches_to_element_equals() {
-    let input = r#"
-struct Point { x: int }
-
-impl Point {
-  fn equals(self, other: Point) -> bool {
-    self.x == other.x
-  }
-}
-
-fn test(a: Slice<Point>, b: Slice<Point>) -> bool {
-  a.equals(b)
-}
-"#;
-    assert_emit_snapshot!(input);
-}
-
-#[test]
-fn map_equals_dispatches_to_value_equals() {
-    let input = r#"
-struct Point { x: int }
-
-impl Point {
-  fn equals(self, other: Point) -> bool {
-    self.x == other.x
-  }
-}
-
-fn test(a: Map<string, Point>, b: Map<string, Point>) -> bool {
-  a.equals(b)
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6296,36 +6296,6 @@ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
 }
 
 #[test]
-fn container_equals_map_non_comparable_key_rejected() {
-    let input = r#"
-struct Key { tags: Slice<int> }
-
-fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
-  a.equals(b)
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn container_equals_element_with_bound_mismatched_equals_rejected() {
-    let input = r#"
-struct Box<T> { value: T }
-
-impl<T: Comparable> Box<T> {
-  fn equals(self, other: Box<T>) -> bool {
-    self.value == other.value
-  }
-}
-
-fn test(a: Slice<Box<Slice<int>>>, b: Slice<Box<Slice<int>>>) -> bool {
-  a.equals(b)
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
 fn infer_not_comparable_function() {
     let input = r#"
 fn test() {
@@ -8150,6 +8120,1047 @@ impl Box<int> {
 }
 
 #[test]
+fn equality_rejects_function_field() {
+    let input = r#"
+#[equality]
+struct Handler {
+  on_done: fn(int) -> int,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_interface_field() {
+    let input = r#"
+interface Drawable {
+  fn draw(self)
+}
+
+#[equality]
+struct Widget {
+  shape: Drawable,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_unbounded_generic_field() {
+    let input = r#"
+#[equality]
+struct Box<T> {
+  value: T,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_nested_noncomparable_struct() {
+    let input = r#"
+struct Inner {
+  items: Slice<int>,
+}
+
+#[equality]
+struct Outer {
+  inner: Inner,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_enum_rejects_function_payload() {
+    let input = r#"
+#[equality]
+enum Action {
+  Run(fn(int) -> int),
+  Stop,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_on_function() {
+    let input = r#"
+#[equality]
+fn run() -> int {
+  0
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_on_struct_field() {
+    let input = r#"
+struct Config {
+  #[equality]
+  value: int,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_on_tuple_struct() {
+    let input = r#"
+#[equality]
+struct Pair(int, int)
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_with_arguments() {
+    let input = r#"
+#[equality(foo)]
+struct Point { x: int, y: int }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn compare_noncomparable_struct_suggests_equality() {
+    let input = r#"
+struct Holder {
+  items: Slice<int>,
+}
+
+fn test(a: Holder, b: Holder) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn compare_equality_struct_suggests_equals() {
+    let input = r#"
+#[equality]
+struct Holder {
+  items: Slice<int>,
+}
+
+fn test(a: Holder, b: Holder) {
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_nested_wrong_signature_equals() {
+    let input = r#"
+struct Bad { items: Slice<int> }
+
+impl Bad {
+  fn equals(self, other: int) -> bool { true }
+}
+
+#[equality]
+struct Outer { bad: Bad }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_conflicting_user_equals() {
+    let input = r#"
+type Flag = bool
+
+#[equality]
+struct Foo { value: int }
+
+impl Foo {
+  fn equals(self, other: Foo) -> Flag { true }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_conflicts_with_unexported_equals() {
+    let input = r#"
+#[equality]
+struct Point { x: int }
+
+impl Point {
+  #[go(unexported)]
+  fn equals(self, other: Point) -> bool { false }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_conflicts_with_unexported_wrong_signature_equals() {
+    let input = r#"
+#[equality]
+struct Point { x: int }
+
+impl Point {
+  #[go(unexported)]
+  fn equals(self, other: int) -> bool { false }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_on_type_alias() {
+    let input = r#"
+#[equality]
+type Foo = int
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_in_typedef_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.d.lis",
+        "#[equality]\npub struct Point { pub x: int, pub y: int }",
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("attribute.equality_in_typedef")),
+        "expected `#[equality]` in a typedef to be rejected, got codes: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_rejects_cross_module_private_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "item.lis",
+        r#"
+pub struct Item { pub tags: Slice<string> }
+
+impl Item {
+  fn equals(self, other: Item) -> bool {
+    self.tags.equals(other.tags)
+  }
+}
+"#,
+    );
+
+    let source = r#"
+import "models"
+
+#[equality]
+struct Holder { item: models.Item }
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn equality_rejects_specialized_equals() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+impl Box<int> {
+  fn equals(self, other: Box<int>) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_ufcs_lowered_equals_single_source() {
+    let input = r#"
+#[equality]
+struct Pair<T: Comparable> {
+  f: fn() -> T,
+  a: T,
+}
+
+impl<T: Comparable> Pair<T> {
+  fn equals(self, other: Pair<T>) -> bool {
+    self.a == other.a
+  }
+}
+
+impl Pair<int> {
+  fn get(self) -> int {
+    self.a
+  }
+}
+"#;
+    crate::_harness::infer::infer(input).assert_attribute_code("equality_specialized_equals");
+}
+
+#[test]
+fn equality_rejects_ufcs_lowered_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+#[equality]
+struct Pair<T: Comparable> {
+  f: fn() -> T,
+  a: T,
+}
+
+impl<T: Comparable> Pair<T> {
+  fn equals(self, other: Pair<T>) -> bool {
+    self.a == other.a
+  }
+}
+
+impl Pair<int> {
+  fn get(self) -> int {
+    self.a
+  }
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("attribute.equality_specialized_equals")),
+        "a UFCS-lowered `equals` is emitted as a free function and must be rejected so synthesis does not run over un-gated fields, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_rejects_field_whose_equals_is_ufcs_lowered() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+#[equality]
+struct Wrap {
+  b: Box<int>,
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("attribute.cannot_derive_equality")),
+        "Box's `equals` is UFCS-lowered (a free function), so a `#[equality]` type with a `Box<int>` field cannot derive equality and must be rejected rather than emitting `b.equals(..)` Go that fails to build, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn container_equals_rejected_for_ufcs_lowered_element_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+fn cmp(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {
+  a.equals(b)
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.not_equatable")),
+        "a slice of a type whose `equals` is UFCS-lowered cannot use `.equals()`, so it must be rejected rather than emitting Go that fails to build, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn container_equals_allowed_for_ufcs_non_equality_method_named_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self) -> bool {
+    true
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+fn cmp(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {
+  a.equals(b)
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result.errors.is_empty(),
+        "`fn equals(self) -> bool` is not custom equality, so a comparable `Box<int>` slice must fall back to `==`, not be rejected: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_rejects_enum_payload_whose_equals_is_ufcs_lowered() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+#[equality]
+enum E {
+  V(Box<int>),
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("attribute.cannot_derive_equality")),
+        "an enum payload whose `equals` is UFCS-lowered must be rejected like a struct field, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn container_equals_rejected_for_ufcs_lowered_map_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+fn cmp(a: Map<int, Box<int>>, b: Map<int, Box<int>>) -> bool {
+  a.equals(b)
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.not_equatable")),
+        "a map value whose `equals` is UFCS-lowered must be rejected like a slice element, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn container_equals_allowed_for_ufcs_lowered_comparable_map_key() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.lis",
+        r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+impl<T: Comparable> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+
+impl Box<int> {
+  fn get(self) -> int {
+    self.value
+  }
+}
+
+fn cmp(a: Map<Box<int>, int>, b: Map<Box<int>, int>) -> bool {
+  a.equals(b)
+}
+"#,
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        result.errors.is_empty(),
+        "a map key is compared with `==`, so a comparable `Box<int>` key must be allowed even though its `equals` is UFCS-lowered, got: {:?}",
+        result
+            .errors
+            .iter()
+            .filter_map(|e| e.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_rejects_pointer_receiver_equals() {
+    let input = r#"
+#[equality]
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self: Ref<Inner>, other: Ref<Inner>) -> bool { true }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_public_type_private_equals_cross_module() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "item.lis",
+        r#"
+#[equality]
+pub struct Item { pub tags: Slice<string> }
+
+impl Item {
+  fn equals(self, other: Item) -> bool {
+    self.tags.equals(other.tags)
+  }
+}
+"#,
+    );
+
+    let source = r#"
+import "models"
+
+#[equality]
+struct Holder { item: models.Item }
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn equality_rejects_bounded_equals() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value < other.value
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_stronger_interface_bound_equals() {
+    let input = r#"
+interface Parent {
+  fn p(self)
+}
+
+interface Child {
+  embed Parent
+
+  fn c(self)
+}
+
+#[equality]
+struct Box<T: Parent> { value: T }
+
+impl<T: Child> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_mismatched_generic_interface_bound_equals() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+#[equality]
+struct Box<T: Parent<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_mismatched_user_type_interface_bound_equals() {
+    let input = r#"
+struct Key { v: int }
+struct Other { v: int }
+
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+#[equality]
+struct Box<T: Parent<Key>> { value: T }
+
+impl<T: Parent<Other>> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_embedded_generic_parent_bound_equals() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+interface Child<T> {
+  embed Parent<T>
+
+  fn c(self)
+}
+
+#[equality]
+struct Box<T: Child<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T: Parent<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn less(self, _other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_inherited_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+interface Child<T> {
+  embed Parent<T>
+  fn c(self)
+}
+
+struct Box<T: Child<string>> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn less(self, _other: Box<T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_type_variable_bound_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T: Parent<T>> { value: T }
+
+impl<T: Parent<string>> Box<T> {
+  fn label(self) -> string {
+    self.value.p()
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_cross_impl_interface_instantiations_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<T: Parent<string>> Box<T> {
+  fn as_string(self) -> string { self.value.p() }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_conflicting_cross_impl_renamed_params_rejected() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<U: Parent<int>> Box<U> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<V: Parent<string>> Box<V> {
+  fn as_string(self) -> string { self.value.p() }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn impl_redundant_same_interface_instantiation_accepted() {
+    let input = r#"
+interface Parent<T> { fn p(self) -> T }
+
+struct Box<T> { value: T }
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int(self) -> int { self.value.p() }
+}
+
+impl<T: Parent<int>> Box<T> {
+  fn as_int_again(self) -> int { self.value.p() }
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    result.assert_no_errors();
+}
+
+#[test]
+fn container_equals_rejects_bound_mismatched_user_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Box<T: Comparable> { value: T }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value < other.value
+  }
+}
+
+fn test<T: Comparable>(a: Slice<Box<T>>, b: Slice<Box<T>>) -> bool {
+  a.equals(b)
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn equality_field_rejects_bound_mismatched_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Box<T: Comparable> { items: Slice<T> }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.items.equals(other.items)
+  }
+}
+
+#[equality]
+struct Wrap { box: Box<int> }
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn equality_enum_payload_rejects_bound_mismatched_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Box<T: Comparable> { items: Slice<T> }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.items.equals(other.items)
+  }
+}
+
+#[equality]
+enum Wrap { Wrapped(Box<int>) }
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn equality_field_comparable_with_bound_mismatched_equals_rejected() {
+    let input = r#"
+struct Box<T: Comparable> { value: T }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value < other.value
+  }
+}
+
+#[equality]
+struct Wrap { box: Box<int> }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn container_equals_rejects_bound_mismatched_comparable_element() {
+    let input = r#"
+struct Box<T: Comparable> { value: T }
+
+impl<T: Ordered> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value < other.value
+  }
+}
+
+fn test(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_map_non_comparable_key_rejected() {
+    let input = r#"
+#[equality]
+struct Key { tags: Slice<int> }
+
+#[equality]
+struct Index { values: Map<Key, int> }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn container_equals_map_non_comparable_key_rejected() {
+    let input = r#"
+struct Key { tags: Slice<int> }
+
+fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_partial_generic_equals() {
+    let input = r#"
+#[equality]
+struct Pair<A, B> { a: A, b: B }
+
+impl<T> Pair<T, T> {
+  fn equals(self, other: Pair<T, T>) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_method_with_extra_generic() {
+    let input = r#"
+#[equality]
+struct Handler { run: fn(int) -> int }
+
+impl Handler {
+  fn equals<U>(self, other: Handler) -> bool {
+    true
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_rejects_impl_with_extra_generic() {
+    let input = r#"
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+impl<T: Comparable, U> Box<T> {
+  fn equals(self, other: Box<T>) -> bool {
+    self.value == other.value
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn container_equals_rejected_for_extra_generic_equals() {
+    let input = r#"
+struct Handler { run: fn(int) -> int }
+
+impl Handler {
+  fn equals<U>(self, other: Handler) -> bool {
+    true
+  }
+}
+
+fn test(a: Slice<Handler>, b: Slice<Handler>) -> bool {
+  a.equals(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn compare_tuple_struct_with_slice() {
+    let input = r#"
+struct Pair(Slice<int>)
+
+fn test(a: Pair, b: Pair) -> bool {
+  a == b
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn interpolate_struct_without_stringer() {
     let input = r#"
 struct Point { x: int, y: int }
@@ -8796,112 +9807,4 @@ fn main() {
 }
 "#;
     assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_conflicting_bound_rejected() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-struct Box<T: Parent<string>> { value: T }
-
-impl<T: Parent<int>> Box<T> {
-  fn less(self, _other: Box<T>) -> bool {
-    true
-  }
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_conflicting_inherited_bound_rejected() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-interface Child<T> {
-  embed Parent<T>
-  fn c(self)
-}
-
-struct Box<T: Child<string>> { value: T }
-
-impl<T: Parent<int>> Box<T> {
-  fn less(self, _other: Box<T>) -> bool {
-    true
-  }
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_conflicting_type_variable_bound_rejected() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-struct Box<T: Parent<T>> { value: T }
-
-impl<T: Parent<string>> Box<T> {
-  fn label(self) -> string {
-    self.value.p()
-  }
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_conflicting_cross_impl_interface_instantiations_rejected() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-struct Box<T> { value: T }
-
-impl<T: Parent<int>> Box<T> {
-  fn as_int(self) -> int { self.value.p() }
-}
-
-impl<T: Parent<string>> Box<T> {
-  fn as_string(self) -> string { self.value.p() }
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_conflicting_cross_impl_renamed_params_rejected() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-struct Box<T> { value: T }
-
-impl<U: Parent<int>> Box<U> {
-  fn as_int(self) -> int { self.value.p() }
-}
-
-impl<V: Parent<string>> Box<V> {
-  fn as_string(self) -> string { self.value.p() }
-}
-"#;
-    assert_infer_error_snapshot!(input);
-}
-
-#[test]
-fn impl_redundant_same_interface_instantiation_accepted() {
-    let input = r#"
-interface Parent<T> { fn p(self) -> T }
-
-struct Box<T> { value: T }
-
-impl<T: Parent<int>> Box<T> {
-  fn as_int(self) -> int { self.value.p() }
-}
-
-impl<T: Parent<int>> Box<T> {
-  fn as_int_again(self) -> int { self.value.p() }
-}
-"#;
-    let result = crate::_harness::infer::infer(input);
-    result.assert_no_errors();
 }

--- a/tests/ui/errors/snapshots/compare_equality_struct_suggests_equals.snap
+++ b/tests/ui/errors/snapshots/compare_equality_struct_suggests_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:8:16]
+ 7 │ fn test(a: Holder, b: Holder) {
+ 8 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Holder` cannot be compared with `==`
+ 9 │ }
+   ╰────
+  help: Use `.equals()` to compare `Holder` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/compare_noncomparable_struct_suggests_equality.snap
+++ b/tests/ui/errors/snapshots/compare_noncomparable_struct_suggests_equality.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+   ╭─[test.lis:7:16]
+ 6 │ fn test(a: Holder, b: Holder) {
+ 7 │   let result = a == b;
+   ·                ┬
+   ·                ╰── `Holder` cannot be compared with `==`
+ 8 │ }
+   ╰────
+  help: Mark `Holder` with `#[equality]` to compare it with `.equals()` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/compare_tuple_struct_with_slice.snap
+++ b/tests/ui/errors/snapshots/compare_tuple_struct_with_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:5:3]
+ 4 │ fn test(a: Pair, b: Pair) -> bool {
+ 5 │   a == b
+   ·   ┬
+   ·   ╰── `Pair` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: The `==` and `!=` operators cannot be used on slices because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/container_equals_rejected_for_extra_generic_equals.snap
+++ b/tests/ui/errors/snapshots/container_equals_rejected_for_extra_generic_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+    ╭─[test.lis:11:3]
+ 10 │ fn test(a: Slice<Handler>, b: Slice<Handler>) -> bool {
+ 11 │   a.equals(b)
+    ·   ┬
+    ·   ╰── cannot be compared
+ 12 │ }
+    ╰────
+  help: `Slice<Handler>` cannot be compared because a struct containing non-comparable fields cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/container_equals_rejects_bound_mismatched_comparable_element.snap
+++ b/tests/ui/errors/snapshots/container_equals_rejects_bound_mismatched_comparable_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+    ╭─[test.lis:11:3]
+ 10 │ fn test(a: Slice<Box<int>>, b: Slice<Box<int>>) -> bool {
+ 11 │   a.equals(b)
+    ·   ┬
+    ·   ╰── cannot be compared
+ 12 │ }
+    ╰────
+  help: `Slice<Box<int>>` cannot be compared because a type whose `equals` requires stricter bounds cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/container_equals_rejects_bound_mismatched_user_equals.snap
+++ b/tests/ui/errors/snapshots/container_equals_rejects_bound_mismatched_user_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Invalid comparison
+    ╭─[main.lis:11:3]
+ 10 │ fn test<T: Comparable>(a: Slice<Box<T>>, b: Slice<Box<T>>) -> bool {
+ 11 │   a.equals(b)
+    ·   ┬
+    ·   ╰── cannot be compared
+ 12 │ }
+    ╰────
+  help: `Slice<Box<T>>` cannot be compared because a struct containing non-comparable fields cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/equality_conflicting_user_equals.snap
+++ b/tests/ui/errors/snapshots/equality_conflicting_user_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with your `equals`
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 5 │ struct Foo { value: int }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_conflicting_equals]

--- a/tests/ui/errors/snapshots/equality_conflicts_with_unexported_equals.snap
+++ b/tests/ui/errors/snapshots/equality_conflicts_with_unexported_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with your `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Point { x: int }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_conflicting_equals]

--- a/tests/ui/errors/snapshots/equality_conflicts_with_unexported_wrong_signature_equals.snap
+++ b/tests/ui/errors/snapshots/equality_conflicts_with_unexported_wrong_signature_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with your `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Point { x: int }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_conflicting_equals]

--- a/tests/ui/errors/snapshots/equality_enum_payload_rejects_bound_mismatched_equals.snap
+++ b/tests/ui/errors/snapshots/equality_enum_payload_rejects_bound_mismatched_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+    ╭─[main.lis:11:13]
+ 10 │ #[equality]
+ 11 │ enum Wrap { Wrapped(Box<int>) }
+    ·             ───┬───
+    ·                ╰── `Wrapped` cannot be compared
+    ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Wrap` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_enum_rejects_function_payload.snap
+++ b/tests/ui/errors/snapshots/equality_enum_rejects_function_payload.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:4:3]
+ 3 │ enum Action {
+ 4 │   Run(fn(int) -> int),
+   ·   ─┬─
+   ·    ╰── `Run` cannot be compared
+ 5 │   Stop,
+   ╰────
+  help: `#[equality]` cannot compare functions. Give `Action` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_field_comparable_with_bound_mismatched_equals_rejected.snap
+++ b/tests/ui/errors/snapshots/equality_field_comparable_with_bound_mismatched_equals_rejected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+    ╭─[test.lis:11:15]
+ 10 │ #[equality]
+ 11 │ struct Wrap { box: Box<int> }
+    ·               ─┬─
+    ·                ╰── `box` cannot be compared
+    ╰────
+  help: `#[equality]` cannot compare a type whose `equals` requires stricter bounds. Give `Wrap` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_field_rejects_bound_mismatched_equals.snap
+++ b/tests/ui/errors/snapshots/equality_field_rejects_bound_mismatched_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+    ╭─[main.lis:11:15]
+ 10 │ #[equality]
+ 11 │ struct Wrap { box: Box<int> }
+    ·               ─┬─
+    ·                ╰── `box` cannot be compared
+    ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Wrap` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_map_non_comparable_key_rejected.snap
+++ b/tests/ui/errors/snapshots/equality_map_non_comparable_key_rejected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:6:16]
+ 5 │ #[equality]
+ 6 │ struct Index { values: Map<Key, int> }
+   ·                ───┬──
+   ·                   ╰── `values` cannot be compared
+   ╰────
+  help: `#[equality]` cannot compare a map with a non-comparable key. Give `Index` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_on_function.snap
+++ b/tests/ui/errors/snapshots/equality_on_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` not on a struct or enum
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── not on a struct or enum
+ 3 │ fn run() -> int {
+   ╰────
+  help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/equality_on_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` not on a struct or enum
+   ╭─[test.lis:3:3]
+ 2 │ struct Config {
+ 3 │   #[equality]
+   ·   ─────┬─────
+   ·        ╰── not on a struct or enum
+ 4 │   value: int,
+   ╰────
+  help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_on_tuple_struct.snap
+++ b/tests/ui/errors/snapshots/equality_on_tuple_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` on a tuple struct
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── tuple structs and newtypes are not supported
+ 3 │ struct Pair(int, int)
+   ╰────
+  help: Give the type named fields, or hand-write an `equals` method · code: [attribute.equality_on_tuple_struct]

--- a/tests/ui/errors/snapshots/equality_on_type_alias.snap
+++ b/tests/ui/errors/snapshots/equality_on_type_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` not on a struct or enum
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── not on a struct or enum
+ 3 │ type Foo = int
+   ╰────
+  help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_rejects_bounded_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_bounded_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a bounded `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Box<T: Comparable> { value: T }
+   ╰────
+  help: A hand-written `equals` must carry the same generic bounds as the type, or it strengthens the type for every instantiation. Match the type's bounds, or remove `#[equality]` · code: [attribute.equality_bounded_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_cross_module_private_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_cross_module_private_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[main.lis:5:17]
+ 4 │ #[equality]
+ 5 │ struct Holder { item: models.Item }
+   ·                 ──┬─
+   ·                   ╰── `item` cannot be compared
+   ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Holder` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_embedded_generic_parent_bound_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_embedded_generic_parent_bound_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+    ╭─[test.lis:15:9]
+ 14 │ 
+ 15 │ impl<T: Parent<int>> Box<T> {
+    ·         ─────┬─────
+    ·              ╰── this bound cannot strengthen the receiver type
+ 16 │   fn equals(self, other: Box<T>) -> bool {
+    ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]

--- a/tests/ui/errors/snapshots/equality_rejects_function_field.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_function_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:4:3]
+ 3 │ struct Handler {
+ 4 │   on_done: fn(int) -> int,
+   ·   ───┬───
+   ·      ╰── `on_done` cannot be compared
+ 5 │ }
+   ╰────
+  help: `#[equality]` cannot compare functions. Give `Handler` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_impl_with_extra_generic.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_impl_with_extra_generic.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a specialized `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Box<T: Comparable> { value: T }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool` over the whole type. An `equals` over a partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`), or one with extra type parameters (`fn equals<U>`, `impl<T, U> Box<T>`), is emitted as a free function and cannot satisfy `#[equality]`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_specialized_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_interface_field.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_interface_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:8:3]
+ 7 │ struct Widget {
+ 8 │   shape: Drawable,
+   ·   ──┬──
+   ·     ╰── `shape` cannot be compared
+ 9 │ }
+   ╰────
+  help: `#[equality]` cannot compare interface values. Give `Widget` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_method_with_extra_generic.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_method_with_extra_generic.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a specialized `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Handler { run: fn(int) -> int }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool` over the whole type. An `equals` over a partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`), or one with extra type parameters (`fn equals<U>`, `impl<T, U> Box<T>`), is emitted as a free function and cannot satisfy `#[equality]`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_specialized_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_mismatched_generic_interface_bound_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_mismatched_generic_interface_bound_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+    ╭─[test.lis:9:9]
+  8 │ 
+  9 │ impl<T: Parent<int>> Box<T> {
+    ·         ─────┬─────
+    ·              ╰── this bound cannot strengthen the receiver type
+ 10 │   fn equals(self, other: Box<T>) -> bool {
+    ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]

--- a/tests/ui/errors/snapshots/equality_rejects_mismatched_user_type_interface_bound_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_mismatched_user_type_interface_bound_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Conflicting impl bound
+    ╭─[test.lis:12:9]
+ 11 │ 
+ 12 │ impl<T: Parent<Other>> Box<T> {
+    ·         ──────┬──────
+    ·               ╰── this bound cannot strengthen the receiver type
+ 13 │   fn equals(self, other: Box<T>) -> bool {
+    ╰────
+  help: `Box` already bounds this parameter with a different `Parent` instantiation. A receiver method would embed `Parent` twice, and no type argument satisfies both. Match the type's bound, or relax the type's declaration · code: [infer.impl_bound_conflicts_with_type]

--- a/tests/ui/errors/snapshots/equality_rejects_nested_noncomparable_struct.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_nested_noncomparable_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:8:3]
+ 7 │ struct Outer {
+ 8 │   inner: Inner,
+   ·   ──┬──
+   ·     ╰── `inner` cannot be compared
+ 9 │ }
+   ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Outer` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_nested_wrong_signature_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_nested_wrong_signature_equals.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:9:16]
+ 8 │ #[equality]
+ 9 │ struct Outer { bad: Bad }
+   ·                ─┬─
+   ·                 ╰── `bad` cannot be compared
+   ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Outer` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_partial_generic_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_partial_generic_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a specialized `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Pair<A, B> { a: A, b: B }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool` over the whole type. An `equals` over a partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`), or one with extra type parameters (`fn equals<U>`, `impl<T, U> Box<T>`), is emitted as a free function and cannot satisfy `#[equality]`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_specialized_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_pointer_receiver_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_pointer_receiver_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with your `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Inner { x: int }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_conflicting_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_public_type_private_equals_cross_module.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_public_type_private_equals_cross_module.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[main.lis:5:17]
+ 4 │ #[equality]
+ 5 │ struct Holder { item: models.Item }
+   ·                 ──┬─
+   ·                   ╰── `item` cannot be compared
+   ╰────
+  help: `#[equality]` cannot compare a struct containing non-comparable fields. Give `Holder` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_rejects_specialized_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_specialized_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a specialized `equals`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality]
+   · ─────┬─────
+   ·      ╰── would synthesize an `equals` of its own
+ 3 │ struct Box<T: Comparable> { value: T }
+   ╰────
+  help: `#[equality]` needs a plain `fn equals(self, other: Self) -> bool` over the whole type. An `equals` over a partial or concrete receiver (`impl Box<int>`, `impl<T> Pair<T, T>`), or one with extra type parameters (`fn equals<U>`, `impl<T, U> Box<T>`), is emitted as a free function and cannot satisfy `#[equality]`. Write `equals` in that form, or remove `#[equality]` · code: [attribute.equality_specialized_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_stronger_interface_bound_equals.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_stronger_interface_bound_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` conflicts with a bounded `equals`
+    ╭─[test.lis:12:1]
+ 11 │ 
+ 12 │ #[equality]
+    · ─────┬─────
+    ·      ╰── would synthesize an `equals` of its own
+ 13 │ struct Box<T: Parent> { value: T }
+    ╰────
+  help: A hand-written `equals` must carry the same generic bounds as the type, or it strengthens the type for every instantiation. Match the type's bounds, or remove `#[equality]` · code: [attribute.equality_bounded_equals]

--- a/tests/ui/errors/snapshots/equality_rejects_unbounded_generic_field.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_unbounded_generic_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Cannot derive equality
+   ╭─[test.lis:4:3]
+ 3 │ struct Box<T> {
+ 4 │   value: T,
+   ·   ──┬──
+   ·     ╰── `value` cannot be compared
+ 5 │ }
+   ╰────
+  help: `#[equality]` cannot compare type parameters. Give `Box` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/equality_with_arguments.snap
+++ b/tests/ui/errors/snapshots/equality_with_arguments.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] `#[equality]` takes no arguments
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[equality(foo)]
+   · ────────┬───────
+   ·         ╰── remove the arguments
+ 3 │ struct Point { x: int, y: int }
+   ╰────
+  help: Write `#[equality]` with no arguments · code: [attribute.equality_with_arguments]

--- a/tests/ui/errors/snapshots/infer_not_comparable_enum_with_slice.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_enum_with_slice.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Type mismatch
+  [error] Invalid comparison
     ╭─[test.lis:10:16]
   9 │   let b = Bar.Empty;
  10 │   let result = a == b;
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                ╰── `Bar` cannot be compared with `==`
  11 │ }
     ╰────
-  help: The `==` and `!=` operators cannot be used on an enum containing non-comparable fields because they are not comparable in Go · code: [infer.type_mismatch]
+  help: Mark `Bar` with `#[equality]` to compare it with `.equals()` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_struct_with_slice.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_struct_with_slice.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  [error] Type mismatch
+  [error] Invalid comparison
     ╭─[test.lis:9:16]
   8 │   let b = Foo { items: [3, 4] };
   9 │   let result = a == b;
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                ╰── `Foo` cannot be compared with `==`
  10 │ }
     ╰────
-  help: The `==` and `!=` operators cannot be used on a struct containing non-comparable fields because they are not comparable in Go · code: [infer.type_mismatch]
+  help: Mark `Foo` with `#[equality]` to compare it with `.equals()` · code: [infer.type_mismatch]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15757,146 +15757,6 @@ fn main() {
 }
 
 #[test]
-fn container_equals_keeps_usable_element_equals_alive() {
-    let mut fs = MockFileSystem::new();
-    let source = r#"
-struct Point { x: int }
-
-impl Point {
-  fn equals(self, other: Point) -> bool {
-    self.x == other.x
-  }
-}
-
-fn main() {
-  let a: Slice<Point> = []
-  let b: Slice<Point> = []
-  let _ = a.equals(b)
-}
-"#;
-    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
-
-    let result = compile_check(fs);
-    assert!(
-        result.errors.is_empty(),
-        "unexpected errors: {:?}",
-        result.errors
-    );
-    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
-    assert!(
-        !codes.contains(&"lint.unused_function"),
-        "Slice<Point>.equals dispatches to Point.equals, which must be kept alive: {codes:?}"
-    );
-}
-
-#[test]
-fn container_equals_does_not_keep_wrong_signature_equals_alive() {
-    let mut fs = MockFileSystem::new();
-    let source = r#"
-struct Point { x: int, y: int }
-
-impl Point {
-  fn equals(self) -> bool {
-    self.x == self.y
-  }
-}
-
-fn main() {
-  let a: Slice<Point> = []
-  let b: Slice<Point> = []
-  let _ = a.equals(b)
-}
-"#;
-    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
-
-    let result = compile_check(fs);
-    assert!(
-        result.errors.is_empty(),
-        "unexpected errors: {:?}",
-        result.errors
-    );
-    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
-    assert!(
-        codes.contains(&"lint.unused_function"),
-        "Point.equals has the wrong signature, so Slice<Point>.equals never calls it: {codes:?}"
-    );
-}
-
-#[test]
-fn ufcs_container_equals_keeps_element_equals_alive() {
-    let mut fs = MockFileSystem::new();
-    let source = r#"
-struct Point { x: int }
-
-impl Point {
-  fn equals(self, other: Point) -> bool {
-    self.x == other.x
-  }
-}
-
-fn main() {
-  let a: Slice<Point> = []
-  let b: Slice<Point> = []
-  let _ = Slice.equals(a, b)
-}
-"#;
-    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
-
-    let result = compile_check(fs);
-    assert!(
-        result.errors.is_empty(),
-        "unexpected errors: {:?}",
-        result.errors
-    );
-    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
-    assert!(
-        !codes.contains(&"lint.unused_function"),
-        "Slice.equals(a, b) dispatches to Point.equals, which must be kept alive: {codes:?}"
-    );
-}
-
-#[test]
-fn container_equals_does_not_credit_nested_type_argument_equals() {
-    let mut fs = MockFileSystem::new();
-    let source = r#"
-struct Point { x: int }
-
-impl Point {
-  fn equals(self, other: Point) -> bool {
-    self.x == other.x
-  }
-}
-
-struct Box<T> { value: T }
-
-impl<T> Box<T> {
-  fn equals(self, other: Box<T>) -> bool {
-    true
-  }
-}
-
-fn main() {
-  let a: Slice<Box<Point>> = []
-  let b: Slice<Box<Point>> = []
-  let _ = a.equals(b)
-}
-"#;
-    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
-
-    let result = compile_check(fs);
-    assert!(
-        result.errors.is_empty(),
-        "unexpected errors: {:?}",
-        result.errors
-    );
-    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
-    assert!(
-        codes.contains(&"lint.unused_function"),
-        "Box.equals does not call Point.equals, so Point.equals is unused: {codes:?}"
-    );
-}
-
-#[test]
 fn equals_method_satisfying_interface_is_kept() {
     let mut fs = MockFileSystem::new();
     let source = r#"
@@ -15979,5 +15839,359 @@ fn main() {
         codes.contains(&"lint.unused_function"),
         "the local Inner.equals is unused: `a.equals(b)` dispatches to the imported \
          models.Inner.equals, not the same-named local method: {codes:?}"
+    );
+}
+
+#[test]
+fn equality_user_equals_does_not_root_field_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Inner { v: int }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    self.v == other.v
+  }
+}
+
+#[equality]
+struct Outer { inner: Inner }
+
+impl Outer {
+  fn equals(self, other: Outer) -> bool {
+    true
+  }
+}
+
+fn main() {
+  let a = Outer { inner: Inner { v: 1 } }
+  let b = Outer { inner: Inner { v: 2 } }
+  let _eq = a.equals(b)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let unused_fns = result
+        .lints
+        .iter()
+        .filter(|l| l.code_str() == Some("lint.unused_function"))
+        .count();
+    assert_eq!(
+        unused_fns,
+        1,
+        "Outer's hand-written equals suppresses synthesis and never calls Inner.equals, so Inner.equals must be flagged rather than rooted off the bare attribute: {:?}",
+        result
+            .lints
+            .iter()
+            .filter_map(|l| l.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_keeps_field_equals_but_flags_unrelated_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Inner { v: int }
+
+impl Inner {
+  fn equals(self, other: Inner) -> bool {
+    self.v == other.v
+  }
+}
+
+struct Other { v: int }
+
+impl Other {
+  fn equals(self, other: Other) -> bool {
+    self.v == other.v
+  }
+}
+
+#[equality]
+struct Wrap { inner: Inner }
+
+fn main() {
+  let _w = Wrap { inner: Inner { v: 1 } }
+  let _o = Other { v: 2 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let unused_fns = result
+        .lints
+        .iter()
+        .filter(|l| l.code_str() == Some("lint.unused_function"))
+        .count();
+    assert_eq!(
+        unused_fns,
+        1,
+        "expected only the unrelated Other.equals flagged: {:?}",
+        result
+            .lints
+            .iter()
+            .filter_map(|l| l.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_field_rooting_does_not_credit_undispatched_nested_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct Leaf { v: int }
+
+impl Leaf {
+  fn equals(self, other: Leaf) -> bool {
+    self.v == other.v
+  }
+}
+
+struct Holder<T> { item: T }
+
+impl<T> Holder<T> {
+  fn equals(self, other: Holder<T>) -> bool {
+    true
+  }
+}
+
+#[equality]
+struct Wrap { holder: Holder<Leaf> }
+
+fn main() {
+  let _w = Wrap { holder: Holder { item: Leaf { v: 1 } } }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let unused_fns = result
+        .lints
+        .iter()
+        .filter(|l| l.code_str() == Some("lint.unused_function"))
+        .count();
+    assert_eq!(
+        unused_fns,
+        1,
+        "Wrap.equals dispatches to Holder.equals (kept), which never calls Leaf.equals; only Leaf.equals must be flagged, not rooted through Holder's type argument: {:?}",
+        result
+            .lints
+            .iter()
+            .filter_map(|l| l.code_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn equality_method_satisfying_interface_is_kept() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+interface Eq<T> {
+  fn equals(self, other: T) -> bool
+}
+
+struct Point { x: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn check(_a: Eq<Point>) -> bool {
+  true
+}
+
+fn main() {
+  let p = Point { x: 1 }
+  let _ = check(p)
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        !codes.contains(&"lint.unused_function"),
+        "Point.equals satisfies Eq and must not be flagged unused: {codes:?}"
+    );
+}
+
+#[test]
+fn equality_accepts_alpha_renamed_generic_bound() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+interface Parent<T> {
+  fn p(self, value: T)
+}
+
+#[equality]
+struct Box<T: Parent<T>> { value: T }
+
+impl<U: Parent<U>> Box<U> {
+  fn equals(self, _other: Box<U>) -> bool {
+    true
+  }
+}
+
+fn main() {}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        result.errors.is_empty(),
+        "alpha-equivalent impl bound must be accepted: {:?} {codes:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn equality_imported_field_does_not_root_local_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "models.lis",
+        r#"
+pub struct Inner { pub x: int }
+
+impl Inner {
+  pub fn equals(self, _other: Inner) -> bool { true }
+}
+"#,
+    );
+    let source = r#"
+import "models"
+
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self, _other: Inner) -> bool { true }
+}
+
+#[equality]
+struct Wrap { item: models.Inner }
+
+fn main() {
+  let _ = Wrap { item: models.Inner { x: 1 } }
+  let _ = Inner { x: 2 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "local Inner.equals is unused: Wrap dispatches to the imported models.Inner.equals, \
+         not the local one, so the local method must still be flagged: {codes:?}"
+    );
+}
+
+#[test]
+fn equality_generic_param_field_does_not_root_local_equals() {
+    let mut fs = MockFileSystem::new();
+    let source = r#"
+struct T { x: int }
+
+impl T {
+  fn equals(self, _other: T) -> bool { true }
+}
+
+#[equality]
+struct Box<T: Comparable> { value: T }
+
+fn main() {
+  let _ = Box { value: 1 }
+  let _ = T { x: 2 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "the struct T's equals is unused: the field's `T` is a generic parameter, not the \
+         struct, so the method must still be flagged: {codes:?}"
+    );
+}
+
+#[test]
+fn container_equals_imported_element_does_not_root_local_equals() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "models.lis",
+        r#"
+pub struct Inner { pub x: int }
+
+impl Inner {
+  pub fn equals(self, _other: Inner) -> bool { true }
+}
+"#,
+    );
+    let source = r#"
+import "models"
+
+struct Inner { x: int }
+
+impl Inner {
+  fn equals(self, _other: Inner) -> bool { true }
+}
+
+fn main() {
+  let xs = [models.Inner { x: 1 }]
+  let ys = [models.Inner { x: 1 }]
+  let _ok = xs.equals(ys)
+  let _ = Inner { x: 2 }
+}
+"#;
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", source);
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    let codes: Vec<&str> = result.lints.iter().filter_map(|l| l.code_str()).collect();
+    assert!(
+        codes.contains(&"lint.unused_function"),
+        "local Inner.equals is unused: the slice elements are imported models.Inner, so \
+         `xs.equals(ys)` dispatches to models.Inner.equals, not the local method: {codes:?}"
     );
 }

--- a/tests/ui/lint/snapshots/unknown_attribute.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ pub struct User {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]` · code: [lint.unknown_attribute]

--- a/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ enum Color {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]` · code: [lint.unknown_attribute]


### PR DESCRIPTION
Introduces the `#[equality]` attribute. Mark a struct or enum with this attribute to auto-generate an `equals()` method, so types that `==` cannot compare (those containing a slice or map) can still be compared structurally by value.

```rs
#[equality]
struct Order {
  id: int,
  tags: Slice<string>,
}

let a = Order { id: 1, tags: ["x"] }
let b = Order { id: 1, tags: ["x"] }

a.equals(b) // true
```