### PR TITLE
refactor: centralize emit type and field-export resolution

### DIFF
--- a/crates/emit/src/analyze/mod.rs
+++ b/crates/emit/src/analyze/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod constraint_collector;
 pub(crate) mod facts;
 pub(crate) mod inline_uses;
 pub(crate) mod queries;
+pub(crate) mod resolve_nominal;

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -6,6 +6,7 @@ use crate::Planner;
 use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
 use crate::definitions::structs::is_raw_function_type;
+use crate::names::go_name;
 use syntax::ast::{Pattern, RestPattern, StructKind};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Type, substitute};
@@ -37,31 +38,24 @@ impl Planner<'_> {
     }
 
     pub(crate) fn field_is_embedded(&self, struct_ty: &Type, field_name: &str) -> bool {
-        let resolved = self.facts.peel_alias(&struct_ty.strip_refs());
-        let Type::Nominal { id, .. } = &resolved else {
+        let Some(resolved) = self.resolve_nominal(struct_ty) else {
             return false;
         };
         matches!(
-            self.facts.definition(id.as_str()),
-            Some(Definition {
-                body: DefinitionBody::Struct { fields, .. },
-                ..
-            }) if fields.iter().any(|f| f.name == field_name && f.embedded)
+            &resolved.definition.body,
+            DefinitionBody::Struct { fields, .. }
+                if fields.iter().any(|f| f.name == field_name && f.embedded)
         )
     }
 
     pub(crate) fn field_is_public(&self, struct_ty: &Type, field_name: &str) -> bool {
-        let resolved = self.facts.peel_alias(&struct_ty.strip_refs());
-
-        let Type::Nominal { id, .. } = &resolved else {
+        let Some(resolved) = self.resolve_nominal(struct_ty) else {
             return false;
         };
+        let id = resolved.id.as_str();
 
-        match self.facts.definition(id.as_str()) {
-            Some(Definition {
-                body: DefinitionBody::Struct { fields, .. },
-                ..
-            }) => {
+        match &resolved.definition.body {
+            DefinitionBody::Struct { fields, .. } => {
                 if let Some(field) = fields.iter().find(|f| f.name == field_name) {
                     if field.visibility.is_public() {
                         return true;
@@ -76,25 +70,16 @@ impl Planner<'_> {
                     .map(|d| d.visibility().is_public())
                     .unwrap_or(false)
             }
-            Some(Definition {
-                body: DefinitionBody::Enum { .. },
-                ..
-            }) => {
+            DefinitionBody::Enum { .. } => {
                 let method_key = format!("{}.{}", id, field_name);
                 self.facts
                     .definition(method_key.as_str())
                     .map(|d| d.visibility().is_public())
                     .unwrap_or(false)
             }
-            Some(Definition {
-                visibility,
-                body: DefinitionBody::Interface { definition },
-                ..
-            }) => {
-                if visibility.is_public() && definition.methods.contains_key(field_name) {
-                    return true;
-                }
-                false
+            DefinitionBody::Interface { definition } => {
+                resolved.definition.visibility.is_public()
+                    && definition.methods.contains_key(field_name)
             }
             _ => false,
         }
@@ -106,6 +91,21 @@ impl Planner<'_> {
             || matches!(method_name, "string" | "goString" | "error")
     }
 
+    pub(crate) fn type_uses_exported_members(&self, ty: &Type) -> bool {
+        let Type::Nominal { id, .. } = ty.strip_refs() else {
+            return false;
+        };
+        id.starts_with(go_name::PRELUDE_PREFIX)
+            || self
+                .facts
+                .module_for_qualified_name(id.as_str())
+                .is_some_and(|m| self.facts.is_foreign_module(m))
+    }
+
+    pub(crate) fn struct_field_is_exported(&self, ty: &Type, field: &str) -> bool {
+        self.field_is_public(ty, field) || self.type_uses_exported_members(ty)
+    }
+
     pub(crate) fn type_has_equals(&self, ty: &Type) -> bool {
         let peeled = self.facts.peel_alias(ty);
         let Some(id) = peeled.get_qualified_id() else {
@@ -115,57 +115,47 @@ impl Planner<'_> {
     }
 
     pub(crate) fn has_field(&self, struct_ty: &Type, field_name: &str) -> bool {
-        let Type::Nominal { id, .. } = struct_ty.strip_refs() else {
+        let Some(resolved) = self.resolve_nominal(struct_ty) else {
             return false;
         };
         matches!(
-            self.facts.definition(id.as_str()).map(|d| &d.body),
-            Some(DefinitionBody::Struct { fields, .. })
+            &resolved.definition.body,
+            DefinitionBody::Struct { fields, .. }
                 if fields.iter().any(|f| f.name == field_name)
         )
     }
 
     pub(crate) fn is_tuple_struct_type(&self, ty: &Type) -> bool {
-        let Type::Nominal { id, .. } = ty.strip_refs() else {
-            return false;
-        };
-
-        matches!(
-            self.facts.definition(id.as_str()).map(|d| &d.body),
-            Some(DefinitionBody::Struct {
-                kind: StructKind::Tuple,
-                ..
-            })
-        )
+        self.resolve_nominal(ty).is_some_and(|resolved| {
+            matches!(
+                &resolved.definition.body,
+                DefinitionBody::Struct {
+                    kind: StructKind::Tuple,
+                    ..
+                }
+            )
+        })
     }
 
     pub(crate) fn is_newtype_struct(&self, ty: &Type) -> bool {
-        let Type::Nominal { id, params, .. } = ty.strip_refs() else {
+        let Type::Nominal { params, .. } = ty.strip_refs() else {
             return false;
         };
         if !params.is_empty() {
             return false;
         }
-        self.facts
-            .definition(id.as_str())
-            .is_some_and(|d| d.is_newtype())
+        self.resolve_nominal(ty)
+            .is_some_and(|resolved| resolved.definition.is_newtype())
     }
 
     pub(crate) fn get_newtype_underlying(&self, ty: &Type) -> Option<Type> {
-        let Type::Nominal { id, .. } = ty.strip_refs() else {
-            return None;
-        };
-
-        if let Some(Definition {
-            body:
-                DefinitionBody::Struct {
-                    kind: StructKind::Tuple,
-                    fields,
-                    generics,
-                    ..
-                },
+        let resolved = self.resolve_nominal(ty)?;
+        if let DefinitionBody::Struct {
+            kind: StructKind::Tuple,
+            fields,
+            generics,
             ..
-        }) = self.facts.definition(id.as_str())
+        } = &resolved.definition.body
             && fields.len() == 1
             && generics.is_empty()
         {
@@ -189,18 +179,9 @@ impl Planner<'_> {
     }
 
     pub(crate) fn as_enum(&self, ty: &Type) -> Option<String> {
-        let Type::Nominal { id, .. } = self.facts.peel_alias(ty) else {
-            return None;
-        };
-
-        if matches!(
-            self.facts.definition(id.as_str()).map(|d| &d.body),
-            Some(DefinitionBody::Enum { .. })
-        ) {
-            Some(id.to_string())
-        } else {
-            None
-        }
+        let resolved = self.resolve_nominal(ty)?;
+        matches!(&resolved.definition.body, DefinitionBody::Enum { .. })
+            .then(|| resolved.id.to_string())
     }
 
     /// `Option<T>` where T is a concrete non-nilable Go value type, bridged

--- a/crates/emit/src/analyze/resolve_nominal.rs
+++ b/crates/emit/src/analyze/resolve_nominal.rs
@@ -1,0 +1,19 @@
+use syntax::program::Definition;
+use syntax::types::{Symbol, Type};
+
+use crate::Planner;
+
+pub(crate) struct ResolvedNominal<'a> {
+    pub(crate) id: Symbol,
+    pub(crate) definition: &'a Definition,
+}
+
+impl<'a> Planner<'a> {
+    pub(crate) fn resolve_nominal(&self, ty: &Type) -> Option<ResolvedNominal<'a>> {
+        let Type::Nominal { id, .. } = self.facts.peel_alias(&ty.strip_refs()) else {
+            return None;
+        };
+        let definition = self.facts.definition(id.as_str())?;
+        Some(ResolvedNominal { id, definition })
+    }
+}

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -165,7 +165,7 @@ impl Planner<'_> {
     ) -> bool {
         match dot_access_kind {
             Some(SemanticDotKind::StructField { is_exported }) => {
-                is_exported || self.field_is_public(expression_ty, member)
+                is_exported || self.struct_field_is_exported(expression_ty, member)
             }
             Some(SemanticDotKind::InstanceMethod { is_exported }) => {
                 is_exported || self.method_needs_export(member)
@@ -271,15 +271,7 @@ impl Planner<'_> {
             expression,
             Expression::Identifier { ty, .. } if ty.as_import_namespace().is_some()
         );
-        is_import_namespace_identifier
-            || is_from_prelude(expression_ty)
-            || if let Type::Nominal { id, .. } = expression_ty.strip_refs() {
-                self.facts
-                    .module_for_qualified_name(id.as_str())
-                    .is_some_and(|m| self.facts.is_foreign_module(m))
-            } else {
-                false
-            }
+        is_import_namespace_identifier || self.type_uses_exported_members(expression_ty)
     }
 
     /// Emit the base expression with receiver coercion applied.

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -19,7 +19,6 @@ use crate::utils::observable_after_mutation;
 struct StructCallContext {
     go_type: String,
     enum_ctx: Option<EnumCallContext>,
-    is_prelude: bool,
 }
 
 struct EnumCallContext {
@@ -355,7 +354,7 @@ impl Planner<'_> {
                         .map(|(index, (name, field_ty))| {
                             let go_name = if is_tuple {
                                 format!("F{}", index)
-                            } else if self.field_is_public(ty, &name) {
+                            } else if self.struct_field_is_exported(ty, &name) {
                                 go_name::make_exported(&name)
                             } else {
                                 go_name::escape_keyword(&name).into_owned()
@@ -425,11 +424,7 @@ impl Planner<'_> {
 
         let enum_ctx = enum_id.map(|id| self.compute_enum_call_context(name, &id, fx));
 
-        StructCallContext {
-            go_type,
-            enum_ctx,
-            is_prelude,
-        }
+        StructCallContext { go_type, enum_ctx }
     }
 
     /// Compute the Go type string for a struct call.
@@ -551,7 +546,7 @@ impl Planner<'_> {
                 .unwrap_or_else(|| go_name::make_exported(field_name))
         } else if self.field_is_embedded(ty, field_name) {
             go_name::escape_keyword(field_name).into_owned()
-        } else if ctx.is_prelude || self.field_is_public(ty, field_name) {
+        } else if self.struct_field_is_exported(ty, field_name) {
             go_name::make_exported(field_name)
         } else {
             go_name::escape_keyword(field_name).into_owned()

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -308,12 +308,7 @@ impl Planner<'_> {
     ) -> ValuePlan {
         let inner = self.plan_operand(expression, ctx, fx);
 
-        if let Type::Nominal { id, .. } = &self.facts.peel_alias(ty)
-            && matches!(
-                self.facts.definition(id.as_str()).map(|d| &d.body),
-                Some(DefinitionBody::Interface { .. })
-            )
-        {
+        if self.facts.is_interface(ty) {
             let (mut setup, value) = inner.into_parts();
             let source_ty = expression.get_type();
             let coercion = Coercion::resolve(self, &source_ty, ty, CoercionDirection::Internal);

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -951,7 +951,7 @@ fn compute_struct_field_path(
                     enum_id, variant_name, field.name
                 )
             })
-    } else if planner.field_is_public(ty, &field.name) {
+    } else if planner.struct_field_is_exported(ty, &field.name) {
         go_name::make_exported(&field.name)
     } else {
         go_name::escape_keyword(&field.name).into_owned()

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -320,7 +320,7 @@ impl Planner<'_> {
             let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
             return format!("{}.{}", base_str, field);
         }
-        let field = if self.field_is_public(expression_ty, member) {
+        let field = if self.struct_field_is_exported(expression_ty, member) {
             go_name::make_exported(member)
         } else {
             go_name::escape_keyword(member).into_owned()


### PR DESCRIPTION
Routes emit's structural type classification through a single strip-refs + peel-aliases path and folds the Go field-export decision into a single spot.
