### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.6.0](https://github.com/ivov/lisette/compare/lisette-v0.5.0...lisette-v0.6.0) - 2026-06-28
+
+### Features
+
+- feat: clearer errors for generic syntax and missing block value [#912](https://github.com/ivov/lisette/pull/912) [`f6319be`](https://github.com/ivov/lisette/commit/f6319be703f2b54fd1bd58ea4e41b8085051e989)
+- feat: add `.lis` file icon to VSCode and IntelliJ extensions [#905](https://github.com/ivov/lisette/pull/905) [`60db9b2`](https://github.com/ivov/lisette/commit/60db9b26ddae447af102f2589513ed910dfff56e)
+- feat: autocomplete struct field names [#888](https://github.com/ivov/lisette/pull/888) [`d07c32e`](https://github.com/ivov/lisette/commit/d07c32e8ca06a8abc939752213a04d641d977041)
+- feat: inline subscript assignment targets [#890](https://github.com/ivov/lisette/pull/890) [`b42764b`](https://github.com/ivov/lisette/commit/b42764b9b5b132bad4492fe68549fc99482334fc)
+- feat: suggest tuple for bare multi-value return [#873](https://github.com/ivov/lisette/pull/873) [`72566ea`](https://github.com/ivov/lisette/commit/72566eaa7d2f30aa8fff2abfef0220eb8f729059)
+- feat: lint to suggest `+= 1` for `foo++` [#872](https://github.com/ivov/lisette/pull/872) [`cd9b594`](https://github.com/ivov/lisette/commit/cd9b594348251ede8c80769d842e533f8c195bb9)
+- feat: emit compact go for nil-guarded result/partial calls [#870](https://github.com/ivov/lisette/pull/870) [`b5d5908`](https://github.com/ivov/lisette/commit/b5d59087cac54263bb3681536c93006df5777bd9)
+
+### Fixes
+
+- fix: flag public PascalCase methods in snake_case lint [#904](https://github.com/ivov/lisette/pull/904) [`a9276a9`](https://github.com/ivov/lisette/commit/a9276a956631730ef842b2d9f5fa02fb50b0ee07)
+- fix: keep a single lhs copy in compound assignments [#896](https://github.com/ivov/lisette/pull/896) [`5f4c80e`](https://github.com/ivov/lisette/commit/5f4c80e67c51fb193a96a67cf1bdadc14379c6df)
+- fix: widen snake_case and PascalCase lint coverage [#883](https://github.com/ivov/lisette/pull/883) [`df01f8c`](https://github.com/ivov/lisette/commit/df01f8c9e21b0ffa5bb31e9c03d12aa822d34e74)
+- fix: allow imported constants in const expressions [#871](https://github.com/ivov/lisette/pull/871) [`b6aee9f`](https://github.com/ivov/lisette/commit/b6aee9fd52f0e702d2772c93cd4f08e66b66ee35)
+
+### Internals
+
+- ci: allow initial backticks in commit msg subjects [#907](https://github.com/ivov/lisette/pull/907) [`00c4126`](https://github.com/ivov/lisette/commit/00c41269bc1bed04cc663c6587a093711033b4c8)
+- perf: parallelize cache writes [#906](https://github.com/ivov/lisette/pull/906) [`8659a7b`](https://github.com/ivov/lisette/commit/8659a7bc05e0336bc611b1ced56b4d913c3266ba)
+- perf: one-pass typedef generation for Go dependencies [#903](https://github.com/ivov/lisette/pull/903) [`7e695c6`](https://github.com/ivov/lisette/commit/7e695c61691a28cef5c1804ecd45baffab91897e)
+- chore: bump intellij plugin to 0.1.1 [#901](https://github.com/ivov/lisette/pull/901) [`0771dc8`](https://github.com/ivov/lisette/commit/0771dc8bdda100aff7971ee639afb9a353bd4991)
+- perf: batch typedef generation for faster cold builds [#897](https://github.com/ivov/lisette/pull/897) [`df23d0b`](https://github.com/ivov/lisette/commit/df23d0b41bf1c65d6eb36164652e80ce05093850)
+- test: dogfood test runner via e2e suite [#891](https://github.com/ivov/lisette/pull/891) [`2798ce5`](https://github.com/ivov/lisette/commit/2798ce5f0284abef331facb04b66dbcbcba30445)
+- chore: add zed-release recipe [#885](https://github.com/ivov/lisette/pull/885) [`f422086`](https://github.com/ivov/lisette/commit/f4220866c6fb44ac030226615158421e8a52b63e)
+- refactor: extract dep reconciliation [#884](https://github.com/ivov/lisette/pull/884) [`4cd4be7`](https://github.com/ivov/lisette/commit/4cd4be7c9426041baa14a1b375b514016d9dc5f7)
+- refactor: share type classification between checker and emit [#875](https://github.com/ivov/lisette/pull/875) [`7f90e36`](https://github.com/ivov/lisette/commit/7f90e36ff2a834f9ce0a84cc9d21d418ba850be9)
+- perf: free discarded cache-hit parses in parallel [#874](https://github.com/ivov/lisette/pull/874) [`8ba205c`](https://github.com/ivov/lisette/commit/8ba205cc17ec985c2a284cb4c84edd606e964bfb)
+- test: make report rendering independent of terminal width [#867](https://github.com/ivov/lisette/pull/867) [`f228c3a`](https://github.com/ivov/lisette/commit/f228c3a49c454f52e7c967adb190bace9f9a481a)
+
+
 ## [0.5.0](https://github.com/ivov/lisette/compare/lisette-v0.4.4...lisette-v0.5.0) - 2026-06-24
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -626,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,15 +20,15 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.5.0", path = "../passes" }
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
-format = { package = "lisette-format", version = "=0.5.0", path = "../format" }
-emit = { package = "lisette-emit", version = "=0.5.0", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "=0.5.0", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "=0.6.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.6.0", path = "../passes" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.6.0", path = "../diagnostics" }
+format = { package = "lisette-format", version = "=0.6.0", path = "../format" }
+emit = { package = "lisette-emit", version = "=0.6.0", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "=0.6.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.6.0", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "=0.6.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "=0.6.0", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.6.0", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.5.0", path = "../passes" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
-format = { package = "lisette-format", version = "=0.5.0", path = "../format" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "=0.6.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.6.0", path = "../passes" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.6.0", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "=0.6.0", path = "../deps" }
+format = { package = "lisette-format", version = "=0.6.0", path = "../format" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.5.0", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
+semantics = { package = "lisette-semantics", version = "=0.6.0", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.6.0", path = "../diagnostics" }
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.5.0", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "=0.5.0", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "=0.5.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.5.0", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "=0.6.0", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "=0.6.0", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "=0.6.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.6.0", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.6.0 (upcoming)

### Features

- feat: clearer errors for generic syntax and missing block value [#912](https://github.com/ivov/lisette/pull/912) [`f6319be`](https://github.com/ivov/lisette/commit/f6319be703f2b54fd1bd58ea4e41b8085051e989)
- feat: add `.lis` file icon to VSCode and IntelliJ extensions [#905](https://github.com/ivov/lisette/pull/905) [`60db9b2`](https://github.com/ivov/lisette/commit/60db9b26ddae447af102f2589513ed910dfff56e)
- feat: autocomplete struct field names [#888](https://github.com/ivov/lisette/pull/888) [`d07c32e`](https://github.com/ivov/lisette/commit/d07c32e8ca06a8abc939752213a04d641d977041)
- feat: inline subscript assignment targets [#890](https://github.com/ivov/lisette/pull/890) [`b42764b`](https://github.com/ivov/lisette/commit/b42764b9b5b132bad4492fe68549fc99482334fc)
- feat: suggest tuple for bare multi-value return [#873](https://github.com/ivov/lisette/pull/873) [`72566ea`](https://github.com/ivov/lisette/commit/72566eaa7d2f30aa8fff2abfef0220eb8f729059)
- feat: lint to suggest `+= 1` for `foo++` [#872](https://github.com/ivov/lisette/pull/872) [`cd9b594`](https://github.com/ivov/lisette/commit/cd9b594348251ede8c80769d842e533f8c195bb9)
- feat: emit compact go for nil-guarded result/partial calls [#870](https://github.com/ivov/lisette/pull/870) [`b5d5908`](https://github.com/ivov/lisette/commit/b5d59087cac54263bb3681536c93006df5777bd9)

### Fixes

- fix: flag public PascalCase methods in snake_case lint [#904](https://github.com/ivov/lisette/pull/904) [`a9276a9`](https://github.com/ivov/lisette/commit/a9276a956631730ef842b2d9f5fa02fb50b0ee07)
- fix: keep a single lhs copy in compound assignments [#896](https://github.com/ivov/lisette/pull/896) [`5f4c80e`](https://github.com/ivov/lisette/commit/5f4c80e67c51fb193a96a67cf1bdadc14379c6df)
- fix: widen snake_case and PascalCase lint coverage [#883](https://github.com/ivov/lisette/pull/883) [`df01f8c`](https://github.com/ivov/lisette/commit/df01f8c9e21b0ffa5bb31e9c03d12aa822d34e74)
- fix: allow imported constants in const expressions [#871](https://github.com/ivov/lisette/pull/871) [`b6aee9f`](https://github.com/ivov/lisette/commit/b6aee9fd52f0e702d2772c93cd4f08e66b66ee35)

### Internals

- ci: allow initial backticks in commit msg subjects [#907](https://github.com/ivov/lisette/pull/907) [`00c4126`](https://github.com/ivov/lisette/commit/00c41269bc1bed04cc663c6587a093711033b4c8)
- perf: parallelize cache writes [#906](https://github.com/ivov/lisette/pull/906) [`8659a7b`](https://github.com/ivov/lisette/commit/8659a7bc05e0336bc611b1ced56b4d913c3266ba)
- perf: one-pass typedef generation for Go dependencies [#903](https://github.com/ivov/lisette/pull/903) [`7e695c6`](https://github.com/ivov/lisette/commit/7e695c61691a28cef5c1804ecd45baffab91897e)
- chore: bump intellij plugin to 0.1.1 [#901](https://github.com/ivov/lisette/pull/901) [`0771dc8`](https://github.com/ivov/lisette/commit/0771dc8bdda100aff7971ee639afb9a353bd4991)
- perf: batch typedef generation for faster cold builds [#897](https://github.com/ivov/lisette/pull/897) [`df23d0b`](https://github.com/ivov/lisette/commit/df23d0b41bf1c65d6eb36164652e80ce05093850)
- test: dogfood test runner via e2e suite [#891](https://github.com/ivov/lisette/pull/891) [`2798ce5`](https://github.com/ivov/lisette/commit/2798ce5f0284abef331facb04b66dbcbcba30445)
- chore: add zed-release recipe [#885](https://github.com/ivov/lisette/pull/885) [`f422086`](https://github.com/ivov/lisette/commit/f4220866c6fb44ac030226615158421e8a52b63e)
- refactor: extract dep reconciliation [#884](https://github.com/ivov/lisette/pull/884) [`4cd4be7`](https://github.com/ivov/lisette/commit/4cd4be7c9426041baa14a1b375b514016d9dc5f7)
- refactor: share type classification between checker and emit [#875](https://github.com/ivov/lisette/pull/875) [`7f90e36`](https://github.com/ivov/lisette/commit/7f90e36ff2a834f9ce0a84cc9d21d418ba850be9)
- perf: free discarded cache-hit parses in parallel [#874](https://github.com/ivov/lisette/pull/874) [`8ba205c`](https://github.com/ivov/lisette/commit/8ba205cc17ec985c2a284cb4c84edd606e964bfb)
- test: make report rendering independent of terminal width [#867](https://github.com/ivov/lisette/pull/867) [`f228c3a`](https://github.com/ivov/lisette/commit/f228c3a49c454f52e7c967adb190bace9f9a481a)

