### PR TITLE
feat: go-to-definition for prelude symbols

### DIFF
--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -6,17 +6,27 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 pub use stdlib::Target;
-use stdlib::{GO_STD_CONTENT_HASH, get_go_stdlib_packages, get_go_stdlib_typedef};
+use stdlib::{
+    GO_STD_CONTENT_HASH, LIS_PRELUDE_SOURCE, PRELUDE_CONTENT_HASH, get_go_stdlib_packages,
+    get_go_stdlib_typedef,
+};
 
-/// Disambiguates temp dirs so concurrent stdlib extractions do not share a path.
-static STDLIB_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// Disambiguates temp paths so concurrent typedef extractions do not collide.
+static TYPEDEF_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Test-only override for the home dir stdlib typedefs extract under.
-static STDLIB_TYPEDEF_HOME: OnceLock<PathBuf> = OnceLock::new();
+/// Test-only override for the home dir typedefs extract under.
+static TYPEDEF_HOME: OnceLock<PathBuf> = OnceLock::new();
 
 #[doc(hidden)]
-pub fn set_stdlib_typedef_home(home: PathBuf) {
-    let _ = STDLIB_TYPEDEF_HOME.set(home);
+pub fn set_typedef_home(home: PathBuf) {
+    let _ = TYPEDEF_HOME.set(home);
+}
+
+fn typedef_home() -> Option<PathBuf> {
+    match TYPEDEF_HOME.get() {
+        Some(home) => Some(home.clone()),
+        None => Some(PathBuf::from(std::env::var_os("HOME")?)),
+    }
 }
 
 pub use project_manifest::{
@@ -51,15 +61,15 @@ pub fn typedef_cache_dir(project_root: &Path) -> PathBuf {
 /// existence proves the contents are current, and distinct versions or embedded
 /// stdlibs get distinct dirs.
 fn stdlib_typedef_version_dir() -> Option<PathBuf> {
-    let home = match STDLIB_TYPEDEF_HOME.get() {
-        Some(home) => home.clone(),
-        None => PathBuf::from(std::env::var_os("HOME")?),
-    };
-    Some(home.join(".lisette/cache/stdlib-typedefs").join(format!(
-        "lis@v{}-{:016x}",
-        env!("CARGO_PKG_VERSION"),
-        GO_STD_CONTENT_HASH
-    )))
+    Some(
+        typedef_home()?
+            .join(".lisette/cache/stdlib-typedefs")
+            .join(format!(
+                "lis@v{}-{:016x}",
+                env!("CARGO_PKG_VERSION"),
+                GO_STD_CONTENT_HASH
+            )),
+    )
 }
 
 /// Deterministic on-disk path for a stdlib package's typedef. Pure path
@@ -93,7 +103,7 @@ pub fn ensure_stdlib_extracted(target: Target) {
 
     // Build in a temp dir, then atomically rename into place. The temp name
     // carries the pid and a counter so concurrent extractions don't collide.
-    let counter = STDLIB_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let counter = TYPEDEF_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let tmp = version_dir.join(format!(
         "{}.tmp.{}.{}",
         target.cache_segment(),
@@ -166,6 +176,46 @@ fn prune_stale_version_dirs(current: &Path) {
             let _ = std::fs::remove_dir_all(&path);
         }
     }
+}
+
+fn prelude_typedef_version_dir() -> Option<PathBuf> {
+    Some(
+        typedef_home()?
+            .join(".lisette/cache/prelude-typedefs")
+            .join(format!(
+                "lis@v{}-{:016x}",
+                env!("CARGO_PKG_VERSION"),
+                PRELUDE_CONTENT_HASH
+            )),
+    )
+}
+
+pub fn prelude_typedef_path() -> Option<PathBuf> {
+    Some(prelude_typedef_version_dir()?.join("prelude.d.lis"))
+}
+
+pub fn ensure_prelude_extracted() {
+    let Some(version_dir) = prelude_typedef_version_dir() else {
+        return;
+    };
+    let path = version_dir.join("prelude.d.lis");
+    if path.exists() {
+        return;
+    }
+    if std::fs::create_dir_all(&version_dir).is_err() {
+        return;
+    }
+
+    let counter = TYPEDEF_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = version_dir.join(format!("prelude.tmp.{}.{}", std::process::id(), counter));
+    if std::fs::write(&tmp, LIS_PRELUDE_SOURCE).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    if std::fs::rename(&tmp, &path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    prune_stale_version_dirs(&version_dir);
 }
 
 #[derive(Clone, Copy)]

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -194,6 +194,15 @@ pub fn prelude_typedef_path() -> Option<PathBuf> {
     Some(prelude_typedef_version_dir()?.join("prelude.d.lis"))
 }
 
+pub fn is_generated_typedef_path(path: &Path) -> bool {
+    let Some(home) = typedef_home() else {
+        return false;
+    };
+    let cache = home.join(".lisette/cache");
+    path.starts_with(cache.join("prelude-typedefs"))
+        || path.starts_with(cache.join("stdlib-typedefs"))
+}
+
 pub fn ensure_prelude_extracted() {
     let Some(version_dir) = prelude_typedef_version_dir() else {
         return;
@@ -290,5 +299,24 @@ mod tests {
         assert!(!stale.exists(), "this target's stale temp is removed");
         assert!(completed.exists(), "the completed target dir is kept");
         assert!(other_target_tmp.exists(), "another target's temp is kept");
+    }
+
+    #[test]
+    fn is_generated_typedef_path_matches_only_cache_files() {
+        let Some(home) = typedef_home() else {
+            return;
+        };
+        let cache = home.join(".lisette/cache");
+
+        assert!(is_generated_typedef_path(
+            &cache.join("prelude-typedefs/lis@v1-abc/prelude.d.lis")
+        ));
+        assert!(is_generated_typedef_path(
+            &cache.join("stdlib-typedefs/lis@v1-abc/darwin_arm64/fmt.d.lis")
+        ));
+        assert!(!is_generated_typedef_path(
+            &home.join("project/src/main.lis")
+        ));
+        assert!(!is_generated_typedef_path(Path::new("/etc/passwd")));
     }
 }

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -102,6 +102,13 @@ pub(crate) fn resolve_dot_access_definition(
                     }
                 })
             })
+            .or_else(|| {
+                let in_prelude = format!("prelude.{name}");
+                snapshot
+                    .definitions()
+                    .get(in_prelude.as_str())
+                    .and_then(|d| d.name_span())
+            })
     };
 
     let resolve_by_type = || {
@@ -170,13 +177,15 @@ pub(crate) fn resolve_dot_access_definition(
     })
 }
 
-/// True when the span points into a generated `go:` typedef file. Used by rename
-/// to refuse edits to typedefs, which would diverge from the regenerated content.
-pub(crate) fn is_go_typedef_span(snapshot: &AnalysisSnapshot, span: &syntax::ast::Span) -> bool {
+/// True when the span points into a generated typedef (`go:` or prelude), which rename must refuse.
+pub(crate) fn is_generated_typedef_span(
+    snapshot: &AnalysisSnapshot,
+    span: &syntax::ast::Span,
+) -> bool {
     snapshot
         .files()
         .get(&span.file_id)
-        .is_some_and(|f| f.module_id.starts_with("go:"))
+        .is_some_and(|f| f.module_id.starts_with("go:") || f.module_id == "prelude")
 }
 
 /// Resolve an import alias to the import statement's span.
@@ -282,6 +291,13 @@ pub(crate) fn lookup_definition_span(
         {
             return Some(span);
         }
+    }
+
+    let in_prelude = format!("prelude.{name}");
+    if let Some(definition) = snapshot.definitions().get(in_prelude.as_str())
+        && let Some(span) = definition.name_span()
+    {
+        return Some(span);
     }
 
     None

--- a/crates/lsp/src/document.rs
+++ b/crates/lsp/src/document.rs
@@ -52,6 +52,14 @@ impl SharedState {
     }
 
     pub(crate) async fn publish_diagnostics(&self, uri: Url) {
+        if uri
+            .to_file_path()
+            .is_ok_and(|p| deps::is_generated_typedef_path(&p))
+        {
+            self.client.publish_diagnostics(uri, vec![], None).await;
+            return;
+        }
+
         let version = self.documents.get(&uri).map(|d| d.version);
 
         let diagnostics = self.analyze_and_convert(&uri).await;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -24,7 +24,7 @@ use crate::completion::{
     get_instance_completions, get_module_prefix, get_type_completions, resolve_variable_type,
 };
 use crate::definition::{
-    find_struct_field_span, is_go_typedef_span, lookup_definition_span,
+    find_struct_field_span, is_generated_typedef_span, lookup_definition_span,
     resolve_annotation_definition, resolve_definition_span, resolve_dot_access_definition,
     resolve_enum_in_pattern, resolve_import_span, resolve_match_pattern_definition,
     resolve_struct_call_field, resolve_word_at_offset, word_at_offset,
@@ -62,10 +62,12 @@ impl LanguageServer for Backend {
             *self.project_config.write().await = Some(config);
         }
 
-        // Materialize the stdlib typedefs so the editor can open them. Off the
-        // async executor since the first run for a version writes the full stdlib.
-        let _ = tokio::task::spawn_blocking(|| deps::ensure_stdlib_extracted(deps::Target::host()))
-            .await;
+        // Off the async executor: the first run for a version writes the full stdlib.
+        let _ = tokio::task::spawn_blocking(|| {
+            deps::ensure_stdlib_extracted(deps::Target::host());
+            deps::ensure_prelude_extracted();
+        })
+        .await;
 
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
@@ -912,7 +914,7 @@ impl LanguageServer for Backend {
                 let resolved =
                     resolve_dot_access_definition(expression, member, *span, file, &snapshot);
                 if let Some(definition_span) = resolved
-                    && !is_go_typedef_span(&snapshot, &definition_span)
+                    && !is_generated_typedef_span(&snapshot, &definition_span)
                 {
                     let member_span = syntax::ast::Span::new(
                         span.file_id,
@@ -929,7 +931,9 @@ impl LanguageServer for Backend {
             }
 
             syntax::ast::Expression::Match { arms, .. } => {
-                if resolve_match_pattern_definition(arms, offset, file, &snapshot).is_some()
+                if let Some(def_span) =
+                    resolve_match_pattern_definition(arms, offset, file, &snapshot)
+                    && !is_generated_typedef_span(&snapshot, &def_span)
                     && let Some((word, start, end)) = word_at_offset(&file.source, offset)
                 {
                     let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
@@ -951,8 +955,13 @@ impl LanguageServer for Backend {
                 typed_pattern,
                 ..
             } => {
-                if resolve_enum_in_pattern(pattern, typed_pattern.as_ref(), offset, file, &snapshot)
-                    .is_some()
+                if let Some(def_span) = resolve_enum_in_pattern(
+                    pattern,
+                    typed_pattern.as_ref(),
+                    offset,
+                    file,
+                    &snapshot,
+                ) && !is_generated_typedef_span(&snapshot, &def_span)
                     && let Some((word, start, end)) = word_at_offset(&file.source, offset)
                 {
                     let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
@@ -966,7 +975,8 @@ impl LanguageServer for Backend {
 
             _ => {
                 if let Some((word, start, end)) = word_at_offset(&file.source, offset)
-                    && lookup_definition_span(word, file, &snapshot).is_some()
+                    && let Some(def_span) = lookup_definition_span(word, file, &snapshot)
+                    && !is_generated_typedef_span(&snapshot, &def_span)
                 {
                     let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
                     Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
@@ -1030,8 +1040,7 @@ impl LanguageServer for Backend {
                     member,
                     span,
                     ..
-                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot)
-                    .filter(|s| !is_go_typedef_span(&snapshot, s)),
+                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
 
                 syntax::ast::Expression::Match { arms, .. } => {
                     resolve_match_pattern_definition(arms, offset, file, &snapshot)
@@ -1063,6 +1072,10 @@ impl LanguageServer for Backend {
         let Some(definition_span) = definition_span else {
             return Ok(None);
         };
+
+        if is_generated_typedef_span(&snapshot, &definition_span) {
+            return Ok(None);
+        }
 
         let Some(definition_uri) = snapshot.get_uri(definition_span.file_id).cloned() else {
             return Ok(None);

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -64,8 +64,8 @@ impl AnalysisSnapshot {
                     Ok(uri) => uri,
                     Err(_) => continue,
                 }
-            } else if file.module_id.starts_with("go:") {
-                // Stdlib go: typedef is embedded; nothing on disk to navigate to.
+            } else if file.module_id.starts_with("go:") || file.module_id == "prelude" {
+                // Embedded typedef with no recorded on-disk path; nothing to navigate to.
                 continue;
             } else {
                 let path = module_file_to_path(config, &file.module_id, &file.name);

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -9741,6 +9741,84 @@ async fn goto_definition_stdlib_member_navigates_to_typedef() {
 }
 
 #[tokio::test]
+async fn goto_definition_on_prelude_type_navigates_to_typedef() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "fn get() -> Option<int> {\n  none\n}\nfn main() {\n  let x = get()\n}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.goto_definition(TEST_URI, 0, 13).await;
+    let location = definition_location(
+        &response.expect("go-to-definition on prelude type should return a location"),
+    )
+    .expect("response should contain a location");
+    let path = location.uri.path();
+    assert!(
+        path.contains("prelude-typedefs") && path.ends_with("prelude.d.lis"),
+        "should land in the extracted prelude typedef, got {path}"
+    );
+    assert!(
+        definition_target_text(&location).starts_with("Option"),
+        "should land on the `Option` definition"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_on_prelude_method_navigates_to_typedef() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "fn main() {\n  let s = \"hello\"\n  let n = s.length()\n}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.goto_definition(TEST_URI, 2, 12).await;
+    let location = definition_location(
+        &response.expect("go-to-definition on prelude method should return a location"),
+    )
+    .expect("response should contain a location");
+    let path = location.uri.path();
+    assert!(
+        path.contains("prelude-typedefs") && path.ends_with("prelude.d.lis"),
+        "should land in the extracted prelude typedef, got {path}"
+    );
+    assert!(
+        definition_target_text(&location).starts_with("length"),
+        "should land on the `length` method definition"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn goto_definition_on_prelude_function_navigates_to_typedef() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "fn main() {\n  panic(\"boom\")\n}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.goto_definition(TEST_URI, 1, 3).await;
+    let location = definition_location(
+        &response.expect("go-to-definition on prelude function should return a location"),
+    )
+    .expect("response should contain a location");
+    let path = location.uri.path();
+    assert!(
+        path.contains("prelude-typedefs") && path.ends_with("prelude.d.lis"),
+        "should land in the extracted prelude typedef, got {path}"
+    );
+    assert!(
+        definition_target_text(&location).starts_with("panic"),
+        "should land on the `panic` definition"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_through_propagate_operator() {
     let mut client = TestClient::new().await;
     client.initialize().await;
@@ -10657,6 +10735,46 @@ fn main() -> int {
     assert!(
         response.is_some(),
         "prepare_rename on method via dot access should return a result"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn prepare_rename_on_prelude_method_is_refused() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn main() {\n  let s = \"hello\"\n  let n = s.length()\n}",
+        )
+        .await;
+
+    let response = client.prepare_rename(TEST_URI, 2, 12).await;
+    assert!(
+        response.is_none(),
+        "prepare_rename on a prelude method must be refused, got {response:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn rename_on_prelude_method_is_refused() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn main() {\n  let s = \"hello\"\n  let n = s.length()\n}",
+        )
+        .await;
+
+    let edit = client.rename(TEST_URI, 2, 12, "len").await;
+    assert!(
+        edit.is_none(),
+        "rename on a prelude method must be refused, got {edit:?}"
     );
 
     client.shutdown().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -9767,6 +9767,25 @@ async fn goto_definition_on_prelude_type_navigates_to_typedef() {
 }
 
 #[tokio::test]
+async fn opening_prelude_typedef_publishes_no_diagnostics() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let path = deps::prelude_typedef_path().expect("prelude typedef path");
+    let content = std::fs::read_to_string(&path).expect("prelude cache file should exist");
+    let uri = Url::from_file_path(&path).expect("path to uri").to_string();
+
+    client.open(&uri, &content).await;
+    let diagnostics = client.await_diagnostics().await;
+    assert!(
+        diagnostics.is_empty(),
+        "opening the generated prelude typedef must report no diagnostics, got: {diagnostics:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn goto_definition_on_prelude_method_navigates_to_typedef() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -62,13 +62,13 @@ pub struct TestClient {
     buffered: Vec<Value>,
 }
 
-fn init_test_stdlib_home() {
+fn init_test_typedef_home() {
     static HOME: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
     HOME.get_or_init(|| {
         let dir =
             std::env::temp_dir().join(format!("lisette-lsp-test-home-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create test home dir");
-        deps::set_stdlib_typedef_home(dir.clone());
+        deps::set_typedef_home(dir.clone());
         dir
     });
 }
@@ -76,7 +76,7 @@ fn init_test_stdlib_home() {
 impl TestClient {
     /// Spawn a new LSP server and return a connected client.
     pub async fn new() -> Self {
-        init_test_stdlib_home();
+        init_test_typedef_home();
 
         let (client, server) = tokio::io::duplex(64 * 1024);
         let (server_read, server_write) = tokio::io::split(server);

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -56,14 +56,14 @@ pub fn save_prelude_cache(store: &Store) {
         return;
     };
 
-    let empty_file_map = HashMap::default();
+    let file_id_to_index: HashMap<u32, u32> = [(PRELUDE_FILE_ID, 0)].into_iter().collect();
     let definitions: HashMap<String, CachedDefinition> = module
         .definitions
         .iter()
         .map(|(name, definition)| {
             (
                 name.to_string(),
-                CachedDefinition::from_definition(definition, &empty_file_map),
+                CachedDefinition::from_definition(definition, &file_id_to_index),
             )
         })
         .collect();
@@ -112,13 +112,17 @@ pub fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
         },
     );
 
-    let file_ids: &[u32] = &[];
+    let file_ids: &[u32] = &[PRELUDE_FILE_ID];
     let module = store
         .get_module_mut(PRELUDE_MODULE_ID)
         .expect("prelude module must be registered before loading cached definitions");
     for (qualified_name, cached_definition) in cached.definitions {
         let definition = cached_definition.to_definition(file_ids);
         module.definitions.insert(qualified_name.into(), definition);
+    }
+
+    if let Some(path) = deps::prelude_typedef_path() {
+        store.typedef_paths.insert(PRELUDE_FILE_ID, path);
     }
 }
 

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -27,6 +27,10 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         },
     );
 
+    if let Some(path) = deps::prelude_typedef_path() {
+        store.typedef_paths.insert(PRELUDE_FILE_ID, path);
+    }
+
     let mut checker = TaskState::with_fresh_allocator(sink);
     let module = store
         .get_module(PRELUDE_MODULE_ID)


### PR DESCRIPTION
Go-to-definition now works on prelude symbols: `Option`, `Result`, `assert_type`, etc.

Mirroring @stormpat's Go stdlib typedefs work at #684.