### PR TITLE
feat: lint to suggest `+= 1` for `foo++`

### DIFF
--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1311,7 +1311,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn is_valid_assignment_target(&self, expression: &Expression) -> bool {
+    pub(super) fn is_valid_assignment_target(&self, expression: &Expression) -> bool {
         use Expression::*;
 
         matches!(

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -39,6 +39,12 @@ impl<'source> Parser<'source> {
                 return lhs;
             }
 
+            if self.check_increment_decrement(&lhs, start.byte_offset) {
+                self.depth = depth_before_loop;
+                self.leave_recursion();
+                return lhs;
+            }
+
             if self.at_range() && RANGE_PREC > min_prec {
                 lhs = self.parse_range(Some(lhs.into()), start);
                 continue;
@@ -363,6 +369,57 @@ impl<'source> Parser<'source> {
             "Use `ch.Send(value)` inside a `select` expression",
         );
         self.resync_on_error();
+        true
+    }
+
+    fn check_increment_decrement(&mut self, lhs: &ast::Expression, start_offset: u32) -> bool {
+        let current = self.current_token();
+        let kind = current.kind;
+        if kind != Plus && kind != Minus {
+            return false;
+        }
+        let next = self.stream.peek_ahead(1);
+        if next.kind != kind {
+            return false;
+        }
+        if current.byte_offset + current.byte_length != next.byte_offset {
+            return false;
+        }
+        if !self.is_valid_assignment_target(lhs) {
+            return false;
+        }
+
+        let mut ahead = 2;
+        while matches!(self.stream.peek_ahead(ahead).kind, Comment | DocComment) {
+            ahead += 1;
+        }
+        let after = self.stream.peek_ahead(ahead);
+        let newline_after = {
+            let from = (next.byte_offset + next.byte_length) as usize;
+            let to = after.byte_offset as usize;
+            from <= to && to <= self.source.len() && self.source[from..to].contains('\n')
+        };
+        let ends_statement = newline_after
+            || matches!(
+                after.kind,
+                EOF | Semicolon | RightCurlyBrace | RightParen | RightSquareBracket | Comma
+            )
+            || (after.kind == LeftCurlyBrace && self.in_control_flow_header);
+        if !ends_statement {
+            return false;
+        }
+
+        let (operator, compound) = if kind == Plus {
+            ("++", "+= 1")
+        } else {
+            ("--", "-= 1")
+        };
+        let span = ast::Span::new(self.file_id, current.byte_offset, 2);
+        let target = self.source[start_offset as usize..current.byte_offset as usize].trim_end();
+        let help = format!("Use `{target} {compound}` instead");
+        self.track_error_at(span, format!("Lisette has no `{operator}` operator"), help);
+        self.next();
+        self.next();
         true
     }
 }

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -2607,6 +2607,26 @@ fn test(count: int) {
 }
 
 #[test]
+fn subtraction_of_unary_minus_variable() {
+    let input = r#"
+fn test(a: int, b: int) {
+  let result = a--b;
+}
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn subtraction_of_unary_minus_literal() {
+    let input = r#"
+fn test(a: int) {
+  let result = a--1;
+}
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
 fn unary_minus_parenthesized() {
     let input = r#"
 fn test(a: int, b: int) {

--- a/tests/spec/parse/snapshots/subtraction_of_unary_minus_literal.snap
+++ b/tests/spec/parse/snapshots/subtraction_of_unary_minus_literal.snap
@@ -1,0 +1,149 @@
+---
+source: tests/spec/parse/mod.rs
+description: "\nfn test(a: int) {\n  let result = a--1;\n}\n"
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "a",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 9,
+                        byte_length: 1,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "int",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 3,
+                        },
+                    },
+                ),
+                typed_pattern: None,
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+        ],
+        return_annotation: Unknown,
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Block {
+            items: [
+                Let {
+                    binding: Binding {
+                        pattern: Identifier {
+                            identifier: "result",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 25,
+                                byte_length: 6,
+                            },
+                        },
+                        annotation: None,
+                        typed_pattern: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                    },
+                    value: Binary {
+                        operator: Subtraction,
+                        left: Identifier {
+                            value: "a",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 34,
+                                byte_length: 1,
+                            },
+                            binding_id: None,
+                            qualified: None,
+                        },
+                        right: Unary {
+                            operator: Negative,
+                            expression: Literal {
+                                literal: Integer {
+                                    value: 1,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 37,
+                                    byte_length: 1,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 2,
+                            },
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 34,
+                            byte_length: 4,
+                        },
+                    },
+                    mutable: false,
+                    mut_span: None,
+                    else_block: None,
+                    else_span: None,
+                    assert: false,
+                    typed_pattern: None,
+                    ty: Var {
+                        id: uninferred,
+                    },
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 21,
+                        byte_length: 17,
+                    },
+                },
+            ],
+            ty: Var {
+                id: uninferred,
+            },
+            span: Span {
+                file_id: 0,
+                byte_offset: 17,
+                byte_length: 24,
+            },
+        },
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 40,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/subtraction_of_unary_minus_variable.snap
+++ b/tests/spec/parse/snapshots/subtraction_of_unary_minus_variable.snap
@@ -1,0 +1,173 @@
+---
+source: tests/spec/parse/mod.rs
+description: "\nfn test(a: int, b: int) {\n  let result = a--b;\n}\n"
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "a",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 9,
+                        byte_length: 1,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "int",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 3,
+                        },
+                    },
+                ),
+                typed_pattern: None,
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+            Binding {
+                pattern: Identifier {
+                    identifier: "b",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 17,
+                        byte_length: 1,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "int",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 20,
+                            byte_length: 3,
+                        },
+                    },
+                ),
+                typed_pattern: None,
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+        ],
+        return_annotation: Unknown,
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Block {
+            items: [
+                Let {
+                    binding: Binding {
+                        pattern: Identifier {
+                            identifier: "result",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 33,
+                                byte_length: 6,
+                            },
+                        },
+                        annotation: None,
+                        typed_pattern: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                    },
+                    value: Binary {
+                        operator: Subtraction,
+                        left: Identifier {
+                            value: "a",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 42,
+                                byte_length: 1,
+                            },
+                            binding_id: None,
+                            qualified: None,
+                        },
+                        right: Unary {
+                            operator: Negative,
+                            expression: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 45,
+                                    byte_length: 1,
+                                },
+                                binding_id: None,
+                                qualified: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 44,
+                                byte_length: 2,
+                            },
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 42,
+                            byte_length: 4,
+                        },
+                    },
+                    mutable: false,
+                    mut_span: None,
+                    else_block: None,
+                    else_span: None,
+                    assert: false,
+                    typed_pattern: None,
+                    ty: Var {
+                        id: uninferred,
+                    },
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 29,
+                        byte_length: 17,
+                    },
+                },
+            ],
+            ty: Var {
+                id: uninferred,
+            },
+            span: Span {
+                file_id: 0,
+                byte_offset: 25,
+                byte_length: 24,
+            },
+        },
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 48,
+        },
+    },
+]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6314,6 +6314,107 @@ fn test(ch: Channel<int>) {
 }
 
 #[test]
+fn parse_postfix_increment() {
+    let input = r#"
+fn main() {
+  let mut foo = 0
+  foo++
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_decrement() {
+    let input = r#"
+fn main() {
+  let mut foo = 0
+  foo--
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_field() {
+    let input = r#"
+struct Counter { value: int }
+
+fn main() {
+  let mut c = Counter { value: 0 }
+  c.value++
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_index() {
+    let input = r#"
+fn main() {
+  let mut a = [1, 2, 3]
+  a[0]++
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_in_if_header() {
+    let input = r#"
+fn main() {
+  let mut foo = 0
+  if foo++ {
+    log()
+  }
+}
+
+fn log() {}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_in_for_header() {
+    let input = r#"
+fn main() {
+  let mut xs = [1, 2, 3]
+  for x in xs++ {
+    log(x)
+  }
+}
+
+fn log(x: int) {}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_trailing_comment() {
+    let input = r#"
+fn main() {
+  let mut foo = 0
+  foo++ // bump it
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_postfix_increment_recovers() {
+    let input = r#"
+fn main() {
+  let mut foo = 0
+  foo++
+  log(foo)
+}
+
+fn log(x: int) {}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_fn_as_lambda() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/parse_postfix_decrement.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_decrement.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:6]
+ 3 │   let mut foo = 0
+ 4 │   foo--
+   ·      ─┬
+   ·       ╰── Lisette has no `--` operator
+ 5 │ }
+   ╰────
+  help: Use `foo -= 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:6]
+ 3 │   let mut foo = 0
+ 4 │   foo++
+   ·      ─┬
+   ·       ╰── Lisette has no `++` operator
+ 5 │ }
+   ╰────
+  help: Use `foo += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_field.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:6:10]
+ 5 │   let mut c = Counter { value: 0 }
+ 6 │   c.value++
+   ·          ─┬
+   ·           ╰── Lisette has no `++` operator
+ 7 │ }
+   ╰────
+  help: Use `c.value += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_in_for_header.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_in_for_header.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:14]
+ 3 │   let mut xs = [1, 2, 3]
+ 4 │   for x in xs++ {
+   ·              ─┬
+   ·               ╰── Lisette has no `++` operator
+ 5 │     log(x)
+   ╰────
+  help: Use `xs += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_in_if_header.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_in_if_header.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:9]
+ 3 │   let mut foo = 0
+ 4 │   if foo++ {
+   ·         ─┬
+   ·          ╰── Lisette has no `++` operator
+ 5 │     log()
+   ╰────
+  help: Use `foo += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_index.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_index.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:7]
+ 3 │   let mut a = [1, 2, 3]
+ 4 │   a[0]++
+   ·       ─┬
+   ·        ╰── Lisette has no `++` operator
+ 5 │ }
+   ╰────
+  help: Use `a[0] += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_recovers.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_recovers.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:6]
+ 3 │   let mut foo = 0
+ 4 │   foo++
+   ·      ─┬
+   ·       ╰── Lisette has no `++` operator
+ 5 │   log(foo)
+   ╰────
+  help: Use `foo += 1` instead · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_postfix_increment_trailing_comment.snap
+++ b/tests/ui/errors/snapshots/parse_postfix_increment_trailing_comment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:6]
+ 3 │   let mut foo = 0
+ 4 │   foo++ // bump it
+   ·      ─┬
+   ·       ╰── Lisette has no `++` operator
+ 5 │ }
+   ╰────
+  help: Use `foo += 1` instead · code: [parse.syntax_error]


### PR DESCRIPTION
Unlike Go, Lis has no increment or decrement operator. Reaching for one now points at the compound-assignment form, instead of failing with a generic error.

```
  ✕ Syntax error
   ╭─[main.lis:3:8]
 2 │   let mut count = 0
 3 │   count++
   ·        ─┬
   ·         ╰── Lisette has no ++ operator
   ╰────
  help: Use count += 1 instead
```

Close #861
