### PR TITLE
fix: emit valid go for a shift expression cast to float

### DIFF
--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -2,9 +2,11 @@ use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use syntax::ast::{BinaryOperator, Expression, Literal, UnaryOperator};
+use syntax::program::DefinitionBody;
 use syntax::types::Type;
 
 struct NumericBinaryEmitInfo {
@@ -268,6 +270,113 @@ fn is_literal_expression(expression: &Expression) -> bool {
             ..
         } => is_literal_expression(expression),
         _ => false,
+    }
+}
+
+fn is_constant_binary_op(operator: &BinaryOperator) -> bool {
+    use BinaryOperator::*;
+    matches!(
+        operator,
+        Addition
+            | Subtraction
+            | Multiplication
+            | Division
+            | Remainder
+            | BitwiseAnd
+            | BitwiseOr
+            | BitwiseXor
+            | BitwiseAndNot
+            | ShiftLeft
+            | ShiftRight
+    )
+}
+
+impl Planner<'_> {
+    fn is_go_constant(&self, expression: &Expression) -> bool {
+        match expression {
+            Expression::Literal { literal, .. } => {
+                !matches!(literal, Literal::FormatString(_) | Literal::Slice(_))
+            }
+            Expression::Identifier { value, .. } => self.identifier_is_const(value),
+            Expression::DotAccess {
+                expression: package,
+                member,
+                ..
+            } => self.imported_member_is_const(package, member),
+            Expression::Paren { expression, .. } => self.is_go_constant(expression),
+            Expression::Unary {
+                operator: UnaryOperator::Negative | UnaryOperator::BitwiseNot,
+                expression,
+                ..
+            } => self.is_go_constant(expression),
+            Expression::Binary {
+                operator,
+                left,
+                right,
+                ..
+            } => {
+                is_constant_binary_op(operator)
+                    && self.is_go_constant(left)
+                    && self.is_go_constant(right)
+            }
+            _ => false,
+        }
+    }
+
+    fn identifier_is_const(&self, value: &str) -> bool {
+        match self.scope.resolve_identifier_binding(value) {
+            Some(binding) => binding
+                .as_go_name()
+                .is_some_and(|name| self.is_go_const_binding(name)),
+            None => self.is_go_const_binding(value),
+        }
+    }
+
+    fn imported_member_is_const(&self, package: &Expression, member: &str) -> bool {
+        let Expression::Identifier { value, .. } = package.unwrap_parens() else {
+            return false;
+        };
+        let module = self.module.module_for_alias(value).unwrap_or(value);
+        let body = self
+            .facts
+            .definition(&format!("{module}.{member}"))
+            .or_else(|| {
+                self.facts
+                    .definition(&self.facts.qualified_current_member(value, member))
+            })
+            .map(|definition| &definition.body);
+        match body {
+            Some(DefinitionBody::Value { const_value, .. })
+                if module.starts_with(go_name::GO_IMPORT_PREFIX) =>
+            {
+                const_value.is_some()
+            }
+            Some(DefinitionBody::Value { .. }) => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn contains_untyped_constant_shift(&self, expression: &Expression) -> bool {
+        match expression {
+            Expression::Paren { expression, .. } | Expression::Unary { expression, .. } => {
+                self.contains_untyped_constant_shift(expression)
+            }
+            Expression::Binary {
+                operator,
+                left,
+                right,
+                ..
+            } => {
+                (matches!(
+                    operator,
+                    BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight
+                ) && self.is_go_constant(left)
+                    && !self.is_go_constant(right))
+                    || self.contains_untyped_constant_shift(left)
+                    || self.contains_untyped_constant_shift(right)
+            }
+            _ => false,
+        }
     }
 }
 

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -328,10 +328,40 @@ impl Planner<'_> {
         }
 
         let go_type = self.annotation_to_go_type(target_type, fx);
+
+        if let Some(source_go_type) = self.shift_pin_go_type(expression, ty, fx) {
+            return ValuePlan::Cast {
+                go_type,
+                inner: Box::new(ValuePlan::Cast {
+                    go_type: source_go_type,
+                    inner: Box::new(inner),
+                }),
+            };
+        }
+
         ValuePlan::Cast {
             go_type,
             inner: Box::new(inner),
         }
+    }
+
+    fn shift_pin_go_type(
+        &self,
+        expression: &Expression,
+        target_ty: &Type,
+        fx: &mut EmitEffects,
+    ) -> Option<String> {
+        let target_is_float = target_ty
+            .underlying_simple_kind()
+            .is_some_and(|kind| kind.is_float());
+        if !target_is_float || !self.contains_untyped_constant_shift(expression) {
+            return None;
+        }
+        let source_ty = expression.get_type();
+        source_ty
+            .underlying_simple_kind()
+            .is_some_and(|kind| kind.integer_range().is_some())
+            .then(|| self.go_type_string(&source_ty, fx))
     }
 
     /// Plan a `&inner` reference, hoisting to a temp when the inner is

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -46,6 +46,34 @@ fn main() {
 }
 
 #[test]
+fn cast_shift_imported_module_const_count_needs_no_pin() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "config",
+        "config.lis",
+        r#"
+pub const SHIFT = 60 + 8
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "config"
+
+fn main() {
+  fmt.Println((1 << config.SHIFT) as float64)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn display_cross_module_to_string_exported() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/cast_shift_imported_module_const_count_needs_no_pin.snap
+++ b/tests/spec/build/snapshots/cast_shift_imported_module_const_count_needs_no_pin.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === config/config.go ===
+package config
+
+const SHIFT int = 60 + 8
+
+
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/config"
+)
+
+func main() {
+	fmt.Println(float64((1 << config.SHIFT)))
+}

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -432,6 +432,131 @@ fn test() -> float64 {
 }
 
 #[test]
+fn cast_shift_to_float_pins_integer_type() {
+    let input = r#"
+fn heal(level: int, potency: float64) -> float64 {
+  ((2 << level) as float64) * potency
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_nested_shift_to_float_pins_integer_type() {
+    let input = r#"
+fn scale(level: int) -> float64 {
+  ((2 << level) + 3) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_variable_shift_to_float_needs_no_pin() {
+    let input = r#"
+fn scale(base: int, level: int) -> float64 {
+  (base << level) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_constant_shift_to_float_needs_no_pin() {
+    let input = r#"
+fn scale() -> float64 {
+  (2 << 3) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_with_constant_arithmetic_base_pins() {
+    let input = r#"
+fn scale(level: int) -> float64 {
+  ((1 + 1) << level) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_constant_shift_with_arithmetic_count_needs_no_pin() {
+    let input = r#"
+fn scale() -> float64 {
+  (1 << (50 + 50)) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_with_const_count_needs_no_pin() {
+    let input = r#"
+const SHIFT = 60 + 8
+
+fn scale() -> float64 {
+  (1 << SHIFT) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_with_local_const_count_needs_no_pin() {
+    let input = r#"
+fn scale() -> float64 {
+  const SHIFT = 60 + 8
+  (1 << SHIFT) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_imported_const_shifted_operand_pins() {
+    let input = r#"
+import "go:math"
+
+fn scale(level: int) -> float64 {
+  (math.MaxInt8 << level) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_forward_alias_const_emitted_as_var_pins() {
+    let input = r#"
+const SHIFT = LATER
+const LATER = 60 + 8
+
+fn scale() -> float64 {
+  (1 << SHIFT) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn cast_shift_imported_const_count_no_pin_but_var_count_pins() {
+    let input = r#"
+import "go:math"
+import "go:runtime"
+
+fn const_count() -> float64 {
+  (1 << math.MaxInt8) as float64
+}
+
+fn var_count() -> float64 {
+  (1 << runtime.MemProfileRate) as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn float32_parameter_and_return() {
     let input = r#"
 fn accept_float32(x: float32) -> float32 {

--- a/tests/spec/emit/snapshots/cast_constant_shift_to_float_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_constant_shift_to_float_needs_no_pin.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale() -> float64 {
+    (2 << 3) as float64
+  }
+---
+package main
+
+func scale() float64 {
+	return float64((2 << 3))
+}

--- a/tests/spec/emit/snapshots/cast_constant_shift_with_arithmetic_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_constant_shift_with_arithmetic_count_needs_no_pin.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale() -> float64 {
+    (1 << (50 + 50)) as float64
+  }
+---
+package main
+
+func scale() float64 {
+	return float64((1 << (50 + 50)))
+}

--- a/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
+++ b/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale(level: int) -> float64 {
+    ((2 << level) + 3) as float64
+  }
+---
+package main
+
+func scale(level int) float64 {
+	return float64(int(((2 << level) + 3)))
+}

--- a/tests/spec/emit/snapshots/cast_shift_forward_alias_const_emitted_as_var_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_forward_alias_const_emitted_as_var_pins.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  const SHIFT = LATER
+  const LATER = 60 + 8
+  
+  fn scale() -> float64 {
+    (1 << SHIFT) as float64
+  }
+---
+package main
+
+var SHIFT int = LATER
+
+const LATER int = 60 + 8
+
+func scale() float64 {
+	return float64(int((1 << SHIFT)))
+}

--- a/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  import "go:math"
+  import "go:runtime"
+  
+  fn const_count() -> float64 {
+    (1 << math.MaxInt8) as float64
+  }
+  
+  fn var_count() -> float64 {
+    (1 << runtime.MemProfileRate) as float64
+  }
+---
+package main
+
+import (
+	"math"
+	"runtime"
+)
+
+func const_count() float64 {
+	return float64((1 << math.MaxInt8))
+}
+
+func var_count() float64 {
+	return float64(int((1 << runtime.MemProfileRate)))
+}

--- a/tests/spec/emit/snapshots/cast_shift_imported_const_shifted_operand_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_imported_const_shifted_operand_pins.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  import "go:math"
+  
+  fn scale(level: int) -> float64 {
+    (math.MaxInt8 << level) as float64
+  }
+---
+package main
+
+import "math"
+
+func scale(level int) float64 {
+	return float64(int((math.MaxInt8 << level)))
+}

--- a/tests/spec/emit/snapshots/cast_shift_to_float_pins_integer_type.snap
+++ b/tests/spec/emit/snapshots/cast_shift_to_float_pins_integer_type.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn heal(level: int, potency: float64) -> float64 {
+    ((2 << level) as float64) * potency
+  }
+---
+package main
+
+func heal(level int, potency float64) float64 {
+	return (float64(int((2 << level)))) * potency
+}

--- a/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  const SHIFT = 60 + 8
+  
+  fn scale() -> float64 {
+    (1 << SHIFT) as float64
+  }
+---
+package main
+
+const SHIFT int = 60 + 8
+
+func scale() float64 {
+	return float64((1 << SHIFT))
+}

--- a/tests/spec/emit/snapshots/cast_shift_with_constant_arithmetic_base_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_constant_arithmetic_base_pins.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale(level: int) -> float64 {
+    ((1 + 1) << level) as float64
+  }
+---
+package main
+
+func scale(level int) float64 {
+	return float64(int(((1 + 1) << level)))
+}

--- a/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale() -> float64 {
+    const SHIFT = 60 + 8
+    (1 << SHIFT) as float64
+  }
+---
+package main
+
+func scale() float64 {
+	const SHIFT int = 60 + 8
+	return float64((1 << SHIFT))
+}

--- a/tests/spec/emit/snapshots/cast_variable_shift_to_float_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_variable_shift_to_float_needs_no_pin.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scale(base: int, level: int) -> float64 {
+    (base << level) as float64
+  }
+---
+package main
+
+func scale(base, level int) float64 {
+	return float64((base << level))
+}


### PR DESCRIPTION
Casting a shift expression to a float type now emits compilable Go. The untyped shifted operand was being re-typed to the float target, which Go rejects.

```rs
fn heal(level: int, potency: float64) -> float64 {
  ((2 << level) as float64) * potency
}
```

Fix #766
