### PR TITLE
fix: drop loop label and labeled continue for unguarded matches

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -277,6 +277,7 @@ impl InferCtx<'_, '_> {
             MatchOrigin::IfLet { .. } => BindingKind::IfLet,
             MatchOrigin::Explicit => BindingKind::MatchArm,
         };
+        let match_has_guard = arms.iter().any(|a| a.guard.is_some());
         let new_arms = arms
             .into_iter()
             .map(|a| {
@@ -298,9 +299,13 @@ impl InferCtx<'_, '_> {
                     &result_ty
                 };
                 let saved_in_match_arm = self.scopes.set_in_match_arm(true);
+                let saved_in_guarded = self.scopes.set_in_guarded_match_arm(
+                    self.scopes.is_in_guarded_match_arm() || match_has_guard,
+                );
                 // Arm body is a tail-like context where Never calls are valid.
                 self.scopes.set_in_subexpression(false);
                 let new_expression = self.infer_expression(*a.expression, arm_expected);
+                self.scopes.set_in_guarded_match_arm(saved_in_guarded);
                 self.scopes.set_in_match_arm(saved_in_match_arm);
 
                 self.scopes.pop();
@@ -783,7 +788,9 @@ impl InferCtx<'_, '_> {
         self.check_continue_in_recover_block(span);
         self.check_continue_in_defer_block(span);
 
-        self.mark_loop_needs_label_in_match_arm();
+        if self.scopes.is_in_guarded_match_arm() {
+            self.scopes.mark_current_loop_needs_label();
+        }
 
         Expression::Continue { span }
     }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -119,12 +119,15 @@ impl Scope {
 
 pub struct Scopes {
     stack: Vec<Scope>,
-    /// True when inferring the body of a match/select arm. Consumed by
-    /// `infer_break`/`infer_continue` to decide whether the enclosing loop
-    /// needs a Go label (since Go switch cases do not fall through).
+    /// True when inferring a match/select arm body. Consumed by `infer_break`:
+    /// a Go `break` inside a switch case escapes only the switch.
     in_match_arm: Cell<bool>,
-    /// One entry per enclosing loop; set to `true` when a break/continue is
-    /// encountered inside a match arm. The top is popped by the loop's
+    /// True inside a guarded match arm, which lowers to an inner retry `for`
+    /// loop. Consumed by `infer_continue`: a `continue` there needs a label to
+    /// target the outer loop rather than the retry loop.
+    in_guarded_match_arm: Cell<bool>,
+    /// One entry per enclosing loop; set to `true` by a `break` in a match arm
+    /// or a `continue` in a guarded match arm. The top is popped by the loop's
     /// inference function and recorded on the Loop/While/For/WhileLet AST node.
     loop_needs_label_stack: std::cell::RefCell<Vec<bool>>,
     /// True when inferring inside a compound expression (call arg, binary
@@ -156,6 +159,7 @@ impl Scopes {
         Scopes {
             stack: vec![Scope::new()],
             in_match_arm: Cell::new(false),
+            in_guarded_match_arm: Cell::new(false),
             loop_needs_label_stack: std::cell::RefCell::new(Vec::new()),
             in_subexpression: Cell::new(false),
             dot_access_base: Cell::new(false),
@@ -196,6 +200,7 @@ impl Scopes {
         self.stack.clear();
         self.stack.push(Scope::new());
         self.in_match_arm.set(false);
+        self.in_guarded_match_arm.set(false);
         self.loop_needs_label_stack.borrow_mut().clear();
         self.in_subexpression.set(false);
         self.dot_access_base.set(false);
@@ -433,6 +438,14 @@ impl Scopes {
 
     pub fn set_in_match_arm(&self, value: bool) -> bool {
         self.in_match_arm.replace(value)
+    }
+
+    pub fn is_in_guarded_match_arm(&self) -> bool {
+        self.in_guarded_match_arm.get()
+    }
+
+    pub fn set_in_guarded_match_arm(&self, value: bool) -> bool {
+        self.in_guarded_match_arm.replace(value)
     }
 
     pub fn push_loop_needs_label(&self) {

--- a/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_match_in_loop.snap
@@ -17,10 +17,9 @@ package main
 
 func test(items []int) int {
 	sum := 0
-loop_1:
 	for _, item := range items {
 		if item == 0 {
-			continue loop_1
+			continue
 		}
 		sum += item
 	}


### PR DESCRIPTION
A `continue` inside an unguarded `match` inside a loop now lowers to a bare Go `continue`, and the enclosing loop no longer carries a `loop_N:` label.

```rs
for item in items {
  match item {
    0 => continue,
    n => sum += n,
  }
}
```

Motivated by #764