### PR TITLE
feat: add `--filter` to `lis test` and support test titles

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -33,6 +33,7 @@ pub enum Command {
     Test {
         path: Option<String>,
         go_flags: Vec<String>,
+        filter: Option<String>,
     },
     Overview,
     Help {
@@ -312,9 +313,22 @@ impl Command {
             "test" | "t" => {
                 let mut path = None;
                 let mut go_flags = Vec::new();
+                let mut filter = None;
 
                 while let Some(arg) = arguments.next() {
-                    if arg.starts_with('-') {
+                    if arg == "-f" || arg == "--filter" {
+                        let Some(value) = arguments.next() else {
+                            return Err(ParseError::MissingArgument {
+                                command: "test",
+                                argument: "--filter <pattern>",
+                            });
+                        };
+                        filter = Some(value);
+                    } else if let Some(value) = arg.strip_prefix("--filter=") {
+                        filter = Some(value.to_string());
+                    } else if let Some(value) = arg.strip_prefix("-f=") {
+                        filter = Some(value.to_string());
+                    } else if arg.starts_with('-') {
                         if !try_parse_go_flags(&arg, &mut arguments, &mut go_flags, "test")? {
                             return Err(ParseError::UnknownFlag(arg));
                         }
@@ -335,7 +349,35 @@ impl Command {
                     });
                 }
 
-                Ok(Command::Test { path, go_flags })
+                if let Some(flag) = go_flags
+                    .iter()
+                    .find(|f| crate::go_cli::is_go_selection_flag(f))
+                {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: format!(
+                            "`{}` cannot be passed to `lis test` via `--go-flags`",
+                            flag
+                        ),
+                        reason: "`lis test` selects which tests run and reconciles the report against them"
+                            .to_string(),
+                        hint: "Use `lis test --filter <pattern>` to select tests".to_string(),
+                    });
+                }
+
+                if filter.as_deref() == Some("") {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: "`--filter` requires a non-empty pattern".to_string(),
+                        reason: "an empty pattern matches every test, the same as no filter"
+                            .to_string(),
+                        hint: "Pass a pattern, e.g. `lis test --filter parse`".to_string(),
+                    });
+                }
+
+                Ok(Command::Test {
+                    path,
+                    go_flags,
+                    filter,
+                })
             }
 
             "help" | "--help" => Ok(Command::Help {
@@ -631,11 +673,38 @@ mod tests {
     #[test]
     fn test_accepts_other_go_flags() {
         let Ok(Command::Test { go_flags, .. }) =
-            parse(&["lis", "test", "--go-flags", "-run TestFoo"])
+            parse(&["lis", "test", "--go-flags", "-failfast -tags run"])
         else {
             panic!("expected Test command");
         };
-        assert_eq!(go_flags, vec!["-run", "TestFoo"]);
+        assert_eq!(go_flags, vec!["-failfast", "-tags", "run"]);
+    }
+
+    #[test]
+    fn test_rejects_selection_flags_in_go_flags() {
+        for flag in ["-run", "-skip", "-list"] {
+            assert!(
+                matches!(
+                    parse(&["lis", "test", "--go-flags", flag]),
+                    Err(ParseError::UnexpectedArgument { .. })
+                ),
+                "expected `{flag}` to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rejects_empty_filter() {
+        for args in [
+            vec!["lis", "test", "-f", ""],
+            vec!["lis", "test", "--filter="],
+            vec!["lis", "test", "-f="],
+        ] {
+            assert!(
+                matches!(parse(&args), Err(ParseError::UnexpectedArgument { .. })),
+                "expected {args:?} to be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -488,6 +488,16 @@ pub fn is_go_json_flag(token: &str) -> bool {
         || token.starts_with("--json=")
 }
 
+pub fn is_go_selection_flag(token: &str) -> bool {
+    if !token.starts_with('-') {
+        return false;
+    }
+    let stripped = token.trim_start_matches('-');
+    let stripped = stripped.strip_prefix("test.").unwrap_or(stripped);
+    let base = stripped.split('=').next().unwrap_or(stripped);
+    matches!(base, "run" | "skip" | "list")
+}
+
 /// `go_flags` follow the default `-o` so a caller `-o` wins. `output_path` must
 /// be absolute, since `go build` runs with `build_dir` as cwd.
 pub fn build_binary(
@@ -545,17 +555,43 @@ pub struct TestRun {
     pub success: bool,
 }
 
+/// Run tests. `None` runs every package (`go test ./...`); `Some` runs each
+/// `(package, run_regex)` as its own `go test -run` invocation and aggregates.
 pub fn run_tests(
     build_dir: &Path,
     target: Target,
     go_flags: &[String],
+    scopes: Option<&[(String, String)]>,
+) -> Result<TestRun, GoCliError> {
+    let Some(scopes) = scopes else {
+        return run_go_test(build_dir, target, go_flags, "./...", None);
+    };
+    let mut events = Vec::new();
+    let mut success = true;
+    for (package, run_regex) in scopes {
+        let run = run_go_test(build_dir, target, go_flags, package, Some(run_regex))?;
+        events.extend(run.events);
+        success &= run.success;
+    }
+    Ok(TestRun { events, success })
+}
+
+fn run_go_test(
+    build_dir: &Path,
+    target: Target,
+    go_flags: &[String],
+    package: &str,
+    run_pattern: Option<&str>,
 ) -> Result<TestRun, GoCliError> {
     let mut cmd = go_command(target);
     cmd.arg("test").arg("-json").arg("-count=1");
+    if let Some(pattern) = run_pattern {
+        cmd.arg("-run").arg(pattern);
+    }
     for flag in go_flags {
         cmd.arg(flag);
     }
-    cmd.arg("./...")
+    cmd.arg(package)
         .current_dir(build_dir)
         .stdout(Stdio::piped());
 

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -56,7 +56,7 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         test)
-            COMPREPLY=( $(compgen -W "--go-flags" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--filter --go-flags" -- "$cur") )
             return 0
             ;;
         format)
@@ -137,7 +137,9 @@ _lis() {
                         '--go-flags[Flags passed through to go build]:flags'
                     ;;
                 test)
-                    _arguments '--go-flags[Flags passed through to go test]:flags'
+                    _arguments \
+                        '--filter[Run only tests whose name contains the pattern]:pattern' \
+                        '--go-flags[Flags passed through to go test]:flags'
                     ;;
                 format)
                     _arguments '--check[Check formatting without modifying]'
@@ -191,6 +193,7 @@ complete -c lis -n '__fish_seen_subcommand_from build' -l go-flags -r -d 'Flags 
 complete -c lis -n '__fish_seen_subcommand_from emit' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'
+complete -c lis -n '__fish_seen_subcommand_from test' -s f -l filter -r -d 'Run only tests whose name contains the pattern'
 complete -c lis -n '__fish_seen_subcommand_from test' -l go-flags -r -d 'Flags passed through to go test'
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -170,11 +170,13 @@ Arguments:
     {path:g} {(optional):d}                    Path to dir (default: current dir)
 
 Flags:
+    {--filter, -f:b} {<pattern>:g}             Run only tests whose name contains pattern
     {--go-flags:b} {\"<flags>\"}               Pass flags through to `go test`
 
 Examples:
     `lis test`                           Run all tests in current dir
     `lis test` {~/projects/demo:g}           Run tests in specific dir
+    `lis test` {-f:b} {parse:g}                  Only tests whose name contains \"parse\"
     `lis test` {--go-flags:b} {\"-failfast\"}    Stop at the first failing test",
         ),
 

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -6,10 +6,12 @@ use crate::output::use_color;
 
 use super::build::{BuildOptions, build_locked, with_locked_project};
 
-mod report;
-use report::{build_report, exit_code, render};
+use std::collections::BTreeMap;
 
-pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
+mod report;
+use report::{build_report_filtered, exit_code, matching_tests, render};
+
+pub fn test(path: Option<String>, go_flags: Vec<String>, filter: Option<String>) -> i32 {
     crate::output::print_test_unfinished_notice();
     with_locked_project(path, |prep| {
         let outcome = build_locked(
@@ -25,6 +27,28 @@ pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
             return outcome.code;
         }
 
+        let scopes = match filter.as_deref() {
+            Some(pattern) => {
+                let matched =
+                    matching_tests(&outcome.test_index, &prep.manifest.project.name, pattern);
+                if matched.is_empty() {
+                    eprintln!("\n  No tests match `{pattern}`\n");
+                    return 0;
+                }
+                let mut by_package: BTreeMap<String, Vec<String>> = BTreeMap::new();
+                for (package, go_name) in matched {
+                    by_package.entry(package).or_default().push(go_name);
+                }
+                Some(
+                    by_package
+                        .into_iter()
+                        .map(|(package, names)| (package, format!("^({})$", names.join("|"))))
+                        .collect::<Vec<_>>(),
+                )
+            }
+            None => None,
+        };
+
         let build_dir = match prep.target_dir.canonicalize() {
             Ok(p) => p,
             Err(e) => {
@@ -38,7 +62,12 @@ pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
         };
 
         let started = Instant::now();
-        let run = match go_cli::run_tests(&build_dir, stdlib::Target::host(), &go_flags) {
+        let run = match go_cli::run_tests(
+            &build_dir,
+            stdlib::Target::host(),
+            &go_flags,
+            scopes.as_deref(),
+        ) {
             Ok(run) => run,
             Err(e) => {
                 cli_error!("Failed to run tests", e.message, e.hint);
@@ -46,10 +75,11 @@ pub fn test(path: Option<String>, go_flags: Vec<String>) -> i32 {
             }
         };
 
-        let report = build_report(
+        let report = build_report_filtered(
             &outcome.test_index,
             &run.events,
             &prep.manifest.project.name,
+            filter.as_deref(),
         );
         eprint!(
             "{}",

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -57,6 +57,7 @@ pub struct FailureRecord {
 pub struct TestRow {
     pub package: String,
     pub name: String,
+    pub description: Option<String>,
     pub status: Status,
     pub elapsed: Option<f64>,
     pub output: String,
@@ -72,7 +73,44 @@ pub struct Report {
     build_failed_packages: HashSet<String>,
 }
 
+fn name_or_title_contains(fn_name: &str, title: Option<&str>, pattern: &str) -> bool {
+    fn_name.contains(pattern) || title.is_some_and(|t| t.contains(pattern))
+}
+
+pub fn matching_tests(index: &TestIndex, go_module: &str, filter: &str) -> Vec<(String, String)> {
+    index
+        .tests()
+        .iter()
+        .filter_map(|test| {
+            let prefix = format!("{}.", test.module_id);
+            let fn_name = test
+                .qualified_name
+                .strip_prefix(&prefix)
+                .unwrap_or(&test.qualified_name);
+            if !name_or_title_contains(fn_name, test.title.as_deref(), filter) {
+                return None;
+            }
+            let package = if test.module_id == ENTRY_MODULE_ID {
+                go_module.to_string()
+            } else {
+                format!("{}/{}", go_module, test.module_id)
+            };
+            Some((package, go_test_name(fn_name)))
+        })
+        .collect()
+}
+
+#[cfg(test)]
 pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) -> Report {
+    build_report_filtered(index, events, go_module, None)
+}
+
+pub fn build_report_filtered(
+    index: &TestIndex,
+    events: &[GoTestEvent],
+    go_module: &str,
+    filter: Option<&str>,
+) -> Report {
     let mut terminal: HashMap<(String, String), (Status, Option<f64>)> = HashMap::new();
     let mut started: HashSet<(String, String)> = HashSet::new();
     let mut outputs: HashMap<(String, String), String> = HashMap::new();
@@ -154,6 +192,11 @@ pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) 
             .qualified_name
             .strip_prefix(&prefix)
             .unwrap_or(&test.qualified_name);
+        if let Some(pattern) = filter
+            && !name_or_title_contains(fn_name, test.title.as_deref(), pattern)
+        {
+            continue;
+        }
         let package = if test.module_id == ENTRY_MODULE_ID {
             go_module.to_string()
         } else {
@@ -170,7 +213,8 @@ pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) 
             collect_children(&package, &go_name, &terminal, &started, &outputs, &failures);
         rows.push(TestRow {
             package,
-            name: fn_name.to_string(),
+            name: test.title.clone().unwrap_or_else(|| fn_name.to_string()),
+            description: test.doc.clone(),
             status,
             elapsed,
             output: outputs.get(&key).cloned().unwrap_or_default(),
@@ -263,6 +307,7 @@ fn collect_children(
             TestRow {
                 package: package.to_string(),
                 name: full[prefix.len()..].to_string(),
+                description: None,
                 status,
                 elapsed,
                 output: outputs.get(&key).cloned().unwrap_or_default(),
@@ -346,6 +391,13 @@ fn render_rows(out: &mut String, rows: &[&TestRow], prefix: &str, sources: &Sour
         }
 
         let child_prefix = format!("{prefix}{}", if last { "    " } else { "│   " });
+
+        if let Some(description) = &row.description {
+            for line in description.lines() {
+                out.push_str(&dim(&format!("{child_prefix}  {line}"), color));
+                out.push('\n');
+            }
+        }
 
         if let Some(block) = row
             .failure
@@ -884,5 +936,73 @@ mod tests {
         assert!(text.contains("test returned Err"), "got:\n{text}");
         assert!(text.contains("boom"), "got:\n{text}");
         assert!(text.contains("x.test.lis"), "got:\n{text}");
+    }
+
+    fn titled_index() -> TestIndex {
+        let mut index = TestIndex::default();
+        index.push(TestFunction {
+            module_id: "csv".to_string(),
+            qualified_name: "csv.splits_csv".to_string(),
+            title: Some("splits and trims CSV fields".to_string()),
+            doc: Some("Trims surrounding whitespace before splitting.".to_string()),
+            span: span(),
+        });
+        index.push(TestFunction {
+            module_id: "csv".to_string(),
+            qualified_name: "csv.parses_number".to_string(),
+            title: None,
+            doc: None,
+            span: span(),
+        });
+        index
+    }
+
+    #[test]
+    fn title_replaces_name_and_doc_renders_as_description() {
+        let report = build_report(&titled_index(), &[], "demo");
+        let titled = report
+            .rows
+            .iter()
+            .find(|r| r.name == "splits and trims CSV fields")
+            .expect("title should replace the function name");
+        assert_eq!(
+            titled.description.as_deref(),
+            Some("Trims surrounding whitespace before splitting.")
+        );
+        let text = render(&report, &no_sources(), false, Duration::from_millis(1));
+        assert!(
+            text.contains("splits and trims CSV fields")
+                && text.contains("Trims surrounding whitespace"),
+            "got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn filter_keeps_only_matching_rows_by_name_or_title() {
+        let by_title = build_report_filtered(&titled_index(), &[], "demo", Some("and trims"));
+        assert_eq!(by_title.rows.len(), 1);
+        assert_eq!(by_title.rows[0].name, "splits and trims CSV fields");
+
+        let by_name = build_report_filtered(&titled_index(), &[], "demo", Some("parses"));
+        assert_eq!(by_name.rows.len(), 1);
+        assert_eq!(by_name.rows[0].name, "parses_number");
+    }
+
+    #[test]
+    fn matching_tests_is_case_sensitive_over_name_and_title_with_package() {
+        let index = titled_index();
+        assert_eq!(
+            matching_tests(&index, "demo", "and trims"),
+            vec![("demo/csv".to_string(), "TestSplitsCsv".to_string())]
+        );
+        assert_eq!(
+            matching_tests(&index, "demo", "parses"),
+            vec![("demo/csv".to_string(), "TestParsesNumber".to_string())]
+        );
+        assert!(
+            matching_tests(&index, "demo", "Trims").is_empty(),
+            "case-sensitive: `Trims` must not match the lowercase title term"
+        );
+        assert!(matching_tests(&index, "demo", "zzz").is_empty());
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -77,7 +77,11 @@ fn main() {
             warnings_only,
             format,
         } => handlers::check(path, errors_only, warnings_only, format),
-        Command::Test { path, go_flags } => handlers::test(path, go_flags),
+        Command::Test {
+            path,
+            go_flags,
+            filter,
+        } => handlers::test(path, go_flags, filter),
         Command::Overview => {
             handlers::help::print_main_help();
             0


### PR DESCRIPTION
Adds `--filter` to `lis test` to run only the tests whose name or title contains a substring. Also shows each test's title and doc comment in the report.

> [!IMPORTANT]
> The test runner is work in progress, not ready for use yet!

Follow-up to #800
