### PR TITLE
feat: infer `TestContext` for bare test function param

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -145,7 +145,7 @@ pub fn test_unsupported_signature(name_span: &Span) -> LisetteDiagnostic {
         .with_attribute_code("test_unsupported_signature")
         .with_span_label(name_span, "this test signature is not supported")
         .with_help(
-            "A test is `fn name()` or `fn name(t: TestContext)`, optionally returning `Result<(), error>`.",
+            "A test is `fn name()`, `fn name(t)`, or `fn name(t: TestContext)`, optionally returning `Result<(), error>`.",
         )
 }
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -13,6 +13,7 @@ use super::super::carry_mut::can_carry_mutation_across_fn_boundary;
 use super::super::unify::Dispatched;
 use super::primitives::contains_deref;
 use crate::checker::infer::InferCtx;
+use crate::checker::registration::test_functions::normalize_test_params;
 use crate::checker::scopes::UseContext;
 use crate::store::ENTRY_MODULE_ID;
 
@@ -187,9 +188,10 @@ impl InferCtx<'_, '_> {
 
         let resolved_expected = expected_ty.resolve_in(&self.env);
         let expected_params = resolved_expected.get_function_params().unwrap_or_default();
+        let is_test = attributes.iter().any(|a| a.name == "test");
+        let params = normalize_test_params(params, is_test);
         let new_params = self.infer_function_params(params, expected_params, true);
 
-        let is_test = attributes.iter().any(|a| a.name == "test");
         if is_test
             || new_params
                 .iter()
@@ -1111,6 +1113,10 @@ impl InferCtx<'_, '_> {
             .enumerate()
             .map(|(index, binding)| {
                 let expected_param_ty = match binding.annotation {
+                    // A `#[test]` handle carries a resolved type with no
+                    // annotation. Honor it before falling back to the expected
+                    // function type.
+                    None if !binding.ty.is_uninferred() => Some(binding.ty.clone()),
                     None => expected_params.get(index).cloned(),
                     _ => None,
                 };

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -5,7 +5,7 @@ mod equality;
 mod impl_bounds;
 mod iterate;
 mod methods;
-mod test_functions;
+pub(crate) mod test_functions;
 mod types;
 
 use std::path::PathBuf;
@@ -801,6 +801,14 @@ impl TaskState<'_> {
         self.scopes.push();
         self.put_in_scope(generics);
 
+        let test_params;
+        let params: &[Binding] = if syntax::attributes::has_test_attribute(attributes) {
+            test_params = test_functions::normalize_test_params(params.clone(), true);
+            &test_params
+        } else {
+            params
+        };
+
         let fn_ty = self.extract_signature_parts(store, generics, params, return_annotation, span);
 
         self.scopes.pop();
@@ -1052,12 +1060,10 @@ impl TaskState<'_> {
 
         let param_types: Vec<Type> = params
             .iter()
-            .map(|binding| {
-                binding
-                    .annotation
-                    .as_ref()
-                    .map(|a| self.convert_to_type_inner(store, a, span, true))
-                    .unwrap_or_else(|| self.new_type_var())
+            .map(|binding| match &binding.annotation {
+                Some(a) => self.convert_to_type_inner(store, a, span, true),
+                None if !binding.ty.is_uninferred() => binding.ty.clone(),
+                None => self.new_type_var(),
             })
             .collect();
 

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -2,9 +2,28 @@ use diagnostics::LocalSink;
 use syntax::ast::{Annotation, Attribute, AttributeArg, Binding, Expression};
 use syntax::attributes::test_attribute;
 use syntax::program::TestFunction;
+use syntax::types::{Symbol, Type};
 
 use super::TaskState;
 use crate::store::Store;
+
+pub(crate) fn test_context_type() -> Type {
+    Type::Nominal {
+        id: Symbol::from_parts(crate::prelude::TEST_PRELUDE_MODULE_ID, "TestContext"),
+        params: vec![],
+        underlying_ty: None,
+    }
+}
+
+pub(crate) fn normalize_test_params(mut params: Vec<Binding>, is_test: bool) -> Vec<Binding> {
+    if is_test
+        && let [param] = params.as_mut_slice()
+        && param.annotation.is_none()
+    {
+        param.ty = test_context_type();
+    }
+    params
+}
 
 impl TaskState<'_> {
     /// Collect and validate a module's `#[test]` functions into `facts`
@@ -111,14 +130,13 @@ fn module_shadows_test_context(store: &Store, module_id: &str) -> bool {
 fn params_supported(params: &[Binding], context_shadowed: bool) -> bool {
     match params {
         [] => true,
-        [param] => {
-            !context_shadowed
-                && matches!(
-                    &param.annotation,
-                    Some(Annotation::Constructor { name, params, .. })
-                        if name == "TestContext" && params.is_empty()
-                )
-        }
+        [param] => match &param.annotation {
+            None => true,
+            Some(Annotation::Constructor { name, params, .. }) => {
+                !context_shadowed && name == "TestContext" && params.is_empty()
+            }
+            _ => false,
+        },
         _ => false,
     }
 }

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -1,4 +1,4 @@
-use super::{MAX_TUPLE_ARITY, Parser};
+use super::{MAX_TUPLE_ARITY, ParamMode, Parser};
 use crate::ast::{Annotation, Attribute, Expression, Generic, Span, Visibility};
 use crate::lex::TokenKind::*;
 use crate::types::Type;
@@ -260,7 +260,7 @@ impl<'source> Parser<'source> {
             name,
             name_span,
             generics: vec![],
-            params: self.parse_function_params(),
+            params: self.parse_function_params(ParamMode::Strict),
             return_annotation: self.parse_function_return_annotation(),
             return_type: Type::uninferred(),
             visibility: Visibility::Private,

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -1,6 +1,6 @@
 use ecow::EcoString;
 
-use super::Parser;
+use super::{ParamMode, Parser};
 use crate::ast::{
     Annotation, Attribute, AttributeArg, EnumFieldDefinition, EnumVariant, Expression, Generic,
     ParentInterface, Span, StructFieldDefinition, StructKind, VariantFields, Visibility,
@@ -701,7 +701,11 @@ impl<'source> Parser<'source> {
             let is_public = self.advance_if(Pub);
 
             if self.is(Function) {
-                let method = self.parse_function(method_doc.map(|(text, _)| text), method_attrs);
+                let method = self.parse_function(
+                    method_doc.map(|(text, _)| text),
+                    method_attrs,
+                    ParamMode::Strict,
+                );
                 let method = if is_public {
                     method.set_public()
                 } else {

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
 
 use super::strings::cook_string_contents;
-use super::{MAX_TUPLE_ARITY, ParseError, Parser};
+use super::{MAX_TUPLE_ARITY, ParamMode, ParseError, Parser};
 use crate::ast::{
     Annotation, Attribute, BinaryOperator, Binding, Expression, FormatStringPart, ImportAlias,
     Literal, SelectArm, SelectArmPattern, Span, StructFieldAssignment, StructSpread, UnaryOperator,
@@ -49,7 +49,7 @@ impl<'source> Parser<'source> {
             Function if self.stream.peek_ahead(1).kind == LeftParen => {
                 self.parse_fn_as_lambda_recovery()
             }
-            Function => self.parse_function(None, vec![]),
+            Function => self.parse_function(None, vec![], ParamMode::Strict),
             Match => self.parse_match(),
             If => self.parse_if(),
             Pipe | PipeDouble => self.parse_lambda(),
@@ -607,7 +607,7 @@ impl<'source> Parser<'source> {
         self.track_fn_as_lambda_error();
 
         self.ensure(Function);
-        let params = self.parse_function_params();
+        let params = self.parse_function_params(ParamMode::Strict);
         let return_annotation = self.parse_function_return_annotation();
 
         let body = if self.is(LeftCurlyBrace) {
@@ -847,13 +847,13 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub fn parse_function_params(&mut self) -> Vec<Binding> {
+    pub(crate) fn parse_function_params(&mut self, mode: ParamMode) -> Vec<Binding> {
         self.ensure(LeftParen);
 
         let mut params = vec![];
 
         while self.is_not(RightParen) {
-            params.push(self.parse_binding_with_type());
+            params.push(self.parse_binding_with_type(mode));
             self.expect_comma_or(RightParen);
         }
 
@@ -877,10 +877,11 @@ impl<'source> Parser<'source> {
         params
     }
 
-    pub fn parse_function(
+    pub(crate) fn parse_function(
         &mut self,
         doc: Option<std::string::String>,
         attributes: Vec<Attribute>,
+        param_mode: ParamMode,
     ) -> Expression {
         let start = self.current_token();
 
@@ -894,7 +895,7 @@ impl<'source> Parser<'source> {
         let name_span = Span::new(name_span.file_id, name_span.byte_offset, name.len() as u32);
 
         let generics = self.parse_generics();
-        let params = self.parse_function_params();
+        let params = self.parse_function_params(param_mode);
         let return_annotation = self.parse_function_return_annotation();
 
         let body = if self.is(LeftCurlyBrace) {

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -1,4 +1,5 @@
 use crate::ast::{self, Span};
+use crate::attributes::has_test_attribute;
 use crate::lex;
 use crate::lex::TokenKind::*;
 use crate::lex::{Token, TokenKind};
@@ -9,6 +10,12 @@ pub const TUPLE_FIELDS: &[&str] = &["First", "Second", "Third", "Fourth", "Fifth
 const MAX_DEPTH: u32 = 64;
 const MAX_ERRORS: usize = 50;
 const MAX_LOOKAHEAD: usize = 256;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParamMode {
+    Strict,
+    TestFunction,
+}
 
 mod annotations;
 mod control_flow;
@@ -162,7 +169,15 @@ impl<'source> Parser<'source> {
             Enum => self.parse_enum_definition(doc, attributes),
             Struct => self.parse_struct_definition(doc, attributes),
             Interface => self.parse_interface_definition(doc),
-            Function => self.parse_function(doc, attributes),
+            Function => {
+                // Only a top-level `#[test]` declaration may write a bare handle parameter.
+                let mode = if has_test_attribute(&attributes) {
+                    ParamMode::TestFunction
+                } else {
+                    ParamMode::Strict
+                };
+                self.parse_function(doc, attributes, mode)
+            }
             Impl => self.parse_impl_block(),
             Const => self.parse_const_definition(doc),
             Var => self.parse_var_declaration(doc),
@@ -230,7 +245,7 @@ impl<'source> Parser<'source> {
                 );
                 self.parse_interface_definition(None)
             }
-            Function => self.parse_function(None, vec![]),
+            Function => self.parse_function(None, vec![], ParamMode::Strict),
             Const => self.parse_const_definition(None),
 
             Hash => {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
 
 use super::strings::cook_string_contents;
-use super::{MAX_TUPLE_ARITY, ParseError, Parser};
+use super::{MAX_TUPLE_ARITY, ParamMode, ParseError, Parser};
 use crate::ast::{Annotation, Binding, Literal, Pattern, RestPattern, Span, StructFieldPattern};
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
@@ -624,7 +624,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub fn parse_binding_with_type(&mut self) -> Binding {
+    pub(crate) fn parse_binding_with_type(&mut self, mode: ParamMode) -> Binding {
         if self.is_current_uppercase() && self.stream.peek_ahead(1).kind == Colon {
             let start = self.current_token();
             let name = start.text.to_string();
@@ -687,6 +687,16 @@ impl<'source> Parser<'source> {
                 typed_pattern: None,
                 ty: Type::uninferred(),
                 mutable: false,
+            };
+        }
+
+        if mode == ParamMode::TestFunction && self.is_not(Colon) {
+            return Binding {
+                pattern,
+                annotation: None,
+                typed_pattern: None,
+                ty: Type::uninferred(),
+                mutable: is_mut,
             };
         }
 

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -596,6 +596,16 @@ impl Type {
         }
     }
 
+    pub fn is_uninferred(&self) -> bool {
+        matches!(
+            self,
+            Self::Var {
+                id: TypeVarId::UNINFERRED,
+                ..
+            }
+        )
+    }
+
     pub fn ignored() -> Self {
         Self::Var {
             id: TypeVarId::IGNORED,

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7604,6 +7604,42 @@ fn assert_lowers_to_decomposed_failure_call() {
 }
 
 #[test]
+fn bare_test_handle_uses_param_as_handle() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn cases(t) {\n  let _ = t.run(\"c\", |t| { assert true })\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        go.contains("t testkit.TestContext") && go.contains(".Run("),
+        "a bare handle parameter must be typed `testkit.TestContext` and drive subtests, got:\n{go}"
+    );
+    assert!(
+        !go.contains("lisetteTestCtx"),
+        "the user's bare handle must be the handle, not a synthesized one, got:\n{go}"
+    );
+}
+
+#[test]
 fn assert_equals_lowers_to_labeled_failure() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3907,6 +3907,67 @@ fn test_attribute_with_test_context_accepted() {
 }
 
 #[test]
+fn test_attribute_with_bare_handle_accepted() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nfn checks(t) { let _ = t.run(\"c\", |t| { assert true }) }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        !has_code(&result, "test_unsupported_signature"),
+        "a bare handle parameter must be accepted, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors.is_empty(),
+        "a bare handle test must type-check cleanly, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_with_two_bare_params_rejected() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nfn checks(t, u) { assert true }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "test_unsupported_signature"),
+        "more than one parameter must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_on_impl_method_does_not_relax_params() {
+    let fs = test_attribute_fs(
+        "pub struct Foo { n: int }\n\nimpl Foo {\n  #[test]\n  fn check(x) { let _ = x }\n}",
+        "#[test]\nfn ok() { assert true }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "unexpected_token"),
+        "an impl method stays strict-typed even with `#[test]`, so a bare parameter is a parse error, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_attribute_bare_handle_resolves_to_prelude_under_shadow() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "struct TestContext { x: int }\n\n#[test]\nfn checks(t) { let _ = t.run(\"c\", |t| { assert true }) }",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        result.errors.is_empty(),
+        "a bare handle is positional and resolves to the prelude even when TestContext is shadowed, so `t.run` must resolve cleanly, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn test_attribute_value_named_test_context_does_not_block_param() {
     let fs = test_attribute_fs(
         "pub fn add(a: int, b: int) -> int { a + b }",


### PR DESCRIPTION
A `#[test]` function with `t` can now keep `t` unannotated. The type of `t` here is inferrable because it is only ever allowed to be `TestContext` here.

```rs
#[test("translate moves along each axis")]
fn translate_subtests(t) { // implicitly `t: TestContext`
  t.run("moves right", |t| {
    assert translate(Point { x: 0, y: 0 }, 2, 0) == Point { x: 2, y: 0 }
  })
}
```

The explicit form still works: `fn name(t: TestContext)` and a plain test can still take no parameter.
