### PR TITLE
fix: improve type-argument handling for VarArgs<T>

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -326,6 +326,8 @@ impl Planner<'_> {
     pub(super) fn infer_return_only_type_args(
         &mut self,
         function: &Expression,
+        value_arg_count: usize,
+        has_spread: bool,
         fx: &mut EmitEffects,
     ) -> Option<String> {
         let definition_ty = self.get_callee_definition_type(function)?;
@@ -337,9 +339,19 @@ impl Planner<'_> {
         };
         let generic_params = &f.params;
 
+        // A trailing `VarArgs<T>` is an inference source only when the call passes
+        // variadic args; without them Go can't infer that parameter's type.
+        let variadic_idx = generic_params
+            .iter()
+            .position(|p| p.get_name() == Some("VarArgs"))
+            .filter(|&i| i == generic_params.len() - 1);
+        let variadic_has_args = has_spread || variadic_idx.is_some_and(|i| value_arg_count > i);
+
         let all_inferrable = vars.iter().all(|var| {
             let param_ty = Type::Parameter(var.clone());
-            generic_params.iter().any(|pt| pt.contains_type(&param_ty))
+            generic_params.iter().enumerate().any(|(i, pt)| {
+                pt.contains_type(&param_ty) && (Some(i) != variadic_idx || variadic_has_args)
+            })
         });
 
         let instantiated_ty = function.get_type();

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -12,15 +12,45 @@ use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::CalleePlan;
 use crate::types::native::NativeGoType;
+use syntax::EcoString;
 use syntax::ast::{Expression, StructKind};
 use syntax::program::{CallKind, Definition, DefinitionBody};
 use syntax::types::{
-    SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute,
+    CompoundKind, SimpleKind, SubstitutionMap, Symbol, Type, build_substitution_map, substitute,
 };
 
 struct TupleStructTarget {
     go_ty: String,
     field_tys: Vec<Type>,
+}
+
+/// The shape of a call's value arguments, used to decide which type parameters
+/// Go can infer. `value_count` excludes any receiver argument.
+#[derive(Clone, Copy)]
+pub(crate) struct CallArgShape {
+    pub value_count: usize,
+    pub has_spread: bool,
+}
+
+pub(crate) fn all_type_params_inferrable(
+    vars: &[EcoString],
+    params: &[Type],
+    receiver_count: usize,
+    arg_shape: CallArgShape,
+) -> bool {
+    let variadic_idx = params
+        .iter()
+        .position(|p| p.is_native(CompoundKind::VarArgs))
+        .filter(|&i| i == params.len() - 1);
+    let variadic_has_args = arg_shape.has_spread
+        || variadic_idx.is_some_and(|i| arg_shape.value_count + receiver_count > i);
+
+    vars.iter().all(|var| {
+        let param_ty = Type::Parameter(var.clone());
+        params.iter().enumerate().any(|(i, pt)| {
+            pt.contains_type(&param_ty) && (Some(i) != variadic_idx || variadic_has_args)
+        })
+    })
 }
 
 impl Planner<'_> {
@@ -326,8 +356,7 @@ impl Planner<'_> {
     pub(super) fn infer_return_only_type_args(
         &mut self,
         function: &Expression,
-        value_arg_count: usize,
-        has_spread: bool,
+        arg_shape: CallArgShape,
         fx: &mut EmitEffects,
     ) -> Option<String> {
         let definition_ty = self.get_callee_definition_type(function)?;
@@ -338,21 +367,7 @@ impl Planner<'_> {
             return None;
         };
         let generic_params = &f.params;
-
-        // A trailing `VarArgs<T>` is an inference source only when the call passes
-        // variadic args; without them Go can't infer that parameter's type.
-        let variadic_idx = generic_params
-            .iter()
-            .position(|p| p.get_name() == Some("VarArgs"))
-            .filter(|&i| i == generic_params.len() - 1);
-        let variadic_has_args = has_spread || variadic_idx.is_some_and(|i| value_arg_count > i);
-
-        let all_inferrable = vars.iter().all(|var| {
-            let param_ty = Type::Parameter(var.clone());
-            generic_params.iter().enumerate().any(|(i, pt)| {
-                pt.contains_type(&param_ty) && (Some(i) != variadic_idx || variadic_has_args)
-            })
-        });
+        let all_inferrable = all_type_params_inferrable(&vars, generic_params, 0, arg_shape);
 
         let instantiated_ty = function.get_type();
         let mut mapping: HashMap<String, Type> = HashMap::default();

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1,5 +1,7 @@
 use crate::abi::is_tagged_shape_fn_value;
-use crate::calls::dispatch::is_prelude_variant_constructor;
+use crate::calls::dispatch::{
+    CallArgShape, all_type_params_inferrable, is_prelude_variant_constructor,
+};
 use crate::calls::go_interop::is_go_receiver;
 
 use crate::EmitEffects;
@@ -167,8 +169,10 @@ impl<'a> Planner<'a> {
             function,
             resolved_type_args,
             call_ty,
-            args.len(),
-            spread.is_some(),
+            CallArgShape {
+                value_count: args.len(),
+                has_spread: spread.is_some(),
+            },
             &mut function_string,
             expression_ctx,
             fx,
@@ -261,10 +265,14 @@ impl<'a> Planner<'a> {
     }
 
     /// True when Go can infer every type parameter of a collapsed callee from
-    /// its value parameters, i.e. each Lisette type-param var appears in some
-    /// parameter. A var present only in the return type (or otherwise absent
-    /// from the parameters) is not inferable, so the recipe must be rebuilt.
-    fn collapsed_callee_fully_inferable(&self, function: &Expression) -> bool {
+    /// its value parameters. A var present only in the return type, or only in a
+    /// trailing `VarArgs<T>` the call leaves empty, is not inferable, so the
+    /// recipe must be rebuilt.
+    fn collapsed_callee_fully_inferable(
+        &self,
+        function: &Expression,
+        arg_shape: CallArgShape,
+    ) -> bool {
         let Some(Type::Forall { vars, body }) = self.callee_definition(function).map(|d| d.ty())
         else {
             return false;
@@ -272,10 +280,7 @@ impl<'a> Planner<'a> {
         let Type::Function(f) = body.as_ref() else {
             return false;
         };
-        vars.iter().all(|var| {
-            let param_ty = Type::Parameter(var.clone());
-            f.params.iter().any(|pt| pt.contains_type(&param_ty))
-        })
+        all_type_params_inferrable(vars, &f.params, 0, arg_shape)
     }
 
     fn reconstruct_collapsed_call_type_args(
@@ -376,15 +381,14 @@ impl<'a> Planner<'a> {
         function: &Expression,
         type_args: &[Type],
         call_ty: Option<&Type>,
-        value_arg_count: usize,
-        has_spread: bool,
+        arg_shape: CallArgShape,
         function_string: &mut String,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> String {
-        let has_value_args = value_arg_count > 0 || has_spread;
+        let has_value_args = arg_shape.value_count > 0 || arg_shape.has_spread;
         if let Some(recipe) = self.callee_collapsed_recipe(function) {
-            if has_value_args && self.collapsed_callee_fully_inferable(function) {
+            if has_value_args && self.collapsed_callee_fully_inferable(function, arg_shape) {
                 return String::new();
             }
             return self
@@ -397,8 +401,7 @@ impl<'a> Planner<'a> {
         let slot_ty = ctx.expected_slot_type();
 
         if type_args_string.is_empty()
-            && let Some(inferred) =
-                self.infer_return_only_type_args(function, value_arg_count, has_spread, fx)
+            && let Some(inferred) = self.infer_return_only_type_args(function, arg_shape, fx)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t, fx).unwrap_or(inferred),

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -167,7 +167,8 @@ impl<'a> Planner<'a> {
             function,
             resolved_type_args,
             call_ty,
-            !args.is_empty() || spread.is_some(),
+            args.len(),
+            spread.is_some(),
             &mut function_string,
             expression_ctx,
             fx,
@@ -375,11 +376,13 @@ impl<'a> Planner<'a> {
         function: &Expression,
         type_args: &[Type],
         call_ty: Option<&Type>,
-        has_value_args: bool,
+        value_arg_count: usize,
+        has_spread: bool,
         function_string: &mut String,
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> String {
+        let has_value_args = value_arg_count > 0 || has_spread;
         if let Some(recipe) = self.callee_collapsed_recipe(function) {
             if has_value_args && self.collapsed_callee_fully_inferable(function) {
                 return String::new();
@@ -394,7 +397,8 @@ impl<'a> Planner<'a> {
         let slot_ty = ctx.expected_slot_type();
 
         if type_args_string.is_empty()
-            && let Some(inferred) = self.infer_return_only_type_args(function, fx)
+            && let Some(inferred) =
+                self.infer_return_only_type_args(function, value_arg_count, has_spread, fx)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t, fx).unwrap_or(inferred),

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -1,3 +1,4 @@
+use crate::calls::dispatch::{CallArgShape, all_type_params_inferrable};
 use crate::calls::native::apply_inline_import;
 use crate::calls::regular::effective_param_type;
 use crate::plan::calls::plan_variadic_spread;
@@ -16,6 +17,7 @@ use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
 
 impl Planner<'_> {
+    #[allow(clippy::too_many_arguments)]
     fn ufcs_type_args(
         &mut self,
         function: &Expression,
@@ -23,6 +25,7 @@ impl Planner<'_> {
         member: &str,
         receiver_ty: &Type,
         type_args: &[Type],
+        arg_shape: CallArgShape,
         fx: &mut EmitEffects,
     ) -> Option<String> {
         let method_key = format!("{}.{}", qualified_name, member);
@@ -55,11 +58,11 @@ impl Planner<'_> {
             return (!go_type_strs.is_empty()).then(|| format!("[{}]", go_type_strs.join(", ")));
         }
 
-        let all_inferable = vars.iter().all(|var| {
-            let param_ty = Type::Parameter(var.clone());
-            f.params.iter().any(|pt| pt.contains_type(&param_ty))
-        });
-        if all_inferable {
+        let receiver_count = match function.get_type() {
+            Type::Function(inst) if inst.params.len() + 1 == f.params.len() => 1,
+            _ => 0,
+        };
+        if all_type_params_inferrable(vars, &f.params, receiver_count, arg_shape) {
             return None;
         }
 
@@ -133,6 +136,10 @@ impl Planner<'_> {
             qualified_name,
             member,
             type_args,
+            CallArgShape {
+                value_count: args.len(),
+                has_spread: spread.is_some(),
+            },
             fx,
         );
         (setup, format!("{}({})", fn_name, new_args.join(", ")))
@@ -209,6 +216,7 @@ impl Planner<'_> {
         self.stage_composite(arg, ExpressionContext::value(), fx)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_ufcs_qualified_call(
         &mut self,
         function: &Expression,
@@ -216,10 +224,19 @@ impl Planner<'_> {
         qualified_name: &str,
         member: &str,
         type_args: &[Type],
+        arg_shape: CallArgShape,
         fx: &mut EmitEffects,
     ) -> String {
         let type_args_string = self
-            .ufcs_type_args(function, qualified_name, member, receiver_ty, type_args, fx)
+            .ufcs_type_args(
+                function,
+                qualified_name,
+                member,
+                receiver_ty,
+                type_args,
+                arg_shape,
+                fx,
+            )
             .unwrap_or_default();
 
         let method_key = format!("{}.{}", qualified_name, member);

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -198,6 +198,28 @@ async fn goto_definition_promoted_field() {
 }
 
 #[tokio::test]
+async fn hover_on_explicit_type_arg_call_shows_substituted_signature() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn f<T>(xs: VarArgs<T>) {}\n\nfn main() {\n  f<Option<int>>()\n}",
+        )
+        .await;
+
+    // Hover the `f` callee in `f<Option<int>>()`.
+    let hover = client.hover(TEST_URI, 3, 2).await.expect("hover");
+    let content = hover_content(&hover);
+    assert!(
+        content.contains("VarArgs<Option<int>>"),
+        "expected substituted signature, got: {content}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn hover_promoted_method_shows_type() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -4,7 +4,7 @@ use semantics::facts::Facts;
 
 pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
     for check in std::mem::take(&mut facts.generic_call_checks) {
-        if check.return_ty.has_unbound_variables() {
+        if check.ty.has_unbound_variables() {
             sink.push(diagnostics::infer::cannot_infer_type_argument(check.span));
         }
     }

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -297,7 +297,7 @@ impl<'a> FreezeFolder<'a> {
 
     pub fn freeze_facts(&self, facts: &mut crate::facts::Facts) {
         for check in &mut facts.generic_call_checks {
-            self.env.resolve_in_place(&mut check.return_ty);
+            self.env.resolve_in_place(&mut check.ty);
         }
         for check in &mut facts.empty_collection_checks {
             self.env.resolve_in_place(&mut check.ty);

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -378,14 +378,14 @@ impl InferCtx<'_, '_> {
                 })
             );
 
+        let resolved_callee = callee_ty.resolve_in(&self.env);
+        let variadic_elem_var = resolved_callee.is_variadic();
+        let callee_param_count = resolved_callee.get_function_params().map_or(0, |p| p.len());
         let variadic_elem_ty = if needs_variadic_check {
-            callee_ty.resolve_in(&self.env).is_variadic()
+            variadic_elem_var.clone()
         } else {
             None
         };
-
-        let variadic_elem_var = callee_ty.resolve_in(&self.env).is_variadic();
-        let callee_param_count = callee_ty.resolve_in(&self.env).param_count();
 
         let (param_types, param_mutability, return_ty, bounds) =
             self.extract_call_signature(callee_ty, &args, &callee_expression);
@@ -508,15 +508,17 @@ impl InferCtx<'_, '_> {
             && new_spread.is_none()
             && let Some(elem_ty) = &variadic_elem_var
             && new_args.len() < callee_param_count
-            && !(return_check_recorded
-                && resolved_return.contains_type(&elem_ty.resolve_in(&self.env)))
         {
-            self.facts
-                .generic_call_checks
-                .push(crate::facts::GenericCallCheck {
-                    ty: elem_ty.clone(),
-                    span,
-                });
+            let already_covered = return_check_recorded
+                && resolved_return.contains_type(&elem_ty.resolve_in(&self.env));
+            if !already_covered {
+                self.facts
+                    .generic_call_checks
+                    .push(crate::facts::GenericCallCheck {
+                        ty: elem_ty.clone(),
+                        span,
+                    });
+            }
         }
 
         if type_args.is_empty() && self.callee_has_phantom_type_param(&callee_expression) {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -384,6 +384,9 @@ impl InferCtx<'_, '_> {
             None
         };
 
+        let variadic_elem_var = callee_ty.resolve_in(&self.env).is_variadic();
+        let callee_param_count = callee_ty.resolve_in(&self.env).param_count();
+
         let (param_types, param_mutability, return_ty, bounds) =
             self.extract_call_signature(callee_ty, &args, &callee_expression);
 
@@ -485,14 +488,33 @@ impl InferCtx<'_, '_> {
         self.check_native_mutating_call(&callee_expression, result_unused, &span);
         self.check_native_equals_ufcs(&callee_expression, &new_args);
 
-        if self.is_generic_callee(&callee_expression)
+        let resolved_return = return_ty.resolve_in(&self.env);
+        let return_check_recorded = self.is_generic_callee(&callee_expression)
             && type_args.is_empty()
-            && !self.is_enum_type(store, &return_ty.resolve_in(&self.env))
+            && !self.is_enum_type(store, &resolved_return);
+        if return_check_recorded {
+            self.facts
+                .generic_call_checks
+                .push(crate::facts::GenericCallCheck {
+                    ty: return_ty.clone(),
+                    span,
+                });
+        }
+
+        // A zero-variadic-arg call can't infer its `VarArgs<T>` parameter from args.
+        // Record the element type; the deferred pass rejects it only if it stays
+        // unbound. Skip when the return-type check above already records it.
+        if type_args.is_empty()
+            && new_spread.is_none()
+            && let Some(elem_ty) = &variadic_elem_var
+            && new_args.len() < callee_param_count
+            && !(return_check_recorded
+                && resolved_return.contains_type(&elem_ty.resolve_in(&self.env)))
         {
             self.facts
                 .generic_call_checks
                 .push(crate::facts::GenericCallCheck {
-                    return_ty: return_ty.clone(),
+                    ty: elem_ty.clone(),
                     span,
                 });
         }
@@ -705,8 +727,11 @@ impl InferCtx<'_, '_> {
                     self.unify(&receiver_param, &receiver_ty_stripped, span);
                 }
             }
-            self.unify(&instantiated, &callee_expression.get_type(), span);
         }
+
+        // Write the substituted type back onto the callee node so its type (and
+        // hover) reflects explicit type arguments, as an inferred call already does.
+        self.unify(&instantiated, &callee_expression.get_type(), span);
 
         (instantiated, type_args.to_vec(), resolved_args)
     }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -69,7 +69,9 @@ pub struct Facts {
 
 #[derive(Debug, Clone)]
 pub struct GenericCallCheck {
-    pub return_ty: Type,
+    /// A type that must be fully resolved once inference finishes; if it still has
+    /// unbound type variables, the call's generic parameter couldn't be inferred.
+    pub ty: Type,
     pub span: Span,
 }
 

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1849,3 +1849,36 @@ fn build() -> IntList {
 "#;
     assert_emit_snapshot!(input);
 }
+
+// Zero variadic args, so `T` must be forwarded explicitly: `first[int]()`.
+#[test]
+fn empty_varargs_call_forwards_inferred_type_arg() {
+    let input = r#"
+fn first<T>(xs: VarArgs<T>) -> Option<T> { None }
+
+fn test() {
+  let r: Option<int> = first()
+  if r.unwrap_or(7) != 7 {
+    panic("expected 7")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+// The fixed arg doesn't determine `T`; the variadic got none, so forward it:
+// `g[int](5)`.
+#[test]
+fn empty_varargs_with_fixed_arg_forwards_inferred_type_arg() {
+    let input = r#"
+fn g<T>(head: int, rest: VarArgs<T>) -> Option<T> { None }
+
+fn test() {
+  let r: Option<int> = g(5)
+  if r.unwrap_or(9) != 9 {
+    panic("expected 9")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1882,3 +1882,23 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn empty_varargs_method_call_forwards_inferred_type_arg() {
+    let input = r#"
+struct Box {}
+
+impl Box {
+  fn first<T>(self, xs: VarArgs<T>) -> Option<T> { None }
+}
+
+fn test() {
+  let b = Box {}
+  let r: Option<int> = b.first()
+  if r.unwrap_or(7) != 7 {
+    panic("expected 7")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1758,6 +1758,22 @@ fn main() {
 }
 
 #[test]
+fn interop_collapsed_empty_varargs_reconstructs_type_arg() {
+    let input = r#"
+import "go:example.com/cat"
+
+fn main() {
+  let r: Slice<int> = cat.Cat(1)
+}
+"#;
+    let typedef = r#"
+#[go(collapsed_type_params, "T")]
+pub fn Cat<T>(n: int, xs: VarArgs<T>) -> Slice<T>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/cat", typedef)]);
+}
+
+#[test]
 fn interop_collapsed_type_param_reconstructs_return_only_param() {
     let input = r#"
 import "go:example.com/pick"

--- a/tests/spec/emit/snapshots/empty_varargs_call_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_call_forwards_inferred_type_arg.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/functions.rs
+description: "\nfn first<T>(xs: VarArgs<T>) -> Option<T> { None }\n\nfn test() {\n  let r: Option<int> = first()\n  if r.unwrap_or(7) != 7 {\n    panic(\"expected 7\")\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func first[T any](_ ...T) (T, bool) {
+	return *new(T), false
+}
+
+func test() {
+	option_1 := lisette.OptionFromCommaOk[int](first[int]())
+	r := option_1
+	if r.UnwrapOr(7) != 7 {
+		panic("expected 7")
+	}
+}

--- a/tests/spec/emit/snapshots/empty_varargs_method_call_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_method_call_forwards_inferred_type_arg.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Box {}
+  
+  impl Box {
+    fn first<T>(self, xs: VarArgs<T>) -> Option<T> { None }
+  }
+  
+  fn test() {
+    let b = Box {}
+    let r: Option<int> = b.first()
+    if r.unwrap_or(7) != 7 {
+      panic("expected 7")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box struct{}
+
+func Box_first[T any](_ Box, _ ...T) (T, bool) {
+	return *new(T), false
+}
+
+func test() {
+	b := Box{}
+	option_1 := lisette.OptionFromCommaOk[int](Box_first[int](b))
+	r := option_1
+	if r.UnwrapOr(7) != 7 {
+		panic("expected 7")
+	}
+}

--- a/tests/spec/emit/snapshots/empty_varargs_with_fixed_arg_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_with_fixed_arg_forwards_inferred_type_arg.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/functions.rs
+description: "\nfn g<T>(head: int, rest: VarArgs<T>) -> Option<T> { None }\n\nfn test() {\n  let r: Option<int> = g(5)\n  if r.unwrap_or(9) != 9 {\n    panic(\"expected 9\")\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func g[T any](_ int, _ ...T) (T, bool) {
+	return *new(T), false
+}
+
+func test() {
+	option_1 := lisette.OptionFromCommaOk[int](g[int](5))
+	r := option_1
+	if r.UnwrapOr(9) != 9 {
+		panic("expected 9")
+	}
+}

--- a/tests/spec/emit/snapshots/interop_collapsed_empty_varargs_reconstructs_type_arg.snap
+++ b/tests/spec/emit/snapshots/interop_collapsed_empty_varargs_reconstructs_type_arg.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/cat"
+  
+  fn main() {
+    let r: Slice<int> = cat.Cat(1)
+  }
+---
+package main
+
+import "example.com/cat"
+
+func main() {
+	_ = cat.Cat[int](1)
+}

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2575,3 +2575,41 @@ fn main() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn generic_empty_varargs_method_call_without_type_arg_errors() {
+    infer(
+        r#"
+struct Box {}
+
+impl Box {
+  fn first<T>(self, xs: VarArgs<T>) -> Option<T> { None }
+}
+
+fn main() {
+  let b = Box {}
+  let r = b.first()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn generic_empty_varargs_method_call_with_annotation_ok() {
+    infer(
+        r#"
+struct Box {}
+
+impl Box {
+  fn first<T>(self, xs: VarArgs<T>) -> Option<T> { None }
+}
+
+fn main() {
+  let b = Box {}
+  let r: Option<int> = b.first()
+}
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2476,3 +2476,102 @@ fn main() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn generic_empty_varargs_call_without_type_arg_errors() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) {}
+
+fn main() {
+  f()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn generic_varargs_call_with_args_infers_type() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) {}
+
+fn main() {
+  f(1, 2)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_varargs_call_with_explicit_type_arg_ok() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) {}
+
+fn main() {
+  f<int>()
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_leading_param_with_empty_varargs_ok() {
+    infer(
+        r#"
+fn f<T>(head: T, rest: VarArgs<T>) -> T { head }
+
+fn main() {
+  let x = f(1)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_empty_varargs_with_unresolved_return_type_errors() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) -> Option<T> { None }
+
+fn main() {
+  let r = f()
+}
+"#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn generic_empty_varargs_with_type_resolved_by_later_use_ok() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) -> Option<T> { None }
+
+fn main() {
+  let r = f()
+  let x: int = r.unwrap_or(0)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_empty_varargs_with_type_resolved_by_annotation_ok() {
+    infer(
+        r#"
+fn f<T>(xs: VarArgs<T>) -> Option<T> { None }
+
+fn main() {
+  let r: Option<int> = f()
+}
+"#,
+    )
+    .assert_no_errors();
+}


### PR DESCRIPTION
Currently there is a edge case with `VarArgs` when the user does not provide any arguments to a variadic function. 

Eg.

```rust
fn f1<T>(_: VarArgs<T>) {}

fn main() {
  f1() // No args. T cant be inferred. Go error: cannot infer T
}
```
Also this:

```rust
// T is known but not forwarded to Go
fn f2<T>(_: VarArgs<T>) -> Option<T> { 
  None 
}

let ret: Option<int> = f2() // Go error: cannot infer T

```

This change forces the user to provide a type, in cases where no arguments are provided (when the compiler cant infer a type), and forwards it to the Go side.

```rust
// These are noe a compile error: expected type argument
let _ = f1()
let _ = f2()

// Force the user to provide a type when there is no value
let _ = f1<int>()
let _: Option<int> = f2()

// Also handle late bindings:
let opt = f2()
let _ = opt.unwrap_or(69) // <-- T is bound here, no type is therefore required
```
