### PR TITLE
feat: targeted diagnostic for go's `make()` syntax

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2601,7 +2601,7 @@ fn go_builtin_hint(name: &str) -> Option<&'static str> {
             "Lisette has no `cap` builtin. Use the `.capacity()` method instead, e.g. `items.capacity()`.",
         ),
         "make" => Some(
-            "Lisette has no `make` builtin. Use constructor methods instead, e.g. `Channel.new<int>()`, `Slice.new<int>()`, `Map.new<K, V>()`.",
+            "Lisette has no `make` builtin. Use `Slice.new<T>()`, `Map.new<K, V>()`, or `Channel.new<T>()`.",
         ),
         "append" => Some(
             "Lisette has no `append` builtin. Use the `.append()` method instead, e.g. `items.append(1)`.",

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -10,6 +10,13 @@ use crate::ast::{
 use crate::lex::TokenKind::{self, *};
 use crate::types::Type;
 
+#[derive(Clone, Copy)]
+enum GoMakeKind {
+    Slice,
+    Channel,
+    Map,
+}
+
 impl<'source> Parser<'source> {
     pub fn parse_expression(&mut self) -> Expression {
         if !self.enter_recursion() {
@@ -403,6 +410,14 @@ impl<'source> Parser<'source> {
         type_args: Vec<Annotation>,
     ) -> Expression {
         let start_offset = expression.get_span().byte_offset;
+
+        if type_args.is_empty()
+            && matches!(&expression, Expression::Identifier { value, qualified: None, .. } if value == "make")
+            && let Some(recovered) = self.try_go_make_shim(&expression)
+        {
+            return recovered;
+        }
+
         let (args, spread) = self.collect_call_args();
 
         Expression::Call {
@@ -413,6 +428,126 @@ impl<'source> Parser<'source> {
             type_args,
             span: self.span_from_offset(start_offset),
             call_kind: None,
+        }
+    }
+
+    fn try_go_make_shim(&mut self, callee: &Expression) -> Option<Expression> {
+        let kind = self.classify_go_make()?;
+        let help = match (kind, self.scan_go_make_args()) {
+            (GoMakeKind::Slice, 0) => "Use `Slice.new<T>()` for an empty slice.",
+            (GoMakeKind::Slice, 1) => {
+                "Use `slices.Repeat([value], n)` after importing `go:slices`."
+            }
+            (GoMakeKind::Slice, _) => {
+                "Use `slices.Grow(Slice.new<T>(), capacity)` after importing `go:slices`."
+            }
+            (GoMakeKind::Channel, 0) => "Use `Channel.new<T>()`.",
+            (GoMakeKind::Channel, _) => "Use `Channel.buffered<T>(n)`.",
+            (GoMakeKind::Map, _) => "Use `Map.new<K, V>()`.",
+        };
+
+        let span = callee.get_span();
+        if !self.too_many_errors() {
+            self.errors.push(
+                ParseError::new("Syntax error", span, "Lisette has no `make` builtin")
+                    .with_parse_code("go_make_builtin")
+                    .with_help(help),
+            );
+        }
+
+        self.consume_balanced_parens();
+
+        Some(Expression::Unit {
+            ty: Type::uninferred(),
+            span: self.span_from_offset(span.byte_offset),
+        })
+    }
+
+    fn classify_go_make(&self) -> Option<GoMakeKind> {
+        let first = self.stream.peek_ahead(1);
+        let second = self.stream.peek_ahead(2);
+
+        if first.kind == LeftSquareBracket
+            && second.kind == RightSquareBracket
+            && self.stream.peek_ahead(3).kind == Identifier
+        {
+            return Some(GoMakeKind::Slice);
+        }
+
+        if first.kind == Identifier && first.text == "chan" && second.kind == Identifier {
+            return Some(GoMakeKind::Channel);
+        }
+
+        if first.kind == Identifier
+            && first.text == "map"
+            && second.kind == LeftSquareBracket
+            && self.go_map_type_has_value()
+        {
+            return Some(GoMakeKind::Map);
+        }
+
+        None
+    }
+
+    fn go_map_type_has_value(&self) -> bool {
+        let mut offset = 2;
+        let mut depth = 0usize;
+        loop {
+            match self.stream.peek_ahead(offset).kind {
+                EOF => return false,
+                LeftSquareBracket => depth += 1,
+                RightSquareBracket => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return self.stream.peek_ahead(offset + 1).kind == Identifier;
+                    }
+                }
+                _ => {}
+            }
+            offset += 1;
+        }
+    }
+
+    fn scan_go_make_args(&self) -> usize {
+        let mut offset = 1;
+        let mut paren = 1usize;
+        let mut bracket = 0usize;
+        let mut commas = 0usize;
+        loop {
+            match self.stream.peek_ahead(offset).kind {
+                EOF => break,
+                LeftParen => paren += 1,
+                RightParen => {
+                    paren -= 1;
+                    if paren == 0 {
+                        break;
+                    }
+                }
+                LeftSquareBracket => bracket += 1,
+                RightSquareBracket => bracket = bracket.saturating_sub(1),
+                Comma if paren == 1 && bracket == 0 => commas += 1,
+                _ => {}
+            }
+            offset += 1;
+        }
+        commas
+    }
+
+    fn consume_balanced_parens(&mut self) {
+        let mut depth = 0usize;
+        while !self.at_eof() {
+            let kind = self.current_token().kind;
+            self.next();
+            match kind {
+                LeftParen => depth += 1,
+                RightParen => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
         }
     }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -71,6 +71,66 @@ fn test() {
 }
 
 #[test]
+fn parse_go_make_sized_slice() {
+    let input = r#"
+fn test() {
+  let buffer = make([]byte, 1024)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_go_make_empty_slice() {
+    let input = r#"
+fn test() {
+  let xs = make([]int)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_go_make_slice_with_capacity() {
+    let input = r#"
+fn test() {
+  let xs = make([]int, 0, 16)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_go_make_unbuffered_channel() {
+    let input = r#"
+fn test() {
+  let ch = make(chan int)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_go_make_buffered_channel() {
+    let input = r#"
+fn test() {
+  let ch = make(chan int, 5)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_go_make_map() {
+    let input = r#"
+fn test() {
+  let m = make(map[string]int)
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn infer_go_builtin_append() {
     let input = r#"
 fn test(items: Slice<int>) -> Slice<int> {

--- a/tests/ui/errors/snapshots/infer_go_builtin_make.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_make.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·              ╰── name not found in scope
  4 │ }
    ╰────
-  help: Lisette has no `make` builtin. Use constructor methods instead, e.g. `Channel.new<int>()`, `Slice.new<int>()`, `Map.new<K, V>()` · code: [resolve.name_not_found]
+  help: Lisette has no `make` builtin. Use `Slice.new<T>()`, `Map.new<K, V>()`, or `Channel.new<T>()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/parse_go_make_buffered_channel.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_buffered_channel.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let ch = make(chan int, 5)
+   ·            ──┬─
+   ·              ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `Channel.buffered<T>(n)` · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_empty_slice.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_empty_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let xs = make([]int)
+   ·            ──┬─
+   ·              ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `Slice.new<T>()` for an empty slice · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_map.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_map.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let m = make(map[string]int)
+   ·           ──┬─
+   ·             ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `Map.new<K, V>()` · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_sized_slice.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_sized_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:16]
+ 2 │ fn test() {
+ 3 │   let buffer = make([]byte, 1024)
+   ·                ──┬─
+   ·                  ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `slices.Repeat([value], n)` after importing `go:slices` · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_slice_with_capacity.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_slice_with_capacity.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let xs = make([]int, 0, 16)
+   ·            ──┬─
+   ·              ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `slices.Grow(Slice.new<T>(), capacity)` after importing `go:slices` · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_unbuffered_channel.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_unbuffered_channel.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  [error] Syntax error
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let ch = make(chan int)
+   ·            ──┬─
+   ·              ╰── Lisette has no `make` builtin
+ 4 │ }
+   ╰────
+  help: Use `Channel.new<T>()` · code: [parse.go_make_builtin]


### PR DESCRIPTION
Go's `make()` is not valid Lisette, and until now it produced a vanilla syntax error. The parser now recognizes Go's `make()` shapes and points at the right replacement for each one.

```
  [error] Syntax error
   ╭─[test.lis:3:16]
 2 │ fn test() {
 3 │   let buffer = make([]byte, 1024)
   ·                ──┬─
   ·                  ╰── Lisette has no `make` builtin
 4 │ }
   ╰────
  help: Use `slices.Repeat([value], n)` after importing `go:slices` · code: [parse.go_make_builtin]
```
