### PR TITLE
fix: resolve go subpackage import after cache clear

### DIFF
--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -272,7 +272,10 @@ impl<'a> GoWorkspace<'a> {
         module: GoModule,
         package: &str,
     ) -> Result<Vec<String>, String> {
-        self.go_get(module)?;
+        self.go_get(GoModule {
+            path: package,
+            version: module.version,
+        })?;
 
         let manifest = self.run_bindgen_batch(&[package.to_string()])?;
         let outcome = self.apply_batch_manifest(&manifest, module);


### PR DESCRIPTION
Importing a Go subpackage now works when the module root is not itself an importable package, e.g. a rootless module or a `package main` root.

```rs
import "go:github.com/bedrock-gophers/inv/forminv"
```

Fix #818
