### PR TITLE
feat: capstone test runner

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -298,8 +298,7 @@ fn interface_definition(name: &str, gen_str: &str, method_signatures: &[Expressi
     )
 }
 
-fn build_prelude_index() -> PreludeIndex {
-    let source = stdlib::LIS_PRELUDE_SOURCE;
+fn build_index_from_source(source: &str) -> PreludeIndex {
     let parse_result = syntax::parse::Parser::lex_and_parse_file(source, 0);
 
     let mut types: Vec<TypeInfo> = Vec::new();
@@ -466,7 +465,12 @@ fn build_prelude_index() -> PreludeIndex {
         }
     }
 
-    types.push(TypeInfo {
+    PreludeIndex { types, functions }
+}
+
+fn build_prelude_index() -> PreludeIndex {
+    let mut index = build_index_from_source(stdlib::LIS_PRELUDE_SOURCE);
+    index.types.push(TypeInfo {
         name: "Unit".to_string(),
         generics: Vec::new(),
         definition: "type Unit".to_string(),
@@ -476,8 +480,11 @@ fn build_prelude_index() -> PreludeIndex {
         methods: Vec::new(),
         kind: TypeKind::Primitive,
     });
+    index
+}
 
-    PreludeIndex { types, functions }
+fn build_test_prelude_index() -> PreludeIndex {
+    build_index_from_source(stdlib::LIS_TEST_PRELUDE_SOURCE)
 }
 
 fn build_go_package_index(source: &str, package: &str) -> GoPackageIndex {
@@ -848,6 +855,7 @@ fn print_all(index: &PreludeIndex) {
             "Docs on `map` method on Lisette's `Slice` type",
         ),
         ("prelude", "List all Lisette prelude symbols"),
+        ("test", "How to write and run tests"),
         ("go:", "List all Go stdlib packages"),
         ("go:os", "Docs on Go stdlib `os` package contents"),
         (
@@ -917,6 +925,109 @@ fn print_prelude(index: &PreludeIndex) {
     for (label, leaves) in &categories {
         print_prelude_category(label, label_width, leaves);
     }
+}
+
+fn print_test_code(code: &str) {
+    let lines: Vec<&str> = code.lines().collect();
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    println!();
+    for line in lines {
+        let stripped = if line.len() >= min_indent {
+            &line[min_indent..]
+        } else {
+            line.trim_start()
+        };
+        if use_color() {
+            use owo_colors::OwoColorize;
+            println!("      {}", stripped.dimmed().italic());
+        } else {
+            println!("      {stripped}");
+        }
+    }
+}
+
+fn print_test_topic() {
+    let paragraph = |text: &str| {
+        for line in text.lines() {
+            println!("  {}", format_backticks(line, use_color()));
+        }
+    };
+
+    println!();
+    paragraph("Write and run tests for a Lisette project.");
+    println!();
+    paragraph(
+        "Tests live in `.test.lis` files beside the code they cover. Mark a\n\
+         function with `#[test]` and check it with `assert`:",
+    );
+    print_test_code(
+        "        #[test]
+        fn adds_two_numbers() {
+          assert add(2, 3) == 5
+        }",
+    );
+    println!();
+    paragraph("Bind and check a pattern in one step with `let assert`:");
+    print_test_code(
+        "        #[test]
+        fn parses_a_port() {
+          let assert Some(port) = parse_port(\"8080\")
+          assert port == 8080
+        }",
+    );
+    println!();
+    paragraph("Give a test a readable title, and a doc comment for context:");
+    print_test_code(
+        "        /// A zero-length input is rejected before any work begins.
+        #[test(\"rejects empty input\")]
+        fn rejects_empty() {
+          let assert Err(message) = run(\"\")
+          assert message.contains(\"empty\")
+        }",
+    );
+    println!();
+    paragraph(
+        "Return `Result<(), error>` to use `?` inside a test. Returning `Err`\n\
+         fails it:",
+    );
+    print_test_code(
+        "        #[test]
+        fn loads_config() -> Result<(), error> {
+          let config = load(\"app.toml\")?
+          assert config.port == 8080
+          Ok(())
+        }",
+    );
+
+    println!();
+    println!("  {}", format_bold("The test handle"));
+    println!();
+    paragraph("Take a `t` parameter to reach the test context, for subtests and more:");
+    print_test_code(
+        "        #[test]
+        fn groups_cases(t) {
+          let _ = t.run(\"small inputs\", |t| {
+            assert normalize(1) == 1
+          })
+        }",
+    );
+
+    if let Some(type_info) = build_test_prelude_index()
+        .types
+        .iter()
+        .find(|t| t.name == "TestContext")
+    {
+        print_type(type_info);
+    }
+
+    println!();
+    paragraph("Run them with `lis test`, or `lis test --help` for filters and flags.");
+    println!();
 }
 
 fn prelude_categories(index: &PreludeIndex) -> Vec<(&'static str, Vec<String>)> {
@@ -1125,6 +1236,15 @@ fn format_white(s: &str) -> String {
     if use_color() {
         use owo_colors::OwoColorize;
         s.white().to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+fn format_bold(s: &str) -> String {
+    if use_color() {
+        use owo_colors::OwoColorize;
+        s.bold().to_string()
     } else {
         s.to_string()
     }
@@ -1789,6 +1909,47 @@ pub fn doc(query: Option<String>) -> i32 {
             print_prelude(&index);
             0
         }
+        Some(q) if q.eq_ignore_ascii_case("test") || q.eq_ignore_ascii_case("tests") => {
+            print_test_topic();
+            0
+        }
+        Some(q)
+            if q.eq_ignore_ascii_case("TestContext")
+                || q.to_lowercase().starts_with("testcontext.") =>
+        {
+            let index = build_test_prelude_index();
+            let Some(type_info) = index.types.iter().find(|t| t.name == "TestContext") else {
+                print_test_topic();
+                return 0;
+            };
+            match q.split_once('.') {
+                None => {
+                    print_type(type_info);
+                    0
+                }
+                Some((_, method)) => {
+                    if let Some(method_info) = type_info
+                        .methods
+                        .iter()
+                        .find(|m| m.name.eq_ignore_ascii_case(method))
+                    {
+                        print_method(type_info, method_info);
+                        0
+                    } else {
+                        let help = match suggest_method(method, type_info) {
+                            Some(s) => format!("Did you mean `lis doc TestContext.{}`?", s),
+                            None => "Run `lis doc test` to see the test handle".to_string(),
+                        };
+                        cli_error!(
+                            format!("`TestContext` has no method `{}`", method),
+                            format!("`{}` is not a method on `TestContext`", method),
+                            help
+                        );
+                        1
+                    }
+                }
+            }
+        }
         Some(q) => {
             let index = build_prelude_index();
             let parts: Vec<&str> = q.splitn(2, '.').collect();
@@ -1864,6 +2025,29 @@ pub fn doc(query: Option<String>) -> i32 {
                     1
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prelude_exposes_the_handle_methods() {
+        let index = build_test_prelude_index();
+        let context = index
+            .types
+            .iter()
+            .find(|t| t.name == "TestContext")
+            .expect("`TestContext` is parsed from the test prelude");
+
+        let methods: Vec<&str> = context.methods.iter().map(|m| m.name.as_str()).collect();
+        for expected in ["run", "parallel", "skip", "log"] {
+            assert!(
+                methods.contains(&expected),
+                "the `lis doc test` handle section documents `{expected}`, got: {methods:?}"
+            );
         }
     }
 }

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -177,7 +177,9 @@ Examples:
     `lis test`                           Run all tests in current dir
     `lis test` {~/projects/demo:g}           Run tests in specific dir
     `lis test` {-f:b} {parse:g}                  Only tests whose name contains \"parse\"
-    `lis test` {--go-flags:b} {\"-failfast\":g}    Stop at the first failing test",
+    `lis test` {--go-flags:b} {\"-failfast\":g}    Stop at the first failing test
+
+Run `lis doc test` to learn how to write tests.",
         ),
 
         "add" => print_help(
@@ -271,6 +273,7 @@ Examples:
     `lis doc` {Slice:g}          Docs on Lisette's `Slice` type
     `lis doc` {Slice.map:g}      Docs on `map` method on Lisette's `Slice` type
     `lis doc` {prelude:g}        List all Lisette prelude symbols
+    `lis doc` {test:g}           How to write and run tests
     `lis doc` {go::g}            List all Go stdlib packages
     `lis doc` {go:os:g}          Docs on Go stdlib `os` package contents
     `lis doc` {go:os.File:g}     Docs on `File` type in Go stdlib `os` package

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -9,7 +9,9 @@ use super::build::{BuildOptions, build_locked, with_locked_project};
 
 mod failed;
 mod report;
-use report::{all_test_keys, build_report_filtered, exit_code, matching_tests, render};
+use report::{
+    all_test_keys, build_report_filtered, exit_code, matching_tests, nothing_executed, render,
+};
 
 pub fn test(
     path: Option<String>,
@@ -129,7 +131,7 @@ pub fn test(
                 build_error.to_string(),
                 "The generated Go failed to build; run `lis check`"
             );
-        } else if filter.is_none() {
+        } else if filter.is_none() && !nothing_executed(&report.rows) {
             failed::save(&prep.target_dir, &report.rows);
         }
 

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -549,6 +549,13 @@ pub fn render(report: &Report, sources: &Sources, color: bool, total: Duration) 
 
     out.push('\n');
     out.push_str(&summary(&report.rows, total, color));
+    if nothing_executed(&report.rows) {
+        let note = format_backticks(
+            "No tests ran. `go test` reported success but executed nothing.",
+            color,
+        );
+        out.push_str(&format!("  {note}\n"));
+    }
     out
 }
 
@@ -981,8 +988,10 @@ fn summary(rows: &[TestRow], total: Duration, color: bool) -> String {
     let skipped = count_status(rows, Status::Skipped);
     let unreached = count_status(rows, Status::Unreached);
 
+    let nothing_ran = passed == 0 && failed == 0 && crashed == 0 && skipped == 0 && unreached > 0;
+
     let glyph = mark(
-        if failed > 0 {
+        if failed > 0 || nothing_ran {
             Status::Failed
         } else if crashed > 0 {
             Status::Crashed
@@ -1007,7 +1016,8 @@ fn summary(rows: &[TestRow], total: Duration, color: bool) -> String {
         parts.push(blue(&format!("{skipped} skipped"), color));
     }
     if unreached > 0 {
-        parts.push(format!("{unreached} unreached"));
+        let text = format!("{unreached} unreached");
+        parts.push(if nothing_ran { red(&text, color) } else { text });
     }
 
     format!(
@@ -1163,7 +1173,19 @@ pub fn exit_code(rows: &[TestRow], run_success: bool) -> i32 {
     let any_failure = rows
         .iter()
         .any(|r| matches!(r.status, Status::Failed | Status::Crashed));
-    if !run_success || any_failure { 1 } else { 0 }
+    if !run_success || any_failure || nothing_executed(rows) {
+        1
+    } else {
+        0
+    }
+}
+
+pub fn nothing_executed(rows: &[TestRow]) -> bool {
+    let ran = count_status(rows, Status::Passed)
+        + count_status(rows, Status::Failed)
+        + count_status(rows, Status::Crashed)
+        + count_status(rows, Status::Skipped);
+    ran == 0 && count_status(rows, Status::Unreached) > 0
 }
 
 pub fn failed_keys(rows: &[TestRow]) -> Vec<(String, String)> {
@@ -1445,6 +1467,29 @@ mod tests {
         assert!(text.contains("✓ adds_numbers"));
         assert!(text.contains("2 passed"));
         assert_eq!(exit_code(&report.rows, true), 0);
+    }
+
+    #[test]
+    fn nothing_executed_fails_even_when_go_succeeds() {
+        let index = index(&[(ENTRY_MODULE_ID, "alpha"), (ENTRY_MODULE_ID, "beta")]);
+        let report = build_report(&index, &[], "demo");
+        let text = render(&report, &no_sources(), false, Duration::from_millis(0));
+
+        assert!(text.contains("2 unreached"));
+        assert!(
+            text.contains('✕') && !text.contains('✓'),
+            "an all-unreached run must not read as a green pass, got:\n{text}"
+        );
+        assert!(
+            text.contains("No tests ran"),
+            "a note explains the empty run, got:\n{text}"
+        );
+        assert!(nothing_executed(&report.rows));
+        assert_eq!(
+            exit_code(&report.rows, true),
+            1,
+            "a run that executed nothing must exit non-zero even when `go test` succeeded"
+        );
     }
 
     #[test]

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -918,23 +918,25 @@ fn render_failure(
     let paired = matches!(record.kind.as_str(), "relation" | "labeled");
     let mut diagnostic = LisetteDiagnostic::error(record.message.clone());
     if paired {
-        let label_width = record
-            .operands
-            .iter()
-            .map(|operand| operand.label.chars().count())
-            .max()
-            .unwrap_or(0)
-            + 1;
-        let label = record
-            .operands
-            .iter()
-            .zip(&values)
-            .map(|(operand, value)| {
-                let token = format!("{}:", operand.label);
-                format!("{token:<label_width$} {value}")
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let label = paired_inline_label(&record.operands, &values).unwrap_or_else(|| {
+            let label_width = record
+                .operands
+                .iter()
+                .map(|operand| operand.label.chars().count())
+                .max()
+                .unwrap_or(0)
+                + 1;
+            record
+                .operands
+                .iter()
+                .zip(&values)
+                .map(|(operand, value)| {
+                    let token = format!("{}:", operand.label);
+                    format!("{token:<label_width$} {value}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
         diagnostic = diagnostic.with_span_primary_label(&span, label);
     } else {
         let label = values
@@ -1103,6 +1105,20 @@ fn operand_budget(term_width: usize) -> usize {
     term_width
         .saturating_sub(reserved)
         .clamp(OPERAND_MIN_CHARS, OPERAND_MAX_CHARS)
+}
+
+fn paired_inline_label(operands: &[Operand], values: &[String]) -> Option<String> {
+    let is_scalar = |value: &str| !value.contains(['\n', '{', '[', '(']);
+    if !operands.iter().all(|operand| is_scalar(&operand.value)) {
+        return None;
+    }
+    let line = operands
+        .iter()
+        .zip(values)
+        .map(|(operand, value)| format!("{}: {}", operand.label, value))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    (line.chars().count() <= operand_budget(terminal_width())).then_some(line)
 }
 
 fn first_divergence(a: &str, b: &str) -> usize {
@@ -1448,6 +1464,55 @@ mod tests {
         assert!(
             text.contains("left:") && text.contains("right:"),
             "got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn paired_label_inlines_scalars_but_stacks_composites() {
+        let render_relation = |left: &str, right: &str| {
+            let index = index(&[(ENTRY_MODULE_ID, "cmp")]);
+            let inner = serde_json::json!({
+                "file": 7,
+                "lo": 3,
+                "hi": 9,
+                "kind": "relation",
+                "message": "expected ==",
+                "operands": [
+                    {"label": "left", "value": left},
+                    {"label": "right", "value": right},
+                ],
+            })
+            .to_string();
+            let events = vec![
+                attr_event("demo", "TestCmp", &fail_value(&inner)),
+                event("fail", "demo", Some("TestCmp"), None),
+            ];
+            let report = build_report(&index, &events, "demo");
+            let mut sources = no_sources();
+            sources.insert(
+                7,
+                SourceInfo {
+                    source: "fn cmp() {}\n".to_string(),
+                    filename: "x.test.lis".to_string(),
+                },
+            );
+            render(&report, &sources, false, Duration::from_millis(1))
+        };
+
+        let scalar = render_relation("1", "2");
+        assert!(
+            scalar
+                .lines()
+                .any(|line| line.contains("left: 1") && line.contains("right: 2")),
+            "short scalars share one line, got:\n{scalar}"
+        );
+
+        let composite = render_relation("Point { x: 1, y: 2 }", "Point { x: 1, y: 9 }");
+        assert!(
+            !composite
+                .lines()
+                .any(|line| line.contains("left:") && line.contains("right:")),
+            "composite operands stay stacked, got:\n{composite}"
         );
     }
 

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -288,6 +288,7 @@ pub fn name_not_found(
     span: Span,
     available_names: &[String],
     expected_ty: Option<&Type>,
+    test_fn_name: Option<&str>,
 ) -> LisetteDiagnostic {
     if matches!(variable_name, "nil" | "null" | "Nil" | "undefined") {
         let help = nil_help_for(expected_ty);
@@ -304,10 +305,6 @@ pub fn name_not_found(
             .with_help(hint);
     }
 
-    let mut diagnostic = LisetteDiagnostic::error("Name not found")
-        .with_resolve_code("name_not_found")
-        .with_span_label(&span, "name not found in scope");
-
     let suggestion = available_names
         .iter()
         .filter_map(|c| {
@@ -316,6 +313,24 @@ pub fn name_not_found(
         })
         .min_by_key(|(_, d)| *d)
         .map(|(c, _)| c.clone());
+
+    // `t` is the conventional name for the handle a `#[test]` receives, but it is an
+    // ordinary parameter the test must declare, not an implicit binding. A close-name
+    // suggestion takes precedence, since then the real fix is the typo, not a new param.
+    if suggestion.is_none()
+        && let Some(function) = test_fn_name.filter(|_| variable_name == "t")
+    {
+        return LisetteDiagnostic::error("Undeclared test handle")
+            .with_resolve_code("undeclared_test_handle")
+            .with_span_label(&span, "undeclared")
+            .with_help(format!(
+                "Declare a `t` parameter to receive the test handle: `fn {function}(t)`"
+            ));
+    }
+
+    let mut diagnostic = LisetteDiagnostic::error("Name not found")
+        .with_resolve_code("name_not_found")
+        .with_span_label(&span, "name not found in scope");
 
     if let Some(suggestion) = suggestion {
         diagnostic = diagnostic.with_help(format!("Did you mean `{}`?", suggestion));

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -20,6 +20,7 @@ pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
         if !check.expected_ty.is_unit()
             && !check.expected_ty.is_variable()
             && !check.expected_ty.is_ignored()
+            && !check.expected_ty.is_error()
         {
             sink.push(diagnostics::infer::statement_as_tail(check.span));
         }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -199,6 +199,9 @@ impl InferCtx<'_, '_> {
         {
             self.scopes.mark_test_handle();
         }
+        if is_test {
+            self.scopes.set_test_fn_name(name.clone());
+        }
         self.mark_test_context_params_used(&new_params);
 
         let unit_ty = self.type_unit();

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -561,11 +561,13 @@ impl InferCtx<'_, '_> {
             None
         };
 
+        let test_fn_name = self.scopes.test_fn_name().map(str::to_string);
         self.sink.push(diagnostics::infer::name_not_found(
             variable_name,
             span,
             &available_names,
             hint_ty.as_ref(),
+            test_fn_name.as_deref(),
         ));
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -484,7 +484,7 @@ impl InferCtx<'_, '_> {
                             expected_ty: last_item_expected_ty.clone(),
                             span: item_span,
                         });
-                } else if !expected.is_unit() {
+                } else if !expected.is_unit() && !expected.is_error() {
                     self.sink
                         .push(diagnostics::infer::statement_as_tail(item_span));
                 }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -1,3 +1,4 @@
+use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::cell::Cell;
 use syntax::ast::BindingId;
@@ -86,6 +87,7 @@ pub struct Scope {
     pub type_param_depth: DepthCounter,
     pub use_context: Cell<UseContext>,
     pub in_test_handle: bool,
+    pub test_fn_name: Option<EcoString>,
     /// variable name -> binding ID (for linting)
     pub name_to_binding: HashMap<String, BindingId>,
 }
@@ -114,6 +116,7 @@ impl Scope {
             type_param_depth: DepthCounter::new(),
             use_context: Cell::new(UseContext::Statement),
             in_test_handle: false,
+            test_fn_name: None,
             name_to_binding: HashMap::default(),
         }
     }
@@ -190,6 +193,7 @@ impl Scopes {
         scope.type_param_depth = DepthCounter::with_value(current.type_param_depth.get());
         scope.use_context = Cell::new(current.use_context.get());
         scope.in_test_handle = current.in_test_handle;
+        scope.test_fn_name = current.test_fn_name.clone();
         self.stack.push(scope);
     }
 
@@ -341,6 +345,14 @@ impl Scopes {
 
     pub fn has_test_handle(&self) -> bool {
         self.current().in_test_handle
+    }
+
+    pub fn set_test_fn_name(&mut self, name: EcoString) {
+        self.current_mut().test_fn_name = Some(name);
+    }
+
+    pub fn test_fn_name(&self) -> Option<&str> {
+        self.current().test_fn_name.as_deref()
     }
 
     pub fn increment_loop_depth(&self) {

--- a/docs/intro/roadmap.md
+++ b/docs/intro/roadmap.md
@@ -8,5 +8,4 @@ Status:
 
 Planned work:
 
-- Implement a test runner
 - Make diagnostics configurable

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -301,4 +301,5 @@ a.equals(b) // true
 
 <table><tr>
 <td>← <a href="14-concurrency.md"><code>14-concurrency.md</code></a></td>
+<td align="right"><a href="16-testing.md"><code>16-testing.md</code></a> →</td>
 </tr></table>

--- a/docs/reference/16-testing.md
+++ b/docs/reference/16-testing.md
@@ -1,0 +1,330 @@
+# Testing
+
+Lisette's test runner finds `#[test]` functions in `.test.lis` files and runs them with `lis test`.
+
+## Running tests
+
+`lis test` compiles the project and runs every test in it.
+
+In the test report, tests are grouped by module and file:
+
+```
+  ✓ Compiled `demo` v0.1.0 (120ms)
+
+  math
+    math.test.lis
+      ├── ✓ addition
+      ├── ✓ subtraction
+      ├── ✓ multiplication
+      └── ✓ division
+
+  ✓ 4 passed (104ms)
+```
+
+On failure, the test report includes a `Failures` section:
+
+```
+  ✓ Compiled `demo` v0.1.0 (120ms)
+
+  math
+    math.test.lis
+      ├── ✕ addition
+      ├── ✓ subtraction
+      ├── ✓ multiplication
+      └── ✓ division
+
+  Failures
+
+  ✕ addition · expected ==
+       ╭─[src/math/math.test.lis:3:10]
+     1 │ #[test]
+     2 │ fn addition() {
+     3 │   assert add(2, 2) == 5
+       ·          ───────┬──────
+       ·                 ╰── left: 4 · right: 5
+     4 │ }
+     5 │
+       ╰────
+
+  ✕ 1 failed · 3 passed (104ms)
+```
+
+`lis test` exits non-zero when any test fails, or when a run finishes without having executed any test.
+
+## Test files
+
+Test files end with `.test.lis` and sit in the same module as the logic they cover, so tests can access the module's private symbols directly.
+
+```
+src/
+├── main.lis
+└── math/
+    ├── math.lis         # logic under test
+    └── math.test.lis    # tests internal to math module
+```
+
+`lis check` includes test files and production code. `lis build` and `lis run` exclude test files from the binary.
+
+Tests external to a module are not supported yet.
+
+## Test functions
+
+In a test file, a function marked `#[test]` is found and invoked by the test runner. A test function usually has no parameters and no return type.
+
+```rs
+#[test]
+fn addition() {
+  assert add(2, 2) == 4
+}
+```
+
+Optionally, a test can also carry a title and description:
+
+```rs
+/// Surrounding whitespace is trimmed before the count is taken.
+#[test("counts fields in a CSV row")]
+fn counts_fields() {
+  assert field_count("  a , b ") == 3
+}
+```
+
+The function title replaces the function name in the report, and the description follows beneath:
+
+```
+  Failures
+
+  ✕ counts fields in a CSV row · expected ==
+    Surrounding whitespace is trimmed before the count is taken.
+       ╭─[src/math/math.test.lis:4:10]
+     2 │ #[test("counts fields in a CSV row")]
+     3 │ fn counts_fields() {
+     4 │   assert field_count("  a , b ") == 3
+       ·          ──────────────┬─────────────
+       ·                        ╰── left: 2 · right: 3
+     5 │ }
+       ╰────
+```
+
+`lis test --filter <pattern>` matches against both function names and function titles.
+
+## Assertions
+
+In a test function, the `assert` keyword checks if a boolean expression is `true` or fails the test.
+
+```rs
+#[test]
+fn basics() {
+  assert is_email("name@example.com")
+  assert is_email("not-an-email")
+}
+```
+
+On failure:
+
+```
+  Failures
+
+  ✕ basics · assertion failed
+       ╭─[src/math/math.test.lis:4:10]
+     2 │ fn basics() {
+     3 │   assert is_email("name@example.com")
+     4 │   assert is_email("not-an-email")
+       ·          ────────────┬───────────
+       ·                      ╰── assertion failed
+     5 │ }
+       ╰────
+```
+
+To compare types that are not comparable with `==`, mark them with `#[equality]` and use the `equals` method. See [Equality](15-attributes.md#equality).
+
+```rs
+#[equality]
+struct Order {
+  id: int,
+  tags: Slice<string>,
+}
+
+#[test]
+fn orders_match() {
+  let a = Order { id: 1, tags: ["a"] }
+  let b = Order { id: 9, tags: ["z"] }
+  assert a.equals(b)
+}
+```
+
+On failure:
+
+```
+  Failures
+
+  ✕ orders_match · expected ==
+        ╭─[src/math/math.test.lis:11:10]
+      9 │   let a = Order { id: 1, tags: ["a"] }
+     10 │   let b = Order { id: 9, tags: ["z"] }
+     11 │   assert a.equals(b)
+        ·          ─────┬─────
+        ·               ╰─┤ left:  Order { id: 1, tags: ["a"] }
+        ·                 │ right: Order { id: 9, tags: ["z"] }
+     12 │ }
+        ╰────
+```
+
+Use `let assert` to assert by pattern matching:
+
+```rs
+#[test]
+fn parses_header() {
+  let bytes: Slice<byte> = [0x02, 0x00]
+  let assert Ok(h) = parse_header(bytes) // mismatch fails the test
+  assert h.version == 2
+}
+```
+
+To assert that an expression panics, `recover` from it and match the `Err`.
+
+```rs
+#[test]
+fn panics_out_of_bounds() {
+  let xs = [1, 2, 3]
+  let assert Err(_) = recover { xs[9] } // non-panic fails the test
+}
+```
+
+Use `Result` to assert via the `?` operator:
+
+```rs
+#[test]
+fn round_trips() -> Result<(), error> {
+  let point = Point { x: 1, y: 2 }
+  let bytes = encode(point)? // `Err` fails the test
+  let restored = decode(bytes)? // `Err` fails the test
+  assert restored == point
+  Ok(())
+}
+```
+
+## Test context
+
+A test can take a `t` parameter of type `TestContext`, which works similarly to Go's `testing.T`.
+
+For example, use `t.run` to group assertions into named subtests:
+
+```rs
+fn cases() -> Slice<Case> {
+  [
+    Case { name: "a", input: 1, expected: 2 },
+    Case { name: "b", input: 2, expected: 4 },
+  ]
+}
+
+#[test]
+fn basics(t: TestContext) {
+  for case in cases() {
+    t.run(case.name, |_| {
+      assert compute(case.input) == case.expected
+    })
+  }
+}
+```
+
+If omitted, the type of `t` is inferred:
+
+```rs
+#[test]
+fn basics(t) {
+  for case in cases() {
+    t.run(case.name, |_| {
+      assert compute(case.input) == case.expected
+    })
+  }
+}
+```
+
+`t` is also available as a lambda parameter:
+
+```rs
+#[test]
+fn basics(t) {
+  for case in cases() {
+    t.run(case.name, |t| {
+      t.parallel() // mark concurrent
+      assert compute(case.input) == case.expected
+    })
+  }
+}
+
+```
+
+`t.skip()` stops a test early and records why.
+
+```rs
+#[test]
+fn status_ok(t: TestContext) {
+  if !online() {
+    t.skip("service offline")
+  }
+  assert fetch_status() == 200
+}
+```
+
+On skipping:
+
+```
+  math
+    math.test.lis
+      └── ○ status_ok (service offline)
+
+  ✓ 1 skipped (104ms)
+```
+
+`t.log(value)` displays a value for debugging:
+
+```rs
+#[test]
+fn computes_total(t: TestContext) {
+  let total = add(20, 22)
+  t.log(total)
+  assert total == 42
+}
+```
+
+Logged values appear in a `Logs` section:
+
+```
+  Logs
+
+  ≡ computes_total
+       ╭─[src/math/math.test.lis:4:9]
+     2 │ fn computes_total(t: TestContext) {
+     3 │   let total = add(20, 22)
+     4 │   t.log(total)
+       ·         ──┬──
+       ·           ╰── 42
+     5 │   assert total == 42
+     6 │ }
+       ╰────
+```
+
+## Go test flags
+
+Use `--go-flags` to pass flags through to `go test`.
+
+```sh
+lis test --go-flags "-failfast"
+```
+
+Useful flags:
+
+| Flag           | Effect                                        |
+| -------------- | --------------------------------------------- |
+| `-failfast`    | Stop at the first failing test                |
+| `-race`        | Enable the data race detector                 |
+| `-timeout 30s` | Fail the run if it exceeds the given duration |
+
+To select tests by name, use `lis test --filter` rather than `-run`.
+
+<br>
+
+<table><tr>
+<td>← <a href="15-attributes.md"><code>15-attributes.md</code></a></td>
+</tr></table>

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -23,3 +23,4 @@
 - [`13-go-interop.md`](13-go-interop.md) — Go stdlib packages, type mappings, `.d.lis`
 - [`14-concurrency.md`](14-concurrency.md) — `task`, channels, `select`, iteration
 - [`15-attributes.md`](15-attributes.md) — Serialization tags, custom tags, lint suppression
+- [`16-testing.md`](16-testing.md) — `#[test]`, `assert`, the test context, `lis test`

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4084,6 +4084,25 @@ fn undeclared_t_outside_a_test_keeps_the_generic_hint() {
 }
 
 #[test]
+fn undeclared_handle_in_subtest_suppresses_tail_cascade() {
+    let fs = test_attribute_fs(
+        "pub fn add(a: int, b: int) -> int { a + b }",
+        "#[test]\nfn checks() {\n  t.run(\"sub\", |_| {\n    assert true\n  })\n}",
+    );
+    let result = infer_module("_entry_", fs);
+    assert!(
+        has_code(&result, "resolve.undeclared_test_handle"),
+        "the undeclared handle must still be reported, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "statement_as_tail"),
+        "the assert-tail must not cascade once `t` is unresolved, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn test_attribute_with_return_rejected() {
     let fs = test_attribute_fs(
         "pub fn add(a: int, b: int) -> int { a + b }",

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4059,6 +4059,31 @@ fn test_attribute_with_shadowed_test_context_rejected() {
 }
 
 #[test]
+fn infer_undeclared_test_handle_hints_at_parameter() {
+    let test_src = "#[test]\nfn forgot_the_handle() {\n  t.skip(\"not ready\")\n}\n";
+    let fs = test_attribute_fs("pub fn add(a: int, b: int) -> int { a + b }", test_src);
+    let result = infer_module("_entry_", fs);
+    assert_multimodule_infer_error_snapshot!(result, test_src);
+}
+
+#[test]
+fn undeclared_t_outside_a_test_keeps_the_generic_hint() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", "fn uses() -> int {\n  t\n}");
+    let result = infer_module("main", fs);
+    let diagnostic = result
+        .errors
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.name_not_found"))
+        .expect("expected a name_not_found for `t`");
+    let help = diagnostic.plain_help().unwrap_or_default();
+    assert!(
+        help.contains("Define or import"),
+        "outside a test, `t` must use the generic hint, got: {help:?}"
+    );
+}
+
+#[test]
 fn test_attribute_with_return_rejected() {
     let fs = test_attribute_fs(
         "pub fn add(a: int, b: int) -> int { a + b }",

--- a/tests/ui/errors/snapshots/infer_undeclared_test_handle_hints_at_parameter.snap
+++ b/tests/ui/errors/snapshots/infer_undeclared_test_handle_hints_at_parameter.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Undeclared test handle
+   ╭─[main.lis:3:3]
+ 2 │ fn forgot_the_handle() {
+ 3 │   t.skip("not ready")
+   ·   ┬
+   ·   ╰── undeclared
+ 4 │ }
+   ╰────
+  help: Declare a `t` parameter to receive the test handle: `fn forgot_the_handle(t)` · code: [resolve.undeclared_test_handle]


### PR DESCRIPTION
Final touches on the test runner:
- Using `t` in a test without declaring the param now reports a dedicated diagnostic
- A `lis test` run that executes no tests now fails instead of reporting a green pass with exit 0
- Failed scalar comparisons render on one line e.g. `left: 1 · right: 2` while composites stay stacked
- Reference docs added at `lis doc test` and `docs/reference/16-testing.md`
