### PR TITLE
fix: catch mismatched match/select arms in value position

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1252,6 +1252,22 @@ pub fn branch_type_mismatch(
         .with_help("All branches must return the same type")
 }
 
+pub fn branch_arm_type_mismatch(
+    arm_ty: &Type,
+    arm_span: Span,
+    result_ty: &Type,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type mismatch")
+        .with_infer_code("type_mismatch")
+        .with_span_label(
+            &arm_span,
+            format!("this arm produces `{}`, not `{}`", arm_ty, result_ty),
+        )
+        .with_help(
+            "All arms must produce the same type when the `match` or `select` is used as a value",
+        )
+}
+
 pub fn let_else_must_diverge(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid `else` block")
         .with_infer_code("let_else_must_diverge")

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -1,4 +1,5 @@
 use crate::checker::EnvResolve;
+use crate::facts::BranchSubsumption;
 use syntax::ast::BindingKind;
 use syntax::ast::{Binding, BindingId, Expression, MatchArm, Pattern, Span, TypedPattern};
 use syntax::types::{SimpleKind, Type};
@@ -34,9 +35,17 @@ impl InferCtx<'_, '_> {
         &mut self,
         result_ty: &Type,
         branch_types: &[Type],
+        branch_spans: &[Span],
         span: &Span,
     ) {
         if branch_types.is_empty() {
+            return;
+        }
+        if branch_types
+            .iter()
+            .any(|t| self.contains_pending_branch_var(t))
+        {
+            self.record_branch_subsumption(result_ty, branch_types, branch_spans);
             return;
         }
         match self.reconcile_branch_types(branch_types, span) {
@@ -47,9 +56,55 @@ impl InferCtx<'_, '_> {
                 self.unify(result_ty, &ty, span);
             }
             BranchReconciliation::Failed => {
-                debug_assert!(branch_types.len() >= 2);
-                let _ = self.try_unify(&branch_types[0], &branch_types[1], span);
-                self.unify(result_ty, &branch_types[0], span);
+                self.record_branch_subsumption(result_ty, branch_types, branch_spans);
+            }
+        }
+    }
+
+    fn record_branch_subsumption(
+        &mut self,
+        result_ty: &Type,
+        branch_types: &[Type],
+        branch_spans: &[Span],
+    ) {
+        self.facts.branch_subsumptions.push(BranchSubsumption {
+            result_ty: result_ty.clone(),
+            arms: branch_types
+                .iter()
+                .cloned()
+                .zip(branch_spans.iter().copied())
+                .collect(),
+        });
+    }
+
+    fn contains_pending_branch_var(&self, ty: &Type) -> bool {
+        self.facts.branch_subsumptions.iter().any(|o| {
+            let Type::Var { id, .. } = self.env.shallow_resolve(&o.result_ty) else {
+                return false;
+            };
+            self.env.occurs(id, ty)
+        })
+    }
+
+    pub fn resolve_branch_subsumptions(&mut self) {
+        let obligations = std::mem::take(&mut self.facts.branch_subsumptions);
+        for obligation in obligations.into_iter().rev() {
+            for (arm_ty, arm_span) in &obligation.arms {
+                let arm = arm_ty.resolve_in(&self.env);
+                if arm.is_never() || arm.is_error() {
+                    continue;
+                }
+                let before = self.sink.len();
+                if self
+                    .try_unify(arm_ty, &obligation.result_ty, arm_span)
+                    .is_err()
+                    && self.sink.len() == before
+                {
+                    let result = obligation.result_ty.resolve_in(&self.env);
+                    self.sink.push(diagnostics::infer::branch_arm_type_mismatch(
+                        &arm, *arm_span, &result,
+                    ));
+                }
             }
         }
     }
@@ -412,7 +467,8 @@ impl InferCtx<'_, '_> {
 
         if needs_reconciliation {
             let arm_types: Vec<Type> = new_arms.iter().map(|a| a.expression.get_type()).collect();
-            self.reconcile_and_unify(&result_ty, &arm_types, &span);
+            let arm_spans: Vec<Span> = new_arms.iter().map(|a| a.expression.get_span()).collect();
+            self.reconcile_and_unify(&result_ty, &arm_types, &arm_spans, &span);
         } else if is_statement && let Some(first_arm) = new_arms.first() {
             // In statement position, set the match's type from the first arm so the
             // expression still has a well-defined type for inspection, even though

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -1,10 +1,34 @@
 use crate::checker::EnvResolve;
+use crate::facts::SelectExhaustivenessCheck;
 use syntax::ast::{Expression, MatchArm, Pattern, SelectArm, SelectArmPattern, Span};
 use syntax::types::{Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
 
+fn select_arm_body_span(pattern: &SelectArmPattern) -> Span {
+    match pattern {
+        SelectArmPattern::Receive { body, .. }
+        | SelectArmPattern::Send { body, .. }
+        | SelectArmPattern::WildCard { body } => body.get_span(),
+        SelectArmPattern::MatchReceive {
+            receive_expression, ..
+        } => receive_expression.get_span(),
+    }
+}
+
 impl InferCtx<'_, '_> {
+    pub fn resolve_select_exhaustiveness(&mut self) {
+        for check in std::mem::take(&mut self.facts.select_exhaustiveness_checks) {
+            let resolved = check.result_ty.resolve_in(&self.env);
+            if !resolved.is_unit() && !resolved.is_variable() {
+                self.sink
+                    .push(diagnostics::infer::non_exhaustive_select_expression(
+                        check.span,
+                    ));
+            }
+        }
+    }
+
     pub(super) fn infer_select(
         &mut self,
         arms: Vec<SelectArm>,
@@ -28,8 +52,14 @@ impl InferCtx<'_, '_> {
         self.unify(expected_ty, &result_ty, &span);
 
         let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
+        let value_position = needs_reconciliation && !expected_ty.is_ignored();
 
         let mut arm_target_types: Vec<Type> = if needs_reconciliation {
+            Vec::with_capacity(arms.len())
+        } else {
+            Vec::new()
+        };
+        let mut arm_target_spans: Vec<Span> = if value_position {
             Vec::with_capacity(arms.len())
         } else {
             Vec::new()
@@ -64,9 +94,12 @@ impl InferCtx<'_, '_> {
                     SelectArmPattern::MatchReceive {
                         receive_expression,
                         arms: match_arms,
-                    } => {
-                        self.infer_select_match_receive(receive_expression, match_arms, arm_target)
-                    }
+                    } => self.infer_select_match_receive(
+                        receive_expression,
+                        match_arms,
+                        arm_target,
+                        value_position,
+                    ),
 
                     SelectArmPattern::WildCard { body } => {
                         self.infer_select_wildcard(body, arm_target)
@@ -75,6 +108,9 @@ impl InferCtx<'_, '_> {
 
                 if needs_reconciliation {
                     arm_target_types.push(arm_target.clone());
+                }
+                if value_position {
+                    arm_target_spans.push(select_arm_body_span(&new_arm_pattern));
                 }
 
                 self.scopes.pop();
@@ -85,11 +121,12 @@ impl InferCtx<'_, '_> {
             })
             .collect();
 
-        if needs_reconciliation {
-            self.reconcile_and_unify(&result_ty, &arm_target_types, &span);
+        if value_position {
+            self.reconcile_and_unify(&result_ty, &arm_target_types, &arm_target_spans, &span);
+        } else if needs_reconciliation && let Some(first) = arm_target_types.first() {
+            let _ = self.try_unify(&result_ty, first, &span);
         }
 
-        let resolved_result = result_ty.resolve_in(&self.env);
         let shorthand_receive_count = new_arms
             .iter()
             .filter(|arm| matches!(arm.pattern, SelectArmPattern::Receive { .. }))
@@ -97,14 +134,13 @@ impl InferCtx<'_, '_> {
         let has_default = new_arms
             .iter()
             .any(|arm| matches!(arm.pattern, SelectArmPattern::WildCard { .. }));
-        if !expected_ty.is_ignored()
-            && !resolved_result.is_unit()
-            && !resolved_result.is_variable()
-            && shorthand_receive_count == 1
-            && !has_default
-        {
-            self.sink
-                .push(diagnostics::infer::non_exhaustive_select_expression(span));
+        if !expected_ty.is_ignored() && shorthand_receive_count == 1 && !has_default {
+            self.facts
+                .select_exhaustiveness_checks
+                .push(SelectExhaustivenessCheck {
+                    result_ty: result_ty.clone(),
+                    span,
+                });
         }
 
         Expression::Select {
@@ -238,6 +274,7 @@ impl InferCtx<'_, '_> {
         receive_expression: Box<Expression>,
         match_arms: Vec<MatchArm>,
         result_ty: &Type,
+        value_position: bool,
     ) -> SelectArmPattern {
         let receive_ty = self.new_type_var();
         let new_receive_expression = self.infer_expression(*receive_expression, &receive_ty);
@@ -256,8 +293,14 @@ impl InferCtx<'_, '_> {
         let pattern_ty = receive_ty.resolve_in(&self.env);
 
         let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
+        let reconcile_in_value_position = needs_reconciliation && value_position;
 
         let mut arm_expression_types: Vec<Type> = if needs_reconciliation {
+            Vec::with_capacity(match_arms.len())
+        } else {
+            Vec::new()
+        };
+        let mut arm_expression_spans: Vec<Span> = if reconcile_in_value_position {
             Vec::with_capacity(match_arms.len())
         } else {
             Vec::new()
@@ -296,6 +339,9 @@ impl InferCtx<'_, '_> {
                 if needs_reconciliation {
                     arm_expression_types.push(arm_expected.clone());
                 }
+                if reconcile_in_value_position {
+                    arm_expression_spans.push(new_expression.get_span());
+                }
 
                 self.scopes.pop();
 
@@ -308,9 +354,16 @@ impl InferCtx<'_, '_> {
             })
             .collect();
 
-        if needs_reconciliation {
-            let span = new_receive_expression.get_span();
-            self.reconcile_and_unify(result_ty, &arm_expression_types, &span);
+        let span = new_receive_expression.get_span();
+        if reconcile_in_value_position {
+            self.reconcile_and_unify(
+                result_ty,
+                &arm_expression_types,
+                &arm_expression_spans,
+                &span,
+            );
+        } else if needs_reconciliation && let Some(first) = arm_expression_types.first() {
+            let _ = self.try_unify(result_ty, first, &span);
         }
 
         SelectArmPattern::MatchReceive {

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -65,6 +65,8 @@ impl InferCtx<'_, '_> {
                     .collect();
 
                 ctx.check_reference_sibling_aliasing(&inferred_items);
+                ctx.resolve_branch_subsumptions();
+                ctx.resolve_select_exhaustiveness();
 
                 let frozen_items = {
                     let state = &mut *ctx;

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -55,6 +55,14 @@ pub struct Facts {
     pub empty_collection_checks: Vec<EmptyCollectionCheck>,
     pub statement_tail_checks: Vec<StatementTailCheck>,
 
+    /// Value-position `match`/`select` arms that did not reconcile, drained and
+    /// checked against the use-site result type at the end of `infer_file`.
+    pub branch_subsumptions: Vec<BranchSubsumption>,
+
+    /// Value-position selects with one shorthand receive and no default,
+    /// checked for exhaustiveness once the result type is pinned.
+    pub select_exhaustiveness_checks: Vec<SelectExhaustivenessCheck>,
+
     /// Suppresses contradictory lints from or-patterns whose binding sets disagree.
     pub or_pattern_error_spans: HashSet<Span>,
 
@@ -86,6 +94,18 @@ pub struct StatementTailCheck {
     pub span: Span,
 }
 
+#[derive(Debug, Clone)]
+pub struct BranchSubsumption {
+    pub result_ty: Type,
+    pub arms: Vec<(Type, Span)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectExhaustivenessCheck {
+    pub result_ty: Type,
+    pub span: Span,
+}
+
 impl Facts {
     pub fn new(allocator: Arc<BindingIdAllocator>) -> Self {
         Self {
@@ -103,6 +123,8 @@ impl Facts {
             generic_call_checks: Vec::new(),
             empty_collection_checks: Vec::new(),
             statement_tail_checks: Vec::new(),
+            branch_subsumptions: Vec::new(),
+            select_exhaustiveness_checks: Vec::new(),
             or_pattern_error_spans: HashSet::default(),
             type_error_spans: HashSet::default(),
             usages: Vec::new(),
@@ -234,6 +256,8 @@ impl Facts {
             generic_call_checks,
             empty_collection_checks,
             statement_tail_checks,
+            branch_subsumptions,
+            select_exhaustiveness_checks,
             or_pattern_error_spans,
             type_error_spans,
             usages,
@@ -264,6 +288,9 @@ impl Facts {
         self.generic_call_checks.extend(generic_call_checks);
         self.empty_collection_checks.extend(empty_collection_checks);
         self.statement_tail_checks.extend(statement_tail_checks);
+        self.branch_subsumptions.extend(branch_subsumptions);
+        self.select_exhaustiveness_checks
+            .extend(select_exhaustiveness_checks);
         self.or_pattern_error_spans.extend(or_pattern_error_spans);
         self.type_error_spans.extend(type_error_spans);
 

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -98,6 +98,12 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     }
 
     {
+        let mut ctx = InferCtx::new(&mut checker, &store);
+        ctx.resolve_branch_subsumptions();
+        ctx.resolve_select_exhaustiveness();
+    }
+
+    {
         let folder = semantics::checker::freeze::FreezeFolder::new(&checker.env);
         folder.freeze_facts(&mut checker.facts);
     }

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -196,6 +196,12 @@ impl CompiledTest {
             }
 
             {
+                let mut ctx = InferCtx::new(&mut checker, &store);
+                ctx.resolve_branch_subsumptions();
+                ctx.resolve_select_exhaustiveness();
+            }
+
+            {
                 let folder = semantics::checker::freeze::FreezeFolder::new(&checker.env);
                 folder.freeze_facts(&mut checker.facts);
             }

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -2581,3 +2581,338 @@ fn test() {
 fn panic_in_assignment_expression() {
     infer(r#"{ let x: int = panic("boom") }"#).assert_infer_code("panic_in_expression_position");
 }
+
+#[test]
+fn match_value_arm_with_unit_arm_errors() {
+    infer(
+        r#"
+    fn discard(_x: int) {}
+
+    fn test() {
+      let result = match 1 {
+        1 => 42,
+        _ => discard(1),
+      };
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_value_arm_with_diverging_arm_ok() {
+    infer(
+        r#"
+    fn test() {
+      let result = match 1 {
+        1 => 42,
+        _ => panic("unreachable"),
+      };
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_value_arms_scalar_mismatch_errors() {
+    infer(
+        r#"
+    fn test() {
+      let result = match 1 {
+        1 => "one",
+        _ => 42,
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_value_arms_unrelated_structs_error() {
+    infer(
+        r#"
+    struct A {}
+    struct B {}
+
+    fn test() {
+      let result = match 1 {
+        1 => A {},
+        _ => B {},
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_value_arms_widen_to_interface_via_use_site_ok() {
+    infer(
+        r#"
+    import "go:io"
+
+    struct R1 {}
+    struct R2 {}
+
+    impl R1 {
+      fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) }
+    }
+    impl R2 {
+      fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) }
+    }
+
+    fn pick(flag: bool) -> io.Reader {
+      let r = match flag {
+        true => R1 {},
+        false => R2 {},
+      }
+      r
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn select_value_arm_with_unit_arm_errors() {
+    infer(
+        r#"
+    fn discard(_x: int) {}
+
+    fn test() -> int {
+      let ch = Channel.new<int>()
+      let x = select {
+        let Some(v) = ch.receive() => v,
+        _ => discard(1),
+      }
+      x
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn select_match_receive_inner_value_arm_with_unit_arm_errors() {
+    infer(
+        r#"
+    fn discard(_x: int) {}
+
+    fn test() {
+      let ch = Channel.new<int>()
+      let x = select {
+        match ch.receive() {
+          Some(v) => v,
+          None => discard(1),
+        },
+      }
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_unit_arm_first_does_not_cascade() {
+    let result = infer(
+        r#"
+    fn discard(_x: int) {}
+
+    fn test() -> int {
+      let x = match 1 {
+        1 => discard(1),
+        _ => 42,
+      }
+      x
+    }
+        "#,
+    );
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected only the no-value arm diagnostic, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn select_nested_match_unit_arm_does_not_cascade() {
+    let result = infer(
+        r#"
+    fn discard(_x: int) {}
+
+    fn test() {
+      let ch = Channel.new<int>()
+      let x = select {
+        match ch.receive() {
+          Some(v) => discard(v),
+          None => 0,
+        },
+        _ => 99,
+      }
+    }
+        "#,
+    );
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected only the no-value arm diagnostic, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn match_value_arm_with_unit_alias_arm_errors() {
+    infer(
+        r#"
+    type Void = Unit
+
+    fn discard() -> Void { () }
+
+    fn test() {
+      let x = match 1 {
+        1 => 42,
+        _ => discard(),
+      }
+      let _ = x
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_value_arm_with_unit_named_value_type_ok() {
+    infer(
+        r#"
+    type Unit = int
+
+    fn make() -> Unit { 7 }
+
+    fn test() {
+      let x = match 1 {
+        1 => 42,
+        _ => make(),
+      }
+      let _ = x
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_value_arms_widen_with_diverging_arm_ok() {
+    infer(
+        r#"
+    import "go:io"
+
+    struct R1 {}
+    struct R2 {}
+
+    impl R1 {
+      fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) }
+    }
+    impl R2 {
+      fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) }
+    }
+
+    fn pick(n: int) -> io.Reader {
+      let r = match n {
+        1 => R1 {},
+        2 => R2 {},
+        _ => panic("unreachable"),
+      }
+      r
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_leading_diverging_arm_does_not_mask_mismatch() {
+    infer(
+        r#"
+    fn test() {
+      let x = match 1 {
+        1 => panic("boom"),
+        2 => "a",
+        _ => 42,
+      }
+      let _ = x
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn nested_value_match_widens_to_interface_ok() {
+    let prelude = r#"
+import "go:io"
+struct R1 {}
+struct R2 {}
+struct R3 {}
+impl R1 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) } }
+impl R2 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) } }
+impl R3 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(2) } }
+"#;
+    infer(&format!(
+        "{prelude}\nfn pick(n: int, m: int) -> io.Reader {{\n  let r = match n {{ 1 => match m {{ 1 => R1 {{}}, _ => R2 {{}} }}, _ => R3 {{}} }}\n  r\n}}"
+    ))
+    .assert_no_errors();
+    infer(&format!(
+        "{prelude}\nfn pick(n: int, m: int) -> io.Reader {{\n  let r = match n {{ 1 => R3 {{}}, _ => match m {{ 1 => R1 {{}}, _ => R2 {{}} }} }}\n  r\n}}"
+    ))
+    .assert_no_errors();
+}
+
+#[test]
+fn deferred_select_widening_arms_still_non_exhaustive() {
+    infer(
+        r#"
+import "go:io"
+struct R1 {}
+struct R2 {}
+impl R1 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) } }
+impl R2 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) } }
+fn pick() -> io.Reader {
+  let ch = Channel.new<int>()
+  let r = select {
+    let Some(v) = ch.receive() => R1 {},
+    ch.send(1) => R2 {},
+  }
+  r
+}
+"#,
+    )
+    .assert_infer_code("non_exhaustive_select_expression");
+}
+
+#[test]
+fn nested_value_match_in_tuple_widens_to_interface_ok() {
+    infer(
+        r#"
+import "go:io"
+struct R1 {}
+struct R2 {}
+struct R3 {}
+impl R1 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) } }
+impl R2 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) } }
+impl R3 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(2) } }
+fn pick(n: int, m: int) -> (io.Reader, int) {
+  let r = match n {
+    1 => (match m { 1 => R1 {}, _ => R2 {} }, 0),
+    _ => (R3 {}, 0),
+  }
+  r
+}
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -10814,3 +10814,24 @@ fn main() {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn infer_match_arm_calls_void_function_in_value_position() {
+    let input = r#"
+struct Match {}
+
+fn report(_e: error) {}
+
+fn accept() -> Result<Match, error> {
+  Ok(Match {})
+}
+
+fn run() {
+  let duel = match accept() {
+    Ok(m) => m,
+    Err(e) => report(e),
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/infer_match_arm_calls_void_function_in_value_position.snap
+++ b/tests/ui/errors/snapshots/infer_match_arm_calls_void_function_in_value_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:13:15]
+ 12 │     Ok(m) => m,
+ 13 │     Err(e) => report(e),
+    ·               ────┬────
+    ·                   ╰── this arm produces `()`, not `Match`
+ 14 │   }
+    ╰────
+  help: All arms must produce the same type when the `match` or `select` is used as a value · code: [infer.type_mismatch]


### PR DESCRIPTION
A `match` or `select` used as a value whose arms produce incompatible types now reports a type error pointing at the offending arm, instead of slipping through to Go.

```rs
let duel = match service.accept(target, challenger) {
  Ok(m) => m,
  Err(e) => output.Error(e), // flagged
}
```

Arms that produce different concrete types but widen to a shared interface remain valid.

Fix #839
