### PR TITLE
feat: decompose failing asserts into operand values

### DIFF
--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -36,6 +36,10 @@ struct FailEnvelope {
 struct Operand {
     label: String,
     value: String,
+    #[serde(default)]
+    lo: u32,
+    #[serde(default)]
+    hi: u32,
 }
 
 #[derive(Deserialize, Clone)]
@@ -43,6 +47,8 @@ pub struct FailureRecord {
     file: u32,
     lo: u32,
     hi: u32,
+    #[serde(default)]
+    kind: String,
     message: String,
     #[serde(default)]
     operands: Vec<Operand>,
@@ -368,15 +374,39 @@ fn render_rows(out: &mut String, rows: &[&TestRow], prefix: &str, sources: &Sour
 fn render_failure(record: &FailureRecord, sources: &Sources, color: bool) -> Option<String> {
     let info = sources.get(&record.file)?;
     let span = Span::new(record.file, record.lo, record.hi.saturating_sub(record.lo));
-    let label = record
-        .operands
-        .first()
-        .map(|operand| operand.value.clone())
-        .unwrap_or_else(|| record.message.clone());
+
+    let (label, notes): (String, Vec<String>) = if record.kind == "labeled" {
+        let notes = record
+            .operands
+            .iter()
+            .map(|operand| {
+                let source = info
+                    .source
+                    .get(operand.lo as usize..operand.hi as usize)
+                    .unwrap_or(&operand.label);
+                format!("{}: `{}` is `{}`", operand.label, source, operand.value)
+            })
+            .collect();
+        (record.message.clone(), notes)
+    } else {
+        let label = record
+            .operands
+            .first()
+            .map(|operand| operand.value.clone())
+            .unwrap_or_else(|| record.message.clone());
+        let notes = record
+            .operands
+            .iter()
+            .skip(1)
+            .map(|operand| format!("{}: {}", operand.label, operand.value))
+            .collect();
+        (label, notes)
+    };
+
     let mut diagnostic =
         LisetteDiagnostic::error(record.message.clone()).with_span_primary_label(&span, label);
-    for operand in record.operands.iter().skip(1) {
-        diagnostic = diagnostic.with_note(format!("{}: {}", operand.label, operand.value));
+    if !notes.is_empty() {
+        diagnostic = diagnostic.with_note(notes.join("\n"));
     }
     Some(diagnostics::render::render_to_string(
         &diagnostic,

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1787,6 +1787,24 @@ pub fn colon_in_subscript(
         .with_help(help)
 }
 
+pub fn test_function_not_callable(span: Span, name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is a test, not a callable function"))
+        .with_infer_code("test_function_not_callable")
+        .with_span_label(&span, "a `#[test]` function cannot be called or used as a value")
+        .with_help(
+            "A `#[test]` function is an entry point run by `lis test`. Move shared logic into a separate function",
+        )
+}
+
+pub fn assert_without_test_context(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`assert` outside a test")
+        .with_infer_code("assert_without_test_context")
+        .with_span_label(&span, "no test context is in scope here")
+        .with_help(
+            "`assert` is only valid inside a `#[test]` function or a function that takes a `t: TestContext` parameter",
+        )
+}
+
 pub fn not_callable(
     ty: &Type,
     callee_name: Option<&str>,

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -19,6 +19,14 @@ use syntax::types::Type;
 /// Owned param-destructure record: temp var, pattern, typed pattern, param type.
 type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
 
+pub(crate) fn is_test_context_ty(ty: &Type) -> bool {
+    let stripped = ty.strip_refs();
+    stripped.get_qualified_id().is_some_and(|id| {
+        id.strip_suffix(".TestContext")
+            .is_some_and(|module| module == go_name::TEST_PRELUDE_MODULE)
+    })
+}
+
 fn receiver_type_name(ty: &Type) -> Option<&str> {
     if let Type::Nominal { id, .. } = ty.unwrap_forall() {
         Some(syntax::types::unqualified_name(id.as_str()))
@@ -74,7 +82,27 @@ impl Planner<'_> {
     ) -> String {
         let frame = self.scope.enter_isolated_function();
 
-        let (param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params, fx);
+        let (mut param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params, fx);
+
+        // A `t.run` subtest closure binds its own handle. Name a discarded `|_|`
+        // so `assert` targets the subtest, not the enclosing test.
+        let handle = params
+            .iter()
+            .position(|p| is_test_context_ty(&p.ty))
+            .map(|index| {
+                if param_pairs[index].0 == "_" {
+                    let name = self.fresh_var(Some("lisetteSub"));
+                    self.declare(&name);
+                    param_pairs[index].0 = name.clone();
+                    name
+                } else {
+                    param_pairs[index].0.clone()
+                }
+            });
+        if let Some(name) = handle.clone() {
+            self.push_test_handle(name);
+        }
+
         let return_info = self.lambda_return_info(ty, ctx, fx);
         let body_string = self.emit_lambda_body_with_deferred(
             body,
@@ -83,6 +111,10 @@ impl Planner<'_> {
             return_info.has_return,
             fx,
         );
+
+        if handle.is_some() {
+            self.pop_test_handle();
+        }
 
         self.scope.exit_isolated_function(frame);
 
@@ -281,6 +313,15 @@ impl Planner<'_> {
                     parts.push(return_ty);
                 }
                 let signature = parts.join(" ");
+
+                let test_handle = function_definition.params.iter().find_map(|param| {
+                    is_test_context_ty(&param.ty)
+                        .then(|| this.go_name_for_binding(&param.pattern))
+                        .flatten()
+                });
+                if let Some(name) = test_handle.clone() {
+                    this.push_test_handle(name);
+                }
                 this.emit_function_body_with_deferred_patterns(
                     &mut body,
                     function_definition,
@@ -288,6 +329,9 @@ impl Planner<'_> {
                     &return_ctx,
                     fx,
                 );
+                if test_handle.is_some() {
+                    this.pop_test_handle();
+                }
                 signature
             },
         );

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -1,7 +1,9 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::definitions::functions::is_test_context_ty;
 use crate::names::go_name;
-use syntax::ast::{Expression, Visibility};
+use syntax::ast::{Binding, Expression, FunctionDefinitionView, Pattern, Visibility};
+use syntax::types::{Symbol, Type};
 
 impl Planner<'_> {
     pub(crate) fn emit_top_item(&mut self, item: &Expression, fx: &mut EmitEffects) -> String {
@@ -20,36 +22,10 @@ impl Planner<'_> {
                 let function = item.function_definition_view();
                 let doc_comment = emit_doc(doc);
 
-                let code = self.emit_function(function, None, is_public, fx);
                 if self.facts.is_test(&self.facts.qualified_current(name)) {
-                    let callee = self.pick_go_function_name(function, false, is_public);
-                    let test_name = go_name::go_test_function_name(name);
-                    let test_kit = go_name::GeneratedPackage::TestKit.qualifier();
-                    fx.require_testing();
-                    let testing = go_name::GeneratedPackage::Testing.qualifier();
-                    let call = if function.params.is_empty() {
-                        format!("{callee}()")
-                    } else {
-                        fx.require_testkit();
-                        format!("{callee}({test_kit}.New(t))")
-                    };
-                    let body = if function.return_type.is_result() {
-                        fx.require_testkit();
-                        let span = function.name_span;
-                        let (file, lo, hi) = (
-                            span.file_id,
-                            span.byte_offset,
-                            span.byte_offset + span.byte_length,
-                        );
-                        format!(
-                            "if err := {call}; err != nil {{\n\t\t{test_kit}.Fail(t, {file}, {lo}, {hi}, \"result_err\", \"test returned Err\", {test_kit}.ErrOperand(err))\n\t}}"
-                        )
-                    } else {
-                        call
-                    };
-                    let wrapper = format!("func {test_name}(t *{testing}.T) {{\n\t{body}\n}}");
-                    format!("{doc_comment}{code}\n\n{wrapper}")
+                    self.emit_test_function(name, function, is_public, &doc_comment, fx)
                 } else {
+                    let code = self.emit_function(function, None, is_public, fx);
                     format!("{}{}", doc_comment, code)
                 }
             }
@@ -126,6 +102,71 @@ impl Planner<'_> {
             }
             _ => String::new(),
         }
+    }
+
+    fn emit_test_function(
+        &mut self,
+        name: &str,
+        function: FunctionDefinitionView<'_>,
+        is_public: bool,
+        doc_comment: &str,
+        fx: &mut EmitEffects,
+    ) -> String {
+        fx.require_testing();
+        fx.require_testkit();
+        let test_kit = go_name::GeneratedPackage::TestKit.qualifier();
+        let testing = go_name::GeneratedPackage::Testing.qualifier();
+
+        let injected = self.synthesized_test_handle_params(function);
+        let function = match &injected {
+            Some(params) => FunctionDefinitionView { params, ..function },
+            None => function,
+        };
+
+        let callee = self.pick_go_function_name(function, false, is_public);
+        let test_name = go_name::go_test_function_name(name);
+        let code = self.emit_function(function, None, is_public, fx);
+
+        let call = format!("{callee}({test_kit}.New(t))");
+        let body = if function.return_type.is_result() {
+            let span = function.name_span;
+            format!(
+                "if err := {call}; err != nil {{\n\t\t{test_kit}.Fail(t, {}, {}, {}, \"result_err\", \"test returned Err\", {test_kit}.ErrOperand(err))\n\t}}",
+                span.file_id,
+                span.byte_offset,
+                span.byte_offset + span.byte_length,
+            )
+        } else {
+            call
+        };
+        let wrapper = format!("func {test_name}(t *{testing}.T) {{\n\t{body}\n}}");
+        format!("{doc_comment}{code}\n\n{wrapper}")
+    }
+
+    fn synthesized_test_handle_params(
+        &self,
+        function: FunctionDefinitionView<'_>,
+    ) -> Option<Vec<Binding>> {
+        let has_usable_handle = function.params.iter().any(|param| {
+            is_test_context_ty(&param.ty) && self.go_name_for_binding(&param.pattern).is_some()
+        });
+        if has_usable_handle {
+            return None;
+        }
+        Some(vec![Binding {
+            pattern: Pattern::Identifier {
+                identifier: "lisetteTestCtx".into(),
+                span: function.name_span,
+            },
+            annotation: None,
+            typed_pattern: None,
+            ty: Type::Nominal {
+                id: Symbol::from_parts(go_name::TEST_PRELUDE_MODULE, "TestContext"),
+                params: vec![],
+                underlying_ty: None,
+            },
+            mutable: false,
+        }])
     }
 }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -347,6 +347,18 @@ impl<'a> Planner<'a> {
         self.scope.pop_return_ctx();
     }
 
+    pub(crate) fn push_test_handle(&mut self, name: String) {
+        self.scope.push_test_handle(name);
+    }
+
+    pub(crate) fn pop_test_handle(&mut self) {
+        self.scope.pop_test_handle();
+    }
+
+    pub(crate) fn current_test_handle(&self) -> Option<String> {
+        self.scope.current_test_handle().map(str::to_string)
+    }
+
     /// The enclosing function/lambda/try/recover return context, maintained on
     /// the scope stack and shared cheaply via `Rc`. Defaults to
     /// `ReturnContext::None` outside any function body (e.g. module-level

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -5,6 +5,7 @@ use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
+use crate::names::go_name;
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
     LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan, directed,
@@ -12,7 +13,7 @@ use crate::plan::bodies::{
 use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::utils::wrap_if_struct_literal;
-use syntax::ast::{Expression, Literal};
+use syntax::ast::{BinaryOperator, Expression, Literal};
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -375,8 +376,6 @@ impl Planner<'_> {
         )
     }
 
-    /// Lower `assert <bool>` to a runtime panic on failure. Rich source-spanned
-    /// reporting over the test channel lands in a follow-up.
     pub(crate) fn lower_assert_statement(
         &mut self,
         expression: &Expression,
@@ -390,15 +389,185 @@ impl Planner<'_> {
             unreachable!("lower_assert_statement requires an Assert expression");
         };
         let operand = operand.unwrap_parens();
-        let (mut statements, condition) = self.lower_condition(operand, fx);
-        let directive = self.maybe_line_directive(&expression.get_span());
-        statements.push(directed(
-            directive,
-            LoweredStatement::RawGo(format!(
-                "if !({condition}) {{\npanic(\"assertion failed\")\n}}\n"
-            )),
-        ));
+        fx.require_testkit();
+
+        // Each shape stages its operands into `statements` and returns the
+        // condition, the record kind, and any operand arguments for the call.
+        let mut statements = Vec::new();
+        let shape = if let Expression::Binary {
+            operator,
+            left,
+            right,
+            ..
+        } = operand
+            && is_assert_relation(operator)
+        {
+            self.lower_relation_assert(operator, left, right, &mut statements, fx)
+        } else if let Some((recv, arg)) = self.as_equals_decomposition(operand) {
+            self.lower_labeled_assert(recv, arg, &mut statements, fx)
+        } else {
+            self.lower_bare_assert(operand, &mut statements, fx)
+        };
+
+        let AssertShape {
+            condition,
+            kind,
+            operands,
+        } = shape;
+        let handle = self
+            .current_test_handle()
+            .expect("assert without a test handle should be rejected by semantics");
+        let span = operand.get_span();
+        statements.push(LoweredStatement::RawGo(format!(
+            "if !({condition}) {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"assertion failed\"{operands})\n}}\n",
+            span.file_id,
+            span.byte_offset,
+            span.byte_offset + span.byte_length,
+        )));
         LoweredStatement::Block(LoweredBlock { statements })
+    }
+
+    /// `assert a <op> b`: compare the captured temps via the normal binary
+    /// lowering, reporting both as `left`/`right`.
+    fn lower_relation_assert(
+        &mut self,
+        operator: &BinaryOperator,
+        left: &Expression,
+        right: &Expression,
+        statements: &mut Vec<LoweredStatement>,
+        fx: &mut EmitEffects,
+    ) -> AssertShape {
+        fx.require_fmt();
+        let (test_kit, fmt) = (
+            go_name::GeneratedPackage::TestKit.qualifier(),
+            go_name::GeneratedPackage::Fmt.qualifier(),
+        );
+        let lhs = self.stage_assert_operand(left, "assertLeft", statements, fx);
+        let rhs = self.stage_assert_operand(right, "assertRight", statements, fx);
+        let left_ref = temp_identifier(&lhs, left);
+        let right_ref = temp_identifier(&rhs, right);
+        let (cond_setup, condition) = self
+            .plan_binary(
+                operator,
+                &left_ref,
+                &right_ref,
+                ExpressionContext::value(),
+                fx,
+            )
+            .into_parts();
+        statements.extend(cond_setup);
+        AssertShape {
+            condition,
+            kind: "relation",
+            operands: format!(
+                ", {test_kit}.Operand{{Value: {fmt}.Sprintf(\"left: %v, right: %v\", {lhs}, {rhs})}}"
+            ),
+        }
+    }
+
+    /// `assert recv.equals(arg)`: compare via the canonical equals lowering,
+    /// reporting each operand by its source text and value.
+    fn lower_labeled_assert(
+        &mut self,
+        recv: &Expression,
+        arg: &Expression,
+        statements: &mut Vec<LoweredStatement>,
+        fx: &mut EmitEffects,
+    ) -> AssertShape {
+        fx.require_fmt();
+        let (test_kit, fmt) = (
+            go_name::GeneratedPackage::TestKit.qualifier(),
+            go_name::GeneratedPackage::Fmt.qualifier(),
+        );
+        let recv_ty = recv.get_type();
+        let (recv_span, arg_span) = (recv.get_span(), arg.get_span());
+        let lhs = self.stage_assert_operand(recv, "assertLeft", statements, fx);
+        let rhs = self.stage_assert_operand(arg, "assertRight", statements, fx);
+        let condition = self.render_equality(&lhs, &rhs, &recv_ty, fx);
+        AssertShape {
+            condition,
+            kind: "labeled",
+            operands: format!(
+                ", {test_kit}.Operand{{Label: \"left\", Value: {fmt}.Sprintf(\"%v\", {lhs}), Lo: {}, Hi: {}}}, {test_kit}.Operand{{Label: \"right\", Value: {fmt}.Sprintf(\"%v\", {rhs}), Lo: {}, Hi: {}}}",
+                recv_span.byte_offset,
+                recv_span.byte_offset + recv_span.byte_length,
+                arg_span.byte_offset,
+                arg_span.byte_offset + arg_span.byte_length,
+            ),
+        }
+    }
+
+    /// `assert <expr>`: any other boolean, lowered as-is (no decomposition).
+    fn lower_bare_assert(
+        &mut self,
+        operand: &Expression,
+        statements: &mut Vec<LoweredStatement>,
+        fx: &mut EmitEffects,
+    ) -> AssertShape {
+        let (setup, condition) = self.lower_condition(operand, fx);
+        statements.extend(setup);
+        AssertShape {
+            condition,
+            kind: "bare",
+            operands: String::new(),
+        }
+    }
+
+    /// Capture an `assert` operand into a fresh temp, declared with its inferred
+    /// type so an untyped constant (e.g. a large `uint64` literal) keeps its type.
+    fn stage_assert_operand(
+        &mut self,
+        expression: &Expression,
+        hint: &str,
+        statements: &mut Vec<LoweredStatement>,
+        fx: &mut EmitEffects,
+    ) -> String {
+        let (setup, value) = self
+            .lower_value(expression, ExpressionContext::value(), fx)
+            .into_parts();
+        statements.extend(setup);
+        let name = self.fresh_var(Some(hint));
+        self.declare(&name);
+        // Bind the temp to itself so the relation shape's synthetic identifier resolves.
+        self.scope.bind(name.clone(), name.clone());
+        let go_type = self.go_type_string(&expression.get_type(), fx);
+        statements.push(LoweredStatement::VarDecl {
+            name: name.clone(),
+            go_type,
+            value: Some(value),
+        });
+        name
+    }
+
+    /// A `recv.equals(arg)` whose receiver has an `equals` the compiler can lower
+    /// (a slice, a map, or any type with a usable `equals` method), so the failure
+    /// can show both operands. Anything else falls back to the bare shape.
+    fn as_equals_decomposition<'a>(
+        &self,
+        operand: &'a Expression,
+    ) -> Option<(&'a Expression, &'a Expression)> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } = operand
+        else {
+            return None;
+        };
+        let Expression::DotAccess {
+            expression: recv,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return None;
+        };
+        if member != "equals" || args.len() != 1 {
+            return None;
+        }
+        let recv_ty = self.facts.peel_alias(&recv.get_type());
+        (recv_ty.is_slice() || recv_ty.is_map() || self.type_has_equals(&recv_ty))
+            .then(|| (recv.unwrap_parens(), &args[0]))
     }
 
     /// Lower `while let P = scrutinee { body }`, wrapped as a `WhileLet`
@@ -838,4 +1007,31 @@ impl Planner<'_> {
             }
         }
     }
+}
+
+/// The lowered pieces of an `assert`: the boolean condition, the record kind,
+/// and any `, Operand{...}` arguments appended to the failure call.
+struct AssertShape {
+    condition: String,
+    kind: &'static str,
+    operands: String,
+}
+
+/// A typed identifier for an already-bound temp, so the rebuilt comparison casts as usual.
+fn temp_identifier(name: &str, original: &Expression) -> Expression {
+    Expression::Identifier {
+        value: name.into(),
+        ty: original.get_type(),
+        span: original.get_span(),
+        binding_id: None,
+        qualified: None,
+    }
+}
+
+fn is_assert_relation(operator: &BinaryOperator) -> bool {
+    use BinaryOperator::*;
+    matches!(
+        operator,
+        Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual
+    )
 }

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -15,6 +15,7 @@ pub(crate) struct ScopeState {
     scope_depth: usize,
     loop_stack: Vec<LoopContext>,
     return_ctx_stack: Vec<Rc<ReturnContext>>,
+    test_handle_stack: Vec<String>,
     assign_targets: HashSet<String>,
     go_const_bindings: Vec<HashSet<String>>,
     /// Go identifiers referenced during lowering, for structural liveness.
@@ -39,6 +40,7 @@ impl ScopeState {
             scope_depth: 0,
             loop_stack: Vec::new(),
             return_ctx_stack: Vec::new(),
+            test_handle_stack: Vec::new(),
             assign_targets: HashSet::default(),
             go_const_bindings: vec![HashSet::default()],
             use_frames: Vec::new(),
@@ -211,6 +213,18 @@ impl ScopeState {
 
     pub(crate) fn pop_return_ctx(&mut self) {
         self.return_ctx_stack.pop();
+    }
+
+    pub(crate) fn push_test_handle(&mut self, name: String) {
+        self.test_handle_stack.push(name);
+    }
+
+    pub(crate) fn pop_test_handle(&mut self) {
+        self.test_handle_stack.pop();
+    }
+
+    pub(crate) fn current_test_handle(&self) -> Option<&str> {
+        self.test_handle_stack.last().map(String::as_str)
     }
 
     pub(crate) fn current_return_ctx(&self) -> Option<Rc<ReturnContext>> {

--- a/crates/passes/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/fact_producers/unused_expressions.rs
@@ -330,6 +330,7 @@ fn is_statement_only(expression: &Expression) -> bool {
             | Expression::Assignment { .. }
             | Expression::Defer { .. }
             | Expression::Task { .. }
+            | Expression::Assert { .. }
             | Expression::While { .. }
             | Expression::WhileLet { .. }
             | Expression::For { .. }

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -771,8 +771,13 @@ impl InferCtx<'_, '_> {
             self.sink
                 .push(diagnostics::infer::propagate_in_assert(propagate_span));
         }
+        if !self.scopes.has_test_handle() {
+            self.sink
+                .push(diagnostics::infer::assert_without_test_context(span));
+        }
         let unit_ty = self.type_unit();
         self.unify(expected_ty, &unit_ty, &span);
+
         Expression::Assert {
             expression: new_expression.into(),
             ty: unit_ty,

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -97,6 +97,30 @@ fn has_numeric_member_in_chain(expression: &Expression) -> bool {
 }
 
 impl InferCtx<'_, '_> {
+    pub(super) fn ty_is_test_context(&self, ty: &Type) -> bool {
+        let resolved = ty.resolve_in(&self.env).strip_refs();
+        resolved.get_qualified_id().is_some_and(|id| {
+            id.strip_suffix(".TestContext")
+                .is_some_and(|module| module == crate::prelude::TEST_PRELUDE_MODULE_ID)
+        })
+    }
+
+    fn param_provides_test_handle(&self, param: &Binding) -> bool {
+        matches!(&param.pattern, Pattern::Identifier { identifier, .. } if identifier != "_")
+            && self.ty_is_test_context(&param.ty)
+    }
+
+    fn mark_test_context_params_used(&mut self, params: &[Binding]) {
+        for param in params {
+            if let Pattern::Identifier { identifier, .. } = &param.pattern
+                && self.param_provides_test_handle(param)
+                && let Some(id) = self.scopes.lookup_binding_id(identifier)
+            {
+                self.facts.mark_used(id);
+            }
+        }
+    }
+
     pub(super) fn infer_function(
         &mut self,
         expression: Expression,
@@ -164,6 +188,16 @@ impl InferCtx<'_, '_> {
         let resolved_expected = expected_ty.resolve_in(&self.env);
         let expected_params = resolved_expected.get_function_params().unwrap_or_default();
         let new_params = self.infer_function_params(params, expected_params, true);
+
+        let is_test = attributes.iter().any(|a| a.name == "test");
+        if is_test
+            || new_params
+                .iter()
+                .any(|p| self.param_provides_test_handle(p))
+        {
+            self.scopes.mark_test_handle();
+        }
+        self.mark_test_context_params_used(&new_params);
 
         let unit_ty = self.type_unit();
         let return_ty =
@@ -238,6 +272,14 @@ impl InferCtx<'_, '_> {
         let resolved_expected = expected_ty.resolve_in(&self.env);
         let expected_params = resolved_expected.get_function_params().unwrap_or_default();
         let new_params = self.infer_function_params(params, expected_params, false);
+
+        if new_params
+            .iter()
+            .any(|p| self.param_provides_test_handle(p))
+        {
+            self.scopes.mark_test_handle();
+        }
+        self.mark_test_context_params_used(&new_params);
 
         let default_return = self.new_type_var();
         let return_ty = self.infer_return_type(

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -252,6 +252,12 @@ impl InferCtx<'_, '_> {
             if let Some(definition_span) = definition.name_span() {
                 self.facts.add_usage(span, definition_span);
             }
+            if store.is_test_definition(definition)
+                && store.test_index.contains_qualified(qname.as_str())
+            {
+                self.sink
+                    .push(diagnostics::infer::test_function_not_callable(span, &value));
+            }
             if let DefinitionBody::TypeAlias { .. } = &definition.body
                 && !self.scopes.is_callee_context()
                 && !self.scopes.is_dot_access_base()
@@ -460,12 +466,13 @@ impl InferCtx<'_, '_> {
                     | Expression::Assignment { .. }
                     | Expression::Task { .. }
                     | Expression::Defer { .. }
+                    | Expression::Assert { .. }
             );
 
             let suppress_unused_check = item.is_control_flow();
 
-            // Reject statement-only items (let, =, task, defer) as block tail
-            // when the block is expected to produce a non-unit value.
+            // Reject statement-only items (let, =, task, defer, assert) as block
+            // tail when the block is expected to produce a non-unit value.
             if is_last && is_statement_only {
                 let expected = self.env.resolve(&last_item_expected_ty);
                 if last_item_expected_ty.is_ignored() {

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -85,6 +85,7 @@ pub struct Scope {
     pub negation_depth: DepthCounter,
     pub type_param_depth: DepthCounter,
     pub use_context: Cell<UseContext>,
+    pub in_test_handle: bool,
     /// variable name -> binding ID (for linting)
     pub name_to_binding: HashMap<String, BindingId>,
 }
@@ -112,6 +113,7 @@ impl Scope {
             negation_depth: DepthCounter::new(),
             type_param_depth: DepthCounter::new(),
             use_context: Cell::new(UseContext::Statement),
+            in_test_handle: false,
             name_to_binding: HashMap::default(),
         }
     }
@@ -187,6 +189,7 @@ impl Scopes {
         scope.negation_depth = DepthCounter::with_value(current.negation_depth.get());
         scope.type_param_depth = DepthCounter::with_value(current.type_param_depth.get());
         scope.use_context = Cell::new(current.use_context.get());
+        scope.in_test_handle = current.in_test_handle;
         self.stack.push(scope);
     }
 
@@ -330,6 +333,14 @@ impl Scopes {
             }
             return;
         }
+    }
+
+    pub fn mark_test_handle(&mut self) {
+        self.current_mut().in_test_handle = true;
+    }
+
+    pub fn has_test_handle(&self) -> bool {
+        self.current().in_test_handle
     }
 
     pub fn increment_loop_depth(&self) {

--- a/prelude/testkit/testkit.go
+++ b/prelude/testkit/testkit.go
@@ -32,9 +32,16 @@ func (c TestContext) Parallel() {
 	c.t.Parallel()
 }
 
+// FailAssert reports an `assert` failure over the same channel as Fail.
+func (c TestContext) FailAssert(file int, lo, hi uint32, kind, message string, operands ...Operand) {
+	Fail(c.t, file, lo, hi, kind, message, operands...)
+}
+
 type Operand struct {
 	Label string `json:"label"`
 	Value string `json:"value"`
+	Lo    uint32 `json:"lo,omitempty"`
+	Hi    uint32 `json:"hi,omitempty"`
 }
 
 func ErrOperand(value any) Operand {
@@ -47,7 +54,7 @@ type failRecord struct {
 	Hi       uint32    `json:"hi"`
 	Kind     string    `json:"kind"`
 	Message  string    `json:"message"`
-	Operands []Operand `json:"operands"`
+	Operands []Operand `json:"operands,omitempty"`
 }
 
 // failEnvelope frames one chunk; `lis` orders by I and concatenates D over 0..N.

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -114,6 +114,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         }
 
         checker.finalize_equality(&mut store);
+        checker.finalize_tests(&mut store);
 
         for module_id in &to_infer {
             let prev_module_id = checker.cursor.module_id.clone();

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7450,72 +7450,6 @@ fn test_with_context_emits_testkit_wrapper() {
 }
 
 #[test]
-fn assert_lowers_to_panic() {
-    let mut fs = MockFileSystem::new();
-    fs.add_file(
-        ENTRY_MODULE_ID,
-        "main.lis",
-        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
-    );
-    fs.add_file(
-        "math",
-        "core.lis",
-        "pub fn add(a: int, b: int) -> int { a + b }",
-    );
-    fs.add_file(
-        "math",
-        "core.test.lis",
-        "#[test]\nfn checks() {\n  assert 2 + 2 == 5\n}",
-    );
-    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
-    let go = outputs
-        .iter()
-        .find(|f| f.name.ends_with("core_test.go"))
-        .expect("core_test.go")
-        .to_go();
-    assert!(
-        go.contains("panic(\"assertion failed\")"),
-        "assert must lower to a panic, got:\n{go}"
-    );
-}
-
-#[test]
-fn assert_as_try_block_tail_compiles() {
-    let mut fs = MockFileSystem::new();
-    fs.add_file(
-        ENTRY_MODULE_ID,
-        "main.lis",
-        "fn g() -> Result<int, string> { Ok(1) }\n\nfn f() -> Result<(), string> {\n  try {\n    let _ = g()?\n    assert true\n  }\n}\n\nfn main() {\n  let _ = f()\n}",
-    );
-    let go: String = compile_project_files(fs, "github.com/user/p", false)
-        .iter()
-        .map(|file| file.to_go())
-        .collect();
-    assert!(
-        go.contains("panic(\"assertion failed\")"),
-        "assert as a try-block tail must lower to a panic check, got:\n{go}"
-    );
-}
-
-#[test]
-fn assert_as_if_value_branch_compiles() {
-    let mut fs = MockFileSystem::new();
-    fs.add_file(
-        ENTRY_MODULE_ID,
-        "main.lis",
-        "fn main() {\n  let _ = if true { assert true } else { assert false }\n}",
-    );
-    let go: String = compile_project_files(fs, "github.com/user/p", false)
-        .iter()
-        .map(|file| file.to_go())
-        .collect();
-    assert!(
-        go.contains("panic(\"assertion failed\")"),
-        "assert in an if-as-value branch must lower to a panic check, got:\n{go}"
-    );
-}
-
-#[test]
 fn test_emit_produces_go_test_function() {
     let outputs =
         compile_project_files_with_tests(math_test_project(), "github.com/user/p", false, true);
@@ -7538,6 +7472,245 @@ fn test_emit_produces_go_test_function() {
     assert!(
         go.contains("\"testing\""),
         "expected the testing import, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_lowers_to_decomposed_failure_call() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn arithmetic() {\n  assert 2 + 2 == 5\n}\n\n#[test]\nfn truthy() {\n  assert true\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        go.contains("testkit.TestContext") && go.contains("testkit.New(t)"),
+        "a no-arg test with `assert` must carry a test handle, got:\n{go}"
+    );
+    assert!(
+        go.contains(".FailAssert(") && go.contains("\"relation\""),
+        "a comparison `assert` must report a relation, got:\n{go}"
+    );
+    assert!(
+        go.contains("left: %v, right: %v"),
+        "a relation `assert` must format both operands, got:\n{go}"
+    );
+    assert!(
+        go.contains("\"bare\""),
+        "a non-comparison `assert` must report as bare, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_equals_lowers_to_labeled_failure() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn slices_match() {\n  let xs = [1, 2]\n  let ys = [3, 4]\n  assert xs.equals(ys)\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        go.contains("\"labeled\"") && go.contains("slices.Equal("),
+        "a `.equals()` assert must lower to a labeled record via `slices.Equal`, got:\n{go}"
+    );
+    assert!(
+        go.contains("Label: \"left\"") && go.contains("Label: \"right\""),
+        "a labeled record must carry both operands, got:\n{go}"
+    );
+    assert!(
+        go.contains("Lo:") && go.contains("Hi:"),
+        "labeled operands must carry source spans, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_in_test_context_helper_emits_without_panic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "fn check(t: TestContext, n: int) {\n  assert n > 0\n}\n\n#[test]\nfn uses(t: TestContext) {\n  check(t, 5)\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+    assert!(
+        go.contains("func check(t testkit.TestContext") && go.contains("t.FailAssert("),
+        "an `assert` in a `TestContext` helper must report on its parameter, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_relation_applies_numeric_alias_cast() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub type Score = int\n\npub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn cmp() {\n  let s: Score = 3\n  let n: int = 3\n  assert s == n\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+    assert!(
+        go.contains("Score("),
+        "a numeric-alias comparison in `assert` must apply the cast, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_relation_types_untyped_literal_operand() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn big() {\n  let x: uint64 = 1\n  assert x == 18446744073709551615\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+    assert!(
+        go.contains("uint64 = 18446744073709551615"),
+        "an untyped literal operand must be typed, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_with_discarded_test_param_emits_synthesized_handle() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn checks(_: TestContext) {\n  assert false\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+    assert!(
+        go.contains("testkit.New(t)") && go.contains(".FailAssert("),
+        "a discarded test param must still yield a usable handle, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_in_discarded_subtest_targets_subtest_handle() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn parent(t: TestContext) {\n  let _ = t.run(\"sub\", |_| {\n    assert false\n  })\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+    assert!(
+        !go.contains("func(_ testkit.TestContext)"),
+        "a discarded subtest handle used by `assert` must be named, got:\n{go}"
     );
 }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3991,6 +3991,90 @@ fn local_error_type_shadow_rejected() {
 }
 
 #[test]
+fn assert_without_test_context_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "fn helper() {\n  assert true\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "assert_without_test_context"),
+        "`assert` with no test handle in scope must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn calling_a_test_function_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nfn alpha() {}\n\n#[test]\nfn beta() {\n  alpha()\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_function_not_callable"),
+        "calling a `#[test]` function must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn calling_a_test_file_helper_accepted() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "fn helper() {}\n\n#[test]\nfn alpha() {\n  helper()\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        !has_code(&result, "test_function_not_callable"),
+        "calling a non-test helper must be accepted, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn assert_in_wildcard_handle_helper_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "fn helper(_: TestContext) {\n  assert true\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "assert_without_test_context"),
+        "a discarded `_: TestContext` is not a usable handle, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn local_test_context_type_is_not_the_handle() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "struct TestContext {}\n\nfn helper(t: TestContext) {\n  assert true\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "assert_without_test_context"),
+        "a local `TestContext` type must not be treated as the test handle, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn assert_in_test_context_helper_accepted() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "fn helper(t: TestContext) {\n  assert true\n}\n\n#[test]\nfn checks(t: TestContext) {\n  helper(t)\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        !has_code(&result, "assert_without_test_context"),
+        "`assert` in a helper taking `t: TestContext` must be accepted, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn test_attribute_with_generics_rejected() {
     let fs = test_attribute_fs(
         "pub fn add(a: int, b: int) -> int { a + b }",


### PR DESCRIPTION

Makes `assert` fail with a diagnostic that decomposes the asserted expression, rather than a bare failure.

```
✗ arithmetic
  [error] assertion failed
 3 │   assert 2 + 2 == 5
   ·          ─────┬────
   ·               ╰── left: 4, right: 5
```

> [!IMPORTANT] 
> The test runner is work in progress, not ready for use yet!

Follow-up to #796
