### PR TITLE
fix: recover from invalid attribute arguments

### DIFF
--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -68,9 +68,13 @@ impl<'source> Parser<'source> {
     fn parse_attribute_args(&mut self) -> Vec<AttributeArg> {
         let mut args = vec![];
 
-        while self.is_not(RightParen) && !self.at_eof() {
+        while self.is_not(RightParen) && self.is_not(RightSquareBracket) && !self.at_eof() {
             if let Some(arg) = self.parse_attribute_arg() {
                 args.push(arg);
+            } else {
+                while !self.at_sync_point() && !self.at_eof() {
+                    self.next();
+                }
             }
 
             if !self.advance_if(Comma) {
@@ -78,7 +82,9 @@ impl<'source> Parser<'source> {
             }
         }
 
-        self.ensure(RightParen);
+        if !self.advance_if(RightParen) {
+            self.track_error("expected `)`", "Add `)` to close the attribute arguments");
+        }
         args
     }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -664,6 +664,15 @@ fn main() {
 }
 
 #[test]
+fn parse_attribute_non_string_argument_recovers() {
+    let input = r#"
+#[test(123)]
+fn bad_title_arg() { }
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_missing_closing_brace() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/parse_attribute_non_string_argument_recovers.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_non_string_argument_recovers.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ #[test(123)]
+   ·        ─┬─
+   ·         ╰── expected attribute argument
+ 3 │ fn bad_title_arg() { }
+   ╰────
+  help: Add a flag (e.g. `omitempty`), string (e.g. `"name"`), or raw tag (e.g. `` `json:"name"` ``) · code: [parse.syntax_error]


### PR DESCRIPTION
A malformed `#[...]` attribute arg now produces one clear error instead of a cascade of unrelated ones, and recovery no longer swallows the declaration that follows.