### PR TITLE
fix: infer ref binding type when a match arm diverges

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -265,12 +265,14 @@ impl InferCtx<'_, '_> {
         let neither_is_interface = !self.is_interface(t1) && !self.is_interface(t2);
         let neither_is_unknown = !r1.is_unknown() && !r2.is_unknown();
         let neither_is_error = !r1.is_error() && !r2.is_error();
+        let neither_is_never = !r1.is_never() && !r2.is_never();
 
         either_is_ref
             && both_concrete
             && neither_is_interface
             && neither_is_unknown
             && neither_is_error
+            && neither_is_never
     }
 
     fn is_interface(&self, ty: &Type) -> bool {

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -2947,3 +2947,51 @@ fn if_branches_scalar_mismatch_errors() {
     )
     .assert_type_mismatch();
 }
+
+#[test]
+fn match_value_ref_arm_with_diverging_arm_resolves_receiver() {
+    infer(
+        r#"
+    struct File {}
+
+    impl File {
+      fn Close(self) {}
+    }
+
+    fn create(f: Ref<File>) -> Result<Ref<File>, error> { Ok(f) }
+
+    fn run(f: Ref<File>) {
+      let file = match create(f) {
+        Ok(handle) => handle,
+        Err(err) => { return },
+      }
+      file.Close()
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_value_diverging_arm_first_with_ref_arm_resolves_receiver() {
+    infer(
+        r#"
+    struct File {}
+
+    impl File {
+      fn Close(self) {}
+    }
+
+    fn create(f: Ref<File>) -> Result<Ref<File>, error> { Ok(f) }
+
+    fn run(f: Ref<File>) {
+      let file = match create(f) {
+        Err(err) => { return },
+        Ok(handle) => handle,
+      }
+      file.Close()
+    }
+        "#,
+    )
+    .assert_no_errors();
+}


### PR DESCRIPTION
A `match` used as a value, where one arm produces a value and another diverges, again infers the binding's type when that value is a pointer.

Fix #847. Edge case missed at #842.
