### PR TITLE
feat: render a grouped report for `lis test`

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -323,6 +323,18 @@ impl Command {
                     }
                 }
 
+                if let Some(flag) = go_flags.iter().find(|f| crate::go_cli::is_go_json_flag(f)) {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: format!(
+                            "`{}` cannot be passed to `lis test` via `--go-flags`",
+                            flag
+                        ),
+                        reason: "`lis test` runs `go test -json` and parses that stream to render the report"
+                            .to_string(),
+                        hint: "Remove `-json`; `lis test` manages it".to_string(),
+                    });
+                }
+
                 Ok(Command::Test { path, go_flags })
             }
 
@@ -602,6 +614,28 @@ mod tests {
             parse(&["lis", "run", "--go-flags", "--o=/tmp/x"]),
             Err(ParseError::UnexpectedArgument { .. })
         ));
+    }
+
+    #[test]
+    fn test_rejects_json_flag_in_go_flags() {
+        assert!(matches!(
+            parse(&["lis", "test", "--go-flags", "-json=false"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+        assert!(matches!(
+            parse(&["lis", "test", "--go-flags", "-json"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_accepts_other_go_flags() {
+        let Ok(Command::Test { go_flags, .. }) =
+            parse(&["lis", "test", "--go-flags", "-run TestFoo"])
+        else {
+            panic!("expected Test command");
+        };
+        assert_eq!(go_flags, vec!["-run", "TestFoo"]);
     }
 
     #[test]

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -1,7 +1,9 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+
+use serde::Deserialize;
 
 include!(concat!(env!("OUT_DIR"), "/go_version.rs"));
 
@@ -480,6 +482,12 @@ pub fn is_go_output_flag(token: &str) -> bool {
     matches!(token, "-o" | "--o") || token.starts_with("-o=") || token.starts_with("--o=")
 }
 
+pub fn is_go_json_flag(token: &str) -> bool {
+    matches!(token, "-json" | "--json")
+        || token.starts_with("-json=")
+        || token.starts_with("--json=")
+}
+
 /// `go_flags` follow the default `-o` so a caller `-o` wins. `output_path` must
 /// be absolute, since `go build` runs with `build_dir` as cwd.
 pub fn build_binary(
@@ -515,13 +523,32 @@ pub fn build_binary(
     }
 }
 
+/// One line of `go test -json` output (`elapsed` is in seconds).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GoTestEvent {
+    pub action: String,
+    #[serde(default)]
+    pub package: String,
+    pub test: Option<String>,
+    pub elapsed: Option<f64>,
+    pub output: Option<String>,
+    /// `build-*` events name the package here, not in `package`.
+    pub import_path: Option<String>,
+}
+
+pub struct TestRun {
+    pub events: Vec<GoTestEvent>,
+    pub success: bool,
+}
+
 pub fn run_tests(
     build_dir: &Path,
     target: Target,
     go_flags: &[String],
-) -> Result<bool, GoCliError> {
+) -> Result<TestRun, GoCliError> {
     let mut cmd = go_command(target);
-    cmd.arg("test").arg("-count=1");
+    cmd.arg("test").arg("-json").arg("-count=1");
     for flag in go_flags {
         cmd.arg(flag);
     }
@@ -529,36 +556,28 @@ pub fn run_tests(
         .current_dir(build_dir)
         .stdout(Stdio::piped());
 
-    let mut child = match cmd.spawn() {
-        Ok(child) => child,
-        Err(e) => {
-            return Err(GoCliError {
-                message: format!("Failed to execute `go test`: {}", e),
-                hint: "Check Go installation with `go version`",
-            });
-        }
+    let spawn_error = || GoCliError {
+        message: "Failed to execute `go test`".to_string(),
+        hint: "Check Go installation with `go version`",
     };
 
+    let mut child = cmd.spawn().map_err(|_| spawn_error())?;
+
+    let mut events = Vec::new();
     if let Some(stdout) = child.stdout.take() {
-        let mut sink = std::io::stdout().lock();
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-            if !is_go_test_pass_summary(&line) {
-                let _ = writeln!(sink, "{}", line);
+            if let Ok(event) = serde_json::from_str::<GoTestEvent>(&line) {
+                events.push(event);
             }
         }
     }
 
-    match child.wait() {
-        Ok(status) => Ok(status.success()),
-        Err(e) => Err(GoCliError {
-            message: format!("Failed to execute `go test`: {}", e),
-            hint: "Check Go installation with `go version`",
-        }),
-    }
-}
+    let status = child.wait().map_err(|_| spawn_error())?;
 
-fn is_go_test_pass_summary(line: &str) -> bool {
-    line.split('\t').next().map(str::trim) == Some("ok")
+    Ok(TestRun {
+        events,
+        success: status.success(),
+    })
 }
 
 #[cfg(test)]
@@ -577,17 +596,6 @@ mod tests {
     fn binary_name_uses_last_module_segment() {
         assert_eq!(binary_name("myproj", linux()), "myproj");
         assert_eq!(binary_name("github.com/u/myproj", linux()), "myproj");
-    }
-
-    #[test]
-    fn pass_summary_filter_hides_only_ok_lines() {
-        assert!(is_go_test_pass_summary("ok  \tlis-try\t0.119s"));
-        assert!(is_go_test_pass_summary("ok  \tlis-try\t(cached)"));
-        assert!(!is_go_test_pass_summary("FAIL\tlis-try\t0.123s"));
-        assert!(!is_go_test_pass_summary("?   \tlis-try\t[no test files]"));
-        assert!(!is_go_test_pass_summary(
-            "--- FAIL: TestAddsNumbers (0.00s)"
-        ));
     }
 
     #[test]

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -9,7 +9,7 @@ use crate::lock::acquire_target_lock;
 use crate::workspace::WorkspaceBindgen;
 use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
-use lisette::pipeline::{CompileConfig, CompilePhase, compile};
+use lisette::pipeline::{CompileConfig, CompilePhase, TestIndex, compile};
 
 pub fn emit(path: Option<String>, sourcemap: bool) -> i32 {
     with_locked_project(path, |prep| {
@@ -22,6 +22,7 @@ pub fn emit(path: Option<String>, sourcemap: bool) -> i32 {
                 label: "Emit completed",
             },
         )
+        .code
     })
 }
 
@@ -35,7 +36,8 @@ pub fn build(path: Option<String>, sourcemap: bool, go_flags: Vec<String>) -> i3
                 emit_tests: false,
                 label: "Emit completed",
             },
-        );
+        )
+        .code;
         if emit_code != 0 {
             return emit_code;
         }
@@ -162,6 +164,20 @@ pub(super) struct BuildOptions {
     pub label: &'static str,
 }
 
+pub(super) struct BuildOutcome {
+    pub code: i32,
+    pub test_index: TestIndex,
+}
+
+impl BuildOutcome {
+    fn failed(code: i32) -> Self {
+        Self {
+            code,
+            test_index: TestIndex::default(),
+        }
+    }
+}
+
 fn remove_stale_test_outputs(
     target_dir: &Path,
     manifest: &mut Vec<go_cli::ManifestEntry>,
@@ -179,7 +195,7 @@ fn remove_stale_test_outputs(
     Ok(())
 }
 
-pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
+pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> BuildOutcome {
     let BuildOptions {
         sourcemap,
         quiet,
@@ -196,7 +212,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
             e,
             "Check file permissions on `target/go.mod`"
         );
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     let typedef_cache_dir = deps::typedef_cache_dir(&prep.project_path);
@@ -219,7 +235,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
                 format!("Failed to read `{}`: {}", main_lis.display(), e),
                 "Check file permissions"
             );
-            return 1;
+            return BuildOutcome::failed(1);
         }
     };
 
@@ -290,7 +306,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
     );
 
     if counts.errors > 0 {
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     let heading = "Failed to compile Lisette project to Go";
@@ -310,14 +326,14 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
             format!("Failed to invalidate emit stamps before sourcemap write: {e}"),
             "Check file permissions on `target/cache`, or delete the directory and retry"
         );
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     let mut emit = match go_cli::write_go_outputs(&prep.target_dir, &result.output) {
         Ok(emit) => emit,
         Err(e) => {
             cli_error!(heading, e.message, e.hint);
-            return 1;
+            return BuildOutcome::failed(1);
         }
     };
 
@@ -339,7 +355,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
             format!("Failed to prune stale Go files: {}", e),
             "Check file permissions"
         );
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     if !emit_tests
@@ -350,7 +366,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
             format!("Failed to remove stale test file: {}", e),
             "Check file permissions"
         );
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     // Drop manifest entries whose files pruning removed, so the import-set hash
@@ -370,7 +386,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
             go_cli::write_go_mod(&prep.target_dir, &prep.manifest.project.name, &locator)
         {
             cli_error!(heading, e, "Check file permissions on `target/go.mod`");
-            return 1;
+            return BuildOutcome::failed(1);
         }
     }
 
@@ -381,7 +397,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
         import_set_hash,
     ) {
         cli_error!(heading, e.message, e.hint);
-        return 1;
+        return BuildOutcome::failed(1);
     }
 
     if !sourcemap
@@ -408,7 +424,10 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> i32 {
         );
     }
 
-    0
+    BuildOutcome {
+        code: 0,
+        test_index: result.test_index,
+    }
 }
 
 fn validate_project(project_path: &Path) -> bool {

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -69,7 +69,8 @@ fn run_project(path: &str, args: Vec<String>, sourcemap: bool, go_flags: &[Strin
             emit_tests: false,
             label: "Build completed",
         },
-    );
+    )
+    .code;
     if build_result != 0 {
         return build_result;
     }

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -1,12 +1,18 @@
+use std::time::Instant;
+
 use crate::cli_error;
 use crate::go_cli;
+use crate::output::use_color;
 
 use super::build::{BuildOptions, build_locked, with_locked_project};
+
+mod report;
+use report::{build_report, exit_code, render};
 
 pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
     crate::output::print_test_unfinished_notice();
     with_locked_project(path, |prep| {
-        let emit_code = build_locked(
+        let outcome = build_locked(
             prep,
             BuildOptions {
                 sourcemap: false,
@@ -15,8 +21,8 @@ pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
                 label: "Compiled",
             },
         );
-        if emit_code != 0 {
-            return emit_code;
+        if outcome.code != 0 {
+            return outcome.code;
         }
 
         let build_dir = match prep.target_dir.canonicalize() {
@@ -31,26 +37,31 @@ pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
             }
         };
 
-        let test_start = std::time::Instant::now();
-        match go_cli::run_tests(&build_dir, stdlib::Target::host(), &go_flags) {
-            Ok(true) => {
-                eprintln!(
-                    "  ✓ Tests passed {}",
-                    crate::output::format_elapsed(test_start.elapsed())
-                );
-                0
-            }
-            Ok(false) => {
-                eprintln!(
-                    "  ✗ Tests failed {}",
-                    crate::output::format_elapsed(test_start.elapsed())
-                );
-                1
-            }
+        let started = Instant::now();
+        let run = match go_cli::run_tests(&build_dir, stdlib::Target::host(), &go_flags) {
+            Ok(run) => run,
             Err(e) => {
                 cli_error!("Failed to run tests", e.message, e.hint);
-                1
+                return 1;
             }
+        };
+
+        let report = build_report(
+            &outcome.test_index,
+            &run.events,
+            &prep.manifest.project.name,
+        );
+        eprint!("{}", render(&report, use_color(), started.elapsed()));
+
+        let build_error = report.build_output.trim();
+        if !build_error.is_empty() {
+            cli_error!(
+                "Tests could not run",
+                build_error.to_string(),
+                "The generated Go failed to build; run `lis check`"
+            );
         }
+
+        exit_code(&report.rows, run.success)
     })
 }

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -1,0 +1,482 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
+
+use owo_colors::OwoColorize;
+use semantics::store::ENTRY_MODULE_ID;
+
+use crate::go_cli::GoTestEvent;
+use crate::output::format_elapsed;
+use lisette::pipeline::TestIndex;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Passed,
+    Failed,
+    Aborted,
+    NotRun,
+}
+
+pub struct TestRow {
+    pub package: String,
+    pub name: String,
+    pub status: Status,
+    pub elapsed: Option<f64>,
+    pub output: String,
+}
+
+pub struct Report {
+    pub rows: Vec<TestRow>,
+    pub build_output: String,
+    package_output: HashMap<String, String>,
+    failed_packages: HashSet<String>,
+    build_failed_packages: HashSet<String>,
+}
+
+pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) -> Report {
+    let mut terminal: HashMap<(String, String), (Status, Option<f64>)> = HashMap::new();
+    let mut started: HashSet<(String, String)> = HashSet::new();
+    let mut outputs: HashMap<(String, String), String> = HashMap::new();
+    let mut build_output = String::new();
+    let mut package_output: HashMap<String, String> = HashMap::new();
+    let mut failed_packages: HashSet<String> = HashSet::new();
+    let mut build_failed_packages: HashSet<String> = HashSet::new();
+
+    for event in events {
+        let Some(test) = &event.test else {
+            match event.action.as_str() {
+                "build-output" => {
+                    if let Some(text) = &event.output {
+                        build_output.push_str(text);
+                    }
+                    if let Some(path) = &event.import_path {
+                        build_failed_packages.insert(package_of_import_path(path).to_string());
+                    }
+                }
+                "build-fail" => {
+                    if let Some(path) = &event.import_path {
+                        build_failed_packages.insert(package_of_import_path(path).to_string());
+                    }
+                }
+                "output" => {
+                    if let Some(text) = &event.output {
+                        package_output
+                            .entry(event.package.clone())
+                            .or_default()
+                            .push_str(text);
+                    }
+                }
+                "fail" => {
+                    failed_packages.insert(event.package.clone());
+                }
+                _ => {}
+            }
+            continue;
+        };
+        let key = (event.package.clone(), test.clone());
+        match event.action.as_str() {
+            "run" => {
+                started.insert(key);
+            }
+            "pass" => {
+                terminal.insert(key, (Status::Passed, event.elapsed));
+            }
+            "fail" => {
+                terminal.insert(key, (Status::Failed, event.elapsed));
+            }
+            "output" => {
+                if let Some(text) = &event.output {
+                    outputs.entry(key).or_default().push_str(text);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut rows = Vec::new();
+    for test in index.tests() {
+        let prefix = format!("{}.", test.module_id);
+        let fn_name = test
+            .qualified_name
+            .strip_prefix(&prefix)
+            .unwrap_or(&test.qualified_name);
+        let package = if test.module_id == ENTRY_MODULE_ID {
+            go_module.to_string()
+        } else {
+            format!("{}/{}", go_module, test.module_id)
+        };
+        let key = (package.clone(), go_test_name(fn_name));
+        let (status, elapsed) = match terminal.get(&key).copied() {
+            Some(found) => found,
+            None if started.contains(&key) => (Status::Aborted, None),
+            None => (Status::NotRun, None),
+        };
+        rows.push(TestRow {
+            package,
+            name: fn_name.to_string(),
+            status,
+            elapsed,
+            output: outputs.get(&key).cloned().unwrap_or_default(),
+        });
+    }
+    Report {
+        rows,
+        build_output,
+        package_output,
+        failed_packages,
+        build_failed_packages,
+    }
+}
+
+fn go_test_name(fn_name: &str) -> String {
+    emit::go_test_function_name(fn_name)
+}
+
+/// `go test` names a build failure `pkg [pkg.test]`; strip the suffix to match package events.
+fn package_of_import_path(import_path: &str) -> &str {
+    import_path
+        .split_once(" [")
+        .map_or(import_path, |(pkg, _)| pkg)
+}
+
+pub fn render(report: &Report, color: bool, total: Duration) -> String {
+    let mut out = String::from("\n");
+
+    if report.rows.is_empty() {
+        out.push_str("  No tests found\n");
+        return out;
+    }
+
+    let mut by_package: BTreeMap<&str, Vec<&TestRow>> = BTreeMap::new();
+    for row in &report.rows {
+        by_package.entry(&row.package).or_default().push(row);
+    }
+
+    for (package, mut group) in by_package {
+        group.sort_by(|a, b| a.name.cmp(&b.name));
+        out.push_str(&format!("  {package}\n"));
+        for (i, row) in group.iter().enumerate() {
+            let last = i + 1 == group.len();
+            let branch = if last { "└── " } else { "├── " };
+            let timing = match row.elapsed {
+                Some(seconds) if seconds > 0.0 => {
+                    format!(" {}", format_elapsed(Duration::from_secs_f64(seconds)))
+                }
+                _ => String::new(),
+            };
+            let suffix = match row.status {
+                Status::NotRun => " (not run)",
+                Status::Aborted => " (aborted)",
+                _ => "",
+            };
+            out.push_str(&format!(
+                "    {branch}{} {}{suffix}{timing}\n",
+                mark(row.status, color),
+                row.name
+            ));
+            if matches!(row.status, Status::Failed | Status::Aborted) {
+                let cont = if last { "    " } else { "│   " };
+                for line in row.output.lines() {
+                    let line = line.trim_end();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    out.push_str(&dim(&format!("    {cont}    {line}"), color));
+                    out.push('\n');
+                }
+            }
+        }
+
+        // Crash before any test ran (init/`TestMain` panic): cause is package-level only.
+        if !report.build_failed_packages.contains(package)
+            && report.failed_packages.contains(package)
+            && group.iter().all(|r| r.status == Status::NotRun)
+            && let Some(text) = report.package_output.get(package)
+        {
+            for line in text.lines() {
+                let line = line.trim_end();
+                if line.is_empty() {
+                    continue;
+                }
+                out.push_str(&dim(&format!("        {line}"), color));
+                out.push('\n');
+            }
+        }
+    }
+
+    out.push('\n');
+    out.push_str(&summary(&report.rows, total));
+    out
+}
+
+fn summary(rows: &[TestRow], total: Duration) -> String {
+    let passed = rows.iter().filter(|r| r.status == Status::Passed).count();
+    let failed = rows.iter().filter(|r| r.status == Status::Failed).count();
+    let aborted = rows.iter().filter(|r| r.status == Status::Aborted).count();
+    let not_run = rows.iter().filter(|r| r.status == Status::NotRun).count();
+
+    let mut parts = vec![format!("{passed} passed")];
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if aborted > 0 {
+        parts.push(format!("{aborted} aborted"));
+    }
+    if not_run > 0 {
+        parts.push(format!("{not_run} not run"));
+    }
+    format!("  {} {}\n", parts.join(", "), format_elapsed(total))
+}
+
+/// A non-`Passed` row fails the run only when `go test` itself did; a filtered test must not.
+pub fn exit_code(rows: &[TestRow], run_success: bool) -> i32 {
+    let any_failure = rows
+        .iter()
+        .any(|r| matches!(r.status, Status::Failed | Status::Aborted));
+    if !run_success || any_failure { 1 } else { 0 }
+}
+
+fn mark(status: Status, color: bool) -> String {
+    let symbol = match status {
+        Status::Passed => "✓",
+        Status::Failed | Status::Aborted => "✗",
+        Status::NotRun => "·",
+    };
+    if !color {
+        return symbol.to_string();
+    }
+    match status {
+        Status::Passed => symbol.green().to_string(),
+        Status::Failed | Status::Aborted => symbol.red().to_string(),
+        Status::NotRun => symbol.to_string(),
+    }
+}
+
+fn dim(text: &str, color: bool) -> String {
+    if color {
+        text.dimmed().to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::ast::Span;
+    use syntax::program::TestFunction;
+
+    fn span() -> Span {
+        Span::new(0, 0, 1)
+    }
+
+    fn index(entries: &[(&str, &str)]) -> TestIndex {
+        let mut index = TestIndex::default();
+        for (module_id, name) in entries {
+            index.push(TestFunction {
+                module_id: module_id.to_string(),
+                qualified_name: format!("{module_id}.{name}"),
+                title: None,
+                doc: None,
+                span: span(),
+            });
+        }
+        index
+    }
+
+    fn event(action: &str, package: &str, test: Option<&str>, output: Option<&str>) -> GoTestEvent {
+        GoTestEvent {
+            action: action.to_string(),
+            package: package.to_string(),
+            test: test.map(str::to_string),
+            elapsed: Some(0.003),
+            output: output.map(str::to_string),
+            import_path: None,
+        }
+    }
+
+    fn build_output_event(package: &str, output: &str) -> GoTestEvent {
+        GoTestEvent {
+            action: "build-output".to_string(),
+            package: String::new(),
+            test: None,
+            elapsed: None,
+            output: Some(output.to_string()),
+            import_path: Some(format!("{package} [{package}.test]")),
+        }
+    }
+
+    #[test]
+    fn all_pass_groups_by_package() {
+        let index = index(&[(ENTRY_MODULE_ID, "root_smoke"), ("math", "adds_numbers")]);
+        let events = vec![
+            event("pass", "demo", Some("TestRootSmoke"), None),
+            event("pass", "demo/math", Some("TestAddsNumbers"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(7));
+
+        assert!(text.contains("  demo\n"));
+        assert!(text.contains("✓ root_smoke"));
+        assert!(text.contains("  demo/math\n"));
+        assert!(text.contains("✓ adds_numbers"));
+        assert!(text.contains("2 passed"));
+        assert_eq!(exit_code(&report.rows, true), 0);
+    }
+
+    #[test]
+    fn failed_test_shows_output_and_counts() {
+        let index = index(&[(ENTRY_MODULE_ID, "boom")]);
+        let events = vec![
+            event("fail", "demo", Some("TestBoom"), None),
+            event("output", "demo", Some("TestBoom"), Some("panic: boom\n")),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(2));
+
+        assert!(text.contains("✗ boom"));
+        assert!(text.contains("panic: boom"));
+        assert!(text.contains("1 failed"));
+        assert_eq!(exit_code(&report.rows, false), 1);
+    }
+
+    #[test]
+    fn declared_test_with_no_event_is_not_run() {
+        let index = index(&[(ENTRY_MODULE_ID, "ghost")]);
+        let report = build_report(&index, &[], "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(text.contains("· ghost (not run)"));
+        assert_eq!(exit_code(&report.rows, false), 1);
+    }
+
+    #[test]
+    fn filtered_run_does_not_fail_when_go_succeeds() {
+        let index = index(&[(ENTRY_MODULE_ID, "kept"), (ENTRY_MODULE_ID, "filtered")]);
+        let events = vec![event("pass", "demo", Some("TestKept"), None)];
+        let report = build_report(&index, &events, "demo");
+
+        assert_eq!(exit_code(&report.rows, true), 0);
+        let text = render(&report, false, Duration::from_millis(1));
+        assert!(text.contains("· filtered (not run)"));
+        assert!(text.contains("1 passed, 1 not run"));
+    }
+
+    #[test]
+    fn build_failure_output_is_captured_from_build_output_events() {
+        let index = index(&[(ENTRY_MODULE_ID, "never_runs")]);
+        let events = vec![
+            build_output_event("demo", "# demo\n"),
+            build_output_event("demo", "./ops_test.go:3:5: undefined: foo\n"),
+            event("fail", "demo", None, Some("FAIL\tdemo [build failed]\n")),
+        ];
+        let report = build_report(&index, &events, "demo");
+
+        assert!(report.build_output.contains("undefined: foo"));
+        assert!(!report.build_output.contains("[build failed]"));
+        assert!(report.rows.iter().all(|r| r.status == Status::NotRun));
+        assert_eq!(exit_code(&report.rows, false), 1);
+    }
+
+    #[test]
+    fn build_failure_in_one_package_does_not_hide_panic_in_another() {
+        let index = index(&[("a", "broken"), ("b", "crashes")]);
+        let events = vec![
+            build_output_event("demo/a", "./a_test.go:1:1: undefined: foo\n"),
+            event(
+                "output",
+                "demo/a",
+                None,
+                Some("FAIL\tdemo/a [build failed]\n"),
+            ),
+            event("fail", "demo/a", None, None),
+            event("output", "demo/b", None, Some("panic: boom in b\n")),
+            event("fail", "demo/b", None, None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(report.build_output.contains("undefined: foo"));
+        assert!(text.contains("panic: boom in b"));
+        assert!(!text.contains("[build failed]"));
+    }
+
+    #[test]
+    fn build_output_survives_a_per_test_failure_in_another_package() {
+        let index = index(&[("a", "passes"), ("b", "never_runs")]);
+        let events = vec![
+            event("fail", "demo/a", Some("TestPasses"), None),
+            build_output_event("demo/b", "./b_test.go:1:1: undefined: bar\n"),
+        ];
+        let report = build_report(&index, &events, "demo");
+
+        assert!(report.build_output.contains("undefined: bar"));
+    }
+
+    #[test]
+    fn started_test_without_terminal_is_aborted_and_shows_output() {
+        let index = index(&[(ENTRY_MODULE_ID, "hangs")]);
+        let events = vec![
+            event("run", "demo", Some("TestHangs"), None),
+            event(
+                "output",
+                "demo",
+                Some("TestHangs"),
+                Some("panic: test timed out\n"),
+            ),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(text.contains("✗ hangs (aborted)"));
+        assert!(text.contains("panic: test timed out"));
+        assert!(text.contains("1 aborted"));
+        assert_eq!(exit_code(&report.rows, false), 1);
+    }
+
+    #[test]
+    fn package_panic_before_any_test_shows_cause() {
+        let index = index(&[(ENTRY_MODULE_ID, "one"), (ENTRY_MODULE_ID, "two")]);
+        let events = vec![
+            event("output", "demo", None, Some("panic: init blew up\n")),
+            event("output", "demo", None, Some("goroutine 1 [running]:\n")),
+            event("fail", "demo", None, None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(report.rows.iter().all(|r| r.status == Status::NotRun));
+        assert!(text.contains("panic: init blew up"));
+        assert!(text.contains("goroutine 1"));
+        assert_eq!(exit_code(&report.rows, false), 1);
+    }
+
+    #[test]
+    fn package_panic_is_not_suppressed_by_another_packages_failure() {
+        let index = index(&[("a", "fails"), ("b", "never")]);
+        let events = vec![
+            event("run", "demo/a", Some("TestFails"), None),
+            event("fail", "demo/a", Some("TestFails"), None),
+            event("output", "demo/b", None, Some("panic: boom in b\n")),
+            event("fail", "demo/b", None, None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(text.contains("panic: boom in b"));
+    }
+
+    #[test]
+    fn import_path_normalizes_test_binary_suffix() {
+        assert_eq!(package_of_import_path("demo [demo.test]"), "demo");
+        assert_eq!(package_of_import_path("a/b [a/b.test]"), "a/b");
+        assert_eq!(package_of_import_path("demo"), "demo");
+    }
+
+    #[test]
+    fn empty_index_reports_no_tests() {
+        let report = build_report(&TestIndex::default(), &[], "demo");
+        let text = render(&report, false, Duration::from_millis(0));
+        assert!(text.contains("No tests found"));
+        assert_eq!(exit_code(&report.rows, true), 0);
+    }
+}

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -11,6 +11,7 @@ use semantics::inference::{AnalyzeInput, SemanticConfig};
 
 pub use semantics::inference::CompilePhase;
 use semantics::loader::Loader;
+pub use syntax::program::TestIndex;
 
 const ENTRY_FILE_ID: u32 = 0;
 
@@ -41,6 +42,7 @@ pub struct CompileResult {
     pub user_file_count: usize,
     pub live_modules: Vec<String>,
     pub emit_stamps: Vec<EmitStamp>,
+    pub test_index: TestIndex,
 }
 
 pub fn compile(
@@ -69,6 +71,7 @@ pub fn compile(
             user_file_count: 1,
             live_modules: vec![],
             emit_stamps: vec![],
+            test_index: TestIndex::default(),
         };
     }
 
@@ -120,6 +123,7 @@ pub fn compile(
     let mut errors = semantic_result.errors.clone();
     let lints = semantic_result.lints.clone();
     let live_modules: Vec<String> = semantic_result.modules.keys().cloned().collect();
+    let test_index = semantic_result.test_index.clone();
 
     if failed || config.target_phase == CompilePhase::Check {
         return CompileResult {
@@ -130,6 +134,7 @@ pub fn compile(
             user_file_count,
             live_modules,
             emit_stamps,
+            test_index,
         };
     }
 
@@ -154,6 +159,7 @@ pub fn compile(
             user_file_count,
             live_modules,
             emit_stamps,
+            test_index,
         };
     }
 
@@ -165,6 +171,7 @@ pub fn compile(
         user_file_count,
         live_modules,
         emit_stamps,
+        test_index,
     }
 }
 

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -70,7 +70,7 @@ impl Planner<'_> {
                 self.check_reserved_prefix(&go, name_span, diagnostics);
                 package_block.entry(go).or_default().push(*name_span);
                 if syntax::attributes::has_test_attribute(attributes) {
-                    let wrapper = format!("Test{}", go_name::snake_to_camel(name));
+                    let wrapper = go_name::go_test_function_name(name);
                     package_block.entry(wrapper).or_default().push(*name_span);
                 }
             }

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -23,7 +23,7 @@ impl Planner<'_> {
                 let code = self.emit_function(function, None, is_public, fx);
                 if self.facts.is_test(&self.facts.qualified_current(name)) {
                     let callee = self.pick_go_function_name(function, false, is_public);
-                    let test_name = format!("Test{}", go_name::snake_to_camel(name));
+                    let test_name = go_name::go_test_function_name(name);
                     fx.require_go_import("testing");
                     let wrapper = format!("func {test_name}(t *testing.T) {{\n\t{callee}()\n}}");
                     format!("{doc_comment}{code}\n\n{wrapper}")

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) use utils::is_order_sensitive;
 pub(crate) use utils::write_line;
 
 pub use names::go_name::PRELUDE_IMPORT_PATH;
+pub use names::go_name::go_test_function_name;
 pub use output::OutputFile;
 pub use output::imports;
 

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -42,6 +42,10 @@ pub(crate) fn snake_to_camel(s: &str) -> String {
     s.split('_').map(capitalize_first).collect()
 }
 
+pub fn go_test_function_name(fn_name: &str) -> String {
+    format!("Test{}", snake_to_camel(fn_name))
+}
+
 pub(crate) fn iterate_variants_fn_name(enum_name: &str, exported: bool) -> String {
     let method_segment = if exported {
         snake_to_camel("variants")


### PR DESCRIPTION
`lis test` now prints a grouped-per-module report instead of a single pass/fail line.

```text
  demo
    ├── ✓ adds
    └── ✗ boom
            panic: runtime error: index out of range [9] with length 3

  1 passed, 1 failed (0.12s)
```

Beyond pass and fail, the report distinguishes not-run and aborted tests, and shows the ocmpiler error or panic when the build fails or the binary crashes before a test reports.

> [!IMPORTANT] 
> The test runner is work in progress, not ready for use yet!

Follow-up to #769
