### PR TITLE
chore: release zed extension 0.1.2

### DIFF
--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lisette"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lisette"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -72,7 +72,7 @@ To iterate:
 
 ### Updating
 
-1. Bump `version` in `extension.toml` and `Cargo.toml`.
+1. Bump `version` in `extension.toml` and `Cargo.toml`, then run `cargo build` in `editors/zed` so the matching `zed_lisette` version in `Cargo.lock` updates too.
 2. Find the commit SHA that Zed should build the tree-sitter grammar from and set it in `grammars.lisette.rev` in `extension.toml`.
 
     ```bash
@@ -87,4 +87,5 @@ To iterate:
     rev = "5a8800385fdd4e9fe02b758d9d6298b18fd92b72"
     ```
 
-3. Commit, push, and open a PR to [`zed-industries/extensions`](https://github.com/zed-industries/extensions) bumping the submodule ref and `version` in their `extensions.toml`.
+3. Commit, push, open a PR in this repo with the changes above, and merge it. Note its merge commit SHA.
+4. In your fork of [`zed-industries/extensions`](https://github.com/zed-industries/extensions), point the `extensions/lisette` submodule at that merge commit, bump `version` under `[lisette]` in their `extensions.toml` to match, and open a PR.

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,14 +1,14 @@
 id = "lisette"
 name = "Lisette"
 description = "Language support for Lisette"
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Iván Ovejero <ivov.src@gmail.com>"]
 repository = "https://github.com/ivov/lisette"
 
 [grammars.lisette]
 repository = "https://github.com/ivov/lisette"
-rev = "5469274bebe8d452a8a10ed19233a55bd6593f1e"
+rev = "8ba205cc17ec985c2a284cb4c84edd606e964bfb"
 path = "editors/tree-sitter-lisette"
 
 [language_servers.lisette-lsp]


### PR DESCRIPTION
Bumps the Zed extension to 0.1.2 and advances the bundled tree-sitter grammar pin.

Grammar-related commits since the last rev:

```
1dcb5fa4 feat: add `let assert` for refutable test bindings (#800)
3f859ce6 feat: recognize `assert` keyword (#796)
15563f95 refactor!: drop `impl` for interface embedding in favor of `embed` (#701)
18d79026 refactor: replace `impl` with `embed` for interface embedding (#664)
260463cf refactor!: remove value enums (#588)
```
