### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.5.0](https://github.com/ivov/lisette/compare/lisette-v0.4.4...lisette-v0.5.0) - 2026-06-24
+
+### Fixes
+
+- fix: treat ref-type aliases as underlying ref [#858](https://github.com/ivov/lisette/pull/858) [`ab1d9fd`](https://github.com/ivov/lisette/commit/ab1d9fda9d1b311de2ab57e41c66d688bb869314)
+- fix: point go name collision at import alias not path [#854](https://github.com/ivov/lisette/pull/854) [`bbad1ee`](https://github.com/ivov/lisette/commit/bbad1ee2aeb21f60456d8ce0af0e4ee962733c35)
+- fix: pin internal crate deps exactly and enable semver check [#851](https://github.com/ivov/lisette/pull/851) [`3e7f019`](https://github.com/ivov/lisette/commit/3e7f0195777bc678666103942751103da6675944)
+- fix: infer ref binding type when a match arm diverges [#849](https://github.com/ivov/lisette/pull/849) [`5aaad1e`](https://github.com/ivov/lisette/commit/5aaad1ebd3c61f1d0b49c7abfa967734d93ac1b1)
+
+### Internals
+
+- refactor: unify pattern-collection effect channel [#857](https://github.com/ivov/lisette/pull/857) [`38d16b7`](https://github.com/ivov/lisette/commit/38d16b7a4118fd4bd17a0d444a89a8c494d1f804)
+- refactor: dedupe lsp and passes walks via `children()` [#856](https://github.com/ivov/lisette/pull/856) [`95e8c9a`](https://github.com/ivov/lisette/commit/95e8c9af0711971ae9c30abc716235af8119085e)
+- perf: parallelize source-tree dir walk [#855](https://github.com/ivov/lisette/pull/855) [`eacc21e`](https://github.com/ivov/lisette/commit/eacc21e60e9713f8bfc033a474161fb52845e564)
+- chore: rebuild playground and fix stale wasm bindings [#852](https://github.com/ivov/lisette/pull/852) [`4b78ffc`](https://github.com/ivov/lisette/commit/4b78ffc54e62aad74fe256f902daa73aa0adabdf)
+
+
 ## [0.4.4](https://github.com/ivov/lisette/compare/lisette-v0.4.3...lisette-v0.4.4) - 2026-06-23
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -626,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.4.4"
+version = "0.5.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,15 +20,15 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.4.4", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.4.4", path = "../passes" }
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.4.4", path = "../diagnostics" }
-format = { package = "lisette-format", version = "=0.4.4", path = "../format" }
-emit = { package = "lisette-emit", version = "=0.4.4", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "=0.4.4", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.4.4", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "=0.4.4", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.5.0", path = "../passes" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
+format = { package = "lisette-format", version = "=0.5.0", path = "../format" }
+emit = { package = "lisette-emit", version = "=0.5.0", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "=0.5.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "=0.4.4", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.4.4", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "=0.4.4", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.4.4", path = "../passes" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.4.4", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "=0.4.4", path = "../deps" }
-format = { package = "lisette-format", version = "=0.4.4", path = "../format" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.5.0", path = "../passes" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
+format = { package = "lisette-format", version = "=0.5.0", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.4.4", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.4.4", path = "../diagnostics" }
+semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.4.4", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "=0.4.4", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "=0.4.4", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.4.4", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.5.0 (upcoming)

### Fixes

- fix: treat ref-type aliases as underlying ref [#858](https://github.com/ivov/lisette/pull/858) [`ab1d9fd`](https://github.com/ivov/lisette/commit/ab1d9fda9d1b311de2ab57e41c66d688bb869314)
- fix: point go name collision at import alias not path [#854](https://github.com/ivov/lisette/pull/854) [`bbad1ee`](https://github.com/ivov/lisette/commit/bbad1ee2aeb21f60456d8ce0af0e4ee962733c35)
- fix: pin internal crate deps exactly and enable semver check [#851](https://github.com/ivov/lisette/pull/851) [`3e7f019`](https://github.com/ivov/lisette/commit/3e7f0195777bc678666103942751103da6675944)
- fix: infer ref binding type when a match arm diverges [#849](https://github.com/ivov/lisette/pull/849) [`5aaad1e`](https://github.com/ivov/lisette/commit/5aaad1ebd3c61f1d0b49c7abfa967734d93ac1b1)

### Internals

- refactor: unify pattern-collection effect channel [#857](https://github.com/ivov/lisette/pull/857) [`38d16b7`](https://github.com/ivov/lisette/commit/38d16b7a4118fd4bd17a0d444a89a8c494d1f804)
- refactor: dedupe lsp and passes walks via `children()` [#856](https://github.com/ivov/lisette/pull/856) [`95e8c9a`](https://github.com/ivov/lisette/commit/95e8c9af0711971ae9c30abc716235af8119085e)
- perf: parallelize source-tree dir walk [#855](https://github.com/ivov/lisette/pull/855) [`eacc21e`](https://github.com/ivov/lisette/commit/eacc21e60e9713f8bfc033a474161fb52845e564)
- chore: rebuild playground and fix stale wasm bindings [#852](https://github.com/ivov/lisette/pull/852) [`4b78ffc`](https://github.com/ivov/lisette/commit/4b78ffc54e62aad74fe256f902daa73aa0adabdf)

