### PR TITLE
perf: parallelize cached module loading

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -182,6 +182,7 @@ pub fn compile(
 mod tests {
     use super::*;
     use crate::fs::LocalFileSystem;
+    use semantics::inference::PARALLEL_THRESHOLD;
     use std::fs as stdfs;
     use tempfile::tempdir;
 
@@ -260,6 +261,110 @@ mod tests {
         assert!(
             !root.join("target/cache/leaky.cache").exists(),
             "leaky has warnings; cache must not write it"
+        );
+    }
+
+    fn analyze_cache_state(
+        project_dir: &std::path::Path,
+    ) -> (Vec<String>, Vec<(bool, Option<String>)>) {
+        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let src_main = project_dir.join("src").join("main.lis");
+        let source = stdfs::read_to_string(&src_main).unwrap();
+        let working_dir = src_main
+            .parent()
+            .and_then(|p| p.to_str())
+            .expect("temp project path is valid utf-8");
+        let fs_loader = LocalFileSystem::new(working_dir);
+        let build_result = syntax::build_ast(&source, ENTRY_FILE_ID);
+        let result = analyze(AnalyzeInput {
+            config: SemanticConfig {
+                run_lints: true,
+                standalone_mode: false,
+                load_siblings: true,
+            },
+            loader: &fs_loader,
+            source,
+            filename: "main.lis".to_string(),
+            display_path: "src/main.lis".to_string(),
+            ast: build_result.ast,
+            project_root: Some(project_dir.to_path_buf()),
+            compile_phase: CompilePhase::Check,
+            emit_tests: false,
+            locator,
+            go_module: "test".to_string(),
+            disable_cache: false,
+        })
+        .result;
+
+        let mut cached: Vec<String> = result.cached_modules.iter().cloned().collect();
+        cached.sort();
+        let mut diags: Vec<(bool, Option<String>)> = result
+            .errors
+            .iter()
+            .chain(result.lints.iter())
+            .map(|d| (d.is_error(), d.code_str().map(|s| s.to_string())))
+            .collect();
+        diags.sort();
+        (cached, diags)
+    }
+
+    #[test]
+    fn warm_build_parallel_cache_load_matches_cold() {
+        const N: usize = PARALLEL_THRESHOLD + 1;
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        stdfs::write(
+            root.join("lisette.toml"),
+            "[project]\nname = \"github.com/test/parcache\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let mut main = String::new();
+        for i in 0..N {
+            stdfs::create_dir_all(root.join("src").join(format!("m{i}"))).unwrap();
+            stdfs::write(
+                root.join("src")
+                    .join(format!("m{i}"))
+                    .join(format!("m{i}.lis")),
+                format!("pub fn val() -> int {{ {i} }}\n"),
+            )
+            .unwrap();
+            main.push_str(&format!("import \"m{i}\"\n"));
+        }
+        let sum = (0..N)
+            .map(|i| format!("m{i}.val()"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        main.push_str(&format!("\nfn main() {{\n  let _ = {sum}\n}}\n"));
+        stdfs::write(root.join("src").join("main.lis"), main).unwrap();
+
+        let mut expected: Vec<String> = (0..N).map(|i| format!("m{i}")).collect();
+        expected.sort();
+
+        let (cold_cached, cold_diags) = analyze_cache_state(root);
+        assert!(
+            cold_cached.is_empty(),
+            "cold run must load nothing from cache; got: {cold_cached:?}"
+        );
+        assert!(
+            cold_diags.is_empty(),
+            "fixture must be clean; got: {cold_diags:?}"
+        );
+        for i in 0..N {
+            assert!(
+                root.join(format!("target/cache/m{i}.cache")).exists(),
+                "m{i} must be cached after the cold run"
+            );
+        }
+
+        let (warm_cached, warm_diags) = analyze_cache_state(root);
+        assert_eq!(
+            warm_cached, expected,
+            "warm run must serve every module from cache via the parallel path"
+        );
+        assert_eq!(
+            warm_diags, cold_diags,
+            "warm cross-module resolution must match cold"
         );
     }
 

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
-use syntax::program::File;
+use syntax::program::{File, Module};
 
 use crate::store::{ENTRY_MODULE_ID, Store};
 use types::CachedDefinition;
@@ -356,42 +356,55 @@ fn extract_public_definitions(
         .collect()
 }
 
-/// Register a cached module in the store.
-/// `display_path` for each cached file is recomputed from the project layout
-/// against the current cwd, so warm and cold builds render the same diagnostic
-/// paths even though the cache stores only bare names.
-pub fn register_cached_module(
-    store: &mut Store,
-    module_id: &str,
+pub(crate) struct CachedModuleBuild {
+    pub module_id: String,
+    pub module: Module,
+    /// `(file_id, module_id)` pairs for the store's file -> module index.
+    pub file_map: Vec<(u32, String)>,
+    pub ufcs_methods: Vec<(String, String)>,
+}
+
+pub(crate) fn build_cached_module(
+    module_id: String,
+    file_id_base: u32,
     cached: ModuleInterface,
     project_root: &Path,
-) {
-    store.add_module(module_id);
+) -> CachedModuleBuild {
+    let mut module = Module::new(&module_id);
+    let mut file_ids: Vec<u32> = Vec::with_capacity(cached.files.len());
+    let mut file_map: Vec<(u32, String)> = Vec::with_capacity(cached.files.len());
 
-    let mut file_ids: Vec<u32> = vec![];
-    for cached_file in &cached.files {
-        let file_id = store.new_file_id();
+    for (index, cached_file) in cached.files.iter().enumerate() {
+        let file_id = file_id_base + index as u32;
         file_ids.push(file_id);
+        file_map.push((file_id, module_id.clone()));
 
-        let display_path = cached_file_display_path(project_root, module_id, &cached_file.name);
+        let display_path = cached_file_display_path(project_root, &module_id, &cached_file.name);
         let file = File::new_cached(
-            module_id,
+            &module_id,
             &cached_file.name,
             &display_path,
             &cached_file.source,
             file_id,
         );
-
-        store.store_file(module_id, file);
+        if file.is_d_lis() {
+            module.typedefs.insert(file_id, file);
+        } else {
+            module.files.insert(file_id, file);
+        }
     }
 
-    let module = store.get_module_mut(module_id).unwrap();
     for (qualified_name, cached_definition) in cached.definitions {
         let definition = cached_definition.to_definition(&file_ids);
         module.definitions.insert(qualified_name.into(), definition);
     }
 
-    store.mark_visited(module_id);
+    CachedModuleBuild {
+        module_id,
+        module,
+        file_map,
+        ufcs_methods: cached.ufcs_methods,
+    }
 }
 
 fn cached_file_display_path(project_root: &Path, module_id: &str, bare_name: &str) -> String {

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use diagnostics::LocalSink;
@@ -11,10 +11,10 @@ use syntax::program::{File, Module};
 use deps::TypedefLocator;
 
 use crate::cache::{
-    CompiledModule, compute_emit_artifact_hash, compute_module_hash, get_dependency_module_hashes,
+    CachedModuleBuild, CompiledModule, ModuleInterface, build_cached_module,
+    compute_emit_artifact_hash, compute_module_hash, get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
-    hash_module_sources, is_cache_disabled, prelude as prelude_cache, register_cached_module,
-    try_load_cache,
+    hash_module_sources, is_cache_disabled, prelude as prelude_cache, try_load_cache,
 };
 use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
@@ -61,8 +61,24 @@ pub struct AnalyzeInput<'a> {
     pub disable_cache: bool,
 }
 
-// Tiny projects stay serial to avoid rayon overhead.
-const PARALLEL_THRESHOLD: usize = 4;
+pub const PARALLEL_THRESHOLD: usize = 4;
+
+struct CacheCandidate {
+    module_id: String,
+    topo_rank: usize,
+    files: Vec<File>,
+    full_hash: u64,
+    dep_hashes: HashMap<String, u64>,
+    expected_artifact_hash: Option<u64>,
+    module_hash: u64,
+    production_hash: u64,
+}
+
+struct CacheBuildJob {
+    module_id: String,
+    interface: ModuleInterface,
+    file_id_base: u32,
+}
 
 pub struct InferenceOutput {
     pub store: Store,
@@ -193,9 +209,10 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         let mut go_cache: Option<Option<go_stdlib::GoStdlibCache>> =
             if cache_disabled { Some(None) } else { None };
 
-        let mut to_infer: Vec<String> = Vec::new();
+        let mut to_infer: Vec<(usize, String)> = Vec::new();
+        let mut candidates: Vec<CacheCandidate> = Vec::new();
 
-        for module_id in order {
+        for (topo_rank, module_id) in order.into_iter().enumerate() {
             if module_id.starts_with("go:") {
                 if graph_result.link_only_modules.contains(&module_id) {
                     continue;
@@ -232,29 +249,21 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             let expected_artifact_hash = check_go_files
                 .then(|| compute_emit_artifact_hash(production_hash, &input.go_module));
 
-            if cache_enabled
-                && !is_entry
-                && let Some(ref project_root) = input.project_root
-                && let Some(cached) = try_load_cache(
-                    &module_id,
+            if cache_enabled && !is_entry {
+                candidates.push(CacheCandidate {
+                    module_id,
+                    topo_rank,
+                    files,
                     full_hash,
-                    &dep_hashes,
+                    dep_hashes,
                     expected_artifact_hash,
-                    project_root,
-                    check_go_files,
-                )
-            {
-                checker
-                    .ufcs_methods
-                    .extend(cached.ufcs_methods.iter().cloned());
-                register_cached_module(&mut store, &module_id, cached, project_root);
-                checker.collect_cached_module_tests(&store, &module_id);
-                cached_modules.insert(module_id.clone());
+                    module_hash,
+                    production_hash,
+                });
                 continue;
             }
 
             store.store_module(&module_id, files);
-
             if !is_entry {
                 compiled_modules.push(CompiledModule {
                     module_id: module_id.clone(),
@@ -264,9 +273,22 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
                     dep_hashes,
                 });
             }
-
-            to_infer.push(module_id);
+            to_infer.push((topo_rank, module_id));
         }
+
+        let cache_load = load_cache_candidates(
+            &mut checker,
+            &mut store,
+            candidates,
+            input.project_root.as_deref(),
+            check_go_files,
+        );
+        compiled_modules.extend(cache_load.compiled);
+        cached_modules.extend(cache_load.cached);
+        to_infer.extend(cache_load.to_infer);
+
+        to_infer.sort_by_key(|(topo_rank, _)| *topo_rank);
+        let to_infer: Vec<String> = to_infer.into_iter().map(|(_, id)| id).collect();
 
         let test_ids: Vec<u32> = to_infer
             .iter()
@@ -376,6 +398,85 @@ fn register_go_module(
             );
         }
     }
+}
+
+#[derive(Default)]
+struct CacheLoad {
+    compiled: Vec<CompiledModule>,
+    cached: Vec<String>,
+    to_infer: Vec<(usize, String)>,
+}
+
+/// Merges cache hits into the store and returns the misses to register.
+fn load_cache_candidates(
+    checker: &mut TaskState,
+    store: &mut Store,
+    candidates: Vec<CacheCandidate>,
+    project_root: Option<&Path>,
+    check_go_files: bool,
+) -> CacheLoad {
+    let load = |c: &CacheCandidate| {
+        project_root.and_then(|root| {
+            try_load_cache(
+                &c.module_id,
+                c.full_hash,
+                &c.dep_hashes,
+                c.expected_artifact_hash,
+                root,
+                check_go_files,
+            )
+        })
+    };
+    let loaded: Vec<Option<ModuleInterface>> = if candidates.len() < PARALLEL_THRESHOLD {
+        candidates.iter().map(load).collect()
+    } else {
+        candidates.par_iter().map(load).collect()
+    };
+
+    let mut result = CacheLoad::default();
+    let mut build_jobs: Vec<CacheBuildJob> = Vec::new();
+    for (candidate, interface) in candidates.into_iter().zip(loaded) {
+        let Some(interface) = interface else {
+            let module_id = candidate.module_id;
+            store.store_module(&module_id, candidate.files);
+            result.compiled.push(CompiledModule {
+                module_id: module_id.clone(),
+                module_hash: candidate.module_hash,
+                production_hash: candidate.production_hash,
+                full_hash: candidate.full_hash,
+                dep_hashes: candidate.dep_hashes,
+            });
+            result.to_infer.push((candidate.topo_rank, module_id));
+            continue;
+        };
+        let file_id_base = store.reserve_file_ids(interface.files.len() as u32);
+        build_jobs.push(CacheBuildJob {
+            module_id: candidate.module_id,
+            interface,
+            file_id_base,
+        });
+    }
+
+    let Some(root) = project_root else {
+        return result;
+    };
+    let build = |job: CacheBuildJob| {
+        build_cached_module(job.module_id, job.file_id_base, job.interface, root)
+    };
+    let built: Vec<CachedModuleBuild> = if build_jobs.len() < PARALLEL_THRESHOLD {
+        build_jobs.into_iter().map(build).collect()
+    } else {
+        build_jobs.into_par_iter().map(build).collect()
+    };
+    for build in built {
+        checker.ufcs_methods.extend(build.ufcs_methods);
+        let module_id = build.module_id;
+        store.insert_prebuilt_module(module_id.clone(), build.module, build.file_map);
+        checker.collect_cached_module_tests(store, &module_id);
+        result.cached.push(module_id);
+    }
+
+    result
 }
 
 fn register_modules(

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -163,6 +163,10 @@ impl Store {
         self.next_file_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    pub fn reserve_file_ids(&self, count: u32) -> u32 {
+        self.next_file_id.fetch_add(count, Ordering::Relaxed)
+    }
+
     pub fn register_file(&mut self, file_id: u32, module_id: &str) {
         self.files.insert(file_id, module_id.to_string());
     }
@@ -259,6 +263,21 @@ impl Store {
 
     pub fn get_module_mut(&mut self, module_id: &str) -> Option<&mut Module> {
         self.modules.get_mut(module_id).map(Arc::make_mut)
+    }
+
+    /// Inserts a worker-built module (e.g. cache-decoded) and indexes its files.
+    pub(crate) fn insert_prebuilt_module(
+        &mut self,
+        module_id: String,
+        module: Module,
+        file_map: Vec<(u32, String)>,
+    ) {
+        for (file_id, owner) in file_map {
+            self.files.insert(file_id, owner);
+        }
+        self.module_ids.push(module_id.clone());
+        self.modules.insert(module_id.clone(), Arc::new(module));
+        self.visited_modules.insert(module_id);
     }
 
     /// `Arc`-bump snapshot for a registration worker, which inserts its own


### PR DESCRIPTION
After an edit, re-running `lis check` or `lis build` reuses cached results for the modules the user did not change. That reuse used to happen serially, now it parallelizes across CPU cores, making the wall-clock time for warm runs ~10% to ~17% shorter on 60 to 200 module projects, respectively.
