### PR TITLE
fix: emit plain go functions for stored function values

### DIFF
--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -4,6 +4,8 @@ mod native;
 mod regular;
 mod ufcs;
 
+pub(crate) use regular::effective_param_type;
+
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::abi::AbiShape;

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -13,6 +13,7 @@ use crate::expressions::staging::VariadicCombine;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallbackWrapperKind, NullableCoerceKind};
+use crate::types::native::NativeGoType;
 use crate::utils::{contains_call, reads_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Annotation, Expression};
@@ -33,6 +34,7 @@ struct CallArgsContext<'a> {
     /// Suppresses the Go-fn identity short-circuit on fn-typed params
     /// dispatching into prelude generic helpers (e.g. `OptionAndThen`).
     is_prelude_dispatch: bool,
+    declared_param_types: Option<&'a [Type]>,
     spread: Option<&'a Expression>,
     wrap_spread_to_any: bool,
     combine_variadic: Option<VariadicCombine>,
@@ -170,11 +172,13 @@ impl<'a> Planner<'a> {
         );
 
         let analysis = self.analyze_callee(function);
+        let declared_param_types = self.callee_declared_params(function, args.len());
         let args_ctx = CallArgsContext {
             fn_param_types: &analysis.fn_param_types,
             generic_fn_param_types: analysis.generic_fn_param_types,
             is_go_call: analysis.is_go_call,
             is_prelude_dispatch: analysis.is_prelude_dispatch,
+            declared_param_types,
             spread,
             wrap_spread_to_any: spread_needs_any_wrap(function, spread),
             combine_variadic: call_plan.variadic_combine(0),
@@ -270,6 +274,41 @@ impl<'a> Planner<'a> {
             }
             _ => None,
         }
+    }
+
+    fn declared_callee_definition(&self, function: &Expression) -> Option<&'a Definition> {
+        if let Some(definition) = self.callee_definition(function) {
+            return Some(definition);
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = function.unwrap_parens()
+        else {
+            return None;
+        };
+        let peeled = self.facts.peel_alias(&receiver.get_type().strip_refs());
+        if let Some(native) = NativeGoType::from_type(&peeled) {
+            return self
+                .facts
+                .definition(&format!("prelude.{}.{}", native.lisette_name(), member));
+        }
+        match peeled {
+            Type::Nominal { id, .. } => self.facts.definition(&format!("{}.{}", id, member)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn callee_declared_params(
+        &self,
+        function: &Expression,
+        num_args: usize,
+    ) -> Option<&'a [Type]> {
+        let definition = self.declared_callee_definition(function)?;
+        let params = definition.ty().unwrap_forall().get_function_params()?;
+        let self_offset = params.len().saturating_sub(num_args);
+        params.get(self_offset..)
     }
 
     /// Hoist a Go array-return call into a temp and reslice as `[]T`. Skipped
@@ -372,8 +411,17 @@ impl<'a> Planner<'a> {
         let generic_param_ty = ctx
             .generic_fn_param_types
             .and_then(|params| effective_param_type(index, params));
+        let declared_param_ty = ctx
+            .declared_param_types
+            .and_then(|params| effective_param_type(index, params));
 
-        let plan = self.plan_argument(arg, ctx, effective_param_ty, generic_param_ty);
+        let plan = self.plan_argument(
+            arg,
+            ctx,
+            effective_param_ty,
+            generic_param_ty,
+            declared_param_ty,
+        );
 
         match plan {
             ArgumentPlan::GoCallbackAdapter(kind) => self.lower_callback_wrapper(
@@ -408,7 +456,9 @@ impl<'a> Planner<'a> {
                 let lowered = self.emit_lower_arg_to_tagged(&mut setup, &value, target, fx);
                 (setup, lowered)
             }
-            ArgumentPlan::Direct => self.lower_direct_arg(arg, ctx, effective_param_ty, fx),
+            ArgumentPlan::Direct => {
+                self.lower_direct_arg(arg, ctx, effective_param_ty, declared_param_ty, fx)
+            }
         }
     }
 
@@ -421,6 +471,7 @@ impl<'a> Planner<'a> {
         ctx: &CallArgsContext<'_>,
         effective_param_ty: Option<&Type>,
         generic_param_ty: Option<&Type>,
+        declared_param_ty: Option<&Type>,
     ) -> ArgumentPlan {
         if ctx.is_go_call
             && let Some(kind) = self.detect_callback_wrapper(arg, effective_param_ty)
@@ -443,7 +494,7 @@ impl<'a> Planner<'a> {
         {
             return ArgumentPlan::GoPointerUnwrap;
         }
-        let suppress = would_suppress_tagged_go(ctx, effective_param_ty);
+        let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
         if suppress
             && self
                 .detect_lower_arg_to_tagged(arg, effective_param_ty)
@@ -459,9 +510,10 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         ctx: &CallArgsContext<'_>,
         effective_param_ty: Option<&Type>,
+        declared_param_ty: Option<&Type>,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
-        let suppress = would_suppress_tagged_go(ctx, effective_param_ty);
+        let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
         let arg_ctx = direct_arg_emit_ctx(ctx, effective_param_ty, suppress);
         let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx);
         let final_value = match effective_param_ty {
@@ -834,11 +886,8 @@ fn spread_needs_any_wrap(function: &Expression, spread: Option<&Expression>) -> 
         .is_some_and(|t| !t.is_unknown())
 }
 
-/// True when a prelude-dispatch call's param is a function type — the
-/// condition that triggers `with_forced_tagged_go_function` and gates the
-/// tagged-Go lowering wrap.
-fn would_suppress_tagged_go(ctx: &CallArgsContext<'_>, effective_param_ty: Option<&Type>) -> bool {
-    let unwrapped = effective_param_ty.map(|p| p.unwrap_forall());
+fn would_suppress_tagged_go(ctx: &CallArgsContext<'_>, declared_param_ty: Option<&Type>) -> bool {
+    let unwrapped = declared_param_ty.map(|p| p.unwrap_forall());
     ctx.is_prelude_dispatch && unwrapped.is_some_and(|p| matches!(p, Type::Function(_)))
 }
 

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -156,12 +156,23 @@ impl Planner<'_> {
         };
         let declared_params =
             self.ufcs_declared_user_params(receiver, function, formal_params.len());
+        let suppress_declared = declared_params
+            .is_none()
+            .then(|| self.callee_declared_params(function, args.len()))
+            .flatten();
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
         all_stages.push(self.stage_operand(receiver, ExpressionContext::value(), fx));
         for (i, arg) in args.iter().enumerate() {
             let declared = declared_params.and_then(|p| effective_param_type(i, p));
-            all_stages.push(self.stage_ufcs_arg(arg, declared, formal_params.get(i), fx));
+            let suppress_decl = suppress_declared.and_then(|p| effective_param_type(i, p));
+            all_stages.push(self.stage_ufcs_arg(
+                arg,
+                declared,
+                suppress_decl,
+                formal_params.get(i),
+                fx,
+            ));
         }
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
 
@@ -182,11 +193,12 @@ impl Planner<'_> {
         &mut self,
         arg: &Expression,
         declared_param: Option<&Type>,
+        suppress_declared: Option<&Type>,
         formal_param: Option<&Type>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
         let Some(declared) = declared_param else {
-            return self.stage_prelude_arg(arg, formal_param, fx);
+            return self.stage_prelude_arg(arg, suppress_declared, formal_param, fx);
         };
         let mut setup: Vec<LoweredStatement> = Vec::new();
         if let Some(value) =

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -2,6 +2,7 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
+use crate::calls::effective_param_type;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::{CapturePolicy, StagedExpression};
 use crate::names::go_name;
@@ -91,16 +92,15 @@ impl Planner<'_> {
         StagedExpression::from_typed_setup(setup, value, expression)
     }
 
-    /// Suppresses the Go-fn identity short-circuit when the formal param
-    /// is function-typed (prelude generic callbacks reject multi-return).
     pub(crate) fn stage_prelude_arg(
         &mut self,
         expression: &Expression,
+        declared_param: Option<&syntax::types::Type>,
         param_ty: Option<&syntax::types::Type>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
-        let suppress =
-            param_ty.is_some_and(|p| matches!(p.unwrap_forall(), syntax::types::Type::Function(_)));
+        let suppress = declared_param
+            .is_some_and(|p| matches!(p.unwrap_forall(), syntax::types::Type::Function(_)));
         let arg_ctx = ExpressionContext::value().with_forced_tagged_go_function(suppress);
         let staged = self.stage_composite(expression, arg_ctx, fx);
 
@@ -183,9 +183,13 @@ impl Planner<'_> {
             syntax::types::Type::Function(f) => &f.params,
             _ => &[],
         };
+        let declared_params = self.callee_declared_params(function, args.len());
         args.iter()
             .enumerate()
-            .map(|(i, arg)| self.stage_prelude_arg(arg, formal_params.get(i), fx))
+            .map(|(i, arg)| {
+                let declared = declared_params.and_then(|p| effective_param_type(i, p));
+                self.stage_prelude_arg(arg, declared, formal_params.get(i), fx)
+            })
             .collect()
     }
 

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1603,3 +1603,106 @@ pub struct Group {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cli", typedef)]);
 }
+
+#[test]
+fn interop_some_stores_result_fn_in_lowered_abi() {
+    let input = r#"
+import ext "go:example.com/ext"
+
+fn configure(conf: Ref<ext.Config>) {
+  let mut wrapped: Slice<Option<fn(ext.Config) -> Result<ext.Listener, error>>> = []
+  for listener in ext.WrapListeners(conf.Listeners) {
+    wrapped = wrapped.append(Some(listener))
+  }
+}
+"#;
+    let typedef = r#"
+pub struct Config {
+  pub Listeners: Slice<fn(Config) -> Result<Listener, error>>,
+}
+
+pub interface Listener {}
+
+pub fn WrapListeners(listeners: Slice<fn(Config) -> Result<Listener, error>>) -> Slice<fn(Config) -> Result<Listener, error>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}
+
+#[test]
+fn interop_channel_send_stores_result_fn_in_lowered_abi() {
+    let input = r#"
+import "go:example.com/ext"
+
+fn enqueue(ch: Channel<fn(int) -> Result<string, error>>) {
+  let _ = ch.send(ext.MakeParser())
+}
+"#;
+    let typedef = r#"
+pub fn MakeParser() -> fn(int) -> Result<string, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}
+
+#[test]
+fn interop_unwrap_or_stores_result_fn_in_lowered_abi() {
+    let input = r#"
+import "go:example.com/ext"
+
+fn pick(opt: Option<fn(int) -> Result<string, error>>) {
+  let _ = opt.unwrap_or(ext.MakeParser())
+}
+"#;
+    let typedef = r#"
+pub fn MakeParser() -> fn(int) -> Result<string, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}
+
+#[test]
+fn interop_slice_map_keeps_result_callback_tagged() {
+    let input = r#"
+import "go:example.com/ext"
+
+fn convert_all(xs: Slice<int>) {
+  let _ = xs.map(ext.Parse)
+}
+"#;
+    let typedef = r#"
+pub fn Parse(x: int) -> Result<string, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}
+
+#[test]
+fn interop_aliased_native_receiver_wraps_result_callback() {
+    let input = r#"
+import "go:example.com/ext"
+
+type Ints = Slice<int>
+
+fn convert_all(xs: Ints) {
+  let _ = xs.map(ext.Parse)
+}
+"#;
+    let typedef = r#"
+pub fn Parse(x: int) -> Result<string, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}
+
+#[test]
+fn interop_aliased_option_receiver_wraps_callback() {
+    let input = r#"
+import "go:example.com/ext"
+
+type MyOpt = Option<int>
+
+fn use_it(o: MyOpt) {
+  let _ = o.and_then(ext.Lookup)
+}
+"#;
+    let typedef = r#"
+pub fn Lookup(x: int) -> Option<string>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ext", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_aliased_native_receiver_wraps_result_callback.snap
+++ b/tests/spec/emit/snapshots/interop_aliased_native_receiver_wraps_result_callback.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ext"
+  
+  type Ints = Slice<int>
+  
+  fn convert_all(xs: Ints) {
+    let _ = xs.map(ext.Parse)
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Ints = []int
+
+func convert_all(xs Ints) {
+	_ = lisette.SliceMap(xs, func(arg0 int) lisette.Result[string, error] {
+		ret_1, ret_2 := ext.Parse(arg0)
+		if ret_2 != nil {
+			return lisette.MakeResultErr[string, error](ret_2)
+		} else {
+			return lisette.MakeResultOk[string, error](ret_1)
+		}
+	})
+}

--- a/tests/spec/emit/snapshots/interop_aliased_option_receiver_wraps_callback.snap
+++ b/tests/spec/emit/snapshots/interop_aliased_option_receiver_wraps_callback.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ext"
+  
+  type MyOpt = Option<int>
+  
+  fn use_it(o: MyOpt) {
+    let _ = o.and_then(ext.Lookup)
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type MyOpt = lisette.Option[int]
+
+func use_it(o MyOpt) {
+	lisette.OptionAndThen(o, func(arg0 int) lisette.Option[string] {
+		return lisette.OptionFromCommaOk[string](ext.Lookup(arg0))
+	})
+}

--- a/tests/spec/emit/snapshots/interop_channel_send_stores_result_fn_in_lowered_abi.snap
+++ b/tests/spec/emit/snapshots/interop_channel_send_stores_result_fn_in_lowered_abi.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ext"
+  
+  fn enqueue(ch: Channel<fn(int) -> Result<string, error>>) {
+    let _ = ch.send(ext.MakeParser())
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func enqueue(ch chan func(int) (string, error)) {
+	_ = lisette.ChannelSend(ch, ext.MakeParser())
+}

--- a/tests/spec/emit/snapshots/interop_slice_map_keeps_result_callback_tagged.snap
+++ b/tests/spec/emit/snapshots/interop_slice_map_keeps_result_callback_tagged.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ext"
+  
+  fn convert_all(xs: Slice<int>) {
+    let _ = xs.map(ext.Parse)
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func convert_all(xs []int) {
+	_ = lisette.SliceMap(xs, func(arg0 int) lisette.Result[string, error] {
+		ret_1, ret_2 := ext.Parse(arg0)
+		if ret_2 != nil {
+			return lisette.MakeResultErr[string, error](ret_2)
+		} else {
+			return lisette.MakeResultOk[string, error](ret_1)
+		}
+	})
+}

--- a/tests/spec/emit/snapshots/interop_some_stores_result_fn_in_lowered_abi.snap
+++ b/tests/spec/emit/snapshots/interop_some_stores_result_fn_in_lowered_abi.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import ext "go:example.com/ext"
+  
+  fn configure(conf: Ref<ext.Config>) {
+    let mut wrapped: Slice<Option<fn(ext.Config) -> Result<ext.Listener, error>>> = []
+    for listener in ext.WrapListeners(conf.Listeners) {
+      wrapped = wrapped.append(Some(listener))
+    }
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func configure(conf *ext.Config) {
+	wrapped := ([]lisette.Option[func(ext.Config) (ext.Listener, error)])(nil)
+	for _, listener := range ext.WrapListeners(conf.Listeners) {
+		wrapped = append(wrapped, lisette.MakeOptionSome(listener))
+	}
+}

--- a/tests/spec/emit/snapshots/interop_unwrap_or_stores_result_fn_in_lowered_abi.snap
+++ b/tests/spec/emit/snapshots/interop_unwrap_or_stores_result_fn_in_lowered_abi.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ext"
+  
+  fn pick(opt: Option<fn(int) -> Result<string, error>>) {
+    let _ = opt.unwrap_or(ext.MakeParser())
+  }
+---
+package main
+
+import (
+	"example.com/ext"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func pick(opt lisette.Option[func(int) (string, error)]) {
+	_ = opt.UnwrapOr(ext.MakeParser())
+}


### PR DESCRIPTION
Storing a function that returns `Result` or `Option` or `Partial` into a container no longer emits Go that fails to compile. The function was being wrapped as a callback returning `lisette.Result`, which mismatched thecontainer's plain Go function element type.

```rs
import ext "go:example.com/repro/ext"

fn configure(conf: Ref<ext.Config>) {
  let mut wrapped: Slice<Option<fn(ext.Config) -> Result<ext.Listener, error>>> = []
  for listener in ext.WrapListeners(listeners) {
    wrapped = wrapped.append(Some(listener))
  }
  conf.Listeners = wrapped
}
```

Fix #768