### PR TITLE
refactor: simplify emit value and directive representation

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -19,7 +19,6 @@ use syntax::parse::TUPLE_FIELDS;
 /// A bare `return v0, v1, ...` statement leaf.
 pub(crate) fn multi_value_return(values: Vec<String>) -> LoweredStatement {
     LoweredStatement::Return(ReturnStatementPlan {
-        directive: String::new(),
         form: ReturnForm::Multi { values },
     })
 }
@@ -27,7 +26,6 @@ pub(crate) fn multi_value_return(values: Vec<String>) -> LoweredStatement {
 /// An `if <condition> { return <then_values...> }` tag-check leaf (no else).
 pub(crate) fn tag_check(condition: String, then_values: Vec<String>) -> LoweredStatement {
     LoweredStatement::If(IfPlan {
-        directive: String::new(),
         condition_setup: Vec::new(),
         condition,
         then_body: LoweredBlock {
@@ -645,7 +643,9 @@ fn lowered_tail_fallback(
     hoist_hint: Option<&str>,
     fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
-    let (mut statements, value) = planner.lower_value(expression, ExpressionContext::value(), fx);
+    let (mut statements, value) = planner
+        .lower_value(expression, ExpressionContext::value(), fx)
+        .into_parts();
     let value = match hoist_hint {
         Some(hint) => planner.hoist_tmp_value_statement(&mut statements, hint, &value),
         None => value,
@@ -714,24 +714,28 @@ fn emit_lowered_partial_tail(
         let mut statements = Vec::new();
         let ret = match variant {
             "Ok" => {
-                let (setup, v) =
-                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup, v) = planner
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup);
                 multi_value_return(vec![v, "nil".to_string()])
             }
             "Err" => {
-                let (setup, e) =
-                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup, e) = planner
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup);
                 let ok_ty = planner.facts.peel_alias(&return_ty).ok_type();
                 multi_value_return(vec![lowered_zero(planner, &ok_ty, fx), e])
             }
             "Both" => {
-                let (setup_v, v) =
-                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup_v, v) = planner
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup_v);
-                let (setup_e, e) =
-                    planner.lower_composite_value(&args[1], ExpressionContext::value(), fx);
+                let (setup_e, e) = planner
+                    .lower_composite_value(&args[1], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup_e);
                 multi_value_return(vec![v, e])
             }
@@ -771,8 +775,9 @@ fn lower_nullable_slot_value(
         return match kind {
             Ok(()) => {
                 debug_assert_eq!(args.len(), 1, "Some(...) takes exactly one arg");
-                let (slot_setup, value) =
-                    planner.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (slot_setup, value) = planner
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 setup.extend(slot_setup);
                 value
             }
@@ -782,7 +787,9 @@ fn lower_nullable_slot_value(
     if expression.is_none_literal() {
         return "nil".to_string();
     }
-    let (value_setup, value) = planner.lower_value(expression, ExpressionContext::value(), fx);
+    let (value_setup, value) = planner
+        .lower_value(expression, ExpressionContext::value(), fx)
+        .into_parts();
     setup.extend(value_setup);
     let inner = planner.go_type_string(&slot_ty.ok_type(), fx);
     planner.plan_option_projection(setup, &value, "unwrap", &inner, false, fx)

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -504,7 +504,9 @@ impl Planner<'_> {
             self.go_type_string(&param, fx)
         };
         let (setup, arg_expression) = match args.first() {
-            Some(a) => self.lower_composite_value(a, ExpressionContext::value(), fx),
+            Some(a) => self
+                .lower_composite_value(a, ExpressionContext::value(), fx)
+                .into_parts(),
             None => (Vec::new(), String::new()),
         };
         fx.require_stdlib();

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -9,6 +9,7 @@ use crate::calls::CallBoundary;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::ValuePlan;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -46,7 +47,7 @@ impl Planner<'_> {
         strategy: &GoCallStrategy,
         result_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         match strategy {
             GoCallStrategy::Tuple { arity } => {
                 self.lower_go_tuple_call_wrapped(call_expression, *arity, fx)

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -7,6 +7,7 @@ use crate::calls::go_interop::wrappers::{
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::types::shape::{CollectionKind, NullableCollectionElement, NullableCollectionShape};
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -17,7 +18,7 @@ impl Planner<'_> {
         call_expression: &Expression,
         option_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
         let (wrap_setup, outcome) = self.lower_comma_ok_wrapping(
@@ -28,7 +29,7 @@ impl Planner<'_> {
             fx,
         );
         setup.extend(wrap_setup);
-        (setup, outcome.expect("wrapper produced no slot"))
+        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     pub(super) fn lower_go_sentinel_call_wrapped(
@@ -37,7 +38,7 @@ impl Planner<'_> {
         option_ty: &Type,
         sentinel: i64,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
         let (wrap_setup, outcome) = self.lower_sentinel_wrapping(
@@ -48,7 +49,7 @@ impl Planner<'_> {
             fx,
         );
         setup.extend(wrap_setup);
-        (setup, outcome.expect("wrapper produced no slot"))
+        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.
@@ -157,7 +158,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition,
             then_body: leaf_block(&sink, &some_wrapper),
@@ -200,14 +200,14 @@ impl Planner<'_> {
         call_expression: &Expression,
         option_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
         let raw_var = self.hoist_tmp_value_statement(&mut setup, "raw", &call_str);
         let (wrap_setup, outcome) =
             self.lower_nil_check_option_wrap(&raw_var, option_ty, WrapperTarget::FreshSlot, fx);
         setup.extend(wrap_setup);
-        (setup, outcome.expect("wrapper produced no slot"))
+        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     pub(crate) fn plan_option_projection(
@@ -237,7 +237,6 @@ impl Planner<'_> {
             ))],
         };
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("{}.Tag == {}", opt_var, OPTION_SOME_TAG),
             then_body: body,
@@ -333,7 +332,6 @@ impl Planner<'_> {
                     ))],
                 };
                 let if_plan = IfPlan {
-                    directive: String::new(),
                     condition_setup: Vec::new(),
                     condition,
                     then_body,
@@ -367,7 +365,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::Loop(LoopPlan {
-            directive: String::new(),
             prologue: Vec::new(),
             label: None,
             header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),
@@ -429,7 +426,6 @@ impl Planner<'_> {
                     ElseArm::None
                 };
                 let if_plan = IfPlan {
-                    directive: String::new(),
                     condition_setup: Vec::new(),
                     condition: format!("{}.Tag == {}", val_var, OPTION_SOME_TAG),
                     then_body,
@@ -460,7 +456,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::Loop(LoopPlan {
-            directive: String::new(),
             prologue: Vec::new(),
             label: None,
             header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -12,6 +12,7 @@ use crate::control_flow::propagation::plain_return;
 use crate::is_order_sensitive;
 use crate::names::go_name;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement};
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -153,7 +154,7 @@ impl Planner<'_> {
         call_expression: &Expression,
         arity: usize,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let Expression::Call { ty, .. } = call_expression else {
             unreachable!("lower_go_tuple_call_wrapped called with non-call expression");
         };
@@ -170,7 +171,7 @@ impl Planner<'_> {
 
         let constructor = build_tuple_literal(&temp_vars, ty, fx);
         let tuple = self.hoist_tmp_value_statement(&mut setup, "tup", &constructor);
-        (setup, tuple)
+        value_plan_from_statements(setup, tuple)
     }
 
     pub(super) fn lower_go_partial_call_wrapped(
@@ -178,7 +179,7 @@ impl Planner<'_> {
         call_expression: &Expression,
         partial_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         fx.require_stdlib();
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
@@ -190,7 +191,7 @@ impl Planner<'_> {
             fx,
         );
         setup.extend(wrap_setup);
-        (setup, outcome.expect("wrapper produced no slot"))
+        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     /// Lower a `(T, error)` Go return into a tagged `Partial`.
@@ -222,7 +223,6 @@ impl Planner<'_> {
 
         let then_body = if let Some(check) = &nil_check {
             let inner = IfPlan {
-                directive: String::new(),
                 condition_setup: Vec::new(),
                 condition: check.clone(),
                 then_body: leaf_block(
@@ -250,7 +250,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,
@@ -283,7 +282,7 @@ impl Planner<'_> {
         call_expression: &Expression,
         result_ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         fx.require_stdlib();
         let (mut setup, call_str) =
             self.lower_call(call_expression, None, ExpressionContext::value(), fx);
@@ -295,7 +294,7 @@ impl Planner<'_> {
             fx,
         );
         setup.extend(wrap_setup);
-        (setup, outcome.expect("wrapper produced no slot"))
+        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     pub(crate) fn go_result_needs_nil_guard(&self, ok_ty: &Type) -> bool {
@@ -363,7 +362,6 @@ impl Planner<'_> {
                 fe.emit_success(&ok_val)
             };
             ElseArm::ElseIf(Box::new(IfPlan {
-                directive: String::new(),
                 condition_setup: Vec::new(),
                 condition: nil_condition,
                 then_body: leaf_block(&sink, &nil_err),
@@ -384,7 +382,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,
@@ -427,7 +424,6 @@ impl Planner<'_> {
         };
 
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("{} != nil", err_var),
             then_body,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -505,7 +505,7 @@ impl<'a> Planner<'a> {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
                 let arg_ctx = direct_arg_emit_ctx(ctx, Some(target), true);
-                let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx);
+                let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx).into_parts();
                 let lowered = self.emit_lower_arg_to_tagged(&mut setup, &value, target, fx);
                 (setup, lowered)
             }
@@ -568,7 +568,7 @@ impl<'a> Planner<'a> {
     ) -> (Vec<LoweredStatement>, String) {
         let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
         let arg_ctx = direct_arg_emit_ctx(ctx, effective_param_ty, suppress);
-        let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx);
+        let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx).into_parts();
         let final_value = match effective_param_ty {
             Some(target) => {
                 let coercion =
@@ -648,7 +648,9 @@ impl<'a> Planner<'a> {
         fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let (param_shape, arg_fn, arg_shape) = self.fn_arg_shapes(arg, generic_param_ty)?;
-        let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
+        let (mut setup, value) = self
+            .lower_value(arg, ExpressionContext::value(), fx)
+            .into_parts();
         let mut buffer = String::new();
         let adapted = emit_fn_arg_shape_adapter(
             self,
@@ -697,7 +699,9 @@ impl<'a> Planner<'a> {
             return None;
         }
 
-        let (mut setup, src_value) = self.lower_value(spread, ExpressionContext::value(), fx);
+        let (mut setup, src_value) = self
+            .lower_value(spread, ExpressionContext::value(), fx)
+            .into_parts();
         let src_var = self.hoist_tmp_value_statement(&mut setup, "src", &src_value);
 
         let target_element_ret = match param_shape.as_ref() {
@@ -786,7 +790,9 @@ impl<'a> Planner<'a> {
         kind: CallbackWrapperKind,
         fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
-        let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
+        let (mut setup, value) = self
+            .lower_value(arg, ExpressionContext::value(), fx)
+            .into_parts();
         let result = match kind {
             CallbackWrapperKind::Identity => value,
             CallbackWrapperKind::Wrap => {
@@ -833,7 +839,9 @@ impl<'a> Planner<'a> {
             return (Vec::new(), "nil".to_string());
         }
         let arg_ty = arg.get_type();
-        let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
+        let (mut setup, value) = self
+            .lower_value(arg, ExpressionContext::value(), fx)
+            .into_parts();
         let coercion = Coercion::resolve(self, &arg_ty, param_ty, CoercionDirection::ToGoBoundary);
         let (coercion_setup, coerced) = coercion.lower(self, value, fx);
         setup.extend(coercion_setup);
@@ -884,7 +892,9 @@ impl<'a> Planner<'a> {
                 if arg.is_none_literal() {
                     return (Vec::new(), "nil".to_string());
                 }
-                let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
+                let (mut setup, value) = self
+                    .lower_value(arg, ExpressionContext::value(), fx)
+                    .into_parts();
                 let coercion =
                     Coercion::resolve(self, &arg_ty, &check_ty, CoercionDirection::ToGoBoundary);
                 let (coercion_setup, coerced) = coercion.lower(self, value, fx);
@@ -906,7 +916,9 @@ impl<'a> Planner<'a> {
         if arg.is_none_literal() {
             return (Vec::new(), "nil".to_string());
         }
-        let (mut setup, value) = self.lower_value(arg, ExpressionContext::value(), fx);
+        let (mut setup, value) = self
+            .lower_value(arg, ExpressionContext::value(), fx)
+            .into_parts();
         let coercion = Coercion::resolve(self, arg_ty, arg_ty, CoercionDirection::ToGoBoundary);
         let (coercion_setup, coerced) = coercion.lower(self, value, fx);
         setup.extend(coercion_setup);

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -8,6 +8,7 @@ use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::plan::bodies::{LoweredBlock, LoweredStatement};
 use crate::plan::placement::is_unit_call;
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -19,7 +20,7 @@ impl Planner<'_> {
         items: &[Expression],
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         fx.require_stdlib();
 
         let return_ctx = self.return_ctx();
@@ -45,7 +46,7 @@ impl Planner<'_> {
             body,
             closure_close: "}()\n".to_string(),
         }];
-        (setup, result_var)
+        value_plan_from_statements(setup, result_var)
     }
 
     fn lower_try_body(
@@ -101,8 +102,9 @@ impl Planner<'_> {
             ];
         }
 
-        let (mut statements, final_expression) =
-            self.lower_value(last, ExpressionContext::value(), fx);
+        let (mut statements, final_expression) = self
+            .lower_value(last, ExpressionContext::value(), fx)
+            .into_parts();
         if final_expression.is_empty() {
             statements.push(self.lower_try_unit_return(fallible, fx));
         } else {
@@ -153,7 +155,9 @@ impl Planner<'_> {
                     return None;
                 }
                 if !args.is_empty() {
-                    let (setup, value) = self.lower_value(&args[0], ExpressionContext::value(), fx);
+                    let (setup, value) = self
+                        .lower_value(&args[0], ExpressionContext::value(), fx)
+                        .into_parts();
                     statements.extend(setup);
                     Some(value)
                 } else {
@@ -197,7 +201,7 @@ impl Planner<'_> {
         items: &[Expression],
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         fx.require_stdlib();
 
         let return_ctx = self.return_ctx();
@@ -221,7 +225,7 @@ impl Planner<'_> {
             body,
             closure_close: "})\n".to_string(),
         }];
-        (setup, result_var)
+        value_plan_from_statements(setup, result_var)
     }
 
     fn lower_recover_body_block(
@@ -266,7 +270,9 @@ impl Planner<'_> {
                 self.lower_zero_return(fallible.ok_ty(), fx),
             ];
         }
-        let (mut statements, expression) = self.lower_value(last, ExpressionContext::value(), fx);
+        let (mut statements, expression) = self
+            .lower_value(last, ExpressionContext::value(), fx)
+            .into_parts();
         statements.push(plain_return(expression));
         statements
     }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -5,7 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
-use crate::plan::bodies::{LoopPlan, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{LoopPlan, LoweredBlock, LoweredStatement, directed};
 use crate::types::native::NativeGoType;
 use crate::types::shape::RangeShape;
 use crate::utils::observable_after_mutation;
@@ -71,13 +71,15 @@ impl Planner<'_> {
 
         self.pop_loop();
 
-        LoweredStatement::Loop(LoopPlan {
+        directed(
             directive,
-            prologue,
-            label,
-            header,
-            body: lowered_body,
-        })
+            LoweredStatement::Loop(LoopPlan {
+                prologue,
+                label,
+                header,
+                body: lowered_body,
+            }),
+        )
     }
 
     /// Plan `expr` as an operand, pushing its setup into `prologue` and
@@ -108,7 +110,9 @@ impl Planner<'_> {
         }
         let temp_var = self.fresh_var(Some(prefix));
         self.declare(&temp_var);
-        let (setup, value) = self.lower_composite_value(expr, ExpressionContext::value(), fx);
+        let (setup, value) = self
+            .lower_composite_value(expr, ExpressionContext::value(), fx)
+            .into_parts();
         prologue.extend(setup);
         prologue.push(LoweredStatement::TempBind {
             name: temp_var.clone(),

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -25,7 +25,6 @@ struct WrappedReturnInfo<'a> {
 
 pub(crate) fn plain_return(value: String) -> LoweredStatement {
     LoweredStatement::Return(ReturnStatementPlan {
-        directive: String::new(),
         form: ReturnForm::Plain {
             value: ValuePlan::Operand(value),
         },
@@ -34,7 +33,6 @@ pub(crate) fn plain_return(value: String) -> LoweredStatement {
 
 fn simple_assign(target: String, value: String) -> LoweredStatement {
     LoweredStatement::Assign(AssignPlan {
-        directive: String::new(),
         form: AssignForm::Simple {
             target_capture: Vec::new(),
             target_str: target,
@@ -256,7 +254,6 @@ impl Planner<'_> {
     pub(crate) fn build_return_plan(
         &mut self,
         expression: &Expression,
-        directive: String,
         fx: &mut EmitEffects,
     ) -> ReturnStatementPlan {
         let return_ctx = self.return_ctx();
@@ -279,14 +276,12 @@ impl Planner<'_> {
                 (!Renderer.renders_empty(&body)).then_some(body)
             };
             return ReturnStatementPlan {
-                directive,
                 form: ReturnForm::Unit { side_effect },
             };
         }
 
         if let Some(statements) = transition::try_emit_lowered_tail_return(self, expression, fx) {
             return ReturnStatementPlan {
-                directive,
                 form: ReturnForm::LoweredAbi {
                     body: LoweredBlock { statements },
                 },
@@ -295,14 +290,15 @@ impl Planner<'_> {
 
         if let Some(statements) = self.lower_wrapped_return(expression, fx) {
             return ReturnStatementPlan {
-                directive,
                 form: ReturnForm::Wrapped {
                     body: LoweredBlock { statements },
                 },
             };
         }
 
-        let (mut setup, raw_value) = self.lower_value(expression, ExpressionContext::value(), fx);
+        let (mut setup, raw_value) = self
+            .lower_value(expression, ExpressionContext::value(), fx)
+            .into_parts();
         let mut coercion_buffer = String::new();
         let final_value = self.apply_type_coercion(
             &mut coercion_buffer,
@@ -315,7 +311,6 @@ impl Planner<'_> {
             setup.push(LoweredStatement::RawGo(coercion_buffer));
         }
         ReturnStatementPlan {
-            directive,
             form: ReturnForm::Plain {
                 value: value_plan_from_statements(setup, final_value),
             },
@@ -401,7 +396,9 @@ impl Planner<'_> {
             return Some(statements);
         }
 
-        let (setup, value) = self.lower_value(expression, ExpressionContext::value(), fx);
+        let (setup, value) = self
+            .lower_value(expression, ExpressionContext::value(), fx)
+            .into_parts();
         statements.extend(setup);
         statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
         Some(statements)
@@ -471,16 +468,18 @@ impl Planner<'_> {
         if let Some(shape) = lowered {
             let ok_arg = if matches!(shape, AbiShape::BareError) {
                 if !args.is_empty() {
-                    let (setup, _) =
-                        self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                    let (setup, _) = self
+                        .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                        .into_parts();
                     statements.extend(setup);
                 }
                 String::new()
             } else if args.is_empty() {
                 "struct{}{}".to_string()
             } else {
-                let (setup, value) =
-                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup, value) = self
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup);
                 value
             };
@@ -488,7 +487,9 @@ impl Planner<'_> {
                 transition::lowered_ok_values(shape, &ok_arg),
             ));
         } else {
-            let (setup, arg) = self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+            let (setup, arg) = self
+                .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                .into_parts();
             let success = {
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
                 fe.emit_success(&arg)
@@ -514,16 +515,18 @@ impl Planner<'_> {
                     transition::lowered_none_values(self, shape, return_ty, fx),
                 ));
             } else {
-                let (setup, err_expr) =
-                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup, err_expr) = self
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 let values = transition::lowered_err_values(self, shape, return_ty, &err_expr, fx);
                 statements.extend(setup);
                 statements.push(transition::multi_value_return(values));
             }
         } else {
             let failure = if fallible.is_result() {
-                let (setup, arg) =
-                    self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                let (setup, arg) = self
+                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .into_parts();
                 statements.extend(setup);
                 let mut fe = FalliblePlanner::new(self, fallible, fx);
                 fe.emit_failure(Some(&arg))
@@ -556,8 +559,9 @@ impl Planner<'_> {
         if let Some(plan) = self.plan_call(expression)
             && let CalleePlan::GoInterop(strategy) = plan.callee
         {
-            let (setup, result_var) =
-                self.lower_go_wrapped_call(expression, &strategy, return_ty, fx);
+            let (setup, result_var) = self
+                .lower_go_wrapped_call(expression, &strategy, return_ty, fx)
+                .into_parts();
             statements.extend(setup);
             if let Some(shape) = lowered {
                 statements.extend(transition::emit_lowered_result_return(
@@ -573,7 +577,9 @@ impl Planner<'_> {
             return statements;
         }
         if let Some(shape) = lowered {
-            let (setup, value) = self.lower_value(expression, ExpressionContext::value(), fx);
+            let (setup, value) = self
+                .lower_value(expression, ExpressionContext::value(), fx)
+                .into_parts();
             statements.extend(setup);
             let temp = self.hoist_tmp_value_statement(&mut statements, "v", &value);
             statements.extend(transition::emit_lowered_result_return(

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -67,7 +67,6 @@ impl Planner<'_> {
         }
 
         SelectStatementPlan {
-            directive: String::new(),
             setup,
             retry_loop: needs_retry_loop,
             arms: arm_plans,
@@ -219,7 +218,9 @@ impl Planner<'_> {
     ) -> String {
         let unwrapped = receive_expression.unwrap_parens();
         if let Some((channel, "receive", _)) = extract_channel_op(unwrapped) {
-            let (op_setup, ch) = self.lower_value(channel, ExpressionContext::value(), fx);
+            let (op_setup, ch) = self
+                .lower_value(channel, ExpressionContext::value(), fx)
+                .into_parts();
             setup.extend(op_setup);
             return if channel.get_type().is_ref() {
                 cancel_deref_of_address(ch)
@@ -227,7 +228,9 @@ impl Planner<'_> {
                 ch
             };
         }
-        let (op_setup, ch) = self.lower_value(receive_expression, ExpressionContext::value(), fx);
+        let (op_setup, ch) = self
+            .lower_value(receive_expression, ExpressionContext::value(), fx)
+            .into_parts();
         setup.extend(op_setup);
         ch
     }
@@ -260,7 +263,6 @@ impl Planner<'_> {
 
         let plan = if body_empty {
             IfPlan {
-                directive: String::new(),
                 condition_setup: Vec::new(),
                 condition: format!("!{}", ok_var),
                 then_body: else_block.expect("body_empty && has_else"),
@@ -275,7 +277,6 @@ impl Planner<'_> {
                 None => ElseArm::None,
             };
             IfPlan {
-                directive: String::new(),
                 condition_setup: Vec::new(),
                 condition: ok_var.to_string(),
                 then_body: body_block,
@@ -296,10 +297,7 @@ impl Planner<'_> {
             return Some(LoweredBlock {
                 statements: vec![
                     LoweredStatement::RawGo(format!("{} = nil\n", retry_var)),
-                    LoweredStatement::Continue {
-                        directive: String::new(),
-                        label: None,
-                    },
+                    LoweredStatement::Continue { label: None },
                 ],
             });
         }
@@ -355,7 +353,6 @@ impl Planner<'_> {
             None => ElseArm::None,
         };
         let if_plan = IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: ok_var,
             then_body: LoweredBlock {
@@ -477,7 +474,9 @@ impl Planner<'_> {
         let unwrapped = send_expression.unwrap_parens();
         if let Some((channel, member, args)) = extract_channel_op(unwrapped) {
             let ch_has_call = needs_hoist && contains_call(channel);
-            let (op_setup, mut ch) = self.lower_value(channel, ExpressionContext::value(), fx);
+            let (op_setup, mut ch) = self
+                .lower_value(channel, ExpressionContext::value(), fx)
+                .into_parts();
             setup.extend(op_setup);
             if channel.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
@@ -488,8 +487,9 @@ impl Planner<'_> {
             match member {
                 "send" if !args.is_empty() => {
                     let val_has_call = needs_hoist && contains_call(&args[0]);
-                    let (val_setup, mut val) =
-                        self.lower_composite_value(&args[0], ExpressionContext::value(), fx);
+                    let (val_setup, mut val) = self
+                        .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                        .into_parts();
                     setup.extend(val_setup);
                     if val_has_call {
                         val = self.hoist_tmp_value_statement(setup, "send_val", &val);
@@ -501,8 +501,9 @@ impl Planner<'_> {
             }
         } else {
             let expression_has_call = needs_hoist && contains_call(send_expression);
-            let (op_setup, mut ch) =
-                self.lower_value(send_expression, ExpressionContext::value(), fx);
+            let (op_setup, mut ch) = self
+                .lower_value(send_expression, ExpressionContext::value(), fx)
+                .into_parts();
             setup.extend(op_setup);
             if send_expression.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
@@ -689,7 +690,6 @@ fn build_receive_arms_plan(
 ) -> Option<IfPlan> {
     match (some, none) {
         (Some(some), Some(none)) => Some(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: ok_var.to_string(),
             then_body: some,
@@ -699,14 +699,12 @@ fn build_receive_arms_plan(
             },
         }),
         (Some(some), None) => Some(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: ok_var.to_string(),
             then_body: some,
             else_arm: ElseArm::None,
         }),
         (None, Some(none)) => Some(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("!{}", ok_var),
             then_body: none,

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -74,7 +74,6 @@ impl Planner<'_> {
         identifier: &str,
         expression: &Expression,
         ty: &Type,
-        directive: String,
         fx: &mut EmitEffects,
     ) -> ConstPlan {
         let target_name = self
@@ -107,7 +106,6 @@ impl Planner<'_> {
             self.record_go_const(go_identifier.clone());
         }
         ConstPlan {
-            directive,
             is_const,
             name: go_identifier,
             ty_str,
@@ -122,7 +120,7 @@ impl Planner<'_> {
         ty: &Type,
         fx: &mut EmitEffects,
     ) -> String {
-        let plan = self.build_const_plan(identifier, expression, ty, String::new(), fx);
+        let plan = self.build_const_plan(identifier, expression, ty, fx);
         let mut out = String::new();
         Renderer.render_const_declaration(&mut out, &plan);
         out.trim_end_matches('\n').to_string()

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -6,6 +6,7 @@ use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use syntax::ast::{FormatStringPart, Literal};
 use syntax::types::{SimpleKind, Type};
 
@@ -15,7 +16,7 @@ impl Planner<'_> {
         literal: &Literal,
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let value = match literal {
             Literal::Integer { value, text } => match text {
@@ -102,7 +103,7 @@ impl Planner<'_> {
                 }
             }
         };
-        (setup, value)
+        value_plan_from_statements(setup, value)
     }
 
     fn emit_format_string(

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -44,7 +44,7 @@ impl Planner<'_> {
         };
 
         if let Some(emit_info) = is_casting_needed(operator, &left, &right) {
-            let (setup, value) = self.plan_numeric_binary_with_casts(
+            return self.plan_numeric_binary_with_casts(
                 operator,
                 left_expression,
                 right_expression,
@@ -52,7 +52,6 @@ impl Planner<'_> {
                 ctx,
                 fx,
             );
-            return value_plan_from_statements(setup, value);
         }
 
         let left_ty = &left.ty;
@@ -88,14 +87,13 @@ impl Planner<'_> {
         }
 
         if matches!(operator, BinaryOperator::And | BinaryOperator::Or) {
-            let (setup, value) = self.plan_short_circuit_binary(
+            return self.plan_short_circuit_binary(
                 operator,
                 left_expression,
                 right_expression,
                 ctx,
                 fx,
             );
-            return value_plan_from_statements(setup, value);
         }
 
         let stages = vec![
@@ -113,7 +111,7 @@ impl Planner<'_> {
         right_expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let left_staged = self.stage_composite(left_expression, ctx, fx);
 
         // Wrap RHS setup in an IIFE so it runs only when control reaches the
@@ -129,7 +127,7 @@ impl Planner<'_> {
             )
         };
 
-        (
+        value_plan_from_statements(
             left_staged.setup,
             format!("{} {} {}", left_staged.value, operator, right_string),
         )
@@ -160,8 +158,7 @@ impl Planner<'_> {
         }
 
         if matches!(operator, UnaryOperator::Not) {
-            let (setup, value) = self.plan_unary_not(expression, ctx, fx);
-            return value_plan_from_statements(setup, value);
+            return self.plan_unary_not(expression, ctx, fx);
         }
 
         let op = match operator {
@@ -183,7 +180,7 @@ impl Planner<'_> {
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let target = expression.unwrap_parens();
         let preserve_parens = matches!(expression, Expression::Paren { .. });
         let wrap = |s: String| {
@@ -203,17 +200,17 @@ impl Planner<'_> {
         {
             let plan = self.plan_binary(&flipped, left, right, ctx, fx);
             let (setup, value) = plan.into_parts();
-            return (setup, wrap(value));
+            return value_plan_from_statements(setup, wrap(value));
         }
         if matches!(target, Expression::Call { .. }) {
             let mut setup: Vec<LoweredStatement> = Vec::new();
             if let Some(negated) = self.try_emit_negated_call(&mut setup, target, fx) {
-                return (setup, wrap(negated));
+                return value_plan_from_statements(setup, wrap(negated));
             }
         }
 
         let staged = self.stage_operand(expression, ctx, fx);
-        (staged.setup, format!("!{}", staged.value))
+        value_plan_from_statements(staged.setup, format!("!{}", staged.value))
     }
 
     fn plan_numeric_binary_with_casts(
@@ -224,7 +221,7 @@ impl Planner<'_> {
         info: NumericBinaryEmitInfo,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let stages = vec![
             self.stage_operand(left_expression, ctx, fx),
             self.stage_operand(right_expression, ctx, fx),
@@ -244,7 +241,7 @@ impl Planner<'_> {
         };
 
         let result = format!("{} {} {}", left_string, operator, right_string);
-        (setup, result)
+        value_plan_from_statements(setup, result)
     }
 }
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -64,8 +64,9 @@ impl Planner<'_> {
             return self.capture_operand_into(setup, expression, fx);
         }
 
-        let (composite_setup, expression_string) =
-            self.lower_composite_value(expression, ExpressionContext::value(), fx);
+        let (composite_setup, expression_string) = self
+            .lower_composite_value(expression, ExpressionContext::value(), fx)
+            .into_parts();
         setup.extend(composite_setup);
         self.hoist_tmp_value_statement(setup, prefix, &expression_string)
     }
@@ -88,8 +89,8 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> StagedExpression {
-        let (setup, value) = self.lower_composite_value(expression, ctx, fx);
-        StagedExpression::from_typed_setup(setup, value, expression)
+        let plan = self.lower_composite_value(expression, ctx, fx);
+        StagedExpression::from_plan(plan, expression)
     }
 
     pub(crate) fn stage_prelude_arg(

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -27,7 +27,7 @@ impl Planner<'_> {
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         if let Some(strategy) = self.classify_go_fn_value(expression) {
             if !self.go_fn_matches_lowered_slot(expression, &strategy, ctx) {
                 let mut setup = Vec::new();
@@ -36,16 +36,15 @@ impl Planner<'_> {
                 } else {
                     self.emit_go_fn_wrapper(&mut setup, expression, &strategy, fx)
                 };
-                return (setup, value);
+                return value_plan_from_statements(setup, value);
             }
         } else if self.is_go_array_return_value(expression) {
             let mut setup = Vec::new();
             let value = self.emit_array_return_wrapper(&mut setup, expression, fx);
-            return (setup, value);
+            return value_plan_from_statements(setup, value);
         }
 
-        let plan = self.plan_operand(expression, ctx, fx);
-        plan.into_parts()
+        self.plan_operand(expression, ctx, fx)
     }
 
     pub(crate) fn lower_composite_value(
@@ -53,18 +52,18 @@ impl Planner<'_> {
         expression: &Expression,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         if expression.get_type().is_unit()
             && matches!(
                 expression.unwrap_parens(),
                 Expression::Call { .. } | Expression::Block { .. }
             )
         {
-            let (mut setup, call_str) = self.lower_value(expression, ctx, fx);
+            let (mut setup, call_str) = self.lower_value(expression, ctx, fx).into_parts();
             if !call_str.is_empty() {
                 setup.push(LoweredStatement::RawGo(format!("{call_str}\n")));
             }
-            return (setup, "struct{}{}".to_string());
+            return value_plan_from_statements(setup, "struct{}{}".to_string());
         }
         self.lower_value(expression, ctx, fx)
     }
@@ -158,10 +157,7 @@ impl Planner<'_> {
         fx: &mut EmitEffects,
     ) -> ValuePlan {
         match expression {
-            Expression::Literal { literal, ty, .. } => {
-                let (setup, value) = self.emit_literal(literal, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
+            Expression::Literal { literal, ty, .. } => self.emit_literal(literal, ty, fx),
             Expression::Identifier { value, ty, .. } => {
                 let mut setup: Vec<LoweredStatement> = Vec::new();
                 let raw = self.emit_identifier(value, ty, ctx, fx);
@@ -171,8 +167,7 @@ impl Planner<'_> {
             }
             Expression::Call { ty, .. } => match self.classify_call(expression) {
                 CallBoundary::GoWrapped(strategy) => {
-                    let (setup, value) = self.lower_go_wrapped_call(expression, &strategy, ty, fx);
-                    value_plan_from_statements(setup, value)
+                    self.lower_go_wrapped_call(expression, &strategy, ty, fx)
                 }
                 CallBoundary::LoweredCallee(shape) => {
                     fx.require_stdlib();
@@ -197,15 +192,12 @@ impl Planner<'_> {
             } => ValuePlan::Operand(self.emit_lambda(params, body, ty, ctx, fx)),
             Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
-            | Expression::Block { ty, .. } => {
-                let (setup, value) = self.lower_to_operand_temp(expression, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
+            | Expression::Block { ty, .. } => self.lower_to_operand_temp(expression, ty, fx),
             Expression::Return {
                 expression: return_expression,
                 ..
             } => {
-                let plan = self.build_return_plan(return_expression, String::new(), fx);
+                let plan = self.build_return_plan(return_expression, fx);
                 value_plan_from_statements(vec![LoweredStatement::Return(plan)], String::new())
             }
             Expression::Assignment { target, value, .. } => {
@@ -377,7 +369,6 @@ impl Planner<'_> {
             let mut setup = staged.setup;
             if !staged.value.is_empty() {
                 setup.push(LoweredStatement::Expression(ExpressionStatementPlan {
-                    directive: String::new(),
                     form: ExpressionStatementForm::Async {
                         value: ValuePlan::Operand(staged.value),
                     },
@@ -387,7 +378,9 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, format!("&{}", tmp));
         }
 
-        let (mut setup, emitted) = self.lower_value(inner, ExpressionContext::value(), fx);
+        let (mut setup, emitted) = self
+            .lower_value(inner, ExpressionContext::value(), fx)
+            .into_parts();
 
         let value = if inner.get_type() == *ty {
             emitted
@@ -525,7 +518,6 @@ impl Planner<'_> {
         if let Expression::Block { .. } = expression {
             let body = self.with_fresh_scope(|planner| planner.lower_block_as_body(expression, fx));
             let setup = vec![LoweredStatement::Expression(ExpressionStatementPlan {
-                directive: String::new(),
                 form: ExpressionStatementForm::AsyncBlock {
                     keyword: keyword.to_string(),
                     body,
@@ -539,10 +531,14 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, format!("{} {}", keyword, call_str));
         }
 
-        let (setup, inner) = self.lower_value(expression, ExpressionContext::value(), fx);
+        let (setup, inner) = self
+            .lower_value(expression, ExpressionContext::value(), fx)
+            .into_parts();
         if needs_iife_for_async(expression, &inner) {
             let (mut setup, inner) = self.with_eager_operand_capture(true, |planner| {
-                planner.lower_value(expression, ExpressionContext::value(), fx)
+                planner
+                    .lower_value(expression, ExpressionContext::value(), fx)
+                    .into_parts()
             });
             let mut body_statements = Vec::new();
             if !inner.is_empty() {
@@ -557,7 +553,6 @@ impl Planner<'_> {
                 statements: body_statements,
             };
             setup.push(LoweredStatement::Expression(ExpressionStatementPlan {
-                directive: String::new(),
                 form: ExpressionStatementForm::AsyncBlock {
                     keyword: keyword.to_string(),
                     body,

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -174,7 +174,6 @@ impl Planner<'_> {
             fx,
         );
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: format!("{} == nil", err_var),
             then_body,

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -119,8 +119,9 @@ impl Planner<'_> {
                 }
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
-                let (op_setup, expression) =
-                    self.lower_value(scrutinee, ExpressionContext::value(), fx);
+                let (op_setup, expression) = self
+                    .lower_value(scrutinee, ExpressionContext::value(), fx)
+                    .into_parts();
                 setup.extend(op_setup);
                 ResolvedSubject::Composite { var, expression }
             }
@@ -260,7 +261,6 @@ impl Planner<'_> {
             );
             return LoweredBlock {
                 statements: vec![LoweredStatement::Loop(LoopPlan {
-                    directive: String::new(),
                     prologue: Vec::new(),
                     label,
                     header: "for {\n".to_string(),
@@ -287,7 +287,6 @@ impl Planner<'_> {
         self.exit_scope();
 
         loop_body.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition,
             then_body: LoweredBlock {
@@ -296,7 +295,6 @@ impl Planner<'_> {
             else_arm: ElseArm::Else {
                 body: LoweredBlock {
                     statements: vec![LoweredStatement::Break {
-                        directive: String::new(),
                         label: label.clone(),
                     }],
                 },
@@ -306,7 +304,6 @@ impl Planner<'_> {
 
         LoweredBlock {
             statements: vec![LoweredStatement::Loop(LoopPlan {
-                directive: String::new(),
                 prologue: Vec::new(),
                 label,
                 header: "for {\n".to_string(),
@@ -362,7 +359,6 @@ impl Planner<'_> {
         let guard = guard_parts.join(" || ");
         let else_lowered = self.lower_block_as_body(else_block, fx);
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: guard,
             then_body: else_lowered,
@@ -560,7 +556,6 @@ impl Planner<'_> {
 
         let terminal = LoweredBlock {
             statements: vec![LoweredStatement::Break {
-                directive: String::new(),
                 label: label.map(str::to_string),
             }],
         };
@@ -643,7 +638,6 @@ impl Planner<'_> {
             None => ElseArm::None,
         };
         statements.push(LoweredStatement::If(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition,
             then_body: LoweredBlock {
@@ -759,7 +753,6 @@ fn assemble_if_else_chain(
     while pieces.len() > 1 {
         let (condition, then_body) = pieces.pop().expect("len > 1");
         else_arm = ElseArm::ElseIf(Box::new(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition,
             then_body,
@@ -768,7 +761,6 @@ fn assemble_if_else_chain(
     }
     let (condition, then_body) = pieces.pop().expect("pieces is non-empty");
     LoweredStatement::If(IfPlan {
-        directive: String::new(),
         condition_setup: Vec::new(),
         condition,
         then_body,

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -305,12 +305,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         self.walk(&mut body, &plan.tree, &ctx);
         if !unguarded_exit {
             body.push(LoweredStatement::Break {
-                directive: String::new(),
                 label: Some(label.clone()),
             });
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
-            directive: String::new(),
             prologue: Vec::new(),
             label: Some(label),
             header: "for {\n".to_string(),
@@ -467,7 +465,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 ElseArm::None
             };
             guard_statements.push(LoweredStatement::If(IfPlan {
-                directive: String::new(),
                 condition_setup,
                 condition,
                 then_body,
@@ -541,7 +538,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             None => ElseArm::None,
         };
         IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: condition.to_string(),
             then_body,
@@ -559,7 +555,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let case_plans = self.lower_switch_cases(cases, place);
         let default_block = self.lower_switch_default(default, place);
         SwitchStatementPlan {
-            directive: String::new(),
             kind: SwitchKind::Value {
                 subject: expr.to_string(),
             },
@@ -587,7 +582,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let binding = references_base.then(|| base.to_string());
 
         SwitchStatementPlan {
-            directive: String::new(),
             kind: SwitchKind::Type {
                 subject: base.to_string(),
                 binding,
@@ -682,7 +676,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         }
         match &first.condition {
             Some(condition) => statements.push(LoweredStatement::If(IfPlan {
-                directive: String::new(),
                 condition_setup: Vec::new(),
                 condition: condition.clone(),
                 then_body: body,
@@ -747,7 +740,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                         apply_leaf_terminator(&mut then_body, ctx, body_diverges);
                         self.planner.exit_scope();
                         statements.push(LoweredStatement::If(IfPlan {
-                            directive: String::new(),
                             condition_setup,
                             condition,
                             then_body: LoweredBlock {
@@ -1045,7 +1037,6 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
     let mut else_arm = trailing;
     for branch in branches.into_iter().rev() {
         else_arm = ElseArm::ElseIf(Box::new(IfPlan {
-            directive: String::new(),
             condition_setup: Vec::new(),
             condition: branch.condition,
             then_body: branch.body,
@@ -1053,7 +1044,6 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
         }));
     }
     IfPlan {
-        directive: String::new(),
         condition_setup: Vec::new(),
         condition: head.condition,
         then_body: head.body,
@@ -1091,7 +1081,6 @@ fn apply_leaf_terminator(
         && !body_diverges
     {
         statements.push(LoweredStatement::Break {
-            directive: String::new(),
             label: Some(label.to_string()),
         });
     }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -26,16 +26,25 @@ pub(crate) struct LoweredBlock {
     pub(crate) statements: Vec<LoweredStatement>,
 }
 
+pub(crate) fn directed(directive: String, stmt: LoweredStatement) -> LoweredStatement {
+    if directive.is_empty() {
+        stmt
+    } else {
+        LoweredStatement::Directed {
+            directive,
+            inner: Box::new(stmt),
+        }
+    }
+}
+
 pub(crate) enum LoweredStatement {
     If(IfPlan),
     Loop(LoopPlan),
     Block(LoweredBlock),
     Break {
-        directive: String,
         label: Option<String>,
     },
     Continue {
-        directive: String,
         label: Option<String>,
     },
     Const(ConstPlan),
@@ -67,6 +76,11 @@ pub(crate) enum LoweredStatement {
         body: LoweredBlock,
         closure_close: String,
     },
+    /// A statement preceded by a sourcemap `//line` directive.
+    Directed {
+        directive: String,
+        inner: Box<LoweredStatement>,
+    },
     RawGo(String),
     /// Raw Go whose tail diverges (a never-typed call such as `panic(...)`).
     /// Tracked separately from `RawGo` so divergence is structural rather than
@@ -79,7 +93,6 @@ pub(crate) enum LoweredStatement {
 
 /// A source `const` (or `var` when the value is not Go-const-eligible).
 pub(crate) struct ConstPlan {
-    pub(crate) directive: String,
     pub(crate) is_const: bool,
     pub(crate) name: String,
     pub(crate) ty_str: String,
@@ -88,7 +101,6 @@ pub(crate) struct ConstPlan {
 
 /// A source `return expr` statement, classified by `ReturnForm`.
 pub(crate) struct ReturnStatementPlan {
-    pub(crate) directive: String,
     pub(crate) form: ReturnForm,
 }
 
@@ -120,7 +132,6 @@ pub(crate) enum ReturnForm {
 /// reaches the loop-result slot (or is discarded); a trailing `break`
 /// terminates unless the value already diverged.
 pub(crate) struct BreakValuePlan {
-    pub(crate) directive: String,
     pub(crate) value: ValuePlan,
     pub(crate) disposition: BreakValueDisposition,
     pub(crate) label: Option<String>,
@@ -146,7 +157,6 @@ pub(crate) enum BreakValueDisposition {
 
 /// A `let` binding, classified by shape.
 pub(crate) struct LetPlan {
-    pub(crate) directive: String,
     pub(crate) form: LetForm,
 }
 
@@ -192,7 +202,6 @@ impl LetForm {
 
 /// An assignment statement, structured by shape.
 pub(crate) struct AssignPlan {
-    pub(crate) directive: String,
     pub(crate) form: AssignForm,
 }
 
@@ -232,7 +241,6 @@ pub(crate) enum CompoundKind {
 
 /// A bare expression statement.
 pub(crate) struct ExpressionStatementPlan {
-    pub(crate) directive: String,
     pub(crate) form: ExpressionStatementForm,
 }
 
@@ -257,14 +265,12 @@ pub(crate) enum ExpressionStatementForm {
 }
 
 pub(crate) struct MatchStatementPlan {
-    pub(crate) directive: String,
     pub(crate) body: LoweredBlock,
 }
 
 /// A `switch` statement (value or type switch). The renderer owns the
 /// `switch`/`case`/`default:` syntax.
 pub(crate) struct SwitchStatementPlan {
-    pub(crate) directive: String,
     pub(crate) kind: SwitchKind,
     pub(crate) cases: Vec<SwitchCasePlan>,
     pub(crate) default: Option<LoweredBlock>,
@@ -302,7 +308,6 @@ impl SwitchStatementPlan {
 /// unreachable panic). The renderer owns the `for`/`select`/`case`/`default:`
 /// syntax.
 pub(crate) struct SelectStatementPlan {
-    pub(crate) directive: String,
     /// Side-effecting setup hoisted before the `select` (channel/value temps).
     pub(crate) setup: Vec<LoweredStatement>,
     /// When set, the `select` is wrapped in `for { ... break }` for retry.
@@ -354,7 +359,6 @@ impl SelectArmPlan {
 }
 
 pub(crate) struct WhileLetPlan {
-    pub(crate) directive: String,
     pub(crate) body: LoweredBlock,
 }
 
@@ -362,7 +366,6 @@ pub(crate) struct WhileLetPlan {
 /// iterable capture); `header` is the rendered Go loop opener through the body's
 /// opening brace; `label` is the optional break/continue label.
 pub(crate) struct LoopPlan {
-    pub(crate) directive: String,
     pub(crate) prologue: Vec<LoweredStatement>,
     pub(crate) label: Option<String>,
     pub(crate) header: String,
@@ -370,9 +373,6 @@ pub(crate) struct LoopPlan {
 }
 
 pub(crate) struct IfPlan {
-    /// Empty unless sourcemap; set only on the leading `if`, never on nested
-    /// `else if`s.
-    pub(crate) directive: String,
     /// Side-effecting setup hoisted before the `if` condition (temps from a
     /// condition that lowered to statements).
     pub(crate) condition_setup: Vec<LoweredStatement>,
@@ -439,12 +439,16 @@ impl LoweredStatement {
             LoweredStatement::TempBind { .. }
             | LoweredStatement::VarDecl { .. }
             | LoweredStatement::ClosureBind { .. } => false,
+            LoweredStatement::Directed { inner, .. } => inner.ends_with_diverge(),
             LoweredStatement::RawGo(_) => false,
             LoweredStatement::DivergingRawGo(_) | LoweredStatement::UnreachablePanic => true,
         }
     }
 
     pub(crate) fn blocks_fallthrough(&self) -> bool {
+        if let LoweredStatement::Directed { inner, .. } = self {
+            return inner.blocks_fallthrough();
+        }
         !matches!(self, LoweredStatement::WhileLet(_)) && self.ends_with_diverge()
     }
 }

--- a/crates/emit/src/plan/invariants.rs
+++ b/crates/emit/src/plan/invariants.rs
@@ -20,6 +20,9 @@ fn walk_statement(statement: &LoweredStatement, issues: &mut Vec<String>, path: 
         LoweredStatement::Loop(plan) => walk_loop(plan, issues, &format!("{}/Loop", path)),
         LoweredStatement::Block(body) => walk_block(body, issues, &format!("{}/Block", path)),
         LoweredStatement::Break { .. } | LoweredStatement::Continue { .. } => {}
+        LoweredStatement::Directed { inner, .. } => {
+            walk_statement(inner, issues, &format!("{}/Directed", path))
+        }
         LoweredStatement::Const(_)
         | LoweredStatement::Return(_)
         | LoweredStatement::BreakValue(_)

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -7,9 +7,10 @@ use crate::control_flow::propagation::plain_return;
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
-    LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan,
+    LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan, directed,
 };
 use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::utils::wrap_if_struct_literal;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
@@ -41,7 +42,7 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let Expression::If {
             condition,
             consequence,
@@ -53,7 +54,6 @@ impl Planner<'_> {
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let plan = self.lower_if(
-            String::new(),
             condition,
             consequence,
             alternative,
@@ -63,7 +63,7 @@ impl Planner<'_> {
             },
             fx,
         );
-        (vec![declaration, LoweredStatement::If(plan)], result_var)
+        value_plan_from_statements(vec![declaration, LoweredStatement::If(plan)], result_var)
     }
 
     /// Lower a value-position `match`/`select` to a fresh operand-temp
@@ -74,7 +74,7 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let block = self.lower_branching_to_block(
             expression,
@@ -86,7 +86,7 @@ impl Planner<'_> {
         );
         let mut setup = vec![declaration];
         setup.extend(block.statements);
-        (setup, result_var)
+        value_plan_from_statements(setup, result_var)
     }
 
     /// Lower a value-position `loop` to a fresh operand-temp variable.
@@ -97,7 +97,7 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         let Expression::Loop {
             body, needs_label, ..
         } = expression
@@ -106,15 +106,9 @@ impl Planner<'_> {
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         self.push_loop(result_var.clone());
-        let plan = self.lower_loop_with_header(
-            String::new(),
-            "for {\n".to_string(),
-            body,
-            *needs_label,
-            fx,
-        );
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label, fx);
         self.pop_loop();
-        (vec![declaration, LoweredStatement::Loop(plan)], result_var)
+        value_plan_from_statements(vec![declaration, LoweredStatement::Loop(plan)], result_var)
     }
 
     fn lower_body_until_diverge(
@@ -206,20 +200,22 @@ impl Planner<'_> {
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.lower_if(
-                    directive,
                     condition,
                     consequence,
                     alternative,
                     &PlacePlan::Statement,
                     fx,
                 );
-                LoweredStatement::If(plan)
+                directed(directive, LoweredStatement::If(plan))
             }
             Expression::Loop {
                 body, needs_label, ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                LoweredStatement::Loop(self.lower_infinite_loop(directive, body, *needs_label, fx))
+                directed(
+                    directive,
+                    LoweredStatement::Loop(self.lower_infinite_loop(body, *needs_label, fx)),
+                )
             }
             Expression::While {
                 condition,
@@ -228,13 +224,10 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                LoweredStatement::Loop(self.lower_while(
+                directed(
                     directive,
-                    condition,
-                    body,
-                    *needs_label,
-                    fx,
-                ))
+                    LoweredStatement::Loop(self.lower_while(condition, body, *needs_label, fx)),
+                )
             }
             Expression::Block { .. } => {
                 self.enter_scope();
@@ -245,24 +238,28 @@ impl Planner<'_> {
             Expression::For { .. } => self.lower_for_statement(expression, fx),
             Expression::Continue { .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                LoweredStatement::Continue {
+                directed(
                     directive,
-                    label: self.current_loop_label().map(str::to_string),
-                }
+                    LoweredStatement::Continue {
+                        label: self.current_loop_label().map(str::to_string),
+                    },
+                )
             }
             Expression::Break { value: None, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                LoweredStatement::Break {
+                directed(
                     directive,
-                    label: self.current_loop_label().map(str::to_string),
-                }
+                    LoweredStatement::Break {
+                        label: self.current_loop_label().map(str::to_string),
+                    },
+                )
             }
             Expression::Break {
                 value: Some(value), ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_break_value_plan(value, directive, fx);
-                LoweredStatement::BreakValue(plan)
+                let plan = self.build_break_value_plan(value, fx);
+                directed(directive, LoweredStatement::BreakValue(plan))
             }
             Expression::Const {
                 identifier,
@@ -271,15 +268,15 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_const_plan(identifier, value, ty, directive, fx);
-                LoweredStatement::Const(plan)
+                let plan = self.build_const_plan(identifier, value, ty, fx);
+                directed(directive, LoweredStatement::Const(plan))
             }
             Expression::Return {
                 expression: value, ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_return_plan(value, directive, fx);
-                LoweredStatement::Return(plan)
+                let plan = self.build_return_plan(value, fx);
+                directed(directive, LoweredStatement::Return(plan))
             }
             Expression::Let {
                 binding,
@@ -289,15 +286,8 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_let_plan(
-                    binding,
-                    value,
-                    else_block.as_deref(),
-                    *mutable,
-                    directive,
-                    fx,
-                );
-                LoweredStatement::Let(plan)
+                let plan = self.build_let_plan(binding, value, else_block.as_deref(), *mutable, fx);
+                directed(directive, LoweredStatement::Let(plan))
             }
             Expression::Assignment {
                 target,
@@ -306,25 +296,22 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_assignment_plan(
-                    target,
-                    value,
-                    compound_operator.as_ref(),
-                    directive,
-                    fx,
-                );
-                LoweredStatement::Assign(plan)
+                let plan =
+                    self.build_assignment_plan(target, value, compound_operator.as_ref(), fx);
+                directed(directive, LoweredStatement::Assign(plan))
             }
             Expression::Match { subject, arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 let body = self.lower_match_to_block(subject, arms, &PlacePlan::Statement, fx);
-                LoweredStatement::Match(MatchStatementPlan { directive, body })
+                directed(
+                    directive,
+                    LoweredStatement::Match(MatchStatementPlan { body }),
+                )
             }
             Expression::Select { arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let mut plan = self.lower_select(arms, &PlacePlan::Statement, fx);
-                plan.directive = directive;
-                LoweredStatement::Select(plan)
+                let plan = self.lower_select(arms, &PlacePlan::Statement, fx);
+                directed(directive, LoweredStatement::Select(plan))
             }
             Expression::WhileLet { .. } => self.lower_while_let_statement(expression, fx),
             // Top-level items (Struct/Enum/etc) shouldn't appear inside
@@ -381,7 +368,10 @@ impl Planner<'_> {
                 },
             }
         };
-        LoweredStatement::Expression(ExpressionStatementPlan { directive, form })
+        directed(
+            directive,
+            LoweredStatement::Expression(ExpressionStatementPlan { form }),
+        )
     }
 
     /// Lower `while let P = scrutinee { body }`, wrapped as a `WhileLet`
@@ -413,19 +403,17 @@ impl Planner<'_> {
             fx,
         );
         self.pop_loop();
-        LoweredStatement::WhileLet(WhileLetPlan { directive, body })
+        directed(directive, LoweredStatement::WhileLet(WhileLetPlan { body }))
     }
 
     fn lower_infinite_loop(
         &mut self,
-        directive: String,
         body: &Expression,
         needs_label: bool,
         fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.push_loop("_");
-        let plan =
-            self.lower_loop_with_header(directive, "for {\n".to_string(), body, needs_label, fx);
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body, needs_label, fx);
         self.pop_loop();
         plan
     }
@@ -441,7 +429,6 @@ impl Planner<'_> {
 
     fn lower_while(
         &mut self,
-        directive: String,
         condition: &Expression,
         body: &Expression,
         needs_label: bool,
@@ -465,7 +452,7 @@ impl Planner<'_> {
         } else {
             format!("for {} {{\n", wrap_if_struct_literal(rendered))
         };
-        let plan = self.lower_loop_with_header(directive, header, body, needs_label, fx);
+        let plan = self.lower_loop_with_header(header, body, needs_label, fx);
         self.pop_loop();
         plan
     }
@@ -474,7 +461,6 @@ impl Planner<'_> {
     /// the body in a fresh scope. Caller owns `push_loop`/`pop_loop`.
     pub(crate) fn lower_loop_with_header(
         &mut self,
-        directive: String,
         header: String,
         body: &Expression,
         needs_label: bool,
@@ -486,7 +472,6 @@ impl Planner<'_> {
         let lowered_body = self.lower_block_as_body(body, fx);
         self.exit_scope();
         LoopPlan {
-            directive,
             prologue: Vec::new(),
             label,
             header,
@@ -528,14 +513,7 @@ impl Planner<'_> {
                 alternative,
                 ..
             } => {
-                let plan = self.lower_if(
-                    String::new(),
-                    condition,
-                    consequence,
-                    alternative,
-                    place,
-                    fx,
-                );
+                let plan = self.lower_if(condition, consequence, alternative, place, fx);
                 LoweredBlock {
                     statements: vec![LoweredStatement::If(plan)],
                 }
@@ -646,15 +624,9 @@ impl Planner<'_> {
                 alternative,
                 ..
             } => {
-                let plan = self.lower_if(
-                    directive,
-                    condition,
-                    consequence,
-                    alternative,
-                    &PlacePlan::Return,
-                    fx,
-                );
-                statements.push(LoweredStatement::If(plan));
+                let plan =
+                    self.lower_if(condition, consequence, alternative, &PlacePlan::Return, fx);
+                statements.push(directed(directive, LoweredStatement::If(plan)));
             }
             Expression::Match { subject, arms, .. } => {
                 if !directive.is_empty() {
@@ -664,9 +636,8 @@ impl Planner<'_> {
                 statements.extend(block.statements);
             }
             Expression::Select { arms, .. } => {
-                let mut plan = self.lower_select(arms, &PlacePlan::Return, fx);
-                plan.directive = directive;
-                statements.push(LoweredStatement::Select(plan));
+                let plan = self.lower_select(arms, &PlacePlan::Return, fx);
+                statements.push(directed(directive, LoweredStatement::Select(plan)));
             }
             _ => {
                 if !directive.is_empty() {
@@ -738,7 +709,6 @@ impl Planner<'_> {
 
     pub(crate) fn lower_if(
         &mut self,
-        directive: String,
         condition: &Expression,
         consequence: &Expression,
         alternative: &Expression,
@@ -756,7 +726,6 @@ impl Planner<'_> {
         let else_arm = self.lower_else_chain(alternative, preceding_diverges, place, fx);
 
         IfPlan {
-            directive,
             condition_setup,
             condition,
             then_body,
@@ -807,7 +776,6 @@ impl Planner<'_> {
                 );
                 self.exit_scope();
                 ElseArm::ElseIf(Box::new(IfPlan {
-                    directive: String::new(),
                     condition_setup,
                     condition,
                     then_body,
@@ -824,7 +792,6 @@ impl Planner<'_> {
                     fx,
                 );
                 ElseArm::ElseIf(Box::new(IfPlan {
-                    directive: String::new(),
                     condition_setup,
                     condition,
                     then_body,

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -53,7 +53,6 @@ pub(crate) fn is_unit_call(expression: &Expression) -> bool {
 /// A `target = value` assignment with no lvalue capture.
 pub(crate) fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatement {
     LoweredStatement::Assign(AssignPlan {
-        directive: String::new(),
         form: AssignForm::Simple {
             target_capture: Vec::new(),
             target_str: target_var.to_string(),
@@ -240,7 +239,9 @@ impl Planner<'_> {
         var: &str,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let (mut statements, call_str) = self.lower_value(value, ExpressionContext::value(), fx);
+        let (mut statements, call_str) = self
+            .lower_value(value, ExpressionContext::value(), fx)
+            .into_parts();
         if !call_str.is_empty() {
             statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
         }
@@ -269,13 +270,7 @@ impl Planner<'_> {
         } = expression
         {
             self.push_loop(var);
-            let plan = self.lower_loop_with_header(
-                String::new(),
-                "for {\n".to_string(),
-                body,
-                *needs_label,
-                fx,
-            );
+            let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label, fx);
             self.pop_loop();
             return vec![LoweredStatement::Loop(plan)];
         }
@@ -349,11 +344,10 @@ impl Planner<'_> {
                 {
                     let (arg_setup, call_str) = {
                         let mut fe = FalliblePlanner::new(self, &fallible, fx);
-                        let (arg_setup, arg) = fe.planner.lower_composite_value(
-                            &args[0],
-                            ExpressionContext::value(),
-                            fe.fx,
-                        );
+                        let (arg_setup, arg) = fe
+                            .planner
+                            .lower_composite_value(&args[0], ExpressionContext::value(), fe.fx)
+                            .into_parts();
                         (
                             arg_setup,
                             fe.format_constructor_call(constructor_name, Some(&arg)),
@@ -489,7 +483,9 @@ impl Planner<'_> {
             };
             return self.lower_branching_to_block(last, &place, fx).statements;
         }
-        let (mut setup, expression_string) = self.lower_value(last, ExpressionContext::value(), fx);
+        let (mut setup, expression_string) = self
+            .lower_value(last, ExpressionContext::value(), fx)
+            .into_parts();
         let mut coercion_buffer = String::new();
         let expression_string =
             self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression_string, fx);
@@ -546,7 +542,9 @@ impl Planner<'_> {
             capture.extend(args_setup);
             (format!("append({}, {})", receiver_lv, args_str), capture)
         } else {
-            let (setup, value) = self.lower_value(last, ExpressionContext::value(), fx);
+            let (setup, value) = self
+                .lower_value(last, ExpressionContext::value(), fx)
+                .into_parts();
             (value, setup)
         };
 
@@ -597,6 +595,7 @@ impl Planner<'_> {
             plan.into_parts()
         } else {
             self.lower_value(last, ExpressionContext::value(), fx)
+                .into_parts()
         }
     }
 
@@ -605,11 +604,11 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
         fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> ValuePlan {
         if let Expression::Block { items, .. } = expression {
             if ty.is_never() || ty.is_unit() || matches!(ty, Type::Var { .. } | Type::Forall { .. })
             {
-                return (
+                return value_plan_from_statements(
                     self.lower_block_as_body(expression, fx).statements,
                     String::new(),
                 );
@@ -623,7 +622,7 @@ impl Planner<'_> {
             } else {
                 statements.extend(body);
             }
-            return (statements, result_var);
+            return value_plan_from_statements(statements, result_var);
         }
         if let Expression::Loop { .. } = expression {
             return self.plan_loop_as_operand_temp(expression, ty, fx);
@@ -631,14 +630,13 @@ impl Planner<'_> {
         let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
         let mut statements = vec![declaration];
         statements.extend(self.lower_assign(expression, &result_var, Some(ty), fx));
-        (statements, result_var)
+        value_plan_from_statements(statements, result_var)
     }
 
     /// Build a `BreakValuePlan` for a `break value` statement.
     pub(crate) fn build_break_value_plan(
         &mut self,
         val: &Expression,
-        directive: String,
         fx: &mut EmitEffects,
     ) -> BreakValuePlan {
         let value = self.plan_value(val, ExpressionContext::value(), fx);
@@ -657,7 +655,6 @@ impl Planner<'_> {
         };
         let label = self.current_loop_label().map(str::to_string);
         BreakValuePlan {
-            directive,
             value,
             disposition,
             label,

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -75,7 +75,7 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let (setup, value) = self.lower_value(expression, ctx, fx);
+        let (setup, value) = self.lower_value(expression, ctx, fx).into_parts();
         value_plan_from_statements(setup, value)
     }
 
@@ -140,29 +140,16 @@ impl Planner<'_> {
             Expression::Defer {
                 expression: inner, ..
             } => self.plan_async_wrapper("defer", inner, fx),
-            Expression::TryBlock { items, ty, .. } => {
-                let (setup, value) = self.lower_try_block(items, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
-            Expression::RecoverBlock { items, ty, .. } => {
-                let (setup, value) = self.lower_recover_block(items, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
+            Expression::TryBlock { items, ty, .. } => self.lower_try_block(items, ty, fx),
+            Expression::RecoverBlock { items, ty, .. } => self.lower_recover_block(items, ty, fx),
             Expression::Propagate { expression, .. } => {
                 let (setup, value) = self.lower_propagate(expression, None, fx);
                 value_plan_from_statements(setup, value)
             }
-            Expression::If { ty, .. } => {
-                let (setup, value) = self.plan_if_as_operand_temp(expression, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
-            Expression::Loop { ty, .. } => {
-                let (setup, value) = self.plan_loop_as_operand_temp(expression, ty, fx);
-                value_plan_from_statements(setup, value)
-            }
+            Expression::If { ty, .. } => self.plan_if_as_operand_temp(expression, ty, fx),
+            Expression::Loop { ty, .. } => self.plan_loop_as_operand_temp(expression, ty, fx),
             Expression::Match { ty, .. } | Expression::Select { ty, .. } if !ty.is_never() => {
-                let (setup, value) = self.plan_branching_as_operand_temp(expression, ty, fx);
-                value_plan_from_statements(setup, value)
+                self.plan_branching_as_operand_temp(expression, ty, fx)
             }
             Expression::Call { ty, .. } => match self.classify_call(expression) {
                 CallBoundary::Plain => {
@@ -170,8 +157,7 @@ impl Planner<'_> {
                     value_plan_from_statements(setup, value)
                 }
                 CallBoundary::GoWrapped(strategy) => {
-                    let (setup, value) = self.lower_go_wrapped_call(expression, &strategy, ty, fx);
-                    value_plan_from_statements(setup, value)
+                    self.lower_go_wrapped_call(expression, &strategy, ty, fx)
                 }
                 CallBoundary::LoweredCallee(_) => self.plan_operand_leaf(expression, ctx, fx),
             },

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -48,7 +48,6 @@ impl Renderer {
     /// Render a `select` statement: optional retry-loop framing around the
     /// `select { ... }`, its arms, and any trailing postlude.
     fn render_select(&self, output: &mut String, plan: &SelectStatementPlan) {
-        output.push_str(&plan.directive);
         for statement in &plan.setup {
             self.render_statement(output, statement);
         }
@@ -75,7 +74,6 @@ impl Renderer {
     /// Render a `switch` statement: the value/type-switch header, each
     /// `case`/`default:` plus body, the closing brace, and any postlude.
     fn render_switch(&self, output: &mut String, plan: &SwitchStatementPlan) {
-        output.push_str(&plan.directive);
         match &plan.kind {
             SwitchKind::Value { subject } => write_line!(output, "switch {} {{", subject),
             SwitchKind::Type {
@@ -134,52 +132,38 @@ impl Renderer {
                 self.render_lowered_block(output, body);
                 output.push_str("}\n");
             }
-            LoweredStatement::Break { directive, label } => {
-                output.push_str(directive);
-                match label {
-                    Some(label) => write_line!(output, "break {}", label),
-                    None => output.push_str("break\n"),
-                }
-            }
-            LoweredStatement::Continue { directive, label } => {
-                output.push_str(directive);
-                match label {
-                    Some(label) => write_line!(output, "continue {}", label),
-                    None => output.push_str("continue\n"),
-                }
-            }
+            LoweredStatement::Break { label } => match label {
+                Some(label) => write_line!(output, "break {}", label),
+                None => output.push_str("break\n"),
+            },
+            LoweredStatement::Continue { label } => match label {
+                Some(label) => write_line!(output, "continue {}", label),
+                None => output.push_str("continue\n"),
+            },
             LoweredStatement::Const(plan) => {
-                output.push_str(&plan.directive);
                 self.render_const_declaration(output, plan);
             }
             LoweredStatement::Return(plan) => {
-                output.push_str(&plan.directive);
                 self.render_return_statement(output, plan);
             }
             LoweredStatement::BreakValue(plan) => {
-                output.push_str(&plan.directive);
                 self.render_break_value(output, plan);
             }
             LoweredStatement::Let(plan) => {
-                output.push_str(&plan.directive);
                 self.render_let_statement(output, plan);
             }
             LoweredStatement::Assign(plan) => {
-                output.push_str(&plan.directive);
                 self.render_assign_statement(output, plan);
             }
             LoweredStatement::Expression(plan) => {
-                output.push_str(&plan.directive);
                 self.render_expression_statement(output, plan);
             }
             LoweredStatement::Match(plan) => {
-                output.push_str(&plan.directive);
                 self.render_lowered_block(output, &plan.body);
             }
             LoweredStatement::Select(plan) => self.render_select(output, plan),
             LoweredStatement::Switch(plan) => self.render_switch(output, plan),
             LoweredStatement::WhileLet(plan) => {
-                output.push_str(&plan.directive);
                 self.render_lowered_block(output, &plan.body);
             }
             LoweredStatement::TempBind { name, value } => {
@@ -207,6 +191,10 @@ impl Renderer {
                 );
                 self.render_lowered_block(output, body);
                 output.push_str(closure_close);
+            }
+            LoweredStatement::Directed { directive, inner } => {
+                output.push_str(directive);
+                self.render_statement(output, inner);
             }
             LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
                 output.push_str(code)
@@ -380,7 +368,6 @@ impl Renderer {
     }
 
     fn render_loop(&self, output: &mut String, plan: &LoopPlan) {
-        output.push_str(&plan.directive);
         output.push_str(&self.render_setup(&plan.prologue));
         if let Some(label) = &plan.label {
             write_line!(output, "{}:", label);
@@ -391,7 +378,6 @@ impl Renderer {
     }
 
     fn render_if(&self, output: &mut String, plan: &IfPlan) {
-        output.push_str(&plan.directive);
         output.push_str(&self.render_setup(&plan.condition_setup));
         write_line!(output, "if {} {{", plan.condition);
         self.render_lowered_block(output, &plan.then_body);

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -20,14 +20,12 @@ impl Planner<'_> {
         target: &Expression,
         value: &Expression,
         compound_operator: Option<&BinaryOperator>,
-        directive: String,
         fx: &mut EmitEffects,
     ) -> AssignPlan {
         let raw_body = |statements: Vec<LoweredStatement>| LoweredBlock { statements };
 
         if value.get_type().is_never() {
             return AssignPlan {
-                directive,
                 form: AssignForm::NeverTyped {
                     body: raw_body(vec![self.lower_statement(value, fx)]),
                 },
@@ -61,7 +59,6 @@ impl Planner<'_> {
                 self.emit_left_value(&mut target_capture, target, fx)
             };
             return AssignPlan {
-                directive,
                 form: AssignForm::Compound {
                     target_capture,
                     target_str,
@@ -72,7 +69,6 @@ impl Planner<'_> {
 
         if self.target_binds_to_discard(target) {
             return AssignPlan {
-                directive,
                 form: AssignForm::Discard {
                     body: raw_body(self.lower_discard_value(value, fx)),
                 },
@@ -100,7 +96,6 @@ impl Planner<'_> {
                 self.emit_left_value(&mut target_capture, target, fx)
             };
             return AssignPlan {
-                directive,
                 form: AssignForm::NilClear {
                     target_capture,
                     target_str,
@@ -138,7 +133,6 @@ impl Planner<'_> {
         let (coercion_setup, final_value) = coercion.lower(self, rhs_staged.value, fx);
         value_setup.extend(coercion_setup);
         AssignPlan {
-            directive,
             form: AssignForm::Simple {
                 target_capture,
                 target_str,

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -250,8 +250,9 @@ impl Planner<'_> {
         value: &Expression,
         fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let (mut statements, value_expression) =
-            self.lower_value(value, ExpressionContext::value(), fx);
+        let (mut statements, value_expression) = self
+            .lower_value(value, ExpressionContext::value(), fx)
+            .into_parts();
         statements.push(LoweredStatement::RawGo(format!("{}\n", value_expression)));
         let Some(raw_go_name) = raw_go_name else {
             return statements;
@@ -295,8 +296,9 @@ impl Planner<'_> {
             return statements;
         }
 
-        let (mut statements, value_expression) =
-            self.lower_value(value, ExpressionContext::value(), fx);
+        let (mut statements, value_expression) = self
+            .lower_value(value, ExpressionContext::value(), fx)
+            .into_parts();
         let coercion = Coercion::resolve(
             self,
             &value.get_type(),
@@ -704,10 +706,9 @@ impl Planner<'_> {
         value: &Expression,
         else_block: Option<&Expression>,
         mutable: bool,
-        directive: String,
         fx: &mut EmitEffects,
     ) -> LetPlan {
         let form = LetPlanner::new(self, binding, value, else_block, mutable).build_form(fx);
-        LetPlan { directive, form }
+        LetPlan { form }
     }
 }


### PR DESCRIPTION
Continues refining the `emit` crate's lowered IR, giving statements and value expressions a more uniform shape that is easier to read and extend.
