### PR TITLE
perf: stop cloning emit generic constraints per module

### DIFF
--- a/crates/emit/src/analyze/constraint_collector.rs
+++ b/crates/emit/src/analyze/constraint_collector.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::Planner;
@@ -18,9 +20,9 @@ impl Planner<'_> {
                 collect_demands_from_type(ty, key, names, &mut t);
             });
             self.propagate_constraints(&mut t);
-            t
+            Arc::new(t)
         });
-        let mut table = base.clone();
+        let mut table = GenericConstraintTable::with_base(base.clone());
 
         self.seed_local_functions(files, &mut table);
         self.seed_local_impl_blocks(files, &mut table);

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -31,7 +31,7 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) options: EmitOptions,
     pub(crate) line_indexes: Arc<HashMap<u32, LineIndex>>,
     pub(crate) globals: Arc<GlobalEmitData>,
-    pub(crate) generic_base: Arc<OnceLock<GenericConstraintTable>>,
+    pub(crate) generic_base: Arc<OnceLock<Arc<GenericConstraintTable>>>,
     pub(crate) current_module: ModuleId,
 }
 
@@ -50,7 +50,7 @@ pub(crate) struct EmitFacts<'a> {
     options: EmitOptions,
     line_indexes: Arc<HashMap<u32, LineIndex>>,
     globals: Arc<GlobalEmitData>,
-    generic_base: Arc<OnceLock<GenericConstraintTable>>,
+    generic_base: Arc<OnceLock<Arc<GenericConstraintTable>>>,
     current_module: ModuleId,
 }
 
@@ -76,7 +76,7 @@ impl<'a> EmitFacts<'a> {
         }
     }
 
-    pub(crate) fn generic_base(&self) -> Arc<OnceLock<GenericConstraintTable>> {
+    pub(crate) fn generic_base(&self) -> Arc<OnceLock<Arc<GenericConstraintTable>>> {
         self.generic_base.clone()
     }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -545,7 +545,7 @@ struct SharedEmitContext {
     options: EmitOptions,
     line_indexes: Arc<HashMap<u32, LineIndex>>,
     globals: Arc<GlobalEmitData>,
-    generic_base: Arc<OnceLock<GenericConstraintTable>>,
+    generic_base: Arc<OnceLock<Arc<GenericConstraintTable>>>,
 }
 
 fn emit_module<'a>(

--- a/crates/emit/src/names/constraints.rs
+++ b/crates/emit/src/names/constraints.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap as HashMap;
 
 use syntax::EcoString;
@@ -57,12 +59,32 @@ impl ParamConstraintSet {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct GenericConstraintTable {
     by_symbol: HashMap<String, Vec<ParamConstraintSet>>,
+    base: Option<Arc<GenericConstraintTable>>,
 }
 
 impl GenericConstraintTable {
+    pub(crate) fn with_base(base: Arc<GenericConstraintTable>) -> Self {
+        Self {
+            by_symbol: HashMap::default(),
+            base: Some(base),
+        }
+    }
+
+    fn entry_mut(&mut self, symbol: &str) -> Option<&mut Vec<ParamConstraintSet>> {
+        if !self.by_symbol.contains_key(symbol) {
+            let from_base = self
+                .base
+                .as_deref()
+                .and_then(|b| b.get(symbol))
+                .map(<[ParamConstraintSet]>::to_vec)?;
+            self.by_symbol.insert(symbol.to_string(), from_base);
+        }
+        self.by_symbol.get_mut(symbol)
+    }
+
     /// Idempotent.
     pub(crate) fn ensure_seeded(&mut self, symbol: &str, generics: &[Generic]) {
-        if self.by_symbol.contains_key(symbol) {
+        if self.get(symbol).is_some() {
             return;
         }
         let mut sets = Vec::with_capacity(generics.len());
@@ -80,11 +102,14 @@ impl GenericConstraintTable {
     }
 
     pub(crate) fn get(&self, symbol: &str) -> Option<&[ParamConstraintSet]> {
-        self.by_symbol.get(symbol).map(Vec::as_slice)
+        self.by_symbol
+            .get(symbol)
+            .map(Vec::as_slice)
+            .or_else(|| self.base.as_deref().and_then(|b| b.get(symbol)))
     }
 
     pub(crate) fn add_explicit(&mut self, symbol: &str, param: &str, atom: ConstraintAtom) -> bool {
-        let Some(sets) = self.by_symbol.get_mut(symbol) else {
+        let Some(sets) = self.entry_mut(symbol) else {
             return false;
         };
         let Some(set) = sets.iter_mut().find(|s| s.name.as_str() == param) else {
@@ -94,7 +119,7 @@ impl GenericConstraintTable {
     }
 
     pub(crate) fn mark_inferred_comparable(&mut self, symbol: &str, param: &str) -> bool {
-        let Some(sets) = self.by_symbol.get_mut(symbol) else {
+        let Some(sets) = self.entry_mut(symbol) else {
             return false;
         };
         let Some(set) = sets.iter_mut().find(|s| s.name.as_str() == param) else {


### PR DESCRIPTION
Codegen was rebuilding the project-wide table of generic-type constraints once per module, copying the whole table each time. That table is now shared across modules instead, so codegen is ~20% faster at 200 modules and ~32% at 500, with the gain growing on larger projects.
