### PR TITLE
refactor: unify pattern-collection effect channel

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -1,7 +1,6 @@
 use syntax::ast::Expression;
 use syntax::types::Type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
@@ -67,41 +66,40 @@ impl Coercion {
         self,
         planner: &mut Planner,
         value: String,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let mut statements = Vec::new();
         let value = match self.kind {
             CoercionKind::Identity => value,
             CoercionKind::WrapAsInterface(plan) => {
-                let adapter_name = planner.ensure_adapter_type(plan, fx);
+                let adapter_name = planner.ensure_adapter_type(plan);
                 format!("{}{{inner: {}}}", adapter_name, value)
             }
             CoercionKind::WrapNewtype { ty } => {
-                let type_name = planner.go_type_string(&ty, fx);
+                let type_name = planner.go_type_string(&ty);
                 format!("{}({})", type_name, value)
             }
             CoercionKind::UnwrapNullableOption { ty } => {
-                let inner = planner.go_type_string(&ty.ok_type(), fx);
-                planner.plan_option_projection(&mut statements, &value, "unwrap", &inner, false, fx)
+                let inner = planner.go_type_string(&ty.ok_type());
+                planner.plan_option_projection(&mut statements, &value, "unwrap", &inner, false)
             }
             CoercionKind::UnwrapPointerOption { ty } => {
-                let ptr = format!("*{}", planner.go_type_string(&ty.ok_type(), fx));
-                planner.plan_option_projection(&mut statements, &value, "ptr", &ptr, true, fx)
+                let ptr = format!("*{}", planner.go_type_string(&ty.ok_type()));
+                planner.plan_option_projection(&mut statements, &value, "ptr", &ptr, true)
             }
             CoercionKind::UnwrapOptionToAny => {
-                planner.plan_option_projection(&mut statements, &value, "unwrap", "any", false, fx)
+                planner.plan_option_projection(&mut statements, &value, "unwrap", "any", false)
             }
             CoercionKind::UnwrapNullableCollection { ty, shape } => {
-                planner.plan_collection_nullable_unwrap(&mut statements, &value, &ty, &shape, fx)
+                planner.plan_collection_nullable_unwrap(&mut statements, &value, &ty, &shape)
             }
             CoercionKind::WrapNullableOption { ty } => {
-                planner.plan_nil_check_option_wrap(&mut statements, &value, &ty, fx)
+                planner.plan_nil_check_option_wrap(&mut statements, &value, &ty)
             }
             CoercionKind::WrapPointerOption { ty } => {
-                planner.plan_pointer_to_option_wrap(&mut statements, &value, &ty, fx)
+                planner.plan_pointer_to_option_wrap(&mut statements, &value, &ty)
             }
             CoercionKind::WrapNullableCollection { ty, shape } => {
-                planner.plan_collection_nullable_wrap(&mut statements, &value, &ty, &shape, fx)
+                planner.plan_collection_nullable_wrap(&mut statements, &value, &ty, &shape)
             }
         };
         (statements, value)
@@ -115,7 +113,6 @@ impl Planner<'_> {
         target_ty: Option<&Type>,
         expression: &Expression,
         emitted: String,
-        fx: &mut EmitEffects,
     ) -> String {
         let Some(target) = target_ty else {
             return emitted;
@@ -126,7 +123,7 @@ impl Planner<'_> {
             target,
             CoercionDirection::Internal,
         );
-        let (setup, value) = coercion.lower(self, emitted, fx);
+        let (setup, value) = coercion.lower(self, emitted);
         output.push_str(&Renderer.render_setup(&setup));
         value
     }

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -1,7 +1,6 @@
 pub(crate) mod coercion;
 pub(crate) mod transition;
 
-use crate::EmitEffects;
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::names::go_name::PRELUDE_ERROR_ID;
@@ -83,25 +82,24 @@ impl Planner<'_> {
         &mut self,
         shape: &AbiShape,
         return_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
         let peeled = self.facts.peel_alias(return_ty);
         match shape {
-            AbiShape::BareError => self.go_type_string(&peeled.err_type(), fx),
+            AbiShape::BareError => self.go_type_string(&peeled.err_type()),
             AbiShape::ResultTuple | AbiShape::PartialTuple => {
-                let ok_str = self.go_type_string(&peeled.ok_type(), fx);
-                let err_str = self.go_type_string(&peeled.err_type(), fx);
+                let ok_str = self.go_type_string(&peeled.ok_type());
+                let err_str = self.go_type_string(&peeled.err_type());
                 format!("({}, {})", ok_str, err_str)
             }
             AbiShape::CommaOk => {
-                let inner_str = self.go_type_string(&peeled.ok_type(), fx);
+                let inner_str = self.go_type_string(&peeled.ok_type());
                 format!("({}, bool)", inner_str)
             }
-            AbiShape::NullableReturn => self.go_type_string(&peeled.ok_type(), fx),
+            AbiShape::NullableReturn => self.go_type_string(&peeled.ok_type()),
             AbiShape::Tuple { .. } => {
                 let parts: Vec<String> = tuple_element_types(&peeled)
                     .iter()
-                    .map(|t| self.tuple_slot_lowered_ty_string(t, fx))
+                    .map(|t| self.tuple_slot_lowered_ty_string(t))
                     .collect();
                 format!("({})", parts.join(", "))
             }
@@ -110,16 +108,12 @@ impl Planner<'_> {
 
     /// Render a tuple slot's Go type, lowering `Option<NilableT>` to bare
     /// nilable `T` (the only arity-preserving slot recursion).
-    pub(crate) fn tuple_slot_lowered_ty_string(
-        &mut self,
-        slot_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> String {
+    pub(crate) fn tuple_slot_lowered_ty_string(&mut self, slot_ty: &Type) -> String {
         if self.facts.is_nullable_option(slot_ty) {
             let inner = self.facts.peel_alias(slot_ty).ok_type();
-            return self.go_type_string(&inner, fx);
+            return self.go_type_string(&inner);
         }
-        self.go_type_string(slot_ty, fx)
+        self.go_type_string(slot_ty)
     }
 
     /// `&self` variant of `render_lowered_return_ty`, callable from the

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -1,6 +1,5 @@
 use syntax::types::Type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::abi::{AbiShape, tuple_element_types};
@@ -44,17 +43,16 @@ pub(crate) fn render_lowered_result_return(
     result_value: &str,
     return_ty: &Type,
     shape: &AbiShape,
-    fx: &mut EmitEffects,
 ) {
-    let statements = emit_lowered_result_return(planner, result_value, return_ty, shape, fx);
+    let statements = emit_lowered_result_return(planner, result_value, return_ty, shape);
     let block = LoweredBlock { statements };
     Renderer.render_lowered_block(output, &block);
 }
 
 /// Idiomatic Go zero (`0`, `""`, `nil`, ...) for a lowered failure slot.
-fn lowered_zero(planner: &mut Planner, ok_ty: &Type, fx: &mut EmitEffects) -> String {
+fn lowered_zero(planner: &mut Planner, ok_ty: &Type) -> String {
     let (zero, effects) = planner.zero_value(ok_ty);
-    fx.extend(&effects);
+    planner.absorb_effects(&effects);
     zero
 }
 
@@ -65,13 +63,12 @@ pub(crate) fn lowered_err_values(
     shape: &AbiShape,
     return_ty: &Type,
     err_expr: &str,
-    fx: &mut EmitEffects,
 ) -> Vec<String> {
     match shape {
         AbiShape::BareError => vec![err_expr.to_string()],
         AbiShape::ResultTuple => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-            vec![lowered_zero(planner, &ok_ty, fx), err_expr.to_string()]
+            vec![lowered_zero(planner, &ok_ty), err_expr.to_string()]
         }
         AbiShape::PartialTuple | AbiShape::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
@@ -102,12 +99,11 @@ pub(crate) fn lowered_none_values(
     planner: &mut Planner,
     shape: &AbiShape,
     return_ty: &Type,
-    fx: &mut EmitEffects,
 ) -> Vec<String> {
     match shape {
         AbiShape::CommaOk => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
-            vec![lowered_zero(planner, &inner, fx), "false".to_string()]
+            vec![lowered_zero(planner, &inner), "false".to_string()]
         }
         AbiShape::NullableReturn => vec!["nil".to_string()],
         _ => unreachable!("only Option's `None` lacks a payload"),
@@ -121,13 +117,12 @@ pub(crate) fn emit_lowered_result_return(
     result_value: &str,
     return_ty: &Type,
     shape: &AbiShape,
-    fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
-    fx.require_stdlib();
+    planner.require_stdlib();
     let p = result_value;
-    let ok_zero = |planner: &mut Planner, fx: &mut EmitEffects| {
+    let ok_zero = |planner: &mut Planner| {
         let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-        lowered_zero(planner, &ok_ty, fx)
+        lowered_zero(planner, &ok_ty)
     };
     match shape {
         AbiShape::BareError => vec![
@@ -138,7 +133,7 @@ pub(crate) fn emit_lowered_result_return(
             multi_value_return(vec![format!("{p}.ErrVal")]),
         ],
         AbiShape::ResultTuple => {
-            let zero = ok_zero(planner, fx);
+            let zero = ok_zero(planner);
             vec![
                 tag_check(
                     format!("{p}.Tag == {RESULT_OK_TAG}"),
@@ -148,7 +143,7 @@ pub(crate) fn emit_lowered_result_return(
             ]
         }
         AbiShape::PartialTuple => {
-            let zero = ok_zero(planner, fx);
+            let zero = ok_zero(planner);
             vec![
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_OK_TAG}"),
@@ -162,7 +157,7 @@ pub(crate) fn emit_lowered_result_return(
             ]
         }
         AbiShape::CommaOk => {
-            let zero = ok_zero(planner, fx);
+            let zero = ok_zero(planner);
             vec![
                 tag_check(
                     format!("{p}.Tag == {OPTION_SOME_TAG}"),
@@ -179,7 +174,7 @@ pub(crate) fn emit_lowered_result_return(
             multi_value_return(vec!["nil".to_string()]),
         ],
         AbiShape::Tuple { arity } => {
-            emit_lowered_tuple_return(planner, result_value, return_ty, *arity, fx)
+            emit_lowered_tuple_return(planner, result_value, return_ty, *arity)
         }
     }
 }
@@ -191,7 +186,6 @@ fn emit_lowered_tuple_return(
     result_value: &str,
     return_ty: &Type,
     arity: usize,
-    fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     let peeled = planner.facts.peel_alias(return_ty);
     let slot_tys = tuple_element_types(&peeled);
@@ -210,15 +204,8 @@ fn emit_lowered_tuple_return(
                 .get(i)
                 .filter(|t| planner.facts.is_nullable_option(t))
                 .map(|t| {
-                    let inner = planner.go_type_string(&t.ok_type(), fx);
-                    planner.plan_option_projection(
-                        &mut statements,
-                        &raw,
-                        "unwrap",
-                        &inner,
-                        false,
-                        fx,
-                    )
+                    let inner = planner.go_type_string(&t.ok_type());
+                    planner.plan_option_projection(&mut statements, &raw, "unwrap", &inner, false)
                 })
                 .unwrap_or(raw)
         })
@@ -234,7 +221,6 @@ pub(crate) fn lower_callee_abi_wrapping(
     shape: &AbiShape,
     call_str: &str,
     result_ty: &Type,
-    fx: &mut EmitEffects,
 ) -> (Vec<LoweredStatement>, String) {
     match shape {
         AbiShape::PartialTuple => {
@@ -243,7 +229,6 @@ pub(crate) fn lower_callee_abi_wrapping(
                 result_ty,
                 TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
-                fx,
             );
             (statements, outcome.expect("wrapper produced no slot"))
         }
@@ -253,19 +238,14 @@ pub(crate) fn lower_callee_abi_wrapping(
                 result_ty,
                 TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
-                fx,
             );
             (statements, outcome.expect("wrapper produced no slot"))
         }
         AbiShape::NullableReturn => {
             let mut statements = Vec::new();
             let raw_var = planner.hoist_tmp_value_statement(&mut statements, "raw", call_str);
-            let (wrap, outcome) = planner.lower_nil_check_option_wrap(
-                &raw_var,
-                result_ty,
-                WrapperTarget::FreshSlot,
-                fx,
-            );
+            let (wrap, outcome) =
+                planner.lower_nil_check_option_wrap(&raw_var, result_ty, WrapperTarget::FreshSlot);
             statements.extend(wrap);
             (statements, outcome.expect("wrapper produced no slot"))
         }
@@ -275,7 +255,6 @@ pub(crate) fn lower_callee_abi_wrapping(
                 result_ty,
                 TupleReturnLayout::Packed,
                 WrapperTarget::FreshSlot,
-                fx,
             );
             (statements, outcome.expect("wrapper produced no slot"))
         }
@@ -296,12 +275,12 @@ pub(crate) fn lower_callee_abi_wrapping(
                         .get(i)
                         .filter(|slot_ty| planner.facts.is_nullable_option(slot_ty))
                         .map(|slot_ty| {
-                            planner.plan_nil_check_option_wrap(&mut statements, v, slot_ty, fx)
+                            planner.plan_nil_check_option_wrap(&mut statements, v, slot_ty)
                         })
                         .unwrap_or_else(|| v.clone())
                 })
                 .collect();
-            let tuple = planner.plan_tuple_from_vars(&mut statements, &wrapped, result_ty, fx);
+            let tuple = planner.plan_tuple_from_vars(&mut statements, &wrapped, result_ty);
             (statements, tuple)
         }
     }
@@ -313,40 +292,28 @@ pub(crate) fn emit_return_adapter(
     planner: &mut Planner,
     inner_call: &str,
     lisette_return_type: &Type,
-    fx: &mut EmitEffects,
 ) -> Option<(String, String)> {
     let return_type = lisette_return_type;
 
     if return_type.is_result() {
-        fx.require_stdlib();
-        return Some(emit_result_return_adapter(
-            planner,
-            inner_call,
-            return_type,
-            fx,
-        ));
+        planner.require_stdlib();
+        return Some(emit_result_return_adapter(planner, inner_call, return_type));
     }
     if return_type.is_partial() {
-        fx.require_stdlib();
+        planner.require_stdlib();
         return Some(emit_partial_return_adapter(
             planner,
             inner_call,
             return_type,
-            fx,
         ));
     }
     if return_type.is_option() {
-        fx.require_stdlib();
-        return Some(emit_option_return_adapter(
-            planner,
-            inner_call,
-            return_type,
-            fx,
-        ));
+        planner.require_stdlib();
+        return Some(emit_option_return_adapter(planner, inner_call, return_type));
     }
     if return_type.tuple_arity().is_some_and(|n| n >= 2) {
-        fx.require_stdlib();
-        return emit_tuple_return_adapter(planner, inner_call, return_type, fx);
+        planner.require_stdlib();
+        return emit_tuple_return_adapter(planner, inner_call, return_type);
     }
     None
 }
@@ -356,11 +323,10 @@ fn emit_result_return_adapter(
     planner: &mut Planner,
     inner_call: &str,
     return_type: &Type,
-    fx: &mut EmitEffects,
 ) -> (String, String) {
     let ok_ty = return_type.ok_type();
     let err_ty = return_type.err_type();
-    let err_ty_str = planner.go_type_string(&err_ty, fx);
+    let err_ty_str = planner.go_type_string(&err_ty);
     let res = planner.fresh_var(Some("res"));
     planner.declare(&res);
 
@@ -373,8 +339,8 @@ fn emit_result_return_adapter(
         );
         return (err_ty_str, b);
     }
-    let ok_ty_str = planner.go_type_string(&ok_ty, fx);
-    let ok_zero = lowered_zero(planner, &ok_ty, fx);
+    let ok_ty_str = planner.go_type_string(&ok_ty);
+    let ok_zero = lowered_zero(planner, &ok_ty);
     write_line!(
         b,
         "if {res}.Tag == {ok_tag} {{\nreturn {res}.OkVal, nil\n}}\n\
@@ -388,13 +354,12 @@ fn emit_partial_return_adapter(
     planner: &mut Planner,
     inner_call: &str,
     return_type: &Type,
-    fx: &mut EmitEffects,
 ) -> (String, String) {
     let ok_ty = return_type.ok_type();
     let err_ty = return_type.err_type();
-    let ok_ty_str = planner.go_type_string(&ok_ty, fx);
-    let err_ty_str = planner.go_type_string(&err_ty, fx);
-    let ok_zero = lowered_zero(planner, &ok_ty, fx);
+    let ok_ty_str = planner.go_type_string(&ok_ty);
+    let err_ty_str = planner.go_type_string(&err_ty);
+    let ok_zero = lowered_zero(planner, &ok_ty);
     let res = planner.fresh_var(Some("res"));
     planner.declare(&res);
 
@@ -414,7 +379,6 @@ fn emit_option_return_adapter(
     planner: &mut Planner,
     inner_call: &str,
     return_type: &Type,
-    fx: &mut EmitEffects,
 ) -> (String, String) {
     let inner = return_type.ok_type();
     let some_tag = OPTION_SOME_TAG;
@@ -423,7 +387,7 @@ fn emit_option_return_adapter(
 
     let is_nilable = planner.facts.is_nilable_go_type(&inner);
     if is_nilable {
-        let go_ret = planner.go_type_string(&inner, fx);
+        let go_ret = planner.go_type_string(&inner);
         let b = format!(
             "{opt} := {inner_call}\n\
              if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal\n}}\n\
@@ -432,8 +396,8 @@ fn emit_option_return_adapter(
         return (go_ret, b);
     }
 
-    let inner_ty_str = planner.go_type_string(&inner, fx);
-    let inner_zero = lowered_zero(planner, &inner, fx);
+    let inner_ty_str = planner.go_type_string(&inner);
+    let inner_zero = lowered_zero(planner, &inner);
     let b = format!(
         "{opt} := {inner_call}\n\
          if {opt}.Tag == {some_tag} {{\nreturn {opt}.SomeVal, true\n}}\n\
@@ -449,7 +413,6 @@ fn emit_tuple_return_adapter(
     planner: &mut Planner,
     inner_call: &str,
     return_type: &Type,
-    fx: &mut EmitEffects,
 ) -> Option<(String, String)> {
     let tuple_params: Vec<Type> = match return_type {
         Type::Tuple(elements) => elements.clone(),
@@ -466,7 +429,7 @@ fn emit_tuple_return_adapter(
 
     for (i, slot_ty) in tuple_params.iter().enumerate() {
         let raw_field = format!("{tup}.{}", TUPLE_FIELDS[i]);
-        match emit_return_adapter(planner, &raw_field, slot_ty, fx) {
+        match emit_return_adapter(planner, &raw_field, slot_ty) {
             Some((inner_ret, inner_body)) => {
                 let sub = planner.fresh_var(Some("sub"));
                 planner.declare(&sub);
@@ -477,7 +440,7 @@ fn emit_tuple_return_adapter(
                 ret_types.push(inner_ret);
             }
             None => {
-                ret_types.push(planner.go_type_string(slot_ty, fx));
+                ret_types.push(planner.go_type_string(slot_ty));
                 field_exprs.push(raw_field);
             }
         }
@@ -495,7 +458,6 @@ pub(crate) fn emit_lisette_callback_wrapper(
     setup: &mut Vec<LoweredStatement>,
     fn_value: &str,
     fn_type: &Type,
-    fx: &mut EmitEffects,
 ) -> String {
     let Type::Function(f) = fn_type else {
         return fn_value.to_string();
@@ -504,7 +466,7 @@ pub(crate) fn emit_lisette_callback_wrapper(
 
     let return_type = f.return_type.as_ref();
 
-    let (param_strs, arg_names) = planner.build_wrapper_params(params, fx);
+    let (param_strs, arg_names) = planner.build_wrapper_params(params);
     let params_str = param_strs.join(", ");
 
     let cb_var = planner.hoist_tmp_value_statement(setup, "cb", fn_value);
@@ -513,7 +475,7 @@ pub(crate) fn emit_lisette_callback_wrapper(
     let inner_args: Vec<String> = arg_names
         .iter()
         .zip(params.iter())
-        .map(|(name, param_ty)| lower_arg_to_tagged(planner, &mut prelude, name, param_ty, fx))
+        .map(|(name, param_ty)| lower_arg_to_tagged(planner, &mut prelude, name, param_ty))
         .collect();
 
     let call_str = format!("{}({})", cb_var, inner_args.join(", "));
@@ -528,7 +490,7 @@ pub(crate) fn emit_lisette_callback_wrapper(
         return fn_value.to_string();
     }
 
-    let adapter = emit_return_adapter(planner, &call_str, return_type, fx);
+    let adapter = emit_return_adapter(planner, &call_str, return_type);
     let Some((go_ret, body)) = adapter else {
         return fn_value.to_string();
     };
@@ -546,27 +508,24 @@ pub(crate) fn emit_fn_arg_shape_adapter(
     arg_fn_type: &Type,
     arg_shape: &AbiShape,
     target_shape: Option<&AbiShape>,
-    fx: &mut EmitEffects,
 ) -> Option<String> {
     let params = arg_fn_type.get_function_params()?;
     let arg_ret = arg_fn_type.get_function_ret()?;
 
     let cb_var = planner.hoist_tmp_value(output, "cb", fn_value);
-    let (param_strs, arg_names) = planner.build_wrapper_params(params, fx);
+    let (param_strs, arg_names) = planner.build_wrapper_params(params);
     let inner_call = format!("{}({})", cb_var, arg_names.join(", "));
 
     let outer_ret = match target_shape {
-        Some(shape) => planner.render_lowered_return_ty(shape, arg_ret, fx),
-        None => planner.go_type_string(arg_ret, fx),
+        Some(shape) => planner.render_lowered_return_ty(shape, arg_ret),
+        None => planner.go_type_string(arg_ret),
     };
 
     let (wrap_statements, tagged) =
-        lower_callee_abi_wrapping(planner, arg_shape, &inner_call, arg_ret, fx);
+        lower_callee_abi_wrapping(planner, arg_shape, &inner_call, arg_ret);
     let mut body = Renderer.render_setup(&wrap_statements);
     match target_shape {
-        Some(shape) => {
-            render_lowered_result_return(planner, &mut body, &tagged, arg_ret, shape, fx)
-        }
+        Some(shape) => render_lowered_result_return(planner, &mut body, &tagged, arg_ret, shape),
         None => write_line!(body, "return {}", tagged),
     }
 
@@ -586,7 +545,6 @@ pub(crate) fn lower_arg_to_tagged(
     prelude: &mut String,
     arg_name: &str,
     param_ty: &Type,
-    fx: &mut EmitEffects,
 ) -> String {
     let unwrapped = param_ty.unwrap_forall();
     let Type::Function(f) = unwrapped else {
@@ -598,12 +556,12 @@ pub(crate) fn lower_arg_to_tagged(
         return arg_name.to_string();
     };
 
-    let (inner_param_strs, inner_arg_names) = planner.build_wrapper_params(inner_params, fx);
+    let (inner_param_strs, inner_arg_names) = planner.build_wrapper_params(inner_params);
     let inner_call = format!("{}({})", arg_name, inner_arg_names.join(", "));
-    let tagged_ret = planner.go_type_string(inner_ret, fx);
+    let tagged_ret = planner.go_type_string(inner_ret);
 
     let (wrap_statements, result_var) =
-        lower_callee_abi_wrapping(planner, &shape, &inner_call, inner_ret, fx);
+        lower_callee_abi_wrapping(planner, &shape, &inner_call, inner_ret);
     let mut body = Renderer.render_setup(&wrap_statements);
     write_line!(body, "return {}", result_var);
 
@@ -625,12 +583,11 @@ pub(crate) fn lower_arg_to_tagged(
 pub(crate) fn try_emit_lowered_tail_return(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
-    fx: &mut EmitEffects,
 ) -> Option<Vec<LoweredStatement>> {
     let shape = planner.return_ctx().lowered_shape()?;
     match shape {
-        AbiShape::PartialTuple => Some(emit_lowered_partial_tail(planner, expression, fx)),
-        AbiShape::Tuple { arity } => Some(emit_lowered_tuple_tail(planner, expression, arity, fx)),
+        AbiShape::PartialTuple => Some(emit_lowered_partial_tail(planner, expression)),
+        AbiShape::Tuple { arity } => Some(emit_lowered_tuple_tail(planner, expression, arity)),
         _ => None,
     }
 }
@@ -641,17 +598,16 @@ fn lowered_tail_fallback(
     return_ty: &Type,
     shape: &AbiShape,
     hoist_hint: Option<&str>,
-    fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     let (mut statements, value) = planner
-        .lower_value(expression, ExpressionContext::value(), fx)
+        .lower_value(expression, ExpressionContext::value())
         .into_parts();
     let value = match hoist_hint {
         Some(hint) => planner.hoist_tmp_value_statement(&mut statements, hint, &value),
         None => value,
     };
     statements.extend(emit_lowered_result_return(
-        planner, &value, return_ty, shape, fx,
+        planner, &value, return_ty, shape,
     ));
     statements
 }
@@ -660,7 +616,6 @@ fn emit_lowered_tuple_tail(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
     arity: usize,
-    fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     use syntax::ast::Expression;
     if let Expression::Tuple { elements, .. } = expression
@@ -674,10 +629,10 @@ fn emit_lowered_tuple_tail(
             .map(|(i, e)| match slot_tys.get(i) {
                 Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
                     let mut setup = Vec::new();
-                    let value = lower_nullable_slot_value(planner, &mut setup, e, slot_ty, fx);
+                    let value = lower_nullable_slot_value(planner, &mut setup, e, slot_ty);
                     StagedExpression::from_typed_setup(setup, value, e)
                 }
-                _ => planner.stage_composite(e, ExpressionContext::value(), fx),
+                _ => planner.stage_composite(e, ExpressionContext::value()),
             })
             .collect();
         let (mut statements, parts) = planner.sequence_structured(stages, "_ret");
@@ -692,14 +647,12 @@ fn emit_lowered_tuple_tail(
         &return_ty,
         &AbiShape::Tuple { arity },
         Some("tup"),
-        fx,
     )
 }
 
 fn emit_lowered_partial_tail(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
-    fx: &mut EmitEffects,
 ) -> Vec<LoweredStatement> {
     use syntax::ast::Expression;
     let return_ty = planner.return_ctx().expect_ty();
@@ -715,26 +668,26 @@ fn emit_lowered_partial_tail(
         let ret = match variant {
             "Ok" => {
                 let (setup, v) = planner
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
                 multi_value_return(vec![v, "nil".to_string()])
             }
             "Err" => {
                 let (setup, e) = planner
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
                 let ok_ty = planner.facts.peel_alias(&return_ty).ok_type();
-                multi_value_return(vec![lowered_zero(planner, &ok_ty, fx), e])
+                multi_value_return(vec![lowered_zero(planner, &ok_ty), e])
             }
             "Both" => {
                 let (setup_v, v) = planner
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup_v);
                 let (setup_e, e) = planner
-                    .lower_composite_value(&args[1], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[1], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup_e);
                 multi_value_return(vec![v, e])
@@ -751,7 +704,6 @@ fn emit_lowered_partial_tail(
         &return_ty,
         &AbiShape::PartialTuple,
         None,
-        fx,
     )
 }
 
@@ -762,7 +714,6 @@ fn lower_nullable_slot_value(
     setup: &mut Vec<LoweredStatement>,
     expression: &syntax::ast::Expression,
     slot_ty: &Type,
-    fx: &mut EmitEffects,
 ) -> String {
     use syntax::ast::Expression;
     if let Expression::Call {
@@ -776,7 +727,7 @@ fn lower_nullable_slot_value(
             Ok(()) => {
                 debug_assert_eq!(args.len(), 1, "Some(...) takes exactly one arg");
                 let (slot_setup, value) = planner
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 setup.extend(slot_setup);
                 value
@@ -788,9 +739,9 @@ fn lower_nullable_slot_value(
         return "nil".to_string();
     }
     let (value_setup, value) = planner
-        .lower_value(expression, ExpressionContext::value(), fx)
+        .lower_value(expression, ExpressionContext::value())
         .into_parts();
     setup.extend(value_setup);
-    let inner = planner.go_type_string(&slot_ty.ok_type(), fx);
-    planner.plan_option_projection(setup, &value, "unwrap", &inner, false, fx)
+    let inner = planner.go_type_string(&slot_ty.ok_type());
+    planner.plan_option_projection(setup, &value, "unwrap", &inner, false)
 }

--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -1,6 +1,5 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use crate::EmitEffects;
 use crate::names::go_name;
 use crate::{Planner, PreludeType};
 use syntax::ast::{Expression, Visibility};
@@ -121,10 +120,7 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn collect_local_make_function_code(
-        &mut self,
-        fx: &mut EmitEffects,
-    ) -> HashMap<u32, Vec<String>> {
+    pub(crate) fn collect_local_make_function_code(&mut self) -> HashMap<u32, Vec<String>> {
         let module_prefix = format!("{}.", self.facts.current_module());
         let mut code: HashMap<u32, Vec<String>> = HashMap::default();
 
@@ -158,7 +154,7 @@ impl Planner<'_> {
         for (key, variants, file_id) in local_enums {
             self.module.set_active_file(file_id);
             for variant in &variants {
-                let fn_code = self.create_make_function_code(&key, &variant.name, fx);
+                let fn_code = self.create_make_function_code(&key, &variant.name);
                 code.entry(file_id).or_default().push(fn_code);
             }
         }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::expressions::access::struct_call::emit_struct_literal;
 use crate::names::generics::extract_type_mapping;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -112,21 +111,20 @@ impl Planner<'_> {
         function: &Expression,
         type_args: &[Type],
         call_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> String {
         if !type_args.is_empty() {
-            return self.go_type_string(&type_args[0], fx);
+            return self.go_type_string(&type_args[0]);
         }
         if let Some(call_result_ty) = call_ty
             && let Some(first) = call_result_ty
                 .get_type_params()
                 .and_then(|ps| ps.first().cloned())
         {
-            return self.go_type_string(&first, fx);
+            return self.go_type_string(&first);
         }
         let param = extract_return_type_param(function)
             .expect("constructor must have constructor return type");
-        self.go_type_string(&param, fx)
+        self.go_type_string(&param)
     }
 
     fn resolve_map_types(
@@ -134,12 +132,11 @@ impl Planner<'_> {
         function: &Expression,
         type_args: &[Type],
         call_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> (String, String) {
         if type_args.len() >= 2 {
             return (
-                self.go_type_string(&type_args[0], fx),
-                self.go_type_string(&type_args[1], fx),
+                self.go_type_string(&type_args[0]),
+                self.go_type_string(&type_args[1]),
             );
         }
         if let Some(call_result_ty) = call_ty
@@ -147,8 +144,8 @@ impl Planner<'_> {
             && params.len() >= 2
         {
             return (
-                self.go_type_string(&params[0], fx),
-                self.go_type_string(&params[1], fx),
+                self.go_type_string(&params[0]),
+                self.go_type_string(&params[1]),
             );
         }
         let ty = function.get_type();
@@ -160,36 +157,27 @@ impl Planner<'_> {
             .get_type_params()
             .expect("MapNew must return a type with type arguments");
         (
-            self.go_type_string(&params[0], fx),
-            self.go_type_string(&params[1], fx),
+            self.go_type_string(&params[0]),
+            self.go_type_string(&params[1]),
         )
     }
 
     fn try_lower_native_constructor(
         &mut self,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         match (ctx.native_type, ctx.method) {
             (NativeGoType::Channel, "new") => {
-                let element = self.resolve_element_type(
-                    ctx.function,
-                    ctx.resolved_type_args,
-                    ctx.call_ty,
-                    fx,
-                );
+                let element =
+                    self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
                 Some((Vec::new(), format!("make(chan {})", element)))
             }
             (NativeGoType::Channel, "buffered") => {
-                let element = self.resolve_element_type(
-                    ctx.function,
-                    ctx.resolved_type_args,
-                    ctx.call_ty,
-                    fx,
-                );
+                let element =
+                    self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
                 let (setup, capacity) = match ctx.args.first() {
                     Some(a) => {
-                        let staged = self.stage_operand(a, ExpressionContext::value(), fx);
+                        let staged = self.stage_operand(a, ExpressionContext::value());
                         (staged.setup, staged.value)
                     }
                     None => (Vec::new(), "0".to_string()),
@@ -198,16 +186,12 @@ impl Planner<'_> {
             }
             (NativeGoType::Map, "new") => {
                 let (key, val) =
-                    self.resolve_map_types(ctx.function, ctx.resolved_type_args, ctx.call_ty, fx);
+                    self.resolve_map_types(ctx.function, ctx.resolved_type_args, ctx.call_ty);
                 Some((Vec::new(), format!("make(map[{}]{})", key, val)))
             }
             (NativeGoType::Slice, "new") => {
-                let element = self.resolve_element_type(
-                    ctx.function,
-                    ctx.resolved_type_args,
-                    ctx.call_ty,
-                    fx,
-                );
+                let element =
+                    self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
                 Some((Vec::new(), format!("[]{}{{}}", element)))
             }
             _ => None,
@@ -222,7 +206,6 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         call_expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Expression::Call {
             expression: callee,
@@ -256,10 +239,10 @@ impl Planner<'_> {
         };
         match call_kind {
             CallKind::NativeMethod(_) => {
-                self.try_emit_negated_native_method_dot_access(setup, &native_ctx, fx)
+                self.try_emit_negated_native_method_dot_access(setup, &native_ctx)
             }
             CallKind::NativeMethodIdentifier(_) => {
-                self.try_emit_negated_native_method_identifier(setup, &native_ctx, fx)
+                self.try_emit_negated_native_method_identifier(setup, &native_ctx)
             }
             _ => unreachable!(),
         }
@@ -271,7 +254,6 @@ impl Planner<'_> {
         call_expression: &Expression,
         call_ty: Option<&Type>,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::Call {
             expression: callee,
@@ -292,17 +274,16 @@ impl Planner<'_> {
 
         match &plan.callee {
             CalleePlan::TupleStructConstructor => {
-                if let Some(result) =
-                    self.try_lower_tuple_struct_call(function, args, call_ty, ctx, fx)
+                if let Some(result) = self.try_lower_tuple_struct_call(function, args, call_ty, ctx)
                 {
                     return result;
                 }
             }
             CalleePlan::AssertType => {
-                return self.lower_assert_type(function, args, resolved_type_args, fx);
+                return self.lower_assert_type(function, args, resolved_type_args);
             }
             CalleePlan::UfcsMethod => {
-                return self.lower_ufcs_call(function, args, resolved_type_args, spread, fx);
+                return self.lower_ufcs_call(function, args, resolved_type_args, spread);
             }
             CalleePlan::NativeConstructor(kind)
             | CalleePlan::NativeMethod(kind)
@@ -318,7 +299,7 @@ impl Planner<'_> {
                     native_type: &native_type,
                     method,
                 };
-                return self.lower_native_call(&native_ctx, fx);
+                return self.lower_native_call(&native_ctx);
             }
             CalleePlan::ReceiverMethodUfcs { is_public } => {
                 let method = extract_receiver_ufcs_method(function);
@@ -329,27 +310,22 @@ impl Planner<'_> {
                     &method,
                     *is_public,
                     spread,
-                    fx,
                 );
             }
             CalleePlan::GoInterop(_) | CalleePlan::Regular => {}
         }
 
-        self.lower_regular_call(call_expression, &plan, call_ty, ctx, fx)
+        self.lower_regular_call(call_expression, &plan, call_ty, ctx)
     }
 
-    fn lower_native_call(
-        &mut self,
-        ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
-        if let Some(result) = self.try_lower_native_constructor(ctx, fx) {
+    fn lower_native_call(&mut self, ctx: &NativeCallContext) -> (Vec<LoweredStatement>, String) {
+        if let Some(result) = self.try_lower_native_constructor(ctx) {
             return result;
         }
         if let Expression::DotAccess { .. } = ctx.function {
-            self.lower_native_method_dot_access(ctx, fx)
+            self.lower_native_method_dot_access(ctx)
         } else {
-            self.lower_native_method_identifier(ctx, fx)
+            self.lower_native_method_identifier(ctx)
         }
     }
 
@@ -357,7 +333,6 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         arg_shape: CallArgShape,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let definition_ty = self.get_callee_definition_type(function)?;
         let Type::Forall { vars, body } = definition_ty else {
@@ -393,7 +368,7 @@ impl Planner<'_> {
             return None;
         }
 
-        Some(self.format_type_args(&resolved, fx))
+        Some(self.format_type_args(&resolved))
     }
 
     fn lookup_definition_type(&self, primary: &str, fallback: Option<&str>) -> Option<Type> {
@@ -449,13 +424,12 @@ impl Planner<'_> {
         args: &[Expression],
         call_ty: Option<&Type>,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
-        let target = self.resolve_tuple_struct_target(function, call_ty, fx)?;
+        let target = self.resolve_tuple_struct_target(function, call_ty)?;
 
         let stages: Vec<StagedExpression> = args
             .iter()
-            .map(|a| self.stage_composite(a, ExpressionContext::value(), fx))
+            .map(|a| self.stage_composite(a, ExpressionContext::value()))
             .collect();
         let (mut setup, values) = self.sequence_structured(stages, "_arg");
 
@@ -470,7 +444,7 @@ impl Planner<'_> {
             let value_ty = arg.get_type();
             let coercion =
                 Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
-            let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             field_pairs.push((format!("F{}", i), coerced));
         }
@@ -485,7 +459,6 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         call_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> Option<TupleStructTarget> {
         let ty = function.get_type();
         let Type::Function(f) = ty.unwrap_forall() else {
@@ -530,7 +503,7 @@ impl Planner<'_> {
                 .collect()
         };
 
-        let go_ty = self.go_type_string(&return_ty, fx);
+        let go_ty = self.go_type_string(&return_ty);
         Some(TupleStructTarget { go_ty, field_tys })
     }
 
@@ -539,22 +512,21 @@ impl Planner<'_> {
         function: &Expression,
         args: &[Expression],
         type_args: &[Type],
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let target_ty = if !type_args.is_empty() {
-            self.go_type_string(&type_args[0], fx)
+            self.go_type_string(&type_args[0])
         } else {
             let param = extract_return_type_param(function)
                 .expect("AssertType must have constructor return type");
-            self.go_type_string(&param, fx)
+            self.go_type_string(&param)
         };
         let (setup, arg_expression) = match args.first() {
             Some(a) => self
-                .lower_composite_value(a, ExpressionContext::value(), fx)
+                .lower_composite_value(a, ExpressionContext::value())
                 .into_parts(),
             None => (Vec::new(), String::new()),
         };
-        fx.require_stdlib();
+        self.require_stdlib();
         (
             setup,
             format!(
@@ -590,11 +562,7 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn prelude_container_type_args(
-        &mut self,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    pub(crate) fn prelude_container_type_args(&mut self, ty: &Type) -> Option<String> {
         if !ty.is_option() && !ty.is_result() && !ty.is_partial() {
             return None;
         }
@@ -607,7 +575,7 @@ impl Planner<'_> {
         params
             .iter()
             .any(|p| self.facts.is_interface(p) || self.is_function_alias(p))
-            .then(|| self.format_type_args(params, fx))
+            .then(|| self.format_type_args(params))
     }
 }
 

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -3,7 +3,6 @@ mod wrappers;
 
 pub(crate) use wrappers::{TupleReturnLayout, WrapperTarget};
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::calls::CallBoundary;
 use crate::context::expression::ExpressionContext;
@@ -46,26 +45,23 @@ impl Planner<'_> {
         call_expression: &Expression,
         strategy: &GoCallStrategy,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         match strategy {
             GoCallStrategy::Tuple { arity } => {
-                self.lower_go_tuple_call_wrapped(call_expression, *arity, fx)
+                self.lower_go_tuple_call_wrapped(call_expression, *arity)
             }
-            GoCallStrategy::Result => {
-                self.lower_go_result_call_wrapped(call_expression, result_ty, fx)
-            }
+            GoCallStrategy::Result => self.lower_go_result_call_wrapped(call_expression, result_ty),
             GoCallStrategy::Partial => {
-                self.lower_go_partial_call_wrapped(call_expression, result_ty, fx)
+                self.lower_go_partial_call_wrapped(call_expression, result_ty)
             }
             GoCallStrategy::CommaOk => {
-                self.lower_go_option_call_wrapped(call_expression, result_ty, fx)
+                self.lower_go_option_call_wrapped(call_expression, result_ty)
             }
             GoCallStrategy::NullableReturn => {
-                self.lower_go_single_return_option_wrapped(call_expression, result_ty, fx)
+                self.lower_go_single_return_option_wrapped(call_expression, result_ty)
             }
             GoCallStrategy::Sentinel { value } => {
-                self.lower_go_sentinel_call_wrapped(call_expression, result_ty, *value, fx)
+                self.lower_go_sentinel_call_wrapped(call_expression, result_ty, *value)
             }
         }
     }
@@ -77,23 +73,21 @@ impl Planner<'_> {
         strategy: &GoCallStrategy,
         result_ty: &Type,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         if matches!(strategy, GoCallStrategy::Tuple { .. }) {
             return None;
         }
         let (mut statements, call_str) =
-            self.lower_call(expression, None, ExpressionContext::value(), fx);
+            self.lower_call(expression, None, ExpressionContext::value());
         let wrap = match strategy {
             GoCallStrategy::Tuple { .. } => unreachable!("handled above"),
             GoCallStrategy::Result => {
-                fx.require_stdlib();
+                self.require_stdlib();
                 self.lower_result_wrapping(
                     &call_str,
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
-                    fx,
                 )
                 .0
             }
@@ -103,28 +97,26 @@ impl Planner<'_> {
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
-                    fx,
                 )
                 .0
             }
             GoCallStrategy::NullableReturn => {
                 let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
-                self.lower_nil_check_option_wrap(&raw_var, result_ty, target, fx)
+                self.lower_nil_check_option_wrap(&raw_var, result_ty, target)
                     .0
             }
             GoCallStrategy::Partial => {
-                fx.require_stdlib();
+                self.require_stdlib();
                 self.lower_partial_wrapping(
                     &call_str,
                     result_ty,
                     TupleReturnLayout::Flattened,
                     target,
-                    fx,
                 )
                 .0
             }
             GoCallStrategy::Sentinel { value } => {
-                self.lower_sentinel_wrapping(&call_str, result_ty, *value, target, fx)
+                self.lower_sentinel_wrapping(&call_str, result_ty, *value, target)
                     .0
             }
         };
@@ -155,7 +147,6 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         call_expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Expression::Call {
             expression: callee, ..
@@ -186,7 +177,7 @@ impl Planner<'_> {
         if has_array_return {
             ctx = ctx.with_raw_go_array_return();
         }
-        let (call_setup, call_str) = self.lower_call(call_expression, None, ctx, fx);
+        let (call_setup, call_str) = self.lower_call(call_expression, None, ctx);
         setup.extend(call_setup);
 
         Some(call_str)
@@ -207,9 +198,8 @@ impl Planner<'_> {
         output: &mut String,
         vars: &[String],
         tuple_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
-        let constructor = build_tuple_literal(vars, tuple_ty, fx);
+        let constructor = build_tuple_literal(self, vars, tuple_ty);
         self.hoist_tmp_value(output, "tup", &constructor)
     }
 
@@ -219,9 +209,8 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         vars: &[String],
         tuple_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
-        let constructor = build_tuple_literal(vars, tuple_ty, fx);
+        let constructor = build_tuple_literal(self, vars, tuple_ty);
         self.hoist_tmp_value_statement(statements, "tup", &constructor)
     }
 }
@@ -260,11 +249,7 @@ pub(crate) fn is_go_receiver(expression: &Expression) -> bool {
     false
 }
 
-pub(super) fn build_tuple_literal(
-    vars: &[String],
-    _tuple_ty: &Type,
-    fx: &mut EmitEffects,
-) -> String {
-    fx.require_stdlib();
+pub(super) fn build_tuple_literal(planner: &Planner, vars: &[String], _tuple_ty: &Type) -> String {
+    planner.require_stdlib();
     format!("lisette.MakeTuple{}({})", vars.len(), vars.join(", "))
 }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{
@@ -17,16 +16,14 @@ impl Planner<'_> {
         &mut self,
         call_expression: &Expression,
         option_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
+            self.lower_call(call_expression, None, ExpressionContext::value());
         let (wrap_setup, outcome) = self.lower_comma_ok_wrapping(
             &call_str,
             option_ty,
             TupleReturnLayout::Flattened,
             WrapperTarget::FreshSlot,
-            fx,
         );
         setup.extend(wrap_setup);
         value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
@@ -37,17 +34,11 @@ impl Planner<'_> {
         call_expression: &Expression,
         option_ty: &Type,
         sentinel: i64,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
-        let (wrap_setup, outcome) = self.lower_sentinel_wrapping(
-            &call_str,
-            option_ty,
-            sentinel,
-            WrapperTarget::FreshSlot,
-            fx,
-        );
+            self.lower_call(call_expression, None, ExpressionContext::value());
+        let (wrap_setup, outcome) =
+            self.lower_sentinel_wrapping(&call_str, option_ty, sentinel, WrapperTarget::FreshSlot);
         setup.extend(wrap_setup);
         value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
@@ -59,12 +50,11 @@ impl Planner<'_> {
         option_ty: &Type,
         sentinel: i64,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        fx.require_stdlib();
+        self.require_stdlib();
         let mut statements = Vec::new();
         let raw = self.hoist_tmp_value_statement(&mut statements, "ret", call_str);
-        let inner_ty_str = self.go_type_string(&option_ty.ok_type(), fx);
+        let inner_ty_str = self.go_type_string(&option_ty.ok_type());
         let value_expr = format!(
             "lisette.OptionFromCommaOk[{}]({}, {} != {})",
             inner_ty_str, raw, raw, sentinel
@@ -83,9 +73,8 @@ impl Planner<'_> {
         option_ty: &Type,
         layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        fx.require_stdlib();
+        self.require_stdlib();
         let mut statements = Vec::new();
 
         let inner_ty = option_ty.ok_type();
@@ -96,7 +85,7 @@ impl Planner<'_> {
             needs_nilable_validation || (layout.is_flattened() && inner_tuple_arity.is_some());
 
         if !needs_complex {
-            let inner_ty_str = self.go_type_string(&inner_ty, fx);
+            let inner_ty_str = self.go_type_string(&inner_ty);
             let value_expr = format!("lisette.OptionFromCommaOk[{}]({})", inner_ty_str, call_str);
             let outcome =
                 self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
@@ -127,13 +116,13 @@ impl Planner<'_> {
         )));
 
         let val_expression = if layout.is_flattened() && inner_tuple_arity.is_some() {
-            build_tuple_literal(&val_vars, &inner_ty, fx)
+            build_tuple_literal(self, &val_vars, &inner_ty)
         } else {
             val_vars[0].clone()
         };
 
         let option_ty_str = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.full_type_string()
         };
 
@@ -149,11 +138,11 @@ impl Planner<'_> {
             self.push_wrapper_slot(&mut statements, target, &option_ty_str, "option");
 
         let some_wrapper = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.emit_success(&val_expression)
         };
         let none_wrapper = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.emit_failure(None)
         };
 
@@ -175,12 +164,11 @@ impl Planner<'_> {
         raw_value: &str,
         option_ty: &Type,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        fx.require_stdlib();
+        self.require_stdlib();
         let mut statements = Vec::new();
         let inner_ty = option_ty.ok_type();
-        let inner_ty_str = self.go_type_string(&inner_ty, fx);
+        let inner_ty_str = self.go_type_string(&inner_ty);
         let is_nil_check = if self.is_interface_option(option_ty) {
             format!("lisette.IsNilInterface({})", raw_value)
         } else {
@@ -199,13 +187,12 @@ impl Planner<'_> {
         &mut self,
         call_expression: &Expression,
         option_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
+            self.lower_call(call_expression, None, ExpressionContext::value());
         let raw_var = self.hoist_tmp_value_statement(&mut setup, "raw", &call_str);
         let (wrap_setup, outcome) =
-            self.lower_nil_check_option_wrap(&raw_var, option_ty, WrapperTarget::FreshSlot, fx);
+            self.lower_nil_check_option_wrap(&raw_var, option_ty, WrapperTarget::FreshSlot);
         setup.extend(wrap_setup);
         value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
@@ -217,7 +204,6 @@ impl Planner<'_> {
         slot_hint: &str,
         slot_ty: &str,
         address: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let opt_var = self.hoist_tmp_value_statement(statements, "opt", option_value);
         let slot_var = self.fresh_var(Some(slot_hint));
@@ -228,7 +214,7 @@ impl Planner<'_> {
             value: None,
         });
 
-        fx.require_stdlib();
+        self.require_stdlib();
         let amp = if address { "&" } else { "" };
         let body = LoweredBlock {
             statements: vec![LoweredStatement::RawGo(format!(
@@ -251,10 +237,9 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         ptr_value: &str,
         option_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_stdlib();
-        let inner_ty_str = self.go_type_string(&option_ty.ok_type(), fx);
+        self.require_stdlib();
+        let inner_ty_str = self.go_type_string(&option_ty.ok_type());
         let value_expr = format!("lisette.OptionFromPointer[{}]({})", inner_ty_str, ptr_value);
         self.hoist_tmp_value_statement(statements, "option", &value_expr)
     }
@@ -266,10 +251,9 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         raw_value: &str,
         option_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
         let (wrap_statements, outcome) =
-            self.lower_nil_check_option_wrap(raw_value, option_ty, WrapperTarget::FreshSlot, fx);
+            self.lower_nil_check_option_wrap(raw_value, option_ty, WrapperTarget::FreshSlot);
         statements.extend(wrap_statements);
         outcome.expect("FreshSlot produces a slot")
     }
@@ -280,11 +264,10 @@ impl Planner<'_> {
         raw_value: &str,
         collection_ty: &Type,
         shape: &NullableCollectionShape,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_stdlib();
+        self.require_stdlib();
 
-        let lisette_collection_ty = self.go_type_string(collection_ty, fx);
+        let lisette_collection_ty = self.go_type_string(collection_ty);
         let src_var = self.hoist_tmp_value_statement(statements, "src", raw_value);
         let wrapped_var = self.hoist_tmp_value_statement(
             statements,
@@ -307,11 +290,11 @@ impl Planner<'_> {
                     val_var.clone()
                 };
                 let some_wrapper = {
-                    let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                    let mut fe = FalliblePlanner::new(self, &fallible);
                     fe.emit_success(&some_input)
                 };
                 let none_wrapper = {
-                    let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                    let mut fe = FalliblePlanner::new(self, &fallible);
                     fe.emit_failure(None)
                 };
                 let condition = if is_interface {
@@ -352,7 +335,6 @@ impl Planner<'_> {
                     &val_var,
                     &inner_lisette_ty,
                     inner_shape,
-                    fx,
                 );
                 inner_statements.push(LoweredStatement::RawGo(format!(
                     "{}[{}] = {}\n",
@@ -380,10 +362,9 @@ impl Planner<'_> {
         lisette_value: &str,
         collection_ty: &Type,
         shape: &NullableCollectionShape,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_stdlib();
-        let raw_collection_ty = self.shape_raw_collection_ty(shape, fx);
+        self.require_stdlib();
+        let raw_collection_ty = self.shape_raw_collection_ty(shape);
 
         let src_var = self.hoist_tmp_value_statement(statements, "src", lisette_value);
         let unwrapped_var = self.hoist_tmp_value_statement(
@@ -443,7 +424,6 @@ impl Planner<'_> {
                     &val_var,
                     &inner_lisette_ty,
                     inner_shape,
-                    fx,
                 );
                 inner_statements.push(LoweredStatement::RawGo(format!(
                     "{}[{}] = {}\n",
@@ -481,16 +461,12 @@ impl Planner<'_> {
 
     /// Raw Go type for an unwrapped collection; walks the shape recursively so
     /// nested options lower past the outer `[]` (e.g. to `[][]*T`).
-    fn shape_raw_collection_ty(
-        &mut self,
-        shape: &NullableCollectionShape,
-        fx: &mut EmitEffects,
-    ) -> String {
+    fn shape_raw_collection_ty(&mut self, shape: &NullableCollectionShape) -> String {
         let raw_element_ty = match &shape.element {
             NullableCollectionElement::Option(opt_ty) => {
                 let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
                 let inner_ty = opt_ty.ok_type();
-                let inner_ty_str = self.go_type_string(&inner_ty, fx);
+                let inner_ty_str = self.go_type_string(&inner_ty);
                 if is_pointer_bridged {
                     format!("*{}", inner_ty_str)
                 } else {
@@ -498,11 +474,11 @@ impl Planner<'_> {
                 }
             }
             NullableCollectionElement::Nested(inner_shape) => {
-                self.shape_raw_collection_ty(inner_shape, fx)
+                self.shape_raw_collection_ty(inner_shape)
             }
         };
         if let Some(key_ty) = shape.key_ty.as_ref() {
-            let key_ty_str = self.go_type_string(key_ty, fx);
+            let key_ty_str = self.go_type_string(key_ty);
             format!("map[{}]{}", key_ty_str, raw_element_ty)
         } else {
             format!("[]{}", raw_element_ty)

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::calls::go_interop::build_tuple_literal;
@@ -110,10 +109,9 @@ impl Planner<'_> {
         call_str: &str,
         ok_ty: &Type,
         layout: TupleReturnLayout,
-        fx: &mut EmitEffects,
     ) -> (String, String) {
         let mut buffer = String::new();
-        let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, layout, fx);
+        let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, layout);
         if !buffer.is_empty() {
             statements.push(LoweredStatement::RawGo(buffer));
         }
@@ -153,14 +151,13 @@ impl Planner<'_> {
         &mut self,
         call_expression: &Expression,
         arity: usize,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let Expression::Call { ty, .. } = call_expression else {
             unreachable!("lower_go_tuple_call_wrapped called with non-call expression");
         };
 
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
+            self.lower_call(call_expression, None, ExpressionContext::value());
 
         let temp_vars = self.create_temp_vars("ret", arity);
         setup.push(LoweredStatement::RawGo(format!(
@@ -169,7 +166,7 @@ impl Planner<'_> {
             call_str
         )));
 
-        let constructor = build_tuple_literal(&temp_vars, ty, fx);
+        let constructor = build_tuple_literal(self, &temp_vars, ty);
         let tuple = self.hoist_tmp_value_statement(&mut setup, "tup", &constructor);
         value_plan_from_statements(setup, tuple)
     }
@@ -178,17 +175,15 @@ impl Planner<'_> {
         &mut self,
         call_expression: &Expression,
         partial_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        fx.require_stdlib();
+        self.require_stdlib();
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
+            self.lower_call(call_expression, None, ExpressionContext::value());
         let (wrap_setup, outcome) = self.lower_partial_wrapping(
             &call_str,
             partial_ty,
             TupleReturnLayout::Flattened,
             WrapperTarget::FreshSlot,
-            fx,
         );
         setup.extend(wrap_setup);
         value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
@@ -201,18 +196,16 @@ impl Planner<'_> {
         partial_ty: &Type,
         layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let ok_ty = partial_ty.ok_type();
         let err_ty = partial_ty.err_type();
-        let ok_ty_str = self.go_type_string(&ok_ty, fx);
-        let err_ty_str = self.go_type_string(&err_ty, fx);
+        let ok_ty_str = self.go_type_string(&ok_ty);
+        let err_ty_str = self.go_type_string(&err_ty);
         let pkg = go_name::GO_STDLIB_PKG;
 
         let mut statements = Vec::new();
-        let (err_var, val_var) =
-            self.push_go_returns(&mut statements, call_str, &ok_ty, layout, fx);
-        let nil_check = self.partial_ok_nil_check(&ok_ty, &val_var, fx);
+        let (err_var, val_var) = self.push_go_returns(&mut statements, call_str, &ok_ty, layout);
+        let nil_check = self.partial_ok_nil_check(&ok_ty, &val_var);
 
         let type_params = format!("{}, {}", ok_ty_str, err_ty_str);
         let result_ty_str = format!("{pkg}.Partial[{type_params}]");
@@ -259,14 +252,9 @@ impl Planner<'_> {
     }
 
     /// Nil check for a `Partial` ok value; `None` when the type cannot be nil.
-    fn partial_ok_nil_check(
-        &mut self,
-        ok_ty: &Type,
-        val: &str,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    fn partial_ok_nil_check(&mut self, ok_ty: &Type, val: &str) -> Option<String> {
         if self.facts.as_interface(ok_ty).is_some() {
-            fx.require_stdlib();
+            self.require_stdlib();
             return Some(format!("lisette.IsNilInterface({val})"));
         }
         let peeled = self.facts.peel_alias(ok_ty);
@@ -281,17 +269,15 @@ impl Planner<'_> {
         &mut self,
         call_expression: &Expression,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        fx.require_stdlib();
+        self.require_stdlib();
         let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value(), fx);
+            self.lower_call(call_expression, None, ExpressionContext::value());
         let (wrap_setup, outcome) = self.lower_result_wrapping(
             &call_str,
             result_ty,
             TupleReturnLayout::Flattened,
             WrapperTarget::FreshSlot,
-            fx,
         );
         setup.extend(wrap_setup);
         value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
@@ -313,20 +299,19 @@ impl Planner<'_> {
         result_ty: &Type,
         layout: TupleReturnLayout,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
 
         if fallible.ok_ty().is_unit() {
-            return self.lower_unit_result_wrapping(call_str, &fallible, target, fx);
+            return self.lower_unit_result_wrapping(call_str, &fallible, target);
         }
 
         let mut statements = Vec::new();
         let ok_ty = fallible.ok_ty();
-        let (err_var, ok_val) = self.push_go_returns(&mut statements, call_str, ok_ty, layout, fx);
+        let (err_var, ok_val) = self.push_go_returns(&mut statements, call_str, ok_ty, layout);
 
         let result_ty_str = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.full_type_string()
         };
 
@@ -336,7 +321,7 @@ impl Planner<'_> {
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
         let err_wrapper = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.emit_failure(Some(&err_var))
         };
         let then_body = leaf_block(&sink, &err_wrapper);
@@ -352,13 +337,13 @@ impl Planner<'_> {
             } else {
                 format!("{} == nil", nil_check)
             };
-            fx.require_errors();
+            self.require_errors();
             let nil_err = {
-                let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                let mut fe = FalliblePlanner::new(self, &fallible);
                 fe.emit_failure(Some("errors.New(\"unexpected nil\")"))
             };
             let ok_wrapper = {
-                let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                let mut fe = FalliblePlanner::new(self, &fallible);
                 fe.emit_success(&ok_val)
             };
             ElseArm::ElseIf(Box::new(IfPlan {
@@ -372,7 +357,7 @@ impl Planner<'_> {
             }))
         } else {
             let ok_wrapper = {
-                let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                let mut fe = FalliblePlanner::new(self, &fallible);
                 fe.emit_success(&ok_val)
             };
             ElseArm::Else {
@@ -395,13 +380,12 @@ impl Planner<'_> {
         call_str: &str,
         fallible: &Fallible,
         target: WrapperTarget<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let mut statements = Vec::new();
         let err_var = self.hoist_tmp_value_statement(&mut statements, "ret", call_str);
 
         let result_ty_str = {
-            let mut fe = FalliblePlanner::new(self, fallible, fx);
+            let mut fe = FalliblePlanner::new(self, fallible);
             fe.full_type_string()
         };
 
@@ -409,13 +393,13 @@ impl Planner<'_> {
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
         let err_wrapper = {
-            let mut fe = FalliblePlanner::new(self, fallible, fx);
+            let mut fe = FalliblePlanner::new(self, fallible);
             fe.emit_failure(Some(&err_var))
         };
         let then_body = leaf_block(&sink, &err_wrapper);
 
         let ok_wrapper = {
-            let mut fe = FalliblePlanner::new(self, fallible, fx);
+            let mut fe = FalliblePlanner::new(self, fallible);
             fe.emit_success("struct{}{}")
         };
         let else_arm = ElseArm::Else {
@@ -442,7 +426,6 @@ impl Planner<'_> {
         call_str: &str,
         ok_ty: &Type,
         layout: TupleReturnLayout,
-        fx: &mut EmitEffects,
     ) -> (String, String) {
         if layout.is_flattened()
             && let Type::Tuple(elements) = ok_ty
@@ -450,7 +433,7 @@ impl Planner<'_> {
             let tuple_arity = elements.len();
             let temp_vars = self.create_temp_vars("ret", tuple_arity + 1);
             write_line!(output, "{} := {}", temp_vars.join(", "), call_str);
-            let tuple_var = self.emit_tuple_from_vars(output, &temp_vars[..tuple_arity], ok_ty, fx);
+            let tuple_var = self.emit_tuple_from_vars(output, &temp_vars[..tuple_arity], ok_ty);
             (temp_vars.last().unwrap().clone(), tuple_var)
         } else {
             let val_var = self.fresh_var(Some("ret"));
@@ -514,9 +497,8 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
-        let go_fn_str = self.capture_operand_into(setup, expression, fx);
+        let go_fn_str = self.capture_operand_into(setup, expression);
 
         let is_go_module_fn = matches!(
             expression.unwrap_parens(),
@@ -535,17 +517,13 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn build_wrapper_params(
-        &mut self,
-        params: &[Type],
-        fx: &mut EmitEffects,
-    ) -> (Vec<String>, Vec<String>) {
+    pub(crate) fn build_wrapper_params(&mut self, params: &[Type]) -> (Vec<String>, Vec<String>) {
         let mut param_strs = Vec::new();
         let mut arg_names = Vec::new();
         let last_index = params.len().saturating_sub(1);
         for (i, param_ty) in params.iter().enumerate() {
             let name = format!("arg{}", i);
-            let ty_str = self.go_type_string(param_ty, fx);
+            let ty_str = self.go_type_string(param_ty);
             param_strs.push(format!("{} {}", name, ty_str));
             if i == last_index && param_ty.get_name() == Some("VarArgs") {
                 arg_names.push(format!("{}...", name));
@@ -562,15 +540,14 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Option<(Type, Vec<String>, String)> {
         let fn_type = expression.get_type();
         let (params, return_type) = match fn_type.unwrap_forall() {
             Type::Function(f) => (f.params.clone(), (*f.return_type).clone()),
             _ => return None,
         };
-        let go_fn_str = self.hoist_go_fn_if_needed(setup, expression, fx);
-        let (param_strs, arg_names) = self.build_wrapper_params(&params, fx);
+        let go_fn_str = self.hoist_go_fn_if_needed(setup, expression);
+        let (param_strs, arg_names) = self.build_wrapper_params(&params);
         let call_str = format!("{}({})", go_fn_str, arg_names.join(", "));
         Some((return_type, param_strs, call_str))
     }
@@ -579,15 +556,13 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
-        let Some((return_type, param_strs, call_str)) =
-            self.wrapper_call_parts(setup, expression, fx)
+        let Some((return_type, param_strs, call_str)) = self.wrapper_call_parts(setup, expression)
         else {
-            return self.capture_operand_into(setup, expression, fx);
+            return self.capture_operand_into(setup, expression);
         };
 
-        let ret_ty_str = self.go_type_string(&return_type, fx);
+        let ret_ty_str = self.go_type_string(&return_type);
 
         let arr_var = self.fresh_var(Some("arr"));
         self.declare(&arr_var);
@@ -607,15 +582,14 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         strategy: &GoCallStrategy,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_stdlib();
+        self.require_stdlib();
 
         let (return_type, param_strs, call_str) = self
-            .wrapper_call_parts(setup, expression, fx)
+            .wrapper_call_parts(setup, expression)
             .expect("expected function type");
 
-        let ret_ty_str = self.go_type_string(&return_type, fx);
+        let ret_ty_str = self.go_type_string(&return_type);
 
         let mut statements = Vec::new();
         let outcome = match strategy {
@@ -625,7 +599,6 @@ impl Planner<'_> {
                     &return_type,
                     TupleReturnLayout::Flattened,
                     WrapperTarget::Return,
-                    fx,
                 );
                 statements.extend(wrap);
                 outcome
@@ -636,19 +609,14 @@ impl Planner<'_> {
                     &return_type,
                     TupleReturnLayout::Flattened,
                     WrapperTarget::Return,
-                    fx,
                 );
                 statements.extend(wrap);
                 outcome
             }
             GoCallStrategy::NullableReturn => {
                 let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
-                let (wrap, outcome) = self.lower_nil_check_option_wrap(
-                    &raw_var,
-                    &return_type,
-                    WrapperTarget::Return,
-                    fx,
-                );
+                let (wrap, outcome) =
+                    self.lower_nil_check_option_wrap(&raw_var, &return_type, WrapperTarget::Return);
                 statements.extend(wrap);
                 outcome
             }
@@ -659,7 +627,7 @@ impl Planner<'_> {
                     temp_vars.join(", "),
                     call_str
                 )));
-                Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type, fx))
+                Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type))
             }
             GoCallStrategy::Partial => {
                 let (wrap, outcome) = self.lower_partial_wrapping(
@@ -667,7 +635,6 @@ impl Planner<'_> {
                     &return_type,
                     TupleReturnLayout::Flattened,
                     WrapperTarget::Return,
-                    fx,
                 );
                 statements.extend(wrap);
                 outcome
@@ -678,7 +645,6 @@ impl Planner<'_> {
                     &return_type,
                     *value,
                     WrapperTarget::Return,
-                    fx,
                 );
                 statements.extend(wrap);
                 outcome
@@ -703,27 +669,26 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_stdlib();
+        self.require_stdlib();
 
         let (return_type, param_strs, call_str) = self
-            .wrapper_call_parts(setup, expression, fx)
+            .wrapper_call_parts(setup, expression)
             .expect("expected function type");
 
         let ok_ty = return_type.ok_type();
         let err_ty = return_type.err_type();
         let ret_ty_str = format!(
             "({}, {})",
-            self.go_type_string(&ok_ty, fx),
-            self.go_type_string(&err_ty, fx)
+            self.go_type_string(&ok_ty),
+            self.go_type_string(&err_ty)
         );
         let arity = ok_ty.tuple_arity().expect("tuple ok type");
 
         let mut body = String::new();
         let temp_vars = self.create_temp_vars("ret", arity + 1);
         write_line!(body, "{} := {}", temp_vars.join(", "), call_str);
-        let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars[..arity], &ok_ty, fx);
+        let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars[..arity], &ok_ty);
         write_line!(body, "return {}, {}", tuple_str, temp_vars[arity]);
 
         format!(

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -1,5 +1,4 @@
 use super::NativeCallContext;
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::access::index_access::range_var_bounds;
@@ -286,24 +285,24 @@ pub(super) fn has_inline_negation(native_type: &NativeGoType, method: &str, arit
 /// Resolve the inline rule for a dot-access form, applying the static-receiver
 /// fallback when the standard receiver shape does not match.
 fn apply_inline_lookup(
+    planner: &Planner,
     native_type: &NativeGoType,
     method: &str,
     receiver: &str,
     emitted_args: &[String],
     negated: bool,
-    fx: &mut EmitEffects,
 ) -> Option<String> {
     if let Some((inlined, import)) =
         try_inline_native_method(native_type, method, receiver, emitted_args, negated)
     {
-        apply_inline_import(import, fx);
+        apply_inline_import(planner, import);
         return Some(inlined);
     }
     if let Some((static_receiver, remaining)) = emitted_args.split_first()
         && let Some((inlined, import)) =
             try_inline_native_method(native_type, method, static_receiver, remaining, negated)
     {
-        apply_inline_import(import, fx);
+        apply_inline_import(planner, import);
         return Some(inlined);
     }
     None
@@ -311,15 +310,15 @@ fn apply_inline_lookup(
 
 /// Resolve the inline rule for an identifier-form call (args[0] is the receiver).
 fn apply_inline_identifier_lookup(
+    planner: &Planner,
     ctx: &NativeCallContext,
     emitted_args: &[String],
     negated: bool,
-    fx: &mut EmitEffects,
 ) -> Option<String> {
     let (receiver, remaining) = emitted_args.split_first()?;
     let (inlined, import) =
         try_inline_native_method(ctx.native_type, ctx.method, receiver, remaining, negated)?;
-    apply_inline_import(import, fx);
+    apply_inline_import(planner, import);
     Some(inlined)
 }
 
@@ -327,14 +326,13 @@ impl Planner<'_> {
     pub(super) fn lower_native_method_dot_access(
         &mut self,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::DotAccess { expression, .. } = ctx.function else {
             unreachable!("expected DotAccess for native method call")
         };
 
         if matches!(ctx.native_type, NativeGoType::String) && ctx.method == "substring" {
-            return self.lower_string_substring(expression, ctx.args, fx);
+            return self.lower_string_substring(expression, ctx.args);
         }
 
         if ctx.method == "equals"
@@ -342,28 +340,28 @@ impl Planner<'_> {
         {
             let receiver_ty = self.facts.peel_alias(&expression.get_type().strip_refs());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
-                let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
-                let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty, fx);
+                let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx);
+                let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty);
                 return (setup, body);
             }
         }
 
-        let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
+        let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx);
 
         if let Some(inlined) = apply_inline_lookup(
+            self,
             ctx.native_type,
             ctx.method,
             &receiver,
             &emitted_args,
             false,
-            fx,
         ) {
             return (setup, inlined);
         }
 
         let mut new_args = vec![receiver];
         new_args.extend(emitted_args);
-        fx.require_stdlib();
+        self.require_stdlib();
         let fn_name = format!(
             "{}.{}{}",
             go_name::GO_STDLIB_PKG,
@@ -372,9 +370,9 @@ impl Planner<'_> {
         );
         let type_args_string = if !ctx.resolved_type_args.is_empty() && ctx.call_ty.is_some() {
             let receiver_ty = expression.get_type();
-            self.format_type_args_with_receiver(&receiver_ty, ctx.resolved_type_args, fx)
+            self.format_type_args_with_receiver(&receiver_ty, ctx.resolved_type_args)
         } else {
-            self.format_type_args(ctx.resolved_type_args, fx)
+            self.format_type_args(ctx.resolved_type_args)
         };
         (
             setup,
@@ -389,20 +387,19 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if !has_inline_negation(ctx.native_type, ctx.method, ctx.args.len()) {
             return None;
         }
-        let (stage_setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx, fx);
+        let (stage_setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx);
         setup.extend(stage_setup);
         apply_inline_lookup(
+            self,
             ctx.native_type,
             ctx.method,
             &receiver,
             &emitted_args,
             true,
-            fx,
         )
     }
 
@@ -428,7 +425,6 @@ impl Planner<'_> {
     fn stage_native_dot_access_call(
         &mut self,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, Vec<String>) {
         let Expression::DotAccess { expression, .. } = ctx.function else {
             unreachable!("expected DotAccess for native method call")
@@ -436,7 +432,7 @@ impl Planner<'_> {
 
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + ctx.args.len() + ctx.spread.is_some() as usize);
-        let mut receiver_stage = self.stage_operand(expression, ExpressionContext::value(), fx);
+        let mut receiver_stage = self.stage_operand(expression, ExpressionContext::value());
         let rest_has_call =
             ctx.args.iter().any(contains_call) || ctx.spread.is_some_and(contains_call);
         self.pin_receiver_if_mutated(&mut receiver_stage, expression, rest_has_call);
@@ -444,11 +440,11 @@ impl Planner<'_> {
             receiver_stage.value = format!("*{}", receiver_stage.value);
         }
         all_stages.push(receiver_stage);
-        all_stages.extend(self.stage_native_method_args(ctx.function, ctx.args, fx));
+        all_stages.extend(self.stage_native_method_args(ctx.function, ctx.args));
 
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(1));
-        let (setup, all_values) = self
-            .sequence_with_spread_structured(all_stages, ctx.spread, false, "_arg", combine, fx);
+        let (setup, all_values) =
+            self.sequence_with_spread_structured(all_stages, ctx.spread, false, "_arg", combine);
 
         let receiver = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
@@ -458,13 +454,12 @@ impl Planner<'_> {
     pub(super) fn lower_native_method_identifier(
         &mut self,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         if matches!(ctx.native_type, NativeGoType::String)
             && ctx.method == "substring"
             && ctx.args.len() >= 2
         {
-            return self.lower_string_substring(&ctx.args[0], &ctx.args[1..], fx);
+            return self.lower_string_substring(&ctx.args[0], &ctx.args[1..]);
         }
 
         if ctx.method == "equals"
@@ -475,29 +470,29 @@ impl Planner<'_> {
                 .facts
                 .peel_alias(&receiver_expr.get_type().strip_refs());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
-                let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
+                let (setup, emitted_args) = self.stage_native_identifier_args(ctx);
                 if emitted_args.len() >= 2 {
                     let body =
-                        self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty, fx);
+                        self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty);
                     return (setup, body);
                 }
             }
         }
 
-        let (setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
+        let (setup, emitted_args) = self.stage_native_identifier_args(ctx);
 
-        if let Some(inlined) = apply_inline_identifier_lookup(ctx, &emitted_args, false, fx) {
+        if let Some(inlined) = apply_inline_identifier_lookup(self, ctx, &emitted_args, false) {
             return (setup, inlined);
         }
 
-        fx.require_stdlib();
+        self.require_stdlib();
         let fn_name = format!(
             "{}.{}{}",
             go_name::GO_STDLIB_PKG,
             ctx.native_type.method_prefix(),
             go_name::snake_to_camel(ctx.method)
         );
-        let type_args_string = self.format_type_args(ctx.resolved_type_args, fx);
+        let type_args_string = self.format_type_args(ctx.resolved_type_args);
         (
             setup,
             format!(
@@ -514,39 +509,36 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let receiver_arity = ctx.args.len().saturating_sub(1);
         if !has_inline_negation(ctx.native_type, ctx.method, receiver_arity) {
             return None;
         }
-        let (stage_setup, emitted_args) = self.stage_native_identifier_args(ctx, fx);
+        let (stage_setup, emitted_args) = self.stage_native_identifier_args(ctx);
         setup.extend(stage_setup);
-        apply_inline_identifier_lookup(ctx, &emitted_args, true, fx)
+        apply_inline_identifier_lookup(self, ctx, &emitted_args, true)
     }
 
     fn stage_native_identifier_args(
         &mut self,
         ctx: &NativeCallContext,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
-        let mut stages = self.stage_native_method_args(ctx.function, ctx.args, fx);
+        let mut stages = self.stage_native_method_args(ctx.function, ctx.args);
         if let Some(receiver) = ctx.args.first() {
             let rest_has_call =
                 ctx.args[1..].iter().any(contains_call) || ctx.spread.is_some_and(contains_call);
             self.pin_receiver_if_mutated(&mut stages[0], receiver, rest_has_call);
         }
         let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(0));
-        self.sequence_with_spread_structured(stages, ctx.spread, false, "_arg", combine, fx)
+        self.sequence_with_spread_structured(stages, ctx.spread, false, "_arg", combine)
     }
 
     fn lower_string_substring(
         &mut self,
         receiver_expr: &Expression,
         args: &[Expression],
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
-        fx.require_stdlib();
+        self.require_stdlib();
         let arg = &args[0];
         let is_ref_receiver = receiver_expr.get_type().is_ref();
         let deref = |raw: &str| -> String {
@@ -564,13 +556,12 @@ impl Planner<'_> {
             ..
         } = arg
         {
-            let mut stages =
-                vec![self.stage_operand(receiver_expr, ExpressionContext::value(), fx)];
+            let mut stages = vec![self.stage_operand(receiver_expr, ExpressionContext::value())];
             if let Some(s) = start.as_deref() {
-                stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
+                stages.push(self.stage_operand(s, ExpressionContext::value()));
             }
             if let Some(e) = end.as_deref() {
-                stages.push(self.stage_operand(e, ExpressionContext::value(), fx));
+                stages.push(self.stage_operand(e, ExpressionContext::value()));
             }
             let (setup, values) = self.sequence_structured(stages, "_arg");
             let mut bounds = values.iter().skip(1);
@@ -597,8 +588,8 @@ impl Planner<'_> {
         let range_kind = peel_to_range_type(&arg_ty)
             .and_then(|t| t.get_name())
             .expect("substring arg should resolve to a known range type");
-        let receiver_staged = self.stage_operand(receiver_expr, ExpressionContext::value(), fx);
-        let range_staged = self.stage_or_capture(arg, "range", fx);
+        let receiver_staged = self.stage_operand(receiver_expr, ExpressionContext::value());
+        let range_staged = self.stage_or_capture(arg, "range");
         let (setup, values) = self.sequence_structured(vec![receiver_staged, range_staged], "_arg");
         let (start, end) = range_var_bounds(&values[1], range_kind);
         (
@@ -607,35 +598,29 @@ impl Planner<'_> {
         )
     }
 
-    pub(crate) fn render_equality(
-        &mut self,
-        lhs: &str,
-        rhs: &str,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> String {
+    pub(crate) fn render_equality(&mut self, lhs: &str, rhs: &str, ty: &Type) -> String {
         let peeled = self.facts.peel_alias(ty);
         if peeled.is_ref() {
             return format!("{lhs} == {rhs}");
         }
         if peeled.is_slice() {
-            fx.require_slices();
+            self.require_slices();
             return match peeled.inner() {
                 Some(elem) if self.needs_custom_equality(&elem) => {
-                    let eq = self.equality_closure(&elem, fx);
+                    let eq = self.equality_closure(&elem);
                     format!("slices.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("slices.Equal({lhs}, {rhs})"),
             };
         }
         if peeled.is_map() {
-            fx.require_maps();
+            self.require_maps();
             let value = peeled
                 .as_compound()
                 .and_then(|(_, args)| args.get(1).cloned());
             return match value {
                 Some(value) if self.needs_custom_equality(&value) => {
-                    let eq = self.equality_closure(&value, fx);
+                    let eq = self.equality_closure(&value);
                     format!("maps.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("maps.Equal({lhs}, {rhs})"),
@@ -647,11 +632,11 @@ impl Planner<'_> {
         format!("{lhs} == {rhs}")
     }
 
-    fn equality_closure(&mut self, ty: &Type, fx: &mut EmitEffects) -> String {
-        let go_ty = self.go_type_string(ty, fx);
+    fn equality_closure(&mut self, ty: &Type) -> String {
+        let go_ty = self.go_type_string(ty);
         let a = self.fresh_var(Some("a"));
         let b = self.fresh_var(Some("b"));
-        let body = self.render_equality(&a, &b, ty, fx);
+        let body = self.render_equality(&a, &b, ty);
         format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
     }
 
@@ -675,12 +660,12 @@ fn format_substring_call(receiver: &str, start: Option<&str>, end: Option<&str>)
     }
 }
 
-pub(super) fn apply_inline_import(import: InlineImport, fx: &mut EmitEffects) {
+pub(super) fn apply_inline_import(planner: &Planner, import: InlineImport) {
     match import {
-        InlineImport::Slices => fx.require_slices(),
-        InlineImport::Strings => fx.require_strings(),
-        InlineImport::Maps => fx.require_maps(),
-        InlineImport::Stdlib => fx.require_stdlib(),
+        InlineImport::Slices => planner.require_slices(),
+        InlineImport::Strings => planner.require_strings(),
+        InlineImport::Maps => planner.require_maps(),
+        InlineImport::Stdlib => planner.require_stdlib(),
         InlineImport::None => {}
     }
 }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -4,7 +4,6 @@ use crate::calls::dispatch::{
 };
 use crate::calls::go_interop::is_go_receiver;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::AbiShape;
 use crate::abi::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
@@ -125,7 +124,6 @@ impl<'a> Planner<'a> {
         call_plan: &CallPlan,
         call_ty: Option<&Type>,
         expression_ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::Call {
             expression: callee,
@@ -143,22 +141,16 @@ impl<'a> Planner<'a> {
         if let Some(go_name) = self.get_callee_go_name(function).map(str::to_string) {
             let stages: Vec<StagedExpression> = args
                 .iter()
-                .map(|a| self.stage_operand(a, ExpressionContext::value(), fx))
+                .map(|a| self.stage_operand(a, ExpressionContext::value()))
                 .collect();
             let wrap_to_any = spread_needs_any_wrap(function, spread);
             let combine = call_plan.variadic_combine(0);
-            let (setup, args_strings) = self.sequence_with_spread_structured(
-                stages,
-                spread,
-                wrap_to_any,
-                "_arg",
-                combine,
-                fx,
-            );
+            let (setup, args_strings) =
+                self.sequence_with_spread_structured(stages, spread, wrap_to_any, "_arg", combine);
             return (setup, format!("{}({})", go_name, args_strings.join(", ")));
         }
 
-        let callee_staged = self.stage_operand(function, expression_ctx.callee(), fx);
+        let callee_staged = self.stage_operand(function, expression_ctx.callee());
         let mut function_string = callee_staged.value;
 
         if function.deref_inner().is_some() {
@@ -175,7 +167,6 @@ impl<'a> Planner<'a> {
             },
             &mut function_string,
             expression_ctx,
-            fx,
         );
 
         let analysis = self.analyze_callee(function);
@@ -190,7 +181,7 @@ impl<'a> Planner<'a> {
             wrap_spread_to_any: spread_needs_any_wrap(function, spread),
             combine_variadic: call_plan.variadic_combine(0),
         };
-        let (args_setup, args_strings) = self.emit_call_args(args, &args_ctx, fx);
+        let (args_setup, args_strings) = self.emit_call_args(args, &args_ctx);
 
         let mut setup = callee_staged.setup;
         let callee_needs_pin = setup.is_empty()
@@ -287,7 +278,6 @@ impl<'a> Planner<'a> {
         &mut self,
         function: &Expression,
         recipe: &str,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let definition_ty = self.callee_definition(function)?.ty().clone();
         let Type::Forall { body, .. } = definition_ty else {
@@ -296,7 +286,7 @@ impl<'a> Planner<'a> {
         let instantiated = function.get_type();
         let mut mapping = rustc_hash::FxHashMap::default();
         extract_type_mapping(&body, &instantiated, &mut mapping);
-        self.reconstruct_collapsed_type_args(recipe, &mapping, fx)
+        self.reconstruct_collapsed_type_args(recipe, &mapping)
     }
 
     pub(crate) fn callee_definition(&self, function: &Expression) -> Option<&'a Definition> {
@@ -384,7 +374,6 @@ impl<'a> Planner<'a> {
         arg_shape: CallArgShape,
         function_string: &mut String,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         let has_value_args = arg_shape.value_count > 0 || arg_shape.has_spread;
         if let Some(recipe) = self.callee_collapsed_recipe(function) {
@@ -392,27 +381,27 @@ impl<'a> Planner<'a> {
                 return String::new();
             }
             return self
-                .reconstruct_collapsed_call_type_args(function, &recipe, fx)
+                .reconstruct_collapsed_call_type_args(function, &recipe)
                 .unwrap_or_default();
         }
 
-        let mut type_args_string = self.format_type_args(type_args, fx);
+        let mut type_args_string = self.format_type_args(type_args);
 
         let slot_ty = ctx.expected_slot_type();
 
         if type_args_string.is_empty()
-            && let Some(inferred) = self.infer_return_only_type_args(function, arg_shape, fx)
+            && let Some(inferred) = self.infer_return_only_type_args(function, arg_shape)
         {
             type_args_string = match slot_ty {
-                Some(t) => self.prelude_container_type_args(t, fx).unwrap_or(inferred),
+                Some(t) => self.prelude_container_type_args(t).unwrap_or(inferred),
                 None => inferred,
             };
         }
 
         if type_args_string.is_empty() && is_prelude_variant_constructor(function) {
-            let mut candidate = call_ty.and_then(|t| self.prelude_container_type_args(t, fx));
+            let mut candidate = call_ty.and_then(|t| self.prelude_container_type_args(t));
             if candidate.is_none() {
-                candidate = slot_ty.and_then(|t| self.prelude_container_type_args(t, fx));
+                candidate = slot_ty.and_then(|t| self.prelude_container_type_args(t));
             }
             type_args_string = candidate.unwrap_or_default();
         }
@@ -433,13 +422,12 @@ impl<'a> Planner<'a> {
         &mut self,
         args: &[Expression],
         ctx: &CallArgsContext<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let stages: Vec<StagedExpression> = args
             .iter()
             .enumerate()
             .map(|(i, arg)| {
-                let (setup, value) = self.lower_call_arg(arg, i, ctx, fx);
+                let (setup, value) = self.lower_call_arg(arg, i, ctx);
                 StagedExpression::from_typed_setup(setup, value, arg)
             })
             .collect();
@@ -450,7 +438,6 @@ impl<'a> Planner<'a> {
             ctx.generic_fn_param_types,
             ctx.wrap_spread_to_any,
             ctx.combine_variadic.clone(),
-            fx,
         )
     }
 
@@ -465,7 +452,6 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         index: usize,
         ctx: &CallArgsContext<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let effective_param_ty = effective_param_type(index, ctx.fn_param_types);
         let generic_param_ty = ctx
@@ -488,36 +474,32 @@ impl<'a> Planner<'a> {
                 arg,
                 effective_param_ty.expect("GoCallbackAdapter requires effective_param_ty"),
                 kind,
-                fx,
             ),
             ArgumentPlan::LoweredFnShapeAdapter => self
                 .lower_adapt_lowered_fn_arg_shape(
                     arg,
                     generic_param_ty.expect("LoweredFnShapeAdapter requires generic_param_ty"),
-                    fx,
                 )
                 .expect("detect_lowered_fn_arg_shape ensures Some"),
             ArgumentPlan::NullableCoercion(kind) => self.lower_nullable_coercion(
                 arg,
                 effective_param_ty.expect("NullableCoercion requires effective_param_ty"),
                 kind,
-                fx,
             ),
             ArgumentPlan::GoPointerUnwrap => self.lower_go_pointer_param_unwrap(
                 arg,
                 effective_param_ty.expect("GoPointerUnwrap requires effective_param_ty"),
-                fx,
             ),
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
                 let arg_ctx = direct_arg_emit_ctx(ctx, Some(target), true);
-                let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx).into_parts();
-                let lowered = self.emit_lower_arg_to_tagged(&mut setup, &value, target, fx);
+                let (mut setup, value) = self.lower_composite_value(arg, arg_ctx).into_parts();
+                let lowered = self.emit_lower_arg_to_tagged(&mut setup, &value, target);
                 (setup, lowered)
             }
             ArgumentPlan::Direct => {
-                self.lower_direct_arg(arg, ctx, effective_param_ty, declared_param_ty, fx)
+                self.lower_direct_arg(arg, ctx, effective_param_ty, declared_param_ty)
             }
         }
     }
@@ -571,16 +553,15 @@ impl<'a> Planner<'a> {
         ctx: &CallArgsContext<'_>,
         effective_param_ty: Option<&Type>,
         declared_param_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
         let arg_ctx = direct_arg_emit_ctx(ctx, effective_param_ty, suppress);
-        let (mut setup, value) = self.lower_composite_value(arg, arg_ctx, fx).into_parts();
+        let (mut setup, value) = self.lower_composite_value(arg, arg_ctx).into_parts();
         let final_value = match effective_param_ty {
             Some(target) => {
                 let coercion =
                     Coercion::resolve(self, &arg.get_type(), target, CoercionDirection::Internal);
-                let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+                let (coercion_setup, coerced) = coercion.lower(self, value);
                 setup.extend(coercion_setup);
                 coerced
             }
@@ -596,11 +577,10 @@ impl<'a> Planner<'a> {
         setup: &mut Vec<LoweredStatement>,
         arg: &Expression,
         generic_param_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         self.detect_lowered_fn_arg_shape(arg, generic_param_ty)?;
         let (adapt_setup, value) =
-            self.lower_adapt_lowered_fn_arg_shape(arg, generic_param_ty.unwrap(), fx)?;
+            self.lower_adapt_lowered_fn_arg_shape(arg, generic_param_ty.unwrap())?;
         setup.extend(adapt_setup);
         Some(value)
     }
@@ -652,11 +632,10 @@ impl<'a> Planner<'a> {
         &mut self,
         arg: &Expression,
         generic_param_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let (param_shape, arg_fn, arg_shape) = self.fn_arg_shapes(arg, generic_param_ty)?;
         let (mut setup, value) = self
-            .lower_value(arg, ExpressionContext::value(), fx)
+            .lower_value(arg, ExpressionContext::value())
             .into_parts();
         let mut buffer = String::new();
         let adapted = emit_fn_arg_shape_adapter(
@@ -666,7 +645,6 @@ impl<'a> Planner<'a> {
             &arg_fn,
             &arg_shape,
             param_shape.as_ref(),
-            fx,
         )?;
         if !buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(buffer));
@@ -680,7 +658,6 @@ impl<'a> Planner<'a> {
         &mut self,
         spread: &Expression,
         generic_params: Option<&[Type]>,
-        fx: &mut EmitEffects,
     ) -> Option<StagedExpression> {
         let generic_params = generic_params?;
         let raw_variadic = generic_params.last()?;
@@ -707,18 +684,18 @@ impl<'a> Planner<'a> {
         }
 
         let (mut setup, src_value) = self
-            .lower_value(spread, ExpressionContext::value(), fx)
+            .lower_value(spread, ExpressionContext::value())
             .into_parts();
         let src_var = self.hoist_tmp_value_statement(&mut setup, "src", &src_value);
 
         let target_element_ret = match param_shape.as_ref() {
-            Some(shape) => self.render_lowered_return_ty(shape, arg_ret, fx),
-            None => self.go_type_string(arg_ret, fx),
+            Some(shape) => self.render_lowered_return_ty(shape, arg_ret),
+            None => self.go_type_string(arg_ret),
         };
         let arg_fn_params = arg_fn.get_function_params().unwrap_or(&[]);
         let param_type_strs: Vec<String> = arg_fn_params
             .iter()
-            .map(|p| self.go_type_string(p, fx))
+            .map(|p| self.go_type_string(p))
             .collect();
         let target_element_ty = format!(
             "func({}) {}",
@@ -738,7 +715,6 @@ impl<'a> Planner<'a> {
             &arg_fn,
             &arg_shape,
             param_shape.as_ref(),
-            fx,
         )?;
         write_line!(body, "{}[i] = {}", adapted, closure);
 
@@ -795,10 +771,9 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         effective_param_ty: &Type,
         kind: CallbackWrapperKind,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let (mut setup, value) = self
-            .lower_value(arg, ExpressionContext::value(), fx)
+            .lower_value(arg, ExpressionContext::value())
             .into_parts();
         let result = match kind {
             CallbackWrapperKind::Identity => value,
@@ -807,7 +782,7 @@ impl<'a> Planner<'a> {
                     .facts
                     .resolve_to_function_type(effective_param_ty.unwrap_forall())
                     .expect("Wrap kind only reached when param resolves to a fn type");
-                emit_lisette_callback_wrapper(self, &mut setup, &value, &param_fn_ty, fx)
+                emit_lisette_callback_wrapper(self, &mut setup, &value, &param_fn_ty)
             }
         };
         (setup, result)
@@ -840,17 +815,16 @@ impl<'a> Planner<'a> {
         &mut self,
         arg: &Expression,
         param_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         if arg.is_none_literal() {
             return (Vec::new(), "nil".to_string());
         }
         let arg_ty = arg.get_type();
         let (mut setup, value) = self
-            .lower_value(arg, ExpressionContext::value(), fx)
+            .lower_value(arg, ExpressionContext::value())
             .into_parts();
         let coercion = Coercion::resolve(self, &arg_ty, param_ty, CoercionDirection::ToGoBoundary);
-        let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+        let (coercion_setup, coerced) = coercion.lower(self, value);
         setup.extend(coercion_setup);
         (setup, coerced)
     }
@@ -890,7 +864,6 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         effective_param_ty: &Type,
         kind: NullableCoerceKind,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let arg_ty = arg.get_type();
         match kind {
@@ -900,16 +873,16 @@ impl<'a> Planner<'a> {
                     return (Vec::new(), "nil".to_string());
                 }
                 let (mut setup, value) = self
-                    .lower_value(arg, ExpressionContext::value(), fx)
+                    .lower_value(arg, ExpressionContext::value())
                     .into_parts();
                 let coercion =
                     Coercion::resolve(self, &arg_ty, &check_ty, CoercionDirection::ToGoBoundary);
-                let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+                let (coercion_setup, coerced) = coercion.lower(self, value);
                 setup.extend(coercion_setup);
                 (setup, coerced)
             }
             NullableCoerceKind::NullableInterface => {
-                self.lower_unwrap_go_nullable_arg(arg, &arg_ty, fx)
+                self.lower_unwrap_go_nullable_arg(arg, &arg_ty)
             }
         }
     }
@@ -918,16 +891,15 @@ impl<'a> Planner<'a> {
         &mut self,
         arg: &Expression,
         arg_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         if arg.is_none_literal() {
             return (Vec::new(), "nil".to_string());
         }
         let (mut setup, value) = self
-            .lower_value(arg, ExpressionContext::value(), fx)
+            .lower_value(arg, ExpressionContext::value())
             .into_parts();
         let coercion = Coercion::resolve(self, arg_ty, arg_ty, CoercionDirection::ToGoBoundary);
-        let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+        let (coercion_setup, coerced) = coercion.lower(self, value);
         setup.extend(coercion_setup);
         (setup, coerced)
     }

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -4,7 +4,6 @@ use crate::calls::regular::effective_param_type;
 use crate::plan::calls::plan_variadic_spread;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -26,7 +25,6 @@ impl Planner<'_> {
         receiver_ty: &Type,
         type_args: &[Type],
         arg_shape: CallArgShape,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let method_key = format!("{}.{}", qualified_name, member);
         let definition_ty = self.facts.definition(method_key.as_str())?.ty().clone();
@@ -49,9 +47,9 @@ impl Planner<'_> {
             let mut go_type_strs = Vec::with_capacity(vars.len());
             for (index, var) in vars.iter().enumerate() {
                 let go_type = if index < impl_count {
-                    self.go_type_string(receiver_mapping.get(var.as_str())?, fx)
+                    self.go_type_string(receiver_mapping.get(var.as_str())?)
                 } else {
-                    self.go_type_string(type_args.get(index - impl_count)?, fx)
+                    self.go_type_string(type_args.get(index - impl_count)?)
                 };
                 go_type_strs.push(go_type);
             }
@@ -85,7 +83,7 @@ impl Planner<'_> {
             let resolved = receiver_mapping
                 .get(var.as_str())
                 .or_else(|| inferred_mapping.get(var.as_str()))?;
-            go_type_strs.push(self.go_type_string(resolved, fx));
+            go_type_strs.push(self.go_type_string(resolved));
         }
         (!go_type_strs.is_empty()).then(|| format!("[{}]", go_type_strs.join(", ")))
     }
@@ -96,7 +94,6 @@ impl Planner<'_> {
         args: &[Expression],
         type_args: &[Type],
         spread: Option<&Expression>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::DotAccess {
             expression: receiver,
@@ -117,12 +114,12 @@ impl Planner<'_> {
         };
 
         let (mut setup, receiver_arg, emitted_args) =
-            self.lower_ufcs_call_args(function, receiver, args, spread, fx);
+            self.lower_ufcs_call_args(function, receiver, args, spread);
         let receiver_arg =
             self.apply_receiver_coercion(&mut setup, receiver, receiver_arg, *coercion);
 
         if let Some(inlined) =
-            try_inline_native_ufcs(receiver, member, &receiver_arg, &emitted_args, fx)
+            try_inline_native_ufcs(self, receiver, member, &receiver_arg, &emitted_args)
         {
             return (setup, inlined);
         }
@@ -140,7 +137,6 @@ impl Planner<'_> {
                 value_count: args.len(),
                 has_spread: spread.is_some(),
             },
-            fx,
         );
         (setup, format!("{}({})", fn_name, new_args.join(", ")))
     }
@@ -151,7 +147,6 @@ impl Planner<'_> {
         receiver: &Expression,
         args: &[Expression],
         spread: Option<&Expression>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, Vec<String>) {
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
@@ -169,7 +164,7 @@ impl Planner<'_> {
             .flatten();
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
-        all_stages.push(self.stage_operand(receiver, ExpressionContext::value(), fx));
+        all_stages.push(self.stage_operand(receiver, ExpressionContext::value()));
         for (i, arg) in args.iter().enumerate() {
             let declared = declared_params.and_then(|p| effective_param_type(i, p));
             let suppress_decl = suppress_declared.and_then(|p| effective_param_type(i, p));
@@ -178,7 +173,6 @@ impl Planner<'_> {
                 declared,
                 suppress_decl,
                 formal_params.get(i),
-                fx,
             ));
         }
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
@@ -189,7 +183,6 @@ impl Planner<'_> {
             declared_params,
             false,
             combine,
-            fx,
         );
         let receiver_arg = all_values[0].clone();
         let emitted_args: Vec<String> = all_values[1..].to_vec();
@@ -202,18 +195,15 @@ impl Planner<'_> {
         declared_param: Option<&Type>,
         suppress_declared: Option<&Type>,
         formal_param: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> StagedExpression {
         let Some(declared) = declared_param else {
-            return self.stage_prelude_arg(arg, suppress_declared, formal_param, fx);
+            return self.stage_prelude_arg(arg, suppress_declared, formal_param);
         };
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        if let Some(value) =
-            self.try_adapt_lowered_fn_arg_shape(&mut setup, arg, Some(declared), fx)
-        {
+        if let Some(value) = self.try_adapt_lowered_fn_arg_shape(&mut setup, arg, Some(declared)) {
             return StagedExpression::from_typed_setup(setup, value, arg);
         }
-        self.stage_composite(arg, ExpressionContext::value(), fx)
+        self.stage_composite(arg, ExpressionContext::value())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -225,7 +215,6 @@ impl Planner<'_> {
         member: &str,
         type_args: &[Type],
         arg_shape: CallArgShape,
-        fx: &mut EmitEffects,
     ) -> String {
         let type_args_string = self
             .ufcs_type_args(
@@ -235,7 +224,6 @@ impl Planner<'_> {
                 receiver_ty,
                 type_args,
                 arg_shape,
-                fx,
             )
             .unwrap_or_default();
 
@@ -247,7 +235,7 @@ impl Planner<'_> {
             .unwrap_or(false)
             || self.method_needs_export(member);
 
-        let qualified_method_name = self.qualify_method_call(qualified_name, member, is_public, fx);
+        let qualified_method_name = self.qualify_method_call(qualified_name, member, is_public);
         format!("{}{}", qualified_method_name, type_args_string)
     }
 
@@ -281,7 +269,6 @@ impl Planner<'_> {
         method: &str,
         is_public: bool,
         spread: Option<&Expression>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let go_method = if is_public {
             go_name::snake_to_camel(method)
@@ -291,17 +278,17 @@ impl Planner<'_> {
 
         let stages: Vec<StagedExpression> = args
             .iter()
-            .map(|a| self.stage_composite(a, ExpressionContext::value(), fx))
+            .map(|a| self.stage_composite(a, ExpressionContext::value()))
             .collect();
 
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
         let (setup, emitted_all) =
-            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine, fx);
+            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine);
 
         let receiver = emitted_all[0].clone();
         let emitted_rest: Vec<String> = emitted_all[1..].to_vec();
 
-        let type_args_string = self.format_type_args(type_args, fx);
+        let type_args_string = self.format_type_args(type_args);
 
         let receiver = if let Some(stripped) = receiver.strip_prefix('&') {
             if is_address_of_composite_literal(args.first()) {
@@ -353,11 +340,11 @@ impl<'a> Planner<'a> {
 }
 
 fn try_inline_native_ufcs(
+    planner: &Planner,
     receiver: &Expression,
     member: &str,
     receiver_arg: &str,
     emitted_args: &[String],
-    fx: &mut EmitEffects,
 ) -> Option<String> {
     let native_type = NativeGoType::from_type(&receiver.get_type())?;
     let (inlined, extra_import) = super::native::try_inline_native_method(
@@ -367,7 +354,7 @@ fn try_inline_native_ufcs(
         emitted_args,
         false,
     )?;
-    apply_inline_import(extra_import, fx);
+    apply_inline_import(planner, extra_import);
     Some(inlined)
 }
 

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::names::go_name;
 use syntax::ast::Expression;
@@ -143,30 +142,21 @@ impl Fallible {
 pub(crate) struct FalliblePlanner<'a, 'e> {
     pub(crate) planner: &'a mut Planner<'e>,
     fallible: &'a Fallible,
-    pub(crate) fx: &'a mut EmitEffects,
 }
 
 impl<'a, 'e> FalliblePlanner<'a, 'e> {
-    pub(crate) fn new(
-        planner: &'a mut Planner<'e>,
-        fallible: &'a Fallible,
-        fx: &'a mut EmitEffects,
-    ) -> Self {
-        Self {
-            planner,
-            fallible,
-            fx,
-        }
+    pub(crate) fn new(planner: &'a mut Planner<'e>, fallible: &'a Fallible) -> Self {
+        Self { planner, fallible }
     }
 
     pub(crate) fn ok_type_string(&mut self) -> String {
-        self.planner.go_type_string(self.fallible.ok_ty(), self.fx)
+        self.planner.go_type_string(self.fallible.ok_ty())
     }
 
     pub(crate) fn err_type_string(&mut self) -> Option<String> {
         self.fallible
             .err_ty()
-            .map(|t| self.planner.go_type_string(t, self.fx))
+            .map(|t| self.planner.go_type_string(t))
     }
 
     /// Ok type from the enclosing return context, with the fallible's own ok type as fallback.
@@ -174,14 +164,14 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
         let return_ctx = self.planner.return_ctx();
         if let Some(ty) = return_ctx.ty() {
             let ok_ty = ty.ok_type();
-            self.planner.go_type_string(&ok_ty, self.fx)
+            self.planner.go_type_string(&ok_ty)
         } else {
             self.ok_type_string()
         }
     }
 
     pub(crate) fn full_type_string(&mut self) -> String {
-        self.fx.require_stdlib();
+        self.planner.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
@@ -189,7 +179,6 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
                 self.fallible
                     .err_ty()
                     .expect("Result type must have an error type"),
-                self.fx,
             );
             format!(
                 "{}.{}[{}, {}]",
@@ -204,7 +193,7 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     }
 
     pub(crate) fn emit_success(&mut self, value: &str) -> String {
-        self.fx.require_stdlib();
+        self.planner.require_stdlib();
         let inner_ty = self.ok_type_string();
         let err_ty = self.err_type_string();
         self.fallible
@@ -212,7 +201,7 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     }
 
     pub(crate) fn emit_failure(&mut self, error_value: Option<&str>) -> String {
-        self.fx.require_stdlib();
+        self.planner.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
@@ -230,7 +219,7 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
 
     /// Emit a failure wrapper using the contextual ok type (from return context).
     pub(crate) fn emit_contextual_failure(&mut self, error_value: Option<&str>) -> String {
-        self.fx.require_stdlib();
+        self.planner.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.contextual_ok_type_string();
         if self.fallible.is_result() {

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -1,5 +1,4 @@
 use super::propagation::plain_return;
-use crate::EmitEffects;
 use crate::Planner;
 use crate::ReturnContext;
 use crate::abi::transition;
@@ -15,13 +14,8 @@ use syntax::types::Type;
 impl Planner<'_> {
     /// `try { ... }` → `ClosureBind` over `func() T { ... }()`; value is the
     /// bound result var.
-    pub(crate) fn lower_try_block(
-        &mut self,
-        items: &[Expression],
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> ValuePlan {
-        fx.require_stdlib();
+    pub(crate) fn lower_try_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
+        self.require_stdlib();
 
         let return_ctx = self.return_ctx();
         let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
@@ -31,13 +25,13 @@ impl Planner<'_> {
         let result_var = self.fresh_var(Some("tryResult"));
         self.declare(&result_var);
         let full_ty = {
-            let mut fe = FalliblePlanner::new(self, &fallible, fx);
+            let mut fe = FalliblePlanner::new(self, &fallible);
             fe.full_type_string()
         };
 
         let body_ctx = ReturnContext::TaggedBlock(effective_ty);
         self.push_return_ctx(body_ctx.clone());
-        let body = self.with_fresh_scope(|planner| planner.lower_try_body(items, &fallible, fx));
+        let body = self.with_fresh_scope(|planner| planner.lower_try_body(items, &fallible));
         self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
@@ -49,36 +43,24 @@ impl Planner<'_> {
         value_plan_from_statements(setup, result_var)
     }
 
-    fn lower_try_body(
-        &mut self,
-        items: &[Expression],
-        fallible: &Fallible,
-        fx: &mut EmitEffects,
-    ) -> LoweredBlock {
+    fn lower_try_body(&mut self, items: &[Expression], fallible: &Fallible) -> LoweredBlock {
         let Some((last, rest)) = items.split_last() else {
             return LoweredBlock {
-                statements: vec![self.lower_try_unit_return(fallible, fx)],
+                statements: vec![self.lower_try_unit_return(fallible)],
             };
         };
-        let mut statements: Vec<LoweredStatement> = rest
-            .iter()
-            .map(|item| self.lower_statement(item, fx))
-            .collect();
-        statements.extend(self.lower_try_tail(last, fallible, fx));
+        let mut statements: Vec<LoweredStatement> =
+            rest.iter().map(|item| self.lower_statement(item)).collect();
+        statements.extend(self.lower_try_tail(last, fallible));
         LoweredBlock { statements }
     }
 
     /// Tail of a `try` block: never tail (statement + unreachable panic),
     /// statement-only/unit-call tail (statement + success unit return), or a
     /// value tail (success-wrapped return; unit return when the value is empty).
-    fn lower_try_tail(
-        &mut self,
-        last: &Expression,
-        fallible: &Fallible,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    fn lower_try_tail(&mut self, last: &Expression, fallible: &Fallible) -> Vec<LoweredStatement> {
         if last.diverges().is_some() || last.get_type().is_never() {
-            let mut statements = vec![self.lower_statement(last, fx)];
+            let mut statements = vec![self.lower_statement(last)];
             if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
@@ -97,40 +79,31 @@ impl Planner<'_> {
         );
         if is_statement_only || is_unit_call(last) {
             return vec![
-                self.lower_statement(last, fx),
-                self.lower_try_unit_return(fallible, fx),
+                self.lower_statement(last),
+                self.lower_try_unit_return(fallible),
             ];
         }
 
         let (mut statements, final_expression) = self
-            .lower_value(last, ExpressionContext::value(), fx)
+            .lower_value(last, ExpressionContext::value())
             .into_parts();
         if final_expression.is_empty() {
-            statements.push(self.lower_try_unit_return(fallible, fx));
+            statements.push(self.lower_try_unit_return(fallible));
         } else {
-            statements.push(self.lower_try_success_return(&final_expression, fallible, fx));
+            statements.push(self.lower_try_success_return(&final_expression, fallible));
         }
         statements
     }
 
-    fn lower_try_unit_return(
-        &mut self,
-        fallible: &Fallible,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    fn lower_try_unit_return(&mut self, fallible: &Fallible) -> LoweredStatement {
         let (unit_val, effects) = self.zero_value(fallible.ok_ty());
-        fx.extend(&effects);
-        self.lower_try_success_return(&unit_val, fallible, fx)
+        self.absorb_effects(&effects);
+        self.lower_try_success_return(&unit_val, fallible)
     }
 
-    fn lower_try_success_return(
-        &mut self,
-        value: &str,
-        fallible: &Fallible,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    fn lower_try_success_return(&mut self, value: &str, fallible: &Fallible) -> LoweredStatement {
         let ok_return = {
-            let mut fe = FalliblePlanner::new(self, fallible, fx);
+            let mut fe = FalliblePlanner::new(self, fallible);
             fe.emit_success(value)
         };
         plain_return(ok_return)
@@ -142,7 +115,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         fallible: &Fallible,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let mut statements: Vec<LoweredStatement> = Vec::new();
         let err_arg = match expression {
@@ -156,7 +128,7 @@ impl Planner<'_> {
                 }
                 if !args.is_empty() {
                     let (setup, value) = self
-                        .lower_value(&args[0], ExpressionContext::value(), fx)
+                        .lower_value(&args[0], ExpressionContext::value())
                         .into_parts();
                     statements.extend(setup);
                     Some(value)
@@ -178,15 +150,15 @@ impl Planner<'_> {
             let return_ty = return_ctx.expect_ty();
             let values = if fallible.is_result() {
                 let err_expr = err_arg.as_deref().unwrap_or("");
-                transition::lowered_err_values(self, &shape, &return_ty, err_expr, fx)
+                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
             } else {
-                transition::lowered_none_values(self, &shape, &return_ty, fx)
+                transition::lowered_none_values(self, &shape, &return_ty)
             };
             statements.push(plain_return(values.join(", ")));
         } else {
-            fx.require_stdlib();
+            self.require_stdlib();
             let err_return = {
-                let mut fe = FalliblePlanner::new(self, fallible, fx);
+                let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_contextual_failure(err_arg.as_deref())
             };
             statements.push(plain_return(err_return));
@@ -196,13 +168,8 @@ impl Planner<'_> {
 
     /// `recover { ... }` → `ClosureBind` over
     /// `lisette.RecoverBlock(func() T { ... })`.
-    pub(crate) fn lower_recover_block(
-        &mut self,
-        items: &[Expression],
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> ValuePlan {
-        fx.require_stdlib();
+    pub(crate) fn lower_recover_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
+        self.require_stdlib();
 
         let return_ctx = self.return_ctx();
         let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
@@ -211,12 +178,12 @@ impl Planner<'_> {
 
         let result_var = self.fresh_var(Some("recoverResult"));
         self.declare(&result_var);
-        let inner_ty_str = self.go_type_string(fallible.ok_ty(), fx);
+        let inner_ty_str = self.go_type_string(fallible.ok_ty());
 
         let body_return_ctx = self.return_context_for_type(fallible.ok_ty().clone());
         self.push_return_ctx(body_return_ctx.clone());
         let body =
-            self.with_fresh_scope(|planner| planner.lower_recover_body_block(items, &fallible, fx));
+            self.with_fresh_scope(|planner| planner.lower_recover_body_block(items, &fallible));
         self.pop_return_ctx();
 
         let setup = vec![LoweredStatement::ClosureBind {
@@ -232,18 +199,15 @@ impl Planner<'_> {
         &mut self,
         items: &[Expression],
         fallible: &Fallible,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let Some((last, rest)) = items.split_last() else {
             return LoweredBlock {
-                statements: vec![self.lower_zero_return(fallible.ok_ty(), fx)],
+                statements: vec![self.lower_zero_return(fallible.ok_ty())],
             };
         };
-        let mut statements: Vec<LoweredStatement> = rest
-            .iter()
-            .map(|item| self.lower_statement(item, fx))
-            .collect();
-        statements.extend(self.lower_recover_tail(last, fallible, fx));
+        let mut statements: Vec<LoweredStatement> =
+            rest.iter().map(|item| self.lower_statement(item)).collect();
+        statements.extend(self.lower_recover_tail(last, fallible));
         LoweredBlock { statements }
     }
 
@@ -254,11 +218,10 @@ impl Planner<'_> {
         &mut self,
         last: &Expression,
         fallible: &Fallible,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let item_ty = last.get_type();
         if item_ty.is_never() {
-            let mut statements = vec![self.lower_statement(last, fx)];
+            let mut statements = vec![self.lower_statement(last)];
             if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
@@ -266,21 +229,21 @@ impl Planner<'_> {
         }
         if item_ty.is_unit() || item_ty.is_variable() {
             return vec![
-                self.lower_statement(last, fx),
-                self.lower_zero_return(fallible.ok_ty(), fx),
+                self.lower_statement(last),
+                self.lower_zero_return(fallible.ok_ty()),
             ];
         }
         let (mut statements, expression) = self
-            .lower_value(last, ExpressionContext::value(), fx)
+            .lower_value(last, ExpressionContext::value())
             .into_parts();
         statements.push(plain_return(expression));
         statements
     }
 
     /// A structured zero-value return for a `recover` block's inner type.
-    fn lower_zero_return(&mut self, ty: &Type, fx: &mut EmitEffects) -> LoweredStatement {
+    fn lower_zero_return(&mut self, ty: &Type) -> LoweredStatement {
         let (zero, effects) = self.zero_value(ty);
-        fx.extend(&effects);
+        self.absorb_effects(&effects);
         plain_return(zero)
     }
 }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
@@ -14,11 +13,7 @@ use syntax::types::Type;
 
 impl Planner<'_> {
     /// Lower a `for` statement, dispatching on iterable/pattern shape.
-    pub(crate) fn lower_for_statement(
-        &mut self,
-        full_expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    pub(crate) fn lower_for_statement(&mut self, full_expression: &Expression) -> LoweredStatement {
         let Expression::For {
             binding,
             iterable,
@@ -53,20 +48,20 @@ impl Planner<'_> {
         let label = self.current_loop_label().map(str::to_string);
 
         let (prologue, header, lowered_body) = if is_range {
-            self.lower_range_for(binding, iterable, body, fx)
+            self.lower_range_for(binding, iterable, body)
         } else if let Some(range_shape) = stored_range {
-            self.lower_stored_range_for(binding, iterable, range_shape, body, fx)
+            self.lower_stored_range_for(binding, iterable, range_shape, body)
         } else if let Some((kind, receiver)) = string_view {
             match kind {
-                StringViewKind::Runes => self.lower_runes_for(binding, receiver, body, fx),
-                StringViewKind::Bytes => self.lower_bytes_for(binding, receiver, body, fx),
+                StringViewKind::Runes => self.lower_runes_for(binding, receiver, body),
+                StringViewKind::Bytes => self.lower_bytes_for(binding, receiver, body),
             }
         } else if map_tuple {
-            self.lower_map_tuple_for(binding, iterable, body, fx)
+            self.lower_map_tuple_for(binding, iterable, body)
         } else if is_simple {
-            self.lower_simple_for(binding, iterable, body, fx)
+            self.lower_simple_for(binding, iterable, body)
         } else {
-            self.lower_pattern_site_for(binding, iterable, body, fx)
+            self.lower_pattern_site_for(binding, iterable, body)
         };
 
         self.pop_loop();
@@ -88,9 +83,8 @@ impl Planner<'_> {
         &mut self,
         prologue: &mut Vec<LoweredStatement>,
         expr: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
-        let plan = self.plan_operand(expr, ExpressionContext::value(), fx);
+        let plan = self.plan_operand(expr, ExpressionContext::value());
         let (setup, value) = plan.into_parts();
         prologue.extend(setup);
         value
@@ -103,15 +97,14 @@ impl Planner<'_> {
         prologue: &mut Vec<LoweredStatement>,
         expr: &Expression,
         prefix: &str,
-        fx: &mut EmitEffects,
     ) -> String {
         if !observable_after_mutation(expr) {
-            return self.capture_operand_into(prologue, expr, fx);
+            return self.capture_operand_into(prologue, expr);
         }
         let temp_var = self.fresh_var(Some(prefix));
         self.declare(&temp_var);
         let (setup, value) = self
-            .lower_composite_value(expr, ExpressionContext::value(), fx)
+            .lower_composite_value(expr, ExpressionContext::value())
             .into_parts();
         prologue.extend(setup);
         prologue.push(LoweredStatement::TempBind {
@@ -128,14 +121,13 @@ impl Planner<'_> {
         iterable: &Expression,
         range_shape: RangeShape,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
         let mut prologue = Vec::new();
         let range_var = if self.is_unmutated_identifier(iterable) {
-            self.capture_operand_into(&mut prologue, iterable, fx)
+            self.capture_operand_into(&mut prologue, iterable)
         } else {
-            self.force_capture_into(&mut prologue, iterable, "_range", fx)
+            self.force_capture_into(&mut prologue, iterable, "_range")
         };
         let loop_var = self.bind_loop_pattern(&binding.pattern, Some("_i"));
         let header = match range_shape {
@@ -155,7 +147,7 @@ impl Planner<'_> {
                 unreachable!("RangeTo/RangeToInclusive are not iterable")
             }
         };
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -166,18 +158,17 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
         let mut prologue = Vec::new();
-        let receiver_str = self.capture_operand_into(&mut prologue, receiver, fx);
+        let receiver_str = self.capture_operand_into(&mut prologue, receiver);
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
         let header = if loop_var == "_" {
             format!("for range {} {{\n", receiver_str)
         } else {
             format!("for _, {} := range {} {{\n", loop_var, receiver_str)
         };
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -188,14 +179,13 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         self.enter_scope();
         let mut prologue = Vec::new();
         let receiver_var = if self.is_unmutated_identifier(receiver) {
-            self.capture_operand_into(&mut prologue, receiver, fx)
+            self.capture_operand_into(&mut prologue, receiver)
         } else {
-            self.force_capture_into(&mut prologue, receiver, "_s", fx)
+            self.force_capture_into(&mut prologue, receiver, "_s")
         };
         let index_var = self.fresh_var(Some("_i"));
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
@@ -209,7 +199,7 @@ impl Planner<'_> {
                 loop_var, receiver_var, index_var
             ));
         }
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -220,10 +210,9 @@ impl Planner<'_> {
     fn capture_iterable_operand(
         &mut self,
         iterable: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, bool) {
         let mut prologue = Vec::new();
-        let iter_raw = self.capture_operand_into(&mut prologue, iterable, fx);
+        let iter_raw = self.capture_operand_into(&mut prologue, iterable);
         let iterable_ty = iterable.get_type();
         let iter_expression = if iterable_ty.is_ref() {
             format!("*{}", iter_raw)
@@ -243,9 +232,8 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable, fx);
+        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
         self.enter_scope();
         let loop_var = self.bind_loop_pattern(&binding.pattern, None);
@@ -256,7 +244,7 @@ impl Planner<'_> {
         } else {
             format!("for _, {} := range {} {{\n", loop_var, iter_expression)
         };
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         (prologue, header, lowered_body)
     }
@@ -269,7 +257,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let Pattern::Tuple { elements, .. } = &binding.pattern else {
             unreachable!("lower_map_tuple_for requires a tuple pattern");
@@ -277,7 +264,7 @@ impl Planner<'_> {
         let first = &elements[0];
         let second = &elements[1];
 
-        let (prologue, iter_expression, _) = self.capture_iterable_operand(iterable, fx);
+        let (prologue, iter_expression, _) = self.capture_iterable_operand(iterable);
 
         let first_is_simple =
             matches!(first, Pattern::Identifier { .. } | Pattern::WildCard { .. });
@@ -288,16 +275,9 @@ impl Planner<'_> {
 
         self.enter_scope();
         let (header, lowered_body) = if first_is_simple && second_is_simple {
-            self.lower_map_tuple_simple_body(first, second, &iter_expression, body, fx)
+            self.lower_map_tuple_simple_body(first, second, &iter_expression, body)
         } else {
-            self.lower_map_tuple_compound_body(
-                first,
-                second,
-                &binding.ty,
-                &iter_expression,
-                body,
-                fx,
-            )
+            self.lower_map_tuple_compound_body(first, second, &binding.ty, &iter_expression, body)
         };
         self.exit_scope();
         (prologue, header, lowered_body)
@@ -310,7 +290,6 @@ impl Planner<'_> {
         second: &Pattern,
         iter_expression: &str,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (String, LoweredBlock) {
         let first_is_discard =
             matches!(first, Pattern::WildCard { .. }) || self.go_name_for_binding(first).is_none();
@@ -323,7 +302,7 @@ impl Planner<'_> {
             let value = self.bind_loop_pattern(second, None);
             format!("for {}, {} := range {} {{\n", key, value, iter_expression)
         };
-        (header, self.lower_block_as_body(body, fx))
+        (header, self.lower_block_as_body(body))
     }
 
     /// Compound map-tuple element pattern: capture key/value into fresh vars,
@@ -336,7 +315,6 @@ impl Planner<'_> {
         binding_ty: &Type,
         iter_expression: &str,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (String, LoweredBlock) {
         let element_tys: &[Type] = match binding_ty {
             Type::Tuple(tys) => tys.as_slice(),
@@ -359,7 +337,6 @@ impl Planner<'_> {
             first,
             None,
             first_ty,
-            fx,
         );
         Renderer.render_lowered_block(
             &mut bindings,
@@ -376,7 +353,6 @@ impl Planner<'_> {
             second,
             None,
             second_ty,
-            fx,
         );
         Renderer.render_lowered_block(
             &mut bindings,
@@ -387,7 +363,7 @@ impl Planner<'_> {
         if bindings.len() > after_key {
             self.scope.record_go_use(&value_var);
         }
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         let used = self.scope.exit_use_region();
 
         let mut inner = vec![LoweredStatement::RawGo(bindings)];
@@ -417,14 +393,13 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable, fx);
+        let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
         self.enter_scope();
         let (header, body_block) = if !pattern_has_bindings(&binding.pattern) {
             let header = format!("for range {} {{\n", iter_expression);
-            (header, self.lower_block_as_body(body, fx))
+            (header, self.lower_block_as_body(body))
         } else {
             let item_var = self.fresh_var(Some("item"));
             let header = if single_var {
@@ -439,7 +414,6 @@ impl Planner<'_> {
                 &binding.pattern,
                 binding.typed_pattern.as_ref(),
                 &binding.ty,
-                fx,
             );
             Renderer.render_lowered_block(
                 &mut bindings,
@@ -450,7 +424,7 @@ impl Planner<'_> {
             if !bindings.is_empty() {
                 self.scope.record_go_use(&item_var);
             }
-            let lowered_body = self.lower_block_as_body(body, fx);
+            let lowered_body = self.lower_block_as_body(body);
             let used = self.scope.exit_use_region();
 
             let mut inner = vec![LoweredStatement::RawGo(bindings)];
@@ -476,7 +450,6 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let Expression::Range {
             start,
@@ -490,13 +463,13 @@ impl Planner<'_> {
 
         let mut prologue = Vec::new();
         let mut start_expression = match start {
-            Some(s) => self.capture_operand_into(&mut prologue, s, fx),
+            Some(s) => self.capture_operand_into(&mut prologue, s),
             None => "0".to_string(),
         };
         let checkpoint = prologue.len();
         let end_expression = end
             .as_ref()
-            .map(|e| self.force_capture_into(&mut prologue, e, "_bound", fx));
+            .map(|e| self.force_capture_into(&mut prologue, e, "_bound"));
         if prologue.len() > checkpoint && start.as_ref().is_some_and(|s| is_order_sensitive(s)) {
             // The end bound's capture inserted statements after the start value;
             // hoist start into its own temp before them so it evaluates first.
@@ -527,7 +500,7 @@ impl Planner<'_> {
                 loop_var, start_expression, loop_var
             ),
         };
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         (prologue, header, lowered_body)
     }

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::Renderer;
@@ -49,7 +48,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         result_var_name: Option<&str>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let expression_ty = expression.get_type();
         let fallible = Fallible::from_type(&expression_ty)
@@ -59,21 +57,21 @@ impl Planner<'_> {
 
         // `Err(...)?` / `None?` literal already emits its own return.
         if let Some(var_name) = result_var_name
-            && let Some(head) = self.try_lower_error_constructor(expression, &fallible, fx)
+            && let Some(head) = self.try_lower_error_constructor(expression, &fallible)
         {
             statements.extend(head);
-            self.declare_zero_for_dead_path(&mut statements, var_name, &fallible, fx);
+            self.declare_zero_for_dead_path(&mut statements, var_name, &fallible);
             return (statements, String::new());
         }
 
-        if let Some(fused) = self.try_lower_fused_go_propagate(expression, result_var_name, fx) {
+        if let Some(fused) = self.try_lower_fused_go_propagate(expression, result_var_name) {
             return fused;
         }
 
-        fx.require_stdlib();
-        let (check_setup, check_var) = self.hoist_propagate_check_var(expression, fx);
+        self.require_stdlib();
+        let (check_setup, check_var) = self.hoist_propagate_check_var(expression);
         statements.extend(check_setup);
-        statements.push(self.build_propagate_failure_check(&check_var, &fallible, fx));
+        statements.push(self.build_propagate_failure_check(&check_var, &fallible));
 
         let ok_access = format!("{}.{}", check_var, fallible.ok_field());
         let value = match result_var_name {
@@ -95,19 +93,18 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         var_name: &str,
         fallible: &Fallible,
-        fx: &mut EmitEffects,
     ) {
         if var_name == "_" {
             return;
         }
         let inner_ty = fallible.ok_ty();
         let (zero, effects) = self.zero_value(inner_ty);
-        fx.extend(&effects);
+        self.absorb_effects(&effects);
         if self.is_declared(var_name) {
             statements.push(simple_assign(var_name.to_string(), zero));
         } else {
             // Declared so the dead-path binding stays in scope for later references.
-            let go_ty = self.go_type_string(inner_ty, fx);
+            let go_ty = self.go_type_string(inner_ty);
             statements.push(LoweredStatement::VarDecl {
                 name: var_name.to_string(),
                 go_type: go_ty,
@@ -120,10 +117,9 @@ impl Planner<'_> {
     fn hoist_propagate_check_var(
         &mut self,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         if let Expression::Identifier { value, ty, .. } = expression {
-            let go_name = self.emit_identifier(value, ty, ExpressionContext::value(), fx);
+            let go_name = self.emit_identifier(value, ty, ExpressionContext::value());
             if go_name.contains('(') {
                 let mut setup = Vec::new();
                 let check = self.hoist_tmp_value_statement(&mut setup, "check", &go_name);
@@ -132,7 +128,7 @@ impl Planner<'_> {
                 (Vec::new(), go_name)
             }
         } else {
-            let staged = self.stage_operand(expression, ExpressionContext::value(), fx);
+            let staged = self.stage_operand(expression, ExpressionContext::value());
             let mut setup = staged.setup;
             let check = self.hoist_tmp_value_statement(&mut setup, "check", &staged.value);
             (setup, check)
@@ -144,7 +140,6 @@ impl Planner<'_> {
         &mut self,
         check_var: &str,
         fallible: &Fallible,
-        fx: &mut EmitEffects,
     ) -> LoweredStatement {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
         let success_tag = fallible.success_tag();
@@ -156,13 +151,13 @@ impl Planner<'_> {
             // shape-specific `None` rather than an err-return.
             if fallible.is_result() {
                 let err_expr = format!("{}{}", check_var, err_field);
-                transition::lowered_err_values(self, &shape, &return_ty, &err_expr, fx)
+                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
             } else {
-                transition::lowered_none_values(self, &shape, &return_ty, fx)
+                transition::lowered_none_values(self, &shape, &return_ty)
             }
         } else {
             let err_return = {
-                let mut fe = FalliblePlanner::new(self, fallible, fx);
+                let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_contextual_failure(Some(&format!("{}{}", check_var, err_field)))
             };
             vec![err_return]
@@ -177,7 +172,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         result_var_name: Option<&str>,
-        fx: &mut EmitEffects,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let plan = self.plan_call(expression)?;
         if !matches!(plan.callee, CalleePlan::GoInterop(GoCallStrategy::Result)) {
@@ -204,14 +198,14 @@ impl Planner<'_> {
         self.declare(&err_var);
 
         let (mut statements, call_str) =
-            self.lower_call(expression, None, ExpressionContext::value(), fx);
+            self.lower_call(expression, None, ExpressionContext::value());
         let bind_line = match &val_var {
             Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
             None => format!("_, {} := {}\n", err_var, call_str),
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let failure_values = transition::lowered_err_values(self, &shape, &return_ty, &err_var, fx);
+        let failure_values = transition::lowered_err_values(self, &shape, &return_ty, &err_var);
         statements.push(transition::tag_check(
             format!("{} != nil", err_var),
             failure_values,
@@ -233,9 +227,8 @@ impl Planner<'_> {
     pub(crate) fn lower_propagate_statement(
         &mut self,
         inner: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        self.lower_propagate(inner, Some("_"), fx).0
+        self.lower_propagate(inner, Some("_")).0
     }
 
     fn bind_propagate_ok(&mut self, name: &str, ok_access: &str) -> LoweredStatement {
@@ -251,11 +244,7 @@ impl Planner<'_> {
     }
 
     /// Build a `ReturnStatementPlan`, dispatching on return shape.
-    pub(crate) fn build_return_plan(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> ReturnStatementPlan {
+    pub(crate) fn build_return_plan(&mut self, expression: &Expression) -> ReturnStatementPlan {
         let return_ctx = self.return_ctx();
         let is_unit = return_ctx.ty().is_some_and(Type::is_unit);
         if is_unit {
@@ -271,7 +260,7 @@ impl Planner<'_> {
                 None
             } else {
                 let body = LoweredBlock {
-                    statements: vec![self.lower_statement(expression, fx)],
+                    statements: vec![self.lower_statement(expression)],
                 };
                 (!Renderer.renders_empty(&body)).then_some(body)
             };
@@ -280,7 +269,7 @@ impl Planner<'_> {
             };
         }
 
-        if let Some(statements) = transition::try_emit_lowered_tail_return(self, expression, fx) {
+        if let Some(statements) = transition::try_emit_lowered_tail_return(self, expression) {
             return ReturnStatementPlan {
                 form: ReturnForm::LoweredAbi {
                     body: LoweredBlock { statements },
@@ -288,7 +277,7 @@ impl Planner<'_> {
             };
         }
 
-        if let Some(statements) = self.lower_wrapped_return(expression, fx) {
+        if let Some(statements) = self.lower_wrapped_return(expression) {
             return ReturnStatementPlan {
                 form: ReturnForm::Wrapped {
                     body: LoweredBlock { statements },
@@ -297,16 +286,11 @@ impl Planner<'_> {
         }
 
         let (mut setup, raw_value) = self
-            .lower_value(expression, ExpressionContext::value(), fx)
+            .lower_value(expression, ExpressionContext::value())
             .into_parts();
         let mut coercion_buffer = String::new();
-        let final_value = self.apply_type_coercion(
-            &mut coercion_buffer,
-            return_ctx.ty(),
-            expression,
-            raw_value,
-            fx,
-        );
+        let final_value =
+            self.apply_type_coercion(&mut coercion_buffer, return_ctx.ty(), expression, raw_value);
         if !coercion_buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(coercion_buffer));
         }
@@ -326,7 +310,6 @@ impl Planner<'_> {
     pub(crate) fn lower_wrapped_return(
         &mut self,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let expression_ty = expression.get_type();
         let return_ctx = self.return_ctx();
@@ -342,8 +325,7 @@ impl Planner<'_> {
         let mut statements = Vec::new();
 
         if is_go_never(expression) {
-            let (setup, call_str) =
-                self.lower_call(expression, None, ExpressionContext::value(), fx);
+            let (setup, call_str) = self.lower_call(expression, None, ExpressionContext::value());
             statements.extend(setup);
             // Kept as `RawGo`: this is a Go-never call (`panic(...)`) whose
             // `ends_with_diverge` must stay true; `ExpressionStatementForm::Async`
@@ -364,7 +346,6 @@ impl Planner<'_> {
                 &fallible,
                 &return_ty,
                 lowered.as_ref(),
-                fx,
             ));
             return Some(statements);
         }
@@ -376,7 +357,7 @@ impl Planner<'_> {
         };
 
         if matches!(expression, Expression::Call { .. }) {
-            statements.extend(self.lower_wrapped_call_return(expression, info, fx));
+            statements.extend(self.lower_wrapped_call_return(expression, info));
             return Some(statements);
         }
 
@@ -384,7 +365,7 @@ impl Planner<'_> {
             expression,
             Expression::If { .. } | Expression::IfLet { .. } | Expression::Match { .. }
         ) {
-            let block = self.lower_branching_to_block(expression, &PlacePlan::Return, fx);
+            let block = self.lower_branching_to_block(expression, &PlacePlan::Return);
             statements.extend(block.statements);
             return Some(statements);
         }
@@ -393,17 +374,17 @@ impl Planner<'_> {
             expression: inner, ..
         } = expression
         {
-            let (setup, value) = self.lower_propagate(inner, None, fx);
+            let (setup, value) = self.lower_propagate(inner, None);
             statements.extend(setup);
-            statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
+            statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref()));
             return Some(statements);
         }
 
         let (setup, value) = self
-            .lower_value(expression, ExpressionContext::value(), fx)
+            .lower_value(expression, ExpressionContext::value())
             .into_parts();
         statements.extend(setup);
-        statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref(), fx));
+        statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref()));
         Some(statements)
     }
 
@@ -412,7 +393,6 @@ impl Planner<'_> {
         value: String,
         return_ty: &Type,
         lowered: Option<&AbiShape>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let Some(shape) = lowered else {
             return vec![plain_return(value)];
@@ -422,7 +402,7 @@ impl Planner<'_> {
         let mut statements = Vec::new();
         let temp = self.hoist_tmp_value_statement(&mut statements, "v", &value);
         statements.extend(transition::emit_lowered_result_return(
-            self, &temp, return_ty, shape, fx,
+            self, &temp, return_ty, shape,
         ));
         statements
     }
@@ -434,7 +414,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         info: WrappedReturnInfo<'_>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let WrappedReturnInfo {
             fallible,
@@ -451,12 +430,12 @@ impl Planner<'_> {
         };
         match fallible.classify_constructor(call_expression) {
             Some(ConstructorKind::Success) => {
-                self.lower_success_constructor_return(args, fallible, lowered, fx)
+                self.lower_success_constructor_return(args, fallible, lowered)
             }
             Some(ConstructorKind::Failure) => {
-                self.lower_failure_constructor_return(args, fallible, return_ty, lowered, fx)
+                self.lower_failure_constructor_return(args, fallible, return_ty, lowered)
             }
-            None => self.lower_wrapped_passthrough_return(expression, return_ty, lowered, fx),
+            None => self.lower_wrapped_passthrough_return(expression, return_ty, lowered),
         }
     }
 
@@ -465,14 +444,13 @@ impl Planner<'_> {
         args: &[Expression],
         fallible: &Fallible,
         lowered: Option<&AbiShape>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
             let ok_arg = if matches!(shape, AbiShape::BareError) {
                 if !args.is_empty() {
                     let (setup, _) = self
-                        .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                        .lower_composite_value(&args[0], ExpressionContext::value())
                         .into_parts();
                     statements.extend(setup);
                 }
@@ -481,7 +459,7 @@ impl Planner<'_> {
                 "struct{}{}".to_string()
             } else {
                 let (setup, value) = self
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
                 value
@@ -491,10 +469,10 @@ impl Planner<'_> {
             ));
         } else {
             let (setup, arg) = self
-                .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                .lower_composite_value(&args[0], ExpressionContext::value())
                 .into_parts();
             let success = {
-                let mut fe = FalliblePlanner::new(self, fallible, fx);
+                let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_success(&arg)
             };
             statements.extend(setup);
@@ -509,32 +487,31 @@ impl Planner<'_> {
         fallible: &Fallible,
         return_ty: &Type,
         lowered: Option<&AbiShape>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
             if args.is_empty() {
                 statements.push(transition::multi_value_return(
-                    transition::lowered_none_values(self, shape, return_ty, fx),
+                    transition::lowered_none_values(self, shape, return_ty),
                 ));
             } else {
                 let (setup, err_expr) = self
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
-                let values = transition::lowered_err_values(self, shape, return_ty, &err_expr, fx);
+                let values = transition::lowered_err_values(self, shape, return_ty, &err_expr);
                 statements.extend(setup);
                 statements.push(transition::multi_value_return(values));
             }
         } else {
             let failure = if fallible.is_result() {
                 let (setup, arg) = self
-                    .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                    .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
-                let mut fe = FalliblePlanner::new(self, fallible, fx);
+                let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_failure(Some(&arg))
             } else {
-                let mut fe = FalliblePlanner::new(self, fallible, fx);
+                let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_failure(None)
             };
             statements.push(plain_return(failure));
@@ -548,13 +525,12 @@ impl Planner<'_> {
         expression: &Expression,
         return_ty: &Type,
         lowered: Option<&AbiShape>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered
             && self.callee_matches_lowered_shape(expression, shape)
         {
-            let (setup, call) = self.lower_call(expression, None, ExpressionContext::value(), fx);
+            let (setup, call) = self.lower_call(expression, None, ExpressionContext::value());
             statements.extend(setup);
             statements.push(plain_return(call));
             return statements;
@@ -563,7 +539,7 @@ impl Planner<'_> {
             && let CalleePlan::GoInterop(strategy) = plan.callee
         {
             let (setup, result_var) = self
-                .lower_go_wrapped_call(expression, &strategy, return_ty, fx)
+                .lower_go_wrapped_call(expression, &strategy, return_ty)
                 .into_parts();
             statements.extend(setup);
             if let Some(shape) = lowered {
@@ -572,7 +548,6 @@ impl Planner<'_> {
                     &result_var,
                     return_ty,
                     shape,
-                    fx,
                 ));
             } else {
                 statements.push(plain_return(result_var));
@@ -581,16 +556,16 @@ impl Planner<'_> {
         }
         if let Some(shape) = lowered {
             let (setup, value) = self
-                .lower_value(expression, ExpressionContext::value(), fx)
+                .lower_value(expression, ExpressionContext::value())
                 .into_parts();
             statements.extend(setup);
             let temp = self.hoist_tmp_value_statement(&mut statements, "v", &value);
             statements.extend(transition::emit_lowered_result_return(
-                self, &temp, return_ty, shape, fx,
+                self, &temp, return_ty, shape,
             ));
             return statements;
         }
-        let (setup, call) = self.lower_call(expression, None, ExpressionContext::value(), fx);
+        let (setup, call) = self.lower_call(expression, None, ExpressionContext::value());
         statements.extend(setup);
         statements.push(plain_return(call));
         statements

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
@@ -42,17 +41,16 @@ impl Planner<'_> {
         &mut self,
         arms: &[SelectArm],
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> SelectStatementPlan {
         let needs_retry_loop = arms.iter().any(|arm| {
             matches!(&arm.pattern, SelectArmPattern::Receive { binding, .. } if is_some_pattern(binding))
         });
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        let prep = self.preprocess_select_arms(&mut setup, arms, needs_retry_loop, fx);
+        let prep = self.preprocess_select_arms(&mut setup, arms, needs_retry_loop);
 
         self.enter_scope();
-        let arm_plans = self.lower_select_arms(arms, &prep, place, fx);
+        let arm_plans = self.lower_select_arms(arms, &prep, place);
         self.exit_scope();
 
         let has_default = arms
@@ -79,7 +77,6 @@ impl Planner<'_> {
         arms: &[SelectArm],
         prep: &SelectPrep,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> Vec<SelectArmPlan> {
         let default_body = arms.iter().find_map(|arm| {
             if let SelectArmPattern::WildCard { body } = &arm.pattern {
@@ -113,11 +110,11 @@ impl Planner<'_> {
                         element_ty: receive_expression.get_type().ok_type(),
                         place,
                     };
-                    self.lower_receive_arm(binding, typed_pattern.as_ref(), &receiver_ctx, fx)
+                    self.lower_receive_arm(binding, typed_pattern.as_ref(), &receiver_ctx)
                 }
                 SelectArmPattern::Send { body, .. } => {
                     let parts = prep.send_parts[i].as_ref().unwrap();
-                    self.lower_send_arm(parts, body, place, fx)
+                    self.lower_send_arm(parts, body, place)
                 }
                 SelectArmPattern::MatchReceive {
                     arms: match_arms,
@@ -125,10 +122,10 @@ impl Planner<'_> {
                 } => {
                     let channel = prep.channel_operands[i].as_ref().unwrap();
                     let element_ty = receive_expression.get_type().ok_type();
-                    self.lower_match_receive_arm(match_arms, channel, &element_ty, place, fx)
+                    self.lower_match_receive_arm(match_arms, channel, &element_ty, place)
                 }
                 SelectArmPattern::WildCard { body } => SelectArmPlan::Default {
-                    body: self.lower_block_to_place(body, place, fx),
+                    body: self.lower_block_to_place(body, place),
                 },
             };
             arm_plans.push(plan);
@@ -143,7 +140,6 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         arms: &[SelectArm],
         needs_retry_loop: bool,
-        fx: &mut EmitEffects,
     ) -> SelectPrep {
         let mut send_parts: Vec<Option<SendArmParts>> = Vec::with_capacity(arms.len());
         let mut channel_operands: Vec<Option<String>> = Vec::with_capacity(arms.len());
@@ -154,7 +150,7 @@ impl Planner<'_> {
                 SelectArmPattern::Send {
                     send_expression, ..
                 } => {
-                    let parts = self.prepare_send_arm(setup, send_expression, needs_retry_loop, fx);
+                    let parts = self.prepare_send_arm(setup, send_expression, needs_retry_loop);
                     send_parts.push(Some(parts));
                     channel_operands.push(None);
                     channel_shadows.push(None);
@@ -165,7 +161,7 @@ impl Planner<'_> {
                     ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.lower_channel_operand(setup, receive_expression, fx);
+                    let ch = self.lower_channel_operand(setup, receive_expression);
                     if is_some_pattern(binding) && needs_retry_loop {
                         let shadow = self.hoist_tmp_value_statement(setup, "ch", &ch);
                         channel_operands.push(Some(ch));
@@ -185,7 +181,7 @@ impl Planner<'_> {
                     receive_expression, ..
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
-                    let ch = self.lower_channel_operand(setup, receive_expression, fx);
+                    let ch = self.lower_channel_operand(setup, receive_expression);
                     let ch = if needs_retry_loop && channel_has_call {
                         self.hoist_tmp_value_statement(setup, "ch", &ch)
                     } else {
@@ -214,12 +210,11 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         receive_expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
         let unwrapped = receive_expression.unwrap_parens();
         if let Some((channel, "receive", _)) = extract_channel_op(unwrapped) {
             let (op_setup, ch) = self
-                .lower_value(channel, ExpressionContext::value(), fx)
+                .lower_value(channel, ExpressionContext::value())
                 .into_parts();
             setup.extend(op_setup);
             return if channel.get_type().is_ref() {
@@ -229,7 +224,7 @@ impl Planner<'_> {
             };
         }
         let (op_setup, ch) = self
-            .lower_value(receive_expression, ExpressionContext::value(), fx)
+            .lower_value(receive_expression, ExpressionContext::value())
             .into_parts();
         setup.extend(op_setup);
         ch
@@ -247,14 +242,13 @@ impl Planner<'_> {
         &mut self,
         ok_var: &str,
         ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         // Decide scaffolding on rendered emptiness, not `is_empty`: some lowered
         // statements (e.g. a discard `let _`) render to empty text even when the
         // IR is structurally non-empty.
-        let body_block = self.lower_block_to_place(ctx.body, ctx.place, fx);
+        let body_block = self.lower_block_to_place(ctx.body, ctx.place);
         let body_empty = Renderer.renders_empty(&body_block);
-        let else_block = self.build_ok_else_block(ctx, fx);
+        let else_block = self.build_ok_else_block(ctx);
         let has_else = else_block.is_some();
 
         if body_empty && !has_else {
@@ -288,11 +282,7 @@ impl Planner<'_> {
 
     /// Else branch for an ok-check: retry (`v = nil; continue`) or default
     /// body. `None` when neither applies or the default lowers empty.
-    fn build_ok_else_block(
-        &mut self,
-        ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
-    ) -> Option<LoweredBlock> {
+    fn build_ok_else_block(&mut self, ctx: &SelectReceiveContext) -> Option<LoweredBlock> {
         if let Some(retry_var) = ctx.retry_var {
             return Some(LoweredBlock {
                 statements: vec![
@@ -302,7 +292,7 @@ impl Planner<'_> {
             });
         }
         let default_body = ctx.default_body?;
-        let block = self.lower_block_to_place(default_body, ctx.place, fx);
+        let block = self.lower_block_to_place(default_body, ctx.place);
         (!block.is_empty()).then_some(block)
     }
 
@@ -312,7 +302,6 @@ impl Planner<'_> {
         receiver_var: &str,
         inner_pattern: Option<(&Pattern, Option<&TypedPattern>)>,
         ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
         let ok_var = self.fresh_ok_var();
         let receive_vars = format!("{}, {}", receiver_var, ok_var);
@@ -327,11 +316,9 @@ impl Planner<'_> {
                 ctx.body,
                 ctx.default_body,
                 ctx.place,
-                fx,
             )
         } else {
-            self.lower_block_to_place(ctx.body, ctx.place, fx)
-                .statements
+            self.lower_block_to_place(ctx.body, ctx.place).statements
         };
         let used = self.scope.exit_use_region();
         let body_holder = LoweredBlock {
@@ -345,7 +332,7 @@ impl Planner<'_> {
         then_statements.extend(body_holder.statements);
         self.scope.pop_binding_frame();
 
-        let else_arm = match self.build_ok_else_block(ctx, fx) {
+        let else_arm = match self.build_ok_else_block(ctx) {
             Some(body) => ElseArm::Else {
                 body,
                 inline: false,
@@ -374,16 +361,15 @@ impl Planner<'_> {
         binding: &Pattern,
         typed_pattern: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
         let effective_pattern = unwrap_some_pattern(binding);
         let inner_typed = unwrap_some_typed_pattern(typed_pattern);
 
         self.scope.push_binding_frame();
         if is_some_pattern(binding) {
-            self.lower_receive_arm_with_ok_check(effective_pattern, inner_typed, ctx, fx)
+            self.lower_receive_arm_with_ok_check(effective_pattern, inner_typed, ctx)
         } else {
-            self.lower_receive_arm_simple(effective_pattern, inner_typed, ctx, fx)
+            self.lower_receive_arm_simple(effective_pattern, inner_typed, ctx)
         }
     }
 
@@ -393,20 +379,19 @@ impl Planner<'_> {
         effective_pattern: &Pattern,
         inner_typed: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
         if let Pattern::Identifier { identifier, .. } = effective_pattern
             && let Some(go_name) = self.go_name_for_binding(effective_pattern)
         {
             let var = self.scope.bind(identifier, go_name);
-            return self.lower_ok_guard(&var, None, ctx, fx);
+            return self.lower_ok_guard(&var, None, ctx);
         }
         if matches!(
             effective_pattern,
             Pattern::Identifier { .. } | Pattern::WildCard { .. }
         ) {
             let ok_var = self.fresh_ok_var();
-            let body = self.lower_ok_check(&ok_var, ctx, fx);
+            let body = self.lower_ok_check(&ok_var, ctx);
             self.scope.pop_binding_frame();
             return SelectArmPlan::Receive {
                 receive_vars: Some(format!("_, {}", ok_var)),
@@ -415,12 +400,7 @@ impl Planner<'_> {
             };
         }
         let receiver_var = self.fresh_var(Some("recv"));
-        self.lower_ok_guard(
-            &receiver_var,
-            Some((effective_pattern, inner_typed)),
-            ctx,
-            fx,
-        )
+        self.lower_ok_guard(&receiver_var, Some((effective_pattern, inner_typed)), ctx)
     }
 
     /// Plain receive: `case v := <-ch:` then the arm body.
@@ -429,7 +409,6 @@ impl Planner<'_> {
         effective_pattern: &Pattern,
         inner_typed: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
         let mut body_statements: Vec<LoweredStatement> = Vec::new();
         let receive_vars = if let Pattern::Identifier { identifier, .. } = effective_pattern
@@ -448,11 +427,10 @@ impl Planner<'_> {
                 effective_pattern,
                 inner_typed,
                 &ctx.element_ty,
-                fx,
             ));
             Some(receiver_var)
         };
-        let block = self.lower_block_to_place(ctx.body, ctx.place, fx);
+        let block = self.lower_block_to_place(ctx.body, ctx.place);
         self.scope.pop_binding_frame();
         body_statements.extend(block.statements);
         SelectArmPlan::Receive {
@@ -469,13 +447,12 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         send_expression: &Expression,
         needs_hoist: bool,
-        fx: &mut EmitEffects,
     ) -> SendArmParts {
         let unwrapped = send_expression.unwrap_parens();
         if let Some((channel, member, args)) = extract_channel_op(unwrapped) {
             let ch_has_call = needs_hoist && contains_call(channel);
             let (op_setup, mut ch) = self
-                .lower_value(channel, ExpressionContext::value(), fx)
+                .lower_value(channel, ExpressionContext::value())
                 .into_parts();
             setup.extend(op_setup);
             if channel.get_type().is_ref() {
@@ -488,7 +465,7 @@ impl Planner<'_> {
                 "send" if !args.is_empty() => {
                     let val_has_call = needs_hoist && contains_call(&args[0]);
                     let (val_setup, mut val) = self
-                        .lower_composite_value(&args[0], ExpressionContext::value(), fx)
+                        .lower_composite_value(&args[0], ExpressionContext::value())
                         .into_parts();
                     setup.extend(val_setup);
                     if val_has_call {
@@ -502,7 +479,7 @@ impl Planner<'_> {
         } else {
             let expression_has_call = needs_hoist && contains_call(send_expression);
             let (op_setup, mut ch) = self
-                .lower_value(send_expression, ExpressionContext::value(), fx)
+                .lower_value(send_expression, ExpressionContext::value())
                 .into_parts();
             setup.extend(op_setup);
             if send_expression.get_type().is_ref() {
@@ -521,9 +498,8 @@ impl Planner<'_> {
         parts: &SendArmParts,
         body: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
-        let block = self.lower_block_to_place(body, place, fx);
+        let block = self.lower_block_to_place(body, place);
         match parts {
             SendArmParts::Send(ch, val) => SelectArmPlan::Send {
                 operation: format!("{} <- {}", ch, val),
@@ -543,7 +519,6 @@ impl Planner<'_> {
         channel: &str,
         element_ty: &syntax::types::Type,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> SelectArmPlan {
         self.scope.push_binding_frame();
 
@@ -577,10 +552,9 @@ impl Planner<'_> {
             needs_receiver_destructure,
             element_ty,
             place,
-            fx,
         );
-        let none_block = self
-            .capture_scoped_block(|this| sites::lower_none_arm_body(this, match_arms, place, fx));
+        let none_block =
+            self.capture_scoped_block(|this| sites::lower_none_arm_body(this, match_arms, place));
 
         let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
         if arms_plan.is_some() {
@@ -633,11 +607,10 @@ impl Planner<'_> {
         needs_receiver_destructure: bool,
         element_ty: &syntax::types::Type,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> Option<LoweredBlock> {
         self.capture_scoped_block(|this| {
             if !needs_receiver_destructure {
-                return this.lower_block_to_place(&some_arm.expression, place, fx);
+                return this.lower_block_to_place(&some_arm.expression, place);
             }
             let inner_typed = unwrap_some_typed_pattern(some_arm.typed_pattern.as_ref());
             LoweredBlock {
@@ -653,7 +626,6 @@ impl Planner<'_> {
                     &some_arm.expression,
                     match_arms,
                     place,
-                    fx,
                 ),
             }
         })

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, EnumLayout};
 use crate::definitions::structs::should_synthesize_stringer;
@@ -15,7 +14,6 @@ impl Planner<'_> {
         name: &str,
         generics: &[Generic],
         attributes: &[Attribute],
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if matches!(name, "Option" | "Result" | "Partial") {
             return None;
@@ -40,10 +38,10 @@ impl Planner<'_> {
             Vec::new()
         };
         for ty in &variant_field_types {
-            let _ = self.go_type_string(ty, fx);
+            let _ = self.go_type_string(ty);
         }
 
-        let generics_string = self.generics_to_string_for_symbol(&enum_id, generics, fx);
+        let generics_string = self.generics_to_string_for_symbol(&enum_id, generics);
         let receiver_generics = receiver_generics_string(generics);
         let has_json = attributes.iter().any(|a| a.name == "json");
         let has_iterate = attributes.iter().any(|a| a.name == "iterate");
@@ -84,14 +82,14 @@ impl Planner<'_> {
             result.push_str("\n\n");
             result.push_str(&layout.emit_variants_function(&fn_name));
         }
-        self.append_enum_debug_method(&mut result, name, &receiver_generics, &layout, fx);
+        self.append_enum_debug_method(&mut result, name, &receiver_generics, &layout);
         self.append_to_string_method(&mut result, name, &receiver_generics, attributes);
-        self.append_enum_equals_method(&mut result, name, &enum_id, &receiver_generics, fx);
+        self.append_enum_equals_method(&mut result, name, &enum_id, &receiver_generics);
         if needs_fmt {
-            fx.require_fmt();
+            self.require_fmt();
         }
         if has_json {
-            fx.require_json();
+            self.require_json();
         }
 
         Some(result)
@@ -103,16 +101,15 @@ impl Planner<'_> {
         name: &str,
         receiver_generics: &str,
         layout: &EnumLayout,
-        fx: &mut EmitEffects,
     ) {
         if !self.synthesizes_debug_string(name) {
             return;
         }
         out.push_str("\n\n");
         out.push_str(&layout.emit_debug_method(receiver_generics, prelude_qualifier()));
-        fx.require_fmt();
+        self.require_fmt();
         if layout.debug_uses_prelude() {
-            fx.require_stdlib();
+            self.require_stdlib();
         }
     }
 
@@ -122,7 +119,6 @@ impl Planner<'_> {
         name: &str,
         enum_id: &str,
         receiver_generics: &str,
-        fx: &mut EmitEffects,
     ) {
         if !self.should_synthesize_equals(name) {
             return;
@@ -158,7 +154,7 @@ impl Planner<'_> {
                 .map(|(sem_field, layout_field)| {
                     let lhs = format!("{receiver}.{}", layout_field.go_name);
                     let rhs = format!("other.{}", layout_field.go_name);
-                    self.render_equality(&lhs, &rhs, &sem_field.ty, fx)
+                    self.render_equality(&lhs, &rhs, &sem_field.ty)
                 })
                 .collect();
             cases.push(format!(
@@ -200,7 +196,6 @@ impl Planner<'_> {
         &mut self,
         enum_id: &str,
         variant_name: &str,
-        fx: &mut EmitEffects,
     ) -> String {
         let layout = self
             .module
@@ -245,7 +240,7 @@ impl Planner<'_> {
                 .map(|g| g.name.as_str())
                 .collect::<Vec<_>>()
                 .join(", ");
-            let generics_string = self.generics_to_string_for_symbol(enum_id, &generics, fx);
+            let generics_string = self.generics_to_string_for_symbol(enum_id, &generics);
             (generics_string, format!("[{}]", args))
         };
 
@@ -262,7 +257,7 @@ impl Planner<'_> {
             underlying_ty: None,
         };
 
-        let return_type = self.go_type_string(&return_type, fx);
+        let return_type = self.go_type_string(&return_type);
 
         format!(
             "func {} {} ({}) {} {{\n    return {} {} {{ Tag: {}, {} }}\n}}",

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -1,6 +1,5 @@
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::ReturnContext;
@@ -52,11 +51,10 @@ impl Planner<'_> {
         body: &Expression,
         should_return: bool,
         return_ctx: &ReturnContext,
-        fx: &mut EmitEffects,
     ) {
         self.push_const_frame();
         self.push_return_ctx(return_ctx.clone());
-        self.emit_function_body_inner(output, body, should_return, fx);
+        self.emit_function_body_inner(output, body, should_return);
         self.pop_return_ctx();
         self.pop_const_frame();
     }
@@ -66,9 +64,8 @@ impl Planner<'_> {
         output: &mut String,
         body: &Expression,
         should_return: bool,
-        fx: &mut EmitEffects,
     ) {
-        let lowered = self.lower_function_body(body, should_return, fx);
+        let lowered = self.lower_function_body(body, should_return);
         Renderer.render_lowered_block(output, &lowered);
     }
 
@@ -78,11 +75,10 @@ impl Planner<'_> {
         body: &Expression,
         ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         let frame = self.scope.enter_isolated_function();
 
-        let (mut param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params, fx);
+        let (mut param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params);
 
         // A `t.run` subtest closure binds its own handle. Name a discarded `|_|`
         // so `assert` targets the subtest, not the enclosing test.
@@ -104,7 +100,7 @@ impl Planner<'_> {
         }
 
         let recover = handle.as_ref().map(|name| {
-            fx.require_testkit();
+            self.require_testkit();
             let span = body.get_span();
             format!(
                 "defer {name}.Recover({}, {}, {})\n",
@@ -114,13 +110,12 @@ impl Planner<'_> {
             )
         });
 
-        let return_info = self.lambda_return_info(ty, ctx, fx);
+        let return_info = self.lambda_return_info(ty, ctx);
         let mut body_string = self.emit_lambda_body_with_deferred(
             body,
             &destructure_bindings,
             &return_info.ctx,
             return_info.has_return,
-            fx,
         );
         if let Some(recover) = recover {
             body_string.insert_str(0, &recover);
@@ -143,7 +138,6 @@ impl Planner<'_> {
     fn build_lambda_param_pairs<'a>(
         &mut self,
         params: &'a [Binding],
-        fx: &mut EmitEffects,
     ) -> (Vec<(String, String)>, Vec<LambdaParamDestructure<'a>>) {
         let mut destructure_bindings: Vec<LambdaParamDestructure<'a>> = vec![];
         let param_pairs: Vec<(String, String)> = params
@@ -169,7 +163,7 @@ impl Planner<'_> {
                     ));
                     temp_name
                 };
-                (name, self.go_type_string(&p.ty, fx))
+                (name, self.go_type_string(&p.ty))
             })
             .collect();
         (param_pairs, destructure_bindings)
@@ -177,12 +171,7 @@ impl Planner<'_> {
 
     /// Lambda Go return-type + `ReturnContext`. Go-prelude generic callbacks
     /// suppress lambda return-type lowering so signature and body agree.
-    fn lambda_return_info(
-        &mut self,
-        ty: &Type,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> LambdaReturnInfo {
+    fn lambda_return_info(&mut self, ty: &Type, ctx: ExpressionContext<'_>) -> LambdaReturnInfo {
         let suppress_lowering = ctx.forces_tagged_go_function();
         let argument_flows_to_unknown = ctx.argument_flows_to_unknown();
 
@@ -207,12 +196,9 @@ impl Planner<'_> {
             match ty {
                 Type::Function(f) => match ctx.lowered_shape() {
                     Some(shape) => {
-                        format!(
-                            " {}",
-                            self.render_lowered_return_ty(&shape, &f.return_type, fx)
-                        )
+                        format!(" {}", self.render_lowered_return_ty(&shape, &f.return_type))
                     }
-                    None => format!(" {}", self.go_type_string(&f.return_type, fx)),
+                    None => format!(" {}", self.go_type_string(&f.return_type)),
                 },
                 _ => String::new(),
             }
@@ -233,7 +219,6 @@ impl Planner<'_> {
         destructure_bindings: &[LambdaParamDestructure<'_>],
         return_ctx: &ReturnContext,
         should_return: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let mut body_string = String::new();
         for (temp_name, pattern, typed, param_ty) in destructure_bindings {
@@ -242,11 +227,10 @@ impl Planner<'_> {
                 pattern,
                 *typed,
                 param_ty,
-                fx,
             );
             Renderer.render_lowered_block(&mut body_string, &LoweredBlock { statements });
         }
-        self.emit_function_body(&mut body_string, body, should_return, return_ctx, fx);
+        self.emit_function_body(&mut body_string, body, should_return, return_ctx);
         body_string
     }
 
@@ -268,7 +252,6 @@ impl Planner<'_> {
         function_definition: FunctionDefinitionView<'_>,
         receiver: Option<(String, Type)>,
         is_public: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         if matches!(function_definition.body, Expression::NoOp) {
             return String::new();
@@ -288,24 +271,20 @@ impl Planner<'_> {
             None => function_definition,
         };
         let (params_to_process, receiver_override) =
-            self.extract_receiver(function_definition, receiver.is_some(), fx);
+            self.extract_receiver(function_definition, receiver.is_some());
 
         let mut parts = vec!["func".to_string()];
 
         let (_, receiver_part) =
-            self.emit_receiver_part(params_to_process, &receiver, receiver_override.as_ref(), fx);
+            self.emit_receiver_part(params_to_process, &receiver, receiver_override.as_ref());
         if let Some(part) = receiver_part {
             parts.push(part);
         }
 
         parts.push(self.pick_go_function_name(function_definition, receiver.is_some(), is_public));
 
-        let generics_str = self.build_generics_string(
-            function_definition,
-            params_to_process,
-            receiver.as_ref(),
-            fx,
-        );
+        let generics_str =
+            self.build_generics_string(function_definition, params_to_process, receiver.as_ref());
         if !generics_str.is_empty() {
             parts.push(generics_str);
         }
@@ -314,13 +293,11 @@ impl Planner<'_> {
         let signature = self.with_absorbed_ref_generics(
             params_to_process,
             function_definition.generics,
-            fx,
-            |this, fx| {
+            |this| {
                 let (params_string, return_ty, deferred_patterns) = this.build_signature_tail(
                     function_definition,
                     params_to_process,
                     return_shape.as_ref(),
-                    fx,
                 );
                 parts.push(params_string);
                 if !return_ty.is_empty() {
@@ -341,7 +318,6 @@ impl Planner<'_> {
                     function_definition,
                     deferred_patterns,
                     &return_ctx,
-                    fx,
                 );
                 if test_handle.is_some() {
                     this.pop_test_handle();
@@ -380,10 +356,9 @@ impl Planner<'_> {
         function_definition: FunctionDefinitionView<'_>,
         _params_to_process: &[Binding],
         receiver: Option<&(String, Type)>,
-        fx: &mut EmitEffects,
     ) -> String {
         let symbol = self.symbol_for_function(function_definition.name, receiver);
-        self.generics_to_string_for_symbol(&symbol, function_definition.generics, fx)
+        self.generics_to_string_for_symbol(&symbol, function_definition.generics)
     }
 
     fn symbol_for_function(
@@ -408,16 +383,15 @@ impl Planner<'_> {
         function_definition: FunctionDefinitionView<'_>,
         params_to_process: &[Binding],
         return_shape: Option<&AbiShape>,
-        fx: &mut EmitEffects,
     ) -> (String, String, Vec<DeferredParamDestructure>) {
-        let (params_string, deferred_patterns) = self.emit_function_params(params_to_process, fx);
+        let (params_string, deferred_patterns) = self.emit_function_params(params_to_process);
 
         let return_ty = if function_definition.return_type.is_unit() {
             String::new()
         } else if let Some(shape) = return_shape {
-            self.render_lowered_return_ty(shape, function_definition.return_type, fx)
+            self.render_lowered_return_ty(shape, function_definition.return_type)
         } else {
-            self.go_type_string(function_definition.return_type, fx)
+            self.go_type_string(function_definition.return_type)
         };
 
         (params_string, return_ty, deferred_patterns)
@@ -429,7 +403,6 @@ impl Planner<'_> {
         function_definition: FunctionDefinitionView<'_>,
         deferred_patterns: Vec<DeferredParamDestructure>,
         return_ctx: &ReturnContext,
-        fx: &mut EmitEffects,
     ) {
         let should_return = !function_definition.return_type.is_unit();
         for (var_name, pattern, typed, param_ty) in deferred_patterns {
@@ -438,17 +411,10 @@ impl Planner<'_> {
                 &pattern,
                 typed.as_ref(),
                 &param_ty,
-                fx,
             );
             Renderer.render_lowered_block(body, &LoweredBlock { statements });
         }
-        self.emit_function_body(
-            body,
-            function_definition.body,
-            should_return,
-            return_ctx,
-            fx,
-        );
+        self.emit_function_body(body, function_definition.body, should_return, return_ctx);
     }
 
     fn emit_receiver_part(
@@ -456,7 +422,6 @@ impl Planner<'_> {
         params_to_process: &[Binding],
         receiver: &Option<(String, Type)>,
         receiver_override: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> (Option<String>, Option<String>) {
         let Some((_, receiver_ty)) = receiver else {
             return (None, None);
@@ -474,7 +439,7 @@ impl Planner<'_> {
             .collect();
 
         let actual_ty = receiver_override.unwrap_or(receiver_ty);
-        let ty_string = self.go_type_string(actual_ty, fx);
+        let ty_string = self.go_type_string(actual_ty);
         let mut receiver_var = receiver_name(&ty_string);
 
         if param_names.contains(&receiver_var) {
@@ -498,11 +463,10 @@ impl Planner<'_> {
         &mut self,
         params: &[Binding],
         generics: &[Generic],
-        fx: &mut EmitEffects,
         f: F,
     ) -> R
     where
-        F: FnOnce(&mut Self, &mut EmitEffects) -> R,
+        F: FnOnce(&mut Self) -> R,
     {
         let saved = std::mem::take(&mut self.function_state);
         let bounded_generics: HashSet<&str> = generics
@@ -520,7 +484,7 @@ impl Planner<'_> {
                     .record_absorbed_ref_generic(name.to_string());
             }
         }
-        let result = f(self, fx);
+        let result = f(self);
         self.function_state = saved;
         result
     }
@@ -528,7 +492,6 @@ impl Planner<'_> {
     fn emit_function_params(
         &mut self,
         params_to_process: &[Binding],
-        fx: &mut EmitEffects,
     ) -> (String, Vec<DeferredParamDestructure>) {
         let mut deferred_patterns = Vec::new();
         let mut params = Vec::new();
@@ -566,7 +529,7 @@ impl Planner<'_> {
                     param.ty.clone()
                 }
             };
-            params.push((name, self.go_type_string(&param_type, fx)));
+            params.push((name, self.go_type_string(&param_type)));
         }
         (format!("({})", group_params(&params)), deferred_patterns)
     }
@@ -575,7 +538,6 @@ impl Planner<'_> {
         &mut self,
         function_definition: FunctionDefinitionView<'a>,
         has_receiver: bool,
-        fx: &mut EmitEffects,
     ) -> (&'a [Binding], Option<Type>) {
         let default = (function_definition.params, None);
 
@@ -592,7 +554,7 @@ impl Planner<'_> {
         }
 
         let receiver_ty = &function_definition.params[0].ty;
-        let _ty_str = self.go_type_string(receiver_ty, fx);
+        let _ty_str = self.go_type_string(receiver_ty);
 
         (&function_definition.params[1..], Some(receiver_ty.clone()))
     }

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name;
@@ -19,7 +18,6 @@ impl Planner<'_> {
         ty: &Type,
         methods: &[Expression],
         generics: &[Generic],
-        fx: &mut EmitEffects,
     ) -> String {
         let ctx = ImplContext {
             receiver_name,
@@ -30,18 +28,13 @@ impl Planner<'_> {
 
         methods
             .iter()
-            .filter_map(|method| self.emit_impl_method(method, &ctx, fx))
+            .filter_map(|method| self.emit_impl_method(method, &ctx))
             .collect::<Vec<_>>()
             .join("\n\n")
     }
 
     /// Emit one impl method as a receiver method or a UFCS free function.
-    fn emit_impl_method(
-        &mut self,
-        method: &Expression,
-        ctx: &ImplContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    fn emit_impl_method(&mut self, method: &Expression, ctx: &ImplContext<'_>) -> Option<String> {
         let Expression::Function {
             doc,
             visibility,
@@ -83,13 +76,12 @@ impl Planner<'_> {
                 generics: &combined_generics,
                 ..function
             };
-            self.emit_function(free_function, None, false, fx)
+            self.emit_function(free_function, None, false)
         } else {
             self.emit_function(
                 function,
                 Some((ctx.receiver_name.to_string(), ctx.ty.clone())),
                 should_export,
-                fx,
             )
         };
 

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::AbiShape;
 use crate::abi::transition::emit_return_adapter;
@@ -218,7 +217,6 @@ impl Planner<'_> {
         return_ty: &Type,
         user_shape: &AbiShape,
         interface_shape: &AbiShape,
-        fx: &mut EmitEffects,
     ) -> Option<(String, String)> {
         let (AbiShape::NullableReturn, AbiShape::CommaOk) = (user_shape, interface_shape) else {
             return None;
@@ -228,12 +226,12 @@ impl Planner<'_> {
         let val = self.fresh_var(Some("val"));
         self.declare(&val);
         let nil_check = if is_interface {
-            fx.require_stdlib();
+            self.require_stdlib();
             format!("!lisette.IsNilInterface({})", val)
         } else {
             format!("{} != nil", val)
         };
-        let go_ret = self.render_lowered_return_ty(&AbiShape::CommaOk, return_ty, fx);
+        let go_ret = self.render_lowered_return_ty(&AbiShape::CommaOk, return_ty);
         let body = format!("{val} := {inner_call}\nreturn {val}, {nil_check}\n");
         Some((go_ret, body))
     }
@@ -266,11 +264,7 @@ impl Planner<'_> {
         Some(base)
     }
 
-    pub(crate) fn ensure_adapter_type(
-        &mut self,
-        plan: AdapterPlan,
-        fx: &mut EmitEffects,
-    ) -> String {
+    pub(crate) fn ensure_adapter_type(&mut self, plan: AdapterPlan) -> String {
         let key = (
             concrete_dedup_key(&plan.concrete_ty, &plan.concrete_id),
             plan.interface_id.clone(),
@@ -282,7 +276,7 @@ impl Planner<'_> {
         let index = self.adapter_registry.next_index();
         let adapter_name = adapter_type_name(&plan, index);
 
-        let concrete_go_ty = self.go_type_string(&plan.concrete_ty, fx);
+        let concrete_go_ty = self.go_type_string(&plan.concrete_ty);
 
         let mut declaration = String::new();
         write_line!(declaration, "type {} struct {{", adapter_name);
@@ -291,7 +285,7 @@ impl Planner<'_> {
         declaration.push('\n');
 
         for method in &plan.methods {
-            self.emit_adapter_method(&mut declaration, &adapter_name, method, fx);
+            self.emit_adapter_method(&mut declaration, &adapter_name, method);
             declaration.push('\n');
         }
 
@@ -305,7 +299,6 @@ impl Planner<'_> {
         declaration: &mut String,
         adapter_name: &str,
         method: &AdapterMethod,
-        fx: &mut EmitEffects,
     ) {
         self.enter_scope();
 
@@ -319,7 +312,7 @@ impl Planner<'_> {
         let params_str = param_names
             .iter()
             .zip(method.param_types.iter())
-            .map(|(n, t)| format!("{} {}", n, self.go_type_string(t, fx)))
+            .map(|(n, t)| format!("{} {}", n, self.go_type_string(t)))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -330,7 +323,7 @@ impl Planner<'_> {
         };
         let inner_call = format!("a.inner.{}({})", go_method_name, param_names.join(", "));
 
-        let (go_ret, body) = self.build_adapter_body(method, &inner_call, fx);
+        let (go_ret, body) = self.build_adapter_body(method, &inner_call);
         self.finish_adapter_method(
             declaration,
             adapter_name,
@@ -341,31 +334,26 @@ impl Planner<'_> {
         );
     }
 
-    fn build_adapter_body(
-        &mut self,
-        method: &AdapterMethod,
-        inner_call: &str,
-        fx: &mut EmitEffects,
-    ) -> (String, String) {
+    fn build_adapter_body(&mut self, method: &AdapterMethod, inner_call: &str) -> (String, String) {
         let user_shape = &method.user_shape;
         let interface_shape = &method.interface_shape;
 
         if user_shape == interface_shape
             && let Some(shape) = user_shape
         {
-            let go_ret = self.render_lowered_return_ty(shape, &method.return_type, fx);
+            let go_ret = self.render_lowered_return_ty(shape, &method.return_type);
             return (go_ret, format!("return {}\n", inner_call));
         }
 
         if let (Some(user), Some(interface)) = (user_shape, interface_shape)
             && user != interface
             && let Some(bridge) =
-                self.emit_hint_shift_bridge(inner_call, &method.return_type, user, interface, fx)
+                self.emit_hint_shift_bridge(inner_call, &method.return_type, user, interface)
         {
             return bridge;
         }
 
-        let adapter = emit_return_adapter(self, inner_call, &method.return_type, fx);
+        let adapter = emit_return_adapter(self, inner_call, &method.return_type);
         if let Some(adapter) = adapter {
             return adapter;
         }
@@ -373,7 +361,7 @@ impl Planner<'_> {
         if method.return_type.is_unit() {
             (String::new(), format!("{}\n", inner_call))
         } else {
-            let ret = self.go_type_string(&method.return_type, fx);
+            let ret = self.go_type_string(&method.return_type);
             (ret, format!("return {}\n", inner_call))
         }
     }

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::names::go_name;
 use syntax::ast::{Annotation, Expression, Generic, ParentInterface, Pattern};
@@ -12,7 +11,6 @@ impl Planner<'_> {
         parents: &[ParentInterface],
         generics: &[Generic],
         is_public: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         if self.facts.is_current_module(go_name::PRELUDE_MODULE) {
             return format!("type {} struct{{}}", name);
@@ -20,7 +18,7 @@ impl Planner<'_> {
 
         let filtered = strip_self_referential_bounds(generics, name);
         let symbol = self.facts.qualified_current(name);
-        let generics_str = self.generics_to_string_for_symbol(&symbol, &filtered, fx);
+        let generics_str = self.generics_to_string_for_symbol(&symbol, &filtered);
 
         let mut output = Vec::new();
         output.push(format!(
@@ -30,11 +28,11 @@ impl Planner<'_> {
         ));
 
         for parent in parents {
-            output.push(self.go_type_string(&parent.ty, fx));
+            output.push(self.go_type_string(&parent.ty));
         }
 
         for item in items {
-            output.push(self.emit_interface_method(name, item, is_public, fx));
+            output.push(self.emit_interface_method(name, item, is_public));
         }
 
         output.push("}".to_string());
@@ -48,7 +46,6 @@ impl Planner<'_> {
         interface_name: &str,
         item: &Expression,
         is_public: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let func = item.function_definition_view();
         let ty = item.get_type();
@@ -63,7 +60,7 @@ impl Planner<'_> {
         let args: Vec<String> = all_args
             .iter()
             .skip(if has_self_receiver { 1 } else { 0 })
-            .map(|a| self.go_type_string(a, fx))
+            .map(|a| self.go_type_string(a))
             .collect();
         let raw_return_ty = ty
             .get_function_ret()
@@ -72,8 +69,8 @@ impl Planner<'_> {
         let qualified_id = self.facts.qualified_current(interface_name);
         let hints = self.go_interface_method_hints(&qualified_id, func.name);
         let return_type = match self.classify_with_go_hints(&raw_return_ty, &hints) {
-            Some(shape) => self.render_lowered_return_ty(&shape, &raw_return_ty, fx),
-            None => self.go_type_string(&raw_return_ty, fx),
+            Some(shape) => self.render_lowered_return_ty(&shape, &raw_return_ty),
+            None => self.go_type_string(&raw_return_ty),
         };
 
         let method_name = if is_public || self.method_needs_export(func.name) {

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
 use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
@@ -20,26 +19,18 @@ impl Planner<'_> {
         fields: &[StructFieldDefinition],
         kind: &StructKind,
         struct_attrs: &[Attribute],
-        fx: &mut EmitEffects,
     ) -> String {
         let symbol = self.facts.qualified_current(name);
-        let generics_string = self.generics_to_string_for_symbol(&symbol, generics, fx);
+        let generics_string = self.generics_to_string_for_symbol(&symbol, generics);
 
         if *kind == StructKind::Tuple {
-            return self.emit_tuple_struct(
-                name,
-                &generics_string,
-                fields,
-                generics,
-                struct_attrs,
-                fx,
-            );
+            return self.emit_tuple_struct(name, &generics_string, fields, generics, struct_attrs);
         }
 
         let mut field_strings: Vec<String> = Vec::with_capacity(fields.len());
         let mut stringer_fields: Vec<StringerField> = Vec::with_capacity(fields.len());
         for f in fields {
-            let (field_string, stringer_field) = self.emit_struct_field(f, name, struct_attrs, fx);
+            let (field_string, stringer_field) = self.emit_struct_field(f, name, struct_attrs);
             field_strings.push(field_string);
             stringer_fields.push(stringer_field);
         }
@@ -67,28 +58,15 @@ impl Planner<'_> {
                 stringer_name,
             );
             if !stringer_fields.is_empty() {
-                fx.require_fmt();
+                self.require_fmt();
             }
             format!("{definition}\n\n{string_method}")
         } else {
             definition
         };
-        self.append_struct_debug_method(
-            &mut result,
-            name,
-            &receiver_generics,
-            &stringer_fields,
-            fx,
-        );
+        self.append_struct_debug_method(&mut result, name, &receiver_generics, &stringer_fields);
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
-        self.append_equals_method(
-            &mut result,
-            name,
-            &receiver_generics,
-            fields,
-            struct_attrs,
-            fx,
-        );
+        self.append_equals_method(&mut result, name, &receiver_generics, fields, struct_attrs);
         result
     }
 
@@ -100,9 +78,8 @@ impl Planner<'_> {
         fields: &[StructFieldDefinition],
         generics: &[Generic],
         struct_attrs: &[Attribute],
-        fx: &mut EmitEffects,
     ) -> String {
-        let definition = self.emit_tuple_struct_definition(name, generics_string, fields, fx);
+        let definition = self.emit_tuple_struct_definition(name, generics_string, fields);
         let receiver_generics = receiver_generics_string(generics);
         let mut result = definition;
         if self.is_pointer_backed_newtype(name) {
@@ -110,7 +87,7 @@ impl Planner<'_> {
         }
         if let Some(stringer_name) = self.stringer_method_name(name, struct_attrs) {
             let is_type_alias = fields.len() == 1 && generics_string.is_empty();
-            let underlying_go_type = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
+            let underlying_go_type = is_type_alias.then(|| self.go_type_string(&fields[0].ty));
             let string_method = emit_tuple_struct_stringer_method(
                 name,
                 &receiver_generics,
@@ -120,7 +97,7 @@ impl Planner<'_> {
             );
             if !string_method.is_empty() {
                 if string_method.contains("fmt.") {
-                    fx.require_fmt();
+                    self.require_fmt();
                 }
                 result.push_str("\n\n");
                 result.push_str(&string_method);
@@ -132,7 +109,6 @@ impl Planner<'_> {
             &receiver_generics,
             fields,
             generics_string,
-            fx,
         );
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
         result
@@ -144,10 +120,9 @@ impl Planner<'_> {
         f: &StructFieldDefinition,
         struct_name: &str,
         struct_attrs: &[Attribute],
-        fx: &mut EmitEffects,
     ) -> (String, StringerField) {
         if f.embedded {
-            let field_with_doc = format!("{}{}", emit_doc(&f.doc), self.go_type_string(&f.ty, fx));
+            let field_with_doc = format!("{}{}", emit_doc(&f.doc), self.go_type_string(&f.ty));
             let stringer_field = StringerField {
                 source_name: f.name.to_string(),
                 go_name: struct_field_go_name(f, struct_attrs),
@@ -169,9 +144,9 @@ impl Planner<'_> {
         }
 
         let field_definition = if let Some(tags) = tag_string {
-            format!("{} {} {}", field_name, self.go_type_string(&f.ty, fx), tags)
+            format!("{} {} {}", field_name, self.go_type_string(&f.ty), tags)
         } else {
-            format!("{} {}", field_name, self.go_type_string(&f.ty, fx))
+            format!("{} {}", field_name, self.go_type_string(&f.ty))
         };
 
         let field_with_doc = format!("{}{}", emit_doc(&f.doc), field_definition);
@@ -189,7 +164,6 @@ impl Planner<'_> {
         name: &str,
         generics_string: &str,
         fields: &[StructFieldDefinition],
-        fx: &mut EmitEffects,
     ) -> String {
         let go_type_name = go_name::escape_keyword(name);
 
@@ -198,14 +172,14 @@ impl Planner<'_> {
         }
 
         if fields.len() == 1 && generics_string.is_empty() {
-            let underlying = self.go_type_string(&fields[0].ty, fx);
+            let underlying = self.go_type_string(&fields[0].ty);
             return format!("type {} {}", go_type_name, underlying);
         }
 
         let field_strings: Vec<String> = fields
             .iter()
             .enumerate()
-            .map(|(i, f)| format!("F{} {}", i, self.go_type_string(&f.ty, fx)))
+            .map(|(i, f)| format!("F{} {}", i, self.go_type_string(&f.ty)))
             .collect();
 
         format!(
@@ -271,15 +245,14 @@ impl Planner<'_> {
         name: &str,
         receiver_generics: &str,
         stringer_fields: &[StringerField],
-        fx: &mut EmitEffects,
     ) {
         if !self.synthesizes_debug_string(name) {
             return;
         }
         if !stringer_fields.is_empty() {
-            fx.require_fmt();
+            self.require_fmt();
             if stringer_fields.iter().any(|f| !f.is_function) {
-                fx.require_stdlib();
+                self.require_stdlib();
             }
         }
         out.push_str("\n\n");
@@ -298,13 +271,12 @@ impl Planner<'_> {
         receiver_generics: &str,
         fields: &[StructFieldDefinition],
         generics_string: &str,
-        fx: &mut EmitEffects,
     ) {
         if !self.synthesizes_debug_string(name) {
             return;
         }
         let is_type_alias = fields.len() == 1 && generics_string.is_empty();
-        let underlying = is_type_alias.then(|| self.go_type_string(&fields[0].ty, fx));
+        let underlying = is_type_alias.then(|| self.go_type_string(&fields[0].ty));
         let field_is_function: Vec<bool> =
             fields.iter().map(|f| is_raw_function_type(&f.ty)).collect();
         let uses_prelude = if fields.is_empty() {
@@ -315,10 +287,10 @@ impl Planner<'_> {
             field_is_function.iter().any(|is_function| !is_function)
         };
         if !fields.is_empty() {
-            fx.require_fmt();
+            self.require_fmt();
         }
         if uses_prelude {
-            fx.require_stdlib();
+            self.require_stdlib();
         }
         out.push_str("\n\n");
         out.push_str(&emit_tuple_struct_debug_method(
@@ -389,7 +361,6 @@ impl Planner<'_> {
         receiver_generics: &str,
         fields: &[StructFieldDefinition],
         attributes: &[Attribute],
-        fx: &mut EmitEffects,
     ) {
         if !self.should_synthesize_equals(name) {
             return;
@@ -401,7 +372,7 @@ impl Planner<'_> {
                 let go_field = struct_field_go_name(f, attributes);
                 let lhs = format!("{receiver}.{go_field}");
                 let rhs = format!("other.{go_field}");
-                self.render_equality(&lhs, &rhs, &f.ty, fx)
+                self.render_equality(&lhs, &rhs, &f.ty)
             })
             .collect();
         let body = if comparisons.is_empty() {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
@@ -15,7 +14,6 @@ impl Planner<'_> {
         name: &str,
         generics: &[Generic],
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
         let is_fn_alias;
         let underlying = match ty {
@@ -44,7 +42,7 @@ impl Planner<'_> {
                 ty
             }
         };
-        let ty_string = self.go_type_string(underlying, fx);
+        let ty_string = self.go_type_string(underlying);
 
         if let Type::Nominal { id, .. } = underlying
             && let Some(module) = self.facts.module_for_qualified_name(id.as_str())
@@ -53,11 +51,11 @@ impl Planner<'_> {
             && !go_name::is_go_import(module)
         {
             let module = module.to_string();
-            self.require_module_import_fx(&module, fx);
+            self.require_module_import(&module);
         }
 
         let symbol = self.facts.qualified_current(name);
-        let generics_string = self.generics_to_string_for_symbol(&symbol, generics, fx);
+        let generics_string = self.generics_to_string_for_symbol(&symbol, generics);
 
         let separator = if is_fn_alias { " " } else { " = " };
         format!(
@@ -74,7 +72,6 @@ impl Planner<'_> {
         identifier: &str,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ConstPlan {
         let target_name = self
             .module
@@ -90,11 +87,11 @@ impl Planner<'_> {
             self.try_declare(&fresh);
             fresh
         };
-        let ty_str = self.go_type_string(ty, fx);
+        let ty_str = self.go_type_string(ty);
 
         // `is_go_const_eligible` admits only literals, identifiers, and
         // constexpr unary/binary — none of which carry setup statements.
-        let raw_value = self.plan_value(expression, ExpressionContext::value(), fx);
+        let raw_value = self.plan_value(expression, ExpressionContext::value());
         let value_text = raw_value.operand_text().unwrap_or_default().to_string();
         let value = if value_text.is_empty() {
             ValuePlan::Operand("struct{}{}".to_string())
@@ -118,9 +115,8 @@ impl Planner<'_> {
         identifier: &str,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
-        let plan = self.build_const_plan(identifier, expression, ty, fx);
+        let plan = self.build_const_plan(identifier, expression, ty);
         let mut out = String::new();
         Renderer.render_const_declaration(&mut out, &plan);
         out.trim_end_matches('\n').to_string()

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -4,7 +4,6 @@ use syntax::program::{
 };
 use syntax::types::Type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
@@ -17,7 +16,6 @@ impl Planner<'_> {
         &mut self,
         dot_access: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let Expression::DotAccess {
             expression,
@@ -34,7 +32,7 @@ impl Planner<'_> {
         let receiver_coercion = *receiver_coercion;
 
         if let Some(s) =
-            self.try_emit_pre_receiver_dot(expression, member, result_ty, dot_access_kind, ctx, fx)
+            self.try_emit_pre_receiver_dot(expression, member, result_ty, dot_access_kind, ctx)
         {
             return ValuePlan::Operand(s);
         }
@@ -43,9 +41,9 @@ impl Planner<'_> {
 
         let (mut setup, expression_string) =
             if let Some(module) = expression_ty.as_import_namespace() {
-                (Vec::new(), self.require_module_import_fx(module, fx))
+                (Vec::new(), self.require_module_import(module))
             } else {
-                self.plan_coerced_expression(expression, receiver_coercion, ctx, fx)
+                self.plan_coerced_expression(expression, receiver_coercion, ctx)
             };
 
         if let Some(s) = self.try_emit_tuple_member_dot(
@@ -53,7 +51,6 @@ impl Planner<'_> {
             &expression_ty,
             member,
             dot_access_kind,
-            fx,
         ) {
             return value_plan_from_statements(setup, s);
         }
@@ -70,14 +67,13 @@ impl Planner<'_> {
             &field,
             &expression_ty,
             result_ty,
-            fx,
         ) {
             return value_plan_from_statements(setup, s);
         }
 
         let result = format!("{}.{}", expression_string, field);
         let result =
-            self.append_cross_module_type_args(result, &expression_ty, member, result_ty, ctx, fx);
+            self.append_cross_module_type_args(result, &expression_ty, member, result_ty, ctx);
         value_plan_from_statements(setup, result)
     }
 
@@ -91,12 +87,11 @@ impl Planner<'_> {
         result_ty: &Type,
         dot_access_kind: Option<SemanticDotKind>,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         match dot_access_kind {
-            Some(SemanticDotKind::EnumVariant) => self.emit_enum_variant_dot(member, result_ty, fx),
+            Some(SemanticDotKind::EnumVariant) => self.emit_enum_variant_dot(member, result_ty),
             Some(SemanticDotKind::StaticMethod { .. }) => {
-                self.emit_static_method_dot(expression, member, result_ty, ctx, fx)
+                self.emit_static_method_dot(expression, member, result_ty, ctx)
             }
             Some(SemanticDotKind::InstanceMethodValue {
                 is_exported,
@@ -107,13 +102,12 @@ impl Planner<'_> {
                 result_ty,
                 is_exported,
                 is_pointer_receiver,
-                fx,
             ),
             Some(SemanticDotKind::ModuleMember) | None => {
-                if let Some(s) = self.emit_enum_variant_dot(member, result_ty, fx) {
+                if let Some(s) = self.emit_enum_variant_dot(member, result_ty) {
                     Some(s)
                 } else {
-                    self.emit_static_method_dot(expression, member, result_ty, ctx, fx)
+                    self.emit_static_method_dot(expression, member, result_ty, ctx)
                 }
             }
             _ => None,
@@ -129,7 +123,6 @@ impl Planner<'_> {
         expression_ty: &Type,
         member: &str,
         dot_access_kind: Option<SemanticDotKind>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Ok(index) = member.parse::<usize>() else {
             return None;
@@ -143,8 +136,7 @@ impl Planner<'_> {
             }
             Some(SemanticDotKind::TupleStructField { is_newtype }) => {
                 if is_newtype
-                    && let Some(cast) =
-                        self.try_emit_newtype_cast(expression_ty, expression_string, fx)
+                    && let Some(cast) = self.try_emit_newtype_cast(expression_ty, expression_string)
                 {
                     return Some(cast);
                 }
@@ -188,7 +180,6 @@ impl Planner<'_> {
         field: &str,
         expression_ty: &Type,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if self.go_imported_shape(expression_ty).is_none() || !self.is_go_nullable(result_ty) {
             return None;
@@ -201,7 +192,7 @@ impl Planner<'_> {
             result_ty,
             CoercionDirection::FromGoBoundary,
         );
-        let (coercion_setup, coerced) = coercion.lower(self, raw_var, fx);
+        let (coercion_setup, coerced) = coercion.lower(self, raw_var);
         setup.extend(coercion_setup);
         Some(coerced)
     }
@@ -216,7 +207,6 @@ impl Planner<'_> {
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         if ctx.is_callee() {
             return base_access;
@@ -225,7 +215,7 @@ impl Planner<'_> {
             return base_access;
         };
         let qualified = format!("{}.{}", module, member);
-        match self.format_cross_module_type_args(&qualified, result_ty, fx) {
+        match self.format_cross_module_type_args(&qualified, result_ty) {
             Some(type_args) => format!("{}{}", base_access, type_args),
             None => base_access,
         }
@@ -237,7 +227,6 @@ impl Planner<'_> {
         &mut self,
         expression_ty: &Type,
         expression_string: &str,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let deref_ty = expression_ty.strip_refs();
         let Type::Nominal { id, .. } = &deref_ty else {
@@ -251,7 +240,7 @@ impl Planner<'_> {
             return None;
         };
         let field_ty = fields.first()?.ty.clone();
-        let go_type = self.go_type_string(&field_ty, fx);
+        let go_type = self.go_type_string(&field_ty);
         let operand = if expression_ty.is_ref() {
             format!("*{}", expression_string)
         } else {
@@ -283,12 +272,11 @@ impl Planner<'_> {
         expression: &Expression,
         coercion: Option<ReceiverCoercion>,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let (staged, had_explicit_deref) = if let Some(inner) = expression.deref_inner() {
-            (self.stage_operand(inner, ctx, fx), true)
+            (self.stage_operand(inner, ctx), true)
         } else {
-            (self.stage_operand(expression, ctx, fx), false)
+            (self.stage_operand(expression, ctx), false)
         };
         let mut setup = staged.setup;
         let expression_string = staged.value;
@@ -329,7 +317,6 @@ impl Planner<'_> {
         expression_string: &str,
         expression_ty: &Type,
         index: usize,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let deref_ty = expression_ty.strip_refs();
         let Type::Nominal { ref id, .. } = deref_ty else {
@@ -355,7 +342,7 @@ impl Planner<'_> {
         }
 
         if fields.len() == 1 && generics.is_empty() {
-            let underlying_ty = self.go_type_string(&fields[0].ty, fx);
+            let underlying_ty = self.go_type_string(&fields[0].ty);
             let expression = if expression_ty.is_ref() {
                 format!("*{}", expression_string)
             } else {

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -1,7 +1,6 @@
 use syntax::ast::Expression;
 use syntax::types::peel_to_range_type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
@@ -17,7 +16,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         index: &Expression,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Expression::Range {
             start,
@@ -27,38 +25,34 @@ impl Planner<'_> {
         } = index
         {
             let (setup, value) =
-                self.plan_range_slice(expression, start.as_deref(), end.as_deref(), *inclusive, fx);
+                self.plan_range_slice(expression, start.as_deref(), end.as_deref(), *inclusive);
             return value_plan_from_statements(setup, value);
         }
 
-        let base_staged = self.stage_base_with_deref(expression, fx);
+        let base_staged = self.stage_base_with_deref(expression);
 
         // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`,
         // or `r: Prefix` where `type Prefix = RangeTo<int>`).
         let index_ty = index.get_type();
         if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
             let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
-            let index_staged = self.stage_or_capture(index, "range", fx);
+            let index_staged = self.stage_or_capture(index, "range");
             let (setup, values) =
                 self.sequence_structured(vec![base_staged, index_staged], "_base");
             let value = emit_range_var_slice(&values[0], &values[1], range_kind, needs_cap);
             return value_plan_from_statements(setup, value);
         }
 
-        let index_staged = self.stage_composite(index, ExpressionContext::value(), fx);
+        let index_staged = self.stage_composite(index, ExpressionContext::value());
         let (setup, values) = self.sequence_structured(vec![base_staged, index_staged], "_base");
         value_plan_from_statements(setup, format!("{}[{}]", values[0], values[1]))
     }
 
-    fn stage_base_with_deref(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> StagedExpression {
+    fn stage_base_with_deref(&mut self, expression: &Expression) -> StagedExpression {
         let Some(inner) = expression.deref_inner() else {
-            return self.stage_operand(expression, ExpressionContext::value(), fx);
+            return self.stage_operand(expression, ExpressionContext::value());
         };
-        let s = self.stage_operand(inner, ExpressionContext::value(), fx);
+        let s = self.stage_operand(inner, ExpressionContext::value());
         StagedExpression {
             value: format!("(*{})", s.value),
             setup: s.setup,
@@ -76,17 +70,16 @@ impl Planner<'_> {
         start: Option<&Expression>,
         end: Option<&Expression>,
         inclusive: bool,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
-        let base_staged = self.stage_base_with_deref(expression, fx);
+        let base_staged = self.stage_base_with_deref(expression);
 
         let mut all_stages = vec![base_staged];
         if let Some(s) = start {
-            all_stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
+            all_stages.push(self.stage_operand(s, ExpressionContext::value()));
         }
         if let Some(e) = end {
-            all_stages.push(self.stage_operand(e, ExpressionContext::value(), fx));
+            all_stages.push(self.stage_operand(e, ExpressionContext::value()));
         }
         let (mut setup, values) = self.sequence_structured(all_stages, "_base");
         let base_str = values[0].clone();

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -5,7 +5,6 @@ use syntax::ast::{Expression, StructFieldAssignment, StructSpread};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{CompoundKind, SimpleKind, Type, unqualified_name};
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
@@ -39,9 +38,8 @@ impl Planner<'_> {
         spread: &StructSpread,
         ty: &Type,
         expression_ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let ctx = self.analyze_struct_call(name, ty, fx);
+        let ctx = self.analyze_struct_call(name, ty);
 
         let tag_field = ctx.enum_ctx.as_ref().map(|e| {
             (
@@ -55,7 +53,7 @@ impl Planner<'_> {
 
         let stages: Vec<StagedExpression> = kept
             .iter()
-            .map(|f| self.stage_composite(&f.value, ExpressionContext::value(), fx))
+            .map(|f| self.stage_composite(&f.value, ExpressionContext::value()))
             .collect();
         let (mut setup, emitted_values) = self.sequence_structured(stages, "_field");
 
@@ -74,7 +72,6 @@ impl Planner<'_> {
                 &value_ty,
                 field_ty.as_ref(),
                 is_go_struct,
-                fx,
             );
             field_names.push(field_name);
             field_values.push(value);
@@ -92,7 +89,7 @@ impl Planner<'_> {
                 // Never-typed spread base diverges — emit as statement and
                 // return a zero-value struct literal (dead code follows).
                 if base.get_type().is_never() {
-                    setup.push(self.lower_statement(base, fx));
+                    setup.push(self.lower_statement(base));
                     format!("{}{{}}", ctx.go_type)
                 } else {
                     let mut field_side_effects: Vec<bool> = Vec::new();
@@ -104,17 +101,11 @@ impl Planner<'_> {
                             .iter()
                             .map(|f| observable_after_mutation(&f.value)),
                     );
-                    self.lower_struct_update(
-                        &mut setup,
-                        base,
-                        &field_pairs,
-                        &field_side_effects,
-                        fx,
-                    )
+                    self.lower_struct_update(&mut setup, base, &field_pairs, &field_side_effects)
                 }
             }
             StructSpread::ZeroFill { .. } if !is_go_struct => {
-                self.append_zero_fills(&mut field_pairs, field_assignments, ty, name, &ctx, fx);
+                self.append_zero_fills(&mut field_pairs, field_assignments, ty, name, &ctx);
                 emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
             }
             StructSpread::ZeroFill { .. } | StructSpread::None => {
@@ -137,7 +128,6 @@ impl Planner<'_> {
         value_ty: &Type,
         field_ty: Option<&Type>,
         is_go_struct: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         if is_go_struct {
             let target_ty = field_ty.unwrap_or(value_ty);
@@ -146,13 +136,13 @@ impl Planner<'_> {
             }
             let coercion =
                 Coercion::resolve(self, value_ty, target_ty, CoercionDirection::ToGoBoundary);
-            let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             statements.extend(coercion_setup);
             value = coerced;
         }
         if let Some(field_ty) = field_ty {
             let coercion = Coercion::resolve(self, value_ty, field_ty, CoercionDirection::Internal);
-            let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             statements.extend(coercion_setup);
             value = coerced;
         }
@@ -168,7 +158,6 @@ impl Planner<'_> {
         ty: &Type,
         name: &str,
         ctx: &StructCallContext,
-        fx: &mut EmitEffects,
     ) {
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let Some(unspecified) =
@@ -181,7 +170,7 @@ impl Planner<'_> {
                 continue;
             }
             let go_field_name = self.resolve_struct_call_field_name(&field_name, ty, ctx);
-            let zero = self.lisette_zero(&field_ty, fx);
+            let zero = self.lisette_zero(&field_ty);
             field_pairs.push((go_field_name, zero));
         }
     }
@@ -271,11 +260,11 @@ impl Planner<'_> {
             &map,
         ))
     }
-    fn go_imported_zero(&mut self, ty: &Type, id: &str, fx: &mut EmitEffects) -> String {
+    fn go_imported_zero(&mut self, ty: &Type, id: &str) -> String {
         if self.facts.is_interface(ty) || self.facts.resolve_to_function_type(ty).is_some() {
             return "nil".to_string();
         }
-        let go_ty = self.go_type_string(ty, fx);
+        let go_ty = self.go_type_string(ty);
         // A newtype is a Go named scalar (`type Duration int64`), so a composite
         // literal `Duration{}` is invalid; `*new(Duration)` yields its zero.
         let is_newtype = self.facts.definition(id).is_some_and(|d| d.is_newtype());
@@ -294,7 +283,7 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn lisette_zero(&mut self, ty: &Type, fx: &mut EmitEffects) -> String {
+    pub(crate) fn lisette_zero(&mut self, ty: &Type) -> String {
         match ty {
             Type::Simple(kind) => match kind {
                 SimpleKind::Bool => "false".to_string(),
@@ -306,46 +295,46 @@ impl Planner<'_> {
                 CompoundKind::Slice => {
                     let inner = args
                         .first()
-                        .map(|a| self.go_type_string(a, fx))
+                        .map(|a| self.go_type_string(a))
                         .unwrap_or_else(|| "any".to_string());
                     format!("([]{})(nil)", inner)
                 }
                 CompoundKind::Map => {
                     let key = args
                         .first()
-                        .map(|a| self.go_type_string(a, fx))
+                        .map(|a| self.go_type_string(a))
                         .unwrap_or_else(|| "any".to_string());
                     let val = args
                         .get(1)
-                        .map(|a| self.go_type_string(a, fx))
+                        .map(|a| self.go_type_string(a))
                         .unwrap_or_else(|| "any".to_string());
                     format!("map[{}]{}{{}}", key, val)
                 }
-                _ => format!("{}{{}}", self.go_type_string(ty, fx)),
+                _ => format!("{}{{}}", self.go_type_string(ty)),
             },
             Type::Nominal { id, params, .. } => {
                 if id.as_str() == "prelude.Option" {
                     let inner = params
                         .first()
-                        .map(|a| self.go_type_string(a, fx))
+                        .map(|a| self.go_type_string(a))
                         .unwrap_or_else(|| "any".to_string());
-                    fx.require_stdlib();
+                    self.require_stdlib();
                     return format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, inner);
                 }
                 if go_name::is_go_import(id.as_str()) {
-                    return self.go_imported_zero(ty, id.as_str(), fx);
+                    return self.go_imported_zero(ty, id.as_str());
                 }
 
                 if let Some(underlying) = self.get_newtype_underlying(ty) {
-                    let go_ty = self.go_type_string(ty, fx);
-                    let inner = self.lisette_zero(&underlying, fx);
+                    let go_ty = self.go_type_string(ty);
+                    let inner = self.lisette_zero(&underlying);
                     return format!("{}({})", go_ty, inner);
                 }
 
                 if let Some(fields) =
                     self.lookup_unspecified_fields(ty, "", None, &HashSet::default())
                 {
-                    let go_ty = self.go_type_string(ty, fx);
+                    let go_ty = self.go_type_string(ty);
                     let is_tuple = self.is_tuple_struct_type(ty);
                     let pairs: Vec<(String, String)> = fields
                         .into_iter()
@@ -359,20 +348,19 @@ impl Planner<'_> {
                             } else {
                                 go_name::escape_keyword(&name).into_owned()
                             };
-                            (go_name, self.lisette_zero(&field_ty, fx))
+                            (go_name, self.lisette_zero(&field_ty))
                         })
                         .collect();
                     return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
                 }
                 if let Some(underlying) = ty.get_underlying() {
-                    return self.lisette_zero(underlying, fx);
+                    return self.lisette_zero(underlying);
                 }
-                format!("{}{{}}", self.go_type_string(ty, fx))
+                format!("{}{{}}", self.go_type_string(ty))
             }
             Type::Tuple(elements) => {
-                let parts: Vec<String> =
-                    elements.iter().map(|e| self.lisette_zero(e, fx)).collect();
-                fx.require_stdlib();
+                let parts: Vec<String> = elements.iter().map(|e| self.lisette_zero(e)).collect();
+                self.require_stdlib();
                 format!(
                     "{}.MakeTuple{}({})",
                     go_name::GO_STDLIB_PKG,
@@ -380,7 +368,7 @@ impl Planner<'_> {
                     parts.join(", ")
                 )
             }
-            _ => format!("{}{{}}", self.go_type_string(ty, fx)),
+            _ => format!("{}{{}}", self.go_type_string(ty)),
         }
     }
 
@@ -407,22 +395,17 @@ impl Planner<'_> {
     }
 
     /// Analyze a struct call to determine Go type and enum context.
-    fn analyze_struct_call(
-        &mut self,
-        name: &str,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> StructCallContext {
+    fn analyze_struct_call(&mut self, name: &str, ty: &Type) -> StructCallContext {
         let is_prelude = is_from_prelude(ty);
         let enum_id = self.as_enum(ty);
 
-        let go_type = self.compute_struct_call_go_type(name, ty, is_prelude, enum_id.is_some(), fx);
+        let go_type = self.compute_struct_call_go_type(name, ty, is_prelude, enum_id.is_some());
 
         if let Some(ref id) = enum_id {
-            self.add_enum_imports_if_needed(name, id, fx);
+            self.add_enum_imports_if_needed(name, id);
         }
 
-        let enum_ctx = enum_id.map(|id| self.compute_enum_call_context(name, &id, fx));
+        let enum_ctx = enum_id.map(|id| self.compute_enum_call_context(name, &id));
 
         StructCallContext { go_type, enum_ctx }
     }
@@ -434,12 +417,11 @@ impl Planner<'_> {
         ty: &Type,
         is_prelude: bool,
         is_enum: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         if let Type::Nominal { id, .. } = ty
             && let Some(go) = self.anon_struct_go_type(id)
         {
-            fx.merge_from_go_type(&go);
+            self.note_go_type(&go);
             return go.code;
         }
 
@@ -453,16 +435,16 @@ impl Planner<'_> {
                 let type_args = if self.is_non_generic_alias_call(parts[1], ty) {
                     String::new()
                 } else if let Type::Nominal { params, .. } = ty {
-                    self.format_type_args(params, fx)
+                    self.format_type_args(params)
                 } else {
                     String::new()
                 };
-                let pkg = self.require_module_import_fx(parts[0], fx);
+                let pkg = self.require_module_import(parts[0]);
                 return format!("{}.{}{}", pkg, go_name::snake_to_camel(parts[1]), type_args);
             }
         }
 
-        self.go_type_string(ty, fx)
+        self.go_type_string(ty)
     }
 
     /// True when `type_name` (e.g., `StringFlag`) is a non-generic alias in the
@@ -482,15 +464,10 @@ impl Planner<'_> {
     }
 
     /// Compute the enum-specific context for a struct call.
-    fn compute_enum_call_context(
-        &mut self,
-        name: &str,
-        enum_id: &str,
-        fx: &mut EmitEffects,
-    ) -> EnumCallContext {
+    fn compute_enum_call_context(&mut self, name: &str, enum_id: &str) -> EnumCallContext {
         let variant_name = unqualified_name(name).to_string();
 
-        let tag_constant = self.resolve_variant(name, enum_id, fx);
+        let tag_constant = self.resolve_variant(name, enum_id);
 
         let pointer_fields = if let Some(layout) = self.enum_layout(enum_id) {
             if let Some(variant) = layout.get_variant(&variant_name) {
@@ -515,12 +492,12 @@ impl Planner<'_> {
         }
     }
 
-    fn add_enum_imports_if_needed(&mut self, name: &str, enum_id: &str, fx: &mut EmitEffects) {
+    fn add_enum_imports_if_needed(&mut self, name: &str, enum_id: &str) {
         if let Some(enum_module) = self.facts.module_for_qualified_name(enum_id)
             && !self.facts.is_current_module(enum_module)
         {
             let enum_module = enum_module.to_string();
-            self.require_module_import_fx(&enum_module, fx);
+            self.require_module_import(&enum_module);
         }
 
         let parts: Vec<&str> = name.split('.').collect();
@@ -530,7 +507,7 @@ impl Planner<'_> {
                 .module_for_alias(parts[0])
                 .unwrap_or(parts[0])
                 .to_string();
-            self.require_module_import_fx(&module, fx);
+            self.require_module_import(&module);
         }
     }
 
@@ -559,10 +536,9 @@ impl Planner<'_> {
         base: &Expression,
         fields: &[(String, String)],
         field_side_effects: &[bool],
-        fx: &mut EmitEffects,
     ) -> String {
         if fields.is_empty() {
-            let staged = self.stage_operand(base, ExpressionContext::value(), fx);
+            let staged = self.stage_operand(base, ExpressionContext::value());
             statements.extend(staged.setup);
             return staged.value;
         }
@@ -580,7 +556,7 @@ impl Planner<'_> {
             })
             .collect();
 
-        let base_staged = self.stage_operand(base, ExpressionContext::value(), fx);
+        let base_staged = self.stage_operand(base, ExpressionContext::value());
         statements.extend(base_staged.setup);
         let tmp = self.hoist_tmp_value_statement(statements, "copy", &base_staged.value);
 

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
@@ -12,12 +11,11 @@ impl Planner<'_> {
         &mut self,
         member: &str,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
-        if let Some(s) = self.emit_enum_variant_constructor(member, result_ty, fx) {
+        if let Some(s) = self.emit_enum_variant_constructor(member, result_ty) {
             return Some(s);
         }
-        self.emit_unit_variant_constructor(member, result_ty, fx)
+        self.emit_unit_variant_constructor(member, result_ty)
     }
 
     /// Static method dot access (cross-module, alias, or instance-as-value).
@@ -27,14 +25,11 @@ impl Planner<'_> {
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
-        if let Some(s) =
-            self.emit_cross_module_static_method(expression, member, result_ty, ctx, fx)
-        {
+        if let Some(s) = self.emit_cross_module_static_method(expression, member, result_ty, ctx) {
             return Some(s);
         }
-        if let Some(s) = self.emit_alias_static_method(expression, member, result_ty, fx) {
+        if let Some(s) = self.emit_alias_static_method(expression, member, result_ty) {
             return Some(s);
         }
         None
@@ -46,7 +41,6 @@ impl Planner<'_> {
         &mut self,
         variant_name: &str,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Type::Function(f) = result_ty else {
             return None;
@@ -72,7 +66,7 @@ impl Planner<'_> {
 
         let needs_type_args = ret_params.len() > fn_params.len();
         let type_args = if needs_type_args {
-            self.format_type_args(ret_params, fx)
+            self.format_type_args(ret_params)
         } else {
             String::new()
         };
@@ -81,11 +75,11 @@ impl Planner<'_> {
             if make_fn_name.starts_with(go_name::PRELUDE_PREFIX) {
                 let resolved = go_name::resolve(&make_fn_name);
                 if resolved.needs_stdlib {
-                    fx.require_stdlib();
+                    self.require_stdlib();
                 }
                 format!("{}{}", resolved.name, type_args)
             } else {
-                let pkg = self.require_module_import_fx(enum_module, fx);
+                let pkg = self.require_module_import(enum_module);
                 format!("{}.{}{}", pkg, make_fn_name, type_args)
             }
         } else {
@@ -98,7 +92,6 @@ impl Planner<'_> {
         &mut self,
         variant_name: &str,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Type::Nominal {
             id: enum_id,
@@ -126,16 +119,16 @@ impl Planner<'_> {
         let enum_name = unqualified_name(enum_id);
         let key = format!("{}.{}", enum_name, variant_name);
         let make_fn = self.facts.make_function_name(&key)?.to_string();
-        let type_args = self.format_type_args(params, fx);
+        let type_args = self.format_type_args(params);
 
         if is_prelude {
             let resolved = go_name::resolve(&make_fn);
             if resolved.needs_stdlib {
-                fx.require_stdlib();
+                self.require_stdlib();
             }
             Some(format!("{}{}()", resolved.name, type_args))
         } else if is_cross_module {
-            let pkg = self.require_module_import_fx(enum_module, fx);
+            let pkg = self.require_module_import(enum_module);
             Some(format!("{}.{}{}()", pkg, make_fn, type_args))
         } else {
             Some(format!("{}{}()", make_fn, type_args))
@@ -149,7 +142,6 @@ impl Planner<'_> {
         expression: &Expression,
         member: &str,
         result_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let func_ty = result_ty.unwrap_forall();
         if !matches!(func_ty, Type::Function(_)) {
@@ -165,7 +157,7 @@ impl Planner<'_> {
         let resolved_name = format!("{}.{}", real_type, member);
 
         let capitalized = self.capitalize_static_method_if_public(&resolved_name);
-        let go_name = self.resolve_go_name(&capitalized, fx);
+        let go_name = self.resolve_go_name(&capitalized);
 
         Some(go_name)
     }
@@ -179,7 +171,6 @@ impl Planner<'_> {
         result_ty: &Type,
         is_exported: bool,
         is_pointer_receiver: bool,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if let Expression::Identifier { value, .. } = expression {
             let go_method = if is_exported {
@@ -190,7 +181,7 @@ impl Planner<'_> {
             let type_name = self
                 .resolve_alias_type_name(value)
                 .unwrap_or_else(|| value.to_string());
-            let type_args = self.method_expression_type_args(result_ty, fx);
+            let type_args = self.method_expression_type_args(result_ty);
             return Some(if is_pointer_receiver {
                 format!("(*{}{}).{}", type_name, type_args, go_method)
             } else {
@@ -226,9 +217,9 @@ impl Planner<'_> {
             go_name::escape_keyword(member).into_owned()
         };
 
-        let pkg = self.require_module_import_fx(module_name, fx);
+        let pkg = self.require_module_import(module_name);
         let go_type_name = go_name::snake_to_camel(type_name);
-        let type_args = self.method_expression_type_args(result_ty, fx);
+        let type_args = self.method_expression_type_args(result_ty);
 
         let method_expression = if is_pointer_receiver {
             format!("(*{}.{}{}).{}", pkg, go_type_name, type_args, go_method)
@@ -239,7 +230,7 @@ impl Planner<'_> {
         Some(method_expression)
     }
 
-    fn method_expression_type_args(&mut self, result_ty: &Type, fx: &mut EmitEffects) -> String {
+    fn method_expression_type_args(&mut self, result_ty: &Type) -> String {
         let Type::Function(f) = result_ty.unwrap_forall() else {
             return String::new();
         };
@@ -256,7 +247,7 @@ impl Planner<'_> {
         if receiver_params.is_empty() {
             String::new()
         } else {
-            self.format_type_args(&receiver_params, fx)
+            self.format_type_args(&receiver_params)
         }
     }
 
@@ -268,7 +259,6 @@ impl Planner<'_> {
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if !matches!(result_ty.unwrap_forall(), Type::Function(_)) {
             return None;
@@ -325,10 +315,10 @@ impl Planner<'_> {
         let qualified_method = format!("{}.{}", qualified_type, member);
 
         let is_public = definition.visibility().is_public() || self.method_needs_export(member);
-        let qualified_name = self.qualify_method_call(&qualified_type, member, is_public, fx);
+        let qualified_name = self.qualify_method_call(&qualified_type, member, is_public);
 
         let type_args = if !ctx.is_callee() {
-            self.format_cross_module_type_args(&qualified_method, result_ty, fx)
+            self.format_cross_module_type_args(&qualified_method, result_ty)
                 .unwrap_or_default()
         } else {
             String::new()

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::generics::extract_type_mapping;
@@ -25,7 +24,6 @@ impl Planner<'_> {
         value: &str,
         ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         if let Some(BindingValue::InlineExpr(expr)) = self.scope.resolve_identifier_binding(value) {
             let text = expr.as_str().to_string();
@@ -42,23 +40,23 @@ impl Planner<'_> {
         if let Some(go_name) = &bound_go_name {
             self.scope.record_go_use(go_name);
         }
-        match self.classify_identifier(value, ty, ctx, fx) {
+        match self.classify_identifier(value, ty, ctx) {
             IdentifierKind::UnitValue => "struct{}{}".to_string(),
             IdentifierKind::PublicFunction { capitalized } => capitalized,
             IdentifierKind::UnitConstructor { name, type_args } => {
-                format!("{}{}()", self.resolve_go_name(&name, fx), type_args)
+                format!("{}{}()", self.resolve_go_name(&name), type_args)
             }
             IdentifierKind::ConstructorFunction { name, type_args } => {
-                format!("{}{}", self.resolve_go_name(&name, fx), type_args)
+                format!("{}{}", self.resolve_go_name(&name), type_args)
             }
             IdentifierKind::Regular { name } => {
-                if let Some(expression) = self.try_emit_method_expression(&name, ty, fx) {
+                if let Some(expression) = self.try_emit_method_expression(&name, ty) {
                     return expression;
                 }
                 let resolved = self.capitalize_static_method_if_public(&name);
-                let go_name = self.resolve_go_name(&resolved, fx);
+                let go_name = self.resolve_go_name(&resolved);
                 if !ctx.is_callee()
-                    && let Some(type_args) = self.format_generic_value_type_args(&name, ty, fx)
+                    && let Some(type_args) = self.format_generic_value_type_args(&name, ty)
                 {
                     return format!("{}{}", go_name, type_args);
                 }
@@ -72,7 +70,6 @@ impl Planner<'_> {
         value: &str,
         ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> IdentifierKind {
         if value == "Unit" && ty.is_unit() {
             return IdentifierKind::UnitValue;
@@ -117,9 +114,9 @@ impl Planner<'_> {
                 Type::Nominal { params, .. } => {
                     let type_args = match ctx.expected_slot_type() {
                         Some(t) => self
-                            .prelude_container_type_args(t, fx)
-                            .unwrap_or_else(|| self.format_type_args(params, fx)),
-                        None => self.format_type_args(params, fx),
+                            .prelude_container_type_args(t)
+                            .unwrap_or_else(|| self.format_type_args(params)),
+                        None => self.format_type_args(params),
                     };
                     return IdentifierKind::UnitConstructor { name, type_args };
                 }
@@ -129,8 +126,7 @@ impl Planner<'_> {
                         params: ret_params, ..
                     } = f.return_type.as_ref()
                     {
-                        let type_args =
-                            self.constructor_fn_type_args(&f.params, ret_params, ctx, fx);
+                        let type_args = self.constructor_fn_type_args(&f.params, ret_params, ctx);
                         return IdentifierKind::ConstructorFunction { name, type_args };
                     }
                 }
@@ -151,7 +147,6 @@ impl Planner<'_> {
         fn_params: &[Type],
         ret_params: &[Type],
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         let needs_type_args = !ctx.is_callee()
             || ret_params.len() > fn_params.len()
@@ -162,7 +157,7 @@ impl Planner<'_> {
                 .iter()
                 .any(|t| self.needs_explicit_args_for_go_inference(t));
         if needs_type_args {
-            self.format_type_args(ret_params, fx)
+            self.format_type_args(ret_params)
         } else {
             String::new()
         }
@@ -176,7 +171,6 @@ impl Planner<'_> {
         definition_ty: &Type,
         instantiated_ty: &Type,
         collapsed_recipe: Option<&str>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let Type::Forall { vars, body } = definition_ty else {
             return None;
@@ -186,14 +180,14 @@ impl Planner<'_> {
         extract_type_mapping(body, instantiated_ty, &mut mapping);
 
         if let Some(recipe) = collapsed_recipe {
-            return self.reconstruct_collapsed_type_args(recipe, &mapping, fx);
+            return self.reconstruct_collapsed_type_args(recipe, &mapping);
         }
 
         let args: Vec<String> = vars
             .iter()
             .filter_map(|var| {
                 let concrete = mapping.get(var.as_str())?;
-                Some(self.go_type_string(concrete, fx))
+                Some(self.go_type_string(concrete))
             })
             .collect();
 
@@ -213,7 +207,6 @@ impl Planner<'_> {
         &mut self,
         name: &str,
         instantiated_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let qualified_name = self.facts.qualified_current(name);
         let definition = self.facts.definition(qualified_name.as_str()).or_else(|| {
@@ -223,7 +216,7 @@ impl Planner<'_> {
         let definition_ty = definition.ty().clone();
         let recipe = definition.go_type_param_recipe().map(str::to_string);
 
-        self.format_type_args_from_forall(&definition_ty, instantiated_ty, recipe.as_deref(), fx)
+        self.format_type_args_from_forall(&definition_ty, instantiated_ty, recipe.as_deref())
     }
 
     /// Like `format_generic_value_type_args` but takes a pre-qualified definition name
@@ -232,23 +225,17 @@ impl Planner<'_> {
         &mut self,
         qualified_name: &str,
         instantiated_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let definition = self.facts.definition(qualified_name)?;
         let definition_ty = definition.ty().clone();
         let recipe = definition.go_type_param_recipe().map(str::to_string);
 
-        self.format_type_args_from_forall(&definition_ty, instantiated_ty, recipe.as_deref(), fx)
+        self.format_type_args_from_forall(&definition_ty, instantiated_ty, recipe.as_deref())
     }
 
     /// Return Go method-expression syntax for a `Type.method` referring to an
     /// instance method (first param is `self`); `None` for static methods.
-    fn try_emit_method_expression(
-        &mut self,
-        name: &str,
-        id_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    fn try_emit_method_expression(&mut self, name: &str, id_ty: &Type) -> Option<String> {
         let (type_part, method_part) = name.split_once('.')?;
 
         if method_part.contains('.') {
@@ -300,7 +287,7 @@ impl Planner<'_> {
             if params.is_empty() {
                 String::new()
             } else {
-                self.format_type_args(params, fx)
+                self.format_type_args(params)
             }
         } else {
             String::new()
@@ -314,11 +301,7 @@ impl Planner<'_> {
     }
 
     /// Resolve `module.Type.method` as a cross-module static method call.
-    pub(crate) fn try_resolve_cross_module_static_method(
-        &mut self,
-        name: &str,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    pub(crate) fn try_resolve_cross_module_static_method(&mut self, name: &str) -> Option<String> {
         if !name.contains('.') {
             return None;
         }
@@ -357,7 +340,7 @@ impl Planner<'_> {
             .unwrap_or(true)
             || self.method_needs_export(method_name);
 
-        Some(self.qualify_method_call(&type_id, method_name, is_public, fx))
+        Some(self.qualify_method_call(&type_id, method_name, is_public))
     }
 
     /// `Some(capitalized)` when the identifier names a public function in

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -1,6 +1,5 @@
 use std::fmt::Write;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
@@ -11,12 +10,7 @@ use syntax::ast::{FormatStringPart, Literal};
 use syntax::types::{SimpleKind, Type};
 
 impl Planner<'_> {
-    pub(super) fn emit_literal(
-        &mut self,
-        literal: &Literal,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> ValuePlan {
+    pub(super) fn emit_literal(&mut self, literal: &Literal, ty: &Type) -> ValuePlan {
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let value = match literal {
             Literal::Integer { value, text } => match text {
@@ -50,7 +44,7 @@ impl Planner<'_> {
                 format!("'{}'", convert_escape_sequences(c))
             }
             Literal::FormatString(parts) => {
-                let (fmt_setup, value) = self.emit_format_string(parts, fx);
+                let (fmt_setup, value) = self.emit_format_string(parts);
                 setup = fmt_setup;
                 value
             }
@@ -61,7 +55,7 @@ impl Planner<'_> {
                     .first()
                     .expect("Slice type must have element type")
                     .clone();
-                let element_ty = self.go_type_string(&element_lisette_ty, fx);
+                let element_ty = self.go_type_string(&element_lisette_ty);
 
                 if elements.is_empty() {
                     // Parens around the slice type disambiguate the conversion when
@@ -71,7 +65,7 @@ impl Planner<'_> {
                 } else {
                     let stages: Vec<StagedExpression> = elements
                         .iter()
-                        .map(|e| self.stage_composite(e, ExpressionContext::value(), fx))
+                        .map(|e| self.stage_composite(e, ExpressionContext::value()))
                         .collect();
                     let (slice_setup, rendered) = self.sequence_structured(stages, "_v");
                     setup.extend(slice_setup);
@@ -84,7 +78,7 @@ impl Planner<'_> {
                             &element_lisette_ty,
                             CoercionDirection::Internal,
                         );
-                        let (coercion_setup, coerced) = coercion.lower(self, emitted, fx);
+                        let (coercion_setup, coerced) = coercion.lower(self, emitted);
                         setup.extend(coercion_setup);
                         wrapped.push(coerced);
                     }
@@ -109,7 +103,6 @@ impl Planner<'_> {
     fn emit_format_string(
         &mut self,
         parts: &[FormatStringPart],
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let has_interpolation = parts
             .iter()
@@ -119,7 +112,7 @@ impl Planner<'_> {
             .iter()
             .filter_map(|p| {
                 if let FormatStringPart::Expression(e) = p {
-                    Some(self.stage_composite(e, ExpressionContext::value(), fx))
+                    Some(self.stage_composite(e, ExpressionContext::value()))
                 } else {
                     None
                 }
@@ -165,7 +158,7 @@ impl Planner<'_> {
             return (setup, format!("\"{}\"", format_string));
         }
 
-        fx.require_fmt();
+        self.require_fmt();
         // Solo-expression f-strings round-trip through fmt.Sprint, which skips
         // the format-string parse. Excluded: `%c`, because Sprint on a rune
         // prints the integer codepoint instead of the character.

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
@@ -28,7 +27,6 @@ impl Planner<'_> {
         left_expression: &Expression,
         right_expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if matches!(operator, BinaryOperator::Pipeline) {
             unreachable!("Pipeline operator should have been desugared by now")
@@ -50,7 +48,6 @@ impl Planner<'_> {
                 right_expression,
                 emit_info,
                 ctx,
-                fx,
             );
         }
 
@@ -65,7 +62,7 @@ impl Planner<'_> {
                 && left_ty.is_float()
                 && !left_ty.is_complex()
             {
-                let staged = self.stage_operand(left_expression, ctx, fx);
+                let staged = self.stage_operand(left_expression, ctx);
                 return value_plan_from_statements(
                     staged.setup,
                     format!("complex(0, {}*{})", staged.value, imag_coef),
@@ -78,7 +75,7 @@ impl Planner<'_> {
                 && right_ty.is_float()
                 && !right_ty.is_complex()
             {
-                let staged = self.stage_operand(right_expression, ctx, fx);
+                let staged = self.stage_operand(right_expression, ctx);
                 return value_plan_from_statements(
                     staged.setup,
                     format!("complex(0, {}*{})", staged.value, imag_coef),
@@ -92,13 +89,12 @@ impl Planner<'_> {
                 left_expression,
                 right_expression,
                 ctx,
-                fx,
             );
         }
 
         let stages = vec![
-            self.stage_composite(left_expression, ctx, fx),
-            self.stage_composite(right_expression, ctx, fx),
+            self.stage_composite(left_expression, ctx),
+            self.stage_composite(right_expression, ctx),
         ];
         let (setup, values) = self.sequence_structured(stages, "_left");
         value_plan_from_statements(setup, format!("{} {} {}", values[0], operator, values[1]))
@@ -110,13 +106,12 @@ impl Planner<'_> {
         left_expression: &Expression,
         right_expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let left_staged = self.stage_composite(left_expression, ctx, fx);
+        let left_staged = self.stage_composite(left_expression, ctx);
 
         // Wrap RHS setup in an IIFE so it runs only when control reaches the
         // RHS. Hoisting it before the operator would defeat short-circuit.
-        let right_staged = self.stage_composite(right_expression, ctx, fx);
+        let right_staged = self.stage_composite(right_expression, ctx);
         let right_string = if right_staged.setup.is_empty() {
             right_staged.value
         } else {
@@ -139,7 +134,6 @@ impl Planner<'_> {
         operator: &UnaryOperator,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         // Special case: -9223372036854775808 cannot be written as a positive
         // literal because 9223372036854775808 overflows i64. Go handles this
@@ -158,7 +152,7 @@ impl Planner<'_> {
         }
 
         if matches!(operator, UnaryOperator::Not) {
-            return self.plan_unary_not(expression, ctx, fx);
+            return self.plan_unary_not(expression, ctx);
         }
 
         let op = match operator {
@@ -169,18 +163,13 @@ impl Planner<'_> {
         };
         ValuePlan::Unary {
             op,
-            inner: Box::new(self.plan_operand(expression, ctx, fx)),
+            inner: Box::new(self.plan_operand(expression, ctx)),
         }
     }
 
     /// Plan `!` (logical-not). Comparisons flip operator because `!` binds
     /// tighter than `==` in Go (`!(a == b)` must not emit as `!a == b`).
-    fn plan_unary_not(
-        &mut self,
-        expression: &Expression,
-        ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
-    ) -> ValuePlan {
+    fn plan_unary_not(&mut self, expression: &Expression, ctx: ExpressionContext<'_>) -> ValuePlan {
         let target = expression.unwrap_parens();
         let preserve_parens = matches!(expression, Expression::Paren { .. });
         let wrap = |s: String| {
@@ -198,18 +187,18 @@ impl Planner<'_> {
         } = target
             && let Some(flipped) = flip_comparison(cmp)
         {
-            let plan = self.plan_binary(&flipped, left, right, ctx, fx);
+            let plan = self.plan_binary(&flipped, left, right, ctx);
             let (setup, value) = plan.into_parts();
             return value_plan_from_statements(setup, wrap(value));
         }
         if matches!(target, Expression::Call { .. }) {
             let mut setup: Vec<LoweredStatement> = Vec::new();
-            if let Some(negated) = self.try_emit_negated_call(&mut setup, target, fx) {
+            if let Some(negated) = self.try_emit_negated_call(&mut setup, target) {
                 return value_plan_from_statements(setup, wrap(negated));
             }
         }
 
-        let staged = self.stage_operand(expression, ctx, fx);
+        let staged = self.stage_operand(expression, ctx);
         value_plan_from_statements(staged.setup, format!("!{}", staged.value))
     }
 
@@ -220,23 +209,22 @@ impl Planner<'_> {
         right_expression: &Expression,
         info: NumericBinaryEmitInfo,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let stages = vec![
-            self.stage_operand(left_expression, ctx, fx),
-            self.stage_operand(right_expression, ctx, fx),
+            self.stage_operand(left_expression, ctx),
+            self.stage_operand(right_expression, ctx),
         ];
         let (setup, values) = self.sequence_structured(stages, "_left");
         let left_string = values[0].clone();
         let right_string = values[1].clone();
 
         let left_string = match &info.cast_left_to {
-            Some(ty) => format!("{}({})", self.go_type_string(ty, fx), left_string),
+            Some(ty) => format!("{}({})", self.go_type_string(ty), left_string),
             None => left_string,
         };
 
         let right_string = match &info.cast_right_to {
-            Some(ty) => format!("{}({})", self.go_type_string(ty, fx), right_string),
+            Some(ty) => format!("{}({})", self.go_type_string(ty), right_string),
             None => right_string,
         };
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
@@ -24,16 +23,15 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         prefix: &str,
-        fx: &mut EmitEffects,
     ) -> StagedExpression {
         if matches!(
             expression,
             Expression::Literal { .. } | Expression::Identifier { .. }
         ) {
-            return self.stage_operand(expression, ExpressionContext::value(), fx);
+            return self.stage_operand(expression, ExpressionContext::value());
         }
 
-        let staged = self.stage_operand(expression, ExpressionContext::value(), fx);
+        let staged = self.stage_operand(expression, ExpressionContext::value());
         let mut setup = staged.setup;
         let temp_var = self.hoist_tmp_value_statement(&mut setup, prefix, &staged.value);
         StagedExpression {
@@ -58,14 +56,13 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         prefix: &str,
-        fx: &mut EmitEffects,
     ) -> String {
         if !observable_after_mutation(expression) {
-            return self.capture_operand_into(setup, expression, fx);
+            return self.capture_operand_into(setup, expression);
         }
 
         let (composite_setup, expression_string) = self
-            .lower_composite_value(expression, ExpressionContext::value(), fx)
+            .lower_composite_value(expression, ExpressionContext::value())
             .into_parts();
         setup.extend(composite_setup);
         self.hoist_tmp_value_statement(setup, prefix, &expression_string)
@@ -76,9 +73,8 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> StagedExpression {
-        let plan = self.plan_operand(expression, ctx, fx);
+        let plan = self.plan_operand(expression, ctx);
         StagedExpression::from_plan(plan, expression)
     }
 
@@ -87,9 +83,8 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> StagedExpression {
-        let plan = self.lower_composite_value(expression, ctx, fx);
+        let plan = self.lower_composite_value(expression, ctx);
         StagedExpression::from_plan(plan, expression)
     }
 
@@ -98,17 +93,16 @@ impl Planner<'_> {
         expression: &Expression,
         declared_param: Option<&syntax::types::Type>,
         param_ty: Option<&syntax::types::Type>,
-        fx: &mut EmitEffects,
     ) -> StagedExpression {
         let suppress = declared_param
             .is_some_and(|p| matches!(p.unwrap_forall(), syntax::types::Type::Function(_)));
         let arg_ctx = ExpressionContext::value().with_forced_tagged_go_function(suppress);
-        let staged = self.stage_composite(expression, arg_ctx, fx);
+        let staged = self.stage_composite(expression, arg_ctx);
 
         if suppress {
             let mut setup = staged.setup;
             if let Some(tagged) =
-                self.try_lower_arg_to_tagged(&mut setup, expression, &staged.value, param_ty, fx)
+                self.try_lower_arg_to_tagged(&mut setup, expression, &staged.value, param_ty)
             {
                 return StagedExpression::from_typed_setup(setup, tagged, expression);
             }
@@ -128,10 +122,9 @@ impl Planner<'_> {
         arg: &Expression,
         value: &str,
         param_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         self.detect_lower_arg_to_tagged(arg, param_ty)?;
-        Some(self.emit_lower_arg_to_tagged(setup, value, param_ty.unwrap(), fx))
+        Some(self.emit_lower_arg_to_tagged(setup, value, param_ty.unwrap()))
     }
 
     /// Detect whether a tagged-Go lowering applies. Pure: no emission.
@@ -162,11 +155,10 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         value: &str,
         param_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> String {
         let cb_var = self.hoist_tmp_value_statement(setup, "cb", value);
         let mut buffer = String::new();
-        let tagged = lower_arg_to_tagged(self, &mut buffer, &cb_var, param_ty, fx);
+        let tagged = lower_arg_to_tagged(self, &mut buffer, &cb_var, param_ty);
         if !buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(buffer));
         }
@@ -177,7 +169,6 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         args: &[Expression],
-        fx: &mut EmitEffects,
     ) -> Vec<StagedExpression> {
         let fn_ty = function.get_type();
         let formal_params: &[syntax::types::Type] = match fn_ty.unwrap_forall() {
@@ -189,7 +180,7 @@ impl Planner<'_> {
             .enumerate()
             .map(|(i, arg)| {
                 let declared = declared_params.and_then(|p| effective_param_type(i, p));
-                self.stage_prelude_arg(arg, declared, formal_params.get(i), fx)
+                self.stage_prelude_arg(arg, declared, formal_params.get(i))
             })
             .collect()
     }
@@ -202,10 +193,9 @@ impl Planner<'_> {
         spread_index: usize,
         wrap_to_any: bool,
         combine: Option<VariadicCombine>,
-        fx: &mut EmitEffects,
     ) {
         if wrap_to_any {
-            fx.require_stdlib();
+            self.require_stdlib();
             values[spread_index] = format!(
                 "{}.SliceToAny({})",
                 go_name::GO_STDLIB_PKG,
@@ -214,7 +204,7 @@ impl Planner<'_> {
         }
         match combine {
             Some(c) if spread_index > c.fixed_count => {
-                let element_go = self.go_type_string(&c.element_ty, fx);
+                let element_go = self.go_type_string(&c.element_ty);
                 let leading = values[c.fixed_count..spread_index].join(", ");
                 let spread_value = &values[spread_index];
                 let combined = format!("append([]{element_go}{{{leading}}}, {spread_value}...)...");
@@ -279,15 +269,14 @@ impl Planner<'_> {
         wrap_to_any: bool,
         prefix: &str,
         combine: Option<VariadicCombine>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let spread_index = spread.map(|s| {
-            stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
+            stages.push(self.stage_operand(s, ExpressionContext::value()));
             stages.len() - 1
         });
         let (setup, mut values) = self.sequence_structured(stages, prefix);
         if let Some(i) = spread_index {
-            self.finalize_spread_stage(&mut values, i, wrap_to_any, combine, fx);
+            self.finalize_spread_stage(&mut values, i, wrap_to_any, combine);
         }
         (setup, values)
     }
@@ -304,18 +293,17 @@ impl Planner<'_> {
         adapter_params: Option<&[Type]>,
         wrap_to_any: bool,
         combine: Option<VariadicCombine>,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         if let Some(spread) = spread
             && let Some(adapter_stage) =
-                self.try_emit_variadic_spread_adapter(spread, adapter_params, fx)
+                self.try_emit_variadic_spread_adapter(spread, adapter_params)
         {
             stages.push(adapter_stage);
             let spread_index = stages.len() - 1;
             let (setup, mut values) = self.sequence_structured(stages, "_arg");
-            self.finalize_spread_stage(&mut values, spread_index, wrap_to_any, combine, fx);
+            self.finalize_spread_stage(&mut values, spread_index, wrap_to_any, combine);
             return (setup, values);
         }
-        self.sequence_with_spread_structured(stages, spread, wrap_to_any, "_arg", combine, fx)
+        self.sequence_with_spread_structured(stages, spread, wrap_to_any, "_arg", combine)
     }
 }

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::definitions::functions::is_test_context_ty;
 use crate::names::go_name::{self, testing_qualifier, testkit_qualifier};
@@ -6,7 +5,7 @@ use syntax::ast::{Binding, Expression, FunctionDefinitionView, Pattern, Visibili
 use syntax::types::{Symbol, Type};
 
 impl Planner<'_> {
-    pub(crate) fn emit_top_item(&mut self, item: &Expression, fx: &mut EmitEffects) -> String {
+    pub(crate) fn emit_top_item(&mut self, item: &Expression) -> String {
         match item {
             Expression::Function {
                 doc,
@@ -23,9 +22,9 @@ impl Planner<'_> {
                 let doc_comment = emit_doc(doc);
 
                 if self.facts.is_test(&self.facts.qualified_current(name)) {
-                    self.emit_test_function(name, function, is_public, &doc_comment, fx)
+                    self.emit_test_function(name, function, is_public, &doc_comment)
                 } else {
-                    let code = self.emit_function(function, None, is_public, fx);
+                    let code = self.emit_function(function, None, is_public);
                     format!("{}{}", doc_comment, code)
                 }
             }
@@ -39,8 +38,7 @@ impl Planner<'_> {
                 ..
             } => {
                 let doc_comment = emit_doc(doc);
-                let code =
-                    self.emit_struct_definition(name, generics, fields, kind, attributes, fx);
+                let code = self.emit_struct_definition(name, generics, fields, kind, attributes);
                 format!("{}{}", doc_comment, code)
             }
             Expression::Enum {
@@ -52,7 +50,7 @@ impl Planner<'_> {
             } => {
                 let doc_comment = emit_doc(doc);
                 let code = self
-                    .emit_enum(name, generics, attributes, fx)
+                    .emit_enum(name, generics, attributes)
                     .unwrap_or_default();
                 format!("{}{}", doc_comment, code)
             }
@@ -64,7 +62,7 @@ impl Planner<'_> {
                 ..
             } => {
                 let doc_comment = emit_doc(doc);
-                let code = self.emit_type_alias(name, generics, ty, fx);
+                let code = self.emit_type_alias(name, generics, ty);
                 format!("{}{}", doc_comment, code)
             }
             Expression::Interface {
@@ -79,7 +77,7 @@ impl Planner<'_> {
                 let doc_comment = emit_doc(doc);
                 let is_public = matches!(visibility, Visibility::Public);
                 let code =
-                    self.emit_interface(name, method_signatures, parents, generics, is_public, fx);
+                    self.emit_interface(name, method_signatures, parents, generics, is_public);
                 format!("{}{}", doc_comment, code)
             }
             Expression::ImplBlock {
@@ -88,7 +86,7 @@ impl Planner<'_> {
                 methods,
                 generics,
                 ..
-            } => self.emit_impl_block(receiver_name, ty, methods, generics, fx),
+            } => self.emit_impl_block(receiver_name, ty, methods, generics),
             Expression::Const {
                 doc,
                 identifier,
@@ -97,7 +95,7 @@ impl Planner<'_> {
                 ..
             } => {
                 let doc_comment = emit_doc(doc);
-                let code = self.emit_const(identifier, expression, ty, fx);
+                let code = self.emit_const(identifier, expression, ty);
                 format!("{}{}", doc_comment, code)
             }
             _ => String::new(),
@@ -110,10 +108,9 @@ impl Planner<'_> {
         function: FunctionDefinitionView<'_>,
         is_public: bool,
         doc_comment: &str,
-        fx: &mut EmitEffects,
     ) -> String {
-        fx.require_testing();
-        fx.require_testkit();
+        self.require_testing();
+        self.require_testkit();
         let test_kit = testkit_qualifier();
         let testing = testing_qualifier();
 
@@ -126,7 +123,7 @@ impl Planner<'_> {
         let callee = self.pick_go_function_name(function, false, is_public);
         let test_name = go_name::go_test_function_name(name);
         let handle = go_name::TEST_T_PARAM;
-        let code = self.emit_function(function, None, is_public, fx);
+        let code = self.emit_function(function, None, is_public);
 
         let span = function.name_span;
         let recover = format!(

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -2,7 +2,6 @@ use crate::abi::is_tagged_shape_fn_value;
 use crate::expressions::access::struct_call::emit_struct_literal;
 use syntax::program::DefinitionBody;
 
-use crate::EmitEffects;
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::abi::AbiShape;
@@ -26,32 +25,30 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Some(strategy) = self.classify_go_fn_value(expression) {
             if !self.go_fn_matches_lowered_slot(expression, &strategy, ctx) {
                 let mut setup = Vec::new();
                 let value = if self.go_fn_needs_lowered_tuple_adapter(expression, ctx) {
-                    self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression, fx)
+                    self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression)
                 } else {
-                    self.emit_go_fn_wrapper(&mut setup, expression, &strategy, fx)
+                    self.emit_go_fn_wrapper(&mut setup, expression, &strategy)
                 };
                 return value_plan_from_statements(setup, value);
             }
         } else if self.is_go_array_return_value(expression) {
             let mut setup = Vec::new();
-            let value = self.emit_array_return_wrapper(&mut setup, expression, fx);
+            let value = self.emit_array_return_wrapper(&mut setup, expression);
             return value_plan_from_statements(setup, value);
         }
 
-        self.plan_operand(expression, ctx, fx)
+        self.plan_operand(expression, ctx)
     }
 
     pub(crate) fn lower_composite_value(
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if expression.get_type().is_unit()
             && matches!(
@@ -59,13 +56,13 @@ impl Planner<'_> {
                 Expression::Call { .. } | Expression::Block { .. }
             )
         {
-            let (mut setup, call_str) = self.lower_value(expression, ctx, fx).into_parts();
+            let (mut setup, call_str) = self.lower_value(expression, ctx).into_parts();
             if !call_str.is_empty() {
                 setup.push(LoweredStatement::RawGo(format!("{call_str}\n")));
             }
             return value_plan_from_statements(setup, "struct{}{}".to_string());
         }
-        self.lower_value(expression, ctx, fx)
+        self.lower_value(expression, ctx)
     }
 
     /// Wrap a captured tagged-shape prelude fn ref into a lowered-ABI closure
@@ -77,7 +74,6 @@ impl Planner<'_> {
         ty: &Type,
         raw: String,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> String {
         if ctx.is_callee() || ctx.forces_tagged_go_function() {
             return raw;
@@ -92,7 +88,7 @@ impl Planner<'_> {
         if self.classify_direct_emission(&f.return_type).is_none() {
             return raw;
         }
-        emit_lisette_callback_wrapper(self, setup, &raw, fn_ty, fx)
+        emit_lisette_callback_wrapper(self, setup, &raw, fn_ty)
     }
 
     /// True when a Go function value's natural ABI matches the slot's
@@ -154,30 +150,28 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         match expression {
-            Expression::Literal { literal, ty, .. } => self.emit_literal(literal, ty, fx),
+            Expression::Literal { literal, ty, .. } => self.emit_literal(literal, ty),
             Expression::Identifier { value, ty, .. } => {
                 let mut setup: Vec<LoweredStatement> = Vec::new();
-                let raw = self.emit_identifier(value, ty, ctx, fx);
-                let value =
-                    self.maybe_lower_tagged_fn_ref(&mut setup, expression, ty, raw, ctx, fx);
+                let raw = self.emit_identifier(value, ty, ctx);
+                let value = self.maybe_lower_tagged_fn_ref(&mut setup, expression, ty, raw, ctx);
                 value_plan_from_statements(setup, value)
             }
             Expression::Call { ty, .. } => match self.classify_call(expression) {
                 CallBoundary::GoWrapped(strategy) => {
-                    self.lower_go_wrapped_call(expression, &strategy, ty, fx)
+                    self.lower_go_wrapped_call(expression, &strategy, ty)
                 }
                 CallBoundary::LoweredCallee(shape) => {
-                    fx.require_stdlib();
-                    let (mut setup, call_str) = self.lower_call(expression, Some(ty), ctx, fx);
-                    let (wrap, value) = lower_callee_abi_wrapping(self, &shape, &call_str, ty, fx);
+                    self.require_stdlib();
+                    let (mut setup, call_str) = self.lower_call(expression, Some(ty), ctx);
+                    let (wrap, value) = lower_callee_abi_wrapping(self, &shape, &call_str, ty);
                     setup.extend(wrap);
                     value_plan_from_statements(setup, value)
                 }
                 CallBoundary::Plain => {
-                    let (setup, value) = self.lower_call(expression, Some(ty), ctx, fx);
+                    let (setup, value) = self.lower_call(expression, Some(ty), ctx);
                     value_plan_from_statements(setup, value)
                 }
             },
@@ -189,24 +183,24 @@ impl Planner<'_> {
             }
             | Expression::Function {
                 params, body, ty, ..
-            } => ValuePlan::Operand(self.emit_lambda(params, body, ty, ctx, fx)),
+            } => ValuePlan::Operand(self.emit_lambda(params, body, ty, ctx)),
             Expression::IfLet { ty, .. }
             | Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
-            | Expression::Block { ty, .. } => self.lower_to_operand_temp(expression, ty, fx),
+            | Expression::Block { ty, .. } => self.lower_to_operand_temp(expression, ty),
             Expression::Return {
                 expression: return_expression,
                 ..
             } => {
-                let plan = self.build_return_plan(return_expression, fx);
+                let plan = self.build_return_plan(return_expression);
                 value_plan_from_statements(vec![LoweredStatement::Return(plan)], String::new())
             }
             Expression::Assignment { target, value, .. } => {
-                let setup = self.lower_assignment_operand(target, value, fx);
+                let setup = self.lower_assignment_operand(target, value);
                 value_plan_from_statements(setup, "struct{}{}".to_string())
             }
             Expression::Assert { .. } => value_plan_from_statements(
-                vec![self.lower_assert_statement(expression, fx)],
+                vec![self.lower_assert_statement(expression)],
                 "struct{}{}".to_string(),
             ),
             _ => unreachable!(
@@ -224,7 +218,6 @@ impl Planner<'_> {
         elements: &[Expression],
         ty: &Type,
         in_tail: bool,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         use value_plan_from_statements;
 
@@ -240,7 +233,7 @@ impl Planner<'_> {
             .map(|(i, e)| {
                 let element_ctx =
                     ExpressionContext::value().with_expected_slot_type(slot_types.get(i));
-                self.stage_composite(e, element_ctx, fx)
+                self.stage_composite(e, element_ctx)
             })
             .collect();
         let (mut setup, element_expressions) = self.sequence_structured(stages, "_v");
@@ -255,7 +248,7 @@ impl Planner<'_> {
                         slot,
                         CoercionDirection::Internal,
                     );
-                    let (coercion_setup, coerced) = coercion.lower(self, emitted, fx);
+                    let (coercion_setup, coerced) = coercion.lower(self, emitted);
                     setup.extend(coercion_setup);
                     coerced
                 }
@@ -265,7 +258,7 @@ impl Planner<'_> {
         }
         let element_expressions = wrapped_expressions;
 
-        fx.require_stdlib();
+        self.require_stdlib();
         let arity = element_expressions.len();
 
         let needs_explicit_type_args =
@@ -278,10 +271,8 @@ impl Planner<'_> {
                 element_expressions.join(", ")
             )
         } else {
-            let slot_ty_strs: Vec<String> = slot_types
-                .iter()
-                .map(|t| self.go_type_string(t, fx))
-                .collect();
+            let slot_ty_strs: Vec<String> =
+                slot_types.iter().map(|t| self.go_type_string(t)).collect();
             format!(
                 "lisette.MakeTuple{}[{}]({})",
                 arity,
@@ -302,22 +293,21 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let inner = self.plan_operand(expression, ctx, fx);
+        let inner = self.plan_operand(expression, ctx);
 
         if self.facts.is_interface(ty) {
             let (mut setup, value) = inner.into_parts();
             let source_ty = expression.get_type();
             let coercion = Coercion::resolve(self, &source_ty, ty, CoercionDirection::Internal);
-            let (coercion_setup, coerced) = coercion.lower(self, value, fx);
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             return value_plan_from_statements(setup, coerced);
         }
 
-        let go_type = self.go_type_string(ty, fx);
+        let go_type = self.go_type_string(ty);
 
-        if let Some(source_go_type) = self.shift_pin_go_type(expression, ty, fx) {
+        if let Some(source_go_type) = self.shift_pin_go_type(expression, ty) {
             return ValuePlan::Cast {
                 go_type,
                 inner: Box::new(ValuePlan::Cast {
@@ -333,12 +323,7 @@ impl Planner<'_> {
         }
     }
 
-    fn shift_pin_go_type(
-        &self,
-        expression: &Expression,
-        target_ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> Option<String> {
+    fn shift_pin_go_type(&self, expression: &Expression, target_ty: &Type) -> Option<String> {
         let target_is_float = target_ty
             .underlying_simple_kind()
             .is_some_and(|kind| kind.is_float());
@@ -349,19 +334,14 @@ impl Planner<'_> {
         source_ty
             .underlying_simple_kind()
             .is_some_and(|kind| kind.integer_range().is_some())
-            .then(|| self.go_type_string(&source_ty, fx))
+            .then(|| self.go_type_string(&source_ty))
     }
 
     /// Plan a `&inner` reference, hoisting to a temp when the inner is
     /// Go-unaddressable.
-    pub(crate) fn plan_reference(
-        &mut self,
-        inner: &Expression,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> ValuePlan {
+    pub(crate) fn plan_reference(&mut self, inner: &Expression, ty: &Type) -> ValuePlan {
         if inner.get_type().is_unit() && matches!(inner.unwrap_parens(), Expression::Call { .. }) {
-            let staged = self.stage_operand(inner.unwrap_parens(), ExpressionContext::value(), fx);
+            let staged = self.stage_operand(inner.unwrap_parens(), ExpressionContext::value());
             let mut setup = staged.setup;
             if !staged.value.is_empty() {
                 setup.push(LoweredStatement::Expression(ExpressionStatementPlan {
@@ -375,7 +355,7 @@ impl Planner<'_> {
         }
 
         let (mut setup, emitted) = self
-            .lower_value(inner, ExpressionContext::value(), fx)
+            .lower_value(inner, ExpressionContext::value())
             .into_parts();
 
         let value = if inner.get_type() == *ty {
@@ -411,15 +391,14 @@ impl Planner<'_> {
         &mut self,
         target: &Expression,
         value: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let rhs_staged = self.stage_composite(value, ExpressionContext::value(), fx);
+        let rhs_staged = self.stage_composite(value, ExpressionContext::value());
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut setup, target, !rhs_staged.setup.is_empty(), fx)
+            self.emit_left_value_capturing(&mut setup, target, !rhs_staged.setup.is_empty())
         } else {
-            self.emit_left_value(&mut setup, target, fx)
+            self.emit_left_value(&mut setup, target)
         };
         setup.extend(rhs_staged.setup);
 
@@ -433,7 +412,7 @@ impl Planner<'_> {
         {
             let coercion =
                 Coercion::resolve(self, &value.get_type(), ty, CoercionDirection::ToGoBoundary);
-            let (coercion_setup, unwrapped) = coercion.lower(self, rhs_staged.value, fx);
+            let (coercion_setup, unwrapped) = coercion.lower(self, rhs_staged.value);
             setup.extend(coercion_setup);
             setup.push(LoweredStatement::RawGo(format!(
                 "{} = {}\n",
@@ -454,17 +433,16 @@ impl Planner<'_> {
         end: &Option<Box<Expression>>,
         _inclusive: bool,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let type_string = self.go_type_string(ty, fx);
+        let type_string = self.go_type_string(ty);
 
         let mut stages: Vec<StagedExpression> = Vec::new();
         let has_start = start.is_some();
         if let Some(s) = start {
-            stages.push(self.stage_operand(s, ExpressionContext::value(), fx));
+            stages.push(self.stage_operand(s, ExpressionContext::value()));
         }
         if let Some(e) = end {
-            stages.push(self.stage_operand(e, ExpressionContext::value(), fx));
+            stages.push(self.stage_operand(e, ExpressionContext::value()));
         }
 
         if stages.is_empty() {
@@ -509,10 +487,9 @@ impl Planner<'_> {
         &mut self,
         keyword: &str,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Expression::Block { .. } = expression {
-            let body = self.with_fresh_scope(|planner| planner.lower_block_as_body(expression, fx));
+            let body = self.with_fresh_scope(|planner| planner.lower_block_as_body(expression));
             let setup = vec![LoweredStatement::Expression(ExpressionStatementPlan {
                 form: ExpressionStatementForm::AsyncBlock {
                     keyword: keyword.to_string(),
@@ -523,17 +500,17 @@ impl Planner<'_> {
         }
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        if let Some(call_str) = self.emit_go_call_discarded(&mut setup, expression, fx) {
+        if let Some(call_str) = self.emit_go_call_discarded(&mut setup, expression) {
             return value_plan_from_statements(setup, format!("{} {}", keyword, call_str));
         }
 
         let (setup, inner) = self
-            .lower_value(expression, ExpressionContext::value(), fx)
+            .lower_value(expression, ExpressionContext::value())
             .into_parts();
         if needs_iife_for_async(expression, &inner) {
             let (mut setup, inner) = self.with_eager_operand_capture(true, |planner| {
                 planner
-                    .lower_value(expression, ExpressionContext::value(), fx)
+                    .lower_value(expression, ExpressionContext::value())
                     .into_parts()
             });
             let mut body_statements = Vec::new();

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -35,6 +35,7 @@ pub use output::OutputFile;
 pub use output::imports;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -209,6 +210,61 @@ pub struct Planner<'a> {
     pub(crate) function_state: FunctionEmissionState,
     pub(crate) scope: ScopeState,
     pub(crate) adapter_registry: AdapterRegistry,
+    pub(crate) effects: RefCell<EmitEffects>,
+}
+
+impl Planner<'_> {
+    pub(crate) fn require_stdlib(&self) {
+        self.effects.borrow_mut().require_stdlib();
+    }
+
+    pub(crate) fn require_fmt(&self) {
+        self.effects.borrow_mut().require_fmt();
+    }
+
+    pub(crate) fn require_errors(&self) {
+        self.effects.borrow_mut().require_errors();
+    }
+
+    pub(crate) fn require_slices(&self) {
+        self.effects.borrow_mut().require_slices();
+    }
+
+    pub(crate) fn require_strings(&self) {
+        self.effects.borrow_mut().require_strings();
+    }
+
+    pub(crate) fn require_maps(&self) {
+        self.effects.borrow_mut().require_maps();
+    }
+
+    pub(crate) fn require_json(&self) {
+        self.effects.borrow_mut().require_json();
+    }
+
+    pub(crate) fn require_cmp(&self) {
+        self.effects.borrow_mut().require_cmp();
+    }
+
+    pub(crate) fn require_testkit(&self) {
+        self.effects.borrow_mut().require_testkit();
+    }
+
+    pub(crate) fn require_testing(&self) {
+        self.effects.borrow_mut().require_testing();
+    }
+
+    pub(crate) fn note_go_type(&self, go_type: &crate::types::go_type::GoType) {
+        self.effects.borrow_mut().merge_from_go_type(go_type);
+    }
+
+    pub(crate) fn absorb_effects(&self, other: &EmitEffects) {
+        self.effects.borrow_mut().extend(other);
+    }
+
+    pub(crate) fn take_effects(&self) -> EmitEffects {
+        std::mem::take(&mut *self.effects.borrow_mut())
+    }
 }
 
 impl<'a> Planner<'a> {
@@ -318,6 +374,7 @@ impl<'a> Planner<'a> {
             function_state: FunctionEmissionState::default(),
             scope: ScopeState::new(),
             adapter_registry: AdapterRegistry::default(),
+            effects: RefCell::new(EmitEffects::default()),
         }
     }
 
@@ -501,10 +558,9 @@ impl<'a> Planner<'a> {
                 source.collect_with_blank(function.clone());
             }
 
-            let mut fx = EmitEffects::default();
             for expression in &file.items {
                 self.scope.reset_for_top_level();
-                let code = self.emit_top_item(expression, &mut fx);
+                let code = self.emit_top_item(expression);
                 if !code.is_empty() {
                     source.collect_with_blank(code);
                 }
@@ -517,7 +573,7 @@ impl<'a> Planner<'a> {
             );
 
             self.drain_file_emission_into(&mut source);
-            fx.drain_into(&mut import_builder);
+            self.take_effects().drain_into(&mut import_builder);
             if i == 0 {
                 plan.collection_effects.drain_into(&mut import_builder);
             }

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -1,6 +1,5 @@
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::names::constraints::{ConstraintAtom, ParamConstraintSet, classify_builtin_name};
 use syntax::EcoString;
@@ -41,7 +40,6 @@ impl Planner<'_> {
         &mut self,
         symbol: &str,
         generics: &[Generic],
-        fx: &mut EmitEffects,
     ) -> String {
         if generics.is_empty() {
             return String::new();
@@ -57,7 +55,7 @@ impl Planner<'_> {
                 let set = constraints
                     .as_ref()
                     .and_then(|sets| sets.iter().find(|s| s.name == g.name));
-                let constraint = self.render_constraint(g, set, fx);
+                let constraint = self.render_constraint(g, set);
                 format!("{} {}", g.name, constraint)
             })
             .collect::<Vec<_>>()
@@ -70,7 +68,6 @@ impl Planner<'_> {
         &mut self,
         generic: &Generic,
         constraint_set: Option<&ParamConstraintSet>,
-        fx: &mut EmitEffects,
     ) -> String {
         let (explicit_atoms, inferred_comparable) = match constraint_set {
             Some(set) => (set.explicit.clone(), set.inferred_comparable),
@@ -107,11 +104,11 @@ impl Planner<'_> {
                     comparable_seen = true;
                 }
                 ConstraintAtom::Ordered => {
-                    fx.require_cmp();
+                    self.require_cmp();
                     named_bounds.push("cmp.Ordered".to_string());
                 }
                 ConstraintAtom::Named(ann) => {
-                    named_bounds.push(self.named_bound_go_type(ann, fx));
+                    named_bounds.push(self.named_bound_go_type(ann));
                 }
             }
         }
@@ -127,13 +124,13 @@ impl Planner<'_> {
         }
     }
 
-    fn named_bound_go_type(&mut self, annotation: &Annotation, fx: &mut EmitEffects) -> String {
+    fn named_bound_go_type(&mut self, annotation: &Annotation) -> String {
         let resolved = self
             .facts
             .resolved_bound_type(annotation.get_span())
             .cloned()
             .expect("checker records a resolved type for every generic bound");
-        self.go_type_string(&resolved, fx)
+        self.go_type_string(&resolved)
     }
 }
 

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -5,14 +5,14 @@ use crate::Planner;
 use crate::names::go_name;
 
 impl Planner<'_> {
-    pub(crate) fn resolve_go_name(&mut self, name: &str, fx: &mut EmitEffects) -> String {
+    pub(crate) fn resolve_go_name(&mut self, name: &str) -> String {
         if !name.contains('.')
             && let Some(remapped) = self.module.escape_remap(name)
         {
             return remapped.to_string();
         }
 
-        if let Some(go_call) = self.try_resolve_cross_module_static_method(name, fx) {
+        if let Some(go_call) = self.try_resolve_cross_module_static_method(name) {
             return go_call;
         }
 
@@ -40,7 +40,7 @@ impl Planner<'_> {
 
         let resolved = go_name::resolve(&name);
         if resolved.needs_stdlib {
-            fx.require_stdlib();
+            self.require_stdlib();
         }
         resolved.name
     }
@@ -86,19 +86,24 @@ impl Planner<'_> {
         }
     }
 
-    /// Record the module import into `fx` and return the package qualifier
-    /// exactly as the import renders it: `format_import` sanitizes default
-    /// package names and prints explicit aliases verbatim, so references
-    /// must follow the same rule.
-    pub(crate) fn require_module_import_fx(&self, module: &str, fx: &mut EmitEffects) -> String {
+    /// Record `module`'s Go import into `effects` and return the package
+    /// qualifier exactly as the import renders it: `format_import` sanitizes
+    /// default package names and prints explicit aliases verbatim, so
+    /// references must follow the same rule.
+    pub(crate) fn record_module_import(&self, module: &str, effects: &mut EmitEffects) -> String {
         let path = self.go_import_path_for_module(module);
-        fx.require_go_import(path.clone());
+        effects.require_go_import(path.clone());
         let qualifier = self.go_pkg_qualifier(module);
         if qualifier == go_name::go_package_name(&path) {
             go_name::sanitize_package_name(&qualifier).into_owned()
         } else {
             qualifier
         }
+    }
+
+    /// `record_module_import` writing into the file effects sink.
+    pub(crate) fn require_module_import(&self, module: &str) -> String {
+        self.record_module_import(module, &mut self.effects.borrow_mut())
     }
 
     pub(crate) fn go_import_path_for_module(&self, module: &str) -> String {
@@ -130,7 +135,6 @@ impl Planner<'_> {
         type_id: &str,
         method: &str,
         is_public: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let module = self
             .facts
@@ -138,9 +142,7 @@ impl Planner<'_> {
             .map(str::to_string);
         let type_name = unqualified_name(type_id);
         let computed_alias = match module.as_deref() {
-            Some(m) if self.facts.is_foreign_module(m) => {
-                Some(self.require_module_import_fx(m, fx))
-            }
+            Some(m) if self.facts.is_foreign_module(m) => Some(self.require_module_import(m)),
             _ => None,
         };
         let resolved = go_name::qualify_method(
@@ -152,23 +154,18 @@ impl Planner<'_> {
             computed_alias.as_deref(),
         );
         if resolved.needs_stdlib {
-            fx.require_stdlib();
+            self.require_stdlib();
         }
         resolved.name
     }
 
-    pub(crate) fn resolve_variant(
-        &mut self,
-        identifier: &str,
-        enum_id: &str,
-        fx: &mut EmitEffects,
-    ) -> String {
+    pub(crate) fn resolve_variant(&mut self, identifier: &str, enum_id: &str) -> String {
         let enum_module = self
             .facts
             .module_for_qualified_name(enum_id)
             .unwrap_or(enum_id);
         let computed_alias = if self.facts.is_foreign_module(enum_module) {
-            Some(self.require_module_import_fx(enum_module, fx))
+            Some(self.require_module_import(enum_module))
         } else {
             None
         };
@@ -180,7 +177,7 @@ impl Planner<'_> {
             computed_alias.as_deref(),
         );
         if resolved.needs_stdlib {
-            fx.require_stdlib();
+            self.require_stdlib();
         }
         resolved.name
     }

--- a/crates/emit/src/patterns/binding_decls.rs
+++ b/crates/emit/src/patterns/binding_decls.rs
@@ -6,7 +6,6 @@ use syntax::ast::{
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Type, unqualified_name};
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::expressions::literals::{convert_escape_sequences, emit_raw_string};
 use crate::names::generics;
@@ -163,21 +162,18 @@ impl Planner<'_> {
         pattern: &Pattern,
         ty: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         match pattern {
             Pattern::Identifier { identifier, .. } => {
-                self.declare_pattern_var(statements, pattern, identifier, ty, fx);
+                self.declare_pattern_var(statements, pattern, identifier, ty);
             }
             Pattern::Tuple { elements, .. } => {
-                self.lower_tuple_pattern_declarations(statements, elements, ty, typed, fx);
+                self.lower_tuple_pattern_declarations(statements, elements, ty, typed);
             }
             Pattern::Struct {
                 fields, identifier, ..
             } => {
-                self.lower_struct_pattern_declarations(
-                    statements, fields, identifier, ty, typed, fx,
-                );
+                self.lower_struct_pattern_declarations(statements, fields, identifier, ty, typed);
             }
             Pattern::EnumVariant {
                 fields,
@@ -186,11 +182,11 @@ impl Planner<'_> {
                 ..
             } => {
                 self.lower_enum_variant_pattern_declarations(
-                    statements, fields, identifier, pattern_ty, ty, typed, fx,
+                    statements, fields, identifier, pattern_ty, ty, typed,
                 );
             }
             Pattern::Slice { prefix, rest, .. } => {
-                self.lower_slice_pattern_declarations(statements, prefix, rest, ty, typed, fx);
+                self.lower_slice_pattern_declarations(statements, prefix, rest, ty, typed);
             }
             Pattern::Or { patterns, .. } => {
                 let Some(first) = patterns.first() else {
@@ -200,15 +196,15 @@ impl Planner<'_> {
                     Some(TypedPattern::Or { alternatives }) => alternatives.first(),
                     _ => None,
                 };
-                self.lower_binding_declarations_with_type(statements, first, ty, alt, fx);
+                self.lower_binding_declarations_with_type(statements, first, ty, alt);
             }
             p @ Pattern::AsBinding {
                 pattern: inner,
                 name,
                 ..
             } => {
-                self.lower_binding_declarations_with_type(statements, inner, ty, typed, fx);
-                self.declare_pattern_var(statements, p, name, ty, fx);
+                self.lower_binding_declarations_with_type(statements, inner, ty, typed);
+                self.declare_pattern_var(statements, p, name, ty);
             }
             Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => {}
         }
@@ -221,13 +217,12 @@ impl Planner<'_> {
         pattern: &Pattern,
         lisette_name: &EcoString,
         resolved: &Type,
-        fx: &mut EmitEffects,
     ) {
         let Some(go_name) = self.go_name_for_binding(pattern) else {
             self.scope.bind(lisette_name, "_");
             return;
         };
-        self.declare_var_declaration(statements, lisette_name, go_name, resolved, fx);
+        self.declare_var_declaration(statements, lisette_name, go_name, resolved);
     }
 
     /// Freshen `go_name`, register the binding, emit `var X T`.
@@ -237,7 +232,6 @@ impl Planner<'_> {
         lisette_name: &EcoString,
         go_name: String,
         resolved: &Type,
-        fx: &mut EmitEffects,
     ) {
         let go_name = if self.is_declared(&go_name) {
             self.fresh_var(Some(lisette_name))
@@ -246,7 +240,7 @@ impl Planner<'_> {
         };
         let go_name = self.scope.bind(lisette_name, go_name);
         self.declare(&go_name);
-        let go_ty = self.go_type_string(resolved, fx);
+        let go_ty = self.go_type_string(resolved);
         statements.push(LoweredStatement::VarDecl {
             name: go_name,
             go_type: go_ty,
@@ -261,7 +255,6 @@ impl Planner<'_> {
         elements: &[Pattern],
         resolved: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         let typed_elements: &[TypedPattern] = match typed {
             Some(TypedPattern::Tuple { elements: te, .. }) => te.as_slice(),
@@ -278,7 +271,6 @@ impl Planner<'_> {
                 element,
                 element_ty,
                 typed_elements.get(i),
-                fx,
             );
         }
     }
@@ -292,7 +284,6 @@ impl Planner<'_> {
         identifier: &EcoString,
         resolved: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         match typed {
             Some(TypedPattern::Struct {
@@ -317,7 +308,6 @@ impl Planner<'_> {
                     struct_fields,
                     GenericArgs { generics, params },
                     Some(pattern_fields),
-                    fx,
                 );
             }
             Some(TypedPattern::EnumStructVariant {
@@ -342,10 +332,9 @@ impl Planner<'_> {
                     variant_fields,
                     GenericArgs { generics, params },
                     Some(pattern_fields),
-                    fx,
                 );
             }
-            _ => self.lower_struct_pattern_fallback(statements, fields, identifier, resolved, fx),
+            _ => self.lower_struct_pattern_fallback(statements, fields, identifier, resolved),
         }
     }
 
@@ -356,7 +345,6 @@ impl Planner<'_> {
         fields: &[StructFieldPattern],
         identifier: &EcoString,
         resolved: &Type,
-        fx: &mut EmitEffects,
     ) {
         let Type::Nominal { id, params, .. } = resolved else {
             return;
@@ -373,7 +361,6 @@ impl Planner<'_> {
                     field_definitions,
                     GenericArgs { generics, params },
                     None,
-                    fx,
                 );
             }
             Some(DefinitionBody::Enum {
@@ -387,7 +374,6 @@ impl Planner<'_> {
                         variant_fields_slice(&variant.fields),
                         GenericArgs { generics, params },
                         None,
-                        fx,
                     );
                 }
             }
@@ -406,10 +392,9 @@ impl Planner<'_> {
         pattern_ty: &Type,
         resolved: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         if self.is_tuple_struct_type(pattern_ty) {
-            self.lower_tuple_struct_variant_declarations(statements, fields, resolved, typed, fx);
+            self.lower_tuple_struct_variant_declarations(statements, fields, resolved, typed);
             return;
         }
 
@@ -440,7 +425,6 @@ impl Planner<'_> {
                 variant_fields,
                 GenericArgs { generics, params },
                 typed_fields,
-                fx,
             );
             return;
         }
@@ -467,7 +451,6 @@ impl Planner<'_> {
             variant_fields_slice(&variant.fields),
             GenericArgs { generics, params },
             None,
-            fx,
         );
     }
 
@@ -478,7 +461,6 @@ impl Planner<'_> {
         fields: &[Pattern],
         resolved: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         let Type::Nominal { id, params, .. } = resolved else {
             return;
@@ -506,7 +488,6 @@ impl Planner<'_> {
             field_definitions,
             GenericArgs { generics, params },
             typed_fields,
-            fx,
         );
     }
 
@@ -518,7 +499,6 @@ impl Planner<'_> {
         rest: &RestPattern,
         resolved: &Type,
         typed: Option<&TypedPattern>,
-        fx: &mut EmitEffects,
     ) {
         let (element_ty, typed_prefix): (Type, Option<&[TypedPattern]>) = match typed {
             Some(TypedPattern::Slice {
@@ -544,14 +524,13 @@ impl Planner<'_> {
                 element,
                 &element_ty,
                 typed_child,
-                fx,
             );
         }
 
         if let RestPattern::Bind { name, .. } = rest
             && let Some(go_name) = self.go_name_for_rest_binding(rest)
         {
-            self.declare_var_declaration(statements, name, go_name, resolved, fx);
+            self.declare_var_declaration(statements, name, go_name, resolved);
         }
     }
 
@@ -564,7 +543,6 @@ impl Planner<'_> {
         definitions: &[F],
         generic_args: GenericArgs,
         typed_pf: Option<&[(EcoString, TypedPattern)]>,
-        fx: &mut EmitEffects,
     ) {
         let GenericArgs { generics, params } = generic_args;
         for pattern in patterns {
@@ -582,7 +560,6 @@ impl Planner<'_> {
                 &pattern.value,
                 &field_ty,
                 typed_child,
-                fx,
             );
         }
     }
@@ -595,19 +572,12 @@ impl Planner<'_> {
         definitions: &[F],
         generic_args: GenericArgs,
         typed_fields: Option<&[TypedPattern]>,
-        fx: &mut EmitEffects,
     ) {
         let GenericArgs { generics, params } = generic_args;
         for (i, (pattern, definition)) in patterns.iter().zip(definitions.iter()).enumerate() {
             let field_ty = generics::resolve_field_type(generics, params, definition.ty());
             let typed_child = typed_fields.and_then(|tf| tf.get(i));
-            self.lower_binding_declarations_with_type(
-                statements,
-                pattern,
-                &field_ty,
-                typed_child,
-                fx,
-            );
+            self.lower_binding_declarations_with_type(statements, pattern, &field_ty, typed_child);
         }
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1079,7 +1079,7 @@ fn collect_const_pattern_check(
             if qualifier.is_empty() || qualifier == planner.facts.current_module() {
                 const_name.to_string()
             } else {
-                let qualifier = planner.require_module_import_fx(module, &mut collector.effects);
+                let qualifier = planner.record_module_import(module, &mut collector.effects);
                 format!("{}.{}", qualifier, const_name)
             }
         }
@@ -1187,7 +1187,7 @@ fn collect_tagged_enum_checks(
 ) {
     let enum_module = enum_module_of(planner, variant.ty);
     let alias = if planner.facts.is_foreign_module(enum_module) {
-        Some(planner.require_module_import_fx(enum_module, &mut collector.effects))
+        Some(planner.record_module_import(enum_module, &mut collector.effects))
     } else {
         None
     };
@@ -1345,7 +1345,7 @@ fn resolve_struct_child_path(
     if enum_info.is_some() {
         let enum_module = enum_module_of(planner, ty);
         let alias = if planner.facts.is_foreign_module(enum_module) {
-            Some(planner.require_module_import_fx(enum_module, &mut collector.effects))
+            Some(planner.record_module_import(enum_module, &mut collector.effects))
         } else {
             None
         };

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::abi::AbiShape;
@@ -31,26 +30,25 @@ impl Planner<'_> {
         subject: &Expression,
         arms: &[MatchArm],
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         let mut statements: Vec<LoweredStatement> = Vec::new();
 
         if subject.get_type().is_never() {
-            statements.push(self.lower_statement(subject, fx));
+            statements.push(self.lower_statement(subject));
             return LoweredBlock { statements };
         }
 
-        if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place, fx) {
+        if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place) {
             statements.extend(fused);
             return LoweredBlock { statements };
         }
 
         let subject_ty = subject.get_type();
         let (subject_var, declaration) =
-            self.lower_match_subject_var(&mut statements, subject, arms, fx);
+            self.lower_match_subject_var(&mut statements, subject, arms);
 
         self.scope.enter_use_region();
-        let block = self.lower_match_tree(arms, subject_var.clone(), subject_ty, place, fx);
+        let block = self.lower_match_tree(arms, subject_var.clone(), subject_ty, place);
         let used_set = self.scope.exit_use_region();
         let used = used_set.contains(&subject_var);
 
@@ -83,9 +81,8 @@ impl Planner<'_> {
         subject_var: String,
         subject_ty: syntax::types::Type,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
-        let tree_emitter = TreePlanner::new(self, arms, subject_var, subject_ty, fx);
+        let tree_emitter = TreePlanner::new(self, arms, subject_var, subject_ty);
         tree_emitter.lower(place)
     }
 
@@ -120,7 +117,6 @@ impl Planner<'_> {
         subject: &Expression,
         arms: &[MatchArm],
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let plan = self.plan_call(subject)?;
         let shape = self.fusable_result_shape(subject, &plan)?;
@@ -146,8 +142,7 @@ impl Planner<'_> {
         let err_var = self.fresh_var(Some("ret"));
         self.declare(&err_var);
 
-        let (mut statements, call_str) =
-            self.lower_call(subject, None, ExpressionContext::value(), fx);
+        let (mut statements, call_str) = self.lower_call(subject, None, ExpressionContext::value());
         let bind_line = match &val_var {
             Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
             None => match shape {
@@ -161,17 +156,12 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let then_body = self.lower_fused_arm(
-            ok_name.zip(val_var.as_deref()),
-            &ok_arm.expression,
-            place,
-            fx,
-        );
+        let then_body =
+            self.lower_fused_arm(ok_name.zip(val_var.as_deref()), &ok_arm.expression, place);
         let else_body = self.lower_fused_arm(
             err_name.map(|n| (n, err_var.as_str())),
             &err_arm.expression,
             place,
-            fx,
         );
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -190,7 +180,6 @@ impl Planner<'_> {
         binding: Option<(&str, &str)>,
         body: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         self.scope.push_binding_frame();
         let bound = binding.map(|(name, value)| {
@@ -199,7 +188,7 @@ impl Planner<'_> {
             (go_name, value.to_string())
         });
         self.scope.enter_use_region();
-        let body_block = self.lower_block_to_place(body, place, fx);
+        let body_block = self.lower_block_to_place(body, place);
         let used = self.scope.exit_use_region();
         let mut statements = Vec::new();
         if let Some((go_name, value)) = &bound {
@@ -222,7 +211,6 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         subject: &Expression,
         arms: &[MatchArm],
-        fx: &mut EmitEffects,
     ) -> (String, SubjectDeclaration) {
         let any_guard = arms.iter().any(|arm| arm.has_guard());
         if let Expression::Identifier { value, .. } = subject
@@ -242,13 +230,13 @@ impl Planner<'_> {
             }
         }
         if matches!(subject, Expression::Literal { .. }) {
-            let staged = self.stage_operand(subject, ExpressionContext::value(), fx);
+            let staged = self.stage_operand(subject, ExpressionContext::value());
             setup.extend(staged.setup);
             return (staged.value, SubjectDeclaration::None);
         }
         let var = self.fresh_var(Some("subject"));
         self.declare(&var);
-        let staged = self.stage_composite(subject, ExpressionContext::value(), fx);
+        let staged = self.stage_composite(subject, ExpressionContext::value());
         setup.extend(staged.setup);
         if !any_guard && is_plain_go_identifier(&staged.value) {
             return (staged.value, SubjectDeclaration::None);

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use syntax::ast::{Expression, MatchArm, Pattern, Span, TypedPattern};
 use syntax::types::Type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
@@ -103,7 +102,6 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         subject: PatternSubject<'_>,
-        fx: &mut EmitEffects,
     ) -> ResolvedSubject {
         match subject {
             PatternSubject::Existing { var } => ResolvedSubject::Existing { var },
@@ -126,7 +124,7 @@ impl Planner<'_> {
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
                 let (op_setup, expression) = self
-                    .lower_value(scrutinee, ExpressionContext::value(), fx)
+                    .lower_value(scrutinee, ExpressionContext::value())
                     .into_parts();
                 setup.extend(op_setup);
                 ResolvedSubject::Composite { var, expression }
@@ -142,12 +140,11 @@ impl Planner<'_> {
         pattern: &Pattern,
         typed: Option<&TypedPattern>,
         subject_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
-        let resolved = self.resolve_pattern_subject(&mut statements, subject, fx);
+        let resolved = self.resolve_pattern_subject(&mut statements, subject);
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
-        fx.extend(&info.effects);
+        self.absorb_effects(&info.effects);
 
         let mut body = Vec::new();
         self.scope.enter_use_region();
@@ -172,14 +169,12 @@ impl Planner<'_> {
         binding_ty: &Type,
         scrutinee: &Expression,
         else_block: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         self.lower_refutable_let_site(
             ap,
             binding_ty,
             scrutinee,
             RefutableFail::ElseBlock(else_block),
-            fx,
         )
     }
 
@@ -189,14 +184,12 @@ impl Planner<'_> {
         binding_ty: &Type,
         scrutinee: &Expression,
         pattern_span: Span,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         self.lower_refutable_let_site(
             ap,
             binding_ty,
             scrutinee,
             RefutableFail::AssertFail(pattern_span),
-            fx,
         )
     }
 
@@ -206,14 +199,12 @@ impl Planner<'_> {
         binding_ty: &Type,
         scrutinee: &Expression,
         fail: RefutableFail,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let value_ty = scrutinee.get_type();
         let mut statements = Vec::new();
         let resolved = self.resolve_pattern_subject(
             &mut statements,
             PatternSubject::expression(scrutinee, ap.pattern, Some("subject")),
-            fx,
         );
         let subject = TypedSubject {
             var: resolved.var(),
@@ -222,9 +213,9 @@ impl Planner<'_> {
 
         self.scope.enter_use_region();
         let body = if matches!(ap.pattern, Pattern::Or { .. }) {
-            self.lower_let_else_or_pattern(ap, binding_ty, subject, fail, fx)
+            self.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
         } else {
-            self.lower_let_else_single_pattern(ap, subject, fail, fx)
+            self.lower_let_else_single_pattern(ap, subject, fail)
         };
         let used = self.scope.exit_use_region();
         let body_block = LoweredBlock { statements: body };
@@ -245,7 +236,6 @@ impl Planner<'_> {
         &mut self,
         pattern: &Pattern,
         scrutinee: &Expression,
-        fx: &mut EmitEffects,
     ) -> (String, Vec<LoweredStatement>) {
         if let Expression::Identifier { value, .. } = scrutinee {
             let has_collision = pattern_binds_name(pattern, value);
@@ -258,7 +248,7 @@ impl Planner<'_> {
             }
         }
         let var = self.fresh_var(Some("subject"));
-        let staged = self.stage_operand(scrutinee, ExpressionContext::value(), fx);
+        let staged = self.stage_operand(scrutinee, ExpressionContext::value());
         let mut setup = staged.setup;
         setup.push(LoweredStatement::TempBind {
             name: var.clone(),
@@ -274,12 +264,11 @@ impl Planner<'_> {
         scrutinee: &Expression,
         body: &Expression,
         needs_label: bool,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         self.set_current_loop_label_if_needed(needs_label);
         let label = self.current_loop_label().map(str::to_string);
         let scrutinee_ty = scrutinee.get_type();
-        let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee, fx);
+        let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee);
 
         // Or-patterns with bindings render an `if/else if` chain that closes its
         // own `for`, so they cannot wrap in a structured `Loop`; bridge them as
@@ -297,7 +286,6 @@ impl Planner<'_> {
                 },
                 body,
                 label.as_deref(),
-                fx,
             );
             return LoweredBlock {
                 statements: vec![LoweredStatement::Loop(LoopPlan {
@@ -312,7 +300,7 @@ impl Planner<'_> {
         }
 
         let info = decision_tree::collect_pattern_info(self, pattern, typed, &scrutinee_ty);
-        fx.extend(&info.effects);
+        self.absorb_effects(&info.effects);
         let mut loop_body = subject_setup;
         let (effective, ok_var) =
             apply_refutable_root_assertion(self, &mut loop_body, &info, &subject_var);
@@ -323,7 +311,7 @@ impl Planner<'_> {
         if !matches!(pattern, Pattern::Or { .. }) {
             tree_binding_statements(self, &mut then_body, &info.bindings, &effective, &[body]);
         }
-        then_body.extend(self.lower_block_as_body(body, fx).statements);
+        then_body.extend(self.lower_block_as_body(body).statements);
         self.exit_scope();
 
         loop_body.push(LoweredStatement::If(IfPlan {
@@ -354,20 +342,15 @@ impl Planner<'_> {
         }
     }
 
-    fn lower_refutable_fail(
-        &mut self,
-        fail: RefutableFail,
-        subject_var: &str,
-        fx: &mut EmitEffects,
-    ) -> LoweredBlock {
+    fn lower_refutable_fail(&mut self, fail: RefutableFail, subject_var: &str) -> LoweredBlock {
         match fail {
-            RefutableFail::ElseBlock(else_block) => self.lower_block_as_body(else_block, fx),
+            RefutableFail::ElseBlock(else_block) => self.lower_block_as_body(else_block),
             RefutableFail::AssertFail(span) => {
                 let handle = self
                     .current_test_handle()
                     .expect("let assert without a test handle should be rejected by semantics");
-                fx.require_testkit();
-                fx.require_stdlib();
+                self.require_testkit();
+                self.require_stdlib();
                 let testkit = testkit_qualifier();
                 let prelude = prelude_qualifier();
                 self.scope.record_go_use(subject_var);
@@ -391,7 +374,6 @@ impl Planner<'_> {
         ap: AnnotatedPattern,
         subject: TypedSubject,
         fail: RefutableFail,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern, typed } = ap;
         let TypedSubject {
@@ -399,7 +381,7 @@ impl Planner<'_> {
             ty: subject_ty,
         } = subject;
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
-        fx.extend(&info.effects);
+        self.absorb_effects(&info.effects);
 
         let mut statements = Vec::new();
         let (effective_subject, assert_ok_var) =
@@ -429,7 +411,7 @@ impl Planner<'_> {
             guard_parts.push(wrap_if_struct_literal(negated));
         }
         let guard = guard_parts.join(" || ");
-        let fail_body = self.lower_refutable_fail(fail, subject_var, fx);
+        let fail_body = self.lower_refutable_fail(fail, subject_var);
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
             condition: guard,
@@ -453,7 +435,6 @@ impl Planner<'_> {
         binding_ty: &Type,
         subject: TypedSubject,
         fail: RefutableFail,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern, typed } = ap;
         let TypedSubject {
@@ -465,12 +446,12 @@ impl Planner<'_> {
         };
         let pre_let_snapshot = self.scope.binding_snapshot();
         let mut statements = Vec::new();
-        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty, typed, fx);
+        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty, typed);
         let post_declaration_snapshot = self.scope.binding_snapshot();
 
         let mut asserts = Vec::new();
         let alts =
-            self.collect_let_else_alternatives(&mut asserts, patterns, subject_ty, subject_var, fx);
+            self.collect_let_else_alternatives(&mut asserts, patterns, subject_ty, subject_var);
 
         statements.extend(asserts);
 
@@ -526,7 +507,7 @@ impl Planner<'_> {
             }
             None => {
                 self.scope.restore_binding_snapshot(pre_let_snapshot);
-                let fail_lowered = self.lower_refutable_fail(fail, subject_var, fx);
+                let fail_lowered = self.lower_refutable_fail(fail, subject_var);
                 self.scope
                     .restore_binding_snapshot(post_declaration_snapshot);
                 fail_lowered
@@ -543,14 +524,13 @@ impl Planner<'_> {
         patterns: &[Pattern],
         subject_ty: &Type,
         subject_var: &'s str,
-        fx: &mut EmitEffects,
     ) -> LetElseAlternatives<'s> {
         let collected: Vec<PatternInfo> = patterns
             .iter()
             .map(|alt| decision_tree::collect_pattern_info(self, alt, None, subject_ty))
             .collect();
         for info in &collected {
-            fx.extend(&info.effects);
+            self.absorb_effects(&info.effects);
         }
         let hoisted: Vec<(Cow<'s, str>, Option<String>)> = collected
             .iter()
@@ -577,7 +557,6 @@ impl Planner<'_> {
         subject: TypedSubject,
         body: &Expression,
         label: Option<&str>,
-        fx: &mut EmitEffects,
     ) {
         let TypedSubject {
             var: subject_var,
@@ -588,7 +567,7 @@ impl Planner<'_> {
             .map(|alt| decision_tree::collect_pattern_info(self, alt, None, subject_ty))
             .collect();
         for info in &alternatives {
-            fx.extend(&info.effects);
+            self.absorb_effects(&info.effects);
         }
 
         let unused_names: rustc_hash::FxHashSet<String> = alternatives
@@ -619,7 +598,7 @@ impl Planner<'_> {
             let mut branch = Vec::new();
             let overlays =
                 tree_binding_statements(self, &mut branch, &info.bindings, effective, &[body]);
-            branch.extend(self.lower_block_as_body(body, fx).statements);
+            branch.extend(self.lower_block_as_body(body).statements);
             drop_inline_overlays(self, &overlays);
             self.exit_scope();
 
@@ -641,10 +620,9 @@ impl Planner<'_> {
         body: &Expression,
         default_body: Option<&Expression>,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        self.lower_refutable_arm(subject, ap, body, place, fx, |this, fx| {
-            default_body.map(|default| this.lower_block_to_place(default, place, fx))
+        self.lower_refutable_arm(subject, ap, body, place, |this| {
+            default_body.map(|default| this.lower_block_to_place(default, place))
         })
     }
 
@@ -655,10 +633,9 @@ impl Planner<'_> {
         some_body: &Expression,
         match_arms: &[MatchArm],
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        self.lower_refutable_arm(subject, ap, some_body, place, fx, |this, fx| {
-            Some(lower_none_arm_body(this, match_arms, place, fx))
+        self.lower_refutable_arm(subject, ap, some_body, place, |this| {
+            Some(lower_none_arm_body(this, match_arms, place))
         })
     }
 
@@ -671,8 +648,7 @@ impl Planner<'_> {
         ap: AnnotatedPattern,
         body: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
-        failure: impl FnOnce(&mut Planner, &mut EmitEffects) -> Option<LoweredBlock>,
+        failure: impl FnOnce(&mut Planner) -> Option<LoweredBlock>,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern, typed } = ap;
         let TypedSubject {
@@ -680,14 +656,14 @@ impl Planner<'_> {
             ty: subject_ty,
         } = subject;
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
-        fx.extend(&info.effects);
+        self.absorb_effects(&info.effects);
         let mut statements = Vec::new();
         let (effective, ok_var) =
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if info.checks.is_empty() && ok_var.is_none() {
             tree_binding_statements(self, &mut statements, &info.bindings, &effective, &[body]);
-            let block = self.lower_block_to_place(body, place, fx);
+            let block = self.lower_block_to_place(body, place);
             statements.extend(block.statements);
             return statements;
         }
@@ -699,10 +675,10 @@ impl Planner<'_> {
         let mut then_body = Vec::new();
         let overlays =
             tree_binding_statements(self, &mut then_body, &info.bindings, &effective, &[body]);
-        let block = self.lower_block_to_place(body, place, fx);
+        let block = self.lower_block_to_place(body, place);
         then_body.extend(block.statements);
         drop_inline_overlays(self, &overlays);
-        let else_arm = match failure(self, fx) {
+        let else_arm = match failure(self) {
             Some(body) => ElseArm::Else {
                 body,
                 inline: false,
@@ -725,13 +701,12 @@ pub(crate) fn lower_none_arm_body(
     planner: &mut Planner,
     match_arms: &[MatchArm],
     place: &PlacePlan,
-    fx: &mut EmitEffects,
 ) -> LoweredBlock {
     for match_arm in match_arms {
         if let Pattern::EnumVariant { identifier, .. } = &match_arm.pattern {
             let variant_name = go_name::unqualified_name(identifier);
             if variant_name == "None" {
-                return planner.lower_block_to_place(&match_arm.expression, place, fx);
+                return planner.lower_block_to_place(&match_arm.expression, place);
             }
         }
     }

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1,7 +1,6 @@
 use syntax::ast::{Expression, MatchArm};
 use syntax::types::Type;
 
-use crate::EmitEffects;
 use crate::Planner;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
 use crate::context::expression::ExpressionContext;
@@ -86,7 +85,6 @@ pub(crate) struct TreePlanner<'a, 'e> {
     arms: &'a [MatchArm],
     subject_var: String,
     subject_ty: Type,
-    fx: &'a mut EmitEffects,
 }
 
 impl<'a, 'e> TreePlanner<'a, 'e> {
@@ -95,21 +93,19 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         arms: &'a [MatchArm],
         subject_var: String,
         subject_ty: Type,
-        fx: &'a mut EmitEffects,
     ) -> Self {
         Self {
             planner,
             arms,
             subject_var,
             subject_ty,
-            fx,
         }
     }
 
     pub(crate) fn lower(mut self, place: &PlacePlan) -> LoweredBlock {
         let expanded = expand_or_patterns(self.arms);
         let compiled = compile_expanded_arms(self.planner, &expanded, &self.subject_ty);
-        self.fx.extend(&compiled.effects);
+        self.planner.absorb_effects(&compiled.effects);
         let tree = compiled.decision;
 
         let single_catchall_has_collisions = match &tree {
@@ -125,7 +121,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             &tree,
             single_catchall_has_collisions,
         );
-        self.fx.extend(&lowered.effects);
+        self.planner.absorb_effects(&lowered.effects);
 
         let mut statements: Vec<LoweredStatement> = Vec::new();
         match lowered.plan {
@@ -900,9 +896,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         place: &PlacePlan,
     ) {
         let arm = &self.arms[arm_index];
-        let block = self
-            .planner
-            .lower_block_to_place(&arm.expression, place, self.fx);
+        let block = self.planner.lower_block_to_place(&arm.expression, place);
         statements.extend(block.statements);
     }
 
@@ -913,11 +907,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         arm_index: usize,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let guard_expression = self.arms[arm_index].guard.as_deref()?;
-        let plan = self.planner.plan_operand(
-            guard_expression,
-            ExpressionContext::value().condition(),
-            self.fx,
-        );
+        let plan = self
+            .planner
+            .plan_operand(guard_expression, ExpressionContext::value().condition());
         let (setup, value) = plan.into_parts();
         Some((setup, wrap_if_struct_literal(value)))
     }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
@@ -44,15 +43,11 @@ impl Planner<'_> {
     /// Allocate a fresh operand-temp result var and its `var V T` declaration
     /// as a typed setup leaf. The control-flow that assigns it follows as a
     /// typed `If`/`Loop`/`Match`/`Select` statement.
-    pub(crate) fn operand_temp_declaration(
-        &mut self,
-        ty: &Type,
-        fx: &mut EmitEffects,
-    ) -> (String, LoweredStatement) {
+    pub(crate) fn operand_temp_declaration(&mut self, ty: &Type) -> (String, LoweredStatement) {
         let result_var = self.fresh_var(None);
         let declaration = LoweredStatement::VarDecl {
             name: result_var.clone(),
-            go_type: self.go_type_string(ty, fx),
+            go_type: self.go_type_string(ty),
             value: None,
         };
         self.declare(&result_var);
@@ -66,7 +61,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let Expression::If {
             condition,
@@ -77,7 +71,7 @@ impl Planner<'_> {
         else {
             unreachable!("plan_if_as_operand_temp called on non-If expression");
         };
-        let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
+        let (result_var, declaration) = self.operand_temp_declaration(ty);
         let plan = self.lower_if(
             condition,
             consequence,
@@ -86,7 +80,6 @@ impl Planner<'_> {
                 local: &result_var,
                 target_ty: Some(ty),
             },
-            fx,
         );
         value_plan_from_statements(vec![declaration, LoweredStatement::If(plan)], result_var)
     }
@@ -98,16 +91,14 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
+        let (result_var, declaration) = self.operand_temp_declaration(ty);
         let block = self.lower_branching_to_block(
             expression,
             &PlacePlan::Assign {
                 local: &result_var,
                 target_ty: Some(ty),
             },
-            fx,
         );
         let mut setup = vec![declaration];
         setup.extend(block.statements);
@@ -121,7 +112,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         let Expression::Loop {
             body, needs_label, ..
@@ -129,9 +119,9 @@ impl Planner<'_> {
         else {
             unreachable!("plan_loop_as_operand_temp called on non-Loop expression");
         };
-        let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
+        let (result_var, declaration) = self.operand_temp_declaration(ty);
         self.push_loop(result_var.clone());
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label, fx);
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label);
         self.pop_loop();
         value_plan_from_statements(vec![declaration, LoweredStatement::Loop(plan)], result_var)
     }
@@ -140,18 +130,17 @@ impl Planner<'_> {
         &mut self,
         rest: &[Expression],
         last: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, bool) {
         let mut statements: Vec<LoweredStatement> = Vec::with_capacity(rest.len() + 1);
         for item in rest {
-            let statement = self.lower_statement(item, fx);
+            let statement = self.lower_statement(item);
             let diverged = statement.blocks_fallthrough();
             statements.push(statement);
             if diverged {
                 return (statements, true);
             }
         }
-        statements.extend(self.lower_return_tail(last, fx));
+        statements.extend(self.lower_return_tail(last));
         (statements, false)
     }
 
@@ -159,10 +148,9 @@ impl Planner<'_> {
         &mut self,
         body: &Expression,
         should_return: bool,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         if !should_return {
-            return self.lower_block_as_body(body, fx);
+            return self.lower_block_as_body(body);
         }
 
         let items: &[Expression] = if let Expression::Block { items, .. } = body {
@@ -177,7 +165,7 @@ impl Planner<'_> {
             };
         };
 
-        let (mut statements, diverged) = self.lower_body_until_diverge(rest, last, fx);
+        let (mut statements, diverged) = self.lower_body_until_diverge(rest, last);
         if diverged {
             return LoweredBlock { statements };
         }
@@ -199,7 +187,7 @@ impl Planner<'_> {
         {
             let return_ty = return_ty.clone();
             let (zero, effects) = self.zero_value(&return_ty);
-            fx.extend(&effects);
+            self.absorb_effects(&effects);
             statements.push(plain_return(zero));
         }
 
@@ -211,11 +199,7 @@ impl Planner<'_> {
     /// output as `RawGo`. `return_ctx` is the enclosing function/lambda/try/
     /// recover return context, threaded so nested `return` lowering has an
     /// explicit context.
-    pub(crate) fn lower_statement(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    pub(crate) fn lower_statement(&mut self, expression: &Expression) -> LoweredStatement {
         match expression {
             Expression::If {
                 condition,
@@ -224,13 +208,8 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.lower_if(
-                    condition,
-                    consequence,
-                    alternative,
-                    &PlacePlan::Statement,
-                    fx,
-                );
+                let plan =
+                    self.lower_if(condition, consequence, alternative, &PlacePlan::Statement);
                 directed(directive, LoweredStatement::If(plan))
             }
             Expression::Loop {
@@ -239,7 +218,7 @@ impl Planner<'_> {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 directed(
                     directive,
-                    LoweredStatement::Loop(self.lower_infinite_loop(body, *needs_label, fx)),
+                    LoweredStatement::Loop(self.lower_infinite_loop(body, *needs_label)),
                 )
             }
             Expression::While {
@@ -251,16 +230,16 @@ impl Planner<'_> {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 directed(
                     directive,
-                    LoweredStatement::Loop(self.lower_while(condition, body, *needs_label, fx)),
+                    LoweredStatement::Loop(self.lower_while(condition, body, *needs_label)),
                 )
             }
             Expression::Block { .. } => {
                 self.enter_scope();
-                let body = self.lower_block_as_body(expression, fx);
+                let body = self.lower_block_as_body(expression);
                 self.exit_scope();
                 LoweredStatement::Block(body)
             }
-            Expression::For { .. } => self.lower_for_statement(expression, fx),
+            Expression::For { .. } => self.lower_for_statement(expression),
             Expression::Continue { .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 directed(
@@ -283,7 +262,7 @@ impl Planner<'_> {
                 value: Some(value), ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_break_value_plan(value, fx);
+                let plan = self.build_break_value_plan(value);
                 directed(directive, LoweredStatement::BreakValue(plan))
             }
             Expression::Const {
@@ -293,14 +272,14 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_const_plan(identifier, value, ty, fx);
+                let plan = self.build_const_plan(identifier, value, ty);
                 directed(directive, LoweredStatement::Const(plan))
             }
             Expression::Return {
                 expression: value, ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_return_plan(value, fx);
+                let plan = self.build_return_plan(value);
                 directed(directive, LoweredStatement::Return(plan))
             }
             Expression::Let {
@@ -312,14 +291,8 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.build_let_plan(
-                    binding,
-                    value,
-                    else_block.as_deref(),
-                    *mutable,
-                    *assert,
-                    fx,
-                );
+                let plan =
+                    self.build_let_plan(binding, value, else_block.as_deref(), *mutable, *assert);
                 directed(directive, LoweredStatement::Let(plan))
             }
             Expression::Assignment {
@@ -329,8 +302,7 @@ impl Planner<'_> {
                 ..
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan =
-                    self.build_assignment_plan(target, value, compound_operator.as_ref(), fx);
+                let plan = self.build_assignment_plan(target, value, compound_operator.as_ref());
                 directed(directive, LoweredStatement::Assign(plan))
             }
             Expression::IfLet {
@@ -343,7 +315,7 @@ impl Planner<'_> {
             } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
                 let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
-                let body = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Statement, fx);
+                let body = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Statement);
                 directed(
                     directive,
                     LoweredStatement::Match(MatchStatementPlan { body }),
@@ -351,7 +323,7 @@ impl Planner<'_> {
             }
             Expression::Match { subject, arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let body = self.lower_match_to_block(subject, arms, &PlacePlan::Statement, fx);
+                let body = self.lower_match_to_block(subject, arms, &PlacePlan::Statement);
                 directed(
                     directive,
                     LoweredStatement::Match(MatchStatementPlan { body }),
@@ -359,11 +331,11 @@ impl Planner<'_> {
             }
             Expression::Select { arms, .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let plan = self.lower_select(arms, &PlacePlan::Statement, fx);
+                let plan = self.lower_select(arms, &PlacePlan::Statement);
                 directed(directive, LoweredStatement::Select(plan))
             }
-            Expression::WhileLet { .. } => self.lower_while_let_statement(expression, fx),
-            Expression::Assert { .. } => self.lower_assert_statement(expression, fx),
+            Expression::WhileLet { .. } => self.lower_while_let_statement(expression),
+            Expression::Assert { .. } => self.lower_assert_statement(expression),
             // Top-level items (Struct/Enum/etc) shouldn't appear inside
             // function bodies, but dispatch handles them defensively. They
             // carry their own directive (via `emit_top_item`) so the wrapper
@@ -374,7 +346,7 @@ impl Planner<'_> {
             | Expression::Interface { .. }
             | Expression::ImplBlock { .. } => {
                 let directive = self.maybe_line_directive(&expression.get_span());
-                let code = self.emit_top_item(expression, fx);
+                let code = self.emit_top_item(expression);
                 let mut buffer = directive;
                 if !code.is_empty() {
                     buffer.push_str(&code);
@@ -383,27 +355,23 @@ impl Planner<'_> {
                 LoweredStatement::RawGo(buffer)
             }
             Expression::Call { .. } if self.is_test_log_call(expression) => {
-                self.lower_test_log_statement(expression, fx)
+                self.lower_test_log_statement(expression)
             }
-            _ => self.lower_expression_statement(expression, fx),
+            _ => self.lower_expression_statement(expression),
         }
     }
 
     /// Lower the statement-position fall-through: Task/Defer (async value),
     /// `expr?` propagation, or an otherwise-discarded expression value. The
     /// directive rides on the wrapper so the rendered body stays directive-free.
-    fn lower_expression_statement(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    fn lower_expression_statement(&mut self, expression: &Expression) -> LoweredStatement {
         let unwrapped = expression.unwrap_parens();
         let directive = self.maybe_line_directive(&expression.get_span());
         let form = if matches!(
             unwrapped,
             Expression::Task { .. } | Expression::Defer { .. }
         ) {
-            let value = self.plan_operand(unwrapped, ExpressionContext::value(), fx);
+            let value = self.plan_operand(unwrapped, ExpressionContext::value());
             ExpressionStatementForm::Async { value }
         } else if let Expression::Propagate {
             expression: inner, ..
@@ -411,13 +379,13 @@ impl Planner<'_> {
         {
             ExpressionStatementForm::Propagate {
                 body: LoweredBlock {
-                    statements: self.lower_propagate_statement(inner, fx),
+                    statements: self.lower_propagate_statement(inner),
                 },
             }
         } else {
             ExpressionStatementForm::Discard {
                 body: LoweredBlock {
-                    statements: self.lower_discard_value(unwrapped, fx),
+                    statements: self.lower_discard_value(unwrapped),
                 },
             }
         };
@@ -427,11 +395,7 @@ impl Planner<'_> {
         )
     }
 
-    pub(crate) fn lower_assert_statement(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    pub(crate) fn lower_assert_statement(&mut self, expression: &Expression) -> LoweredStatement {
         let Expression::Assert {
             expression: operand,
             ..
@@ -440,7 +404,7 @@ impl Planner<'_> {
             unreachable!("lower_assert_statement requires an Assert expression");
         };
         let operand = operand.unwrap_parens();
-        fx.require_testkit();
+        self.require_testkit();
 
         // Each shape stages its operands into `statements` and returns the
         // condition, the record kind, and any operand arguments for the call.
@@ -453,11 +417,11 @@ impl Planner<'_> {
         } = operand
             && is_assert_relation(operator)
         {
-            self.lower_relation_assert(operator, left, right, &mut statements, fx)
+            self.lower_relation_assert(operator, left, right, &mut statements)
         } else if let Some((recv, arg)) = self.as_equals_decomposition(operand) {
-            self.lower_labeled_assert(recv, arg, &mut statements, fx)
+            self.lower_labeled_assert(recv, arg, &mut statements)
         } else {
-            self.lower_bare_assert(operand, &mut statements, fx)
+            self.lower_bare_assert(operand, &mut statements)
         };
 
         let AssertShape {
@@ -502,12 +466,8 @@ impl Planner<'_> {
         member.as_str() == "log" && is_test_context_ty(&receiver.get_type())
     }
 
-    pub(crate) fn lower_test_log_statement(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
-        let (mut statements, call) = self.lower_test_log_call(expression, fx);
+    pub(crate) fn lower_test_log_statement(&mut self, expression: &Expression) -> LoweredStatement {
+        let (mut statements, call) = self.lower_test_log_call(expression);
         statements.push(LoweredStatement::RawGo(format!("{call}\n")));
         LoweredStatement::Block(LoweredBlock { statements })
     }
@@ -515,7 +475,6 @@ impl Planner<'_> {
     pub(crate) fn lower_test_log_call(
         &mut self,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::Call {
             expression: callee,
@@ -532,16 +491,16 @@ impl Planner<'_> {
         else {
             unreachable!("lower_test_log_call requires a method receiver");
         };
-        fx.require_testkit();
-        fx.require_stdlib();
+        self.require_testkit();
+        self.require_stdlib();
 
         let mut statements = Vec::new();
         let (recv_setup, handle) = self
-            .lower_value(receiver, ExpressionContext::value(), fx)
+            .lower_value(receiver, ExpressionContext::value())
             .into_parts();
         statements.extend(recv_setup);
         let (arg_setup, value) = self
-            .lower_value(&args[0], ExpressionContext::value(), fx)
+            .lower_value(&args[0], ExpressionContext::value())
             .into_parts();
         statements.extend(arg_setup);
 
@@ -564,21 +523,14 @@ impl Planner<'_> {
         left: &Expression,
         right: &Expression,
         statements: &mut Vec<LoweredStatement>,
-        fx: &mut EmitEffects,
     ) -> AssertShape {
-        fx.require_stdlib();
-        let lhs = self.stage_assert_operand(left, "assertLeft", statements, fx);
-        let rhs = self.stage_assert_operand(right, "assertRight", statements, fx);
+        self.require_stdlib();
+        let lhs = self.stage_assert_operand(left, "assertLeft", statements);
+        let rhs = self.stage_assert_operand(right, "assertRight", statements);
         let left_ref = temp_identifier(&lhs, left);
         let right_ref = temp_identifier(&rhs, right);
         let (cond_setup, condition) = self
-            .plan_binary(
-                operator,
-                &left_ref,
-                &right_ref,
-                ExpressionContext::value(),
-                fx,
-            )
+            .plan_binary(operator, &left_ref, &right_ref, ExpressionContext::value())
             .into_parts();
         statements.extend(cond_setup);
         AssertShape {
@@ -595,13 +547,12 @@ impl Planner<'_> {
         recv: &Expression,
         arg: &Expression,
         statements: &mut Vec<LoweredStatement>,
-        fx: &mut EmitEffects,
     ) -> AssertShape {
-        fx.require_stdlib();
+        self.require_stdlib();
         let recv_ty = recv.get_type();
-        let lhs = self.stage_assert_operand(recv, "assertLeft", statements, fx);
-        let rhs = self.stage_assert_operand(arg, "assertRight", statements, fx);
-        let condition = self.render_equality(&lhs, &rhs, &recv_ty, fx);
+        let lhs = self.stage_assert_operand(recv, "assertLeft", statements);
+        let rhs = self.stage_assert_operand(arg, "assertRight", statements);
+        let condition = self.render_equality(&lhs, &rhs, &recv_ty);
         AssertShape {
             condition,
             kind: "labeled",
@@ -615,9 +566,8 @@ impl Planner<'_> {
         &mut self,
         operand: &Expression,
         statements: &mut Vec<LoweredStatement>,
-        fx: &mut EmitEffects,
     ) -> AssertShape {
-        let (setup, condition) = self.lower_condition(operand, fx);
+        let (setup, condition) = self.lower_condition(operand);
         statements.extend(setup);
         AssertShape {
             condition,
@@ -634,17 +584,16 @@ impl Planner<'_> {
         expression: &Expression,
         hint: &str,
         statements: &mut Vec<LoweredStatement>,
-        fx: &mut EmitEffects,
     ) -> String {
         let (setup, value) = self
-            .lower_value(expression, ExpressionContext::value(), fx)
+            .lower_value(expression, ExpressionContext::value())
             .into_parts();
         statements.extend(setup);
         let name = self.fresh_var(Some(hint));
         self.declare(&name);
         // Bind the temp to itself so the relation shape's synthetic identifier resolves.
         self.scope.bind(name.clone(), name.clone());
-        let go_type = self.go_type_string(&expression.get_type(), fx);
+        let go_type = self.go_type_string(&expression.get_type());
         statements.push(LoweredStatement::VarDecl {
             name: name.clone(),
             go_type,
@@ -686,11 +635,7 @@ impl Planner<'_> {
 
     /// Lower `while let P = scrutinee { body }`, wrapped as a `WhileLet`
     /// statement.
-    fn lower_while_let_statement(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredStatement {
+    fn lower_while_let_statement(&mut self, expression: &Expression) -> LoweredStatement {
         let Expression::WhileLet {
             pattern,
             typed_pattern,
@@ -710,30 +655,20 @@ impl Planner<'_> {
             scrutinee,
             body,
             *needs_label,
-            fx,
         );
         self.pop_loop();
         directed(directive, LoweredStatement::WhileLet(WhileLetPlan { body }))
     }
 
-    fn lower_infinite_loop(
-        &mut self,
-        body: &Expression,
-        needs_label: bool,
-        fx: &mut EmitEffects,
-    ) -> LoopPlan {
+    fn lower_infinite_loop(&mut self, body: &Expression, needs_label: bool) -> LoopPlan {
         self.push_loop("_");
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body, needs_label, fx);
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body, needs_label);
         self.pop_loop();
         plan
     }
 
-    fn lower_condition(
-        &mut self,
-        condition: &Expression,
-        fx: &mut EmitEffects,
-    ) -> (Vec<LoweredStatement>, String) {
-        let plan = self.plan_operand(condition, ExpressionContext::value().condition(), fx);
+    fn lower_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, String) {
+        let plan = self.plan_operand(condition, ExpressionContext::value().condition());
         plan.into_parts()
     }
 
@@ -742,10 +677,9 @@ impl Planner<'_> {
         condition: &Expression,
         body: &Expression,
         needs_label: bool,
-        fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.push_loop("_");
-        let (setup, rendered) = self.lower_condition(condition, fx);
+        let (setup, rendered) = self.lower_condition(condition);
         let header = if !setup.is_empty() {
             // Condition produced setup statements (temps); they must re-run each
             // iteration, so move everything inside the loop.
@@ -762,7 +696,7 @@ impl Planner<'_> {
         } else {
             format!("for {} {{\n", wrap_if_struct_literal(rendered))
         };
-        let plan = self.lower_loop_with_header(header, body, needs_label, fx);
+        let plan = self.lower_loop_with_header(header, body, needs_label);
         self.pop_loop();
         plan
     }
@@ -774,12 +708,11 @@ impl Planner<'_> {
         header: String,
         body: &Expression,
         needs_label: bool,
-        fx: &mut EmitEffects,
     ) -> LoopPlan {
         self.set_current_loop_label_if_needed(needs_label);
         let label = self.current_loop_label().map(str::to_string);
         self.enter_scope();
-        let lowered_body = self.lower_block_as_body(body, fx);
+        let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
         LoopPlan {
             prologue: Vec::new(),
@@ -790,11 +723,7 @@ impl Planner<'_> {
     }
 
     /// Lower a branch arm body in statement position (`PlacePlan::Statement`).
-    pub(crate) fn lower_block_as_body(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredBlock {
+    pub(crate) fn lower_block_as_body(&mut self, expression: &Expression) -> LoweredBlock {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
             items
         } else {
@@ -802,7 +731,7 @@ impl Planner<'_> {
         };
         let statements = items
             .iter()
-            .map(|item| self.lower_statement(item, fx))
+            .map(|item| self.lower_statement(item))
             .collect();
         LoweredBlock { statements }
     }
@@ -814,7 +743,6 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         match expression {
             Expression::If {
@@ -823,7 +751,7 @@ impl Planner<'_> {
                 alternative,
                 ..
             } => {
-                let plan = self.lower_if(condition, consequence, alternative, place, fx);
+                let plan = self.lower_if(condition, consequence, alternative, place);
                 LoweredBlock {
                     statements: vec![LoweredStatement::If(plan)],
                 }
@@ -837,13 +765,13 @@ impl Planner<'_> {
                 ..
             } => {
                 let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
-                self.lower_match_to_block(scrutinee, &arms, place, fx)
+                self.lower_match_to_block(scrutinee, &arms, place)
             }
             Expression::Match { subject, arms, .. } => {
-                self.lower_match_to_block(subject, arms, place, fx)
+                self.lower_match_to_block(subject, arms, place)
             }
             Expression::Select { arms, .. } => LoweredBlock {
-                statements: vec![LoweredStatement::Select(self.lower_select(arms, place, fx))],
+                statements: vec![LoweredStatement::Select(self.lower_select(arms, place))],
             },
             _ => unreachable!("lower_branching_to_block: expected if/if-let/match/select"),
         }
@@ -854,13 +782,12 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         match place {
-            PlacePlan::Statement => self.lower_block_as_body(expression, fx),
-            PlacePlan::Return => self.lower_block_to_return(expression, fx),
+            PlacePlan::Statement => self.lower_block_as_body(expression),
+            PlacePlan::Return => self.lower_block_to_return(expression),
             PlacePlan::Assign { local, target_ty } => {
-                self.lower_block_to_assign(expression, local, *target_ty, fx)
+                self.lower_block_to_assign(expression, local, *target_ty)
             }
         }
     }
@@ -873,26 +800,21 @@ impl Planner<'_> {
         expression: &Expression,
         local: &str,
         target_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> LoweredBlock {
         if expression.get_type().is_result() || expression.get_type().is_option() {
             return LoweredBlock {
-                statements: self.lower_option_result_assignment(local, target_ty, expression, fx),
+                statements: self.lower_option_result_assignment(local, target_ty, expression),
             };
         }
         LoweredBlock {
-            statements: self.lower_block_to_var(expression, local, target_ty, false, fx),
+            statements: self.lower_block_to_var(expression, local, target_ty, false),
         }
     }
 
     /// Lower a block in return position: non-tail items become statements,
     /// the tail returns. A tail `let` (`let x = if ...; x`) is elided into the
     /// surrounding return place; function bodies skip that elision.
-    fn lower_block_to_return(
-        &mut self,
-        expression: &Expression,
-        fx: &mut EmitEffects,
-    ) -> LoweredBlock {
+    fn lower_block_to_return(&mut self, expression: &Expression) -> LoweredBlock {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
             items
         } else {
@@ -905,7 +827,7 @@ impl Planner<'_> {
             };
         };
 
-        let (statements, _) = self.lower_body_until_diverge(rest, last, fx);
+        let (statements, _) = self.lower_body_until_diverge(rest, last);
         LoweredBlock { statements }
     }
 
@@ -913,11 +835,7 @@ impl Planner<'_> {
     /// statements. Shared by branch-arm return lowering and function-body
     /// lowering; only leaf values and lowered-ABI returns become `RawGo`,
     /// `if`/`if let`/`match`/`select` tails recurse structurally with a `Return` place.
-    pub(crate) fn lower_return_tail(
-        &mut self,
-        last: &Expression,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    pub(crate) fn lower_return_tail(&mut self, last: &Expression) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         let return_span = last.get_span();
         let last = if let Expression::Return { expression, .. } = last {
@@ -928,13 +846,13 @@ impl Planner<'_> {
 
         if last.get_type().is_unit() {
             if !matches!(last, Expression::Unit { .. }) {
-                statements.push(self.lower_statement(last, fx));
+                statements.push(self.lower_statement(last));
             }
             return statements;
         }
 
         if last.get_type().is_never() {
-            return self.lower_never_return_tail(last, &return_span, fx);
+            return self.lower_never_return_tail(last, &return_span);
         }
 
         let directive = self.maybe_line_directive(&return_span);
@@ -945,8 +863,7 @@ impl Planner<'_> {
                 alternative,
                 ..
             } => {
-                let plan =
-                    self.lower_if(condition, consequence, alternative, &PlacePlan::Return, fx);
+                let plan = self.lower_if(condition, consequence, alternative, &PlacePlan::Return);
                 statements.push(directed(directive, LoweredStatement::If(plan)));
             }
             Expression::IfLet {
@@ -961,30 +878,30 @@ impl Planner<'_> {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
                 let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
-                let block = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Return, fx);
+                let block = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Return);
                 statements.extend(block.statements);
             }
             Expression::Match { subject, arms, .. } => {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                let block = self.lower_match_to_block(subject, arms, &PlacePlan::Return, fx);
+                let block = self.lower_match_to_block(subject, arms, &PlacePlan::Return);
                 statements.extend(block.statements);
             }
             Expression::Select { arms, .. } => {
-                let plan = self.lower_select(arms, &PlacePlan::Return, fx);
+                let plan = self.lower_select(arms, &PlacePlan::Return);
                 statements.push(directed(directive, LoweredStatement::Select(plan)));
             }
             _ => {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                if let Some(tail) = try_emit_lowered_tail_return(self, last, fx) {
+                if let Some(tail) = try_emit_lowered_tail_return(self, last) {
                     statements.extend(tail);
-                } else if let Some(wrapped) = self.lower_wrapped_return(last, fx) {
+                } else if let Some(wrapped) = self.lower_wrapped_return(last) {
                     statements.extend(wrapped);
                 } else {
-                    statements.extend(self.lower_plain_return_tail(last, fx));
+                    statements.extend(self.lower_plain_return_tail(last));
                 }
             }
         }
@@ -996,14 +913,13 @@ impl Planner<'_> {
         &mut self,
         last: &Expression,
         return_span: &syntax::ast::Span,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let directive = self.maybe_line_directive(return_span);
         let mut statements: Vec<LoweredStatement> = Vec::new();
         if !directive.is_empty() {
             statements.push(LoweredStatement::RawGo(directive));
         }
-        statements.push(self.lower_statement(last, fx));
+        statements.push(self.lower_statement(last));
         if !is_go_never(last) && !is_breakless_loop(last) {
             statements.push(LoweredStatement::UnreachablePanic);
         }
@@ -1012,29 +928,20 @@ impl Planner<'_> {
 
     /// Kept as `RawGo`, not `ReturnForm::Plain`: a structured `Return` would
     /// flatten the enclosing `else` for a multi-line return value.
-    fn lower_plain_return_tail(
-        &mut self,
-        last: &Expression,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    fn lower_plain_return_tail(&mut self, last: &Expression) -> Vec<LoweredStatement> {
         if requires_temp_var(last) {
-            let staged = self.stage_operand(last, ExpressionContext::value(), fx);
+            let staged = self.stage_operand(last, ExpressionContext::value());
             let mut statements = staged.setup;
             if !staged.value.is_empty() {
                 statements.push(plain_return(staged.value));
             }
             statements
         } else {
-            let (mut statements, expression_string) = self.lower_tail_value(last, fx);
+            let (mut statements, expression_string) = self.lower_tail_value(last);
             let return_ctx = self.return_ctx();
             let mut coercion = String::new();
-            let expression_string = self.apply_type_coercion(
-                &mut coercion,
-                return_ctx.ty(),
-                last,
-                expression_string,
-                fx,
-            );
+            let expression_string =
+                self.apply_type_coercion(&mut coercion, return_ctx.ty(), last, expression_string);
             if !coercion.is_empty() {
                 statements.push(LoweredStatement::RawGo(coercion));
             }
@@ -1049,17 +956,16 @@ impl Planner<'_> {
         consequence: &Expression,
         alternative: &Expression,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> IfPlan {
-        let (condition_setup, condition_string) = self.lower_condition(condition, fx);
+        let (condition_setup, condition_string) = self.lower_condition(condition);
         let condition = wrap_if_struct_literal(condition_string);
 
         self.enter_scope();
-        let then_body = self.lower_block_to_place(consequence, place, fx);
+        let then_body = self.lower_block_to_place(consequence, place);
         self.exit_scope();
 
         let preceding_diverges = then_body.ends_with_diverge();
-        let else_arm = self.lower_else_chain(alternative, preceding_diverges, place, fx);
+        let else_arm = self.lower_else_chain(alternative, preceding_diverges, place);
 
         IfPlan {
             condition_setup,
@@ -1074,7 +980,6 @@ impl Planner<'_> {
         alternative: &Expression,
         preceding_diverges: bool,
         place: &PlacePlan,
-        fx: &mut EmitEffects,
     ) -> ElseArm {
         let is_empty_alternative = match alternative {
             Expression::Unit { .. } => true,
@@ -1092,7 +997,7 @@ impl Planner<'_> {
             ..
         } = alternative
         {
-            let (condition_setup, condition_string) = self.lower_condition(condition, fx);
+            let (condition_setup, condition_string) = self.lower_condition(condition);
             let condition = wrap_if_struct_literal(condition_string);
 
             // With-setup else-if renders as a nested block (`} else { setup; if
@@ -1102,14 +1007,10 @@ impl Planner<'_> {
             if !condition_setup.is_empty() {
                 self.enter_scope();
                 self.enter_scope();
-                let then_body = self.lower_block_to_place(consequence, place, fx);
+                let then_body = self.lower_block_to_place(consequence, place);
                 self.exit_scope();
-                let inner = self.lower_else_chain(
-                    next_alternative,
-                    then_body.ends_with_diverge(),
-                    place,
-                    fx,
-                );
+                let inner =
+                    self.lower_else_chain(next_alternative, then_body.ends_with_diverge(), place);
                 self.exit_scope();
                 ElseArm::ElseIf(Box::new(IfPlan {
                     condition_setup,
@@ -1119,14 +1020,10 @@ impl Planner<'_> {
                 }))
             } else {
                 self.enter_scope();
-                let then_body = self.lower_block_to_place(consequence, place, fx);
+                let then_body = self.lower_block_to_place(consequence, place);
                 self.exit_scope();
-                let inner = self.lower_else_chain(
-                    next_alternative,
-                    then_body.ends_with_diverge(),
-                    place,
-                    fx,
-                );
+                let inner =
+                    self.lower_else_chain(next_alternative, then_body.ends_with_diverge(), place);
                 ElseArm::ElseIf(Box::new(IfPlan {
                     condition_setup,
                     condition,
@@ -1135,11 +1032,11 @@ impl Planner<'_> {
                 }))
             }
         } else if preceding_diverges {
-            let body = self.lower_block_to_place(alternative, place, fx);
+            let body = self.lower_block_to_place(alternative, place);
             ElseArm::Else { body, inline: true }
         } else {
             self.enter_scope();
-            let body = self.lower_block_to_place(alternative, place, fx);
+            let body = self.lower_block_to_place(alternative, place);
             self.exit_scope();
             ElseArm::Else {
                 body,

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -44,8 +44,8 @@ impl Planner<'_> {
         self.collect_generic_constraints(files);
         self.collect_escape_remap(files);
         let collision_diagnostics = self.detect_name_collisions(files);
-        let mut make_functions_by_file =
-            self.collect_local_make_function_code(&mut collection_effects);
+        let mut make_functions_by_file = self.collect_local_make_function_code();
+        collection_effects.extend(&self.take_effects());
 
         let package_name = if self.facts.is_entry_module(module_id) {
             "main".to_string()

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::analyze::inline_uses::region_blocks_inline;
 use crate::context::expression::ExpressionContext;
@@ -192,11 +191,7 @@ pub(crate) fn expression_contains_binding(expression: &Expression, name: &str) -
 impl Planner<'_> {
     /// Lower a discarded expression into structured statements: a bare
     /// side-effecting call (`f()`), a `_ = value` discard, or a propagate.
-    pub(crate) fn lower_discard_value(
-        &mut self,
-        value: &Expression,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    pub(crate) fn lower_discard_value(&mut self, value: &Expression) -> Vec<LoweredStatement> {
         let unwrapped = value.unwrap_parens();
 
         if is_side_effect_free_discard(unwrapped) {
@@ -204,12 +199,12 @@ impl Planner<'_> {
         }
 
         if let Expression::Propagate { expression, .. } = unwrapped {
-            return self.lower_propagate(expression, Some("_"), fx).0;
+            return self.lower_propagate(expression, Some("_")).0;
         }
 
         let value_ty = value.get_type();
         if value_ty.is_unit() || value_ty.is_variable() || value_ty.is_never() {
-            let staged = self.stage_operand(value, ExpressionContext::value(), fx);
+            let staged = self.stage_operand(value, ExpressionContext::value());
             let mut statements = staged.setup;
             if !staged.value.is_empty() {
                 if matches!(unwrapped, Expression::Call { .. }) {
@@ -229,13 +224,13 @@ impl Planner<'_> {
 
         if let Expression::Call { .. } = unwrapped {
             let mut statements: Vec<LoweredStatement> = Vec::new();
-            if let Some(raw) = self.emit_go_call_discarded(&mut statements, unwrapped, fx) {
+            if let Some(raw) = self.emit_go_call_discarded(&mut statements, unwrapped) {
                 statements.push(LoweredStatement::RawGo(format!("{}\n", raw)));
                 return statements;
             }
         }
 
-        let staged = self.stage_operand(value, ExpressionContext::value(), fx);
+        let staged = self.stage_operand(value, ExpressionContext::value());
         let mut statements = staged.setup;
         statements.push(LoweredStatement::RawGo(format!("_ = {}\n", staged.value)));
         statements
@@ -243,14 +238,9 @@ impl Planner<'_> {
 
     /// Emit a unit-typed call as a statement, then store `struct{}{}` into
     /// `var`.
-    fn lower_unit_call_into_var(
-        &mut self,
-        value: &Expression,
-        var: &str,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    fn lower_unit_call_into_var(&mut self, value: &Expression, var: &str) -> Vec<LoweredStatement> {
         let (mut statements, call_str) = self
-            .lower_value(value, ExpressionContext::value(), fx)
+            .lower_value(value, ExpressionContext::value())
             .into_parts();
         if !call_str.is_empty() {
             statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
@@ -267,12 +257,11 @@ impl Planner<'_> {
         expression: &Expression,
         var: &str,
         target_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let ty = expression.get_type();
         let is_fallible = ty.is_result() || ty.is_option();
         if is_fallible {
-            return self.lower_option_result_assignment(var, target_ty, expression, fx);
+            return self.lower_option_result_assignment(var, target_ty, expression);
         }
 
         if let Expression::Loop {
@@ -280,7 +269,7 @@ impl Planner<'_> {
         } = expression
         {
             self.push_loop(var);
-            let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label, fx);
+            let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label);
             self.pop_loop();
             return vec![LoweredStatement::Loop(plan)];
         }
@@ -288,20 +277,19 @@ impl Planner<'_> {
         if let Expression::Block { items, .. } = expression
             && items.len() > 1
         {
-            let statements = self.lower_block_to_var(expression, var, target_ty, true, fx);
+            let statements = self.lower_block_to_var(expression, var, target_ty, true);
             return vec![LoweredStatement::Block(LoweredBlock { statements })];
         }
 
-        self.lower_block_to_var(expression, var, target_ty, false, fx)
+        self.lower_block_to_var(expression, var, target_ty, false)
     }
 
     fn lower_plain_assign(
         &mut self,
         target_var: &str,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
-        let value = self.plan_operand(expression, ExpressionContext::value(), fx);
+        let value = self.plan_operand(expression, ExpressionContext::value());
         vec![simple_assign(target_var, value)]
     }
 
@@ -314,14 +302,13 @@ impl Planner<'_> {
         target_var: &str,
         target_ty: Option<&Type>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let ty = target_ty
             .filter(|t| t.is_option() || t.is_result())
             .cloned()
             .unwrap_or_else(|| expression.get_type());
         let Some(fallible) = Fallible::from_type(&ty) else {
-            return self.lower_plain_assign(target_var, expression, fx);
+            return self.lower_plain_assign(target_var, expression);
         };
 
         let actual_expression = if let Expression::Block { items, .. } = expression {
@@ -345,7 +332,7 @@ impl Planner<'_> {
                     Some(ConstructorKind::Success) => fallible.ok_constructor(),
                     Some(ConstructorKind::Failure) => fallible.err_constructor(),
                     None => {
-                        return self.lower_plain_assign(target_var, expression, fx);
+                        return self.lower_plain_assign(target_var, expression);
                     }
                 };
                 if kind == Some(ConstructorKind::Success)
@@ -353,10 +340,10 @@ impl Planner<'_> {
                         && fallible.err_constructor_takes_arg())
                 {
                     let (arg_setup, call_str) = {
-                        let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                        let mut fe = FalliblePlanner::new(self, &fallible);
                         let (arg_setup, arg) = fe
                             .planner
-                            .lower_composite_value(&args[0], ExpressionContext::value(), fe.fx)
+                            .lower_composite_value(&args[0], ExpressionContext::value())
                             .into_parts();
                         (
                             arg_setup,
@@ -367,7 +354,7 @@ impl Planner<'_> {
                     vec![simple_assign(target_var, value)]
                 } else {
                     let call_str = {
-                        let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                        let mut fe = FalliblePlanner::new(self, &fallible);
                         fe.format_constructor_call(constructor_name, None)
                     };
                     vec![simple_assign(target_var, ValuePlan::Operand(call_str))]
@@ -378,15 +365,15 @@ impl Planner<'_> {
                     == Some(ConstructorKind::Failure)
                 {
                     let call_str = {
-                        let mut fe = FalliblePlanner::new(self, &fallible, fx);
+                        let mut fe = FalliblePlanner::new(self, &fallible);
                         fe.format_constructor_call(fallible.err_constructor(), None)
                     };
                     vec![simple_assign(target_var, ValuePlan::Operand(call_str))]
                 } else {
-                    self.lower_plain_assign(target_var, expression, fx)
+                    self.lower_plain_assign(target_var, expression)
                 }
             }
-            _ => self.lower_block_to_var(expression, target_var, None, false, fx),
+            _ => self.lower_block_to_var(expression, target_var, None, false),
         }
     }
 
@@ -400,7 +387,6 @@ impl Planner<'_> {
         var: &str,
         target_ty: Option<&Type>,
         has_go_braces: bool,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let is_block = matches!(expression, Expression::Block { .. });
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
@@ -415,9 +401,9 @@ impl Planner<'_> {
         if let Some((last, rest)) = items.split_last() {
             let is_new_target = self.scope.try_acquire_assign_target(var);
             for item in rest {
-                statements.push(self.lower_statement(item, fx));
+                statements.push(self.lower_statement(item));
             }
-            statements.extend(self.lower_assign_tail(last, var, target_ty, fx));
+            statements.extend(self.lower_assign_tail(last, var, target_ty));
             if is_new_target {
                 self.scope.release_assign_target(var);
             }
@@ -455,7 +441,6 @@ impl Planner<'_> {
         last: &Expression,
         var: &str,
         target_ty: Option<&Type>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         if matches!(
             last,
@@ -468,19 +453,19 @@ impl Planner<'_> {
                 | Expression::For { .. }
                 | Expression::Const { .. }
         ) {
-            return vec![self.lower_statement(last, fx)];
+            return vec![self.lower_statement(last)];
         }
         if last.get_type().is_never() {
-            let mut statements = vec![self.lower_statement(last, fx)];
+            let mut statements = vec![self.lower_statement(last)];
             if !is_go_never(last) && !is_breakless_loop(last) {
                 statements.push(LoweredStatement::UnreachablePanic);
             }
             return statements;
         }
         if is_unit_call(last) {
-            return self.lower_unit_call_into_var(last, var, fx);
+            return self.lower_unit_call_into_var(last, var);
         }
-        if let Some(statements) = self.lower_append_to_var(var, last, fx) {
+        if let Some(statements) = self.lower_append_to_var(var, last) {
             return statements;
         }
         if matches!(
@@ -494,14 +479,14 @@ impl Planner<'_> {
                 local: var,
                 target_ty,
             };
-            return self.lower_branching_to_block(last, &place, fx).statements;
+            return self.lower_branching_to_block(last, &place).statements;
         }
         let (mut setup, expression_string) = self
-            .lower_value(last, ExpressionContext::value(), fx)
+            .lower_value(last, ExpressionContext::value())
             .into_parts();
         let mut coercion_buffer = String::new();
         let expression_string =
-            self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression_string, fx);
+            self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression_string);
         if !coercion_buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(coercion_buffer));
         }
@@ -514,7 +499,6 @@ impl Planner<'_> {
         &mut self,
         var: &str,
         last: &Expression,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let Expression::Call {
             expression: func,
@@ -545,18 +529,18 @@ impl Planner<'_> {
 
         let (value, mut statements) = if receiver_is_lvalue {
             let (args_setup, args_str) =
-                self.lower_append_args(func, args, (**spread).as_ref(), is_extend, fx);
+                self.lower_append_args(func, args, (**spread).as_ref(), is_extend);
             let rhs_has_setup = !args_setup.is_empty()
                 || args.iter().any(contains_call)
                 || (**spread).as_ref().is_some_and(contains_call);
             let mut capture: Vec<LoweredStatement> = Vec::new();
             let receiver_lv =
-                self.emit_left_value_capturing(&mut capture, unwrapped, rhs_has_setup, fx);
+                self.emit_left_value_capturing(&mut capture, unwrapped, rhs_has_setup);
             capture.extend(args_setup);
             (format!("append({}, {})", receiver_lv, args_str), capture)
         } else {
             let (setup, value) = self
-                .lower_value(last, ExpressionContext::value(), fx)
+                .lower_value(last, ExpressionContext::value())
                 .into_parts();
             (value, setup)
         };
@@ -582,15 +566,14 @@ impl Planner<'_> {
         args: &[Expression],
         spread: Option<&Expression>,
         is_extend: bool,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let stages: Vec<StagedExpression> = args
             .iter()
-            .map(|a| self.stage_composite(a, ExpressionContext::value(), fx))
+            .map(|a| self.stage_composite(a, ExpressionContext::value()))
             .collect();
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
         let (setup, emitted_args) =
-            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine, fx);
+            self.sequence_with_spread_structured(stages, spread, false, "_arg", combine);
         let args_str = emitted_args.join(", ");
         let suffix = if is_extend { "..." } else { "" };
         (setup, format!("{}{}", args_str, suffix))
@@ -601,13 +584,12 @@ impl Planner<'_> {
     pub(crate) fn lower_tail_value(
         &mut self,
         last: &Expression,
-        fx: &mut EmitEffects,
     ) -> (Vec<LoweredStatement>, String) {
         if let Expression::Tuple { elements, ty, .. } = last {
-            let plan = self.plan_tuple_value(elements, ty, true, fx);
+            let plan = self.plan_tuple_value(elements, ty, true);
             plan.into_parts()
         } else {
-            self.lower_value(last, ExpressionContext::value(), fx)
+            self.lower_value(last, ExpressionContext::value())
                 .into_parts()
         }
     }
@@ -616,19 +598,18 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ty: &Type,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if let Expression::Block { items, .. } = expression {
             if ty.is_never() || ty.is_unit() || matches!(ty, Type::Var { .. } | Type::Forall { .. })
             {
                 return value_plan_from_statements(
-                    self.lower_block_as_body(expression, fx).statements,
+                    self.lower_block_as_body(expression).statements,
                     String::new(),
                 );
             }
-            let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
+            let (result_var, declaration) = self.operand_temp_declaration(ty);
             let needs_braces = items.len() > 1;
-            let body = self.lower_block_to_var(expression, &result_var, None, needs_braces, fx);
+            let body = self.lower_block_to_var(expression, &result_var, None, needs_braces);
             let mut statements = vec![declaration];
             if needs_braces {
                 statements.push(LoweredStatement::Block(LoweredBlock { statements: body }));
@@ -638,21 +619,17 @@ impl Planner<'_> {
             return value_plan_from_statements(statements, result_var);
         }
         if let Expression::Loop { .. } = expression {
-            return self.plan_loop_as_operand_temp(expression, ty, fx);
+            return self.plan_loop_as_operand_temp(expression, ty);
         }
-        let (result_var, declaration) = self.operand_temp_declaration(ty, fx);
+        let (result_var, declaration) = self.operand_temp_declaration(ty);
         let mut statements = vec![declaration];
-        statements.extend(self.lower_assign(expression, &result_var, Some(ty), fx));
+        statements.extend(self.lower_assign(expression, &result_var, Some(ty)));
         value_plan_from_statements(statements, result_var)
     }
 
     /// Build a `BreakValuePlan` for a `break value` statement.
-    pub(crate) fn build_break_value_plan(
-        &mut self,
-        val: &Expression,
-        fx: &mut EmitEffects,
-    ) -> BreakValuePlan {
-        let value = self.plan_value(val, ExpressionContext::value(), fx);
+    pub(crate) fn build_break_value_plan(&mut self, val: &Expression) -> BreakValuePlan {
+        let value = self.plan_value(val, ExpressionContext::value());
         let value_is_empty = value.operand_text().is_some_and(str::is_empty);
         let is_propagate_diverged = value_is_empty && matches!(val, Expression::Propagate { .. });
         let disposition = if is_propagate_diverged {

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::calls::CallBoundary;
 use crate::context::expression::ExpressionContext;
@@ -73,9 +72,8 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
-        let (setup, value) = self.lower_value(expression, ctx, fx).into_parts();
+        let (setup, value) = self.lower_value(expression, ctx).into_parts();
         value_plan_from_statements(setup, value)
     }
 
@@ -85,86 +83,83 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         ctx: ExpressionContext<'_>,
-        fx: &mut EmitEffects,
     ) -> ValuePlan {
         if self.is_test_log_call(expression) {
-            let (setup, call) = self.lower_test_log_call(expression, fx);
+            let (setup, call) = self.lower_test_log_call(expression);
             return value_plan_from_statements(setup, call);
         }
         match expression {
             Expression::Paren { expression, .. } => {
-                ValuePlan::Paren(Box::new(self.plan_operand(expression, ctx, fx)))
+                ValuePlan::Paren(Box::new(self.plan_operand(expression, ctx)))
             }
-            Expression::Cast { expression, ty, .. } => self.plan_cast(expression, ty, ctx, fx),
+            Expression::Cast { expression, ty, .. } => self.plan_cast(expression, ty, ctx),
             Expression::IndexedAccess {
                 expression, index, ..
-            } => self.plan_index_access(expression, index, fx),
+            } => self.plan_index_access(expression, index),
             Expression::Binary {
                 operator,
                 left,
                 right,
                 ..
-            } => self.plan_binary(operator, left, right, ctx, fx),
+            } => self.plan_binary(operator, left, right, ctx),
             Expression::Unary {
                 operator,
                 expression,
                 ..
-            } => self.plan_unary(operator, expression, ctx, fx),
-            Expression::Tuple { elements, ty, .. } => {
-                self.plan_tuple_value(elements, ty, false, fx)
-            }
+            } => self.plan_unary(operator, expression, ctx),
+            Expression::Tuple { elements, ty, .. } => self.plan_tuple_value(elements, ty, false),
             Expression::Range {
                 start,
                 end,
                 inclusive,
                 ty,
                 ..
-            } => self.plan_range_value(start, end, *inclusive, ty, fx),
+            } => self.plan_range_value(start, end, *inclusive, ty),
             Expression::StructCall {
                 name,
                 field_assignments,
                 spread,
                 ty,
                 ..
-            } => self.plan_struct_call(name, field_assignments, spread, ty, ctx, fx),
+            } => self.plan_struct_call(name, field_assignments, spread, ty, ctx),
             Expression::Reference {
                 expression: inner,
                 ty,
                 ..
-            } => self.plan_reference(inner, ty, fx),
-            Expression::DotAccess { .. } => self.plan_dot_access(expression, ctx, fx),
+            } => self.plan_reference(inner, ty),
+            Expression::DotAccess { .. } => self.plan_dot_access(expression, ctx),
             Expression::Task {
                 expression: inner, ..
-            } => self.plan_async_wrapper("go", inner, fx),
+            } => self.plan_async_wrapper("go", inner),
             Expression::Defer {
                 expression: inner, ..
-            } => self.plan_async_wrapper("defer", inner, fx),
-            Expression::TryBlock { items, ty, .. } => self.lower_try_block(items, ty, fx),
-            Expression::RecoverBlock { items, ty, .. } => self.lower_recover_block(items, ty, fx),
+            } => self.plan_async_wrapper("defer", inner),
+            Expression::TryBlock { items, ty, .. } => self.lower_try_block(items, ty),
+            Expression::RecoverBlock { items, ty, .. } => self.lower_recover_block(items, ty),
             Expression::Propagate { expression, .. } => {
-                let (setup, value) = self.lower_propagate(expression, None, fx);
+                let (setup, value) = self.lower_propagate(expression, None);
                 value_plan_from_statements(setup, value)
             }
-            Expression::If { ty, .. } => self.plan_if_as_operand_temp(expression, ty, fx),
-            Expression::Loop { ty, .. } => self.plan_loop_as_operand_temp(expression, ty, fx),
+            Expression::If { ty, .. } => self.plan_if_as_operand_temp(expression, ty),
+            Expression::Loop { ty, .. } => self.plan_loop_as_operand_temp(expression, ty),
             Expression::IfLet { ty, .. }
             | Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
                 if !ty.is_never() =>
             {
-                self.plan_branching_as_operand_temp(expression, ty, fx)
+                self.plan_branching_as_operand_temp(expression, ty)
             }
             Expression::Call { ty, .. } => match self.classify_call(expression) {
                 CallBoundary::Plain => {
-                    let (setup, value) = self.lower_call(expression, Some(ty), ctx, fx);
+                    let (setup, value) = self.lower_call(expression, Some(ty), ctx);
                     value_plan_from_statements(setup, value)
                 }
                 CallBoundary::GoWrapped(strategy) => {
-                    self.lower_go_wrapped_call(expression, &strategy, ty, fx)
+                    self.lower_go_wrapped_call(expression, &strategy, ty)
                 }
-                CallBoundary::LoweredCallee(_) => self.plan_operand_leaf(expression, ctx, fx),
+                CallBoundary::LoweredCallee(_) => self.plan_operand_leaf(expression, ctx),
             },
-            _ => self.plan_operand_leaf(expression, ctx, fx),
+            _ => self.plan_operand_leaf(expression, ctx),
         }
     }
 }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::context::expression::ExpressionContext;
@@ -20,14 +19,13 @@ impl Planner<'_> {
         target: &Expression,
         value: &Expression,
         compound_operator: Option<&BinaryOperator>,
-        fx: &mut EmitEffects,
     ) -> AssignPlan {
         let raw_body = |statements: Vec<LoweredStatement>| LoweredBlock { statements };
 
         if value.get_type().is_never() {
             return AssignPlan {
                 form: AssignForm::NeverTyped {
-                    body: raw_body(vec![self.lower_statement(value, fx)]),
+                    body: raw_body(vec![self.lower_statement(value)]),
                 },
             };
         }
@@ -43,7 +41,7 @@ impl Planner<'_> {
                 };
                 (kind, false)
             } else {
-                let staged = self.stage_operand(rhs, ExpressionContext::value(), fx);
+                let staged = self.stage_operand(rhs, ExpressionContext::value());
                 let rhs_has_setup =
                     !staged.setup.is_empty() || self.rhs_contains_effectful_call(rhs);
                 let kind = CompoundKind::OpAssign {
@@ -54,9 +52,9 @@ impl Planner<'_> {
             };
             let mut target_capture: Vec<LoweredStatement> = Vec::new();
             let target_str = if is_order_sensitive(target) {
-                self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup, fx)
+                self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
             } else {
-                self.emit_left_value(&mut target_capture, target, fx)
+                self.emit_left_value(&mut target_capture, target)
             };
             return AssignPlan {
                 form: AssignForm::Compound {
@@ -70,7 +68,7 @@ impl Planner<'_> {
         if self.target_binds_to_discard(target) {
             return AssignPlan {
                 form: AssignForm::Discard {
-                    body: raw_body(self.lower_discard_value(value, fx)),
+                    body: raw_body(self.lower_discard_value(value)),
                 },
             };
         }
@@ -91,9 +89,9 @@ impl Planner<'_> {
         {
             let mut target_capture: Vec<LoweredStatement> = Vec::new();
             let target_str = if is_order_sensitive(target) {
-                self.emit_left_value_capturing(&mut target_capture, target, false, fx)
+                self.emit_left_value_capturing(&mut target_capture, target, false)
             } else {
-                self.emit_left_value(&mut target_capture, target, fx)
+                self.emit_left_value(&mut target_capture, target)
             };
             return AssignPlan {
                 form: AssignForm::NilClear {
@@ -106,13 +104,13 @@ impl Planner<'_> {
         // `target = value`. Stage RHS first (so the target capture knows
         // whether RHS produced setup), capture the target, then fold RHS
         // setup + coercion setup into the value plan in emission order.
-        let rhs_staged = self.stage_composite(value, ExpressionContext::value(), fx);
+        let rhs_staged = self.stage_composite(value, ExpressionContext::value());
         let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
         let mut target_capture: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup, fx)
+            self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
         } else {
-            self.emit_left_value(&mut target_capture, target, fx)
+            self.emit_left_value(&mut target_capture, target)
         };
         let mut value_setup = rhs_staged.setup;
         let coercion = if let Some(target_ty) = go_field_ty {
@@ -130,7 +128,7 @@ impl Planner<'_> {
                 CoercionDirection::Internal,
             )
         };
-        let (coercion_setup, final_value) = coercion.lower(self, rhs_staged.value, fx);
+        let (coercion_setup, final_value) = coercion.lower(self, rhs_staged.value);
         value_setup.extend(coercion_setup);
         AssignPlan {
             form: AssignForm::Simple {
@@ -239,7 +237,6 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
         let expression = expression.unwrap_parens();
         match expression {
@@ -252,29 +249,29 @@ impl Planner<'_> {
                 expression, member, ..
             } => {
                 let base = expression.deref_inner().unwrap_or(expression);
-                let base_str = self.capture_operand_into(setup, base, fx);
+                let base_str = self.capture_operand_into(setup, base);
                 let expression_ty = expression.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member, fx)
+                self.format_dot_access_lvalue(&base_str, &expression_ty, member)
             }
             Expression::IndexedAccess {
                 expression, index, ..
             } => {
                 let expression_string = if let Some(inner) = expression.deref_inner() {
-                    let inner_str = self.capture_operand_into(setup, inner, fx);
+                    let inner_str = self.capture_operand_into(setup, inner);
                     format!("(*{})", inner_str)
                 } else {
-                    self.capture_operand_into(setup, expression, fx)
+                    self.capture_operand_into(setup, expression)
                 };
-                let index_str = self.capture_operand_into(setup, index, fx);
+                let index_str = self.capture_operand_into(setup, index);
                 format!("{}[{}]", expression_string, index_str)
             }
             Expression::Unary {
                 operator: UnaryOperator::Deref,
                 expression,
                 ..
-            } => self.emit_deref_lvalue(setup, expression, false, fx),
+            } => self.emit_deref_lvalue(setup, expression, false),
             Expression::Call { .. } if expression.get_type().is_ref() => {
-                let call_str = self.capture_operand_into(setup, expression, fx);
+                let call_str = self.capture_operand_into(setup, expression);
                 self.hoist_tmp_value_statement(setup, "ref", &call_str)
             }
             _ => "_".to_string(),
@@ -289,9 +286,8 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         pointee: &Expression,
         rhs_has_setup: bool,
-        fx: &mut EmitEffects,
     ) -> String {
-        let pointee_string = self.capture_operand_into(setup, pointee, fx);
+        let pointee_string = self.capture_operand_into(setup, pointee);
         let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
             || (rhs_has_setup && observable_after_mutation(pointee));
         if needs_capture {
@@ -309,11 +305,9 @@ impl Planner<'_> {
         base_str: &str,
         expression_ty: &Type,
         member: &str,
-        fx: &mut EmitEffects,
     ) -> String {
         if let Ok(index) = member.parse::<usize>() {
-            let access =
-                self.try_emit_tuple_struct_field_access(base_str, expression_ty, index, fx);
+            let access = self.try_emit_tuple_struct_field_access(base_str, expression_ty, index);
             if let Some(access) = access {
                 return access;
             }
@@ -336,7 +330,6 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         rhs_has_setup: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let expression = expression.unwrap_parens();
         match expression {
@@ -345,8 +338,8 @@ impl Planner<'_> {
                 index,
                 ..
             } => {
-                let base_str = self.emit_indexed_base_lvalue(setup, base, fx);
-                let index_str = self.emit_index_lvalue(setup, index, rhs_has_setup, fx);
+                let base_str = self.emit_indexed_base_lvalue(setup, base);
+                let index_str = self.emit_index_lvalue(setup, index, rhs_has_setup);
                 format!("{}[{}]", base_str, index_str)
             }
             Expression::DotAccess {
@@ -356,26 +349,26 @@ impl Planner<'_> {
             } => {
                 let base_str = if let Some(inner) = base.deref_inner() {
                     if rhs_has_setup {
-                        self.emit_force_capture(setup, inner, "ref", fx)
+                        self.emit_force_capture(setup, inner, "ref")
                     } else {
-                        self.capture_operand_into(setup, inner, fx)
+                        self.capture_operand_into(setup, inner)
                     }
                 } else if is_order_sensitive(base) {
-                    self.emit_left_value_capturing(setup, base, rhs_has_setup, fx)
+                    self.emit_left_value_capturing(setup, base, rhs_has_setup)
                 } else if rhs_has_setup && base.get_type().is_ref() {
-                    self.emit_force_capture(setup, base, "ref", fx)
+                    self.emit_force_capture(setup, base, "ref")
                 } else {
-                    self.emit_left_value(setup, base, fx)
+                    self.emit_left_value(setup, base)
                 };
                 let expression_ty = base.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member, fx)
+                self.format_dot_access_lvalue(&base_str, &expression_ty, member)
             }
             Expression::Unary {
                 operator: UnaryOperator::Deref,
                 expression: inner,
                 ..
-            } => self.emit_deref_lvalue(setup, inner, rhs_has_setup, fx),
-            _ => self.emit_left_value(setup, expression, fx),
+            } => self.emit_deref_lvalue(setup, inner, rhs_has_setup),
+            _ => self.emit_left_value(setup, expression),
         }
     }
 
@@ -386,14 +379,13 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         base: &Expression,
-        fx: &mut EmitEffects,
     ) -> String {
         let force = is_order_sensitive(base);
         if let Some(inner) = base.deref_inner() {
-            let inner_str = self.emit_base_operand(setup, inner, force, fx);
+            let inner_str = self.emit_base_operand(setup, inner, force);
             format!("(*{})", inner_str)
         } else {
-            self.emit_base_operand(setup, base, force, fx)
+            self.emit_base_operand(setup, base, force)
         }
     }
 
@@ -402,12 +394,11 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         force_capture: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         if force_capture {
-            self.emit_force_capture(setup, expression, "base", fx)
+            self.emit_force_capture(setup, expression, "base")
         } else {
-            self.capture_operand_into(setup, expression, fx)
+            self.capture_operand_into(setup, expression)
         }
     }
 
@@ -419,7 +410,6 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         index: &Expression,
         rhs_has_setup: bool,
-        fx: &mut EmitEffects,
     ) -> String {
         let needs_capture = if rhs_has_setup {
             !matches!(index.unwrap_parens(), Expression::Literal { .. })
@@ -427,9 +417,9 @@ impl Planner<'_> {
             is_order_sensitive(index)
         };
         if needs_capture {
-            self.emit_force_capture(setup, index, "idx", fx)
+            self.emit_force_capture(setup, index, "idx")
         } else {
-            self.capture_operand_into(setup, index, fx)
+            self.capture_operand_into(setup, index)
         }
     }
 }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,4 +1,3 @@
-use crate::EmitEffects;
 use crate::Planner;
 use crate::abi::coercion::{Coercion, CoercionDirection};
 use crate::calls::go_interop::{GoCallStrategy, WrapperTarget};
@@ -79,12 +78,11 @@ fn maybe_clone_subslice(
     value: &Expression,
     mutable: bool,
     expression: String,
-    fx: &mut EmitEffects,
 ) -> String {
     if !is_mutable_subslice(planner, value, mutable) {
         return expression;
     }
-    fx.require_slices();
+    planner.require_slices();
     format!("slices.Clone({})", expression)
 }
 
@@ -171,7 +169,6 @@ impl Planner<'_> {
         &mut self,
         let_spec: LetSpec,
         raw_go_name: Option<&str>,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let LetSpec {
             identifier,
@@ -180,29 +177,29 @@ impl Planner<'_> {
             ..
         } = let_spec;
         if is_unit_call(value) {
-            return self.lower_let_unit_call(identifier, raw_go_name, value, fx);
+            return self.lower_let_unit_call(identifier, raw_go_name, value);
         }
         let needs_temp = requires_temp_var(value);
         let Some(raw_go_name) = raw_go_name else {
             self.scope.bind(identifier, "_");
             return if needs_temp {
-                self.lower_let_temp("_", value, binding_ty, fx)
+                self.lower_let_temp("_", value, binding_ty)
             } else {
-                self.lower_discard_value(value, fx)
+                self.lower_discard_value(value)
             };
         };
         if needs_temp {
             let go_identifier = escape_reserved(raw_go_name);
             if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
                 let fresh = self.fresh_var(Some(identifier));
-                let statements = self.lower_let_temp(&fresh, value, binding_ty, fx);
+                let statements = self.lower_let_temp(&fresh, value, binding_ty);
                 self.scope.bind(identifier, &fresh);
                 return statements;
             }
             self.scope.bind(identifier, raw_go_name);
-            return self.lower_let_temp(&go_identifier, value, binding_ty, fx);
+            return self.lower_let_temp(&go_identifier, value, binding_ty);
         }
-        self.lower_let_direct(let_spec, raw_go_name, fx)
+        self.lower_let_direct(let_spec, raw_go_name)
     }
 
     /// `let x = expr?`. Adds a leading `var x T` when the binding widens to
@@ -213,7 +210,6 @@ impl Planner<'_> {
         raw_go_name: Option<&str>,
         value: &Expression,
         binding_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let Expression::Propagate {
             expression: inner, ..
@@ -223,14 +219,14 @@ impl Planner<'_> {
         };
         let Some(raw_go_name) = raw_go_name else {
             self.scope.bind(identifier, "_");
-            return self.lower_propagate(inner, Some("_"), fx).0;
+            return self.lower_propagate(inner, Some("_")).0;
         };
         let go_identifier = self.choose_let_go_name(identifier, raw_go_name, false);
         let widens_to_interface =
             self.facts.is_interface(binding_ty) && *binding_ty != value.get_type();
         let mut statements = Vec::new();
         if widens_to_interface {
-            let var_ty = self.go_type_string(binding_ty, fx);
+            let var_ty = self.go_type_string(binding_ty);
             statements.push(LoweredStatement::VarDecl {
                 name: go_identifier.clone(),
                 go_type: var_ty,
@@ -238,7 +234,7 @@ impl Planner<'_> {
             });
             self.declare(&go_identifier);
         }
-        statements.extend(self.lower_propagate(inner, Some(&go_identifier), fx).0);
+        statements.extend(self.lower_propagate(inner, Some(&go_identifier)).0);
         self.scope.bind(identifier, &go_identifier);
         self.try_declare(&go_identifier);
         statements
@@ -251,10 +247,9 @@ impl Planner<'_> {
         identifier: &str,
         raw_go_name: Option<&str>,
         value: &Expression,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let (mut statements, value_expression) = self
-            .lower_value(value, ExpressionContext::value(), fx)
+            .lower_value(value, ExpressionContext::value())
             .into_parts();
         statements.push(LoweredStatement::RawGo(format!("{}\n", value_expression)));
         let Some(raw_go_name) = raw_go_name else {
@@ -280,12 +275,7 @@ impl Planner<'_> {
         statements
     }
 
-    fn lower_let_direct(
-        &mut self,
-        let_spec: LetSpec,
-        raw_go_name: &str,
-        fx: &mut EmitEffects,
-    ) -> Vec<LoweredStatement> {
+    fn lower_let_direct(&mut self, let_spec: LetSpec, raw_go_name: &str) -> Vec<LoweredStatement> {
         let LetSpec {
             identifier,
             value,
@@ -294,13 +284,13 @@ impl Planner<'_> {
         } = let_spec;
         if !mutable
             && let Some(statements) =
-                self.try_lower_let_into_wrapper_slot(identifier, raw_go_name, value, binding_ty, fx)
+                self.try_lower_let_into_wrapper_slot(identifier, raw_go_name, value, binding_ty)
         {
             return statements;
         }
 
         let (mut statements, value_expression) = self
-            .lower_value(value, ExpressionContext::value(), fx)
+            .lower_value(value, ExpressionContext::value())
             .into_parts();
         let coercion = Coercion::resolve(
             self,
@@ -308,9 +298,9 @@ impl Planner<'_> {
             binding_ty,
             CoercionDirection::Internal,
         );
-        let (coercion_setup, value_expression) = coercion.lower(self, value_expression, fx);
+        let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
         statements.extend(coercion_setup);
-        let value_expression = maybe_clone_subslice(self, value, mutable, value_expression, fx);
+        let value_expression = maybe_clone_subslice(self, value, mutable, value_expression);
 
         let go_identifier = self.scope.bind(identifier, raw_go_name);
         let is_new = self.try_declare(&go_identifier);
@@ -324,7 +314,7 @@ impl Planner<'_> {
                 value: value_expression,
             });
         } else if needs_explicit_type_declaration(self, value, binding_ty) {
-            let var_ty = self.go_type_string(binding_ty, fx);
+            let var_ty = self.go_type_string(binding_ty);
             statements.push(LoweredStatement::VarDecl {
                 name: go_identifier,
                 go_type: var_ty,
@@ -347,7 +337,6 @@ impl Planner<'_> {
         raw_go_name: &str,
         value: &Expression,
         binding_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<Vec<LoweredStatement>> {
         let go_identifier = escape_reserved(raw_go_name);
         if self.is_declared(&go_identifier)
@@ -367,7 +356,7 @@ impl Planner<'_> {
             return None;
         }
         let target = WrapperTarget::Slot(&go_identifier);
-        let statements = self.lower_go_wrapped_call_to(value, &strategy, binding_ty, target, fx)?;
+        let statements = self.lower_go_wrapped_call_to(value, &strategy, binding_ty, target)?;
         // `push_wrapper_slot` / `push_simple_wrapper_value` already declared
         // `go_identifier`; only the binding from the user-name still needs setup.
         self.scope.bind(identifier, go_identifier.as_ref());
@@ -379,16 +368,15 @@ impl Planner<'_> {
         name: &str,
         value: &Expression,
         binding_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if !self.is_declared(name) {
-            if let Some(declaration) = self.let_temp_var_declaration(name, value, binding_ty, fx) {
+            if let Some(declaration) = self.let_temp_var_declaration(name, value, binding_ty) {
                 statements.push(declaration);
             }
             self.try_declare(name);
         }
-        statements.extend(self.lower_assign(value, name, Some(binding_ty), fx));
+        statements.extend(self.lower_assign(value, name, Some(binding_ty)));
         statements
     }
 
@@ -397,7 +385,6 @@ impl Planner<'_> {
         name: &str,
         value: &Expression,
         binding_ty: &Type,
-        fx: &mut EmitEffects,
     ) -> Option<LoweredStatement> {
         if name == "_" {
             return None;
@@ -412,18 +399,18 @@ impl Planner<'_> {
 
         let var_ty = if has_variable_ok_ty {
             if !binding_ty.is_variable() && !binding_ty.ok_type().is_variable() {
-                self.go_type_string(binding_ty, fx)
+                self.go_type_string(binding_ty)
             } else if let Some(ctx_ty) = return_ctx.ty().cloned() {
                 if Fallible::from_type(&ctx_ty).is_some() {
-                    self.go_type_string(&ctx_ty, fx)
+                    self.go_type_string(&ctx_ty)
                 } else {
-                    self.go_type_string(&resolved_ty, fx)
+                    self.go_type_string(&resolved_ty)
                 }
             } else {
-                self.go_type_string(&resolved_ty, fx)
+                self.go_type_string(&resolved_ty)
             }
         } else {
-            self.go_type_string(&resolved_ty, fx)
+            self.go_type_string(&resolved_ty)
         };
         Some(LoweredStatement::VarDecl {
             name: name.to_string(),
@@ -470,7 +457,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
     }
 
     /// Classify the binding and build the matching `LetForm`.
-    pub(crate) fn build_form(mut self, fx: &mut EmitEffects) -> LetForm {
+    pub(crate) fn build_form(mut self) -> LetForm {
         // Never-typed values diverge (break/continue/return). Declare the
         // binding so dead code can reference it, then emit the value as a
         // statement.
@@ -480,7 +467,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             {
                 let go_identifier = self.planner.scope.bind(identifier, &raw_go_name);
                 self.planner.try_declare(&go_identifier);
-                let var_ty = self.planner.go_type_string(&self.binding.ty, fx);
+                let var_ty = self.planner.go_type_string(&self.binding.ty);
                 Some(Box::new(LoweredStatement::VarDecl {
                     name: go_identifier,
                     go_type: var_ty,
@@ -492,7 +479,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             return LetForm::Never {
                 declaration,
                 body: LoweredBlock {
-                    statements: vec![self.planner.lower_statement(self.value, fx)],
+                    statements: vec![self.planner.lower_statement(self.value)],
                 },
             };
         }
@@ -510,7 +497,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                         &self.binding.ty,
                         self.value,
                         span,
-                        fx,
                     )
                 } else {
                     let else_block = self
@@ -521,7 +507,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                         &self.binding.ty,
                         self.value,
                         else_block,
-                        fx,
                     )
                 };
                 LetForm::Refutable {
@@ -529,13 +514,13 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 }
             }
             LetKind::SimpleIdentifier => LetForm::SimpleIdentifier {
-                body: self.lower_simple_identifier(fx),
+                body: self.lower_simple_identifier(),
             },
             LetKind::Discard => LetForm::Discard {
-                body: self.lower_discard(fx),
+                body: self.lower_discard(),
             },
             LetKind::MultiValueCall => LetForm::MultiValueCall {
-                body: self.lower_multi_value_call(fx),
+                body: self.lower_multi_value_call(),
             },
             LetKind::ComplexPattern => {
                 let value_ty = self.value.get_type();
@@ -544,7 +529,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                     &self.binding.pattern,
                     self.binding.typed_pattern.as_ref(),
                     &value_ty,
-                    fx,
                 );
                 LetForm::ComplexPattern {
                     body: LoweredBlock { statements },
@@ -599,7 +583,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             && extract_simple_tuple_vars(&self.binding.pattern).is_some()
     }
 
-    fn lower_simple_identifier(&mut self, fx: &mut EmitEffects) -> LoweredBlock {
+    fn lower_simple_identifier(&mut self) -> LoweredBlock {
         let Pattern::Identifier { identifier, .. } = &self.binding.pattern else {
             unreachable!("lower_simple_identifier called with non-identifier pattern");
         };
@@ -610,7 +594,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 raw_go_name.as_deref(),
                 self.value,
                 &self.binding.ty,
-                fx,
             );
             return LoweredBlock { statements };
         }
@@ -622,18 +605,17 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 mutable: self.mutable,
             },
             raw_go_name.as_deref(),
-            fx,
         );
         LoweredBlock { statements }
     }
 
-    fn lower_discard(&mut self, fx: &mut EmitEffects) -> LoweredBlock {
+    fn lower_discard(&mut self) -> LoweredBlock {
         LoweredBlock {
-            statements: self.planner.lower_discard_value(self.value, fx),
+            statements: self.planner.lower_discard_value(self.value),
         }
     }
 
-    fn lower_multi_value_call(&mut self, fx: &mut EmitEffects) -> LoweredBlock {
+    fn lower_multi_value_call(&mut self) -> LoweredBlock {
         let Pattern::Tuple { elements, .. } = &self.binding.pattern else {
             unreachable!("lower_multi_value_call called with non-tuple pattern");
         };
@@ -673,7 +655,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
 
         let (mut statements, call_str) =
             self.planner
-                .lower_call(self.value, None, ExpressionContext::value(), fx);
+                .lower_call(self.value, None, ExpressionContext::value());
 
         for (identifier, go_name) in planned.iter().flatten() {
             self.planner.scope.bind(*identifier, go_name);
@@ -725,10 +707,8 @@ impl Planner<'_> {
         else_block: Option<&Expression>,
         mutable: bool,
         assert: bool,
-        fx: &mut EmitEffects,
     ) -> LetPlan {
-        let form =
-            LetPlanner::new(self, binding, value, else_block, mutable, assert).build_form(fx);
+        let form = LetPlanner::new(self, binding, value, else_block, mutable, assert).build_form();
         LetPlan { form }
     }
 }

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -118,18 +118,18 @@ impl Planner<'_> {
         build_param_typed(format!("{}[{}]", kind.leaf_name(), type_args), &param_types)
     }
 
-    /// Render a type to Go text, recording stdlib + Go-import effects in `fx`.
-    pub(crate) fn go_type_string(&self, ty: &Type, fx: &mut EmitEffects) -> String {
+    /// Render a type to Go text, recording its stdlib + Go-import effects.
+    pub(crate) fn go_type_string(&self, ty: &Type) -> String {
         let result = self.go_type(ty);
-        fx.merge_from_go_type(&result);
+        self.note_go_type(&result);
         result.code
     }
 
-    pub(crate) fn format_type_args(&mut self, params: &[Type], fx: &mut EmitEffects) -> String {
+    pub(crate) fn format_type_args(&mut self, params: &[Type]) -> String {
         if params.is_empty() {
             return String::new();
         }
-        let args: Vec<String> = params.iter().map(|p| self.go_type_string(p, fx)).collect();
+        let args: Vec<String> = params.iter().map(|p| self.go_type_string(p)).collect();
         format!("[{}]", args.join(", "))
     }
 
@@ -137,11 +137,10 @@ impl Planner<'_> {
         &mut self,
         recipe: &str,
         mapping: &rustc_hash::FxHashMap<String, Type>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         let mut parts = Vec::new();
         for entry in split_top_level_commas(recipe) {
-            parts.push(self.render_recipe_entry(entry.trim(), mapping, fx)?);
+            parts.push(self.render_recipe_entry(entry.trim(), mapping)?);
         }
         (!parts.is_empty()).then(|| format!("[{}]", parts.join(", ")))
     }
@@ -150,14 +149,13 @@ impl Planner<'_> {
         &mut self,
         entry: &str,
         mapping: &rustc_hash::FxHashMap<String, Type>,
-        fx: &mut EmitEffects,
     ) -> Option<String> {
         if let Some(elem) = entry
             .strip_prefix("Slice<")
             .and_then(|s| s.strip_suffix('>'))
         {
             let ty = mapping.get(elem.trim())?;
-            return Some(format!("[]{}", self.go_type_string(ty, fx)));
+            return Some(format!("[]{}", self.go_type_string(ty)));
         }
         if let Some(inner) = entry.strip_prefix("Map<").and_then(|s| s.strip_suffix('>')) {
             let (key, value) = inner.split_once(',')?;
@@ -165,11 +163,11 @@ impl Planner<'_> {
             let value_ty = mapping.get(value.trim())?;
             return Some(format!(
                 "map[{}]{}",
-                self.go_type_string(key_ty, fx),
-                self.go_type_string(value_ty, fx)
+                self.go_type_string(key_ty),
+                self.go_type_string(value_ty)
             ));
         }
-        Some(self.go_type_string(mapping.get(entry)?, fx))
+        Some(self.go_type_string(mapping.get(entry)?))
     }
 
     fn emit_tuple_type(&self, elements: &[Type]) -> GoType {
@@ -363,20 +361,19 @@ impl Planner<'_> {
         &mut self,
         receiver_ty: &Type,
         type_args: &[Type],
-        fx: &mut EmitEffects,
     ) -> String {
         let mut go_type_strs = Vec::new();
         if let Some(params) = receiver_ty.get_type_params() {
             let params = params.to_vec();
             for param in &params {
-                go_type_strs.push(self.go_type_string(param, fx));
+                go_type_strs.push(self.go_type_string(param));
             }
         }
         for ta in type_args {
-            go_type_strs.push(self.go_type_string(ta, fx));
+            go_type_strs.push(self.go_type_string(ta));
         }
         if go_type_strs.is_empty() {
-            self.format_type_args(type_args, fx)
+            self.format_type_args(type_args)
         } else {
             format!("[{}]", go_type_strs.join(", "))
         }


### PR DESCRIPTION
Stops threading `EmitEffects` as a `&mut` parameter through the emit crate. Import effects now accumulate in a planner-owned sink drained once per file at the render boundary, which removes the parameter from roughly ~360 signatures.