### PR TITLE
feat: suggest tuple for bare multi-value return

### DIFF
--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -1,4 +1,4 @@
-use super::Parser;
+use super::{MAX_TUPLE_ARITY, Parser};
 use crate::ast::{Expression, MatchArm, Span};
 use crate::lex::TokenKind::*;
 use crate::types::Type;
@@ -164,7 +164,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(super) fn parse_return(&mut self) -> Expression {
+    pub(super) fn parse_return(&mut self, recover_bare_multi_value: bool) -> Expression {
         let start = self.current_token();
 
         self.ensure(Return);
@@ -177,10 +177,66 @@ impl<'source> Parser<'source> {
             _ => self.parse_expression(),
         };
 
+        let expression = if recover_bare_multi_value && self.is(Comma) {
+            self.recover_bare_multi_return(expression)
+        } else {
+            expression
+        };
+
         Expression::Return {
             expression: expression.into(),
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
+        }
+    }
+
+    fn recover_bare_multi_return(&mut self, first: Expression) -> Expression {
+        let comma = self.current_token();
+        let mut elements = vec![first];
+
+        while self.is(Comma) {
+            self.next();
+            if self.at_eof()
+                || self.is(Semicolon)
+                || self.is(RightCurlyBrace)
+                || self.at_item_boundary()
+                || self.newline_before_current()
+            {
+                break;
+            }
+            elements.push(self.parse_expression());
+        }
+
+        if elements.len() == 1 {
+            self.track_error_at(
+                self.span_from_token(comma),
+                "unexpected trailing comma",
+                "Remove the trailing comma after the return value.",
+            );
+            return elements.into_iter().next().expect("len is 1");
+        }
+
+        let span = elements[0].get_span().merge(
+            elements
+                .last()
+                .expect("seeded with the first value")
+                .get_span(),
+        );
+
+        if elements.len() > MAX_TUPLE_ARITY {
+            self.error_tuple_arity(elements.len(), span);
+        } else {
+            let suggestion = format!(
+                "return ({})",
+                &self.source[span.byte_offset as usize..span.end() as usize]
+            );
+            self.error_bare_multi_return(span, &suggestion);
+        }
+
+        Expression::Tuple {
+            elements,
+            ty: Type::uninferred(),
+            span,
         }
     }
 

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -59,7 +59,7 @@ impl<'source> Parser<'source> {
             Recover => self.parse_recover_block(),
             Select => self.parse_select(),
             Loop => self.parse_loop(),
-            Return => self.parse_return(),
+            Return => self.parse_return(false),
             Break => self.parse_break(),
             Continue => self.parse_continue(),
             DotDot | DotDotEqual => self.parse_range(None, self.current_token()),

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -264,7 +264,7 @@ impl<'source> Parser<'source> {
             }
 
             Let => self.parse_let(),
-            Return => self.parse_return(),
+            Return => self.parse_return(true),
             For => self.parse_for(),
             While => self.parse_while(),
             Loop => self.parse_loop(),
@@ -694,6 +694,23 @@ impl<'source> Parser<'source> {
             .with_help(format!(
                 "Use Go-style alias syntax: `import {alias} \"{path}\"`"
             ));
+
+        self.errors.push(error);
+    }
+
+    fn error_bare_multi_return(&mut self, span: ast::Span, suggestion: &str) {
+        if self.too_many_errors() {
+            return;
+        }
+        let error = ParseError::new(
+            "Multiple return values must be a tuple",
+            span,
+            "wrap these values in parentheses",
+        )
+        .with_parse_code("bare_multi_value_return")
+        .with_help(format!(
+            "To return multiple values, use a tuple: `{suggestion}`"
+        ));
 
         self.errors.push(error);
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -982,6 +982,57 @@ fn f() -> (int,) {}
 }
 
 #[test]
+fn parse_bare_multi_value_return() {
+    let input = r#"
+fn divmod(a: int, b: int) -> (int, int) {
+  return a / b, a % b
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_bare_multi_value_return_identifiers() {
+    let input = r#"
+fn pair(a: int, b: int) -> (int, int) {
+  return a, b
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_return_trailing_comma() {
+    let input = r#"
+fn f() -> int {
+  return 1,
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_bare_multi_value_return_too_many() {
+    let input = r#"
+fn f() -> int {
+  return 1, 2, 3, 4, 5, 6
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_return_trailing_comma_does_not_consume_next_statement() {
+    let input = r#"
+fn f() -> int {
+  return 1,
+  return 2
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_error_enum_variant_missing_paren() {
     let input = r#"
 enum E { A(int }

--- a/tests/ui/errors/snapshots/parse_bare_multi_value_return.snap
+++ b/tests/ui/errors/snapshots/parse_bare_multi_value_return.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Multiple return values must be a tuple
+   ╭─[test.lis:3:10]
+ 2 │ fn divmod(a: int, b: int) -> (int, int) {
+ 3 │   return a / b, a % b
+   ·          ──────┬─────
+   ·                ╰── wrap these values in parentheses
+ 4 │ }
+   ╰────
+  help: To return multiple values, use a tuple: `return (a / b, a % b)` · code: [parse.bare_multi_value_return]

--- a/tests/ui/errors/snapshots/parse_bare_multi_value_return_identifiers.snap
+++ b/tests/ui/errors/snapshots/parse_bare_multi_value_return_identifiers.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Multiple return values must be a tuple
+   ╭─[test.lis:3:10]
+ 2 │ fn pair(a: int, b: int) -> (int, int) {
+ 3 │   return a, b
+   ·          ──┬─
+   ·            ╰── wrap these values in parentheses
+ 4 │ }
+   ╰────
+  help: To return multiple values, use a tuple: `return (a, b)` · code: [parse.bare_multi_value_return]

--- a/tests/ui/errors/snapshots/parse_bare_multi_value_return_too_many.snap
+++ b/tests/ui/errors/snapshots/parse_bare_multi_value_return_too_many.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid tuple
+   ╭─[test.lis:3:10]
+ 2 │ fn f() -> int {
+ 3 │   return 1, 2, 3, 4, 5, 6
+   ·          ────────┬───────
+   ·                  ╰── 6-element tuple not allowed
+ 4 │ }
+   ╰────
+  help: For >5 elements, use a struct with named fields · code: [parse.tuple_element_count]

--- a/tests/ui/errors/snapshots/parse_return_trailing_comma.snap
+++ b/tests/ui/errors/snapshots/parse_return_trailing_comma.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:11]
+ 2 │ fn f() -> int {
+ 3 │   return 1,
+   ·           ┬
+   ·           ╰── unexpected trailing comma
+ 4 │ }
+   ╰────
+  help: Remove the trailing comma after the return value · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_return_trailing_comma_does_not_consume_next_statement.snap
+++ b/tests/ui/errors/snapshots/parse_return_trailing_comma_does_not_consume_next_statement.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:11]
+ 2 │ fn f() -> int {
+ 3 │   return 1,
+   ·           ┬
+   ·           ╰── unexpected trailing comma
+ 4 │   return 2
+   ╰────
+  help: Remove the trailing comma after the return value · code: [parse.syntax_error]


### PR DESCRIPTION
Writing a Go-style multi-return without parens now produces a diagnostic pointing at the tuple form.

```
  ✕ Multiple return values must be a tuple
   ╭─[test.lis:3:10]
 2 │ fn pair(a: int, b: int) -> (int, int) {
 3 │   return a, b
   ·          ──┬─
   ·            ╰── wrap these values in parentheses
 4 │ }
   ╰────
  help: To return multiple values, use a tuple: `return (a, b)` · code: [parse.bare_multi_value_return]
```

Close #862
