### PR TITLE
fix: reserve test wrapper handle names to avoid shadowing

### DIFF
--- a/crates/diagnostics/src/emit.rs
+++ b/crates/diagnostics/src/emit.rs
@@ -32,7 +32,7 @@ pub fn reserved_go_prefix(name: &str, prefix: &str, span: &Span) -> LisetteDiagn
         .with_span_primary_label(span, "uses a reserved prefix")
         .with_help(format!(
             "`{}` starts with `{}`, which is reserved for compiler-generated \
-             interface adapters. Rename the declaration.",
+             code. Rename the declaration.",
             name, prefix
         ))
 }

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -32,7 +32,7 @@ impl Planner<'_> {
             }
         }
 
-        self.collect_import_aliases(files, &mut package_block);
+        self.collect_import_aliases(files, &mut package_block, &mut diagnostics);
 
         report_collisions(package_block, &mut diagnostics);
         for (_, members) in sort_by_key(selectors) {
@@ -382,7 +382,12 @@ impl Planner<'_> {
         }
     }
 
-    fn collect_import_aliases(&self, files: &[&File], package_block: &mut SpanMap) {
+    fn collect_import_aliases(
+        &self,
+        files: &[&File],
+        package_block: &mut SpanMap,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
         let go_package_names = self.facts.go_package_names();
         let unused = self.facts.unused_imports_for_current_module();
         for file in files {
@@ -397,6 +402,11 @@ impl Planner<'_> {
                     continue;
                 }
                 let qualifier = go_name::sanitize_package_name(&alias);
+                let span = match &import.alias {
+                    Some(ImportAlias::Named(_, span)) => *span,
+                    _ => import.name_span,
+                };
+                self.check_reserved_prefix(qualifier.as_ref(), &span, diagnostics);
                 if let Some(spans) = package_block.get_mut(qualifier.as_ref()) {
                     spans.push(import.name_span);
                 }
@@ -423,12 +433,8 @@ impl Planner<'_> {
     }
 
     fn check_reserved_prefix(&self, go: &str, span: &Span, out: &mut Vec<LisetteDiagnostic>) {
-        if go.starts_with(go_name::ADAPTER_TYPE_PREFIX) {
-            out.push(emit_diag::reserved_go_prefix(
-                go,
-                go_name::ADAPTER_TYPE_PREFIX,
-                span,
-            ));
+        if let Some(prefix) = go_name::reserved_prefix_of(go) {
+            out.push(emit_diag::reserved_go_prefix(go, prefix, span));
         }
     }
 

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -125,19 +125,20 @@ impl Planner<'_> {
 
         let callee = self.pick_go_function_name(function, false, is_public);
         let test_name = go_name::go_test_function_name(name);
+        let handle = go_name::TEST_T_PARAM;
         let code = self.emit_function(function, None, is_public, fx);
 
         let span = function.name_span;
         let recover = format!(
-            "defer {test_kit}.Recover(t, {}, {}, {})",
+            "defer {test_kit}.Recover({handle}, {}, {}, {})",
             span.file_id,
             span.byte_offset,
             span.byte_offset + span.byte_length,
         );
-        let call = format!("{callee}({test_kit}.New(t))");
+        let call = format!("{callee}({test_kit}.New({handle}))");
         let body = if function.return_type.is_result() {
             format!(
-                "if err := {call}; err != nil {{\n\t\t{test_kit}.Fail(t, {}, {}, {}, \"result_err\", \"test returned Err\", {test_kit}.ErrOperand(err))\n\t}}",
+                "if err := {call}; err != nil {{\n\t\t{test_kit}.Fail({handle}, {}, {}, {}, \"result_err\", \"test returned Err\", {test_kit}.ErrOperand(err))\n\t}}",
                 span.file_id,
                 span.byte_offset,
                 span.byte_offset + span.byte_length,
@@ -145,7 +146,8 @@ impl Planner<'_> {
         } else {
             call
         };
-        let wrapper = format!("func {test_name}(t *{testing}.T) {{\n\t{recover}\n\t{body}\n}}");
+        let wrapper =
+            format!("func {test_name}({handle} *{testing}.T) {{\n\t{recover}\n\t{body}\n}}");
         format!("{doc_comment}{code}\n\n{wrapper}")
     }
 
@@ -161,7 +163,7 @@ impl Planner<'_> {
         }
         Some(vec![Binding {
             pattern: Pattern::Identifier {
-                identifier: "lisetteTestCtx".into(),
+                identifier: go_name::TEST_CTX_PARAM.into(),
                 span: function.name_span,
             },
             annotation: None,

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -19,6 +19,21 @@ pub(crate) const GO_STDLIB_PKG: &str = "lisette";
 
 pub(crate) const ADAPTER_TYPE_PREFIX: &str = "_lisAdapter_";
 
+pub(crate) const TEST_HANDLE_PREFIX: &str = "_lisTest_";
+
+pub(crate) const TEST_T_PARAM: &str = "_lisTest_t";
+
+pub(crate) const TEST_CTX_PARAM: &str = "_lisTest_ctx";
+
+pub(crate) const RESERVED_GO_PREFIXES: &[&str] = &[ADAPTER_TYPE_PREFIX, TEST_HANDLE_PREFIX];
+
+pub(crate) fn reserved_prefix_of(go: &str) -> Option<&'static str> {
+    RESERVED_GO_PREFIXES
+        .iter()
+        .find(|&&prefix| go.starts_with(prefix))
+        .copied()
+}
+
 pub const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
 
 pub(crate) const TEST_PRELUDE_MODULE: &str = "**test_prelude";

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -262,6 +262,40 @@ fn main() {}
 }
 
 #[test]
+fn test_wrapper_for_function_named_t_builds_and_runs() {
+    if !go_available() {
+        eprintln!("skipping test_wrapper_for_function_named_t_builds_and_runs: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/tcollide\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/main.lis"), "fn main() {}\n").unwrap();
+    fs::write(project.join("src/probe.test.lis"), "#[test]\nfn t() {}\n").unwrap();
+
+    let output = lis(&project, "test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "a #[test] function named `t` must build and run:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !combined.contains("is not a function"),
+        "the wrapper's *testing.T handle must not shadow `func t`:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
 fn run_executes_binary_in_invocation_cwd() {
     if !go_available() {
         eprintln!("skipping run_executes_binary_in_invocation_cwd: `go` not found");

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6287,6 +6287,75 @@ fn main() {
 }
 
 #[test]
+fn reserved_go_prefix_rejects_test_handle_namespace() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn _lisTest_helper() -> int { 1 }
+
+fn main() {
+  let _ = _lisTest_helper()
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes.iter().any(|code| code == "emit.reserved_go_prefix"),
+        "the _lisTest_ prefix is reserved; got: {codes:?}"
+    );
+}
+
+#[test]
+fn reserved_go_prefix_rejects_import_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import _lisAdapter_fmt \"go:fmt\"\n\nfn main() {\n  _lisAdapter_fmt.Println(\"x\")\n}",
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        codes.iter().any(|code| code == "emit.reserved_go_prefix"),
+        "a reserved-prefix import alias is a package-scope name and must be rejected; got: {codes:?}"
+    );
+}
+
+#[test]
+fn reserved_prefix_alias_cannot_shadow_synthesized_test_handle() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "import _lisTest_ctx \"go:fmt\"\n\n#[test]\nfn checks() {\n  _lisTest_ctx.Println(\"x\")\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let codes: Vec<_> = outputs
+        .iter()
+        .flat_map(|f| f.diagnostics.iter())
+        .filter_map(|d| d.code_str().map(str::to_string))
+        .collect();
+    assert!(
+        codes.iter().any(|c| c == "emit.reserved_go_prefix"),
+        "an alias in the test-handle namespace must be rejected before it can shadow the synthesized handle; got: {codes:?}"
+    );
+}
+
+#[test]
 fn go_name_collision_silent_for_unused_function() {
     let mut fs = MockFileSystem::new();
     fs.add_file(
@@ -7520,7 +7589,7 @@ fn test_with_context_emits_testkit_wrapper() {
     let go = test_file.to_go();
 
     assert!(
-        go.contains("testkit.New(t)"),
+        go.contains("testkit.New(_lisTest_t)"),
         "wrapper must construct the context, got:\n{go}"
     );
     assert!(
@@ -7550,12 +7619,80 @@ fn test_emit_produces_go_test_function() {
 
     let go = test_file.to_go();
     assert!(
-        go.contains("func TestAddition(t *testing.T)"),
+        go.contains("func TestAddition(_lisTest_t *testing.T)"),
         "expected a Go test function, got:\n{go}"
     );
     assert!(
         go.contains("\"testing\""),
         "expected the testing import, got:\n{go}"
+    );
+}
+
+#[test]
+fn test_wrapper_handle_does_not_shadow_function_named_t() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file("math", "core.test.lis", "#[test]\nfn t() {}");
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        !go.contains("(t *testing.T)"),
+        "the wrapper's *testing.T handle must not be named `t`, or it shadows `func t`, got:\n{go}"
+    );
+    assert!(
+        go.contains("t(testkit.New(_lisTest_t))"),
+        "the wrapper must call the package function `t`, passing the reserved handle, got:\n{go}"
+    );
+}
+
+#[test]
+fn synthesized_test_handle_does_not_shadow_user_function() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file(
+        "math",
+        "core.test.lis",
+        "fn lisetteTestCtx() -> int { 1 }\n\n#[test]\nfn checks() {\n  assert lisetteTestCtx() == 1\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go();
+
+    assert!(
+        go.contains("func checks(_lisTest_ctx testkit.TestContext)"),
+        "the synthesized handle must use a reserved name user code cannot produce, got:\n{go}"
+    );
+    assert!(
+        go.contains("= lisetteTestCtx()"),
+        "the test body must call the package function, not the synthesized handle, got:\n{go}"
     );
 }
 
@@ -7586,7 +7723,7 @@ fn assert_lowers_to_decomposed_failure_call() {
         .to_go();
 
     assert!(
-        go.contains("testkit.TestContext") && go.contains("testkit.New(t)"),
+        go.contains("testkit.TestContext") && go.contains("testkit.New(_lisTest_t)"),
         "a no-arg test with `assert` must carry a test handle, got:\n{go}"
     );
     assert!(
@@ -7826,7 +7963,7 @@ fn assert_with_discarded_test_param_emits_synthesized_handle() {
         .expect("expected a core_test.go output")
         .to_go();
     assert!(
-        go.contains("testkit.New(t)") && go.contains(".FailAssert("),
+        go.contains("testkit.New(_lisTest_t)") && go.contains(".FailAssert("),
         "a discarded test param must still yield a usable handle, got:\n{go}"
     );
 }


### PR DESCRIPTION
A `#[test]` function whose emitted Go name literally matches the test wrapper's internal handle no longer produces Go that `go test` rejects at build time.