### PR TITLE
refactor: share type classification between checker and emit

### DIFF
--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -6,60 +6,47 @@ use syntax::ast::{Expression, Visibility};
 use syntax::program::{DefinitionBody, File};
 
 impl Planner<'_> {
-    pub(crate) fn collect_local_exported_method_names(&mut self, files: &[&File]) {
-        for file in files {
-            for item in &file.items {
-                if let syntax::ast::Expression::Interface {
-                    visibility: syntax::ast::Visibility::Public,
+    pub(crate) fn collect_local_method_facts(&mut self, files: &[&File]) {
+        for item in files.iter().flat_map(|file| &file.items) {
+            match item {
+                Expression::Interface {
+                    visibility: Visibility::Public,
                     method_signatures,
                     ..
-                } = item
-                {
+                } => {
                     for method in method_signatures {
                         let func = method.function_definition_view();
                         self.module
                             .record_exported_method_name(func.name.to_string());
                     }
                 }
-
-                if let syntax::ast::Expression::ImplBlock { methods, .. } = item {
-                    for method in methods {
-                        if let syntax::ast::Expression::Function {
-                            name,
-                            visibility: syntax::ast::Visibility::Public,
-                            ..
-                        } = method
-                        {
-                            self.module.record_exported_method_name(name.to_string());
-                        }
-                    }
-                }
+                Expression::ImplBlock {
+                    receiver_name,
+                    methods,
+                    ..
+                } => self.record_impl_method_facts(receiver_name, methods),
+                _ => {}
             }
         }
     }
 
-    pub(crate) fn collect_user_to_string_types(&mut self, files: &[&File]) {
-        for file in files {
-            for item in &file.items {
-                let Expression::ImplBlock {
-                    receiver_name,
-                    methods,
-                    ..
-                } = item
-                else {
-                    continue;
-                };
-                for method in methods {
-                    if !is_display_to_string(method) {
-                        continue;
-                    }
-                    let qualified = self.facts.qualified_current(receiver_name);
-                    if self.facts.is_ufcs_method(qualified.as_str(), "to_string") {
-                        continue;
-                    }
-                    self.module
-                        .record_user_to_string_type(receiver_name.to_string());
-                }
+    fn record_impl_method_facts(&mut self, receiver_name: &str, methods: &[Expression]) {
+        for method in methods {
+            if let Expression::Function {
+                name,
+                visibility: Visibility::Public,
+                ..
+            } = method
+            {
+                self.module.record_exported_method_name(name.to_string());
+            }
+            if is_display_to_string(method)
+                && !self
+                    .facts
+                    .is_ufcs_method(&self.facts.qualified_current(receiver_name), "to_string")
+            {
+                self.module
+                    .record_user_to_string_type(receiver_name.to_string());
             }
         }
     }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -114,6 +114,10 @@ impl<'a> EmitFacts<'a> {
         peel_alias(self.definitions, ty)
     }
 
+    pub(crate) fn strip_and_peel(&self, ty: &Type) -> Type {
+        self.peel_alias(&ty.strip_refs())
+    }
+
     pub(crate) fn as_interface(&self, ty: &Type) -> Option<String> {
         as_interface(self.definitions, ty)
     }
@@ -264,16 +268,7 @@ pub(crate) fn is_nullable_option(definitions: &HashMap<Symbol, Definition>, ty: 
 }
 
 pub(crate) fn is_nilable_go_type(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> bool {
-    resolves_to_pointer(definitions, ty)
-        || as_interface(definitions, ty).is_some()
-        || resolve_to_function_type(definitions, ty).is_some()
-}
-
-pub(crate) fn resolves_to_pointer(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> bool {
-    fn as_pointer(ty: &Type) -> bool {
-        ty.is_ref() || ty.get_underlying().is_some_and(|u| u.is_ref())
-    }
-    as_pointer(ty) || as_pointer(&peel_alias(definitions, ty))
+    syntax::types::is_nilable_go_type(ty, |id| definitions.get(id))
 }
 
 pub(crate) fn as_interface(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Option<String> {

--- a/crates/emit/src/analyze/resolve_nominal.rs
+++ b/crates/emit/src/analyze/resolve_nominal.rs
@@ -10,7 +10,7 @@ pub(crate) struct ResolvedNominal<'a> {
 
 impl<'a> Planner<'a> {
     pub(crate) fn resolve_nominal(&self, ty: &Type) -> Option<ResolvedNominal<'a>> {
-        let Type::Nominal { id, .. } = self.facts.peel_alias(&ty.strip_refs()) else {
+        let Type::Nominal { id, .. } = self.facts.strip_and_peel(ty) else {
             return None;
         };
         let definition = self.facts.definition(id.as_str())?;

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -96,9 +96,7 @@ impl Planner<'_> {
 
 fn extract_return_type_param(function: &Expression) -> Option<Type> {
     let ty = function.get_type();
-    let Type::Function(f) = ty.unwrap_forall() else {
-        return None;
-    };
+    let f = ty.as_function_type()?;
     let Type::Nominal { params, .. } = f.return_type.as_ref() else {
         return None;
     };
@@ -149,7 +147,7 @@ impl Planner<'_> {
             );
         }
         let ty = function.get_type();
-        let Type::Function(f) = ty.unwrap_forall() else {
+        let Some(f) = ty.as_function_type() else {
             unreachable!("MapNew must be a function");
         };
         let params = f
@@ -461,9 +459,7 @@ impl Planner<'_> {
         call_ty: Option<&Type>,
     ) -> Option<TupleStructTarget> {
         let ty = function.get_type();
-        let Type::Function(f) = ty.unwrap_forall() else {
-            return None;
-        };
+        let f = ty.as_function_type()?;
         let return_ty = call_ty
             .cloned()
             .unwrap_or_else(|| f.return_type.as_ref().clone());

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -505,9 +505,7 @@ impl Planner<'_> {
             && is_go_receiver(receiver)
         {
             let fn_type = expression.get_type();
-            let Type::Function(f) = fn_type.unwrap_forall() else {
-                return None;
-            };
+            let f = fn_type.as_function_type()?;
             let return_type = f.return_type.clone();
 
             let go_hints = if let Expression::DotAccess {
@@ -592,10 +590,8 @@ impl Planner<'_> {
         expression: &Expression,
     ) -> Option<(Type, Vec<String>, String)> {
         let fn_type = expression.get_type();
-        let (params, return_type) = match fn_type.unwrap_forall() {
-            Type::Function(f) => (f.params.clone(), (*f.return_type).clone()),
-            _ => return None,
-        };
+        let f = fn_type.as_function_type()?;
+        let (params, return_type) = (f.params.clone(), (*f.return_type).clone());
         let go_fn_str = self.hoist_go_fn_if_needed(setup, expression);
         let (param_strs, arg_names) = self.build_wrapper_params(&params);
         let call_str = format!("{}({})", go_fn_str, arg_names.join(", "));

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -338,7 +338,7 @@ impl Planner<'_> {
         if ctx.method == "equals"
             && matches!(ctx.native_type, NativeGoType::Slice | NativeGoType::Map)
         {
-            let receiver_ty = self.facts.peel_alias(&expression.get_type().strip_refs());
+            let receiver_ty = self.facts.strip_and_peel(&expression.get_type());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx);
                 let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty);
@@ -466,9 +466,7 @@ impl Planner<'_> {
             && matches!(ctx.native_type, NativeGoType::Slice | NativeGoType::Map)
             && let Some(receiver_expr) = ctx.args.first()
         {
-            let receiver_ty = self
-                .facts
-                .peel_alias(&receiver_expr.get_type().strip_refs());
+            let receiver_ty = self.facts.strip_and_peel(&receiver_expr.get_type());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let (setup, emitted_args) = self.stage_native_identifier_args(ctx);
                 if emitted_args.len() >= 2 {

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -326,7 +326,7 @@ impl<'a> Planner<'a> {
         else {
             return None;
         };
-        let peeled = self.facts.peel_alias(&receiver.get_type().strip_refs());
+        let peeled = self.facts.strip_and_peel(&receiver.get_type());
         if let Some(native) = NativeGoType::from_type(&peeled) {
             return self
                 .facts

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -105,7 +105,7 @@ impl Planner<'_> {
             unreachable!("lower_ufcs_call called on non-DotAccess");
         };
 
-        let receiver_ty = self.facts.peel_alias(&receiver.get_type().strip_refs());
+        let receiver_ty = self.facts.strip_and_peel(&receiver.get_type());
         let Type::Nominal {
             id: qualified_name, ..
         } = &receiver_ty
@@ -152,10 +152,10 @@ impl Planner<'_> {
         // up 1:1 with the user args. Pair each so a function-typed param
         // suppresses the Go-fn-value identity short-circuit before dispatch
         // into prelude helpers like `lisette.OptionAndThen`.
-        let formal_params: Vec<Type> = match function.get_type().unwrap_forall() {
-            Type::Function(f) => f.params.clone(),
-            _ => Vec::new(),
-        };
+        let formal_params: Vec<Type> = function
+            .get_type()
+            .as_function_type()
+            .map_or_else(Vec::new, |f| f.params.clone());
         let declared_params =
             self.ufcs_declared_user_params(receiver, function, formal_params.len());
         let suppress_declared = declared_params

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -118,8 +118,15 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
     ) -> (Vec<LoweredStatement>, String) {
-        if let Expression::Identifier { value, ty, .. } = expression {
-            let go_name = self.emit_identifier(value, ty, ExpressionContext::value());
+        if let Expression::Identifier {
+            value,
+            ty,
+            qualified,
+            ..
+        } = expression
+        {
+            let go_name =
+                self.emit_identifier(value, qualified.as_deref(), ty, ExpressionContext::value());
             if go_name.contains('(') {
                 let mut setup = Vec::new();
                 let check = self.hoist_tmp_value_statement(&mut setup, "check", &go_name);

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -171,9 +171,7 @@ impl Planner<'_> {
         impl_ty: &Type,
         subst_map: &SubstitutionMap,
     ) -> Option<(AdapterMethod, bool)> {
-        let Type::Function(f) = impl_ty.unwrap_forall() else {
-            return None;
-        };
+        let f = impl_ty.as_function_type()?;
         let params = &f.params;
         let param_types: Vec<Type> = if params.is_empty() {
             Vec::new()

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -157,7 +157,7 @@ impl Planner<'_> {
         let resolved_name = format!("{}.{}", real_type, member);
 
         let capitalized = self.capitalize_static_method_if_public(&resolved_name);
-        let go_name = self.resolve_go_name(&capitalized);
+        let go_name = self.resolve_go_name(&capitalized, None);
 
         Some(go_name)
     }
@@ -231,7 +231,7 @@ impl Planner<'_> {
     }
 
     fn method_expression_type_args(&mut self, result_ty: &Type) -> String {
-        let Type::Function(f) = result_ty.unwrap_forall() else {
+        let Some(f) = result_ty.as_function_type() else {
             return String::new();
         };
         let Some(first_param) = f.params.first() else {

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -22,6 +22,7 @@ impl Planner<'_> {
     pub(crate) fn emit_identifier(
         &mut self,
         value: &str,
+        qualified: Option<&str>,
         ty: &Type,
         ctx: ExpressionContext<'_>,
     ) -> String {
@@ -44,17 +45,17 @@ impl Planner<'_> {
             IdentifierKind::UnitValue => "struct{}{}".to_string(),
             IdentifierKind::PublicFunction { capitalized } => capitalized,
             IdentifierKind::UnitConstructor { name, type_args } => {
-                format!("{}{}()", self.resolve_go_name(&name), type_args)
+                format!("{}{}()", self.resolve_go_name(&name, None), type_args)
             }
             IdentifierKind::ConstructorFunction { name, type_args } => {
-                format!("{}{}", self.resolve_go_name(&name), type_args)
+                format!("{}{}", self.resolve_go_name(&name, None), type_args)
             }
             IdentifierKind::Regular { name } => {
                 if let Some(expression) = self.try_emit_method_expression(&name, ty) {
                     return expression;
                 }
                 let resolved = self.capitalize_static_method_if_public(&name);
-                let go_name = self.resolve_go_name(&resolved);
+                let go_name = self.resolve_go_name(&resolved, qualified);
                 if !ctx.is_callee()
                     && let Some(type_args) = self.format_generic_value_type_args(&name, ty)
                 {
@@ -301,41 +302,22 @@ impl Planner<'_> {
     }
 
     /// Resolve `module.Type.method` as a cross-module static method call.
-    pub(crate) fn try_resolve_cross_module_static_method(&mut self, name: &str) -> Option<String> {
-        if !name.contains('.') {
-            return None;
-        }
-
-        let last_dot = name.rfind('.')?;
-        let method_name = &name[last_dot + 1..];
-        let type_and_module = &name[..last_dot];
-
-        let type_name = if let Some(dot_position) = type_and_module.rfind('.') {
-            &type_and_module[dot_position + 1..]
-        } else if let Some(slash_position) = type_and_module.rfind('/') {
-            &type_and_module[slash_position + 1..]
-        } else {
-            return None;
-        };
-
-        let module_name = if let Some(dot_position) = type_and_module.rfind('.') {
-            type_and_module[..dot_position].to_string()
-        } else if let Some(slash_position) = type_and_module.rfind('/') {
-            type_and_module[..slash_position].to_string()
-        } else {
-            return None;
-        };
-
+    pub(crate) fn try_resolve_cross_module_static_method(
+        &mut self,
+        qualified: Option<&str>,
+    ) -> Option<String> {
+        let id = qualified?;
+        let module_name = self.facts.module_for_qualified_name(id)?.to_string();
         if self.facts.is_current_module(&module_name) {
             return None;
         }
+        let after_module = id.strip_prefix(&module_name)?.strip_prefix('.')?;
+        let (type_part, method_name) = after_module.rsplit_once('.')?;
+        let type_id = format!("{}.{}", module_name, type_part);
 
-        let type_id = format!("{}.{}", module_name, type_name);
-
-        let method_key = format!("{}.{}", type_id, method_name);
         let is_public = self
             .facts
-            .definition(method_key.as_str())
+            .definition(id)
             .map(|d| d.visibility().is_public())
             .unwrap_or(true)
             || self.method_needs_export(method_name);

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -143,9 +143,7 @@ impl Planner<'_> {
             return None;
         }
         let param_ty = param_ty?;
-        let Type::Function(f) = param_ty.unwrap_forall() else {
-            return None;
-        };
+        let f = param_ty.as_function_type()?;
         self.classify_direct_emission(&f.return_type)?;
         Some(())
     }
@@ -171,10 +169,8 @@ impl Planner<'_> {
         args: &[Expression],
     ) -> Vec<StagedExpression> {
         let fn_ty = function.get_type();
-        let formal_params: &[syntax::types::Type] = match fn_ty.unwrap_forall() {
-            syntax::types::Type::Function(f) => &f.params,
-            _ => &[],
-        };
+        let formal_params: &[syntax::types::Type] =
+            fn_ty.as_function_type().map_or(&[], |f| &f.params);
         let declared_params = self.callee_declared_params(function, args.len());
         args.iter()
             .enumerate()

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -103,7 +103,7 @@ impl Planner<'_> {
             return false;
         }
         let fn_ty = expression.get_type();
-        let Type::Function(f) = fn_ty.unwrap_forall() else {
+        let Some(f) = fn_ty.as_function_type() else {
             return false;
         };
         let Some(shape) = self.classify_direct_emission(&f.return_type) else {
@@ -138,7 +138,7 @@ impl Planner<'_> {
             return false;
         }
         let fn_ty = expression.get_type();
-        let Type::Function(f) = fn_ty.unwrap_forall() else {
+        let Some(f) = fn_ty.as_function_type() else {
             return false;
         };
         self.fallible_tuple_return(&f.return_type)
@@ -153,9 +153,14 @@ impl Planner<'_> {
     ) -> ValuePlan {
         match expression {
             Expression::Literal { literal, ty, .. } => self.emit_literal(literal, ty),
-            Expression::Identifier { value, ty, .. } => {
+            Expression::Identifier {
+                value,
+                ty,
+                qualified,
+                ..
+            } => {
                 let mut setup: Vec<LoweredStatement> = Vec::new();
-                let raw = self.emit_identifier(value, ty, ctx);
+                let raw = self.emit_identifier(value, qualified.as_deref(), ty, ctx);
                 let value = self.maybe_lower_tagged_fn_ref(&mut setup, expression, ty, raw, ctx);
                 value_plan_from_statements(setup, value)
             }

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -5,14 +5,14 @@ use crate::Planner;
 use crate::names::go_name;
 
 impl Planner<'_> {
-    pub(crate) fn resolve_go_name(&mut self, name: &str) -> String {
+    pub(crate) fn resolve_go_name(&mut self, name: &str, qualified: Option<&str>) -> String {
         if !name.contains('.')
             && let Some(remapped) = self.module.escape_remap(name)
         {
             return remapped.to_string();
         }
 
-        if let Some(go_call) = self.try_resolve_cross_module_static_method(name) {
+        if let Some(go_call) = self.try_resolve_cross_module_static_method(qualified) {
             return go_call;
         }
 

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -39,8 +39,7 @@ impl Planner<'_> {
         self.facts.set_current_module(module_id);
         let mut collection_effects = EmitEffects::default();
         self.collect_module_aliases(files);
-        self.collect_local_exported_method_names(files);
-        self.collect_user_to_string_types(files);
+        self.collect_local_method_facts(files);
         self.collect_generic_constraints(files);
         self.collect_escape_remap(files);
         let collision_diagnostics = self.detect_name_collisions(files);

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -468,23 +468,7 @@ impl Store {
     }
 
     pub fn is_nilable_go_type(&self, ty: &Type) -> bool {
-        if ty.is_ref() || matches!(ty, Type::Function(_)) {
-            return true;
-        }
-        let Type::Nominal { id, .. } = ty else {
-            return false;
-        };
-        if self.get_definition(id.as_str()).is_none() {
-            return false;
-        }
-        if self.get_interface(id.as_str()).is_some() {
-            return true;
-        }
-        match ty.get_underlying() {
-            Some(Type::Function(_)) => true,
-            Some(u) if u.is_ref() => true,
-            _ => false,
-        }
+        syntax::types::is_nilable_go_type(ty, |id| self.get_definition(id))
     }
 
     pub fn peel_alias(&self, ty: &Type) -> Type {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use ecow::EcoString;
 
 use crate::ast::Generic;
+use crate::program::{Definition, DefinitionBody};
 
 /// Dot-qualified identifier for a named type, method, value, or variant.
 ///
@@ -1451,6 +1452,36 @@ where
     current
 }
 
+pub fn is_nilable_go_type<'a>(ty: &Type, lookup: impl Fn(&str) -> Option<&'a Definition>) -> bool {
+    let is_alias = |id: &str| lookup(id).is_some_and(Definition::is_type_alias);
+    let is_interface = |id: &str| matches!(lookup(id), Some(d) if matches!(d.body, DefinitionBody::Interface { .. }));
+    resolves_to_pointer(ty, is_alias)
+        || resolves_to_interface(ty, is_alias, is_interface)
+        || resolves_to_function(ty, is_alias)
+}
+
+fn resolves_to_pointer<FA: Fn(&str) -> bool>(ty: &Type, is_alias: FA) -> bool {
+    fn as_pointer(ty: &Type) -> bool {
+        ty.is_ref() || ty.get_underlying().is_some_and(Type::is_ref)
+    }
+    as_pointer(ty) || as_pointer(&peel_alias(ty, is_alias))
+}
+
+fn resolves_to_interface<FA, FI>(ty: &Type, is_alias: FA, is_interface: FI) -> bool
+where
+    FA: Fn(&str) -> bool,
+    FI: Fn(&str) -> bool,
+{
+    matches!(peel_alias(ty, is_alias), Type::Nominal { id, .. } if is_interface(id.as_str()))
+}
+
+fn resolves_to_function<FA: Fn(&str) -> bool>(ty: &Type, is_alias: FA) -> bool {
+    fn as_function(ty: &Type) -> bool {
+        matches!(ty, Type::Function(_)) || matches!(ty.get_underlying(), Some(Type::Function(_)))
+    }
+    as_function(ty) || as_function(&peel_alias(ty, is_alias))
+}
+
 /// Walk an alias chain by id alone; used when no `Type` with
 /// `underlying_ty` is available (e.g. Go-name resolution).
 pub fn peel_alias_id<F>(id: &str, next_alias: F) -> String
@@ -1476,6 +1507,13 @@ impl Type {
         match self {
             Type::Forall { body, .. } => body.as_ref(),
             other => other,
+        }
+    }
+
+    pub fn as_function_type(&self) -> Option<&FunctionType> {
+        match self.unwrap_forall() {
+            Type::Function(f) => Some(f),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Hoists the `is_nilable_go_type` Go-nilability check into `syntax::types` as a single shared implementation, removing the divergent copies between checker and emit. Emit now also reads `Type::as_function_type` and the checker-resolved `Identifier.qualified` instead of re-deriving function types and cross-module name resolution.