### PR TITLE
feat: discover tests in unimported modules

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -302,6 +302,45 @@ impl Loader for LocalFileSystem {
 
         HashMap::default()
     }
+
+    fn test_module_ids(&self) -> Vec<String> {
+        let Some(root) = self.search_paths.first() else {
+            return Vec::new();
+        };
+        let mut with_test: HashSet<PathBuf> = HashSet::default();
+        let mut with_production: HashSet<PathBuf> = HashSet::default();
+        for path in collect_lis_filepaths_recursive(root) {
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(dir) = path.parent() else {
+                continue;
+            };
+            if name.ends_with(".test.lis") {
+                with_test.insert(dir.to_path_buf());
+            } else {
+                with_production.insert(dir.to_path_buf());
+            }
+        }
+        with_test
+            .iter()
+            .filter(|dir| with_production.contains(*dir))
+            .filter_map(|dir| dir.strip_prefix(root).ok())
+            .map(module_id_from_rel)
+            .collect()
+    }
+}
+
+fn module_id_from_rel(rel: &Path) -> String {
+    let joined: Vec<&str> = rel
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect();
+    if joined.is_empty() {
+        ENTRY_MODULE_ID.to_string()
+    } else {
+        joined.join("/")
+    }
 }
 
 #[cfg(test)]

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -153,6 +153,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     }
 
     let entry_module = store.entry_module_id().to_string();
+    let discover_test_modules = input.project_root.is_some();
     let mut graph_result = build_module_graph(
         &mut store,
         Some(input.loader),
@@ -161,6 +162,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         input.config.standalone_mode,
         &input.locator,
         include_tests,
+        discover_test_modules,
     );
 
     for cycle in &graph_result.cycles {

--- a/crates/semantics/src/loader.rs
+++ b/crates/semantics/src/loader.rs
@@ -21,9 +21,17 @@ impl FileContent {
 
 pub type Files = HashMap<String, FileContent>;
 
+fn is_production_lis(name: &str) -> bool {
+    name.ends_with(".lis") && !name.ends_with(".test.lis")
+}
+
 pub trait Loader {
     /// Scans a folder and returns all `.lis` files keyed by bare filename.
     fn scan_folder(&self, folder: &str) -> Files;
+
+    fn test_module_ids(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 /// In-memory `Loader` keyed by folder. Use for tests, benches, the wasm
@@ -66,5 +74,16 @@ impl MemoryLoader {
 impl Loader for MemoryLoader {
     fn scan_folder(&self, folder: &str) -> Files {
         self.folders.get(folder).cloned().unwrap_or_default()
+    }
+
+    fn test_module_ids(&self) -> Vec<String> {
+        self.folders
+            .iter()
+            .filter(|(_, files)| {
+                files.keys().any(|name| name.ends_with(".test.lis"))
+                    && files.keys().any(|name| is_production_lis(name))
+            })
+            .map(|(folder, _)| folder.clone())
+            .collect()
     }
 }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -30,6 +30,7 @@ pub struct ModuleGraphResult {
     pub link_only_modules: HashSet<ModuleId>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_module_graph(
     store: &mut Store,
     loader: Option<&dyn Loader>,
@@ -38,10 +39,17 @@ pub fn build_module_graph(
     standalone_mode: bool,
     locator: &TypedefLocator,
     include_tests: bool,
+    discover_test_modules: bool,
 ) -> ModuleGraphResult {
     let mut edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut production_edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut to_visit = vec![entry_module.to_string()];
+    if include_tests
+        && discover_test_modules
+        && let Some(loader) = loader
+    {
+        to_visit.extend(loader.test_module_ids());
+    }
     let mut visited: HashSet<ModuleId> = HashSet::default();
     let mut files: HashMap<ModuleId, Vec<File>> = HashMap::default();
     let mut import_spans: HashMap<ModuleId, Span> = HashMap::default();

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -55,6 +55,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         false,
         &locator,
         true,
+        true,
     );
 
     if sink.has_errors() {

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -612,3 +612,94 @@ fn main() {
         "program did not run:\nstdout: {stdout}\nstderr: {stderr}"
     );
 }
+
+#[test]
+fn orphan_module_tests_are_discovered() {
+    if !go_available() {
+        eprintln!("skipping orphan_module_tests_are_discovered: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/orphan")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"orphandemo\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/main.lis"), "fn main() {\n}\n").unwrap();
+    fs::write(
+        project.join("src/orphan/orphan.lis"),
+        "pub fn helper() -> int { 42 }\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/orphan/orphan.test.lis"),
+        "#[test]\nfn orphan_pass() { assert helper() == 42 }\n\n#[test]\nfn orphan_fail() { assert helper() == 999 }\n",
+    )
+    .unwrap();
+
+    let output = lis(&project, "test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        combined.contains("orphan_pass") && combined.contains("orphan_fail"),
+        "tests in an unimported module must be discovered:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !output.status.success(),
+        "the failing orphan test must make the run fail:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn single_file_check_ignores_unrelated_test_modules() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::create_dir_all(dir.join("sub")).unwrap();
+    fs::write(dir.join("standalone.lis"), "pub fn hi() -> int { 1 }\n").unwrap();
+    fs::write(
+        dir.join("sub/broken.test.lis"),
+        "#[test]\nfn bad() { let _: int = \"type error\" }\n",
+    )
+    .unwrap();
+
+    let output = lis(&dir.join("standalone.lis"), "check");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a standalone single-file check must not pull in an unrelated test module:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn loose_dir_check_does_not_duplicate_child_diagnostics() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::create_dir_all(dir.join("child")).unwrap();
+    fs::write(dir.join("top.lis"), "pub fn top() -> int { 1 }\n").unwrap();
+    fs::write(dir.join("child/child.lis"), "pub fn ch() -> int { 2 }\n").unwrap();
+    fs::write(
+        dir.join("child/child.test.lis"),
+        "#[test]\nfn child_bad() { let _: int = \"err\" }\n",
+    )
+    .unwrap();
+
+    let output = lis(dir, "check");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let hits = combined.matches("child_bad").count();
+    assert_eq!(
+        hits, 1,
+        "a loose-directory check must report a child module's diagnostic once, not once per ancestor sweep:\n{combined}"
+    );
+}

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -109,6 +109,7 @@ fn test_only_imports_excluded_from_production_edges() {
         false,
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(
@@ -144,6 +145,7 @@ fn graph_simple_dependency() {
         false,
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(result.cycles.is_empty());
@@ -174,6 +176,7 @@ fn graph_missing_module() {
         false,
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(sink.has_errors());
@@ -200,6 +203,7 @@ fn graph_cycle_detection() {
         false,
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(!result.cycles.is_empty());
@@ -222,6 +226,7 @@ fn graph_standalone_third_party_go_import_uses_module_not_found() {
         true, // standalone mode
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(sink.has_errors());
@@ -245,6 +250,7 @@ fn graph_project_third_party_go_import_undeclared() {
         false, // project mode
         &default_resolver(),
         true,
+        false,
     );
 
     assert!(sink.has_errors());
@@ -273,7 +279,16 @@ fn graph_declared_dep_missing_typedef() {
     let resolver = deps::TypedefLocator::new(go_deps, None, stdlib::Target::host());
 
     let sink = LocalSink::new();
-    let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver, true);
+    let _result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        false,
+        &resolver,
+        true,
+        false,
+    );
 
     assert!(sink.has_errors());
 
@@ -314,7 +329,16 @@ fn graph_subpackage_missing_typedef_points_at_add() {
     let resolver = deps::TypedefLocator::new(go_deps, None, stdlib::Target::host());
 
     let sink = LocalSink::new();
-    let _result = build_module_graph(&mut store, Some(&fs), "main", &sink, false, &resolver, true);
+    let _result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        "main",
+        &sink,
+        false,
+        &resolver,
+        true,
+        false,
+    );
 
     assert!(sink.has_errors());
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3587,6 +3587,30 @@ fn main() {
 }
 
 #[test]
+fn unimported_module_test_file_checked() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "_entry_",
+        "main.lis",
+        r#"fn main() {
+}"#,
+    );
+    fs.add_file("orphan", "orphan.lis", "pub fn helper() -> int { 42 }");
+    fs.add_file(
+        "orphan",
+        "orphan.test.lis",
+        "#[test]\nfn bad() { let _: int = \"x\" }",
+    );
+
+    let result = infer_module("_entry_", fs);
+
+    assert!(
+        result.errors.iter().any(|d| d.is_error()),
+        "a type error in a test file of a module the entry never imports must still be reported"
+    );
+}
+
+#[test]
 fn dot_test_file_included_under_check() {
     let mut fs = MockFileSystem::new();
     fs.add_file(
@@ -3639,6 +3663,36 @@ fn main() {
             .iter()
             .any(|d| d.code_str().is_some_and(|c| c.contains("module_not_found"))),
         "a production import of a module with only test files must not resolve, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn unimported_production_import_of_test_only_module_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("_entry_", "main.lis", "fn main() {\n}");
+    fs.add_file("aaa", "aaa.test.lis", "pub fn sample() -> int { 1 }");
+    fs.add_file(
+        "zzz",
+        "zzz.lis",
+        r#"import "aaa"
+
+pub fn use_it() -> int { aaa.sample() }"#,
+    );
+    fs.add_file(
+        "zzz",
+        "zzz.test.lis",
+        "#[test]\nfn z() { assert use_it() == 1 }",
+    );
+
+    let result = infer_module("_entry_", fs);
+
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|d| d.code_str().is_some_and(|c| c.contains("module_not_found"))),
+        "an orphan module's production import of a test-only module must be rejected regardless of seeding order, got: {:?}",
         result.errors
     );
 }


### PR DESCRIPTION
`lis test` now discovers and runs `#[test]` functions in modules under `src/` even if nothing imports them from `src/main.lis`.