### PR TITLE
feat: add `--failed` flag to `lis test`

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -34,6 +34,7 @@ pub enum Command {
         path: Option<String>,
         go_flags: Vec<String>,
         filter: Option<String>,
+        failed: bool,
     },
     Overview,
     Help {
@@ -314,6 +315,7 @@ impl Command {
                 let mut path = None;
                 let mut go_flags = Vec::new();
                 let mut filter = None;
+                let mut failed = false;
 
                 while let Some(arg) = arguments.next() {
                     if arg == "-f" || arg == "--filter" {
@@ -328,6 +330,8 @@ impl Command {
                         filter = Some(value.to_string());
                     } else if let Some(value) = arg.strip_prefix("-f=") {
                         filter = Some(value.to_string());
+                    } else if arg == "--failed" {
+                        failed = true;
                     } else if arg.starts_with('-') {
                         if !try_parse_go_flags(&arg, &mut arguments, &mut go_flags, "test")? {
                             return Err(ParseError::UnknownFlag(arg));
@@ -373,10 +377,20 @@ impl Command {
                     });
                 }
 
+                if failed && filter.is_some() {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: "`--failed` and `--filter` cannot be combined".to_string(),
+                        reason: "`--failed` reruns the previous run's failures, a fixed set"
+                            .to_string(),
+                        hint: "Use one or the other".to_string(),
+                    });
+                }
+
                 Ok(Command::Test {
                     path,
                     go_flags,
                     filter,
+                    failed,
                 })
             }
 
@@ -517,6 +531,20 @@ mod tests {
 
     fn parse(parts: &[&str]) -> Result<Command, ParseError> {
         Command::parse(parts.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn test_failed_flag_parses() {
+        let Ok(Command::Test { failed, filter, .. }) = parse(&["lis", "test", "--failed"]) else {
+            panic!("expected Test command");
+        };
+        assert!(failed);
+        assert!(filter.is_none());
+    }
+
+    #[test]
+    fn test_failed_and_filter_conflict() {
+        assert!(parse(&["lis", "test", "--failed", "-f", "parse"]).is_err());
     }
 
     #[test]

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -56,7 +56,7 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         test)
-            COMPREPLY=( $(compgen -W "--filter --go-flags" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--filter --failed --go-flags" -- "$cur") )
             return 0
             ;;
         format)
@@ -139,6 +139,7 @@ _lis() {
                 test)
                     _arguments \
                         '--filter[Run only tests whose name contains the pattern]:pattern' \
+                        '--failed[Rerun the tests that failed last time]' \
                         '--go-flags[Flags passed through to go test]:flags'
                     ;;
                 format)
@@ -194,6 +195,7 @@ complete -c lis -n '__fish_seen_subcommand_from emit' -l sourcemap -d 'Include l
 complete -c lis -n '__fish_seen_subcommand_from run' -l sourcemap -d 'Include line directives for stack traces'
 complete -c lis -n '__fish_seen_subcommand_from run' -l go-flags -r -d 'Flags passed through to go build'
 complete -c lis -n '__fish_seen_subcommand_from test' -s f -l filter -r -d 'Run only tests whose name contains the pattern'
+complete -c lis -n '__fish_seen_subcommand_from test' -l failed -d 'Rerun the tests that failed last time'
 complete -c lis -n '__fish_seen_subcommand_from test' -l go-flags -r -d 'Flags passed through to go test'
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -170,6 +170,7 @@ Arguments:
 
 Flags:
     {-f:b}, {--filter:b} {<pattern>:g}             Run only tests whose name contains pattern
+    {--failed:b}                           Rerun the tests that failed last time
     {--go-flags:b} {\"<flags>\":g}               Pass flags through to `go test`
 
 Examples:

--- a/crates/cli/src/handlers/test/failed.rs
+++ b/crates/cli/src/handlers/test/failed.rs
@@ -1,0 +1,93 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::report::{TestRow, failed_keys};
+
+#[derive(Serialize, Deserialize, Default)]
+struct LastFailures {
+    failures: Vec<FailedTest>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct FailedTest {
+    package: String,
+    test: String,
+}
+
+fn last_failures_path(target_dir: &Path) -> PathBuf {
+    target_dir.join(".lisette").join("last-failures.json")
+}
+
+pub fn save(target_dir: &Path, rows: &[TestRow]) {
+    let failures = failed_keys(rows)
+        .into_iter()
+        .map(|(package, test)| FailedTest { package, test })
+        .collect();
+    let path = last_failures_path(target_dir);
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(json) = serde_json::to_string(&LastFailures { failures }) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+pub fn load(target_dir: &Path) -> HashSet<(String, String)> {
+    let Ok(json) = std::fs::read_to_string(last_failures_path(target_dir)) else {
+        return HashSet::new();
+    };
+    serde_json::from_str::<LastFailures>(&json)
+        .map(|state| {
+            state
+                .failures
+                .into_iter()
+                .map(|f| (f.package, f.test))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::report::Status;
+    use super::*;
+    use syntax::ast::Span;
+
+    fn row(package: &str, go_name: &str, status: Status) -> TestRow {
+        TestRow {
+            package: package.into(),
+            go_name: go_name.into(),
+            name: go_name.into(),
+            description: None,
+            status,
+            elapsed: None,
+            output: String::new(),
+            failure: None,
+            skip_reason: None,
+            children: vec![],
+            span: Span::new(0, 0, 0),
+        }
+    }
+
+    #[test]
+    fn save_then_load_keeps_only_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        let rows = vec![
+            row("pkg", "TestA", Status::Passed),
+            row("pkg", "TestB", Status::Failed),
+        ];
+        save(dir.path(), &rows);
+
+        let loaded = load(dir.path());
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded.contains(&("pkg".to_string(), "TestB".to_string())));
+    }
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load(dir.path()).is_empty());
+    }
+}

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashSet};
 use std::time::Duration;
 
 use crate::cli_error;
@@ -6,12 +7,16 @@ use crate::output::use_color;
 
 use super::build::{BuildOptions, build_locked, with_locked_project};
 
-use std::collections::BTreeMap;
-
+mod failed;
 mod report;
-use report::{build_report_filtered, exit_code, matching_tests, render};
+use report::{all_test_keys, build_report_filtered, exit_code, matching_tests, render};
 
-pub fn test(path: Option<String>, go_flags: Vec<String>, filter: Option<String>) -> i32 {
+pub fn test(
+    path: Option<String>,
+    go_flags: Vec<String>,
+    filter: Option<String>,
+    failed: bool,
+) -> i32 {
     crate::output::print_preview_notice("Test runner", false);
     with_locked_project(path, |prep| {
         let outcome = build_locked(
@@ -27,27 +32,54 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, filter: Option<String>)
             return outcome.code;
         }
 
-        let scopes = match filter.as_deref() {
-            Some(pattern) => {
-                let matched =
-                    matching_tests(&outcome.test_index, &prep.manifest.project.name, pattern);
-                if matched.is_empty() {
-                    eprintln!("\n  No tests match `{pattern}`\n");
-                    return 0;
-                }
-                let mut by_package: BTreeMap<String, Vec<String>> = BTreeMap::new();
-                for (package, go_name) in matched {
-                    by_package.entry(package).or_default().push(go_name);
-                }
-                Some(
-                    by_package
-                        .into_iter()
-                        .map(|(package, names)| (package, format!("^({})$", names.join("|"))))
-                        .collect::<Vec<_>>(),
-                )
+        let go_module = &prep.manifest.project.name;
+
+        let selected: Option<HashSet<(String, String)>> = if failed {
+            let live = all_test_keys(&outcome.test_index, go_module);
+            let set: HashSet<(String, String)> = failed::load(&prep.target_dir)
+                .into_iter()
+                .filter(|key| live.contains(key))
+                .collect();
+            if set.is_empty() {
+                let message = crate::output::format_backticks(
+                    "No failures to rerun. Run `lis test` first.",
+                    use_color(),
+                );
+                eprintln!("\n  {message}\n");
+                return 0;
             }
-            None => None,
+            Some(set)
+        } else if let Some(pattern) = filter.as_deref() {
+            let matched = matching_tests(&outcome.test_index, go_module, pattern);
+            if matched.is_empty() {
+                let message = crate::output::format_backticks(
+                    &format!("No tests match `{pattern}`"),
+                    use_color(),
+                );
+                eprintln!("\n  {message}\n");
+                return 0;
+            }
+            Some(matched.into_iter().collect())
+        } else {
+            None
         };
+
+        let scopes = selected.as_ref().map(|set| {
+            let mut by_package: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            for (package, go_name) in set {
+                by_package
+                    .entry(package.clone())
+                    .or_default()
+                    .push(go_name.clone());
+            }
+            by_package
+                .into_iter()
+                .map(|(package, mut names)| {
+                    names.sort();
+                    (package, format!("^({})$", names.join("|")))
+                })
+                .collect::<Vec<_>>()
+        });
 
         let build_dir = match prep.target_dir.canonicalize() {
             Ok(p) => p,
@@ -77,8 +109,8 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, filter: Option<String>)
         let report = build_report_filtered(
             &outcome.test_index,
             &run.events,
-            &prep.manifest.project.name,
-            filter.as_deref(),
+            go_module,
+            selected.as_ref(),
         );
         eprint!(
             "{}",
@@ -97,6 +129,8 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, filter: Option<String>)
                 build_error.to_string(),
                 "The generated Go failed to build; run `lis check`"
             );
+        } else if filter.is_none() {
+            failed::save(&prep.target_dir, &report.rows);
         }
 
         exit_code(&report.rows, run.success)

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -66,6 +66,7 @@ pub struct FailureRecord {
 
 pub struct TestRow {
     pub package: String,
+    pub go_name: String,
     pub name: String,
     pub description: Option<String>,
     pub status: Status,
@@ -114,6 +115,26 @@ pub fn matching_tests(index: &TestIndex, go_module: &str, filter: &str) -> Vec<(
         .collect()
 }
 
+pub fn all_test_keys(index: &TestIndex, go_module: &str) -> HashSet<(String, String)> {
+    index
+        .tests()
+        .iter()
+        .map(|test| {
+            let prefix = format!("{}.", test.module_id);
+            let fn_name = test
+                .qualified_name
+                .strip_prefix(&prefix)
+                .unwrap_or(&test.qualified_name);
+            let package = if test.module_id == ENTRY_MODULE_ID {
+                go_module.to_string()
+            } else {
+                format!("{}/{}", go_module, test.module_id)
+            };
+            (package, go_test_name(fn_name))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 pub fn build_report(index: &TestIndex, events: &[GoTestEvent], go_module: &str) -> Report {
     build_report_filtered(index, events, go_module, None)
@@ -123,7 +144,7 @@ pub fn build_report_filtered(
     index: &TestIndex,
     events: &[GoTestEvent],
     go_module: &str,
-    filter: Option<&str>,
+    selected: Option<&HashSet<(String, String)>>,
 ) -> Report {
     let mut terminal: HashMap<(String, String), (Status, Option<f64>)> = HashMap::new();
     let mut started: HashSet<(String, String)> = HashSet::new();
@@ -229,11 +250,6 @@ pub fn build_report_filtered(
             .qualified_name
             .strip_prefix(&prefix)
             .unwrap_or(&test.qualified_name);
-        if let Some(pattern) = filter
-            && !name_or_title_contains(fn_name, test.title.as_deref(), pattern)
-        {
-            continue;
-        }
         let package = if test.module_id == ENTRY_MODULE_ID {
             go_module.to_string()
         } else {
@@ -241,6 +257,11 @@ pub fn build_report_filtered(
         };
         let go_name = go_test_name(fn_name);
         let key = (package.clone(), go_name.clone());
+        if let Some(set) = selected
+            && !set.contains(&key)
+        {
+            continue;
+        }
         let (status, elapsed) = match tables.terminal.get(&key).copied() {
             Some(found) => found,
             None if tables.started.contains(&key) => (Status::Aborted, None),
@@ -249,6 +270,7 @@ pub fn build_report_filtered(
         let children = collect_children(&package, &go_name, &tables);
         rows.push(TestRow {
             package,
+            go_name: go_name.clone(),
             name: test.title.clone().unwrap_or_else(|| fn_name.to_string()),
             description: test.doc.clone(),
             status,
@@ -339,6 +361,7 @@ fn collect_children(package: &str, parent: &str, tables: &EventTables) -> Vec<Te
             };
             TestRow {
                 package: package.to_string(),
+                go_name: full.clone(),
                 name: segment.to_string(),
                 description: None,
                 status,
@@ -790,6 +813,13 @@ pub fn exit_code(rows: &[TestRow], run_success: bool) -> i32 {
         .iter()
         .any(|r| matches!(r.status, Status::Failed | Status::Aborted));
     if !run_success || any_failure { 1 } else { 0 }
+}
+
+pub fn failed_keys(rows: &[TestRow]) -> Vec<(String, String)> {
+    rows.iter()
+        .filter(|r| matches!(r.status, Status::Failed | Status::Aborted))
+        .map(|r| (r.package.clone(), r.go_name.clone()))
+        .collect()
 }
 
 fn mark(status: Status, color: bool) -> String {
@@ -1376,14 +1406,29 @@ mod tests {
     }
 
     #[test]
-    fn filter_keeps_only_matching_rows_by_name_or_title() {
-        let by_title = build_report_filtered(&titled_index(), &[], "demo", Some("and trims"));
-        assert_eq!(by_title.rows.len(), 1);
-        assert_eq!(by_title.rows[0].name, "splits and trims CSV fields");
+    fn selected_set_keeps_only_those_rows() {
+        let only_splits: HashSet<(String, String)> =
+            [("demo/csv".to_string(), "TestSplitsCsv".to_string())]
+                .into_iter()
+                .collect();
+        let report = build_report_filtered(&titled_index(), &[], "demo", Some(&only_splits));
+        assert_eq!(report.rows.len(), 1);
+        assert_eq!(report.rows[0].name, "splits and trims CSV fields");
+        assert_eq!(report.rows[0].go_name, "TestSplitsCsv");
+    }
 
-        let by_name = build_report_filtered(&titled_index(), &[], "demo", Some("parses"));
-        assert_eq!(by_name.rows.len(), 1);
-        assert_eq!(by_name.rows[0].name, "parses_number");
+    #[test]
+    fn failed_keys_collects_failed_top_level_tests() {
+        let index = index(&[(ENTRY_MODULE_ID, "good"), (ENTRY_MODULE_ID, "bad")]);
+        let events = vec![
+            event("pass", "demo", Some("TestGood"), None),
+            event("fail", "demo", Some("TestBad"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        assert_eq!(
+            failed_keys(&report.rows),
+            vec![("demo".to_string(), "TestBad".to_string())]
+        );
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -81,7 +81,8 @@ fn main() {
             path,
             go_flags,
             filter,
-        } => handlers::test(path, go_flags, filter),
+            failed,
+        } => handlers::test(path, go_flags, filter, failed),
         Command::Overview => {
             handlers::help::print_main_help();
             0


### PR DESCRIPTION
Adds a `--failed` flag to `lis test`, which reruns only the tests that failed in the previous run, instead of the whole suite. The typical fix-and-recheck loop is `lis test --failed` until it reports nothing left to rerun.
