### PR TITLE
ci: group changelog and release notes by commit type

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -6,6 +6,8 @@ Lisette is under active development. Any version before 1.0.0 may include breaki
 body = '''
 
 ## [{{ version | trim_start_matches(pat="lisette-v") }}](https://github.com/ivov/lisette/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
 {% for commit in commits | sort(attribute="author.timestamp") | reverse %}
 {%- set subject = commit.raw_message | split(pat="\n") | first | trim -%}
 {%- set sha = commit.id | truncate(length=7, end="") -%}
@@ -17,6 +19,7 @@ body = '''
 - {{ subject }} [`{{ sha }}`](https://github.com/ivov/lisette/commit/{{ commit.id }})
 {%- endif %}
 {%- endfor %}
+{% endfor %}
 
 '''
 trim = true
@@ -30,7 +33,9 @@ commit_preprocessors = [
 commit_parsers = [
   { message = "^chore: bump stdlib typedefs", skip = true },
   { message = "^chore: release", skip = true },
-  { message = ".*", group = "all" },
+  { message = "^feat", group = "<!-- 0 -->Features" },
+  { message = "^fix", group = "<!-- 1 -->Fixes" },
+  { message = ".*", group = "<!-- 2 -->Internals" },
 ]
 include_paths = ["**"]
 tag_pattern = "lisette-v[0-9]*"

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,7 +3,7 @@ commit-msg:
     conventional-commit:
       run: |
         MSG=$(head -1 {1})
-        echo "$MSG" | grep -qE "^(feat|fix|refactor|test|docs|chore|ci|perf|build)(\(.+\))?!?: [a-z].*" || { echo "Commit message must follow Conventional Commits: <type>: <description> (lowercase after colon)"; exit 1; }
+        echo "$MSG" | grep -qE "^(feat|fix|refactor|test|docs|chore|ci|perf)(\(.+\))?!?: [a-z].*" || { echo "Commit message must follow Conventional Commits: <type>: <description> (lowercase after colon)"; exit 1; }
         LEN=$(echo -n "$MSG" | wc -c | tr -d ' ')
         [ "$LEN" -le 72 ] || { echo "Commit subject is $LEN chars (max 72)"; exit 1; }
 


### PR DESCRIPTION
Changelog, release PR body, and GitHub release notes now group entries under `Features`, `Fixes`, and `Internals` headings instead of one flat chronological list. Entries stay newest-first within each section.

Also drops the unused `build` type from commit msg validation.
