### PR TITLE
fix: take recursive-enum constructor fields by value

### DIFF
--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -214,14 +214,6 @@ impl<'a> EmitFacts<'a> {
             .map(String::as_str)
     }
 
-    pub(crate) fn has_make_function_name(&self, key: &str) -> bool {
-        self.globals.make_function_names.contains_key(key)
-    }
-
-    pub(crate) fn make_function_keys(&self) -> impl Iterator<Item = &str> {
-        self.globals.make_function_names.keys().map(String::as_str)
-    }
-
     pub(crate) fn go_call_strategy(&self, qualified_name: &str) -> Option<&GoCallStrategy> {
         self.globals.go_call_strategies.get(qualified_name)
     }

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -275,6 +275,7 @@ impl Planner<'_> {
                     FieldTypeInfo {
                         go_type,
                         is_function,
+                        is_recursive: recursive,
                     },
                 );
             }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -15,7 +15,7 @@ use crate::types::native::NativeGoType;
 use syntax::ast::{Annotation, Expression, StructKind};
 use syntax::program::{CallKind, Definition, DefinitionBody};
 use syntax::types::{
-    SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute, unqualified_name,
+    SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute,
 };
 
 struct TupleStructTarget {
@@ -389,97 +389,6 @@ impl Planner<'_> {
                         .unwrap_or(module_name);
                     let qualified = format!("{}.{}.{}", module_name, type_name, member);
                     return self.lookup_definition_type(&qualified, None);
-                }
-                None
-            }
-            _ => None,
-        }
-    }
-
-    pub(super) fn get_recursive_enum_pointer_indices(
-        &mut self,
-        function: &Expression,
-    ) -> HashSet<usize> {
-        let Some((enum_id, variant_name)) = self.get_make_function_info(function) else {
-            return HashSet::default();
-        };
-
-        let Some(layout) = self.enum_layout(&enum_id) else {
-            return HashSet::default();
-        };
-
-        let Some(variant) = layout.get_variant(&variant_name) else {
-            return HashSet::default();
-        };
-
-        variant
-            .fields
-            .iter()
-            .enumerate()
-            .filter(|(_, f)| f.go_type.starts_with('*'))
-            .map(|(i, _)| i)
-            .collect()
-    }
-
-    fn get_make_function_info(&mut self, function: &Expression) -> Option<(String, String)> {
-        fn enum_id_from_type(ty: &Type) -> Option<String> {
-            if let Type::Function(f) = ty.unwrap_forall()
-                && let Type::Nominal { id, .. } = f.return_type.as_ref()
-            {
-                return Some(id.to_string());
-            }
-            None
-        }
-
-        match function {
-            Expression::Identifier { value, ty, .. } => {
-                let enum_id = enum_id_from_type(ty)?;
-                let variant = unqualified_name(value);
-                let enum_name = unqualified_name(&enum_id);
-                let qualified = format!("{}.{}", enum_name, variant);
-                if self.facts.has_make_function_name(&qualified) {
-                    return Some((enum_id, variant.to_string()));
-                }
-                if let Type::Function(f) = ty.unwrap_forall() {
-                    for key in self.facts.make_function_keys() {
-                        if let Some((e_name, v_name)) = key.split_once('.')
-                            && e_name == enum_name
-                            && v_name == variant
-                            && let Some(layout) = self.enum_layout(&enum_id)
-                            && let Some(v) = layout.get_variant(v_name)
-                            && v.fields.len() == f.params.len()
-                        {
-                            return Some((enum_id, v_name.to_string()));
-                        }
-                    }
-                }
-                None
-            }
-            Expression::DotAccess {
-                expression,
-                member,
-                ty,
-                ..
-            } => {
-                if let Expression::Identifier {
-                    value: enum_name, ..
-                } = expression.as_ref()
-                {
-                    let qualified = format!("{}.{}", enum_name, member);
-                    if self.facts.has_make_function_name(&qualified) {
-                        let enum_id = enum_id_from_type(ty)?;
-                        return Some((enum_id, member.to_string()));
-                    }
-                }
-                if let Expression::DotAccess {
-                    member: type_name, ..
-                } = expression.as_ref()
-                {
-                    let qualified = format!("{}.{}", type_name, member);
-                    if self.facts.has_make_function_name(&qualified) {
-                        let enum_id = enum_id_from_type(ty)?;
-                        return Some((enum_id, member.to_string()));
-                    }
                 }
                 None
             }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -444,6 +444,7 @@ impl Planner<'_> {
                     for key in self.facts.make_function_keys() {
                         if let Some((e_name, v_name)) = key.split_once('.')
                             && e_name == enum_name
+                            && v_name == variant
                             && let Some(layout) = self.enum_layout(&enum_id)
                             && let Some(v) = layout.get_variant(v_name)
                             && v.fields.len() == f.params.len()

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1,7 +1,6 @@
 use crate::abi::is_tagged_shape_fn_value;
 use crate::calls::dispatch::is_prelude_variant_constructor;
 use crate::calls::go_interop::is_go_receiver;
-use rustc_hash::FxHashSet as HashSet;
 
 use crate::EmitEffects;
 use crate::Planner;
@@ -24,7 +23,6 @@ use syntax::types::Type;
 struct CalleeAnalysis<'a> {
     fn_param_types: Vec<Type>,
     generic_fn_param_types: Option<&'a [Type]>,
-    pointer_indices: HashSet<usize>,
     is_go_call: bool,
     is_prelude_dispatch: bool,
 }
@@ -32,7 +30,6 @@ struct CalleeAnalysis<'a> {
 struct CallArgsContext<'a> {
     fn_param_types: &'a [Type],
     generic_fn_param_types: Option<&'a [Type]>,
-    pointer_indices: &'a HashSet<usize>,
     is_go_call: bool,
     /// Suppresses the Go-fn identity short-circuit on fn-typed params
     /// dispatching into prelude generic helpers (e.g. `OptionAndThen`).
@@ -177,7 +174,6 @@ impl<'a> Planner<'a> {
         let args_ctx = CallArgsContext {
             fn_param_types: &analysis.fn_param_types,
             generic_fn_param_types: analysis.generic_fn_param_types,
-            pointer_indices: &analysis.pointer_indices,
             is_go_call: analysis.is_go_call,
             is_prelude_dispatch: analysis.is_prelude_dispatch,
             spread,
@@ -222,7 +218,6 @@ impl<'a> Planner<'a> {
     }
 
     fn analyze_callee(&mut self, function: &Expression) -> CalleeAnalysis<'a> {
-        let pointer_indices = self.get_recursive_enum_pointer_indices(function);
         let fn_param_types: Vec<Type> = function
             .get_type()
             .unwrap_forall()
@@ -248,7 +243,6 @@ impl<'a> Planner<'a> {
         CalleeAnalysis {
             fn_param_types,
             generic_fn_param_types,
-            pointer_indices,
             is_go_call,
             is_prelude_dispatch,
         }
@@ -363,11 +357,11 @@ impl<'a> Planner<'a> {
     }
 
     /// Classify and lower a single call argument: dispatch is plan-driven and
-    /// returns typed setup. The plain `Direct` / `RecursiveEnumPointer` /
-    /// `TaggedGoLowering` paths produce typed `TempBind` setup; the remaining
-    /// adapter paths (`GoCallbackAdapter`, `LoweredFnShapeAdapter`,
-    /// `NullableCoercion`, `GoPointerUnwrap`) capture their string emission as
-    /// a single `RawGo` until each is individually converted.
+    /// returns typed setup. The plain `Direct` / `TaggedGoLowering` paths produce
+    /// typed `TempBind` setup; the remaining adapter paths (`GoCallbackAdapter`,
+    /// `LoweredFnShapeAdapter`, `NullableCoercion`, `GoPointerUnwrap`) capture
+    /// their string emission as a single `RawGo` until each is individually
+    /// converted.
     fn lower_call_arg(
         &mut self,
         arg: &Expression,
@@ -380,7 +374,7 @@ impl<'a> Planner<'a> {
             .generic_fn_param_types
             .and_then(|params| effective_param_type(index, params));
 
-        let plan = self.plan_argument(arg, index, ctx, effective_param_ty, generic_param_ty);
+        let plan = self.plan_argument(arg, ctx, effective_param_ty, generic_param_ty);
 
         match plan {
             ArgumentPlan::GoCallbackAdapter(kind) => self.lower_callback_wrapper(
@@ -407,14 +401,6 @@ impl<'a> Planner<'a> {
                 effective_param_ty.expect("GoPointerUnwrap requires effective_param_ty"),
                 fx,
             ),
-            ArgumentPlan::RecursiveEnumPointer => {
-                let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
-                if matches!(arg, Expression::Reference { .. }) || arg.get_type().is_ref() {
-                    return (setup, value);
-                }
-                let temp = self.hoist_tmp_value_statement(&mut setup, "ptr", &value);
-                (setup, format!("&{}", temp))
-            }
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
@@ -437,7 +423,6 @@ impl<'a> Planner<'a> {
     fn plan_argument(
         &self,
         arg: &Expression,
-        index: usize,
         ctx: &CallArgsContext<'_>,
         effective_param_ty: Option<&Type>,
         generic_param_ty: Option<&Type>,
@@ -462,9 +447,6 @@ impl<'a> Planner<'a> {
                 .is_some()
         {
             return ArgumentPlan::GoPointerUnwrap;
-        }
-        if ctx.pointer_indices.contains(&index) {
-            return ArgumentPlan::RecursiveEnumPointer;
         }
         let suppress = would_suppress_tagged_go(ctx, effective_param_ty);
         if suppress

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -33,12 +33,14 @@ pub(crate) struct FieldLayout {
     pub(crate) go_name: String,
     pub(crate) go_type: String,
     pub(crate) is_function: bool,
+    pub(crate) is_recursive: bool,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct FieldTypeInfo {
     pub(crate) go_type: String,
     pub(crate) is_function: bool,
+    pub(crate) is_recursive: bool,
 }
 
 pub(crate) type FieldTypeMap = HashMap<(usize, usize), FieldTypeInfo>;
@@ -107,12 +109,14 @@ impl EnumLayout {
                     .map(|i| i.go_type.clone())
                     .unwrap_or_else(|| "any".to_string());
                 let is_function = info.is_some_and(|i| i.is_function);
+                let is_recursive = info.is_some_and(|i| i.is_recursive);
 
                 FieldLayout {
                     source_name,
                     go_name,
                     go_type,
                     is_function,
+                    is_recursive,
                 }
             })
             .collect();

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -202,9 +202,16 @@ impl Planner<'_> {
             .enumerate()
             .map(|(index, field)| {
                 let argument = format!("arg{}", index);
-                let param = format!("{} {}", argument, field.go_type);
-                let field_assignment = format!("{}: {}", field.go_name, argument);
-                (field_assignment, param)
+                if field.is_recursive {
+                    let pointee = field.go_type.trim_start_matches('*');
+                    let param = format!("{} {}", argument, pointee);
+                    let field_assignment = format!("{}: &{}", field.go_name, argument);
+                    (field_assignment, param)
+                } else {
+                    let param = format!("{} {}", argument, field.go_type);
+                    let field_assignment = format!("{}: {}", field.go_name, argument);
+                    (field_assignment, param)
+                }
             })
             .unzip();
         let fields = fields.join(", ");

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -385,10 +385,10 @@ impl Planner<'_> {
         }
     }
 
-    /// Address a struct-call field whose enum variant stores it behind a pointer
-    /// (recursive-enum cycle breaker). Fields that are already a reference or a
-    /// `Ref<T>` value pass through unchanged; others are captured into a temp so
-    /// Go can take their address.
+    /// Address a struct-call field stored behind a compiler-inserted pointer
+    /// (recursive-enum cycle breaker). Such a field is by value, so capture it
+    /// into a temp Go can take the address of. User `Ref<T>` fields are not
+    /// recursive and pass through this untouched.
     fn wrap_recursive_enum_field(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
@@ -401,9 +401,6 @@ impl Planner<'_> {
             .as_ref()
             .is_some_and(|e| e.pointer_fields.contains(field.name.as_str()));
         if !needs_pointer {
-            return value;
-        }
-        if matches!(*field.value, Expression::Reference { .. }) || field.value.get_type().is_ref() {
             return value;
         }
         let temp = self.hoist_tmp_value_statement(statements, "ptr", &value);
@@ -505,7 +502,7 @@ impl Planner<'_> {
                 variant
                     .fields
                     .iter()
-                    .filter(|f| f.go_type.starts_with('*'))
+                    .filter(|f| f.is_recursive)
                     .map(|f| f.source_name.clone())
                     .collect()
             } else {

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -63,8 +63,6 @@ pub(crate) enum ArgumentPlan {
     NullableCoercion(NullableCoerceKind),
     /// Unwrap a Go pointer parameter at the call site (`&x` or `*x`).
     GoPointerUnwrap,
-    /// `&` wrap for recursive enum constructor arguments.
-    RecursiveEnumPointer,
     /// Lower a tagged Go-function value (prelude-dispatch arg).
     TaggedGoLowering,
 }

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1681,12 +1681,9 @@ fn run() -> Option<int> {
     assert_emit_snapshot!(input);
 }
 
-// Regression: a plain function that returns an enum and happens to share a
-// variant's arity must not be classified as that variant's constructor.
-// `prepend` returns `IntList` with 2 params, just like `Cons(int, IntList)`.
-// The make-function fallback matched by enum name + arity alone, so
-// `prepend(...)` became `IntList.Cons` and emitted its list arg as `&list`
-// (`*IntList`) where a by-value `IntList` is expected, producing uncompilable Go.
+// A plain function whose return type and arity coincide with a variant
+// (`prepend` vs `Cons(int, IntList)`) is a normal call, not a constructor: its
+// recursive arg is passed by value, never addressed.
 #[test]
 fn function_returning_enum_with_variant_arity_is_not_a_constructor() {
     let input = r#"
@@ -1701,6 +1698,28 @@ fn prepend(value: int, list: IntList) -> IntList {
 
 fn small() -> IntList {
   prepend(1, prepend(2, IntList.Empty))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+// A recursive-enum constructor is a first-class value: its make-function takes
+// the recursive field by value (`arg1 IntList`), so passing it to a higher-order
+// function matches the expected `fn(int, IntList) -> IntList` signature.
+#[test]
+fn recursive_enum_constructor_passed_to_higher_order_function() {
+    let input = r#"
+enum IntList {
+  Empty,
+  Cons(int, IntList),
+}
+
+fn apply(f: fn(int, IntList) -> IntList, x: int, xs: IntList) -> IntList {
+  f(x, xs)
+}
+
+fn build() -> IntList {
+  apply(IntList.Cons, 1, apply(IntList.Cons, 2, IntList.Empty))
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1680,3 +1680,28 @@ fn run() -> Option<int> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+// Regression: a plain function that returns an enum and happens to share a
+// variant's arity must not be classified as that variant's constructor.
+// `prepend` returns `IntList` with 2 params, just like `Cons(int, IntList)`.
+// The make-function fallback matched by enum name + arity alone, so
+// `prepend(...)` became `IntList.Cons` and emitted its list arg as `&list`
+// (`*IntList`) where a by-value `IntList` is expected, producing uncompilable Go.
+#[test]
+fn function_returning_enum_with_variant_arity_is_not_a_constructor() {
+    let input = r#"
+enum IntList {
+  Empty,
+  Cons(int, IntList),
+}
+
+fn prepend(value: int, list: IntList) -> IntList {
+  IntList.Cons(value, list)
+}
+
+fn small() -> IntList {
+  prepend(1, prepend(2, IntList.Empty))
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/function_returning_enum_with_variant_arity_is_not_a_constructor.snap
+++ b/tests/spec/emit/snapshots/function_returning_enum_with_variant_arity_is_not_a_constructor.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/functions.rs
+description: "\nenum IntList {\n  Empty,\n  Cons(int, IntList),\n}\n\nfn prepend(value: int, list: IntList) -> IntList {\n  IntList.Cons(value, list)\n}\n\nfn small() -> IntList {\n  prepend(1, prepend(2, IntList.Empty))\n}\n"
+---
+package main
+
+func MakeIntListEmpty() IntList {
+	return IntList{Tag: IntListEmpty}
+}
+
+func MakeIntListCons(arg0 int, arg1 *IntList) IntList {
+	return IntList{Tag: IntListCons, Cons0: arg0, Cons1: arg1}
+}
+
+type IntListTag int
+
+const (
+	IntListEmpty IntListTag = iota
+	IntListCons
+)
+
+type IntList struct {
+	Tag   IntListTag
+	Cons0 int
+	Cons1 *IntList
+}
+
+func prepend(value int, list IntList) IntList {
+	_arg_2 := value
+	ptr_1 := list
+	return MakeIntListCons(_arg_2, &ptr_1)
+}
+
+func small() IntList {
+	return prepend(1, prepend(2, MakeIntListEmpty()))
+}

--- a/tests/spec/emit/snapshots/recursive_enum_constructor_passed_to_higher_order_function.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_constructor_passed_to_higher_order_function.snap
@@ -7,12 +7,12 @@ description: |
     Cons(int, IntList),
   }
   
-  fn prepend(value: int, list: IntList) -> IntList {
-    IntList.Cons(value, list)
+  fn apply(f: fn(int, IntList) -> IntList, x: int, xs: IntList) -> IntList {
+    f(x, xs)
   }
   
-  fn small() -> IntList {
-    prepend(1, prepend(2, IntList.Empty))
+  fn build() -> IntList {
+    apply(IntList.Cons, 1, apply(IntList.Cons, 2, IntList.Empty))
   }
 ---
 package main
@@ -38,10 +38,10 @@ type IntList struct {
 	Cons1 *IntList
 }
 
-func prepend(value int, list IntList) IntList {
-	return MakeIntListCons(value, list)
+func apply(f func(int, IntList) IntList, x int, xs IntList) IntList {
+	return f(x, xs)
 }
 
-func small() IntList {
-	return prepend(1, prepend(2, MakeIntListEmpty()))
+func build() IntList {
+	return apply(MakeIntListCons, 1, apply(MakeIntListCons, 2, MakeIntListEmpty()))
 }

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -16,8 +16,8 @@ description: |
 ---
 package main
 
-func MakeListCons(arg0 int, arg1 *List) List {
-	return List{Tag: ListCons, Cons0: arg0, Cons1: arg1}
+func MakeListCons(arg0 int, arg1 List) List {
+	return List{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
 func MakeListNil() List {

--- a/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
@@ -24,8 +24,8 @@ func MakeNodeLeaf(arg0 int) Node {
 	return Node{Tag: NodeLeaf, Value: arg0}
 }
 
-func MakeNodeBranch(arg0 *Node, arg1 *Node) Node {
-	return Node{Tag: NodeBranch, Left: arg0, Right: arg1}
+func MakeNodeBranch(arg0 Node, arg1 Node) Node {
+	return Node{Tag: NodeBranch, Left: &arg0, Right: &arg1}
 }
 
 type NodeTag int

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -20,8 +20,8 @@ func MakeTreeLeaf[T any](arg0 T) Tree[T] {
 	return Tree[T]{Tag: TreeLeaf, Leaf: arg0}
 }
 
-func MakeTreeNode[T any](arg0 *Tree[T], arg1 *Tree[T]) Tree[T] {
-	return Tree[T]{Tag: TreeNode, Left: arg0, Right: arg1}
+func MakeTreeNode[T any](arg0 Tree[T], arg1 Tree[T]) Tree[T] {
+	return Tree[T]{Tag: TreeNode, Left: &arg0, Right: &arg1}
 }
 
 type TreeTag int

--- a/tests/spec/emit/snapshots/recursive_enum_tree.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tree.snap
@@ -17,8 +17,8 @@ func MakeTreeLeaf(arg0 int) Tree {
 	return Tree{Tag: TreeLeaf, Leaf: arg0}
 }
 
-func MakeTreeNode(arg0 *Tree, arg1 *Tree) Tree {
-	return Tree{Tag: TreeNode, Node0: arg0, Node1: arg1}
+func MakeTreeNode(arg0 Tree, arg1 Tree) Tree {
+	return Tree{Tag: TreeNode, Node0: &arg0, Node1: &arg1}
 }
 
 type TreeTag int
@@ -36,7 +36,5 @@ type Tree struct {
 }
 
 func test() Tree {
-	ptr_1 := MakeTreeLeaf(1)
-	ptr_2 := MakeTreeLeaf(2)
-	return MakeTreeNode(&ptr_1, &ptr_2)
+	return MakeTreeNode(MakeTreeLeaf(1), MakeTreeLeaf(2))
 }

--- a/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
@@ -24,8 +24,8 @@ func MakeNodeLeaf(arg0 int) Node {
 	return Node{Tag: NodeLeaf, Leaf: arg0}
 }
 
-func MakeNodeBranch(arg0 *Node, arg1 *Node) Node {
-	return Node{Tag: NodeBranch, Branch0: arg0, Branch1: arg1}
+func MakeNodeBranch(arg0 Node, arg1 Node) Node {
+	return Node{Tag: NodeBranch, Branch0: &arg0, Branch1: &arg1}
 }
 
 type NodeTag int
@@ -43,10 +43,8 @@ type Node struct {
 }
 
 func main() {
-	ptr_1 := MakeNodeLeaf(1)
-	ptr_2 := MakeNodeLeaf(2)
-	n := MakeNodeBranch(&ptr_1, &ptr_2)
-	ptr_1_3 := 3
+	n := MakeNodeBranch(MakeNodeLeaf(1), MakeNodeLeaf(2))
+	ptr_1 := 3
 	fmt.Println(n)
-	fmt.Println(ptr_1_3)
+	fmt.Println(ptr_1)
 }

--- a/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
@@ -19,8 +19,8 @@ func MakeListNil() List {
 	return List{Tag: ListNil}
 }
 
-func MakeListCons(arg0 int, arg1 *List) List {
-	return List{Tag: ListCons, Cons0: arg0, Cons1: arg1}
+func MakeListCons(arg0 int, arg1 List) List {
+	return List{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
 type ListTag int
@@ -38,7 +38,6 @@ type List struct {
 
 func main() {
 	make_ := MakeListCons
-	ptr_1 := MakeListNil()
-	xs := make_(1, &ptr_1)
+	xs := make_(1, MakeListNil())
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
@@ -17,8 +17,8 @@ func MakeListNil[T any]() List[T] {
 	return List[T]{Tag: ListNil}
 }
 
-func MakeListCons[T any](arg0 T, arg1 *List[T]) List[T] {
-	return List[T]{Tag: ListCons, Cons0: arg0, Cons1: arg1}
+func MakeListCons[T any](arg0 T, arg1 List[T]) List[T] {
+	return List[T]{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
 type ListTag int
@@ -35,7 +35,5 @@ type List[T any] struct {
 }
 
 func test() List[int] {
-	ptr_1 := MakeListNil[int]()
-	ptr_2 := MakeListCons(2, &ptr_1)
-	return MakeListCons(1, &ptr_2)
+	return MakeListCons(1, MakeListCons(2, MakeListNil[int]()))
 }


### PR DESCRIPTION
I was benchmarking lisette and claude code found a bug where a function would be overiden by a constructor if they had the same arity.


------------ AI comment -------------------------------
The make-function fallback in call dispatch matched a function to an enum variant's constructor by enum name + arity alone, ignoring the variant name. A plain function returning an enum with the same arity as one of its variants (e.g. `prepend(int, IntList) -> IntList` vs `Cons(int, IntList)`) was emitted as the constructor, passing its recursive arg by pointer (`&list`, `*IntList`) where a by-value `IntList` is expected, producing uncompilable Go.

Add the missing `v_name == variant` guard so only the actual variant matches.