### PR TITLE
feat: recognize and validate `#[test]` functions

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -248,4 +248,86 @@ mod tests {
             "leaky has warnings; cache must not write it"
         );
     }
+
+    fn test_index_names(project_dir: &std::path::Path) -> Vec<String> {
+        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let src_main = project_dir.join("src").join("main.lis");
+        let source = stdfs::read_to_string(&src_main).unwrap();
+        let working_dir = src_main
+            .parent()
+            .and_then(|p| p.to_str())
+            .expect("temp project path is valid utf-8");
+        let fs_loader = LocalFileSystem::new(working_dir);
+        let build_result = syntax::build_ast(&source, ENTRY_FILE_ID);
+        let output = analyze(AnalyzeInput {
+            config: SemanticConfig {
+                run_lints: true,
+                standalone_mode: false,
+                load_siblings: true,
+            },
+            loader: &fs_loader,
+            source,
+            filename: "main.lis".to_string(),
+            display_path: "src/main.lis".to_string(),
+            ast: build_result.ast,
+            project_root: Some(project_dir.to_path_buf()),
+            compile_phase: CompilePhase::Check,
+            locator,
+            go_module: "test".to_string(),
+            disable_cache: false,
+        });
+        let mut names: Vec<String> = output
+            .result
+            .test_index
+            .tests()
+            .iter()
+            .map(|t| t.qualified_name.clone())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn test_index_retains_cached_module_tests_on_warm_build() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        stdfs::create_dir_all(root.join("src").join("math")).unwrap();
+        stdfs::write(
+            root.join("lisette.toml"),
+            "[project]\nname = \"github.com/test/tests\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("main.lis"),
+            "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("math").join("math.lis"),
+            "pub fn add(a: int, b: int) -> int { a + b }\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("math").join("math.test.lis"),
+            "#[test]\npub fn alpha() {}\n",
+        )
+        .unwrap();
+
+        let cold = test_index_names(root);
+        assert!(
+            cold.contains(&"math.alpha".to_string()),
+            "cold run must record math.alpha, got: {cold:?}"
+        );
+
+        assert!(
+            root.join("target/cache/math.cache").exists(),
+            "math must be cached after the cold run for this test to be meaningful"
+        );
+
+        let warm = test_index_names(root);
+        assert_eq!(
+            cold, warm,
+            "tests in a cached module must survive a warm build"
+        );
+    }
 }

--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -119,6 +119,27 @@ pub fn equality_with_arguments(attribute_span: &Span) -> LisetteDiagnostic {
         .with_help("Write `#[equality]` with no arguments")
 }
 
+pub fn test_not_on_function(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[test]` not on a function")
+        .with_attribute_code("test_not_on_function")
+        .with_span_label(attribute_span, "not on a function")
+        .with_help("Only a free function can be marked `#[test]`")
+}
+
+pub fn test_outside_test_file(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[test]` outside a test file")
+        .with_attribute_code("test_outside_test_file")
+        .with_span_label(attribute_span, "only allowed in a `.test.lis` file")
+        .with_help("Move this function into a `.test.lis` file")
+}
+
+pub fn test_invalid_argument(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[test]` takes at most one string title")
+        .with_attribute_code("test_invalid_argument")
+        .with_span_label(attribute_span, "write `#[test]` or `#[test(\"title\")]`")
+        .with_help("Give a single string title, or no argument")
+}
+
 pub fn equality_on_tuple_struct(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[equality]` on a tuple struct")
         .with_attribute_code("equality_on_tuple_struct")

--- a/crates/diagnostics/src/result.rs
+++ b/crates/diagnostics/src/result.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ParseError;
 use syntax::program::{
-    Definition, EmitInput, EqualityIndex, File, ModuleInfo, MutationInfo, UnusedInfo,
+    Definition, EmitInput, EqualityIndex, File, ModuleInfo, MutationInfo, TestIndex, UnusedInfo,
 };
 use syntax::types::Symbol;
 
@@ -22,6 +22,7 @@ pub struct SemanticResult {
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
     pub equality_index: EqualityIndex,
+    pub test_index: TestIndex,
     /// File ID -> on-disk path of the `.d.lis` typedef. Populated for third-party
     /// go: typedefs read from `target/.lisette/typedefs/...`; absent for embedded
     /// stdlib typedefs.
@@ -44,6 +45,7 @@ impl SemanticResult {
             cached_modules: HashSet::default(),
             ufcs_methods: HashSet::default(),
             equality_index: EqualityIndex::default(),
+            test_index: TestIndex::default(),
             typedef_paths: HashMap::default(),
             go_package_names: HashMap::default(),
             go_module_ids: HashSet::default(),
@@ -65,6 +67,7 @@ impl SemanticResult {
             cached_modules: self.cached_modules,
             ufcs_methods: self.ufcs_methods,
             equality_index: self.equality_index,
+            test_index: self.test_index,
             go_package_names: self.go_package_names,
             go_module_ids: self.go_module_ids,
         }

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -373,7 +373,11 @@ fn is_instance_method(ty: &syntax::types::Type, type_id: &str) -> bool {
     }
 }
 
-pub(crate) fn attribute_completions(source: &str, offset: usize) -> Option<Vec<CompletionItem>> {
+pub(crate) fn attribute_completions(
+    source: &str,
+    offset: usize,
+    is_test_file: bool,
+) -> Option<Vec<CompletionItem>> {
     let tokens = Lexer::new(source, 0).lex().tokens;
     let split = tokens.partition_point(|t| (t.byte_offset as usize) < offset);
     let (before, after) = tokens.split_at(split);
@@ -382,14 +386,14 @@ pub(crate) fn attribute_completions(source: &str, offset: usize) -> Option<Vec<C
         return None;
     }
 
-    let items = match enclosing_context(before) {
+    let mut items = match enclosing_context(before) {
         EnclosingContext::Struct => collect(attributes_for(AttributeTarget::StructField)),
         EnclosingContext::Parenthesized | EnclosingContext::Enum | EnclosingContext::Function => {
             Vec::new()
         }
         EnclosingContext::Impl => match following_item(after).item {
             FollowingItem::Target(AttributeTarget::Function) | FollowingItem::Unknown => {
-                collect(attributes_for(AttributeTarget::Function))
+                collect(attributes_for(AttributeTarget::Method))
             }
             _ => Vec::new(),
         },
@@ -402,7 +406,7 @@ pub(crate) fn attribute_completions(source: &str, offset: usize) -> Option<Vec<C
             | Following {
                 item: FollowingItem::Unknown,
                 is_pub: false,
-            } => collect(attributes_for(AttributeTarget::Function)),
+            } => collect(attributes_for(AttributeTarget::Method)),
             _ => Vec::new(),
         },
         EnclosingContext::TopLevel => match following_item(after).item {
@@ -411,6 +415,10 @@ pub(crate) fn attribute_completions(source: &str, offset: usize) -> Option<Vec<C
             FollowingItem::Unknown => collect(top_level_attributes()),
         },
     };
+
+    if !is_test_file {
+        items.retain(|item| item.label != "test");
+    }
 
     Some(items)
 }
@@ -591,18 +599,18 @@ mod attribute_completion_tests {
     /// Runs `attribute_completions` with the cursor at the `|` marker (which is
     /// stripped before scanning) and returns the offered labels, or `None` when
     /// the cursor is not in attribute position.
-    fn labels_at(src_with_cursor: &str) -> Option<Vec<String>> {
+    fn labels_at(src_with_cursor: &str, is_test_file: bool) -> Option<Vec<String>> {
         let offset = src_with_cursor
             .find('|')
             .expect("test input needs a `|` cursor");
         let source = src_with_cursor.replacen('|', "", 1);
-        attribute_completions(&source, offset)
+        attribute_completions(&source, offset, is_test_file)
             .map(|items| items.into_iter().map(|i| i.label).collect())
     }
 
     #[test]
     fn top_level_struct_offers_serialization_tag_and_display() {
-        let labels = labels_at("#[|\nstruct Point { x: int }").unwrap();
+        let labels = labels_at("#[|\nstruct Point { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(labels.contains(&"display".to_string()));
         assert!(labels.contains(&"equality".to_string()));
@@ -613,7 +621,7 @@ mod attribute_completion_tests {
 
     #[test]
     fn top_level_enum_offers_iterate_display_and_json() {
-        let labels = labels_at("#[|\nenum Direction { North, South }").unwrap();
+        let labels = labels_at("#[|\nenum Direction { North, South }", false).unwrap();
         assert!(labels.contains(&"iterate".to_string()));
         assert!(labels.contains(&"display".to_string()));
         assert!(labels.contains(&"equality".to_string()));
@@ -625,7 +633,7 @@ mod attribute_completion_tests {
 
     #[test]
     fn struct_field_offers_serialization_and_tag_not_display() {
-        let labels = labels_at("struct S {\n  #[|\n  x: int\n}").unwrap();
+        let labels = labels_at("struct S {\n  #[|\n  x: int\n}", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(labels.contains(&"tag".to_string()));
         assert!(!labels.contains(&"display".to_string()));
@@ -636,56 +644,70 @@ mod attribute_completion_tests {
 
     #[test]
     fn method_in_impl_offers_allow_only() {
-        let labels = labels_at("impl S {\n  #[|\n  fn run(self) {}\n}").unwrap();
+        let labels = labels_at("impl S {\n  #[|\n  fn run(self) {}\n}", false).unwrap();
         assert_eq!(labels, vec!["allow".to_string()]);
     }
 
     #[test]
     fn method_in_interface_offers_allow_only() {
-        let labels = labels_at("interface I {\n  #[|\n  fn run(self)\n}").unwrap();
+        let labels = labels_at("interface I {\n  #[|\n  fn run(self)\n}", false).unwrap();
         assert_eq!(labels, vec!["allow".to_string()]);
     }
 
     #[test]
+    fn top_level_fn_offers_allow_and_test() {
+        let labels = labels_at("#[|\nfn run() {}", true).unwrap();
+        assert!(labels.contains(&"allow".to_string()), "got: {labels:?}");
+        assert!(labels.contains(&"test".to_string()), "got: {labels:?}");
+    }
+
+    #[test]
+    fn top_level_fn_in_production_file_omits_test() {
+        let labels = labels_at("#[|\nfn run() {}", false).unwrap();
+        assert!(labels.contains(&"allow".to_string()), "got: {labels:?}");
+        assert!(!labels.contains(&"test".to_string()), "got: {labels:?}");
+    }
+
+    #[test]
     fn interface_parent_embed_offers_nothing() {
-        let labels = labels_at("interface Child {\n  #[|\n  embed Parent\n}").unwrap();
+        let labels = labels_at("interface Child {\n  #[|\n  embed Parent\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn comment_between_attribute_and_enum_resolves_target() {
-        let labels = labels_at("#[|\n// note\nenum E { A }").unwrap();
+        let labels = labels_at("#[|\n// note\nenum E { A }", false).unwrap();
         assert!(labels.contains(&"iterate".to_string()));
         assert!(!labels.contains(&"allow".to_string()));
     }
 
     #[test]
     fn doc_comment_after_attribute_offers_nothing() {
-        let labels = labels_at("#[|\n/// doc\nstruct S {}").unwrap();
+        let labels = labels_at("#[|\n/// doc\nstruct S {}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn interface_pub_fn_offers_nothing() {
-        let labels = labels_at("interface I {\n  #[|\n  pub fn run(self)\n}").unwrap();
+        let labels = labels_at("interface I {\n  #[|\n  pub fn run(self)\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn impl_pub_fn_offers_allow() {
-        let labels = labels_at("impl S {\n  #[|\n  pub fn run(self) {}\n}").unwrap();
+        let labels = labels_at("impl S {\n  #[|\n  pub fn run(self) {}\n}", false).unwrap();
         assert_eq!(labels, vec!["allow".to_string()]);
     }
 
     #[test]
     fn interface_partial_pub_offers_nothing() {
-        let labels = labels_at("interface I {\n  #[|\n  pub\n}").unwrap();
+        let labels = labels_at("interface I {\n  #[|\n  pub\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn attribute_arg_backtick_paren_resolves_target() {
-        let labels = labels_at("#[|tag(`json:\")\"`)]\nstruct S { x: int }").unwrap();
+        let labels = labels_at("#[|tag(`json:\")\"`)]\nstruct S { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
         assert!(!labels.contains(&"allow".to_string()));
@@ -693,7 +715,7 @@ mod attribute_completion_tests {
 
     #[test]
     fn stacked_attribute_string_bracket_resolves_target() {
-        let labels = labels_at("#[|\n#[json(\"x]\")]\nstruct S { x: int }").unwrap();
+        let labels = labels_at("#[|\n#[json(\"x]\")]\nstruct S { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
         assert!(!labels.contains(&"allow".to_string()));
@@ -701,43 +723,43 @@ mod attribute_completion_tests {
 
     #[test]
     fn function_params_offer_nothing() {
-        let labels = labels_at("fn f(#[| x: int) {}").unwrap();
+        let labels = labels_at("fn f(#[| x: int) {}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn tuple_struct_field_offers_nothing() {
-        let labels = labels_at("struct S(#[| int)").unwrap();
+        let labels = labels_at("struct S(#[| int)", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn method_param_offers_nothing() {
-        let labels = labels_at("impl S {\n  fn m(#[| x: int) {}\n}").unwrap();
+        let labels = labels_at("impl S {\n  fn m(#[| x: int) {}\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn enum_variant_position_offers_nothing() {
-        let labels = labels_at("enum E {\n  #[|\n  A\n}").unwrap();
+        let labels = labels_at("enum E {\n  #[|\n  A\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn function_body_offers_nothing() {
-        let labels = labels_at("fn main() {\n  #[|\n}").unwrap();
+        let labels = labels_at("fn main() {\n  #[|\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn function_body_inside_nested_block_offers_nothing() {
-        let labels = labels_at("fn main() {\n  if true {\n    #[|\n  }\n}").unwrap();
+        let labels = labels_at("fn main() {\n  if true {\n    #[|\n  }\n}", false).unwrap();
         assert!(labels.is_empty());
     }
 
     #[test]
     fn unknown_top_level_target_offers_full_union() {
-        let labels = labels_at("#[|").unwrap();
+        let labels = labels_at("#[|", false).unwrap();
         for expected in ["json", "display", "iterate", "allow", "tag"] {
             assert!(labels.contains(&expected.to_string()), "missing {expected}");
         }
@@ -746,7 +768,7 @@ mod attribute_completion_tests {
     #[test]
     fn before_attribute_rejecting_declaration_offers_nothing() {
         for decl in ["interface S {}", "impl S {}", "const X = 1", "type A = int"] {
-            let labels = labels_at(&format!("#[|\n{decl}")).unwrap();
+            let labels = labels_at(&format!("#[|\n{decl}"), false).unwrap();
             assert!(
                 labels.is_empty(),
                 "expected nothing before `{decl}`, got {labels:?}"
@@ -756,43 +778,43 @@ mod attribute_completion_tests {
 
     #[test]
     fn partial_name_still_resolves_target() {
-        let labels = labels_at("#[js|\nstruct Point { x: int }").unwrap();
+        let labels = labels_at("#[js|\nstruct Point { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
     }
 
     #[test]
     fn stacked_attributes_resolve_to_following_item() {
-        let labels = labels_at("#[display]\n#[|\nstruct Point { x: int }").unwrap();
+        let labels = labels_at("#[display]\n#[|\nstruct Point { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
     }
 
     #[test]
     fn pub_modifier_is_skipped() {
-        let labels = labels_at("#[|\npub struct Point { x: int }").unwrap();
+        let labels = labels_at("#[|\npub struct Point { x: int }", false).unwrap();
         assert!(labels.contains(&"json".to_string()));
         assert!(!labels.contains(&"iterate".to_string()));
     }
 
     #[test]
     fn not_in_attribute_position_yields_none() {
-        assert!(labels_at("let x = |5").is_none());
-        assert!(labels_at("fn main() { let y = |x }").is_none());
+        assert!(labels_at("let x = |5", false).is_none());
+        assert!(labels_at("fn main() { let y = |x }", false).is_none());
     }
 
     #[test]
     fn hash_inside_string_is_not_an_attribute() {
-        assert!(labels_at("fn main() { let s = \"#[|\" }").is_none());
+        assert!(labels_at("fn main() { let s = \"#[|\" }", false).is_none());
     }
 
     #[test]
     fn closed_attribute_is_not_in_name_position() {
-        assert!(labels_at("#[json]|\nstruct Point { x: int }").is_none());
+        assert!(labels_at("#[json]|\nstruct Point { x: int }", false).is_none());
     }
 
     #[test]
     fn cursor_in_argument_list_is_not_name_position() {
-        assert!(labels_at("struct S {\n  #[json(|\n  x: int\n}").is_none());
+        assert!(labels_at("struct S {\n  #[json(|\n  x: int\n}", false).is_none());
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1150,7 +1150,8 @@ impl LanguageServer for Backend {
         // An in-progress `#[ ... ]` is exclusive: when the cursor is in attribute
         // position, offer only the attributes relevant to the target it attaches
         // to, never the general keyword/identifier completions below.
-        if let Some(items) = attribute_completions(&file.source, offset as usize) {
+        let is_test_file = uri.path().ends_with(".test.lis");
+        if let Some(items) = attribute_completions(&file.source, offset as usize, is_test_file) {
             return Ok(Some(CompletionResponse::Array(items)));
         }
 

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -146,6 +146,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         cached_modules,
         ufcs_methods,
         equality_index: store.equality_index,
+        test_index: store.test_index,
         typedef_paths: store.typedef_paths,
         go_package_names: store.go_package_names,
         go_module_ids,

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -5,6 +5,7 @@ mod equality;
 mod impl_bounds;
 mod iterate;
 mod methods;
+mod test_functions;
 mod types;
 
 use std::path::PathBuf;
@@ -231,6 +232,7 @@ impl TaskState<'_> {
         self.ufcs_methods.extend(ufcs_entries);
 
         self.register_module_equality(store, id);
+        self.register_module_tests(store, id);
     }
 
     /// Register a Go module (stdlib or third-party). Unlike regular modules,

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -1,0 +1,130 @@
+use diagnostics::LocalSink;
+use syntax::ast::{Attribute, AttributeArg, Expression};
+use syntax::program::TestFunction;
+
+use super::TaskState;
+use crate::store::Store;
+
+impl TaskState<'_> {
+    /// Collect and validate a module's `#[test]` functions into `facts`
+    /// (merge-safe, since this runs during parallel registration).
+    pub(super) fn register_module_tests(&mut self, store: &Store, module_id: &str) {
+        let module = store.get_module(module_id).expect("module must exist");
+        let mut records: Vec<TestFunction> = Vec::new();
+        for file in module.files.values().chain(module.typedefs.values()) {
+            let in_test_file = file.is_test();
+            for item in &file.items {
+                collect_test_candidates(item, module_id, in_test_file, &mut records, self.sink);
+            }
+        }
+        self.facts.test_functions.extend(records);
+    }
+
+    pub(crate) fn collect_cached_module_tests(&mut self, store: &Store, module_id: &str) {
+        let Some(module) = store.get_module(module_id) else {
+            return;
+        };
+        let discard = LocalSink::new();
+        let mut records: Vec<TestFunction> = Vec::new();
+        for file in module.files.values() {
+            if !file.is_test() {
+                continue;
+            }
+            let parsed = syntax::build_ast(&file.source, file.id);
+            for item in &parsed.ast {
+                collect_test_candidates(item, module_id, true, &mut records, &discard);
+            }
+        }
+        self.facts.test_functions.extend(records);
+    }
+
+    pub fn finalize_tests(&mut self, store: &mut Store) {
+        for test in std::mem::take(&mut self.facts.test_functions) {
+            store.test_index.push(test);
+        }
+    }
+}
+
+fn test_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
+    attributes.iter().find(|a| a.name == "test")
+}
+
+fn flag_misplaced(attributes: &[Attribute], sink: &LocalSink) {
+    if let Some(attribute) = test_attribute(attributes) {
+        sink.push(diagnostics::attribute::test_not_on_function(
+            &attribute.span,
+        ));
+    }
+}
+
+fn flag_misplaced_methods(methods: &[Expression], sink: &LocalSink) {
+    for method in methods {
+        if let Expression::Function { attributes, .. } = method {
+            flag_misplaced(attributes, sink);
+        }
+    }
+}
+
+fn parse_title(args: &[AttributeArg]) -> Result<Option<String>, ()> {
+    match args {
+        [] => Ok(None),
+        [AttributeArg::String(title)] => Ok(Some(title.clone())),
+        _ => Err(()),
+    }
+}
+
+fn collect_test_candidates(
+    item: &Expression,
+    module_id: &str,
+    in_test_file: bool,
+    records: &mut Vec<TestFunction>,
+    sink: &LocalSink,
+) {
+    match item {
+        Expression::Function {
+            attributes,
+            name,
+            name_span,
+            doc,
+            ..
+        } => {
+            let Some(attribute) = test_attribute(attributes) else {
+                return;
+            };
+            if !in_test_file {
+                sink.push(diagnostics::attribute::test_outside_test_file(
+                    &attribute.span,
+                ));
+                return;
+            }
+            let Ok(title) = parse_title(&attribute.args) else {
+                sink.push(diagnostics::attribute::test_invalid_argument(
+                    &attribute.span,
+                ));
+                return;
+            };
+            records.push(TestFunction {
+                module_id: module_id.to_string(),
+                qualified_name: format!("{}.{}", module_id, name),
+                title,
+                doc: doc.clone(),
+                span: *name_span,
+            });
+        }
+        Expression::Struct {
+            attributes, fields, ..
+        } => {
+            flag_misplaced(attributes, sink);
+            for field in fields {
+                flag_misplaced(&field.attributes, sink);
+            }
+        }
+        Expression::Enum { attributes, .. } => flag_misplaced(attributes, sink),
+        Expression::TypeAlias { attributes, .. } => flag_misplaced(attributes, sink),
+        Expression::Interface {
+            method_signatures, ..
+        } => flag_misplaced_methods(method_signatures, sink),
+        Expression::ImplBlock { methods, .. } => flag_misplaced_methods(methods, sink),
+        _ => {}
+    }
+}

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use diagnostics::{PatternIssue, UnusedExpressionKind};
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
+use syntax::program::TestFunction;
 use syntax::types::Type;
 
 #[derive(Debug, Default)]
@@ -47,6 +48,7 @@ pub struct Facts {
     pub expression_only_fstrings: Vec<Span>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<String>>,
     pub equality_derivations: Vec<String>,
+    pub test_functions: Vec<TestFunction>,
 
     // Drained by passes::deferred via mem::take.
     pub generic_call_checks: Vec<GenericCallCheck>,
@@ -102,6 +104,7 @@ impl Facts {
             usage_set: HashSet::default(),
             interface_satisfied_methods: HashMap::default(),
             equality_derivations: Vec::new(),
+            test_functions: Vec::new(),
         }
     }
 
@@ -231,8 +234,10 @@ impl Facts {
             usage_set: _,
             interface_satisfied_methods,
             equality_derivations,
+            test_functions,
         } = other;
         self.equality_derivations.extend(equality_derivations);
+        self.test_functions.extend(test_functions);
 
         self.bindings.extend(bindings);
         self.dead_code.extend(dead_code);

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -246,6 +246,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
                     .ufcs_methods
                     .extend(cached.ufcs_methods.iter().cloned());
                 register_cached_module(&mut store, &module_id, cached, project_root);
+                checker.collect_cached_module_tests(&store, &module_id);
                 cached_modules.insert(module_id.clone());
                 continue;
             }
@@ -481,6 +482,7 @@ fn infer_modules(
     binding_ids: &Arc<BindingIdAllocator>,
 ) {
     checker.finalize_equality(store);
+    checker.finalize_tests(store);
 
     let module_files: Vec<(String, Vec<File>)> = to_infer
         .iter()

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -8,6 +8,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use syntax::ast::{EnumVariant, Expression, Literal, StructFieldDefinition};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, ModuleId,
+    TestIndex,
 };
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
@@ -117,6 +118,7 @@ pub struct Store {
     pub closed_domains: HashMap<Symbol, ClosedDomain>,
     pub bound_conflict_types: HashSet<String>,
     pub equality_index: EqualityIndex,
+    pub test_index: TestIndex,
     /// File IDs of `.test.lis` files, for detecting test-file context during
     /// inference after a module's `files` have been taken out.
     pub test_file_ids: HashSet<u32>,
@@ -153,6 +155,7 @@ impl Store {
             closed_domains: Default::default(),
             bound_conflict_types: Default::default(),
             equality_index: Default::default(),
+            test_index: Default::default(),
             test_file_ids: Default::default(),
         }
     }
@@ -273,6 +276,7 @@ impl Store {
             closed_domains: HashMap::default(),
             bound_conflict_types: HashSet::default(),
             equality_index: EqualityIndex::default(),
+            test_index: TestIndex::default(),
             test_file_ids: self.test_file_ids.clone(),
         }
     }

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -6,8 +6,8 @@ pub enum AttributeTarget {
     Struct,
     StructField,
     Enum,
-    /// A function or an `impl`/`interface` method.
     Function,
+    Method,
 }
 
 pub struct AttributeInfo {
@@ -87,7 +87,7 @@ pub const ATTRIBUTES: &[AttributeInfo] = &[
     AttributeInfo {
         name: "allow",
         detail: "suppress a lint",
-        targets: &[Function],
+        targets: &[Function, Method],
     },
     AttributeInfo {
         name: "iterate",
@@ -103,6 +103,11 @@ pub const ATTRIBUTES: &[AttributeInfo] = &[
         name: "equality",
         detail: "derive `equals`",
         targets: &[Struct, Enum],
+    },
+    AttributeInfo {
+        name: "test",
+        detail: "mark a test function",
+        targets: &[Function],
     },
 ];
 

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -66,6 +66,38 @@ impl UnusedInfo {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TestFunction {
+    pub module_id: String,
+    pub qualified_name: String,
+    pub title: Option<String>,
+    pub doc: Option<String>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TestIndex {
+    tests: Vec<TestFunction>,
+}
+
+impl TestIndex {
+    pub fn push(&mut self, test: TestFunction) {
+        self.tests.push(test);
+    }
+
+    pub fn tests(&self) -> &[TestFunction] {
+        &self.tests
+    }
+
+    pub fn len(&self) -> usize {
+        self.tests.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tests.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct EqualityIndex {
     by_id: HashMap<String, EqualityInfo>,
@@ -185,6 +217,7 @@ pub struct EmitInput {
     pub cached_modules: HashSet<String>,
     pub ufcs_methods: HashSet<(String, String)>,
     pub equality_index: EqualityIndex,
+    pub test_index: TestIndex,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
 }

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -8,7 +8,8 @@ pub use definition::{
     Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute, Visibility,
 };
 pub use emit_input::{
-    EmitInput, EqualityIndex, EqualityInfo, EqualityUnusableReason, MutationInfo, UnusedInfo,
+    EmitInput, EqualityIndex, EqualityInfo, EqualityUnusableReason, MutationInfo, TestFunction,
+    TestIndex, UnusedInfo,
 };
 pub use file::{File, FileImport};
 pub use module::{Module, ModuleId, ModuleInfo};

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7042,3 +7042,81 @@ fn test_file_allowed_as_check_entry() {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn test_index_records_test_functions() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn alpha() {}\n\n/// Checks beta.\n#[test(\"beta title\")]\nfn beta() {}",
+    );
+
+    let result = compile_check(fs);
+
+    assert!(
+        !result.errors.iter().any(|d| d.is_error()),
+        "no errors expected, got: {:?}",
+        result.errors
+    );
+
+    let tests = result.test_index.tests();
+    assert_eq!(tests.len(), 2, "expected 2 tests, got: {tests:?}");
+
+    let alpha = tests
+        .iter()
+        .find(|t| t.qualified_name == "math.alpha")
+        .expect("alpha must be recorded");
+    assert_eq!(alpha.title, None);
+
+    let beta = tests
+        .iter()
+        .find(|t| t.qualified_name == "math.beta")
+        .expect("beta must be recorded");
+    assert_eq!(beta.title.as_deref(), Some("beta title"));
+    assert!(
+        beta.doc
+            .as_deref()
+            .is_some_and(|d| d.contains("Checks beta")),
+        "beta doc must be captured, got: {:?}",
+        beta.doc
+    );
+}
+
+#[test]
+fn test_index_complete_under_parallel_registration() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"m1\"\nimport \"m2\"\nimport \"m3\"\nimport \"m4\"\n\nfn main() {\n  let _ = m1.v() + m2.v() + m3.v() + m4.v()\n}",
+    );
+    for m in ["m1", "m2", "m3", "m4"] {
+        fs.add_file(m, "core.lis", "pub fn v() -> int { 1 }");
+        fs.add_file(m, "core.test.lis", "#[test]\nfn checks() {}");
+    }
+
+    let result = compile_check(fs);
+
+    assert!(
+        !result.errors.iter().any(|d| d.is_error()),
+        "no errors expected, got: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.test_index.len(),
+        4,
+        "every module's test must be recorded under parallel registration, got: {:?}",
+        result.test_index.tests()
+    );
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3681,6 +3681,95 @@ fn main() {
     );
 }
 
+fn has_code(result: &crate::_harness::infer::InferResult, code: &str) -> bool {
+    result
+        .errors
+        .iter()
+        .any(|d| d.code_str().is_some_and(|c| c.contains(code)))
+}
+
+fn test_attribute_fs(math_core: &str, math_test: &str) -> MockFileSystem {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "_entry_",
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file("math", "core.lis", math_core);
+    fs.add_file("math", "core.test.lis", math_test);
+    fs
+}
+
+#[test]
+fn test_attribute_on_struct_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nstruct Fixture {\n  value: int,\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_not_on_function"),
+        "`#[test]` on a struct must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_on_method_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "struct Fixture {\n  value: int,\n}\n\nimpl Fixture {\n  #[test]\n  fn check(self) {}\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_not_on_function"),
+        "`#[test]` on a method must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_in_production_file_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }\n\n#[test]\nfn checks() {}",
+        "fn unused() {}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_outside_test_file"),
+        "`#[test]` in a production file must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_with_flag_argument_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test(snake_case)]\nfn checks() {}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_invalid_argument"),
+        "`#[test]` with a flag argument must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_with_two_arguments_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test(\"one\", \"two\")]\nfn checks() {}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_invalid_argument"),
+        "`#[test]` with two arguments must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
 #[test]
 fn dot_test_file_sees_private_symbols() {
     let mut fs = MockFileSystem::new();

--- a/tests/ui/lint/snapshots/unknown_attribute.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ pub struct User {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]` · code: [lint.unknown_attribute]

--- a/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ enum Color {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]` · code: [lint.unknown_attribute]


### PR DESCRIPTION
Recognizes `#[test]` functions in `.test.lis` files, with an optional title.

```rs
// math/math.test.lis

#[test]
fn addition() {
  // ...
}

/// Trims surrounding whitespace before splitting each field.
#[test("splits and trims CSV fields")]
fn splits_csv() {
  // ...
}
```

`#[test]` is rejected when it sits on anything but a function, when it lives outside a `.test.lis` file, or when given an argument other than a single string title. Editor completion offers `#[test]` only where valid.

Follow-up to #756
