### PR TITLE
feat: in-test logging with `t.log`

### DIFF
--- a/crates/cli/src/handlers/test/failed.rs
+++ b/crates/cli/src/handlers/test/failed.rs
@@ -66,6 +66,7 @@ mod tests {
             output: String::new(),
             failure: None,
             skip_reason: None,
+            logs: vec![],
             children: vec![],
             span: Span::new(0, 0, 0),
         }

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Style};
 use semantics::store::ENTRY_MODULE_ID;
 use serde::Deserialize;
 use syntax::ast::Span;
@@ -21,11 +21,13 @@ struct EventTables {
     failures: HashMap<(String, String), FailureRecord>,
     skip_reasons: HashMap<(String, String), String>,
     subtest_names: HashMap<(String, String), String>,
+    logs: HashMap<(String, String), Vec<LogRecord>>,
 }
 
 const FAIL_ATTR_KEY: &str = "lisette-fail";
 const SKIP_ATTR_KEY: &str = "lisette-skip";
 const SUBTEST_ATTR_KEY: &str = "lisette-subtest";
+const LOG_ATTR_KEY: &str = "lisette-log";
 
 const DESC_MAX_WIDTH: usize = 100;
 const DESC_MIN_WIDTH: usize = 20;
@@ -69,6 +71,14 @@ pub struct FailureRecord {
     operands: Vec<Operand>,
 }
 
+#[derive(Deserialize, Clone)]
+pub struct LogRecord {
+    file: u32,
+    lo: u32,
+    hi: u32,
+    value: String,
+}
+
 pub struct TestRow {
     pub package: String,
     pub go_name: String,
@@ -79,6 +89,7 @@ pub struct TestRow {
     pub output: String,
     pub failure: Option<FailureRecord>,
     pub skip_reason: Option<String>,
+    pub logs: Vec<LogRecord>,
     pub children: Vec<TestRow>,
     pub span: Span,
 }
@@ -161,6 +172,7 @@ pub fn build_report_filtered(
     let mut fail_chunks: FailChunks = HashMap::new();
     let mut skip_reasons: HashMap<(String, String), String> = HashMap::new();
     let mut subtest_names: HashMap<(String, String), String> = HashMap::new();
+    let mut logs: HashMap<(String, String), Vec<LogRecord>> = HashMap::new();
     let mut test_elapsed: f64 = 0.0;
 
     for event in events {
@@ -190,6 +202,17 @@ pub fn build_report_filtered(
             && let Some(name) = decode_hex(value).and_then(|b| String::from_utf8(b).ok())
         {
             subtest_names.insert((event.package.clone(), test.clone()), name);
+            continue;
+        }
+        if event.action == "attr"
+            && event.key.as_deref() == Some(LOG_ATTR_KEY)
+            && let (Some(test), Some(value)) = (&event.test, &event.value)
+            && let Some(record) =
+                decode_hex(value).and_then(|b| serde_json::from_slice::<LogRecord>(&b).ok())
+        {
+            logs.entry((event.package.clone(), test.clone()))
+                .or_default()
+                .push(record);
             continue;
         }
         let Some(test) = &event.test else {
@@ -256,6 +279,7 @@ pub fn build_report_filtered(
         failures: reassemble_failures(fail_chunks),
         skip_reasons,
         subtest_names,
+        logs,
     };
 
     let mut rows = Vec::new();
@@ -293,6 +317,7 @@ pub fn build_report_filtered(
             output: tables.outputs.get(&key).cloned().unwrap_or_default(),
             failure: tables.failures.get(&key).cloned(),
             skip_reason: tables.skip_reasons.get(&key).cloned(),
+            logs: tables.logs.get(&key).cloned().unwrap_or_default(),
             children,
             span: test.span,
         });
@@ -406,6 +431,7 @@ fn subtest_rows(
                 output: tables.outputs.get(&key).cloned().unwrap_or_default(),
                 failure: tables.failures.get(&key).cloned(),
                 skip_reason: tables.skip_reasons.get(&key).cloned(),
+                logs: tables.logs.get(&key).cloned().unwrap_or_default(),
                 children: subtest_rows(package, full, children_of, tables),
                 span: Span::new(0, 0, 0),
             }
@@ -518,6 +544,7 @@ pub fn render(report: &Report, sources: &Sources, color: bool, total: Duration) 
         }
     }
 
+    render_logs(&mut out, &report.rows, &report.go_module, sources, color);
     render_failures(&mut out, &report.rows, &report.go_module, sources, color);
 
     out.push('\n');
@@ -552,7 +579,6 @@ fn render_package_rows(
 }
 
 fn render_rows(out: &mut String, rows: &[&TestRow], prefix: &str, color: bool, term_width: usize) {
-    let any_described = rows.iter().any(|r| r.description.is_some());
     for (i, row) in rows.iter().enumerate() {
         let last = i + 1 == rows.len();
         let branch = if last { "└── " } else { "├── " };
@@ -613,34 +639,125 @@ fn render_rows(out: &mut String, rows: &[&TestRow], prefix: &str, color: bool, t
             ));
         }
 
-        if let Some(description) = &row.description {
-            let line = description.split_whitespace().collect::<Vec<_>>().join(" ");
-            if !line.is_empty() {
-                let gutter = if row.children.is_empty() {
-                    "  "
-                } else {
-                    "│ "
-                };
-                let indent = child_prefix.chars().count() + gutter.chars().count();
-                let width = term_width
-                    .saturating_sub(indent)
-                    .clamp(DESC_MIN_WIDTH, DESC_MAX_WIDTH);
-                for wrapped in wrap_description(&line, width, DESC_MAX_LINES) {
-                    out.push_str(&format!(
-                        "{child_prefix}{gutter}{}\n",
-                        format_description(&wrapped, color)
-                    ));
-                }
-            }
-        }
-
         let children: Vec<&TestRow> = row.children.iter().collect();
         render_rows(out, &children, &child_prefix, color, term_width);
+    }
+}
 
-        if any_described && !last {
-            out.push_str(&format!("{prefix}│\n"));
+fn render_logs(
+    out: &mut String,
+    rows: &[TestRow],
+    go_module: &str,
+    sources: &Sources,
+    color: bool,
+) {
+    let multi_package = rows
+        .iter()
+        .map(|r| &r.package)
+        .collect::<HashSet<_>>()
+        .len()
+        > 1;
+    let mut blocks: Vec<(String, String)> = Vec::new();
+    for row in rows {
+        let prefix = if multi_package {
+            package_display(&row.package, go_module).to_string()
+        } else {
+            String::new()
+        };
+        collect_logs(row, &prefix, sources, color, &mut blocks);
+    }
+    if blocks.is_empty() {
+        return;
+    }
+
+    out.push('\n');
+    let heading = if color {
+        "Logs".bold().to_string()
+    } else {
+        "Logs".to_string()
+    };
+    out.push_str(&format!("  {heading}\n"));
+    let glyph = "≡";
+    for (path, body) in blocks {
+        out.push('\n');
+        out.push_str(&format!("  {glyph} {}\n", path.replace('`', "")));
+        for line in body.lines() {
+            out.push_str(&format!("    {line}\n"));
         }
     }
+}
+
+fn collect_logs(
+    row: &TestRow,
+    prefix: &str,
+    sources: &Sources,
+    color: bool,
+    blocks: &mut Vec<(String, String)>,
+) {
+    let path = if prefix.is_empty() {
+        row.name.clone()
+    } else {
+        format!("{prefix} › {}", row.name)
+    };
+    for record in &row.logs {
+        if let Some(body) = render_log(record, sources, color) {
+            blocks.push((path.clone(), body));
+        }
+    }
+    for child in &row.children {
+        collect_logs(child, &path, sources, color, blocks);
+    }
+}
+
+fn render_log(record: &LogRecord, sources: &Sources, color: bool) -> Option<String> {
+    let info = sources.get(&record.file)?;
+    let span = Span::new(record.file, record.lo, record.hi.saturating_sub(record.lo));
+    let diagnostic = LisetteDiagnostic::info(String::new())
+        .with_span_primary_label(&span, truncate_log_value(&record.value))
+        .with_label_accent(Style::new());
+    let rendered = diagnostics::render::render_to_string(
+        &diagnostic,
+        &info.source,
+        &info.filename,
+        color,
+        Style::new(),
+        2,
+    );
+    let body = rendered.lines().skip(1).collect::<Vec<_>>().join("\n");
+    Some(dim_source_lines(&body, color))
+}
+
+fn dim_source_lines(frame: &str, color: bool) -> String {
+    if !color {
+        return frame.to_string();
+    }
+    frame
+        .lines()
+        .map(|line| match line.find('│') {
+            Some(pos) => {
+                let (head, code) = line.split_at(pos + '│'.len_utf8());
+                format!("{head}{}", code.dimmed())
+            }
+            None => line.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn truncate_log_value(value: &str) -> String {
+    if value.chars().count() <= OPERAND_MAX_CHARS {
+        return value.to_string();
+    }
+    let head: String = value.chars().take(OPERAND_MAX_CHARS - 1).collect();
+    format!("{head}…")
+}
+
+struct FailureBlock {
+    status: Status,
+    path: String,
+    description: Option<String>,
+    kind: Option<String>,
+    body: String,
 }
 
 fn render_failures(
@@ -658,7 +775,7 @@ fn render_failures(
         .collect::<HashSet<_>>()
         .len()
         > 1;
-    let mut blocks: Vec<(Status, String, Option<String>, String)> = Vec::new();
+    let mut blocks: Vec<FailureBlock> = Vec::new();
     for row in rows {
         let prefix = if multi_package {
             package_display(&row.package, go_module).to_string()
@@ -678,22 +795,40 @@ fn render_failures(
         "Failures".to_string()
     };
     out.push_str(&format!("  {heading}\n"));
-    for (status, path, kind, body) in blocks {
+    for block in blocks {
         out.push('\n');
-        let glyph = mark(status, color);
-        let bare = path.replace('`', "");
-        let name = match status {
+        let glyph = mark(block.status, color);
+        let bare = block.path.replace('`', "");
+        let name = match block.status {
             Status::Crashed => yellow(&bare, color),
             _ => red(&bare, color),
         };
-        match kind {
+        match block.kind {
             Some(kind) => out.push_str(&format!("  {glyph} {name} · {kind}\n")),
             None => out.push_str(&format!("  {glyph} {name}\n")),
         }
-        for line in body.lines() {
+        if let Some(line) = failure_description_line(block.description.as_deref(), color) {
+            out.push_str(&format!("    {line}\n"));
+        }
+        for line in block.body.lines() {
             out.push_str(&format!("    {line}\n"));
         }
     }
+}
+
+fn failure_description_line(description: Option<&str>, color: bool) -> Option<String> {
+    let collapsed = description?
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let width = terminal_width()
+        .saturating_sub(4)
+        .clamp(DESC_MIN_WIDTH, DESC_MAX_WIDTH);
+    let line = wrap_description(&collapsed, width, 1).into_iter().next()?;
+    Some(format_description(&line, color))
 }
 
 fn collect_failures(
@@ -701,7 +836,7 @@ fn collect_failures(
     prefix: &str,
     sources: &Sources,
     color: bool,
-    blocks: &mut Vec<(Status, String, Option<String>, String)>,
+    blocks: &mut Vec<FailureBlock>,
 ) {
     let path = if prefix.is_empty() {
         row.name.clone()
@@ -715,7 +850,13 @@ fn collect_failures(
             .as_ref()
             .and_then(|record| render_failure(record, sources, color))
         {
-            blocks.push((row.status, path.clone(), Some(kind), body));
+            blocks.push(FailureBlock {
+                status: row.status,
+                path: path.clone(),
+                description: row.description.clone(),
+                kind: Some(kind),
+                body,
+            });
         } else if !has_failing_descendant(row) {
             let text = row
                 .output
@@ -726,7 +867,13 @@ fn collect_failures(
                 .collect::<Vec<_>>()
                 .join("\n");
             if !text.is_empty() {
-                blocks.push((row.status, path.clone(), None, text));
+                blocks.push(FailureBlock {
+                    status: row.status,
+                    path: path.clone(),
+                    description: row.description.clone(),
+                    kind: None,
+                    body: text,
+                });
             }
         }
     }
@@ -750,7 +897,7 @@ fn render_failure(
     let info = sources.get(&record.file)?;
     let span = Span::new(record.file, record.lo, record.hi.saturating_sub(record.lo));
 
-    let budget = operand_budget(terminal_width(), record.operands.len());
+    let budget = operand_budget(terminal_width());
     let anchor = match record.operands.as_slice() {
         [left, right] => first_divergence(&left.value, &right.value),
         _ => 0,
@@ -762,57 +909,77 @@ fn render_failure(
         .collect();
 
     let paired = matches!(record.kind.as_str(), "relation" | "labeled");
-    let (label, notes): (String, Vec<String>) = if paired {
+    let mut diagnostic = LisetteDiagnostic::error(record.message.clone());
+    if paired {
+        let label_width = record
+            .operands
+            .iter()
+            .map(|operand| operand.label.chars().count())
+            .max()
+            .unwrap_or(0)
+            + 1;
         let label = record
             .operands
             .iter()
             .zip(&values)
-            .map(|(operand, value)| format!("{}: {}", operand.label, value))
+            .map(|(operand, value)| {
+                let token = format!("{}:", operand.label);
+                format!("{token:<label_width$} {value}")
+            })
             .collect::<Vec<_>>()
-            .join(" · ");
-        (label, Vec::new())
+            .join("\n");
+        diagnostic = diagnostic.with_span_primary_label(&span, label);
     } else {
         let label = values
             .first()
             .cloned()
             .unwrap_or_else(|| record.message.clone());
-        let notes = record
+        diagnostic = diagnostic.with_span_primary_label(&span, label);
+        let notes: Vec<String> = record
             .operands
             .iter()
             .zip(&values)
             .skip(1)
             .map(|(operand, value)| format!("{}: {}", operand.label, value))
             .collect();
-        (label, notes)
-    };
-
-    let mut diagnostic =
-        LisetteDiagnostic::error(record.message.clone()).with_span_primary_label(&span, label);
-    if !notes.is_empty() {
-        diagnostic = diagnostic.with_note(notes.join("\n"));
+        if !notes.is_empty() {
+            diagnostic = diagnostic.with_note(notes.join("\n"));
+        }
     }
-    let rendered =
-        diagnostics::render::render_to_string(&diagnostic, &info.source, &info.filename, color);
+    let rendered = diagnostics::render::render_to_string(
+        &diagnostic,
+        &info.source,
+        &info.filename,
+        color,
+        Style::new().red(),
+        2,
+    );
     let body = rendered.lines().skip(1).collect::<Vec<_>>().join("\n");
     Some((record.message.clone(), body))
 }
 
-fn count_skipped(rows: &[TestRow]) -> usize {
+fn count_status(rows: &[TestRow], status: Status) -> usize {
     rows.iter()
-        .map(|r| (r.status == Status::Skipped) as usize + count_skipped(&r.children))
+        .map(|r| {
+            let own = (counts_in_own_right(r) && r.status == status) as usize;
+            own + count_status(&r.children, status)
+        })
         .sum()
 }
 
+fn counts_in_own_right(row: &TestRow) -> bool {
+    row.children.is_empty()
+        || row.status == Status::Skipped
+        || (matches!(row.status, Status::Failed | Status::Crashed)
+            && (row.failure.is_some() || !has_failing_descendant(row)))
+}
+
 fn summary(rows: &[TestRow], total: Duration, color: bool) -> String {
-    let passed = rows.iter().filter(|r| r.status == Status::Passed).count();
-    let failed = rows.iter().filter(|r| r.status == Status::Failed).count();
-    let crashed = rows.iter().filter(|r| r.status == Status::Crashed).count();
-    // A skip does not propagate to the parent row (unlike pass/fail), so count skips at any depth.
-    let skipped = count_skipped(rows);
-    let unreached = rows
-        .iter()
-        .filter(|r| r.status == Status::Unreached)
-        .count();
+    let passed = count_status(rows, Status::Passed);
+    let failed = count_status(rows, Status::Failed);
+    let crashed = count_status(rows, Status::Crashed);
+    let skipped = count_status(rows, Status::Skipped);
+    let unreached = count_status(rows, Status::Unreached);
 
     let glyph = mark(
         if failed > 0 {
@@ -832,7 +999,10 @@ fn summary(rows: &[TestRow], total: Duration, color: bool) -> String {
     if crashed > 0 {
         parts.push(yellow(&format!("{crashed} crashed"), color));
     }
-    parts.push(green(&format!("{passed} passed"), color));
+    let no_other_counts = failed == 0 && crashed == 0 && skipped == 0 && unreached == 0;
+    if passed > 0 || no_other_counts {
+        parts.push(green(&format!("{passed} passed"), color));
+    }
     if skipped > 0 {
         parts.push(blue(&format!("{skipped} skipped"), color));
     }
@@ -917,10 +1087,12 @@ fn terminal_width() -> usize {
         .unwrap_or(100)
 }
 
-fn operand_budget(term_width: usize, operands: usize) -> usize {
-    let operands = operands.max(1);
-    let reserved = 30 + 11 * operands;
-    (term_width.saturating_sub(reserved) / operands).clamp(OPERAND_MIN_CHARS, OPERAND_MAX_CHARS)
+fn operand_budget(term_width: usize) -> usize {
+    // Reserve the gutter and frame plus one `label: ` prefix.
+    let reserved = 41;
+    term_width
+        .saturating_sub(reserved)
+        .clamp(OPERAND_MIN_CHARS, OPERAND_MAX_CHARS)
 }
 
 fn first_divergence(a: &str, b: &str) -> usize {
@@ -1006,7 +1178,7 @@ fn mark(status: Status, color: bool) -> String {
         Status::Passed => "✓",
         Status::Failed => "✕",
         Status::Crashed => "▲",
-        Status::Skipped => "#",
+        Status::Skipped => "○",
         Status::Unreached => "⊘",
     };
     if !color {
@@ -1125,6 +1297,20 @@ mod tests {
             import_path: None,
             key: Some(SUBTEST_ATTR_KEY.to_string()),
             value: Some(hex_encode(name)),
+        }
+    }
+
+    fn log_attr_event(package: &str, test: &str, file: u32, value: &str) -> GoTestEvent {
+        let record = format!(r#"{{"file":{file},"lo":0,"hi":5,"value":{value:?}}}"#);
+        GoTestEvent {
+            action: "attr".to_string(),
+            package: package.to_string(),
+            test: Some(test.to_string()),
+            elapsed: None,
+            output: None,
+            import_path: None,
+            key: Some(LOG_ATTR_KEY.to_string()),
+            value: Some(hex_encode(&record)),
         }
     }
 
@@ -1262,6 +1448,35 @@ mod tests {
     }
 
     #[test]
+    fn logged_values_render_in_a_logs_section_for_a_passing_test() {
+        let index = index(&[(ENTRY_MODULE_ID, "inspects")]);
+        let events = vec![
+            log_attr_event("demo", "TestInspects", 7, "42"),
+            event("pass", "demo", Some("TestInspects"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+
+        let mut sources = no_sources();
+        sources.insert(
+            7,
+            SourceInfo {
+                source: "fn inspects() {\n  t.log(count)\n}\n".to_string(),
+                filename: "x.test.lis".to_string(),
+            },
+        );
+        let text = render(&report, &sources, false, Duration::from_millis(1));
+
+        assert!(text.contains("Logs"), "a Logs section appears:\n{text}");
+        assert!(
+            text.contains("inspects"),
+            "the logging test is named:\n{text}"
+        );
+        assert!(text.contains("42"), "the logged value is shown:\n{text}");
+        assert!(text.contains("1 passed"));
+        assert_eq!(exit_code(&report.rows, true), 0);
+    }
+
+    #[test]
     fn every_module_groups_its_tests_under_filenames() {
         let mut index = TestIndex::default();
         for (name, file) in [("adds", 1u32), ("subtracts", 2u32)] {
@@ -1350,6 +1565,25 @@ mod tests {
     }
 
     #[test]
+    fn summary_counts_subtests_not_their_parent() {
+        let index = index(&[(ENTRY_MODULE_ID, "parent")]);
+        let events = vec![
+            event("run", "demo", Some("TestParent"), None),
+            event("run", "demo", Some("TestParent/alpha"), None),
+            event("pass", "demo", Some("TestParent/alpha"), None),
+            event("run", "demo", Some("TestParent/beta"), None),
+            event("pass", "demo", Some("TestParent/beta"), None),
+            event("pass", "demo", Some("TestParent"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+        let text = render(&report, &no_sources(), false, Duration::from_millis(1));
+        assert!(
+            text.contains("2 passed"),
+            "two passing subtests count as two, not one parent, got:\n{text}"
+        );
+    }
+
+    #[test]
     fn skipped_test_shows_reason_and_is_not_a_failure() {
         let index = index(&[(ENTRY_MODULE_ID, "wip")]);
         let events = vec![
@@ -1362,7 +1596,7 @@ mod tests {
         assert_eq!(report.rows[0].skip_reason.as_deref(), Some("not ready"));
 
         let text = render(&report, &no_sources(), false, Duration::from_millis(1));
-        assert!(text.contains("# wip (not ready)"), "got:\n{text}");
+        assert!(text.contains("○ wip (not ready)"), "got:\n{text}");
         assert!(text.contains("1 skipped"));
         assert_eq!(exit_code(&report.rows, true), 0, "a skip is not a failure");
     }
@@ -1382,7 +1616,7 @@ mod tests {
 
         let row_line = text
             .lines()
-            .find(|line| line.contains("# wip"))
+            .find(|line| line.contains("○ wip"))
             .expect("the skipped row must render");
         assert!(
             !row_line.contains("this reason"),
@@ -1415,7 +1649,7 @@ mod tests {
         assert_eq!(child.skip_reason.as_deref(), Some("needs net"));
 
         let text = render(&report, &no_sources(), false, Duration::from_millis(1));
-        assert!(text.contains("# child (needs net)"), "got:\n{text}");
+        assert!(text.contains("○ child (needs net)"), "got:\n{text}");
         assert!(
             text.contains("1 skipped"),
             "a skipped subtest must count in the footer, got:\n{text}"
@@ -1438,12 +1672,16 @@ mod tests {
 
         let text = render(&report, &no_sources(), false, Duration::from_millis(1));
         assert!(
-            text.contains("# parent (rest not ready)"),
+            text.contains("○ parent (rest not ready)"),
             "a skipped grouping keeps its marker and reason, got:\n{text}"
         );
         assert!(
             text.contains("✓ child"),
             "its child still renders, got:\n{text}"
+        );
+        assert!(
+            text.contains("1 passed") && text.contains("1 skipped"),
+            "the passing child and the skipped grouping both count, got:\n{text}"
         );
     }
 
@@ -1474,6 +1712,10 @@ mod tests {
         assert!(
             text.contains("parent panicked"),
             "a failed parent's own output must show even with subtests, got:\n{text}"
+        );
+        assert!(
+            text.contains("1 failed") && text.contains("1 passed"),
+            "the failed grouping and its passing child both count, got:\n{text}"
         );
     }
 
@@ -1843,6 +2085,44 @@ mod tests {
         assert!(text.contains("x.test.lis"), "got:\n{text}");
     }
 
+    #[test]
+    fn failure_block_shows_test_description() {
+        let mut index = TestIndex::default();
+        index.push(TestFunction {
+            module_id: ENTRY_MODULE_ID.to_string(),
+            qualified_name: format!("{ENTRY_MODULE_ID}.multiplies"),
+            title: None,
+            doc: Some(
+                "Guards the multiplication that downstream calculations rely on.".to_string(),
+            ),
+            span: span(),
+        });
+        let inner = r#"{"file":7,"lo":3,"hi":9,"message":"assertion failed","operands":[{"label":"left","value":"42"},{"label":"right","value":"43"}]}"#;
+        let events = vec![
+            attr_event("demo", "TestMultiplies", &fail_value(inner)),
+            event("fail", "demo", Some("TestMultiplies"), None),
+        ];
+        let report = build_report(&index, &events, "demo");
+
+        let mut sources = no_sources();
+        sources.insert(
+            7,
+            SourceInfo {
+                source: "fn multiplies() {}\n".to_string(),
+                filename: "x.test.lis".to_string(),
+            },
+        );
+        let text = render(&report, &sources, false, Duration::from_millis(1));
+        let failures = text
+            .split("Failures")
+            .nth(1)
+            .expect("a Failures section should render");
+        assert!(
+            failures.contains("Guards the multiplication that downstream calculations rely on."),
+            "the failure block should show the test description, got:\n{text}"
+        );
+    }
+
     fn titled_index() -> TestIndex {
         let mut index = TestIndex::default();
         index.push(TestFunction {
@@ -1863,7 +2143,7 @@ mod tests {
     }
 
     #[test]
-    fn title_replaces_name_and_doc_renders_as_description() {
+    fn title_replaces_name_and_description_stays_off_the_tree() {
         let report = build_report(&titled_index(), &[], "demo");
         let titled = report
             .rows
@@ -1876,9 +2156,12 @@ mod tests {
         );
         let text = render(&report, &no_sources(), false, Duration::from_millis(1));
         assert!(
-            text.contains("splits and trims CSV fields")
-                && text.contains("Trims surrounding whitespace"),
-            "got:\n{text}"
+            text.contains("splits and trims CSV fields"),
+            "the title shows in the tree, got:\n{text}"
+        );
+        assert!(
+            !text.contains("Trims surrounding whitespace"),
+            "the description must not render in the tree, got:\n{text}"
         );
     }
 

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -146,6 +146,7 @@ pub fn compile(
         &config.go_module,
         EmitOptions {
             sourcemap: config.sourcemap,
+            emit_tests: config.emit_tests,
         },
     );
 

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -1,5 +1,5 @@
 use miette::{Diagnostic, LabeledSpan, Severity};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Style};
 use std::fmt;
 use std::sync::Arc;
 
@@ -187,6 +187,7 @@ pub struct LisetteDiagnostic {
     code: Option<String>,
     file_id: Option<u32>,
     use_color: bool,
+    label_accent: Option<Style>,
 }
 
 impl fmt::Display for LisetteDiagnostic {
@@ -279,16 +280,20 @@ impl Diagnostic for LisetteDiagnostic {
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
         let use_color = self.use_color;
         let severity = self.severity;
+        let accent = self.label_accent;
 
         let formatted_labels = self.labels.iter().map(move |span| {
             if let Some(label) = span.label() {
                 let formatted = if use_color {
-                    let base_style = match severity {
-                        Severity::Error => |s: &str| format!("{}", s.red()),
-                        Severity::Warning => |s: &str| format!("{}", s.yellow()),
-                        Severity::Advice => |s: &str| format!("{}", s.blue()),
+                    let style = move |s: &str| match accent {
+                        Some(accent) => format!("{}", s.style(accent)),
+                        None => match severity {
+                            Severity::Error => format!("{}", s.red()),
+                            Severity::Warning => format!("{}", s.yellow()),
+                            Severity::Advice => format!("{}", s.blue()),
+                        },
                     };
-                    format_with_backticks(label, true, base_style)
+                    format_with_backticks(label, true, style)
                 } else {
                     label.to_string()
                 };
@@ -333,7 +338,13 @@ impl LisetteDiagnostic {
             code: None,
             file_id: None,
             use_color: false,
+            label_accent: None,
         }
+    }
+
+    pub fn with_label_accent(mut self, accent: Style) -> Self {
+        self.label_accent = Some(accent);
+        self
     }
 
     pub fn error(message: impl Into<String>) -> Self {

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -130,6 +130,27 @@ fn color_handler(highlight: Style) -> GraphicalReportHandler {
     GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
 }
 
+fn accent_handler(accent: Style) -> GraphicalReportHandler {
+    let theme = GraphicalTheme {
+        characters: ThemeCharacters {
+            error: "✕".into(),
+            warning: "▲".into(),
+            advice: "●".into(),
+            ..ThemeCharacters::unicode()
+        },
+        styles: ThemeStyles {
+            error: Style::new().red(),
+            warning: Style::new().yellow(),
+            advice: accent,
+            link: Style::new(),
+            help: Style::new().dimmed(),
+            highlights: vec![accent],
+            ..ThemeStyles::ansi()
+        },
+    };
+    GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
+}
+
 fn nocolor_handler() -> GraphicalReportHandler {
     let theme = GraphicalTheme {
         characters: ThemeCharacters {
@@ -165,12 +186,15 @@ pub fn render_to_string(
     source: &str,
     filename: &str,
     use_color: bool,
+    accent: Style,
+    context_lines: usize,
 ) -> String {
     let handler = if use_color {
-        color_handler(Style::new().red())
+        accent_handler(accent)
     } else {
         nocolor_handler()
-    };
+    }
+    .with_context_lines(context_lines);
     let report = diagnostic
         .clone()
         .with_color(use_color)

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -8,7 +8,9 @@ use crate::Planner;
 use crate::definitions::enum_layout::{
     ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, ENUM_TAG_FIELD,
 };
-use crate::definitions::structs::{should_synthesize_stringer, struct_field_go_name};
+use crate::definitions::structs::{
+    DEBUG_STRING_METHOD, should_synthesize_stringer, struct_field_go_name,
+};
 use crate::names::go_name;
 
 type SpanMap = HashMap<String, Vec<Span>>;
@@ -153,6 +155,12 @@ impl Planner<'_> {
                         .or_default()
                         .push(*name_span);
                 }
+                if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
+                    members
+                        .entry(DEBUG_STRING_METHOD.to_string())
+                        .or_default()
+                        .push(*name_span);
+                }
             }
             Expression::Enum {
                 name,
@@ -234,6 +242,12 @@ impl Planner<'_> {
                 if self.should_synthesize_equals(name) {
                     members
                         .entry(self.equals_method_go_name())
+                        .or_default()
+                        .push(*name_span);
+                }
+                if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
+                    members
+                        .entry(DEBUG_STRING_METHOD.to_string())
                         .or_default()
                         .push(*name_span);
                 }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -243,6 +243,10 @@ impl<'a> EmitFacts<'a> {
         self.options.sourcemap
     }
 
+    pub(crate) fn emit_tests_enabled(&self) -> bool {
+        self.options.emit_tests
+    }
+
     pub(crate) fn line_index(&self, file_id: u32) -> Option<&LineIndex> {
         self.line_indexes.get(&file_id)
     }

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::definitions::structs::stringer_verb;
+use crate::definitions::structs::{debug_verb, stringer_verb};
 use crate::names::go_name;
 use crate::utils::receiver_name;
 use syntax::ast::{EnumVariant, Generic};
@@ -305,6 +305,85 @@ impl EnumLayout {
         format!(
             "return fmt.Sprintf(\"{}{}{}{}{}\", {})",
             prefix,
+            variant.name,
+            open,
+            placeholders,
+            close,
+            args.join(", ")
+        )
+    }
+
+    pub(crate) fn emit_debug_method(&self, receiver_generics: &str, prelude: &str) -> String {
+        let receiver = receiver_name(&self.enum_name);
+        let go_type_name = go_name::escape_keyword(&self.enum_name);
+        let receiver_type = format!("{}{}", go_type_name, receiver_generics);
+
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "func ({receiver} {receiver_type}) DebugString() string {{"
+        ));
+        lines.push(format!("switch {receiver}.Tag {{"));
+
+        for variant in &self.variants {
+            lines.push(format!("case {}:", variant.tag_constant));
+            lines.push(self.build_variant_debug_line(variant, &receiver, prelude));
+        }
+
+        lines.push("default:".to_string());
+        lines.push(format!(
+            "return fmt.Sprintf(\"{}(%d)\", {receiver}.Tag)",
+            self.enum_name
+        ));
+        lines.push("}".to_string());
+        lines.push("}".to_string());
+
+        lines.join("\n")
+    }
+
+    pub(crate) fn debug_uses_prelude(&self) -> bool {
+        self.variants
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .any(|f| !f.is_function)
+    }
+
+    fn build_variant_debug_line(
+        &self,
+        variant: &VariantLayout,
+        receiver: &str,
+        prelude: &str,
+    ) -> String {
+        if variant.fields.is_empty() {
+            return format!("return \"{}\"", variant.name);
+        }
+        let args: Vec<String> = variant
+            .fields
+            .iter()
+            .map(|f| {
+                if f.is_function {
+                    format!("{receiver}.{}", f.go_name)
+                } else {
+                    format!("{prelude}.Debug({receiver}.{})", f.go_name)
+                }
+            })
+            .collect();
+        let (open, close, placeholders) = if variant.is_struct_variant {
+            let parts: Vec<String> = variant
+                .fields
+                .iter()
+                .map(|f| format!("{}: {}", f.source_name, debug_verb(f.is_function)))
+                .collect();
+            (" { ", " }", parts.join(", "))
+        } else {
+            let parts: Vec<&str> = variant
+                .fields
+                .iter()
+                .map(|f| debug_verb(f.is_function))
+                .collect();
+            ("(", ")", parts.join(", "))
+        };
+        format!(
+            "return fmt.Sprintf(\"{}{}{}{}\", {})",
             variant.name,
             open,
             placeholders,

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -1,9 +1,9 @@
 use crate::EmitEffects;
 use crate::Planner;
-use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
+use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, EnumLayout};
 use crate::definitions::structs::should_synthesize_stringer;
 use crate::names::generics::receiver_generics_string;
-use crate::names::go_name;
+use crate::names::go_name::{self, prelude_qualifier};
 use crate::utils::receiver_name;
 use syntax::ast::{Attribute, Generic};
 use syntax::program::{Definition, DefinitionBody};
@@ -84,6 +84,7 @@ impl Planner<'_> {
             result.push_str("\n\n");
             result.push_str(&layout.emit_variants_function(&fn_name));
         }
+        self.append_enum_debug_method(&mut result, name, &receiver_generics, &layout, fx);
         self.append_to_string_method(&mut result, name, &receiver_generics, attributes);
         self.append_enum_equals_method(&mut result, name, &enum_id, &receiver_generics, fx);
         if needs_fmt {
@@ -94,6 +95,25 @@ impl Planner<'_> {
         }
 
         Some(result)
+    }
+
+    fn append_enum_debug_method(
+        &self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        layout: &EnumLayout,
+        fx: &mut EmitEffects,
+    ) {
+        if !self.synthesizes_debug_string(name) {
+            return;
+        }
+        out.push_str("\n\n");
+        out.push_str(&layout.emit_debug_method(receiver_generics, prelude_qualifier()));
+        fx.require_fmt();
+        if layout.debug_uses_prelude() {
+            fx.require_stdlib();
+        }
     }
 
     fn append_enum_equals_method(

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -4,11 +4,13 @@ use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_MET
 use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::expressions::top_items::emit_doc;
 use crate::names::generics::receiver_generics_string;
-use crate::names::go_name;
+use crate::names::go_name::{self, prelude_qualifier};
 use crate::utils::receiver_name;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructKind};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::Type;
+
+pub(crate) const DEBUG_STRING_METHOD: &str = "DebugString";
 
 impl Planner<'_> {
     pub(crate) fn emit_struct_definition(
@@ -71,6 +73,13 @@ impl Planner<'_> {
         } else {
             definition
         };
+        self.append_struct_debug_method(
+            &mut result,
+            name,
+            &receiver_generics,
+            &stringer_fields,
+            fx,
+        );
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
         self.append_equals_method(
             &mut result,
@@ -117,6 +126,14 @@ impl Planner<'_> {
                 result.push_str(&string_method);
             }
         }
+        self.append_tuple_struct_debug_method(
+            &mut result,
+            name,
+            &receiver_generics,
+            fields,
+            generics_string,
+            fx,
+        );
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
         result
     }
@@ -223,6 +240,94 @@ impl Planner<'_> {
         let has_go_stringer =
             is_user_stringer("goString") || is_user_stringer(ENUM_GO_STRINGER_METHOD);
         (has_stringer, has_go_stringer)
+    }
+
+    pub(crate) fn debug_string_override(&self, name: &str) -> bool {
+        let qualified = self.facts.qualified_current(name);
+        let methods = self
+            .facts
+            .definition(qualified.as_str())
+            .and_then(|definition| match &definition.body {
+                DefinitionBody::Struct { methods, .. }
+                | DefinitionBody::Enum { methods, .. }
+                | DefinitionBody::TypeAlias { methods, .. } => Some(methods),
+                _ => None,
+            });
+        let has_signature = |method_name: &str| {
+            methods.is_some_and(|m| m.get(method_name).is_some_and(Type::is_stringer_signature))
+                && !self.facts.is_ufcs_method(&qualified, method_name)
+        };
+        (self.method_needs_export("debug_string") && has_signature("debug_string"))
+            || has_signature(DEBUG_STRING_METHOD)
+    }
+
+    pub(crate) fn synthesizes_debug_string(&self, name: &str) -> bool {
+        self.facts.emit_tests_enabled() && !self.debug_string_override(name)
+    }
+
+    fn append_struct_debug_method(
+        &self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        stringer_fields: &[StringerField],
+        fx: &mut EmitEffects,
+    ) {
+        if !self.synthesizes_debug_string(name) {
+            return;
+        }
+        if !stringer_fields.is_empty() {
+            fx.require_fmt();
+            if stringer_fields.iter().any(|f| !f.is_function) {
+                fx.require_stdlib();
+            }
+        }
+        out.push_str("\n\n");
+        out.push_str(&emit_struct_debug_method(
+            name,
+            receiver_generics,
+            stringer_fields,
+            prelude_qualifier(),
+        ));
+    }
+
+    fn append_tuple_struct_debug_method(
+        &mut self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        fields: &[StructFieldDefinition],
+        generics_string: &str,
+        fx: &mut EmitEffects,
+    ) {
+        if !self.synthesizes_debug_string(name) {
+            return;
+        }
+        let is_type_alias = fields.len() == 1 && generics_string.is_empty();
+        let underlying = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
+        let field_is_function: Vec<bool> =
+            fields.iter().map(|f| is_raw_function_type(&f.ty)).collect();
+        let uses_prelude = if fields.is_empty() {
+            false
+        } else if is_type_alias {
+            true
+        } else {
+            field_is_function.iter().any(|is_function| !is_function)
+        };
+        if !fields.is_empty() {
+            fx.require_fmt();
+        }
+        if uses_prelude {
+            fx.require_stdlib();
+        }
+        out.push_str("\n\n");
+        out.push_str(&emit_tuple_struct_debug_method(
+            name,
+            receiver_generics,
+            &field_is_function,
+            underlying.as_deref(),
+            prelude_qualifier(),
+        ));
     }
 
     pub(crate) fn should_synthesize_to_string(&self, name: &str, attributes: &[Attribute]) -> bool {
@@ -371,6 +476,10 @@ pub(crate) fn stringer_verb(is_function: bool) -> &'static str {
     if is_function { "%p" } else { "%v" }
 }
 
+pub(crate) fn debug_verb(is_function: bool) -> &'static str {
+    if is_function { "%p" } else { "%s" }
+}
+
 fn is_option_type(ty: &Type) -> bool {
     match ty {
         Type::Nominal {
@@ -423,6 +532,41 @@ fn emit_struct_stringer_method(
     )
 }
 
+fn emit_struct_debug_method(
+    name: &str,
+    receiver_generics: &str,
+    fields: &[StringerField],
+    prelude: &str,
+) -> String {
+    let receiver = receiver_name(name);
+    let go_type_name = go_name::escape_keyword(name);
+    let receiver_type = format!("{go_type_name}{receiver_generics}");
+    if fields.is_empty() {
+        return format!(
+            "func ({receiver} {receiver_type}) DebugString() string {{\nreturn \"{name}\"\n}}"
+        );
+    }
+    let format_parts: Vec<String> = fields
+        .iter()
+        .map(|f| format!("{}: {}", f.source_name, debug_verb(f.is_function)))
+        .collect();
+    let args: Vec<String> = fields
+        .iter()
+        .map(|f| {
+            if f.is_function {
+                format!("{receiver}.{}", f.go_name)
+            } else {
+                format!("{prelude}.Debug({receiver}.{})", f.go_name)
+            }
+        })
+        .collect();
+    format!(
+        "func ({receiver} {receiver_type}) DebugString() string {{\nreturn fmt.Sprintf(\"{name} {{ {} }}\", {})\n}}",
+        format_parts.join(", "),
+        args.join(", ")
+    )
+}
+
 fn emit_tuple_struct_stringer_method(
     name: &str,
     receiver_generics: &str,
@@ -449,6 +593,48 @@ fn emit_tuple_struct_stringer_method(
         .collect();
     format!(
         "func ({receiver} {receiver_type}) {method_name}() string {{\nreturn fmt.Sprintf(\"{name}({})\", {})\n}}",
+        placeholders.join(", "),
+        args.join(", ")
+    )
+}
+
+fn emit_tuple_struct_debug_method(
+    name: &str,
+    receiver_generics: &str,
+    field_is_function: &[bool],
+    underlying_go_type: Option<&str>,
+    prelude: &str,
+) -> String {
+    let receiver = receiver_name(name);
+    let go_type_name = go_name::escape_keyword(name);
+    let receiver_type = format!("{go_type_name}{receiver_generics}");
+    if field_is_function.is_empty() {
+        return format!(
+            "func ({receiver} {receiver_type}) DebugString() string {{\nreturn \"{name}\"\n}}"
+        );
+    }
+    if let Some(underlying) = underlying_go_type {
+        return format!(
+            "func ({receiver} {receiver_type}) DebugString() string {{\nreturn fmt.Sprintf(\"{name}(%s)\", {prelude}.Debug({underlying}({receiver})))\n}}"
+        );
+    }
+    let placeholders: Vec<&str> = field_is_function
+        .iter()
+        .map(|is_function| debug_verb(*is_function))
+        .collect();
+    let args: Vec<String> = field_is_function
+        .iter()
+        .enumerate()
+        .map(|(i, is_function)| {
+            if *is_function {
+                format!("{receiver}.F{i}")
+            } else {
+                format!("{prelude}.Debug({receiver}.F{i})")
+            }
+        })
+        .collect();
+    format!(
+        "func ({receiver} {receiver_type}) DebugString() string {{\nreturn fmt.Sprintf(\"{name}({})\", {})\n}}",
         placeholders.join(", "),
         args.join(", ")
     )

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -1,7 +1,7 @@
 use crate::EmitEffects;
 use crate::Planner;
 use crate::definitions::functions::is_test_context_ty;
-use crate::names::go_name;
+use crate::names::go_name::{self, testing_qualifier, testkit_qualifier};
 use syntax::ast::{Binding, Expression, FunctionDefinitionView, Pattern, Visibility};
 use syntax::types::{Symbol, Type};
 
@@ -114,8 +114,8 @@ impl Planner<'_> {
     ) -> String {
         fx.require_testing();
         fx.require_testkit();
-        let test_kit = go_name::GeneratedPackage::TestKit.qualifier();
-        let testing = go_name::GeneratedPackage::Testing.qualifier();
+        let test_kit = testkit_qualifier();
+        let testing = testing_qualifier();
 
         let injected = self.synthesized_test_handle_params(function);
         let function = match &injected {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -57,6 +57,7 @@ use syntax::types::{Symbol, Type};
 #[derive(Clone, Debug, Default)]
 pub struct EmitOptions {
     pub sourcemap: bool,
+    pub emit_tests: bool,
 }
 
 #[derive(Default)]
@@ -298,7 +299,10 @@ impl<'a> Planner<'a> {
             bound_types: config.bound_types,
             entry_module: config.module_id.to_string(),
             go_module: config.go_module.to_string(),
-            options: EmitOptions { sourcemap },
+            options: EmitOptions {
+                sourcemap,
+                emit_tests: false,
+            },
             line_indexes,
             globals,
             generic_base: Arc::new(OnceLock::new()),

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -348,6 +348,18 @@ impl GeneratedPackage {
     }
 }
 
+pub(crate) fn prelude_qualifier() -> &'static str {
+    GeneratedPackage::Prelude.qualifier()
+}
+
+pub(crate) fn testkit_qualifier() -> &'static str {
+    GeneratedPackage::TestKit.qualifier()
+}
+
+pub(crate) fn testing_qualifier() -> &'static str {
+    GeneratedPackage::Testing.qualifier()
+}
+
 pub(crate) fn is_generated_import_qualifier(name: &str) -> bool {
     GeneratedPackage::ALL
         .iter()

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -7,7 +7,7 @@ use syntax::types::Type;
 use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
-use crate::names::go_name;
+use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::binding_emit::{
     apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
@@ -368,8 +368,8 @@ impl Planner<'_> {
                     .expect("let assert without a test handle should be rejected by semantics");
                 fx.require_testkit();
                 fx.require_stdlib();
-                let testkit = go_name::GeneratedPackage::TestKit.qualifier();
-                let prelude = go_name::GeneratedPackage::Prelude.qualifier();
+                let testkit = testkit_qualifier();
+                let prelude = prelude_qualifier();
                 self.scope.record_go_use(subject_var);
                 let (file, lo, hi) = (
                     span.file_id,

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -4,8 +4,8 @@ use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
-use crate::definitions::functions::{is_breakless_loop, is_go_never};
-use crate::names::go_name;
+use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
+use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
     LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan, directed,
@@ -382,6 +382,9 @@ impl Planner<'_> {
                 }
                 LoweredStatement::RawGo(buffer)
             }
+            Expression::Call { .. } if self.is_test_log_call(expression) => {
+                self.lower_test_log_statement(expression, fx)
+            }
             _ => self.lower_expression_statement(expression, fx),
         }
     }
@@ -460,6 +463,7 @@ impl Planner<'_> {
         let AssertShape {
             condition,
             kind,
+            message,
             operands,
         } = shape;
         let handle = self
@@ -467,12 +471,89 @@ impl Planner<'_> {
             .expect("assert without a test handle should be rejected by semantics");
         let span = operand.get_span();
         statements.push(LoweredStatement::RawGo(format!(
-            "if !({condition}) {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"assertion failed\"{operands})\n}}\n",
+            "if !({condition}) {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"{message}\"{operands})\n}}\n",
             span.file_id,
             span.byte_offset,
             span.byte_offset + span.byte_length,
         )));
         LoweredStatement::Block(LoweredBlock { statements })
+    }
+
+    pub(crate) fn is_test_log_call(&self, expression: &Expression) -> bool {
+        let Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } = expression.unwrap_parens()
+        else {
+            return false;
+        };
+        if args.len() != 1 {
+            return false;
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return false;
+        };
+        member.as_str() == "log" && is_test_context_ty(&receiver.get_type())
+    }
+
+    pub(crate) fn lower_test_log_statement(
+        &mut self,
+        expression: &Expression,
+        fx: &mut EmitEffects,
+    ) -> LoweredStatement {
+        let (mut statements, call) = self.lower_test_log_call(expression, fx);
+        statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+        LoweredStatement::Block(LoweredBlock { statements })
+    }
+
+    pub(crate) fn lower_test_log_call(
+        &mut self,
+        expression: &Expression,
+        fx: &mut EmitEffects,
+    ) -> (Vec<LoweredStatement>, String) {
+        let Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } = expression.unwrap_parens()
+        else {
+            unreachable!("lower_test_log_call requires a call");
+        };
+        let Expression::DotAccess {
+            expression: receiver,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            unreachable!("lower_test_log_call requires a method receiver");
+        };
+        fx.require_testkit();
+        fx.require_stdlib();
+
+        let mut statements = Vec::new();
+        let (recv_setup, handle) = self
+            .lower_value(receiver, ExpressionContext::value(), fx)
+            .into_parts();
+        statements.extend(recv_setup);
+        let (arg_setup, value) = self
+            .lower_value(&args[0], ExpressionContext::value(), fx)
+            .into_parts();
+        statements.extend(arg_setup);
+
+        let prelude = prelude_qualifier();
+        let span = args[0].get_span();
+        let call = format!(
+            "{handle}.Log({}, {}, {}, {prelude}.Debug({value}))",
+            span.file_id,
+            span.byte_offset,
+            span.byte_offset + span.byte_length,
+        );
+        (statements, call)
     }
 
     /// `assert a <op> b`: compare the captured temps via the normal binary
@@ -503,6 +584,7 @@ impl Planner<'_> {
         AssertShape {
             condition,
             kind: "relation",
+            message: format!("expected {operator}"),
             operands: paired_operands(&lhs, &rhs),
         }
     }
@@ -523,6 +605,7 @@ impl Planner<'_> {
         AssertShape {
             condition,
             kind: "labeled",
+            message: "expected ==".to_string(),
             operands: paired_operands(&lhs, &rhs),
         }
     }
@@ -539,6 +622,7 @@ impl Planner<'_> {
         AssertShape {
             condition,
             kind: "bare",
+            message: "assertion failed".to_string(),
             operands: String::new(),
         }
     }
@@ -1070,14 +1154,12 @@ impl Planner<'_> {
 struct AssertShape {
     condition: String,
     kind: &'static str,
+    message: String,
     operands: String,
 }
 
 fn paired_operands(lhs: &str, rhs: &str) -> String {
-    let (test_kit, prelude) = (
-        go_name::GeneratedPackage::TestKit.qualifier(),
-        go_name::GeneratedPackage::Prelude.qualifier(),
-    );
+    let (test_kit, prelude) = (testkit_qualifier(), prelude_qualifier());
     format!(
         ", {test_kit}.Operand{{Label: \"left\", Value: {prelude}.Debug({lhs})}}, {test_kit}.Operand{{Label: \"right\", Value: {prelude}.Debug({rhs})}}"
     )

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -87,6 +87,10 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
         fx: &mut EmitEffects,
     ) -> ValuePlan {
+        if self.is_test_log_call(expression) {
+            let (setup, call) = self.lower_test_log_call(expression, fx);
+            return value_plan_from_statements(setup, call);
+        }
         match expression {
             Expression::Paren { expression, .. } => {
                 ValuePlan::Paren(Box::new(self.plan_operand(expression, ctx, fx)))

--- a/crates/stdlib/test_prelude.d.lis
+++ b/crates/stdlib/test_prelude.d.lis
@@ -10,4 +10,7 @@ impl TestContext {
 
     /// Skip this test at runtime with a reason.
     pub fn skip(self, reason: string) -> Never
+
+    /// Log a value while debugging.
+    pub fn log(self, value: Unknown)
 }

--- a/prelude/debug.go
+++ b/prelude/debug.go
@@ -2,7 +2,10 @@ package lisette
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"strconv"
+	"strings"
 )
 
 // Debugger renders a value for diagnostics, quoting nested strings (unlike Stringer's display form).
@@ -10,14 +13,40 @@ type Debugger interface {
 	DebugString() string
 }
 
-// Debug renders v for a diagnostic: strings quoted, a Debugger via DebugString, else display form.
+// Debug renders v for a diagnostic: strings quoted, a Debugger via DebugString,
+// slices and maps element-wise, else display form.
 func Debug(v any) string {
-	switch x := v.(type) {
-	case string:
-		return strconv.Quote(x)
-	case Debugger:
-		return x.DebugString()
-	default:
-		return fmt.Sprintf("%v", x)
+	if s, ok := v.(string); ok {
+		return strconv.Quote(s)
 	}
+
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return "nil"
+	}
+	if d, ok := v.(Debugger); ok {
+		return d.DebugString()
+	}
+
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		parts := make([]string, rv.Len())
+		for i := range parts {
+			parts[i] = Debug(rv.Index(i).Interface())
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	case reflect.Map:
+		if rv.Len() == 0 {
+			return "{}"
+		}
+		parts := make([]string, 0, rv.Len())
+		for _, key := range rv.MapKeys() {
+			parts = append(parts, Debug(key.Interface())+": "+Debug(rv.MapIndex(key).Interface()))
+		}
+		sort.Strings(parts)
+		return "{ " + strings.Join(parts, ", ") + " }"
+	case reflect.Pointer:
+		return Debug(rv.Elem().Interface())
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/prelude/debug_test.go
+++ b/prelude/debug_test.go
@@ -1,0 +1,18 @@
+package lisette
+
+import "testing"
+
+type valueReceiverDebug struct{ x int }
+
+func (v valueReceiverDebug) DebugString() string { return "vd" }
+
+func TestDebugTypedNilPointerDoesNotPanic(t *testing.T) {
+	var p *valueReceiverDebug
+	if got := Debug(p); got != "nil" {
+		t.Fatalf("Debug(typed nil) = %q, want \"nil\"", got)
+	}
+	v := valueReceiverDebug{x: 1}
+	if got := Debug(&v); got != "vd" {
+		t.Fatalf("Debug(&value) = %q, want \"vd\"", got)
+	}
+}

--- a/prelude/testkit/testkit.go
+++ b/prelude/testkit/testkit.go
@@ -39,6 +39,26 @@ func (c TestContext) Skip(reason string) {
 	c.t.SkipNow()
 }
 
+type logRecord struct {
+	File  int    `json:"file"`
+	Lo    uint32 `json:"lo"`
+	Hi    uint32 `json:"hi"`
+	Value string `json:"value"`
+}
+
+// Log reports a logged value to lis.
+func (c TestContext) Log(file int, lo, hi uint32, value string) {
+	const maxRunes = 256
+	if runes := []rune(value); len(runes) > maxRunes {
+		value = string(runes[:maxRunes]) + "…"
+	}
+	inner, err := json.Marshal(logRecord{file, lo, hi, value})
+	if err != nil {
+		return
+	}
+	c.t.Attr("lisette-log", hex.EncodeToString(inner))
+}
+
 // Recover turns an uncaught panic into a Lisette failure anchored at the test, so it reports like an
 // assertion instead of dumping a Go stack. Test wrappers defer this.
 func Recover(t *testing.T, file int, lo, hi uint32) {

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -218,7 +218,10 @@ fn emit_and_write(
     let files = Planner::emit(
         &result.into_emit_input(),
         &module,
-        EmitOptions { sourcemap: false },
+        EmitOptions {
+            sourcemap: false,
+            emit_tests: false,
+        },
     );
     let dir = work.join("emitted");
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -186,7 +186,10 @@ pub fn compile_project_files_with_tests(
     Planner::emit(
         &analysis.into_emit_input(),
         go_module,
-        EmitOptions { sourcemap },
+        EmitOptions {
+            sourcemap,
+            emit_tests,
+        },
     )
 }
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -737,3 +737,40 @@ fn loose_dir_check_does_not_duplicate_child_diagnostics() {
         "a loose-directory check must report a child module's diagnostic once, not once per ancestor sweep:\n{combined}"
     );
 }
+
+#[test]
+fn t_log_renders_logged_values_in_a_logs_section() {
+    if !go_available() {
+        eprintln!("skipping t_log_renders_logged_values_in_a_logs_section: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"logdemo\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/main.lis"), "fn main() {\n}\n").unwrap();
+    fs::write(
+        project.join("src/demo.test.lis"),
+        "#[test]\nfn logs_a_value(t: TestContext) {\n  let user = \"alice\"\n  t.log(user)\n  assert user.length() == 5\n}\n",
+    )
+    .unwrap();
+
+    let output = lis(&project, "test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "lis test should pass with a logged value:\n{combined}"
+    );
+    assert!(
+        combined.contains("Logs") && combined.contains("\"alice\""),
+        "the report should show the logged value in a Logs section:\n{combined}"
+    );
+}

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7731,6 +7731,10 @@ fn assert_lowers_to_decomposed_failure_call() {
         "a comparison `assert` must report a relation, got:\n{go}"
     );
     assert!(
+        go.contains("\"relation\", \"expected ==\""),
+        "a comparison `assert` must name the relation in its message, got:\n{go}"
+    );
+    assert!(
         go.contains("Operand{Label: \"left\", Value: lisette.Debug(")
             && go.contains("Operand{Label: \"right\", Value: lisette.Debug("),
         "a relation `assert` must report both operands labeled and through Debug, got:\n{go}"
@@ -7738,6 +7742,115 @@ fn assert_lowers_to_decomposed_failure_call() {
     assert!(
         go.contains("\"bare\""),
         "a non-comparison `assert` must report as bare, got:\n{go}"
+    );
+}
+
+#[test]
+fn test_log_in_value_position_keeps_span_arguments() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", "fn main() {}");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.test.lis",
+        "#[test]\nfn logs(t: TestContext) {\n  let _ = t.log(5)\n  assert true\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .map(|f| f.to_go())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        go.contains(".Log(") && go.contains("lisette.Debug("),
+        "a `t.log` in value position must still emit the span-carrying Log call, got:\n{go}"
+    );
+}
+
+#[test]
+fn user_debug_string_suppresses_synthesized_one() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", "fn main() {}");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.test.lis",
+        "pub struct Point { pub x: int }\n\
+         impl Point {\n  pub fn debug_string(self) -> string { \"custom\" }\n}\n\
+         #[test]\nfn logs(t: TestContext) {\n  t.log(Point { x: 1 })\n  assert true\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .map(|f| f.to_go())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(
+        go.matches("DebugString() string {").count(),
+        1,
+        "a user `debug_string` must suppress the synthesized DebugString, got:\n{go}"
+    );
+    assert!(
+        go.contains("\"custom\""),
+        "the user's DebugString body must be the one kept, got:\n{go}"
+    );
+}
+
+#[test]
+fn private_debug_string_does_not_suppress_synthesis() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", "fn main() {}");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.test.lis",
+        "pub struct Point { pub x: int }\n\
+         impl Point {\n  fn debug_string(self) -> string { \"priv\" }\n}\n\
+         #[test]\nfn logs(t: TestContext) {\n  \
+         let _ = Point { x: 1 }.debug_string()\n  t.log(Point { x: 1 })\n  assert true\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .map(|f| f.to_go())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        go.contains("DebugString() string {"),
+        "a private debug_string must not suppress the synthesized DebugString, got:\n{go}"
+    );
+}
+
+#[test]
+fn exact_debug_string_is_recognized_as_override() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(ENTRY_MODULE_ID, "main.lis", "fn main() {}");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.test.lis",
+        "pub struct Point { pub x: int }\n\
+         impl Point {\n  pub fn DebugString(self) -> string { \"exact\" }\n}\n\
+         #[test]\nfn logs(t: TestContext) {\n  t.log(Point { x: 1 })\n  assert true\n}",
+    );
+
+    let outputs = compile_project_files_with_tests(fs, "github.com/user/p", false, true);
+    let go = outputs
+        .iter()
+        .map(|f| f.to_go())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(
+        go.matches("DebugString() string {").count(),
+        1,
+        "an exact `DebugString` method must suppress synthesis, got:\n{go}"
+    );
+    assert!(
+        go.contains("\"exact\""),
+        "the user's exact DebugString must be kept, got:\n{go}"
     );
 }
 


### PR DESCRIPTION
Adds `t.log(value)` for logging a value while a test runs. This log shows up in the test report with a Miette-style callsite snippet.

```rs
#[test]
fn computes_total(t: TestContext) {
  let total = price * quantity
  t.log(total)
  assert total == 42
}
```
