### PR TITLE
feat: introduce `TestContext` for test functions

### DIFF
--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -8,7 +8,7 @@ use crate::go_cli::GoTestEvent;
 use crate::output::format_elapsed;
 use lisette::pipeline::TestIndex;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Status {
     Passed,
     Failed,
@@ -22,6 +22,7 @@ pub struct TestRow {
     pub status: Status,
     pub elapsed: Option<f64>,
     pub output: String,
+    pub children: Vec<TestRow>,
 }
 
 pub struct Report {
@@ -104,18 +105,21 @@ pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) 
         } else {
             format!("{}/{}", go_module, test.module_id)
         };
-        let key = (package.clone(), go_test_name(fn_name));
+        let go_name = go_test_name(fn_name);
+        let key = (package.clone(), go_name.clone());
         let (status, elapsed) = match terminal.get(&key).copied() {
             Some(found) => found,
             None if started.contains(&key) => (Status::Aborted, None),
             None => (Status::NotRun, None),
         };
+        let children = collect_children(&package, &go_name, &terminal, &started, &outputs);
         rows.push(TestRow {
             package,
             name: fn_name.to_string(),
             status,
             elapsed,
             output: outputs.get(&key).cloned().unwrap_or_default(),
+            children,
         });
     }
     Report {
@@ -129,6 +133,46 @@ pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) 
 
 fn go_test_name(fn_name: &str) -> String {
     emit::go_test_function_name(fn_name)
+}
+
+fn collect_children(
+    package: &str,
+    parent: &str,
+    terminal: &HashMap<(String, String), (Status, Option<f64>)>,
+    started: &HashSet<(String, String)>,
+    outputs: &HashMap<(String, String), String>,
+) -> Vec<TestRow> {
+    let prefix = format!("{parent}/");
+    let mut direct: Vec<&String> = terminal
+        .keys()
+        .chain(started.iter())
+        .filter(|(pkg, name)| {
+            pkg == package && name.starts_with(&prefix) && !name[prefix.len()..].contains('/')
+        })
+        .map(|(_, name)| name)
+        .collect();
+    direct.sort();
+    direct.dedup();
+
+    direct
+        .into_iter()
+        .map(|full| {
+            let key = (package.to_string(), full.clone());
+            let (status, elapsed) = match terminal.get(&key).copied() {
+                Some(found) => found,
+                None if started.contains(&key) => (Status::Aborted, None),
+                None => (Status::NotRun, None),
+            };
+            TestRow {
+                package: package.to_string(),
+                name: full[prefix.len()..].to_string(),
+                status,
+                elapsed,
+                output: outputs.get(&key).cloned().unwrap_or_default(),
+                children: collect_children(package, full, terminal, started, outputs),
+            }
+        })
+        .collect()
 }
 
 /// `go test` names a build failure `pkg [pkg.test]`; strip the suffix to match package events.
@@ -154,37 +198,7 @@ pub fn render(report: &Report, color: bool, total: Duration) -> String {
     for (package, mut group) in by_package {
         group.sort_by(|a, b| a.name.cmp(&b.name));
         out.push_str(&format!("  {package}\n"));
-        for (i, row) in group.iter().enumerate() {
-            let last = i + 1 == group.len();
-            let branch = if last { "└── " } else { "├── " };
-            let timing = match row.elapsed {
-                Some(seconds) if seconds > 0.0 => {
-                    format!(" {}", format_elapsed(Duration::from_secs_f64(seconds)))
-                }
-                _ => String::new(),
-            };
-            let suffix = match row.status {
-                Status::NotRun => " (not run)",
-                Status::Aborted => " (aborted)",
-                _ => "",
-            };
-            out.push_str(&format!(
-                "    {branch}{} {}{suffix}{timing}\n",
-                mark(row.status, color),
-                row.name
-            ));
-            if matches!(row.status, Status::Failed | Status::Aborted) {
-                let cont = if last { "    " } else { "│   " };
-                for line in row.output.lines() {
-                    let line = line.trim_end();
-                    if line.is_empty() {
-                        continue;
-                    }
-                    out.push_str(&dim(&format!("    {cont}    {line}"), color));
-                    out.push('\n');
-                }
-            }
-        }
+        render_rows(&mut out, &group, "    ", color);
 
         // Crash before any test ran (init/`TestMain` panic): cause is package-level only.
         if !report.build_failed_packages.contains(package)
@@ -206,6 +220,49 @@ pub fn render(report: &Report, color: bool, total: Duration) -> String {
     out.push('\n');
     out.push_str(&summary(&report.rows, total));
     out
+}
+
+fn render_rows(out: &mut String, rows: &[&TestRow], prefix: &str, color: bool) {
+    for (i, row) in rows.iter().enumerate() {
+        let last = i + 1 == rows.len();
+        let branch = if last { "└── " } else { "├── " };
+        let timing = match row.elapsed {
+            Some(seconds) if seconds > 0.0 => {
+                format!(" {}", format_elapsed(Duration::from_secs_f64(seconds)))
+            }
+            _ => String::new(),
+        };
+        if row.children.is_empty() {
+            let suffix = match row.status {
+                Status::NotRun => " (not run)",
+                Status::Aborted => " (aborted)",
+                _ => "",
+            };
+            out.push_str(&format!(
+                "{prefix}{branch}{} {}{suffix}{timing}\n",
+                mark(row.status, color),
+                row.name
+            ));
+        } else {
+            out.push_str(&format!("{prefix}{branch}{}{timing}\n", row.name));
+        }
+
+        let child_prefix = format!("{prefix}{}", if last { "    " } else { "│   " });
+
+        if matches!(row.status, Status::Failed | Status::Aborted) {
+            for line in row.output.lines() {
+                let line = line.trim_end();
+                if line.is_empty() {
+                    continue;
+                }
+                out.push_str(&dim(&format!("{child_prefix}    {line}"), color));
+                out.push('\n');
+            }
+        }
+
+        let children: Vec<&TestRow> = row.children.iter().collect();
+        render_rows(out, &children, &child_prefix, color);
+    }
 }
 
 fn summary(rows: &[TestRow], total: Duration) -> String {
@@ -321,6 +378,88 @@ mod tests {
         assert!(text.contains("✓ adds_numbers"));
         assert!(text.contains("2 passed"));
         assert_eq!(exit_code(&report.rows, true), 0);
+    }
+
+    #[test]
+    fn subtests_nest_under_their_parent() {
+        let index = index(&[(ENTRY_MODULE_ID, "parent")]);
+        let events = vec![
+            event("run", "demo", Some("TestParent"), None),
+            event("run", "demo", Some("TestParent/alpha"), None),
+            event("pass", "demo", Some("TestParent/alpha"), None),
+            event("pass", "demo", Some("TestParent"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        assert_eq!(report.rows.len(), 1);
+        assert_eq!(report.rows[0].children.len(), 1);
+        assert_eq!(report.rows[0].children[0].name, "alpha");
+
+        let text = render(&report, false, Duration::from_millis(1));
+        let parent_line = text.lines().position(|l| l.contains("parent")).unwrap();
+        let child_line = text.lines().position(|l| l.contains("alpha")).unwrap();
+        assert!(child_line > parent_line, "subtest renders under its parent");
+        assert!(text.contains("✓ alpha"), "leaf subtest keeps its mark");
+        assert!(
+            !text.contains("✓ parent"),
+            "a passing grouping has no redundant tick, got:\n{text}"
+        );
+        assert!(text.contains("1 passed"));
+    }
+
+    #[test]
+    fn parent_own_output_shows_even_with_subtests() {
+        let index = index(&[(ENTRY_MODULE_ID, "parent")]);
+        let events = vec![
+            event("run", "demo", Some("TestParent"), None),
+            event("run", "demo", Some("TestParent/child"), None),
+            event("pass", "demo", Some("TestParent/child"), None),
+            event(
+                "output",
+                "demo",
+                Some("TestParent"),
+                Some("parent panicked\n"),
+            ),
+            event("fail", "demo", Some("TestParent"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, false, Duration::from_millis(1));
+
+        assert!(
+            !text.contains("✗ parent") && !text.contains("✓ parent"),
+            "a grouping carries no sigil, got:\n{text}"
+        );
+        assert!(text.contains("✓ child"));
+        assert!(
+            text.contains("parent panicked"),
+            "a failed parent's own output must show even with subtests, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn nested_subtest_failure_attaches_to_leaf() {
+        let index = index(&[(ENTRY_MODULE_ID, "parent")]);
+        let events = vec![
+            event("run", "demo", Some("TestParent"), None),
+            event("run", "demo", Some("TestParent/group"), None),
+            event("run", "demo", Some("TestParent/group/inner"), None),
+            event(
+                "output",
+                "demo",
+                Some("TestParent/group/inner"),
+                Some("boom\n"),
+            ),
+            event("fail", "demo", Some("TestParent/group/inner"), None),
+            event("fail", "demo", Some("TestParent/group"), None),
+            event("fail", "demo", Some("TestParent"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let inner = &report.rows[0].children[0].children[0];
+        assert_eq!(inner.name, "inner");
+        assert_eq!(inner.status, Status::Failed);
+
+        let text = render(&report, false, Duration::from_millis(1));
+        assert!(text.contains("boom"));
+        assert_eq!(exit_code(&report.rows, false), 1);
     }
 
     #[test]

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -149,6 +149,15 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
         simple_name.len() as u32,
     );
 
+    if simple_name == "TestContext" {
+        return LisetteDiagnostic::error("Type not found")
+            .with_resolve_code("type_not_found")
+            .with_span_label(&name_span, "only available in test files")
+            .with_help(
+                "`TestContext` is given to `#[test]` functions in `.test.lis` files and is not available in production code",
+            );
+    }
+
     let looks_like_type_param = simple_name.len() == 1
         && simple_name.chars().next().is_some_and(|c| c.is_uppercase())
         || ["Key", "Value", "Item", "Error", "Elem", "In", "Out"].contains(&simple_name);

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -62,6 +62,13 @@ pub fn cannot_import_prelude(span: Span) -> LisetteDiagnostic {
         .with_help("Remove this import. Use e.g. `Option` or `prelude.Option` directly.")
 }
 
+pub fn reserved_module_import(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid import")
+        .with_resolve_code("reserved_module_import")
+        .with_span_label(&span, "the `**` prefix is reserved for the compiler")
+        .with_help("Rename the module so its import path does not begin with `**`.")
+}
+
 pub fn wrong_test_file_suffix(display_path: &str) -> LisetteDiagnostic {
     let help = match display_path.strip_suffix("_test.lis") {
         Some(stem) => format!(

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -199,6 +199,9 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn go_import_path(&self, module: &str) -> String {
+        if module == go_name::TEST_PRELUDE_MODULE {
+            return go_name::TESTKIT_IMPORT_PATH.to_string();
+        }
         format!("{}/{}", self.go_module, module)
     }
 

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -24,8 +24,18 @@ impl Planner<'_> {
                 if self.facts.is_test(&self.facts.qualified_current(name)) {
                     let callee = self.pick_go_function_name(function, false, is_public);
                     let test_name = go_name::go_test_function_name(name);
-                    fx.require_go_import("testing");
-                    let wrapper = format!("func {test_name}(t *testing.T) {{\n\t{callee}()\n}}");
+                    fx.require_testing();
+                    let testing = go_name::GeneratedPackage::Testing.qualifier();
+                    let call = if function.params.is_empty() {
+                        format!("{callee}()")
+                    } else {
+                        fx.require_testkit();
+                        format!(
+                            "{callee}({}.New(t))",
+                            go_name::GeneratedPackage::TestKit.qualifier()
+                        )
+                    };
+                    let wrapper = format!("func {test_name}(t *{testing}.T) {{\n\t{call}\n}}");
                     format!("{doc_comment}{code}\n\n{wrapper}")
                 } else {
                     format!("{}{}", doc_comment, code)

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -21,6 +21,10 @@ pub(crate) const ADAPTER_TYPE_PREFIX: &str = "_lisAdapter_";
 
 pub const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
 
+pub(crate) const TEST_PRELUDE_MODULE: &str = "**test_prelude";
+pub const TESTKIT_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude/testkit";
+pub(crate) const TESTKIT_PKG: &str = "testkit";
+
 pub(crate) use syntax::types::unqualified_name;
 
 pub(crate) fn capitalize_first(s: &str) -> String {
@@ -280,6 +284,8 @@ pub(crate) enum GeneratedPackage {
     Maps,
     Json,
     Cmp,
+    TestKit,
+    Testing,
 }
 
 impl GeneratedPackage {
@@ -292,6 +298,8 @@ impl GeneratedPackage {
         GeneratedPackage::Maps,
         GeneratedPackage::Json,
         GeneratedPackage::Cmp,
+        GeneratedPackage::TestKit,
+        GeneratedPackage::Testing,
     ];
 
     pub(crate) fn path(self) -> &'static str {
@@ -304,6 +312,8 @@ impl GeneratedPackage {
             GeneratedPackage::Maps => "maps",
             GeneratedPackage::Json => "encoding/json",
             GeneratedPackage::Cmp => "cmp",
+            GeneratedPackage::TestKit => TESTKIT_IMPORT_PATH,
+            GeneratedPackage::Testing => "testing",
         }
     }
 
@@ -317,6 +327,8 @@ impl GeneratedPackage {
             GeneratedPackage::Maps => "maps",
             GeneratedPackage::Json => "json",
             GeneratedPackage::Cmp => "cmp",
+            GeneratedPackage::TestKit => TESTKIT_PKG,
+            GeneratedPackage::Testing => "testing",
         }
     }
 }

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -110,6 +110,9 @@ impl Planner<'_> {
     }
 
     pub(crate) fn go_pkg_qualifier(&self, module: &str) -> String {
+        if module == go_name::TEST_PRELUDE_MODULE {
+            return go_name::TESTKIT_PKG.to_string();
+        }
         if let Some(alias) = self.module.module_alias(module) {
             return alias.to_string();
         }

--- a/crates/emit/src/state/effects.rs
+++ b/crates/emit/src/state/effects.rs
@@ -5,11 +5,11 @@ use crate::output::imports::ImportBuilder;
 use crate::types::go_type::GoType;
 
 #[derive(Debug, Clone, Copy, Default)]
-struct GeneratedImportSet(u8);
+struct GeneratedImportSet(u16);
 
 impl GeneratedImportSet {
     fn insert(&mut self, package: GeneratedPackage) {
-        self.0 |= 1 << package as u8;
+        self.0 |= 1 << package as u16;
     }
 
     fn union(&mut self, other: Self) {
@@ -20,7 +20,7 @@ impl GeneratedImportSet {
         GeneratedPackage::ALL
             .iter()
             .copied()
-            .filter(move |package| self.0 & (1 << *package as u8) != 0)
+            .filter(move |package| self.0 & (1 << *package as u16) != 0)
     }
 }
 
@@ -63,6 +63,14 @@ impl EmitEffects {
         self.generated.insert(GeneratedPackage::Cmp);
     }
 
+    pub(crate) fn require_testkit(&mut self) {
+        self.generated.insert(GeneratedPackage::TestKit);
+    }
+
+    pub(crate) fn require_testing(&mut self) {
+        self.generated.insert(GeneratedPackage::Testing);
+    }
+
     pub(crate) fn require_go_import(&mut self, path: impl Into<String>) {
         self.go_imports.push(path.into());
     }
@@ -80,9 +88,17 @@ impl EmitEffects {
     }
 
     pub(crate) fn drain_into(&self, builder: &mut ImportBuilder) {
-        let modules: HashSet<String> = self.go_imports.iter().cloned().collect();
+        let mut generated = self.generated;
+        let mut modules: HashSet<String> = HashSet::default();
+        for path in &self.go_imports {
+            if path == GeneratedPackage::TestKit.path() {
+                generated.insert(GeneratedPackage::TestKit);
+            } else {
+                modules.insert(path.clone());
+            }
+        }
         builder.extend_with_modules(&modules);
-        for package in self.generated.iter() {
+        for package in generated.iter() {
             builder.require_generated(package);
         }
     }

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -21,11 +21,12 @@ pub const CACHE_FORMAT_VERSION: u32 = 1;
 /// Compiler version hash. Caches from different compiler versions are invalid.
 pub const COMPILER_VERSION_HASH: u64 = const_fnv1a_hash(env!("CARGO_PKG_VERSION").as_bytes());
 
-/// Combined stdlib content hash. Changes to any stdlib file (prelude.d.lis
-/// or any typedefs/*.d.lis) will change this hash, invalidating all user module caches.
+/// Combined stdlib content hash. Changes to any stdlib file (prelude.d.lis,
+/// test_prelude.d.lis, or any typedefs/*.d.lis) will change this hash, invalidating
+/// all user module caches.
 pub const STDLIB_HASH: u64 = stdlib::STDLIB_CONTENT_HASH;
 
-/// Prelude-only content hash (prelude.d.lis).
+/// Prelude content hash (prelude.d.lis + test_prelude.d.lis).
 pub const PRELUDE_HASH: u64 = stdlib::PRELUDE_CONTENT_HASH;
 
 /// Go stdlib-only content hash (typedefs/*.d.lis).

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -85,6 +85,7 @@ pub(crate) enum FileContextKind {
     Standard,
     ImportedTypedef,
     Prelude,
+    TestPrelude,
 }
 
 struct SavedFileContext {
@@ -692,6 +693,12 @@ impl<'s> TaskState<'s> {
         match kind {
             FileContextKind::Standard => {
                 self.put_prelude_in_scope(store);
+                if self.current_file_is_test(store) {
+                    self.put_unprefixed_module_in_scope(
+                        store,
+                        crate::prelude::TEST_PRELUDE_MODULE_ID,
+                    );
+                }
                 self.put_unprefixed_module_in_scope(store, module_id);
             }
             FileContextKind::ImportedTypedef => {
@@ -706,6 +713,10 @@ impl<'s> TaskState<'s> {
                     .insert(self_alias, module_id.into());
             }
             FileContextKind::Prelude => {
+                self.put_unprefixed_module_in_scope(store, module_id);
+            }
+            FileContextKind::TestPrelude => {
+                self.put_prelude_in_scope(store);
                 self.put_unprefixed_module_in_scope(store, module_id);
             }
         }

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -1,5 +1,5 @@
 use diagnostics::LocalSink;
-use syntax::ast::{Annotation, Attribute, AttributeArg, Expression};
+use syntax::ast::{Annotation, Attribute, AttributeArg, Binding, Expression};
 use syntax::attributes::test_attribute;
 use syntax::program::TestFunction;
 
@@ -11,11 +11,19 @@ impl TaskState<'_> {
     /// (merge-safe, since this runs during parallel registration).
     pub(super) fn register_module_tests(&mut self, store: &Store, module_id: &str) {
         let module = store.get_module(module_id).expect("module must exist");
+        let context_shadowed = module_shadows_test_context(store, module_id);
         let mut records: Vec<TestFunction> = Vec::new();
         for file in module.files.values().chain(module.typedefs.values()) {
             let in_test_file = file.is_test();
             for item in &file.items {
-                collect_test_candidates(item, module_id, in_test_file, &mut records, self.sink);
+                collect_test_candidates(
+                    item,
+                    module_id,
+                    in_test_file,
+                    context_shadowed,
+                    &mut records,
+                    self.sink,
+                );
             }
         }
         self.facts.test_functions.extend(records);
@@ -25,6 +33,7 @@ impl TaskState<'_> {
         let Some(module) = store.get_module(module_id) else {
             return;
         };
+        let context_shadowed = module_shadows_test_context(store, module_id);
         let discard = LocalSink::new();
         let mut records: Vec<TestFunction> = Vec::new();
         for file in module.files.values() {
@@ -33,7 +42,14 @@ impl TaskState<'_> {
             }
             let parsed = syntax::build_ast(&file.source, file.id);
             for item in &parsed.ast {
-                collect_test_candidates(item, module_id, true, &mut records, &discard);
+                collect_test_candidates(
+                    item,
+                    module_id,
+                    true,
+                    context_shadowed,
+                    &mut records,
+                    &discard,
+                );
             }
         }
         self.facts.test_functions.extend(records);
@@ -70,6 +86,28 @@ fn is_unit_return(annotation: &Annotation) -> bool {
     }
 }
 
+fn module_shadows_test_context(store: &Store, module_id: &str) -> bool {
+    let qualified = format!("{module_id}.TestContext");
+    store
+        .get_definition(&qualified)
+        .is_some_and(|definition| !definition.is_value(&qualified))
+}
+
+fn params_supported(params: &[Binding], context_shadowed: bool) -> bool {
+    match params {
+        [] => true,
+        [param] => {
+            !context_shadowed
+                && matches!(
+                    &param.annotation,
+                    Some(Annotation::Constructor { name, params, .. })
+                        if name == "TestContext" && params.is_empty()
+                )
+        }
+        _ => false,
+    }
+}
+
 fn parse_title(args: &[AttributeArg]) -> Result<Option<String>, ()> {
     match args {
         [] => Ok(None),
@@ -82,6 +120,7 @@ fn collect_test_candidates(
     item: &Expression,
     module_id: &str,
     in_test_file: bool,
+    context_shadowed: bool,
     records: &mut Vec<TestFunction>,
     sink: &LocalSink,
 ) {
@@ -111,7 +150,10 @@ fn collect_test_candidates(
                 ));
                 return;
             };
-            if !generics.is_empty() || !params.is_empty() || !is_unit_return(return_annotation) {
+            if !generics.is_empty()
+                || !params_supported(params, context_shadowed)
+                || !is_unit_return(return_annotation)
+            {
                 sink.push(diagnostics::attribute::test_unsupported_signature(
                     name_span,
                 ));

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -22,7 +22,7 @@ use crate::diagnostics::emit_for_locator_result;
 use crate::facts::{BindingIdAllocator, Facts};
 use crate::loader::Loader;
 use crate::module_graph::build_module_graph;
-use crate::prelude::parse_and_register_prelude;
+use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use crate::store::{ENTRY_MODULE_ID, Store};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -167,6 +167,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     if !prelude_cache_hit {
         parse_and_register_prelude(&mut store, &sink);
     }
+    parse_and_register_test_prelude(&mut store, &sink);
 
     let cache_enabled = input.project_root.is_some() && !cache_disabled && !input.disable_cache;
     let check_go_files = input.compile_phase == CompilePhase::Emit;

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -276,6 +276,13 @@ fn process_file_imports(
             continue;
         }
 
+        if file_import.name.starts_with("**") {
+            sink.push(diagnostics::module_graph::reserved_module_import(
+                file_import.span,
+            ));
+            continue;
+        }
+
         if let Some(go_pkg) = file_import.name.strip_prefix("go:") {
             let is_blank = matches!(file_import.alias, Some(ImportAlias::Blank(_)));
 

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -1,5 +1,5 @@
 use diagnostics::LocalSink;
-use stdlib::LIS_PRELUDE_SOURCE;
+use stdlib::{LIS_PRELUDE_SOURCE, LIS_TEST_PRELUDE_SOURCE};
 use syntax::program::{File, Visibility};
 
 use crate::call_classification::compute_module_ufcs;
@@ -8,6 +8,10 @@ use crate::store::Store;
 
 pub const PRELUDE_MODULE_ID: &str = "prelude";
 pub const PRELUDE_FILE_ID: u32 = 1;
+
+/// Synthetic, internal module id. The `**` prefix is reserved: imports beginning with
+/// it are rejected during module-graph processing, so no user module can collide here.
+pub const TEST_PRELUDE_MODULE_ID: &str = "**test_prelude";
 
 pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
     let result = syntax::build_ast(LIS_PRELUDE_SOURCE, PRELUDE_FILE_ID);
@@ -43,6 +47,54 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         PRELUDE_FILE_ID,
         &[],
         FileContextKind::Prelude,
+        |checker, store| {
+            for file in module.all_typedefs() {
+                checker.register_type_names(store, &file.items, &Visibility::Public);
+            }
+
+            for file in module.all_typedefs() {
+                checker.register_type_definitions(store, &file.items);
+                checker.register_impl_blocks(store, &file.items);
+                checker.register_values(store, &file.items, &Visibility::Public);
+            }
+        },
+    );
+}
+
+/// Registers the test-only prelude module (`TestContext`). Scopes the main prelude during
+/// registration so the signatures resolve, so it must run after the prelude.
+pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
+    let file_id = store.new_file_id();
+    let result = syntax::build_ast(LIS_TEST_PRELUDE_SOURCE, file_id);
+
+    sink.extend_parse_errors(result.errors);
+
+    store.mark_visited(TEST_PRELUDE_MODULE_ID);
+    store.add_module(TEST_PRELUDE_MODULE_ID);
+    store.store_file(
+        TEST_PRELUDE_MODULE_ID,
+        File {
+            id: file_id,
+            module_id: TEST_PRELUDE_MODULE_ID.to_string(),
+            name: "test_prelude.d.lis".to_string(),
+            display_path: "test_prelude.d.lis".to_string(),
+            source: LIS_TEST_PRELUDE_SOURCE.to_string(),
+            items: result.ast,
+        },
+    );
+
+    let mut checker = TaskState::with_fresh_allocator(sink);
+    let module = store
+        .get_module(TEST_PRELUDE_MODULE_ID)
+        .cloned()
+        .expect("test_prelude module must exist");
+
+    checker.with_file_context_mut(
+        store,
+        TEST_PRELUDE_MODULE_ID,
+        file_id,
+        &[],
+        FileContextKind::TestPrelude,
         |checker, store| {
             for file in module.all_typedefs() {
                 checker.register_type_names(store, &file.items, &Visibility::Public);

--- a/crates/stdlib/build.rs
+++ b/crates/stdlib/build.rs
@@ -16,6 +16,11 @@ fn main() {
     let prelude_source = fs::read_to_string(&prelude_dlis_path).expect("prelude.d.lis not found");
     prelude_contents.insert(("prelude.d.lis".to_string(), prelude_source));
 
+    let test_prelude_dlis_path = manifest_path.join("test_prelude.d.lis");
+    let test_prelude_source =
+        fs::read_to_string(&test_prelude_dlis_path).expect("test_prelude.d.lis not found");
+    prelude_contents.insert(("test_prelude.d.lis".to_string(), test_prelude_source));
+
     let mut go_std_contents: BTreeSet<(String, String)> = BTreeSet::new();
     let go_std_dir = manifest_path.join("typedefs");
     if go_std_dir.exists() {
@@ -32,7 +37,7 @@ fn main() {
     let mut file = fs::File::create(&dest_path).unwrap();
     writeln!(
         file,
-        "/// Hash of all stdlib content (prelude.d.lis + typedefs/*.d.lis)."
+        "/// Hash of all stdlib content (prelude.d.lis + test_prelude.d.lis + typedefs/*.d.lis)."
     )
     .unwrap();
     writeln!(
@@ -40,7 +45,11 @@ fn main() {
         "pub const STDLIB_CONTENT_HASH: u64 = {combined_hash};"
     )
     .unwrap();
-    writeln!(file, "/// Hash of prelude.d.lis content.").unwrap();
+    writeln!(
+        file,
+        "/// Hash of prelude content (prelude.d.lis + test_prelude.d.lis)."
+    )
+    .unwrap();
     writeln!(
         file,
         "pub const PRELUDE_CONTENT_HASH: u64 = {prelude_hash};"
@@ -54,6 +63,10 @@ fn main() {
     writeln!(file, "pub const GO_STD_CONTENT_HASH: u64 = {go_std_hash};").unwrap();
 
     println!("cargo:rerun-if-changed={}", prelude_dlis_path.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        test_prelude_dlis_path.display()
+    );
 }
 
 fn collect_dlis_files(dir: &Path, base: &Path, contents: &mut BTreeSet<(String, String)>) {

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -8,4 +8,6 @@ pub use target::{Target, format_targets};
 
 pub const LIS_PRELUDE_SOURCE: &str = include_str!("../prelude.d.lis");
 
+pub const LIS_TEST_PRELUDE_SOURCE: &str = include_str!("../test_prelude.d.lis");
+
 include!(concat!(env!("OUT_DIR"), "/stdlib_hash.rs"));

--- a/crates/stdlib/test_prelude.d.lis
+++ b/crates/stdlib/test_prelude.d.lis
@@ -1,0 +1,10 @@
+/// The handle passed to a `#[test]` function, backed by Go's `*testing.T`.
+pub type TestContext
+
+impl TestContext {
+    /// Run `body` as a named subtest. Returns whether it succeeded.
+    pub fn run(self, name: string, body: fn(TestContext) -> ()) -> bool
+
+    /// Signal that this test may run in parallel with other parallel tests.
+    pub fn parallel(self)
+}

--- a/crates/syntax/src/program/module.rs
+++ b/crates/syntax/src/program/module.rs
@@ -75,7 +75,10 @@ impl Module {
     }
 
     pub fn is_internal(&self) -> bool {
-        self.id == "prelude" || self.id == "**nominal" || self.id.starts_with("go:")
+        self.id == "prelude"
+            || self.id == "**test_prelude"
+            || self.id == "**nominal"
+            || self.id.starts_with("go:")
     }
 
     pub fn is_empty_stub(&self) -> bool {

--- a/prelude/testkit/testkit.go
+++ b/prelude/testkit/testkit.go
@@ -1,0 +1,29 @@
+// Package testkit backs Lisette's test-only TestContext. It is imported only by
+// generated *_test.go files, so `go build` never pulls testing into production.
+package testkit
+
+import "testing"
+
+// TestContext wraps *testing.T. The field is unexported so Lisette code reaches
+// the handle only through the methods below.
+type TestContext struct {
+	t *testing.T
+}
+
+// New wraps a *testing.T. Generated test wrappers call this to construct the
+// handle passed to a #[test] function.
+func New(t *testing.T) TestContext {
+	return TestContext{t: t}
+}
+
+// Run runs body as a named subtest, re-wrapping the subtest's *testing.T.
+func (c TestContext) Run(name string, body func(TestContext)) bool {
+	return c.t.Run(name, func(inner *testing.T) {
+		body(TestContext{t: inner})
+	})
+}
+
+// Parallel marks this test as eligible to run in parallel.
+func (c TestContext) Parallel() {
+	c.t.Parallel()
+}

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -19,7 +19,7 @@ pub const TEST_MODULE_ID: &str = "test";
 
 use diagnostics::LocalSink;
 use semantics::checker::TaskState;
-use semantics::prelude::parse_and_register_prelude;
+use semantics::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use semantics::store::Store;
 use syntax::program::{Definition, DefinitionBody, Visibility};
 use syntax::types::{CompoundKind, Type};
@@ -27,6 +27,7 @@ use syntax::types::{CompoundKind, Type};
 pub fn init_prelude(store: &mut Store) {
     let sink = LocalSink::new();
     parse_and_register_prelude(store, &sink);
+    parse_and_register_test_prelude(store, &sink);
 }
 
 pub fn register_test_builtins(store: &mut Store, _checker: &mut TaskState) {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7410,6 +7410,46 @@ fn math_test_project() -> MockFileSystem {
 }
 
 #[test]
+fn test_with_context_emits_testkit_wrapper() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn parallel_check(t: TestContext) {\n  t.parallel()\n  let _ = t.run(\"sub\", |s| { s.parallel() })\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let test_file = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output");
+    let go = test_file.to_go();
+
+    assert!(
+        go.contains("testkit.New(t)"),
+        "wrapper must construct the context, got:\n{go}"
+    );
+    assert!(
+        go.contains("testkit.TestContext"),
+        "the context type must be package-qualified, got:\n{go}"
+    );
+    assert!(
+        go.contains("github.com/ivov/lisette/prelude/testkit"),
+        "the testkit package must be imported, got:\n{go}"
+    );
+}
+
+#[test]
 fn test_emit_produces_go_test_function() {
     let outputs =
         compile_project_files_with_tests(math_test_project(), "github.com/user/p", false, true);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3688,6 +3688,35 @@ fn has_code(result: &crate::_harness::infer::InferResult, code: &str) -> bool {
         .any(|d| d.code_str().is_some_and(|c| c.contains(code)))
 }
 
+#[test]
+fn import_of_reserved_double_star_module_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", "import \"**test_prelude\"");
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "reserved_module_import"),
+        "a `**`-prefixed import must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_context_in_production_file_gives_test_only_hint() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", "pub fn nope(t: TestContext) {}");
+    let result = infer_module("main", fs);
+    let diagnostic = result
+        .errors
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.type_not_found"))
+        .expect("expected a type_not_found for TestContext in a production file");
+    let help = diagnostic.plain_help().unwrap_or_default();
+    assert!(
+        help.contains(".test.lis") && !help.contains("import"),
+        "the hint must point to test files, not encourage importing, got: {help:?}"
+    );
+}
+
 fn test_attribute_fs(math_core: &str, math_test: &str) -> MockFileSystem {
     let mut fs = MockFileSystem::new();
     fs.add_file(
@@ -3780,6 +3809,53 @@ fn test_attribute_with_parameter_rejected() {
     assert!(
         has_code(&result, "test_unsupported_signature"),
         "a parameterized test must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_with_test_context_accepted() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nfn checks(t: TestContext) { t.parallel() }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        !has_code(&result, "test_unsupported_signature"),
+        "a single TestContext parameter must be accepted, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "type_not_found"),
+        "TestContext must resolve in a test file, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_value_named_test_context_does_not_block_param() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "fn TestContext() {}\n\n#[test]\nfn checks(t: TestContext) { t.parallel() }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        !has_code(&result, "test_unsupported_signature"),
+        "a value named TestContext does not occupy the type position, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_with_shadowed_test_context_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "struct TestContext { x: int }\n\n#[test]\nfn checks(t: TestContext) { let _ = t.x }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_unsupported_signature"),
+        "a locally shadowed TestContext must not be accepted as the context param, got: {:?}",
         result.errors
     );
 }


### PR DESCRIPTION
Adds a param of type `TestContext` to `#[test]` functions, giving tests access to subtests and parallel execution.

```rs
#[test]
fn my_test(t: TestContext) {
  // ...
}
```

> [!IMPORTANT] 
> The test runner is work in progress, not ready for use yet!

Follow-up to #777
