### PR TITLE
fix: allow if/else branches to widen to an interface

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1234,38 +1234,17 @@ pub fn invalid_division_order(
 }
 
 pub fn branch_type_mismatch(
-    consequence_ty: &Type,
-    consequence_span: Span,
-    alternative_ty: &Type,
-    alternative_span: Span,
-) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Type mismatch")
-        .with_infer_code("type_mismatch")
-        .with_span_label(
-            &consequence_span,
-            format!("this branch returns `{}`", consequence_ty),
-        )
-        .with_span_label(
-            &alternative_span,
-            format!("this branch returns `{}`", alternative_ty),
-        )
-        .with_help("All branches must return the same type")
-}
-
-pub fn branch_arm_type_mismatch(
-    arm_ty: &Type,
-    arm_span: Span,
+    branch_ty: &Type,
+    branch_span: Span,
     result_ty: &Type,
 ) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Type mismatch")
         .with_infer_code("type_mismatch")
         .with_span_label(
-            &arm_span,
-            format!("this arm produces `{}`, not `{}`", arm_ty, result_ty),
+            &branch_span,
+            format!("this branch produces `{}`, not `{}`", branch_ty, result_ty),
         )
-        .with_help(
-            "All arms must produce the same type when the `match` or `select` is used as a value",
-        )
+        .with_help("All branches must produce the same type when used as a value")
 }
 
 pub fn let_else_must_diverge(span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -101,7 +101,7 @@ impl InferCtx<'_, '_> {
                     && self.sink.len() == before
                 {
                     let result = obligation.result_ty.resolve_in(&self.env);
-                    self.sink.push(diagnostics::infer::branch_arm_type_mismatch(
+                    self.sink.push(diagnostics::infer::branch_type_mismatch(
                         &arm, *arm_span, &result,
                     ));
                 }
@@ -262,30 +262,12 @@ impl InferCtx<'_, '_> {
         } else if is_expression && !expected_is_concrete {
             let consequence_span = new_consequence.get_span();
             let alternative_span = new_alternative.get_span();
-
-            let resolved_consequence = consequence_ty.resolve_in(&self.env);
-            let resolved_alternative = alternative_ty.resolve_in(&self.env);
-
-            match self
-                .reconcile_branch_types(&[consequence_ty.clone(), alternative_ty.clone()], &span)
-            {
-                BranchReconciliation::FirstBranch => {
-                    self.unify(expected_ty, &consequence_ty, &consequence_span);
-                }
-                BranchReconciliation::Widened(ref ty) => {
-                    self.unify(expected_ty, ty, &alternative_span);
-                }
-                BranchReconciliation::Failed => {
-                    let _ = self.try_unify(&consequence_ty, &alternative_ty, &span);
-                    self.sink.push(diagnostics::infer::branch_type_mismatch(
-                        &resolved_consequence,
-                        consequence_span,
-                        &resolved_alternative,
-                        alternative_span,
-                    ));
-                    self.unify(expected_ty, &consequence_ty, &consequence_span);
-                }
-            }
+            self.reconcile_and_unify(
+                expected_ty,
+                &[consequence_ty.clone(), alternative_ty.clone()],
+                &[consequence_span, alternative_span],
+                &span,
+            );
         }
 
         let result_ty = if has_no_else {

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -2916,3 +2916,34 @@ fn pick(n: int, m: int) -> (io.Reader, int) {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn if_branches_widen_to_interface_via_use_site_ok() {
+    infer(
+        r#"
+import "go:io"
+struct R1 {}
+struct R2 {}
+impl R1 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(0) } }
+impl R2 { fn Read(self, mut _p: Slice<uint8>) -> Partial<int, error> { Partial.Ok(1) } }
+fn pick(flag: bool) -> io.Reader {
+  let r = if flag { R1 {} } else { R2 {} }
+  r
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn if_branches_scalar_mismatch_errors() {
+    infer(
+        r#"
+    fn test() {
+      let x = if true { "a" } else { 42 }
+      let _ = x
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}

--- a/tests/ui/errors/snapshots/infer_branch_type_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_branch_type_mismatch.snap
@@ -2,12 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
-   ╭─[test.lis:3:19]
+   ╭─[test.lis:3:31]
  2 │ fn test() {
  3 │   let x = if true { 42 } else { "hello" };
-   ·                   ───┬──      ─────┬─────
-   ·                      │             ╰── this branch returns `string`
-   ·                      ╰── this branch returns `int`
+   ·                               ─────┬─────
+   ·                                    ╰── this branch produces `string`, not `int`
  4 │ }
    ╰────
-  help: All branches must return the same type · code: [infer.type_mismatch]
+  help: All branches must produce the same type when used as a value · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_match_arm_calls_void_function_in_value_position.snap
+++ b/tests/ui/errors/snapshots/infer_match_arm_calls_void_function_in_value_position.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  12 │     Ok(m) => m,
  13 │     Err(e) => report(e),
     ·               ────┬────
-    ·                   ╰── this arm produces `()`, not `Match`
+    ·                   ╰── this branch produces `()`, not `Match`
  14 │   }
     ╰────
-  help: All arms must produce the same type when the `match` or `select` is used as a value · code: [infer.type_mismatch]
+  help: All branches must produce the same type when used as a value · code: [infer.type_mismatch]

--- a/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
+++ b/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
@@ -1,4 +1,4 @@
 ---
 source: tests/ui/unix.rs
 ---
-src/main.lis:3:19: error: Type mismatch [infer.type_mismatch]
+src/main.lis:3:8: error: Duplicate binding [infer.duplicate_binding_in_pattern]

--- a/tests/ui/unix.rs
+++ b/tests/ui/unix.rs
@@ -37,8 +37,8 @@ fn main() {
 #[test]
 fn unix_multi_label_emits_single_location() {
     let source = r#"
-fn test() {
-  let x = if true { 42 } else { "hello" };
+fn main() {
+  let (x, (y, x)) = (1, (2, 3));
 }
 "#;
     let result = infer(source);


### PR DESCRIPTION
An if/else used as a value whose branches produce different types that satisfy a common interface is now accepted, instead of rejected as a type mismatch.

```rs
fn pick(round: bool) -> Shape {
  let s = if round { Circle { r: 1.0 } } else { Square { side: 1.0 } }
  s
}
```
