### PR TITLE
fix: preserve value-less const declarations when formatting

### DIFF
--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -463,11 +463,13 @@ impl<'a> Formatter<'a> {
             None => Document::Sequence(vec![]),
         };
 
-        Document::str("const ")
-            .append(name)
-            .append(type_doc)
-            .append(" = ")
-            .append(self.expression(value))
+        let declaration = Document::str("const ").append(name).append(type_doc);
+
+        if matches!(value, Expression::NoOp) {
+            declaration
+        } else {
+            declaration.append(" = ").append(self.expression(value))
+        }
     }
 
     pub(super) fn binding(&mut self, binding: &'a Binding) -> Document<'a> {

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -268,6 +268,11 @@ fn const_public() {
 }
 
 #[test]
+fn const_declaration_without_value() {
+    assert_format_snapshot!("pub const NoError: Unknown");
+}
+
+#[test]
 fn var_simple() {
     assert_format_snapshot!("var ErrNotFound: error");
 }

--- a/tests/spec/format/snapshots/const_declaration_without_value.snap
+++ b/tests/spec/format/snapshots/const_declaration_without_value.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "pub const NoError: Unknown"
+---
+pub const NoError: Unknown


### PR DESCRIPTION
`lis format` no longer corrupts `const` declarations that have no initializer. 

Formatting e.g. `pub const NoError: Unknown` was rewriting it to a dngling `pub const NoError: Unknown = ` which then failed to parse. This surfaced in the context of bidngen because generated typedefs declare opaque consts (e.g. values whose type lives in an internal Go package) without a value.

```rs
pub const NoError: Unknown
```

This now round-trips through `lis format` unchanged, instead of becoming unparseable.

Fix #813
