### PR TITLE
feat: support iterating over `iter.Seq` and `iter.Seq2` in for loops

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1405,7 +1405,9 @@ pub fn tuple_literal_required_in_loop(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid loop pattern")
         .with_infer_code("invalid_pattern")
         .with_span_label(&span, "tuple literal required here")
-        .with_help("Use `(key, value)` destructuring pattern for map or enumerated iteration")
+        .with_help(
+            "Use a `(key, value)` destructuring pattern for map, enumerated, or paired-iterator iteration",
+        )
 }
 
 pub fn propagate_on_partial(span: Span) -> LisetteDiagnostic {

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -210,8 +210,9 @@ impl Planner<'_> {
         (prologue, header, lowered_body)
     }
 
-    /// Returns `(prologue, range_expression, is_channel)`. Refs are deref'd;
-    /// channels yield one value per iteration (not a pair).
+    /// Returns `(prologue, range_expression, single_var)`. Refs are deref'd;
+    /// `single_var` is set for iterables that yield one value per step (channels
+    /// and `iter.Seq<V>`), which use `for v := range` rather than `for _, v`.
     fn capture_iterable_operand(
         &mut self,
         iterable: &Expression,
@@ -228,7 +229,8 @@ impl Planner<'_> {
         let is_channel = self
             .native_shape(&iterable_ty)
             .is_some_and(|s| matches!(s.kind, NativeGoType::Channel | NativeGoType::Receiver));
-        (prologue, iter_expression, is_channel)
+        let single_var = is_channel || self.iter_seq_arity(&iterable_ty) == Some(1);
+        (prologue, iter_expression, single_var)
     }
 
     /// `for x in xs` over a non-specialized iterable.
@@ -239,13 +241,13 @@ impl Planner<'_> {
         body: &Expression,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
+        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable, fx);
 
         self.enter_scope();
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
         let header = if loop_var == "_" {
             format!("for range {} {{\n", iter_expression)
-        } else if is_channel {
+        } else if single_var {
             format!("for {} := range {} {{\n", loop_var, iter_expression)
         } else {
             format!("for _, {} := range {} {{\n", loop_var, iter_expression)
@@ -413,7 +415,7 @@ impl Planner<'_> {
         body: &Expression,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        let (prologue, iter_expression, is_channel) = self.capture_iterable_operand(iterable, fx);
+        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable, fx);
 
         self.enter_scope();
         let (header, body_block) = if !pattern_has_bindings(&binding.pattern) {
@@ -421,7 +423,7 @@ impl Planner<'_> {
             (header, self.lower_block_as_body(body, fx))
         } else {
             let item_var = self.fresh_var(Some("item"));
-            let header = if is_channel {
+            let header = if single_var {
                 format!("for {} := range {} {{\n", item_var, iter_expression)
             } else {
                 format!("for _, {} := range {} {{\n", item_var, iter_expression)
@@ -583,6 +585,18 @@ impl Planner<'_> {
     fn is_map_tuple_iterable(&self, iterable_ty: &Type) -> bool {
         self.native_shape(iterable_ty)
             .is_some_and(|s| matches!(s.kind, NativeGoType::Map | NativeGoType::EnumeratedSlice))
+            || self.iter_seq_arity(iterable_ty) == Some(2)
+    }
+
+    fn iter_seq_arity(&self, iterable_ty: &Type) -> Option<usize> {
+        let Type::Nominal { id, .. } = iterable_ty.strip_refs() else {
+            return None;
+        };
+        match id.as_str() {
+            "go:iter.Seq" => Some(1),
+            "go:iter.Seq2" => Some(2),
+            _ => None,
+        }
     }
 
     fn is_unmutated_identifier(&self, expression: &Expression) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -12,6 +12,23 @@ enum BranchReconciliation {
     Failed,
 }
 
+#[derive(Clone, Copy)]
+enum IterSeqKind {
+    Seq,
+    Seq2,
+}
+
+fn iter_seq_kind(ty: &Type) -> Option<IterSeqKind> {
+    let Type::Nominal { id, .. } = ty else {
+        return None;
+    };
+    match id.as_str() {
+        "go:iter.Seq" => Some(IterSeqKind::Seq),
+        "go:iter.Seq2" => Some(IterSeqKind::Seq2),
+        _ => None,
+    }
+}
+
 impl InferCtx<'_, '_> {
     pub(crate) fn reconcile_and_unify(
         &mut self,
@@ -477,7 +494,17 @@ impl InferCtx<'_, '_> {
         let iterable_ty = self.new_type_var();
         let new_iterable = self.infer_expression(*iterable, &iterable_ty);
 
-        let resolved_iterable_ty = store.peel_alias(&iterable_ty.resolve_in(&self.env));
+        let resolved_unpeeled = iterable_ty.resolve_in(&self.env);
+        let iter_seq = iter_seq_kind(&resolved_unpeeled);
+
+        // `iter.Seq<V>` / `iter.Seq2<K, V>` are Go range-over-func iterators
+        // stored as function aliases. Keep the nominal so its name and type args
+        // stay available; peeling expands it to an unnamed `fn(...)` shape.
+        let resolved_iterable_ty = if iter_seq.is_some() {
+            resolved_unpeeled
+        } else {
+            store.peel_alias(&resolved_unpeeled)
+        };
 
         let iterable_is_error = resolved_iterable_ty.is_error();
 
@@ -526,6 +553,14 @@ impl InferCtx<'_, '_> {
                 }
             }
             "Map" if iterable_ty_args.len() >= 2 => Type::Tuple(vec![
+                iterable_ty_args[0].clone(),
+                iterable_ty_args[1].clone(),
+            ]),
+
+            "Seq" if iter_seq.is_some() && !iterable_ty_args.is_empty() => {
+                iterable_ty_args[0].clone()
+            }
+            "Seq2" if iter_seq.is_some() && iterable_ty_args.len() >= 2 => Type::Tuple(vec![
                 iterable_ty_args[0].clone(),
                 iterable_ty_args[1].clone(),
             ]),
@@ -589,7 +624,8 @@ impl InferCtx<'_, '_> {
         // When iterating over types that yield multiple values (`Map`, `EnumeratedSlice`),
         // Go's `range` returns multiple values, so the binding must be a tuple literal.
         // This does NOT apply to `Slice<(A, B)>` where the element is already a tuple value.
-        let requires_tuple_destructuring = matches!(iterable_ty_name, "Map" | "EnumeratedSlice");
+        let requires_tuple_destructuring = matches!(iterable_ty_name, "Map" | "EnumeratedSlice")
+            || matches!(iter_seq, Some(IterSeqKind::Seq2));
         if requires_tuple_destructuring && element_ty.is_tuple() {
             match &new_binding.pattern {
                 Pattern::Tuple { .. } => (),

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -522,6 +522,77 @@ fn test(m: Map<string, int>) -> int {
 }
 
 #[test]
+fn for_loop_iter_seq_single_value() {
+    let input = r#"
+import "go:maps"
+import "go:fmt"
+
+fn main() {
+  let m = Map.from([("a", 1)])
+  for k in maps.Keys(m) {
+    fmt.Println(k)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_iter_seq2_key_value() {
+    let input = r#"
+import "go:maps"
+import "go:fmt"
+
+fn main() {
+  let m = Map.from([("a", 1)])
+  for (k, v) in maps.All(m) {
+    fmt.Println(f"{k}={v}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_iter_seq_compound_pattern() {
+    let input = r#"
+import "go:slices"
+import "go:fmt"
+
+struct Point {
+  x: int,
+  y: int,
+}
+
+fn main() {
+  let points = [Point { x: 1, y: 2 }]
+  for Point { x, y } in slices.Values(points) {
+    fmt.Println(f"{x},{y}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_iter_seq_break() {
+    let input = r#"
+import "go:slices"
+import "go:fmt"
+
+fn main() {
+  for n in slices.Values([1, 2, 3]) {
+    if n > 1 {
+      break
+    }
+    fmt.Println(f"{n}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_loop_map_both_wildcards() {
     let input = r#"
 fn test(m: Map<string, int>) -> int {

--- a/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:maps"
+  import "go:fmt"
+  
+  fn main() {
+    let m = Map.from([("a", 1)])
+    for (k, v) in maps.All(m) {
+      fmt.Println(f"{k}={v}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"maps"
+)
+
+func main() {
+	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})
+	for k, v := range maps.All(m) {
+		fmt.Printf("%s=%d\n", k, v)
+	}
+}

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_break.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_break.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:slices"
+  import "go:fmt"
+  
+  fn main() {
+    for n in slices.Values([1, 2, 3]) {
+      if n > 1 {
+        break
+      }
+      fmt.Println(f"{n}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+func main() {
+	for n := range slices.Values([]int{1, 2, 3}) {
+		if n > 1 {
+			break
+		}
+		fmt.Println(fmt.Sprint(n))
+	}
+}

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_compound_pattern.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_compound_pattern.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:slices"
+  import "go:fmt"
+  
+  struct Point {
+    x: int,
+    y: int,
+  }
+  
+  fn main() {
+    let points = [Point { x: 1, y: 2 }]
+    for Point { x, y } in slices.Values(points) {
+      fmt.Println(f"{x},{y}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+type Point struct {
+	x int
+	y int
+}
+
+func main() {
+	points := []Point{Point{
+		x: 1,
+		y: 2,
+	}}
+	for item_1 := range slices.Values(points) {
+		x := item_1.x
+		y := item_1.y
+		fmt.Printf("%d,%d\n", x, y)
+	}
+}

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:maps"
+  import "go:fmt"
+  
+  fn main() {
+    let m = Map.from([("a", 1)])
+    for k in maps.Keys(m) {
+      fmt.Println(k)
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"maps"
+)
+
+func main() {
+	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})
+	for k := range maps.Keys(m) {
+		fmt.Println(k)
+	}
+}


### PR DESCRIPTION
Adds support for iterating over Go's `iter.Seq<V>` and `iter.Seq2<K, V>` directly in `for ... in` loops. These are the return type of common Go stdlib functions such as `maps.Keys`, `maps.Values`, `slices.Values`, and `strings.Lines`. 

```rs
import "go:maps"
import "go:fmt"

fn main() {
  let m = Map.from([("a", 1), ("b", 2)])

  for k in maps.Keys(m) {
    fmt.Println(k)
  }

  for (k, v) in maps.All(m) {
    fmt.Println(f"{k}={v}")
  }
}
```
