### PR TITLE
feat: improve DX for `for` and `while` loops in value position

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2330,6 +2330,19 @@ pub fn break_value_in_non_loop(span: Span) -> LisetteDiagnostic {
         .with_help("`break` with a value is only meaningful in `loop` expressions, which can return the value. In `for` and `while` loops, use `break` without a value.")
 }
 
+pub fn loop_produces_no_value(span: &Span, keyword: &str, expected_ty: &str) -> LisetteDiagnostic {
+    let keyword_span = Span::new(span.file_id, span.byte_offset, keyword.len() as u32);
+    LisetteDiagnostic::error("Type mismatch")
+        .with_infer_code("loop_produces_no_value")
+        .with_span_label(
+            &keyword_span,
+            format!("evaluates to `()`, but expected `{expected_ty}` here"),
+        )
+        .with_help(format!(
+            "`{keyword}` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration."
+        ))
+}
+
 pub fn defer_in_loop(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`defer` inside loop")
         .with_infer_code("defer_in_loop")

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -406,8 +406,7 @@ impl InferCtx<'_, '_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
-        let unit_ty = self.type_unit();
-        self.unify(expected_ty, &unit_ty, &span);
+        self.unify_statement_loop(expected_ty, &span, "while");
 
         let new_condition = self.infer_condition(*condition, &span);
         if let Some(span) = Self::find_propagate(&new_condition) {
@@ -440,8 +439,7 @@ impl InferCtx<'_, '_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
-        let unit_ty = self.type_unit();
-        self.unify(expected_ty, &unit_ty, &span);
+        self.unify_statement_loop(expected_ty, &span, "while");
 
         let scrutinee_ty = self.new_type_var();
         let new_scrutinee = self.infer_expression(*scrutinee, &scrutinee_ty);
@@ -488,8 +486,7 @@ impl InferCtx<'_, '_> {
         expected_ty: &Type,
     ) -> Expression {
         let store = self.store;
-        let unit_ty = self.type_unit();
-        self.unify(expected_ty, &unit_ty, &span);
+        self.unify_statement_loop(expected_ty, &span, "for");
 
         let iterable_ty = self.new_type_var();
         let new_iterable = self.infer_expression(*iterable, &iterable_ty);

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -68,6 +68,22 @@ impl InferCtx<'_, '_> {
         }
     }
 
+    pub(super) fn unify_statement_loop(&mut self, expected_ty: &Type, span: &Span, keyword: &str) {
+        let unit_ty = self.type_unit();
+        if let Err(unify_error) = self.try_unify(expected_ty, &unit_ty, span) {
+            if unify_error == UnifyError::AlreadyReported {
+                return;
+            }
+            let expected = expected_ty.resolve_in(&self.env);
+            let (types, _) = Type::remove_vars(&[&expected]);
+            self.sink.push(diagnostics::infer::loop_produces_no_value(
+                span,
+                keyword,
+                &types[0].to_string(),
+            ));
+        }
+    }
+
     pub(super) fn try_unify(
         &mut self,
         t1: &Type,

--- a/docs/reference/04-control-flow.md
+++ b/docs/reference/04-control-flow.md
@@ -1,10 +1,18 @@
 # Control Flow
 
-Lisette is expression-oriented: blocks, `if`/`else`, and `loop` produce values. `for` and `while` are statements, so they do not produce values. Branching with `match` is covered in [`08-pattern-matching.md`](08-pattern-matching.md).
+Lisette is expression-oriented, so its control flow constructs produce values:
+
+- block → value from last expression
+- `if... else` → value from branch
+- `loop` → value from `break` or `()` for bare `break`
+- `for` → always `()`
+- `while` → always `()`
+
+Branching with `match` is covered in [`08-pattern-matching.md`](08-pattern-matching.md).
 
 ## Blocks
 
-A block is a sequence of expressions in braces. The last expression is the block's value. Bindings inside are not visible outside.
+A block is a sequence of expressions inside braces. The last expression is the block's value. Bindings inside are not visible outside.
 
 ```rust
 let value = {
@@ -71,6 +79,8 @@ let value = if let Some(x) = opt {
 
 Iterates over a collection or range.
 
+A `for` loop runs for side effects and always evaluates to `()`. If you need a loop that evaluates to a value, use `loop` with `break <value>`.
+
 ```rust
 for item in items {
   process(item)
@@ -135,11 +145,11 @@ for i in 0.. {
 }
 ```
 
-`for` is a statement, so it does not produce a value.
-
 ## `while`
 
-Repeats while a condition is true.
+Repeats while a condition is true. 
+
+A `while` loop runs for its side effects and always evaluates to `()`. For a loop that evaluates to a value, use `loop` with `break <value>`.
 
 ```rust
 let mut count = 0
@@ -158,8 +168,6 @@ while let Some(item) = iter.next() {
 }
 ```
 
-`while` is a statement, so it does not produce a value.
-
 ## `loop`
 
 An infinite loop. Exit with `break`.
@@ -172,16 +180,18 @@ loop {
 }
 ```
 
-`break` can carry a value, making `loop` an expression. All `break` expressions in a loop must produce the same type. A bare `break` gives the loop type `()`.
+A `loop` has no exit other than `break`, which can carry a value, so a `loop` evaluates to the value carried by `break`. 
 
 ```rust
 let result = loop {
   let n = try_next()
-  if n > 0 {
+  if n > 5 {
     break n
   }
 }
 ```
+
+A bare `break` gives the loop type `()`.
 
 ## `break` / `continue`
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8247,6 +8247,57 @@ fn test() {
 }
 
 #[test]
+fn infer_for_loop_in_tail_position() {
+    let input = r#"
+fn test() -> int {
+  let mut total = 0
+  for i in 0..10 {
+    total += i
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_for_open_ended_range_in_tail_position() {
+    let input = r#"
+fn returns_string() -> string {
+  for i in 2.. {
+    let _ = i
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_while_loop_in_tail_position() {
+    let input = r#"
+fn test() -> int {
+  let mut n = 0
+  while n < 10 {
+    n += 1
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_while_let_loop_in_tail_position() {
+    let input = r#"
+fn test() -> int {
+  let mut opt = Some(1)
+  while let Some(_) = opt {
+    opt = None
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_invalid_main_with_return_type() {
     let mut fs = MockFileSystem::new();
     let source = r#"

--- a/tests/ui/errors/snapshots/infer_for_loop_in_tail_position.snap
+++ b/tests/ui/errors/snapshots/infer_for_loop_in_tail_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:4:3]
+ 3 │   let mut total = 0
+ 4 │   for i in 0..10 {
+   ·   ─┬─
+   ·    ╰── evaluates to `()`, but expected `int` here
+ 5 │     total += i
+   ╰────
+  help: `for` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration · code: [infer.loop_produces_no_value]

--- a/tests/ui/errors/snapshots/infer_for_open_ended_range_in_tail_position.snap
+++ b/tests/ui/errors/snapshots/infer_for_open_ended_range_in_tail_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:3:3]
+ 2 │ fn returns_string() -> string {
+ 3 │   for i in 2.. {
+   ·   ─┬─
+   ·    ╰── evaluates to `()`, but expected `string` here
+ 4 │     let _ = i
+   ╰────
+  help: `for` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration · code: [infer.loop_produces_no_value]

--- a/tests/ui/errors/snapshots/infer_while_let_loop_in_tail_position.snap
+++ b/tests/ui/errors/snapshots/infer_while_let_loop_in_tail_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:4:3]
+ 3 │   let mut opt = Some(1)
+ 4 │   while let Some(_) = opt {
+   ·   ──┬──
+   ·     ╰── evaluates to `()`, but expected `int` here
+ 5 │     opt = None
+   ╰────
+  help: `while` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration · code: [infer.loop_produces_no_value]

--- a/tests/ui/errors/snapshots/infer_while_loop_in_tail_position.snap
+++ b/tests/ui/errors/snapshots/infer_while_loop_in_tail_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Type mismatch
+   ╭─[test.lis:4:3]
+ 3 │   let mut n = 0
+ 4 │   while n < 10 {
+   ·   ──┬──
+   ·     ╰── evaluates to `()`, but expected `int` here
+ 5 │     n += 1
+   ╰────
+  help: `while` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration · code: [infer.loop_produces_no_value]


### PR DESCRIPTION
Improves the type-mismatch error shown when a `for` or `while` loop sits where a value is expected, e.g. the tail of a function with a non-unit return type.

```rs
fn count_to_ten() -> string {
  let mut total = 0
  for i in 0..10 {
    total += i
  }
}
```

```
[error] Type mismatch
   ╭─[example.lis:3:3]
 2 │   let mut total = 0
 3 │   for i in 0..10 {
   ·   ─┬─
   ·    ╰── evaluates to `()`, but expected `string` here
 4 │     total += i
   ╰────
  help: `for` loops are for side effects and always evaluate to `()`. Use `loop` with `break <value>` to produce a value during iteration · code: [infer.loop_produces_no_value]
```

Motivated by #763