### PR TITLE
fix: render subtest panics with a source frame

### DIFF
--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -103,14 +103,28 @@ impl Planner<'_> {
             self.push_test_handle(name);
         }
 
+        let recover = handle.as_ref().map(|name| {
+            fx.require_testkit();
+            let span = body.get_span();
+            format!(
+                "defer {name}.Recover({}, {}, {})\n",
+                span.file_id,
+                span.byte_offset,
+                span.byte_offset + span.byte_length,
+            )
+        });
+
         let return_info = self.lambda_return_info(ty, ctx, fx);
-        let body_string = self.emit_lambda_body_with_deferred(
+        let mut body_string = self.emit_lambda_body_with_deferred(
             body,
             &destructure_bindings,
             &return_info.ctx,
             return_info.has_return,
             fx,
         );
+        if let Some(recover) = recover {
+            body_string.insert_str(0, &recover);
+        }
 
         if handle.is_some() {
             self.pop_test_handle();

--- a/prelude/testkit/testkit.go
+++ b/prelude/testkit/testkit.go
@@ -46,6 +46,14 @@ func Recover(t *testing.T, file int, lo, hi uint32) {
 	}
 }
 
+// Recover is the subtest analogue of the package-level Recover, deferred on a
+// `t.run` handle. recover() must stay in this method to catch the subtest's panic.
+func (c TestContext) Recover(file int, lo, hi uint32) {
+	if r := recover(); r != nil {
+		Fail(c.t, file, lo, hi, "panic", fmt.Sprintf("panic: %v", r))
+	}
+}
+
 // FailAssert reports an `assert` failure over the same channel as Fail.
 func (c TestContext) FailAssert(file int, lo, hi uint32, kind, message string, operands ...Operand) {
 	Fail(c.t, file, lo, hi, kind, message, operands...)

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7863,6 +7863,74 @@ fn assert_in_discarded_subtest_targets_subtest_handle() {
 }
 
 #[test]
+fn subtest_closure_defers_recover_on_its_handle() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn grouped(t) {\n  let _ = t.run(\"inner\", |s| { s.parallel() })\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        go.contains("defer s.Recover("),
+        "a subtest closure must defer Recover on its own handle so an escaping panic renders a spanned frame, got:\n{go}"
+    );
+}
+
+#[test]
+fn discarded_subtest_handle_is_named_so_recover_can_target_it() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "#[test]\nfn grouped(t) {\n  let _ = t.run(\"inner\", |_| { panic(\"boom\") })\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        !go.contains("func(_ testkit.TestContext)"),
+        "a discarded subtest handle must be named so the deferred Recover has a receiver, got:\n{go}"
+    );
+    assert!(
+        go.contains("defer lisetteSub_") && go.contains(".Recover("),
+        "a subtest that only panics must still defer Recover on its synthesized handle, got:\n{go}"
+    );
+}
+
+#[test]
 fn let_assert_lowers_to_failure_on_mismatch() {
     let mut fs = MockFileSystem::new();
     fs.add_file(


### PR DESCRIPTION
A panic inside a `t.run(...)` subtest now renders a source frame with the decoded panic message, the same failure a panic in a top-level `#[test]` produces. Before this a subtest panic was falling bck to the raw `go test` transcript.

```rs
#[test]
fn grouped(t) {
  t.run("inner_fails", |_s| { panic("nested boom") })
}
```

`lis test` now reports:

```
  ✕ grouped › inner_fails · panic: nested boom
        ╭─[src/demo.test.lis:8:29]
      8 │   t.run("inner_fails", |_s| { panic("nested boom") })
        ·                             ────────────┬───────────
        ·                                         ╰── panic: nested boom
        ╰────
```
