### PR TITLE
feat: tighten emitted go output for go-interop result calls

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -53,8 +53,15 @@ pub(crate) fn render_lowered_result_return(
     Renderer.render_lowered_block(output, &block);
 }
 
+/// Idiomatic Go zero (`0`, `""`, `nil`, ...) for a lowered failure slot.
+fn lowered_zero(planner: &mut Planner, ok_ty: &Type, fx: &mut EmitEffects) -> String {
+    let (zero, effects) = planner.zero_value(ok_ty);
+    fx.extend(&effects);
+    zero
+}
+
 /// The lowered Go-return values for an `Err`-with-payload failure, in the
-/// enclosing function's lowered shape (e.g. `["*new(T)", err]`).
+/// enclosing function's lowered shape (e.g. `[zero, err]`).
 pub(crate) fn lowered_err_values(
     planner: &mut Planner,
     shape: &AbiShape,
@@ -66,8 +73,7 @@ pub(crate) fn lowered_err_values(
         AbiShape::BareError => vec![err_expr.to_string()],
         AbiShape::ResultTuple => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-            let ok_ty_str = planner.go_type_string(&ok_ty, fx);
-            vec![format!("*new({})", ok_ty_str), err_expr.to_string()]
+            vec![lowered_zero(planner, &ok_ty, fx), err_expr.to_string()]
         }
         AbiShape::PartialTuple | AbiShape::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
@@ -93,7 +99,7 @@ pub(crate) fn lowered_ok_values(shape: &AbiShape, ok_expr: &str) -> Vec<String> 
 }
 
 /// The lowered Go-return values for a bare `None`, in an Option-shaped fn's
-/// lowered shape (e.g. `["*new(T)", "false"]`).
+/// lowered shape (e.g. `[zero, "false"]`).
 pub(crate) fn lowered_none_values(
     planner: &mut Planner,
     shape: &AbiShape,
@@ -103,8 +109,7 @@ pub(crate) fn lowered_none_values(
     match shape {
         AbiShape::CommaOk => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
-            let inner_str = planner.go_type_string(&inner, fx);
-            vec![format!("*new({})", inner_str), "false".to_string()]
+            vec![lowered_zero(planner, &inner, fx), "false".to_string()]
         }
         AbiShape::NullableReturn => vec!["nil".to_string()],
         _ => unreachable!("only Option's `None` lacks a payload"),
@@ -122,9 +127,9 @@ pub(crate) fn emit_lowered_result_return(
 ) -> Vec<LoweredStatement> {
     fx.require_stdlib();
     let p = result_value;
-    let ok_ty_str = |planner: &mut Planner, fx: &mut EmitEffects| {
+    let ok_zero = |planner: &mut Planner, fx: &mut EmitEffects| {
         let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-        planner.go_type_string(&ok_ty, fx)
+        lowered_zero(planner, &ok_ty, fx)
     };
     match shape {
         AbiShape::BareError => vec![
@@ -135,17 +140,17 @@ pub(crate) fn emit_lowered_result_return(
             multi_value_return(vec![format!("{p}.ErrVal")]),
         ],
         AbiShape::ResultTuple => {
-            let t = ok_ty_str(planner, fx);
+            let zero = ok_zero(planner, fx);
             vec![
                 tag_check(
                     format!("{p}.Tag == {RESULT_OK_TAG}"),
                     vec![format!("{p}.OkVal"), "nil".to_string()],
                 ),
-                multi_value_return(vec![format!("*new({t})"), format!("{p}.ErrVal")]),
+                multi_value_return(vec![zero, format!("{p}.ErrVal")]),
             ]
         }
         AbiShape::PartialTuple => {
-            let t = ok_ty_str(planner, fx);
+            let zero = ok_zero(planner, fx);
             vec![
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_OK_TAG}"),
@@ -153,19 +158,19 @@ pub(crate) fn emit_lowered_result_return(
                 ),
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_ERR_TAG}"),
-                    vec![format!("*new({t})"), format!("{p}.ErrVal")],
+                    vec![zero, format!("{p}.ErrVal")],
                 ),
                 multi_value_return(vec![format!("{p}.OkVal"), format!("{p}.ErrVal")]),
             ]
         }
         AbiShape::CommaOk => {
-            let t = ok_ty_str(planner, fx);
+            let zero = ok_zero(planner, fx);
             vec![
                 tag_check(
                     format!("{p}.Tag == {OPTION_SOME_TAG}"),
                     vec![format!("{p}.SomeVal"), "true".to_string()],
                 ),
-                multi_value_return(vec![format!("*new({t})"), "false".to_string()]),
+                multi_value_return(vec![zero, "false".to_string()]),
             ]
         }
         AbiShape::NullableReturn => vec![
@@ -371,10 +376,11 @@ fn emit_result_return_adapter(
         return (err_ty_str, b);
     }
     let ok_ty_str = planner.go_type_string(&ok_ty, fx);
+    let ok_zero = lowered_zero(planner, &ok_ty, fx);
     write_line!(
         b,
         "if {res}.Tag == {ok_tag} {{\nreturn {res}.OkVal, nil\n}}\n\
-         return *new({ok_ty_str}), {res}.ErrVal"
+         return {ok_zero}, {res}.ErrVal"
     );
     (format!("({ok_ty_str}, {err_ty_str})"), b)
 }
@@ -390,13 +396,14 @@ fn emit_partial_return_adapter(
     let err_ty = return_type.err_type();
     let ok_ty_str = planner.go_type_string(&ok_ty, fx);
     let err_ty_str = planner.go_type_string(&err_ty, fx);
+    let ok_zero = lowered_zero(planner, &ok_ty, fx);
     let res = planner.fresh_var(Some("res"));
     planner.declare(&res);
 
     let b = format!(
         "{res} := {inner_call}\n\
          if {res}.Tag == {PARTIAL_OK_TAG} {{\nreturn {res}.OkVal, nil\n}}\n\
-         if {res}.Tag == {PARTIAL_ERR_TAG} {{\nreturn *new({ok_ty_str}), {res}.ErrVal\n}}\n\
+         if {res}.Tag == {PARTIAL_ERR_TAG} {{\nreturn {ok_zero}, {res}.ErrVal\n}}\n\
          return {res}.OkVal, {res}.ErrVal\n"
     );
     (format!("({ok_ty_str}, {err_ty_str})"), b)
@@ -428,10 +435,11 @@ fn emit_option_return_adapter(
     }
 
     let inner_ty_str = planner.go_type_string(&inner, fx);
+    let inner_zero = lowered_zero(planner, &inner, fx);
     let b = format!(
         "{opt} := {inner_call}\n\
          if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal, true\n}}\n\
-         return *new({inner_ty_str}), false\n"
+         return {inner_zero}, false\n"
     );
     (format!("({inner_ty_str}, bool)"), b)
 }
@@ -716,8 +724,7 @@ fn emit_lowered_partial_tail(
                     planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
                 statements.extend(setup);
                 let ok_ty = planner.facts.peel_alias(&return_ty).ok_type();
-                let ok_ty_str = planner.go_type_string(&ok_ty, fx);
-                multi_value_return(vec![format!("*new({})", ok_ty_str), e])
+                multi_value_return(vec![lowered_zero(planner, &ok_ty, fx), e])
             }
             "Both" => {
                 let (setup_v, v) =

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -298,6 +298,15 @@ impl Planner<'_> {
         (setup, outcome.expect("wrapper produced no slot"))
     }
 
+    pub(crate) fn go_result_needs_nil_guard(&self, ok_ty: &Type) -> bool {
+        ok_ty.is_ref()
+            || self
+                .facts
+                .as_interface(ok_ty)
+                .as_deref()
+                .is_some_and(|id| id != go_name::PRELUDE_ERROR_ID)
+    }
+
     /// Lower a `(T, error)` Go return into a tagged `Result`.
     pub(crate) fn lower_result_wrapping(
         &mut self,
@@ -322,11 +331,7 @@ impl Planner<'_> {
             fe.full_type_string()
         };
 
-        let interface_id = self.facts.as_interface(ok_ty);
-        let needs_nil_guard = ok_ty.is_ref()
-            || interface_id
-                .as_deref()
-                .is_some_and(|id| id != go_name::PRELUDE_ERROR_ID);
+        let needs_nil_guard = self.go_result_needs_nil_guard(ok_ty);
 
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -5,7 +5,7 @@ use crate::ReturnContext;
 use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
-use crate::definitions::functions::is_go_never;
+use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::plan::bodies::{LoweredBlock, LoweredStatement};
 use crate::plan::placement::is_unit_call;
 use syntax::ast::Expression;
@@ -78,7 +78,7 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         if last.diverges().is_some() || last.get_type().is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
-            if !is_go_never(last) {
+            if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;
@@ -255,7 +255,7 @@ impl Planner<'_> {
         let item_ty = last.get_type();
         if item_ty.is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
-            if !is_go_never(last) {
+            if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,4 +1,5 @@
 use crate::EmitEffects;
+use crate::GoCallStrategy;
 use crate::Planner;
 use crate::Renderer;
 use crate::abi::AbiShape;
@@ -65,6 +66,10 @@ impl Planner<'_> {
             statements.extend(head);
             self.declare_zero_for_dead_path(&mut statements, var_name, &fallible, fx);
             return (statements, String::new());
+        }
+
+        if let Some(fused) = self.try_lower_fused_go_propagate(expression, result_var_name, fx) {
+            return fused;
         }
 
         fx.require_stdlib();
@@ -166,6 +171,64 @@ impl Planner<'_> {
         };
 
         transition::tag_check(format!("{}.Tag != {}", check_var, success_tag), values)
+    }
+
+    /// Fuse `go_call()?` into `v, err := call(); if err != nil { return ... }`,
+    /// skipping the `lisette.Result`.
+    fn try_lower_fused_go_propagate(
+        &mut self,
+        expression: &Expression,
+        result_var_name: Option<&str>,
+        fx: &mut EmitEffects,
+    ) -> Option<(Vec<LoweredStatement>, String)> {
+        let plan = self.plan_call(expression)?;
+        if !matches!(plan.callee, CalleePlan::GoInterop(GoCallStrategy::Result)) {
+            return None;
+        }
+        let ok_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
+        if ok_ty.is_unit()
+            || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_))
+            || self.go_result_needs_nil_guard(&ok_ty)
+        {
+            return None;
+        }
+        let return_ctx = self.return_ctx();
+        let shape = return_ctx.lowered_shape()?;
+        let return_ty = return_ctx.expect_ty();
+
+        let want_value = !matches!(result_var_name, Some("_"));
+        let val_var = want_value.then(|| {
+            let v = self.fresh_var(Some("ret"));
+            self.declare(&v);
+            v
+        });
+        let err_var = self.fresh_var(Some("ret"));
+        self.declare(&err_var);
+
+        let (mut statements, call_str) =
+            self.lower_call(expression, None, ExpressionContext::value(), fx);
+        let bind_line = match &val_var {
+            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
+            None => format!("_, {} := {}\n", err_var, call_str),
+        };
+        statements.push(LoweredStatement::RawGo(bind_line));
+
+        let failure_values = transition::lowered_err_values(self, &shape, &return_ty, &err_var, fx);
+        statements.push(transition::tag_check(
+            format!("{} != nil", err_var),
+            failure_values,
+        ));
+
+        let value = match result_var_name {
+            None => val_var.expect("ok value requested when result_var_name is None"),
+            Some("_") => "_".to_string(),
+            Some(name) => {
+                let v = val_var.expect("ok value requested for a named binding");
+                statements.push(self.bind_propagate_ok(name, &v));
+                name.to_string()
+            }
+        };
+        Some((statements, value))
     }
 
     /// Statement-position `inner?` (discards the ok value).

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -550,6 +550,10 @@ pub(crate) fn is_go_never(expression: &Expression) -> bool {
     }
 }
 
+pub(crate) fn is_breakless_loop(expression: &Expression) -> bool {
+    matches!(expression, Expression::Loop { body, .. } if !body.contains_break())
+}
+
 /// Renamed definition parts for methods on native Go receiver types; the
 /// caller rebinds its view to borrow these.
 type NativeMethodOverride = (ecow::EcoString, Vec<Binding>);

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,13 +1,15 @@
 use crate::EmitEffects;
+use crate::GoCallStrategy;
 use crate::Planner;
 use crate::abi::AbiShape;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::tree_emitter::TreePlanner;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
-use crate::plan::calls::CallReturnShape;
+use crate::plan::calls::{CallPlan, CallReturnShape, CalleePlan};
 use crate::state::bindings::BindingValue;
 use syntax::ast::{Expression, MatchArm, Pattern};
+use syntax::types::Type;
 
 /// How to render the subject declaration line, based on body usage.
 enum SubjectDeclaration {
@@ -87,6 +89,30 @@ impl Planner<'_> {
         tree_emitter.lower(place)
     }
 
+    /// The shape a match subject fuses against: lowered Lisette `Result` callees
+    /// and single-value Go `(T, error)` calls. `None` keeps the lift-then-match
+    /// path (Partial, Option, comma-ok, flattened multi-returns).
+    fn fusable_result_shape(&self, subject: &Expression, plan: &CallPlan) -> Option<AbiShape> {
+        let shape = match (&plan.callee, &plan.return_shape) {
+            (_, CallReturnShape::Lowered(shape)) => shape.clone(),
+            (CalleePlan::GoInterop(GoCallStrategy::Result), _) => {
+                let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
+                if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_))
+                    || self.go_result_needs_nil_guard(&ok_ty)
+                {
+                    return None;
+                }
+                if ok_ty.is_unit() {
+                    AbiShape::BareError
+                } else {
+                    AbiShape::ResultTuple
+                }
+            }
+            _ => return None,
+        };
+        matches!(shape, AbiShape::ResultTuple | AbiShape::BareError).then_some(shape)
+    }
+
     /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
     /// when the scrutinee is a lowered call with simple `Ok`/`Err` arms.
     fn lower_fused_lowered_match(
@@ -97,14 +123,7 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let plan = self.plan_call(subject)?;
-        let CallReturnShape::Lowered(shape) = plan.return_shape else {
-            return None;
-        };
-        // Match-fusion only handles `Result`'s binary `Ok`/`Err` arms;
-        // Partial (3-way) and Option (Some/None) fall through to lift-then-match.
-        if !matches!(shape, AbiShape::ResultTuple | AbiShape::BareError) {
-            return None;
-        }
+        let shape = self.fusable_result_shape(subject, &plan)?;
         let (ok_arm, err_arm) = classify_result_arms(arms)?;
 
         // Err always carries a payload; Ok may not under BareError.
@@ -232,12 +251,24 @@ impl Planner<'_> {
         self.declare(&var);
         let staged = self.stage_composite(subject, ExpressionContext::value(), fx);
         setup.extend(staged.setup);
+        if !any_guard && is_plain_go_identifier(&staged.value) {
+            return (staged.value, SubjectDeclaration::None);
+        }
         let declaration = SubjectDeclaration::Deferred {
             var: var.clone(),
             expression: staged.value,
         };
         (var, declaration)
     }
+}
+
+fn is_plain_go_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Recognize `[Ok(<...>), Err(<...>)]` (in either order, no guards).

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -4,7 +4,7 @@ use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
-use crate::definitions::functions::is_go_never;
+use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
     LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan,
@@ -697,7 +697,7 @@ impl Planner<'_> {
             statements.push(LoweredStatement::RawGo(directive));
         }
         statements.push(self.lower_statement(last, fx));
-        if !is_go_never(last) {
+        if !is_go_never(last) && !is_breakless_loop(last) {
             statements.push(LoweredStatement::UnreachablePanic);
         }
         statements

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -3,7 +3,7 @@ use crate::Planner;
 use crate::analyze::inline_uses::region_blocks_inline;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
-use crate::definitions::functions::is_go_never;
+use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::expressions::emission::StagedExpression;
 use crate::plan::bodies::{
     AssignForm, AssignPlan, BreakValueDisposition, BreakValuePlan, LoweredBlock, LoweredStatement,
@@ -468,7 +468,7 @@ impl Planner<'_> {
         }
         if last.get_type().is_never() {
             let mut statements = vec![self.lower_statement(last, fx)];
-            if !is_go_never(last) {
+            if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;

--- a/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
@@ -25,7 +25,7 @@ func main() {
 		if option_3.Tag == lisette.OptionSome {
 			return option_3.SomeVal, true
 		}
-		return *new(Face), false
+		return nil, false
 	})
 	var option_6 lisette.Option[Face]
 	if ret_5 && !lisette.IsNilInterface(ret_4) {

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
@@ -24,8 +24,7 @@ func main() {
 	} else {
 		result_4 = lisette.MakePartialOk[[]byte, error](ret_2)
 	}
-	subject_1 := result_4
-	switch subject_1.Tag {
+	switch result_4.Tag {
 	case lisette.PartialOk:
 		fmt.Print("ok")
 	case lisette.PartialBoth:

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
@@ -23,8 +23,7 @@ func main() {
 	} else {
 		result_4 = lisette.MakePartialOk[ast.Expr, error](ret_2)
 	}
-	subject_1 := result_4
-	switch subject_1.Tag {
+	switch result_4.Tag {
 	case lisette.PartialOk:
 		fmt.Print("ok")
 	case lisette.PartialBoth:

--- a/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
+++ b/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
@@ -14,9 +14,8 @@ func main() {
 	m := sync.Map{}
 	m.Store("key", "value")
 	option_2 := lisette.OptionFromCommaOk[any](m.Load("key"))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
-		v := subject_1.SomeVal
+	if option_2.Tag == lisette.OptionSome {
+		v := option_2.SomeVal
 		fmt.Printf("got: %v\n", v)
 	} else {
 		fmt.Println("not found")

--- a/tests/spec/build/snapshots/nullable_option_fn_arg_adapts_to_comma_ok_generic_param.snap
+++ b/tests/spec/build/snapshots/nullable_option_fn_arg_adapts_to_comma_ok_generic_param.snap
@@ -25,6 +25,6 @@ func main() {
 		if option_3.Tag == lisette.OptionSome {
 			return option_3.SomeVal, true
 		}
-		return *new(Face), false
+		return nil, false
 	})
 }

--- a/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
+++ b/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
@@ -30,7 +30,7 @@ func main() {
 		if option_3.Tag == lisette.OptionSome {
 			return option_3.SomeVal, true
 		}
-		return *new(Face), false
+		return nil, false
 	})
 	var option_7 lisette.Option[Face]
 	if ret_6 && !lisette.IsNilInterface(ret_5) {

--- a/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
+++ b/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
@@ -12,9 +12,8 @@ import (
 func find(haystack, needle string) int {
 	ret_2 := strings.Index(haystack, needle)
 	option_3 := lisette.OptionFromCommaOk[int](ret_2, ret_2 != -1)
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	if option_3.Tag == lisette.OptionSome {
+		return option_3.SomeVal
 	}
 	return -2
 }

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -7,7 +7,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 )
 
 type Widget struct {
@@ -20,17 +19,12 @@ func (w Widget) MarshalJSON() ([]uint8, error) {
 
 func main() {
 	w := Widget{id: 7}
-	ret_2, ret_3 := json.Marshal(w)
-	var result_4 lisette.Result[[]byte, error]
-	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[[]byte, error](ret_3)
+	ret_1, ret_2 := json.Marshal(w)
+	if ret_2 == nil {
+		b := ret_1
+		fmt.Println(string(b))
 	} else {
-		result_4 = lisette.MakeResultOk[[]byte, error](ret_2)
-	}
-	subject_1 := result_4
-	if subject_1.Tag == lisette.ResultOk {
-		fmt.Println(string(subject_1.OkVal))
-	} else {
-		fmt.Println(subject_1.ErrVal)
+		e := ret_2
+		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -2147,6 +2147,20 @@ fn test(items: Slice<int>) -> int {
 }
 
 #[test]
+fn breakless_loop_tail_omits_unreachable_panic() {
+    let input = r#"
+fn serve(n: int) -> int {
+  loop {
+    if n > 0 {
+      return n
+    }
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn continue_in_match_in_loop() {
     let input = r#"
 fn test(items: Slice<int>) -> int {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1040,6 +1040,19 @@ pub fn Close() -> Result<error, error>
 }
 
 #[test]
+fn propagate_go_pointer_result_keeps_nil_guard() {
+    let input = r#"
+import "go:os"
+
+fn open_first(path: string) -> Result<int, error> {
+  let _ = os.Open(path)?
+  Ok(0)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_parallel_error_tuple_return() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
+++ b/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
@@ -27,5 +27,5 @@ func run() (int, bool) {
 	if v_5.Tag == lisette.OptionSome {
 		return v_5.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/blocking_receive.snap
+++ b/tests/spec/emit/snapshots/blocking_receive.snap
@@ -17,5 +17,5 @@ func test() (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/breakless_loop_tail_omits_unreachable_panic.snap
+++ b/tests/spec/emit/snapshots/breakless_loop_tail_omits_unreachable_panic.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn serve(n: int) -> int {
+    loop {
+      if n > 0 {
+        return n
+      }
+    }
+  }
+---
+package main
+
+func serve(n int) int {
+	for {
+		if n > 0 {
+			return n
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -26,10 +26,7 @@ description: |
 ---
 package main
 
-import (
-	"example.com/svc"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/svc"
 
 type Loader struct{}
 
@@ -38,18 +35,13 @@ func (l Loader) Load(_ string) (int, error) {
 }
 
 func run(s svc.Alias) int {
-	ret_2, ret_3 := s.Load("k")
-	var result_4 lisette.Result[int, error]
-	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[int, error](ret_3)
+	ret_1, ret_2 := s.Load("k")
+	if ret_2 == nil {
+		n := ret_1
+		return n
 	} else {
-		result_4 = lisette.MakeResultOk[int, error](ret_2)
+		return 0
 	}
-	subject_1 := result_4
-	if subject_1.Tag == lisette.ResultOk {
-		return subject_1.OkVal
-	}
-	return 0
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/chained_option_construction.snap
+++ b/tests/spec/emit/snapshots/chained_option_construction.snap
@@ -26,5 +26,5 @@ func test() (int, bool) {
 	if v_2.Tag == lisette.OptionSome {
 		return v_2.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/chained_propagate_option.snap
+++ b/tests/spec/emit/snapshots/chained_propagate_option.snap
@@ -14,11 +14,11 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func get_nested(outer lisette.Option[lisette.Option[int]]) (int, bool) {
 	if outer.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	inner := outer.SomeVal
 	if inner.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	val := inner.SomeVal
 	return val, true

--- a/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
@@ -38,7 +38,7 @@ func run() (int, error) {
 	}
 	check_4 := result_3
 	if check_4.Tag != lisette.ResultOk {
-		return *new(int), check_4.ErrVal
+		return 0, check_4.ErrVal
 	}
 	return add(check_4.OkVal, side()), nil
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -39,7 +39,7 @@ func run() (int, error) {
 	}
 	check_4 := result_3
 	if check_4.Tag != lisette.ResultOk {
-		return *new(int), check_4.ErrVal
+		return 0, check_4.ErrVal
 	}
 	return add(_arg_5, check_4.OkVal), nil
 }

--- a/tests/spec/emit/snapshots/err_with_errors_new.snap
+++ b/tests/spec/emit/snapshots/err_with_errors_new.snap
@@ -17,7 +17,7 @@ import "errors"
 
 func might_fail(n int) (int, error) {
 	if n < 0 {
-		return *new(int), errors.New("negative")
+		return 0, errors.New("negative")
 	}
 	return n, nil
 }

--- a/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
@@ -23,7 +23,7 @@ func fallible(ok bool) (int, error) {
 	if ok {
 		return 1, nil
 	}
-	return *new(int), errors.New("nope")
+	return 0, errors.New("nope")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
@@ -23,7 +23,7 @@ func fallible(ok bool) (int, error) {
 	if ok {
 		return 1, nil
 	}
-	return *new(int), errors.New("nope")
+	return 0, errors.New("nope")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
@@ -23,7 +23,7 @@ func fallible(ok bool) (int, error) {
 	if ok {
 		return 1, nil
 	}
-	return *new(int), errors.New("nope")
+	return 0, errors.New("nope")
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
+++ b/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
@@ -34,11 +34,10 @@ func main() {
 	} else {
 		result_6 = lisette.MakeResultOk[lisette.Tuple2[string, string], error](tup_5)
 	}
-	subject_1 := result_6
-	if subject_1.Tag == lisette.ResultOk {
-		_ = subject_1.OkVal.First
-		_ = subject_1.OkVal.Second
+	if result_6.Tag == lisette.ResultOk {
+		_ = result_6.OkVal.First
+		_ = result_6.OkVal.Second
 	} else {
-		_ = subject_1.ErrVal
+		_ = result_6.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_without_else_branch.snap
@@ -23,16 +23,15 @@ import (
 
 func divide(a, b int) (int, bool) {
 	if b == 0 {
-		return *new(int), false
+		return 0, false
 	}
 	return a / b, true
 }
 
 func test() {
 	option_2 := lisette.OptionFromCommaOk[int](divide(100, 10))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
-		x := subject_1.SomeVal
+	if option_2.Tag == lisette.OptionSome {
+		x := option_2.SomeVal
 		fmt.Printf("Result: %d\n", x)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
@@ -25,9 +25,8 @@ import (
 
 func apply(f func(string) (string, bool), key string) string {
 	option_2 := lisette.OptionFromCommaOk[string](f(key))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal
 	}
 	return "unset"
 }

--- a/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
+++ b/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
@@ -42,11 +42,10 @@ loop_1:
 		} else {
 			result_8 = lisette.MakeResultOk[lisette.Tuple2[rune, int], error](tup_7)
 		}
-		subject_3 := result_8
-		if subject_3.Tag == lisette.ResultOk {
-			r_2 = subject_3.OkVal.First
+		if result_8.Tag == lisette.ResultOk {
+			r_2 = result_8.OkVal.First
 		} else {
-			if subject_3.ErrVal == io.EOF {
+			if result_8.ErrVal == io.EOF {
 				break loop_1
 			}
 			panic("error")

--- a/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
@@ -26,8 +26,7 @@ import (
 func apply(f func(string) *flag.Flag, name string) bool {
 	raw_2 := f(name)
 	option_3 := lisette.OptionFromNilable[*flag.Flag](raw_2, raw_2 == nil)
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
+	if option_3.Tag == lisette.OptionSome {
 		return true
 	}
 	return false

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -23,9 +23,8 @@ import (
 func main() {
 	raw_2 := evts.Peek()
 	option_3 := lisette.OptionFromNilable[evts.Msg](raw_2, lisette.IsNilInterface(raw_2))
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
-		fmt.Println(subject_1.SomeVal)
+	if option_3.Tag == lisette.OptionSome {
+		fmt.Println(option_3.SomeVal)
 	} else {
 		fmt.Println("none")
 	}

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -13,22 +13,13 @@ description: |
 ---
 package main
 
-import (
-	"example.com/legacy"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/legacy"
 
 func main() {
-	ret_2, ret_3 := legacy.Close()
-	var result_4 lisette.Result[error, error]
-	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[error, error](ret_3)
-	} else {
-		result_4 = lisette.MakeResultOk[error, error](ret_2)
-	}
-	subject_1 := result_4
-	if subject_1.Tag == lisette.ResultOk {
-		_ = subject_1.OkVal
+	ret_1, ret_2 := legacy.Close()
+	if ret_2 == nil {
+		stored := ret_1
+		_ = stored
 	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_try_block.snap
@@ -44,7 +44,7 @@ func make_() (func(string) (int, error), error) {
 	if v_3.Tag == lisette.ResultOk {
 		return v_3.OkVal, nil
 	}
-	return *new(func(string) (int, error)), v_3.ErrVal
+	return nil, v_3.ErrVal
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -28,9 +28,8 @@ func main() {
 	for _, bucket := range buckets {
 		raw_2 := bucket.Name
 		option_3 := lisette.OptionFromPointer[string](raw_2)
-		subject_1 := option_3
-		if subject_1.Tag == lisette.OptionSome {
-			fmt.Println(subject_1.SomeVal)
+		if option_3.Tag == lisette.OptionSome {
+			fmt.Println(option_3.SomeVal)
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
@@ -23,8 +23,7 @@ func main() {
 	bucket := aws.Bucket{}
 	raw_2 := bucket.Name
 	option_3 := lisette.OptionFromPointer[string](raw_2)
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
-		_ = subject_1.SomeVal
+	if option_3.Tag == lisette.OptionSome {
+		_ = option_3.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
@@ -25,9 +25,8 @@ func main() {
 	ctx := context.Background()
 	raw_2 := ctx.Err()
 	option_3 := lisette.OptionFromNilable[error](raw_2, lisette.IsNilInterface(raw_2))
-	subject_1 := option_3
-	if subject_1.Tag == lisette.OptionSome {
-		fmt.Println(subject_1.SomeVal.Error())
+	if option_3.Tag == lisette.OptionSome {
+		fmt.Println(option_3.SomeVal.Error())
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
+++ b/tests/spec/emit/snapshots/let_binding_shadows_go_predeclared_type.snap
@@ -31,5 +31,5 @@ func parse(s string) (int, error) {
 	if result.Tag == lisette.ResultOk {
 		return result.OkVal, nil
 	}
-	return *new(int), result.ErrVal
+	return 0, result.ErrVal
 }

--- a/tests/spec/emit/snapshots/let_else_option_direct_call.snap
+++ b/tests/spec/emit/snapshots/let_else_option_direct_call.snap
@@ -19,7 +19,7 @@ func get_value(s string) (int, bool) {
 	if s == "ok" {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
@@ -39,16 +39,15 @@ func test() {
 	} else {
 		result_4 = lisette.MakePartialOk[lisette.Tuple2[int, string], error](ret_2)
 	}
-	subject_1 := result_4
-	switch subject_1.Tag {
+	switch result_4.Tag {
 	case lisette.PartialOk:
-		_ = subject_1.OkVal.First
-		_ = subject_1.OkVal.Second
+		_ = result_4.OkVal.First
+		_ = result_4.OkVal.Second
 	case lisette.PartialErr:
-		_ = subject_1.ErrVal
+		_ = result_4.ErrVal
 	default:
-		_ = subject_1.OkVal.First
-		_ = subject_1.OkVal.Second
-		_ = subject_1.ErrVal
+		_ = result_4.OkVal.First
+		_ = result_4.OkVal.Second
+		_ = result_4.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
@@ -34,11 +34,10 @@ func test() {
 	} else {
 		result_4 = lisette.MakeResultOk[lisette.Tuple2[int, string], error](ret_2)
 	}
-	subject_1 := result_4
-	if subject_1.Tag == lisette.ResultOk {
-		_ = subject_1.OkVal.First
-		_ = subject_1.OkVal.Second
+	if result_4.Tag == lisette.ResultOk {
+		_ = result_4.OkVal.First
+		_ = result_4.OkVal.Second
 	} else {
-		_ = subject_1.ErrVal
+		_ = result_4.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
+++ b/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
@@ -30,7 +30,7 @@ func maybe(flag bool) (int, bool) {
 	if flag {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/map_get.snap
+++ b/tests/spec/emit/snapshots/map_get.snap
@@ -15,5 +15,5 @@ func test(m map[string]int, key string) (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -23,7 +23,7 @@ import (
 
 func safe_divide(a, b float64) (float64, bool) {
 	if b == 0.0 {
-		return *new(float64), false
+		return 0.0, false
 	}
 	return a / b, true
 }
@@ -31,9 +31,8 @@ func safe_divide(a, b float64) (float64, bool) {
 func parse_and_divide(a, b float64) lisette.Result[string, string] {
 	var result float64
 	option_2 := lisette.OptionFromCommaOk[float64](safe_divide(a, b))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
-		result = subject_1.SomeVal
+	if option_2.Tag == lisette.OptionSome {
+		result = option_2.SomeVal
 	} else {
 		return lisette.MakeResultErr[string, string]("division by zero")
 	}

--- a/tests/spec/emit/snapshots/match_returning_option.snap
+++ b/tests/spec/emit/snapshots/match_returning_option.snap
@@ -15,5 +15,5 @@ func test(flag bool) (int, bool) {
 	if flag {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
@@ -25,13 +25,12 @@ func maybe(b bool) (int, bool) {
 	if b {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() {
 	option_2 := lisette.OptionFromCommaOk[int](maybe(true))
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
+	if option_2.Tag == lisette.OptionSome {
 		noop()
 	} else {
 		noop()

--- a/tests/spec/emit/snapshots/match_with_wildcard_returning_option.snap
+++ b/tests/spec/emit/snapshots/match_with_wildcard_returning_option.snap
@@ -19,6 +19,6 @@ func test(n int) (int, bool) {
 	case 2:
 		return 20, true
 	default:
-		return *new(int), false
+		return 0, false
 	}
 }

--- a/tests/spec/emit/snapshots/multiple_option_constructions.snap
+++ b/tests/spec/emit/snapshots/multiple_option_constructions.snap
@@ -16,5 +16,5 @@ func test(flag bool) (int, bool) {
 	if flag {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/option_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/option_direct_as_argument.snap
@@ -22,7 +22,7 @@ func maybe_int(b bool) (int, bool) {
 	if b {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func unwrap_or(o lisette.Option[int], fallback int) int {

--- a/tests/spec/emit/snapshots/option_in_array_literal.snap
+++ b/tests/spec/emit/snapshots/option_in_array_literal.snap
@@ -18,7 +18,7 @@ func maybe(x int) (int, bool) {
 	if x > 0 {
 		return x, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/option_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/option_in_tuple_literal.snap
@@ -22,14 +22,14 @@ func maybe_int(x int) (int, bool) {
 	if x > 0 {
 		return x, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func maybe_string(s string) (string, bool) {
 	if s != "" {
 		return s, true
 	}
-	return *new(string), false
+	return "", false
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/option_none_construction.snap
+++ b/tests/spec/emit/snapshots/option_none_construction.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test() (int, bool) {
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
@@ -20,7 +20,7 @@ func main() {
 		if opt_2.Tag == lisette.OptionSome {
 			return opt_2.SomeVal, true
 		}
-		return *new(int), false
+		return 0, false
 	}
 	opt := lisette.MakeOptionSome(1)
 	_arg_6 := opt

--- a/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
+++ b/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
@@ -23,7 +23,7 @@ func main() {
 		if opt_4.Tag == lisette.OptionSome {
 			return opt_4.SomeVal, true
 		}
-		return *new(int), false
+		return 0, false
 	}
 	option_5 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) (int, bool) {
 		return v * 2, true

--- a/tests/spec/emit/snapshots/prelude_method_value_type_instantiation.snap
+++ b/tests/spec/emit/snapshots/prelude_method_value_type_instantiation.snap
@@ -19,7 +19,7 @@ func main() {
 		if opt_2.Tag == lisette.OptionSome {
 			return opt_2.SomeVal, true
 		}
-		return *new(int), false
+		return 0, false
 	}
 	option_3 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) int {
 		return v + 1

--- a/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
+++ b/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
@@ -19,7 +19,7 @@ func main() {
 		if opt_2.Tag == lisette.OptionSome {
 			return opt_2.SomeVal, true
 		}
-		return *new(int), false
+		return 0, false
 	}
 	option_3 := lisette.OptionFromCommaOk[int](f(42))
 	x := option_3

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_result_tuple.snap
@@ -18,7 +18,7 @@ package main
 import "errors"
 
 func fail() (int, error) {
-	return *new(int), errors.New("boom")
+	return 0, errors.New("boom")
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_lowered_option_comma_ok.snap
@@ -14,7 +14,7 @@ description: |
 package main
 
 func missing() (int, bool) {
-	return *new(int), false
+	return 0, false
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_none_tail_position.snap
@@ -17,13 +17,13 @@ import lisette "github.com/ivov/lisette/prelude"
 func f() (int, bool) {
 	check_1 := lisette.MakeOptionNone[lisette.Option[int]]()
 	if check_1.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	v_2 := check_1.SomeVal
 	if v_2.Tag == lisette.OptionSome {
 		return v_2.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() (int, bool) {

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:os"
+  
+  fn open_first(path: string) -> Result<int, error> {
+    let _ = os.Open(path)?
+    Ok(0)
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func open_first(path string) (int, error) {
+	ret_1, ret_2 := os.Open(path)
+	var result_3 lisette.Result[*os.File, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[*os.File, error](ret_2)
+	} else if ret_1 == nil {
+		result_3 = lisette.MakeResultErr[*os.File, error](errors.New("unexpected nil"))
+	} else {
+		result_3 = lisette.MakeResultOk[*os.File, error](ret_1)
+	}
+	check_4 := result_3
+	if check_4.Tag != lisette.ResultOk {
+		return 0, check_4.ErrVal
+	}
+	return 0, nil
+}

--- a/tests/spec/emit/snapshots/propagate_on_variable.snap
+++ b/tests/spec/emit/snapshots/propagate_on_variable.snap
@@ -15,7 +15,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() (int, bool) {
 	x := lisette.MakeOptionSome(42)
 	if x.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	y := x.SomeVal
 	return y + 1, true

--- a/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_on_variable_in_expression.snap
@@ -14,7 +14,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func test() (int, bool) {
 	x := lisette.MakeOptionSome(10)
 	if x.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	return x.SomeVal + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_option_in_function.snap
+++ b/tests/spec/emit/snapshots/propagate_option_in_function.snap
@@ -16,14 +16,14 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func maybe_get() (int, bool) {
-	return *new(int), false
+	return 0, false
 }
 
 func process() (int, bool) {
 	option_1 := lisette.OptionFromCommaOk[int](maybe_get())
 	check_2 := option_1
 	if check_2.Tag != lisette.OptionSome {
-		return *new(int), false
+		return 0, false
 	}
 	x := check_2.SomeVal
 	return x + 1, true

--- a/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
+++ b/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
@@ -37,7 +37,7 @@ func process() (int, error) {
 	}
 	check_5 := result_4
 	if check_5.Tag != lisette.ResultOk {
-		return *new(int), check_5.ErrVal
+		return 0, check_5.ErrVal
 	}
 	x_1 := check_5.OkVal
 	return x_1 + 1, nil

--- a/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
+++ b/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
@@ -21,7 +21,7 @@ func test() (struct{}, bool) {
 	option_1 := lisette.OptionFromCommaOk[int](maybe())
 	check_2 := option_1
 	if check_2.Tag != lisette.OptionSome {
-		return *new(struct{}), false
+		return struct{}{}, false
 	}
 	return struct{}{}, true
 }

--- a/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
+++ b/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
@@ -23,5 +23,5 @@ func (m MyError) Error() string {
 }
 
 func might_fail() (int, error) {
-	return *new(int), MyError{msg: "oops"}
+	return 0, MyError{msg: "oops"}
 }

--- a/tests/spec/emit/snapshots/return_option_from_variable.snap
+++ b/tests/spec/emit/snapshots/return_option_from_variable.snap
@@ -22,5 +22,5 @@ func test(flag bool) (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/sentinel_hinted_tail_call_wraps_in_wrapper_fn.snap
+++ b/tests/spec/emit/snapshots/sentinel_hinted_tail_call_wraps_in_wrapper_fn.snap
@@ -25,7 +25,7 @@ func find(haystack, needle string) (int, bool) {
 	if option_2.Tag == lisette.OptionSome {
 		return option_2.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/slice_find.snap
+++ b/tests/spec/emit/snapshots/slice_find.snap
@@ -17,5 +17,5 @@ func test(s []int) (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/slice_get.snap
+++ b/tests/spec/emit/snapshots/slice_get.snap
@@ -15,5 +15,5 @@ func test(s []int, i int) (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -39,7 +39,7 @@ func run() (int, error) {
 	}
 	check_4 := result_3
 	if check_4.Tag != lisette.ResultOk {
-		return *new(int), check_4.ErrVal
+		return 0, check_4.ErrVal
 	}
 	return variadic(_arg_5, check_4.OkVal...), nil
 }

--- a/tests/spec/emit/snapshots/struct_field_init_option_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_option_function.snap
@@ -26,7 +26,7 @@ func get_opt(b bool) (int, bool) {
 	if b {
 		return 42, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
+++ b/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
@@ -35,14 +35,14 @@ func get_int(x int) (int, bool) {
 	if x > 0 {
 		return x, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func get_string(s string) (string, bool) {
 	if s != "" {
 		return s, true
 	}
-	return *new(string), false
+	return "", false
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_binding_same_name_as_subject.snap
@@ -27,6 +27,5 @@ func test() int {
 		c: 3,
 		d: 4,
 	}
-	subject_1 := b
-	return subject_1.a + subject_1.b
+	return b.a + b.b
 }

--- a/tests/spec/emit/snapshots/try_block_diverging_final_expression.snap
+++ b/tests/spec/emit/snapshots/try_block_diverging_final_expression.snap
@@ -30,7 +30,6 @@ func test() {
 		for {
 			panic("unreachable")
 		}
-		panic("unreachable")
 	}()
 	result = tryResult_1
 	_ = result

--- a/tests/spec/emit/snapshots/try_block_panic_tail_option_context.snap
+++ b/tests/spec/emit/snapshots/try_block_panic_tail_option_context.snap
@@ -25,5 +25,5 @@ func test() (int, bool) {
 	if v_3.Tag == lisette.OptionSome {
 		return v_3.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/tuple_index_chained_with_method_call.snap
+++ b/tests/spec/emit/snapshots/tuple_index_chained_with_method_call.snap
@@ -17,5 +17,5 @@ func test() (int, bool) {
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true
 	}
-	return *new(int), false
+	return 0, false
 }

--- a/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
+++ b/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
@@ -31,6 +31,6 @@ func handle(e events.Event) (int, bool) {
 		}
 		return -subject_1.X, true
 	default:
-		return *new(int), false
+		return 0, false
 	}
 }

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -27,7 +27,7 @@ func next_item(counter int) (int, bool) {
 	if counter < 5 {
 		return counter, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/wrap_err_propagation.snap
+++ b/tests/spec/emit/snapshots/wrap_err_propagation.snap
@@ -14,7 +14,7 @@ import lisette "github.com/ivov/lisette/prelude"
 func load(r lisette.Result[int, error]) (int, error) {
 	check_1 := lisette.ResultWrapErr(r, "loading config")
 	if check_1.Tag != lisette.ResultOk {
-		return *new(int), check_1.ErrVal
+		return 0, check_1.ErrVal
 	}
 	n := check_1.OkVal
 	return n, nil

--- a/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
@@ -20,7 +20,7 @@ func foo() (int, bool) {
 	if true {
 		return 1, true
 	}
-	return *new(int), false
+	return 0, false
 }
 
 func main() {


### PR DESCRIPTION
Fallible interop calls now emit tighter Go, i.e. a `match` or `?` on a Go function returning `(T, error)` checks the error directly instead of building an intermediate `lisette.Result`.

For `let n = strconv.Atoi(s)?` inside a `Result<int, error>` function, the emitted Go goes from:

```go
ret_1, ret_2 := strconv.Atoi(s)
var result_3 lisette.Result[int, error]
if ret_2 != nil {
	result_3 = lisette.MakeResultErr[int, error](ret_2)
} else {
	result_3 = lisette.MakeResultOk[int, error](ret_1)
}
check_4 := result_3
if check_4.Tag != lisette.ResultOk {
	return *new(int), check_4.ErrVal
}
n := check_4.OkVal
```

to:

```go
ret_1, ret_2 := strconv.Atoi(s)
if ret_2 != nil {
	return 0, ret_2
}
n := ret_1
```

Includes two smaller niceties: emitted zero values use idiomatic literals (`0`, `""`, `nil`) instead of `*new(T)` for known types, and a breakless `loop { ... }` no longer emits a trailing `panic("unreachable")` that `go vet` flagged as unreachable code.

Motivated by #764
