### PR TITLE
feat: emit compact go for nil-guarded result/partial calls

### DIFF
--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -1,7 +1,7 @@
 mod nullable;
 mod wrappers;
 
-pub(crate) use wrappers::{TupleReturnLayout, WrapperTarget};
+pub(crate) use wrappers::{NilGuard, TupleReturnLayout, WrapperTarget};
 
 use crate::Planner;
 use crate::calls::CallBoundary;

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -19,6 +19,34 @@ use syntax::types::Type;
 use super::GoCallStrategy;
 
 #[derive(Clone, Copy)]
+pub(crate) enum NilGuard {
+    /// Pointer ok-type: `ptr == nil`.
+    Pointer,
+    /// Non-error interface ok-type: `lisette.IsNilInterface(v)`.
+    Interface,
+}
+
+impl NilGuard {
+    pub(crate) fn is_nil(self, var: &str) -> String {
+        match self {
+            NilGuard::Pointer => format!("{var} == nil"),
+            NilGuard::Interface => format!("lisette.IsNilInterface({var})"),
+        }
+    }
+
+    pub(crate) fn non_nil(self, var: &str) -> String {
+        match self {
+            NilGuard::Pointer => format!("{var} != nil"),
+            NilGuard::Interface => format!("!lisette.IsNilInterface({var})"),
+        }
+    }
+
+    pub(crate) fn is_interface(self) -> bool {
+        matches!(self, NilGuard::Interface)
+    }
+}
+
+#[derive(Clone, Copy)]
 pub(crate) enum WrapperTarget<'a> {
     /// Allocate a fresh `var slot T` and write `slot = X` per branch.
     FreshSlot,
@@ -251,18 +279,29 @@ impl Planner<'_> {
         (statements, outcome)
     }
 
-    /// Nil check for a `Partial` ok value; `None` when the type cannot be nil.
-    fn partial_ok_nil_check(&mut self, ok_ty: &Type, val: &str) -> Option<String> {
+    /// Whether a `Partial` ok value can be Go nil, which makes the bare `Err`
+    /// variant reachable (a nil value alongside a non-nil error).
+    pub(crate) fn partial_ok_is_nilable(&self, ok_ty: &Type) -> bool {
         if self.facts.as_interface(ok_ty).is_some() {
-            self.require_stdlib();
-            return Some(format!("lisette.IsNilInterface({val})"));
+            return true;
         }
         let peeled = self.facts.peel_alias(ok_ty);
-        let nilable = self.facts.is_nilable_go_type(ok_ty)
+        self.facts.is_nilable_go_type(ok_ty)
             || peeled.is_map()
             || peeled.is_slice()
-            || peeled.is_channel();
-        nilable.then(|| format!("{val} == nil"))
+            || peeled.is_channel()
+    }
+
+    pub(crate) fn partial_ok_nil_check(&mut self, ok_ty: &Type, val: &str) -> Option<String> {
+        if !self.partial_ok_is_nilable(ok_ty) {
+            return None;
+        }
+        if self.facts.as_interface(ok_ty).is_some() {
+            self.require_stdlib();
+            Some(format!("lisette.IsNilInterface({val})"))
+        } else {
+            Some(format!("{val} == nil"))
+        }
     }
 
     pub(super) fn lower_go_result_call_wrapped(
@@ -290,6 +329,17 @@ impl Planner<'_> {
                 .as_interface(ok_ty)
                 .as_deref()
                 .is_some_and(|id| id != go_name::PRELUDE_ERROR_ID)
+    }
+
+    pub(crate) fn result_nil_guard(&self, ok_ty: &Type) -> Option<NilGuard> {
+        if !self.go_result_needs_nil_guard(ok_ty) {
+            return None;
+        }
+        Some(if self.facts.is_interface(ok_ty) {
+            NilGuard::Interface
+        } else {
+            NilGuard::Pointer
+        })
     }
 
     /// Lower a `(T, error)` Go return into a tagged `Result`.

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -178,18 +178,16 @@ impl Planner<'_> {
             return None;
         }
         let ok_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
-        if ok_ty.is_unit()
-            || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_))
-            || self.go_result_needs_nil_guard(&ok_ty)
-        {
+        if ok_ty.is_unit() || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
             return None;
         }
+        let nil_guard = self.result_nil_guard(&ok_ty);
         let return_ctx = self.return_ctx();
         let shape = return_ctx.lowered_shape()?;
         let return_ty = return_ctx.expect_ty();
 
         let want_value = !matches!(result_var_name, Some("_"));
-        let val_var = want_value.then(|| {
+        let val_var = (want_value || nil_guard.is_some()).then(|| {
             let v = self.fresh_var(Some("ret"));
             self.declare(&v);
             v
@@ -210,6 +208,23 @@ impl Planner<'_> {
             format!("{} != nil", err_var),
             failure_values,
         ));
+
+        if let Some(guard) = nil_guard {
+            let val = val_var
+                .as_deref()
+                .expect("nil guard requires the value var");
+            if guard.is_interface() {
+                self.require_stdlib();
+            }
+            self.require_errors();
+            let nil_failure = transition::lowered_err_values(
+                self,
+                &shape,
+                &return_ty,
+                "errors.New(\"unexpected nil\")",
+            );
+            statements.push(transition::tag_check(guard.is_nil(val), nil_failure));
+        }
 
         let value = match result_var_name {
             None => val_var.expect("ok value requested when result_var_name is None"),

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,6 +1,7 @@
 use crate::GoCallStrategy;
 use crate::Planner;
 use crate::abi::AbiShape;
+use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::tree_emitter::TreePlanner;
@@ -9,6 +10,11 @@ use crate::plan::calls::{CallPlan, CallReturnShape, CalleePlan};
 use crate::state::bindings::BindingValue;
 use syntax::ast::{Expression, MatchArm, Pattern};
 use syntax::types::Type;
+
+struct FusedShape {
+    shape: AbiShape,
+    nil_guard: Option<NilGuard>,
+}
 
 /// How to render the subject declaration line, based on body usage.
 enum SubjectDeclaration {
@@ -39,6 +45,11 @@ impl Planner<'_> {
         }
 
         if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place) {
+            statements.extend(fused);
+            return LoweredBlock { statements };
+        }
+
+        if let Some(fused) = self.lower_fused_partial_match(subject, arms, place) {
             statements.extend(fused);
             return LoweredBlock { statements };
         }
@@ -89,25 +100,25 @@ impl Planner<'_> {
     /// The shape a match subject fuses against: lowered Lisette `Result` callees
     /// and single-value Go `(T, error)` calls. `None` keeps the lift-then-match
     /// path (Partial, Option, comma-ok, flattened multi-returns).
-    fn fusable_result_shape(&self, subject: &Expression, plan: &CallPlan) -> Option<AbiShape> {
-        let shape = match (&plan.callee, &plan.return_shape) {
-            (_, CallReturnShape::Lowered(shape)) => shape.clone(),
+    fn fusable_result_shape(&self, subject: &Expression, plan: &CallPlan) -> Option<FusedShape> {
+        let (shape, nil_guard) = match (&plan.callee, &plan.return_shape) {
+            (_, CallReturnShape::Lowered(shape)) => (shape.clone(), None),
             (CalleePlan::GoInterop(GoCallStrategy::Result), _) => {
                 let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
-                if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_))
-                    || self.go_result_needs_nil_guard(&ok_ty)
-                {
+                if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
                     return None;
                 }
-                if ok_ty.is_unit() {
+                let shape = if ok_ty.is_unit() {
                     AbiShape::BareError
                 } else {
                     AbiShape::ResultTuple
-                }
+                };
+                (shape, self.result_nil_guard(&ok_ty))
             }
             _ => return None,
         };
-        matches!(shape, AbiShape::ResultTuple | AbiShape::BareError).then_some(shape)
+        matches!(shape, AbiShape::ResultTuple | AbiShape::BareError)
+            .then_some(FusedShape { shape, nil_guard })
     }
 
     /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
@@ -119,7 +130,7 @@ impl Planner<'_> {
         place: &PlacePlan,
     ) -> Option<Vec<LoweredStatement>> {
         let plan = self.plan_call(subject)?;
-        let shape = self.fusable_result_shape(subject, &plan)?;
+        let FusedShape { shape, nil_guard } = self.fusable_result_shape(subject, &plan)?;
         let (ok_arm, err_arm) = classify_result_arms(arms)?;
 
         // Err always carries a payload; Ok may not under BareError.
@@ -132,13 +143,13 @@ impl Planner<'_> {
         let ok_name = ok_binding.filter(|n| *n != "_");
         let err_name = err_binding.filter(|n| *n != "_");
 
-        let val_var = if matches!(shape, AbiShape::ResultTuple) && ok_name.is_some() {
+        let need_val =
+            matches!(shape, AbiShape::ResultTuple) && (ok_name.is_some() || nil_guard.is_some());
+        let val_var = need_val.then(|| {
             let v = self.fresh_var(Some("ret"));
             self.declare(&v);
-            Some(v)
-        } else {
-            None
-        };
+            v
+        });
         let err_var = self.fresh_var(Some("ret"));
         self.declare(&err_var);
 
@@ -156,16 +167,42 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let then_body =
-            self.lower_fused_arm(ok_name.zip(val_var.as_deref()), &ok_arm.expression, place);
-        let else_body = self.lower_fused_arm(
-            err_name.map(|n| (n, err_var.as_str())),
+        let (then_body, _) = self.lower_fused_arm(
+            &[ok_name.zip(val_var.as_deref())],
+            &ok_arm.expression,
+            place,
+        );
+        let (mut else_body, err_used) = self.lower_fused_arm(
+            &[err_name.map(|n| (n, err_var.as_str()))],
             &err_arm.expression,
             place,
         );
+
+        let condition = match nil_guard {
+            Some(guard) => {
+                let val = val_var
+                    .as_deref()
+                    .expect("nil guard requires the value var");
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                if err_used {
+                    self.require_errors();
+                    else_body.statements.insert(
+                        0,
+                        LoweredStatement::RawGo(format!(
+                            "if {err_var} == nil {{\n{err_var} = errors.New(\"unexpected nil\")\n}}\n"
+                        )),
+                    );
+                }
+                format!("{} == nil && {}", err_var, guard.non_nil(val))
+            }
+            None => format!("{} == nil", err_var),
+        };
+
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: format!("{} == nil", err_var),
+            condition,
             then_body,
             else_arm: ElseArm::Else {
                 body: else_body,
@@ -175,35 +212,146 @@ impl Planner<'_> {
         Some(statements)
     }
 
+    fn fusable_partial(&self, subject: &Expression, plan: &CallPlan) -> bool {
+        let is_partial = matches!(
+            (&plan.callee, &plan.return_shape),
+            (_, CallReturnShape::Lowered(AbiShape::PartialTuple))
+                | (CalleePlan::GoInterop(GoCallStrategy::Partial), _)
+        );
+        if !is_partial {
+            return false;
+        }
+        let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
+        !matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_))
+    }
+
+    fn lower_fused_partial_match(
+        &mut self,
+        subject: &Expression,
+        arms: &[MatchArm],
+        place: &PlacePlan,
+    ) -> Option<Vec<LoweredStatement>> {
+        let plan = self.plan_call(subject)?;
+        if !self.fusable_partial(subject, &plan) {
+            return None;
+        }
+        let (ok_arm, both_arm, err_arm) = classify_partial_arms(arms)?;
+
+        let ok_binding = simple_payload_binding(ok_arm)?;
+        let err_binding = simple_payload_binding(err_arm)?;
+        let (both_val_binding, both_err_binding) = partial_both_bindings(both_arm)?;
+        let ok_name = (ok_binding != "_").then_some(ok_binding);
+        let err_name = (err_binding != "_").then_some(err_binding);
+        let both_val = (both_val_binding != "_").then_some(both_val_binding);
+        let both_err = (both_err_binding != "_").then_some(both_err_binding);
+
+        let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
+        let nilable = self.partial_ok_is_nilable(&ok_ty);
+        let val_used = ok_name.is_some() || both_val.is_some() || nilable;
+
+        let val_var = val_used.then(|| {
+            let v = self.fresh_var(Some("ret"));
+            self.declare(&v);
+            v
+        });
+        let err_var = self.fresh_var(Some("ret"));
+        self.declare(&err_var);
+
+        let (mut statements, call_str) = self.lower_call(subject, None, ExpressionContext::value());
+        let bind_line = match &val_var {
+            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
+            None => format!("_, {} := {}\n", err_var, call_str),
+        };
+        statements.push(LoweredStatement::RawGo(bind_line));
+
+        let (ok_body, _) = self.lower_fused_arm(
+            &[ok_name.zip(val_var.as_deref())],
+            &ok_arm.expression,
+            place,
+        );
+        let both_body = self
+            .lower_fused_arm(
+                &[
+                    both_val.zip(val_var.as_deref()),
+                    both_err.zip(Some(err_var.as_str())),
+                ],
+                &both_arm.expression,
+                place,
+            )
+            .0;
+
+        let nil_check = val_var
+            .as_deref()
+            .and_then(|v| self.partial_ok_nil_check(&ok_ty, v));
+
+        let else_arm = match nil_check {
+            Some(check) => {
+                let (err_body, _) = self.lower_fused_arm(
+                    &[err_name.zip(Some(err_var.as_str()))],
+                    &err_arm.expression,
+                    place,
+                );
+                ElseArm::ElseIf(Box::new(IfPlan {
+                    condition_setup: Vec::new(),
+                    condition: check,
+                    then_body: err_body,
+                    else_arm: ElseArm::Else {
+                        body: both_body,
+                        inline: false,
+                    },
+                }))
+            }
+            None => ElseArm::Else {
+                body: both_body,
+                inline: false,
+            },
+        };
+
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: format!("{} == nil", err_var),
+            then_body: ok_body,
+            else_arm,
+        }));
+        Some(statements)
+    }
+
     fn lower_fused_arm(
         &mut self,
-        binding: Option<(&str, &str)>,
+        bindings: &[Option<(&str, &str)>],
         body: &Expression,
         place: &PlacePlan,
-    ) -> LoweredBlock {
+    ) -> (LoweredBlock, bool) {
         self.scope.push_binding_frame();
-        let bound = binding.map(|(name, value)| {
-            let go_name = self.scope.bind(name, name);
-            self.declare(&go_name);
-            (go_name, value.to_string())
-        });
+        let bound: Vec<Option<(String, String)>> = bindings
+            .iter()
+            .map(|binding| {
+                binding.map(|(name, value)| {
+                    let go_name = self.scope.bind(name, name);
+                    self.declare(&go_name);
+                    (go_name, value.to_string())
+                })
+            })
+            .collect();
         self.scope.enter_use_region();
         let body_block = self.lower_block_to_place(body, place);
         let used = self.scope.exit_use_region();
         let mut statements = Vec::new();
-        if let Some((go_name, value)) = &bound {
+        let mut any_referenced = false;
+        for (go_name, value) in bound.iter().flatten() {
             statements.push(LoweredStatement::TempBind {
                 name: go_name.clone(),
                 value: value.clone(),
             });
-            let references = used.contains(go_name);
-            if !references {
+            if used.contains(go_name) {
+                any_referenced = true;
+            } else {
                 statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
             }
         }
         statements.extend(body_block.statements);
         self.scope.pop_binding_frame();
-        LoweredBlock { statements }
+        (LoweredBlock { statements }, any_referenced)
     }
 
     fn lower_match_subject_var(
@@ -288,6 +436,50 @@ fn classify_result_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm)> {
     }
 }
 
+fn classify_partial_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm, &MatchArm)> {
+    if arms.len() != 3 || arms.iter().any(|a| a.has_guard()) {
+        return None;
+    }
+    let kind = |arm: &MatchArm| -> Option<&'static str> {
+        let Pattern::EnumVariant {
+            identifier, rest, ..
+        } = &arm.pattern
+        else {
+            return None;
+        };
+        if *rest {
+            return None;
+        }
+        match identifier.as_str() {
+            "Ok" | "Partial.Ok" => Some("Ok"),
+            "Both" | "Partial.Both" => Some("Both"),
+            "Err" | "Partial.Err" => Some("Err"),
+            _ => None,
+        }
+    };
+    let (mut ok, mut both, mut err) = (None, None, None);
+    for arm in arms {
+        let slot = match kind(arm)? {
+            "Ok" => &mut ok,
+            "Both" => &mut both,
+            _ => &mut err,
+        };
+        if slot.is_some() {
+            return None;
+        }
+        *slot = Some(arm);
+    }
+    Some((ok?, both?, err?))
+}
+
+fn field_binding(pattern: &Pattern) -> Option<&str> {
+    match pattern {
+        Pattern::Identifier { identifier, .. } => Some(identifier.as_str()),
+        Pattern::WildCard { .. } => Some("_"),
+        _ => None,
+    }
+}
+
 /// `Some(name)` for `Variant(identifier)`, `Some("_")` for `Variant(_)`, `None`
 /// for empty/unit/complex payloads.
 fn simple_payload_binding(arm: &MatchArm) -> Option<&str> {
@@ -297,11 +489,17 @@ fn simple_payload_binding(arm: &MatchArm) -> Option<&str> {
     if fields.len() != 1 {
         return None;
     }
-    match &fields[0] {
-        Pattern::Identifier { identifier, .. } => Some(identifier.as_str()),
-        Pattern::WildCard { .. } => Some("_"),
-        _ => None,
+    field_binding(&fields[0])
+}
+
+fn partial_both_bindings(arm: &MatchArm) -> Option<(&str, &str)> {
+    let Pattern::EnumVariant { fields, .. } = &arm.pattern else {
+        return None;
+    };
+    if fields.len() != 2 {
+        return None;
     }
+    Some((field_binding(&fields[0])?, field_binding(&fields[1])?))
 }
 
 /// True when an Ok arm has no value to bind: empty `Ok` or `Ok(())`,

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
@@ -6,30 +6,18 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"io"
 	"strings"
 )
 
 func main() {
 	reader := strings.NewReader("hello")
-	ret_2, ret_3 := io.ReadAll(reader)
-	var result_4 lisette.Partial[[]byte, error]
-	if ret_3 != nil {
-		if ret_2 == nil {
-			result_4 = lisette.MakePartialErr[[]byte, error](ret_3)
-		} else {
-			result_4 = lisette.MakePartialBoth[[]byte, error](ret_2, ret_3)
-		}
-	} else {
-		result_4 = lisette.MakePartialOk[[]byte, error](ret_2)
-	}
-	switch result_4.Tag {
-	case lisette.PartialOk:
+	ret_1, ret_2 := io.ReadAll(reader)
+	if ret_2 == nil {
 		fmt.Print("ok")
-	case lisette.PartialBoth:
-		fmt.Print("both")
-	default:
+	} else if ret_1 == nil {
 		fmt.Print("err")
+	} else {
+		fmt.Print("both")
 	}
 }

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
@@ -7,28 +7,16 @@ package main
 import (
 	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
-	"go/ast"
 	"go/parser"
 )
 
 func main() {
-	ret_2, ret_3 := parser.ParseExpr("1 + 2")
-	var result_4 lisette.Partial[ast.Expr, error]
-	if ret_3 != nil {
-		if lisette.IsNilInterface(ret_2) {
-			result_4 = lisette.MakePartialErr[ast.Expr, error](ret_3)
-		} else {
-			result_4 = lisette.MakePartialBoth[ast.Expr, error](ret_2, ret_3)
-		}
-	} else {
-		result_4 = lisette.MakePartialOk[ast.Expr, error](ret_2)
-	}
-	switch result_4.Tag {
-	case lisette.PartialOk:
+	ret_1, ret_2 := parser.ParseExpr("1 + 2")
+	if ret_2 == nil {
 		fmt.Print("ok")
-	case lisette.PartialBoth:
-		fmt.Print("both")
-	default:
+	} else if lisette.IsNilInterface(ret_1) {
 		fmt.Print("err")
+	} else {
+		fmt.Print("both")
 	}
 }

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1053,6 +1053,19 @@ fn open_first(path: string) -> Result<int, error> {
 }
 
 #[test]
+fn propagate_go_pointer_result_returns_value_fuses() {
+    let input = r#"
+import "go:os"
+
+fn open(path: string) -> Result<Ref<os.File>, error> {
+  let file = os.Open(path)?
+  Ok(file)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_parallel_error_tuple_return() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/partial.rs
+++ b/tests/spec/emit/partial.rs
@@ -99,6 +99,46 @@ fn test(p: Partial<int, string>) -> bool {
 }
 
 #[test]
+fn fused_partial_match_on_go_write_call() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn write_all(file: Ref<os.File>) {
+  match file.Write(['h', 'i']) {
+    Ok(n) => fmt.Println(n),
+    Both(n, _) => fmt.Println(n),
+    Err(e) => {
+      fmt.Println(e)
+      return
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_partial_match_on_lowered_call() {
+    let input = r#"
+import "go:errors"
+
+fn attempt(ok: bool) -> Partial<int, error> {
+  if ok { Partial.Ok(1) } else { Partial.Err(errors.New("nope")) }
+}
+
+fn test() -> int {
+  match attempt(true) {
+    Partial.Ok(n) => n,
+    Partial.Both(n, _) => n,
+    Partial.Err(_) => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn lisette_function_returning_partial_tuple_uses_packed_abi() {
     let input = r#"
 fn pair<A, B>(a: A, b: B) -> Partial<(A, B), error> {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -703,6 +703,78 @@ fn test() {
 }
 
 #[test]
+fn fused_go_pointer_result_match_unused_err() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test() {
+  let file = match os.Create("f") {
+    Ok(f) => f,
+    Err(e) => {
+      fmt.Println("error")
+      return
+    },
+  }
+  defer file.Close()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_pointer_result_match_used_err() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test() {
+  let file = match os.Create("f") {
+    Ok(f) => f,
+    Err(e) => {
+      fmt.Println(e)
+      return
+    },
+  }
+  defer file.Close()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_pointer_result_match_ok_wildcard() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test() {
+  match os.Create("f") {
+    Ok(_) => fmt.Println("made"),
+    Err(e) => fmt.Println(e),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_interface_result_match_uses_nil_interface_guard() {
+    let input = r#"
+import "go:net"
+import "go:fmt"
+
+fn test() {
+  match net.Dial("tcp", "addr") {
+    Ok(conn) => { let _ = conn },
+    Err(e) => fmt.Println(e),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn while_let_option_function_call() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
+++ b/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:net"
+  import "go:fmt"
+  
+  fn test() {
+    match net.Dial("tcp", "addr") {
+      Ok(conn) => { let _ = conn },
+      Err(e) => fmt.Println(e),
+    }
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"net"
+)
+
+func test() {
+	ret_1, ret_2 := net.Dial("tcp", "addr")
+	if ret_2 == nil && !lisette.IsNilInterface(ret_1) {
+		conn := ret_1
+		_ = conn
+	} else {
+		if ret_2 == nil {
+			ret_2 = errors.New("unexpected nil")
+		}
+		e := ret_2
+		fmt.Println(e)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test() {
+    match os.Create("f") {
+      Ok(_) => fmt.Println("made"),
+      Err(e) => fmt.Println(e),
+    }
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func test() {
+	ret_1, ret_2 := os.Create("f")
+	if ret_2 == nil && ret_1 != nil {
+		fmt.Println("made")
+	} else {
+		if ret_2 == nil {
+			ret_2 = errors.New("unexpected nil")
+		}
+		e := ret_2
+		fmt.Println(e)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_unused_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_unused_err.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test() {
+    let file = match os.Create("f") {
+      Ok(f) => f,
+      Err(e) => {
+        fmt.Println("error")
+        return
+      },
+    }
+    defer file.Close()
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func test() {
+	var file *os.File
+	ret_1, ret_2 := os.Create("f")
+	if ret_2 == nil && ret_1 != nil {
+		f := ret_1
+		file = f
+	} else {
+		e := ret_2
+		_ = e
+		fmt.Println("error")
+		return
+	}
+	defer file.Close()
+}

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test() {
+    let file = match os.Create("f") {
+      Ok(f) => f,
+      Err(e) => {
+        fmt.Println(e)
+        return
+      },
+    }
+    defer file.Close()
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func test() {
+	var file *os.File
+	ret_1, ret_2 := os.Create("f")
+	if ret_2 == nil && ret_1 != nil {
+		f := ret_1
+		file = f
+	} else {
+		if ret_2 == nil {
+			ret_2 = errors.New("unexpected nil")
+		}
+		e := ret_2
+		fmt.Println(e)
+		return
+	}
+	defer file.Close()
+}

--- a/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn write_all(file: Ref<os.File>) {
+    match file.Write(['h', 'i']) {
+      Ok(n) => fmt.Println(n),
+      Both(n, _) => fmt.Println(n),
+      Err(e) => {
+        fmt.Println(e)
+        return
+      },
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func write_all(file *os.File) {
+	ret_1, ret_2 := file.Write([]byte{'h', 'i'})
+	if ret_2 == nil {
+		n := ret_1
+		fmt.Println(n)
+	} else {
+		n := ret_1
+		fmt.Println(n)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:errors"
+  
+  fn attempt(ok: bool) -> Partial<int, error> {
+    if ok { Partial.Ok(1) } else { Partial.Err(errors.New("nope")) }
+  }
+  
+  fn test() -> int {
+    match attempt(true) {
+      Partial.Ok(n) => n,
+      Partial.Both(n, _) => n,
+      Partial.Err(_) => 0,
+    }
+  }
+---
+package main
+
+import "errors"
+
+func attempt(ok bool) (int, error) {
+	if ok {
+		return 1, nil
+	}
+	return 0, errors.New("nope")
+}
+
+func test() int {
+	ret_1, ret_2 := attempt(true)
+	if ret_2 == nil {
+		n := ret_1
+		return n
+	} else {
+		n := ret_1
+		return n
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
@@ -13,23 +13,16 @@ package main
 
 import (
 	"errors"
-	lisette "github.com/ivov/lisette/prelude"
 	"os"
 )
 
 func open_first(path string) (int, error) {
 	ret_1, ret_2 := os.Open(path)
-	var result_3 lisette.Result[*os.File, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[*os.File, error](ret_2)
-	} else if ret_1 == nil {
-		result_3 = lisette.MakeResultErr[*os.File, error](errors.New("unexpected nil"))
-	} else {
-		result_3 = lisette.MakeResultOk[*os.File, error](ret_1)
+		return 0, ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return 0, check_4.ErrVal
+	if ret_1 == nil {
+		return 0, errors.New("unexpected nil")
 	}
 	return 0, nil
 }

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_returns_value_fuses.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_returns_value_fuses.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:os"
+  
+  fn open(path: string) -> Result<Ref<os.File>, error> {
+    let file = os.Open(path)?
+    Ok(file)
+  }
+---
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+func open(path string) (*os.File, error) {
+	ret_1, ret_2 := os.Open(path)
+	if ret_2 != nil {
+		return nil, ret_2
+	}
+	if ret_1 == nil {
+		return nil, errors.New("unexpected nil")
+	}
+	file := ret_1
+	return file, nil
+}


### PR DESCRIPTION
Matching or `?`-propagating a call that returns a pointer, interface, or `Partial` value now emits direct Go error handling, instead of building a `Result` or `Partial` as an intermediary.

```rs
match os.Create(name) {
  Ok(f) => write(f),
  Err(_) => return,
}
```

now emits:

```go
ret_1, ret_2 := os.Create(name)
if ret_2 == nil && ret_1 != nil {
	f := ret_1
	write(f)
} else {
	return
}
```

The pointer and interface cases keep their nil guard (a Go `(nil, nil)` still routes to the `Err` arm), and `Partial` calls fuse the same way over their `Ok`/`Both`/`Err` arms.

Fix #860
