### PR TITLE
fix: scope emitted go import aliases to each file

### DIFF
--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -116,38 +116,7 @@ impl Planner<'_> {
                     continue;
                 };
                 self.module
-                    .record_module_alias(import.name.to_string(), alias);
-            }
-        }
-    }
-
-    /// Register cross-module imports for any bound types referenced in these generics.
-    /// In-module, Go-imported, and prelude modules don't need explicit imports.
-    pub(crate) fn record_bound_imports(
-        &mut self,
-        generics: &[syntax::ast::Generic],
-        fx: &mut EmitEffects,
-    ) {
-        for generic in generics {
-            for bound in &generic.bounds {
-                let syntax::ast::Annotation::Constructor { name, .. } = bound else {
-                    continue;
-                };
-                let Some((module, _)) = name.split_once('.') else {
-                    continue;
-                };
-                if self.facts.is_current_module(module)
-                    || go_name::is_go_import(module)
-                    || module == go_name::PRELUDE_MODULE
-                {
-                    continue;
-                }
-                let canonical = self
-                    .module
-                    .module_for_alias(module)
-                    .unwrap_or(module)
-                    .to_string();
-                self.require_module_import_fx(&canonical, fx);
+                    .record_module_alias(file.id, import.name.to_string(), alias);
             }
         }
     }
@@ -187,6 +156,7 @@ impl Planner<'_> {
             .collect();
 
         for (key, variants, file_id) in local_enums {
+            self.module.set_active_file(file_id);
             for variant in &variants {
                 let fn_code = self.create_make_function_code(&key, &variant.name, fx);
                 code.entry(file_id).or_default().push(fn_code);

--- a/crates/emit/src/analyze/constraint_collector.rs
+++ b/crates/emit/src/analyze/constraint_collector.rs
@@ -1,6 +1,5 @@
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::names::constraints::{GenericConstraintTable, classify_bound_annotation};
 use crate::names::go_name;
@@ -10,7 +9,7 @@ use syntax::program::{DefinitionBody, File, Interface};
 use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 impl Planner<'_> {
-    pub(crate) fn collect_generic_constraints(&mut self, files: &[&File], fx: &mut EmitEffects) {
+    pub(crate) fn collect_generic_constraints(&mut self, files: &[&File]) {
         let base_cell = self.facts.generic_base();
         let base = base_cell.get_or_init(|| {
             let mut t = GenericConstraintTable::default();
@@ -24,7 +23,7 @@ impl Planner<'_> {
         let mut table = base.clone();
 
         self.seed_local_functions(files, &mut table);
-        self.seed_local_impl_blocks(files, &mut table, fx);
+        self.seed_local_impl_blocks(files, &mut table);
         self.collect_demands_from_local_functions(files, &mut table);
         self.collect_demands_from_local_impl_blocks(files, &mut table);
 
@@ -64,27 +63,7 @@ impl Planner<'_> {
         }
     }
 
-    fn seed_local_impl_blocks(
-        &mut self,
-        files: &[&File],
-        table: &mut GenericConstraintTable,
-        fx: &mut EmitEffects,
-    ) {
-        let impl_generics_lists: Vec<Vec<Generic>> = files
-            .iter()
-            .flat_map(|f| &f.items)
-            .filter_map(|item| match item {
-                Expression::ImplBlock {
-                    generics: impl_generics,
-                    ..
-                } => Some(impl_generics.clone()),
-                _ => None,
-            })
-            .collect();
-        for impl_generics in &impl_generics_lists {
-            self.record_bound_imports(impl_generics, fx);
-        }
-
+    fn seed_local_impl_blocks(&mut self, files: &[&File], table: &mut GenericConstraintTable) {
         for file in files {
             for item in &file.items {
                 let Expression::ImplBlock {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -238,6 +238,11 @@ impl Planner<'_> {
         if let Some(layout) = self.module.enum_layout(enum_id) {
             return Some(layout);
         }
+        let _active = self
+            .facts
+            .definition(enum_id)
+            .and_then(|d| d.name_span)
+            .map(|span| self.module.with_active_file(span.file_id));
         let layout = self.compute_enum_layout(enum_id)?;
         self.module.record_enum_layout(enum_id.to_string(), layout);
         self.module.enum_layout(enum_id)

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -472,6 +472,7 @@ impl<'a> Planner<'a> {
         for (i, (file, file_plan)) in files.iter().zip(&plan.files).enumerate() {
             debug_assert_eq!(file.id, file_plan.file_id, "plan/file order mismatch");
 
+            self.module.set_active_file(file.id);
             let mut source = OutputCollector::new();
 
             for function in &file_plan.make_functions {

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -41,7 +41,7 @@ impl Planner<'_> {
         self.collect_module_aliases(files);
         self.collect_local_exported_method_names(files);
         self.collect_user_to_string_types(files);
-        self.collect_generic_constraints(files, &mut collection_effects);
+        self.collect_generic_constraints(files);
         self.collect_escape_remap(files);
         let collision_diagnostics = self.detect_name_collisions(files);
         let mut make_functions_by_file =

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use rustc_hash::FxHashMap as HashMap;
@@ -13,8 +13,10 @@ pub(crate) struct ModuleState {
     tag_exported_fields: HashSet<String>,
     exported_method_names: HashSet<String>,
     user_to_string_types: HashSet<String>,
-    module_aliases: HashMap<String, String>,
+    file_module_aliases: HashMap<u32, HashMap<String, String>>,
+    file_reverse_aliases: HashMap<u32, HashMap<String, String>>,
     reverse_module_aliases: HashMap<String, String>,
+    active_file: Cell<Option<u32>>,
     escape_remap: HashMap<String, String>,
     generic_constraints: GenericConstraintTable,
 }
@@ -60,21 +62,53 @@ impl ModuleState {
 
     pub(crate) fn record_module_alias(
         &mut self,
+        file_id: u32,
         module: impl Into<String>,
         alias: impl Into<String>,
     ) {
         let module = module.into();
         let alias = alias.into();
-        self.module_aliases.insert(module.clone(), alias.clone());
+        self.file_module_aliases
+            .entry(file_id)
+            .or_default()
+            .insert(module.clone(), alias.clone());
+        self.file_reverse_aliases
+            .entry(file_id)
+            .or_default()
+            .insert(alias.clone(), module.clone());
         self.reverse_module_aliases.insert(alias, module);
     }
 
     pub(crate) fn module_alias(&self, module: &str) -> Option<&str> {
-        self.module_aliases.get(module).map(String::as_str)
+        let file_id = self.active_file.get()?;
+        self.file_module_aliases
+            .get(&file_id)?
+            .get(module)
+            .map(String::as_str)
     }
 
     pub(crate) fn module_for_alias(&self, alias: &str) -> Option<&str> {
+        if let Some(file_id) = self.active_file.get()
+            && let Some(module) = self
+                .file_reverse_aliases
+                .get(&file_id)
+                .and_then(|m| m.get(alias))
+        {
+            return Some(module);
+        }
         self.reverse_module_aliases.get(alias).map(String::as_str)
+    }
+
+    pub(crate) fn set_active_file(&self, file_id: u32) {
+        self.active_file.set(Some(file_id));
+    }
+
+    pub(crate) fn with_active_file(&self, file_id: u32) -> ActiveFileGuard<'_> {
+        let previous = self.active_file.replace(Some(file_id));
+        ActiveFileGuard {
+            state: self,
+            previous,
+        }
     }
 
     pub(crate) fn record_escape_remap(
@@ -96,6 +130,17 @@ impl ModuleState {
 
     pub(crate) fn generic_constraints_for(&self, symbol: &str) -> Option<&[ParamConstraintSet]> {
         self.generic_constraints.get(symbol)
+    }
+}
+
+pub(crate) struct ActiveFileGuard<'a> {
+    state: &'a ModuleState,
+    previous: Option<u32>,
+}
+
+impl Drop for ActiveFileGuard<'_> {
+    fn drop(&mut self) {
+        self.state.active_file.set(self.previous);
     }
 }
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6809,6 +6809,250 @@ fn main() {
 }
 
 #[test]
+fn cross_file_inferred_go_type_emits_matching_import() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "helper.lis",
+        r#"
+import t "go:time"
+
+pub fn count(xs: Slice<t.Duration>) -> int {
+  0
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(count([]))
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn cross_file_inferred_local_type_emits_matching_import() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "box.lis",
+        r#"
+pub struct Box<T> {
+  pub items: Slice<T>,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "maker.lis",
+        r#"
+import u "util"
+
+pub fn count(xs: Slice<u.Box<string>>) -> int {
+  0
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(count([]))
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn same_alias_in_impl_bounds_does_not_leak_imports() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "iface_a",
+        "lib.lis",
+        r#"
+pub interface Drawable {
+  fn draw(self) -> string
+}
+"#,
+    );
+
+    fs.add_file(
+        "iface_b",
+        "lib.lis",
+        r#"
+pub interface Renderable {
+  fn render(self) -> string
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "a.lis",
+        r#"
+import s "iface_a"
+
+pub struct BoxA<T> {
+  pub v: T,
+}
+
+impl<T: s.Drawable> BoxA<T> {
+  pub fn show(self) -> string {
+    self.v.draw()
+  }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "b.lis",
+        r#"
+import s "iface_b"
+
+pub struct BoxB<T> {
+  pub v: T,
+}
+
+impl<T: s.Renderable> BoxB<T> {
+  pub fn show(self) -> string {
+    self.v.render()
+  }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn same_alias_for_different_modules_resolves_per_file() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "pkg_a",
+        "typ.lis",
+        r#"
+pub struct Thing {
+  pub n: int,
+}
+"#,
+    );
+
+    fs.add_file(
+        "pkg_b",
+        "typ.lis",
+        r#"
+pub struct Gadget {
+  pub m: int,
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "a.lis",
+        r#"
+import p "pkg_a"
+
+pub fn make_thing() -> p.Thing {
+  p.Thing { n: 1 }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "b.lis",
+        r#"
+import p "pkg_b"
+
+pub fn make_gadget() -> p.Gadget {
+  p.Gadget { m: 2 }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let _ = make_thing()
+  let _ = make_gadget()
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn same_go_path_keeps_each_files_own_alias() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "a.lis",
+        r#"
+import x "go:time"
+
+pub fn from_a(d: x.Duration) -> x.Duration {
+  d
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "b.lis",
+        r#"
+import y "go:time"
+
+pub fn from_b(d: y.Duration) -> y.Duration {
+  d
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn generated_fmt_requirement_reuses_unaliased_source_import() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/build/snapshots/cross_file_inferred_go_type_emits_matching_import.snap
+++ b/tests/spec/build/snapshots/cross_file_inferred_go_type_emits_matching_import.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === helper.go ===
+package main
+
+import t "time"
+
+func Count(_ []t.Duration) int {
+	return 0
+}
+
+
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println(Count(([]time.Duration)(nil)))
+}

--- a/tests/spec/build/snapshots/cross_file_inferred_local_type_emits_matching_import.snap
+++ b/tests/spec/build/snapshots/cross_file_inferred_local_type_emits_matching_import.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/util"
+)
+
+func main() {
+	fmt.Println(Count(([]util.Box[string])(nil)))
+}
+
+
+// === maker.go ===
+package main
+
+import u "github.com/user/myproject/util"
+
+func Count(_ []u.Box[string]) int {
+	return 0
+}
+
+
+// === util/box.go ===
+package util
+
+type Box[T any] struct {
+	Items []T
+}

--- a/tests/spec/build/snapshots/same_alias_for_different_modules_resolves_per_file.snap
+++ b/tests/spec/build/snapshots/same_alias_for_different_modules_resolves_per_file.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === a.go ===
+package main
+
+import p "github.com/user/myproject/pkg_a"
+
+func MakeThing() p.Thing {
+	return p.Thing{N: 1}
+}
+
+
+// === b.go ===
+package main
+
+import p "github.com/user/myproject/pkg_b"
+
+func MakeGadget() p.Gadget {
+	return p.Gadget{M: 2}
+}
+
+
+// === main.go ===
+package main
+
+func main() {
+	_ = MakeThing()
+	_ = MakeGadget()
+}
+
+
+// === pkg_a/typ.go ===
+package pkg_a
+
+type Thing struct {
+	N int
+}
+
+
+// === pkg_b/typ.go ===
+package pkg_b
+
+type Gadget struct {
+	M int
+}

--- a/tests/spec/build/snapshots/same_alias_in_impl_bounds_does_not_leak_imports.snap
+++ b/tests/spec/build/snapshots/same_alias_in_impl_bounds_does_not_leak_imports.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === a.go ===
+package main
+
+import s "github.com/user/myproject/iface_a"
+
+type BoxA[T s.Drawable] struct {
+	V T
+}
+
+func (b BoxA[T]) Show() string {
+	return b.V.Draw()
+}
+
+
+// === b.go ===
+package main
+
+import s "github.com/user/myproject/iface_b"
+
+type BoxB[T s.Renderable] struct {
+	V T
+}
+
+func (b BoxB[T]) Show() string {
+	return b.V.Render()
+}
+
+
+// === iface_a/lib.go ===
+package iface_a
+
+type Drawable interface {
+	Draw() string
+}
+
+
+// === iface_b/lib.go ===
+package iface_b
+
+type Renderable interface {
+	Render() string
+}
+
+
+// === main.go ===
+package main
+
+func main() {}

--- a/tests/spec/build/snapshots/same_go_path_keeps_each_files_own_alias.snap
+++ b/tests/spec/build/snapshots/same_go_path_keeps_each_files_own_alias.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === a.go ===
+package main
+
+import x "time"
+
+func FromA(d x.Duration) x.Duration {
+	return d
+}
+
+
+// === b.go ===
+package main
+
+import y "time"
+
+func FromB(d y.Duration) y.Duration {
+	return d
+}
+
+
+// === main.go ===
+package main
+
+func main() {}


### PR DESCRIPTION
Emitted Go now qualifies each imported package with the alias that file actually imports it under, instead of one package-wide alias shared across all files. A type inferred from another file (so the current file has no import for it) is emitted with the package's own name and a matching import, rather than borrowing an alias from a sibling file.

```rs
// format.lis imports the package under an alias and uses it directly
import apirole "go:github.com/zenomcpe/api/sdks/go/role"
fn role_names(all: Slice<apirole.Role>) -> string { ... }

// list.lis never imports it, the tyype is inferred from a call
fn list_roles(service: Ref<roles.Service>, target: string) {
  let result = service.Roles(target) // Result<Slice<apirole.Role>, error>
}
```

Fix #767
