### PR TITLE
fix: widen snake_case and PascalCase lint coverage

### DIFF
--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -159,17 +159,10 @@ fn collect_identifier_spans(pattern: &Pattern, out: &mut Vec<Span>) {
             .iter()
             .for_each(|p| collect_identifier_spans(p, out)),
         Pattern::AsBinding {
-            pattern,
-            name,
-            span,
+            pattern, name_span, ..
         } => {
             collect_identifier_spans(pattern, out);
-            let name_len = name.len() as u32;
-            out.push(Span::new(
-                span.file_id,
-                span.byte_offset + span.byte_length - name_len,
-                name_len,
-            ));
+            out.push(*name_span);
         }
         Pattern::Literal { .. } | Pattern::WildCard { .. } | Pattern::Unit { .. } => {}
     }

--- a/crates/passes/src/passes/checks/interpolation_stringer.rs
+++ b/crates/passes/src/passes/checks/interpolation_stringer.rs
@@ -17,8 +17,8 @@ pub(crate) fn run(
 ) {
     visit_ast(
         items,
-        &mut |expression| check_expression(expression, store, ufcs_methods, sink),
-        &mut |_| {},
+        &mut |expression, _| check_expression(expression, store, ufcs_methods, sink),
+        &mut |_, _| {},
     );
 }
 

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -138,6 +138,8 @@ fn run_file_checks(
         is_d_lis: file.is_d_lis(),
         sink,
         claimed_spans: Default::default(),
+        function_role: Default::default(),
+        pattern_role: Default::default(),
     };
     node_walk::run(&file.items, &ctx);
     interpolation_stringer::run(&file.items, store, ufcs_methods, sink);

--- a/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
@@ -346,12 +346,12 @@ pub(super) fn mentions_identifier(expression: &Expression, name: &str) -> bool {
     let mut found = false;
     visit_ast(
         std::slice::from_ref(expression),
-        &mut |node| {
+        &mut |node, _| {
             if let Expression::Identifier { value, .. } = node {
                 found |= value.as_str() == name;
             }
         },
-        &mut |_| {},
+        &mut |_, _| {},
     );
     found
 }
@@ -363,7 +363,7 @@ pub(super) fn has_escaping_control_flow(body: &Expression) -> bool {
     let mut found = false;
     visit_ast(
         std::slice::from_ref(body),
-        &mut |node| {
+        &mut |node, _| {
             found |= matches!(
                 node,
                 Expression::Return { .. }
@@ -373,7 +373,7 @@ pub(super) fn has_escaping_control_flow(body: &Expression) -> bool {
                     | Expression::Defer { .. }
             );
         },
-        &mut |_| {},
+        &mut |_, _| {},
     );
     found
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_map_or.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_map_or.rs
@@ -116,12 +116,12 @@ fn maps_binding(body: &Expression, binding: &str) -> bool {
     let mut shadowed = false;
     visit_ast(
         std::slice::from_ref(body),
-        &mut |node| {
+        &mut |node, _| {
             if matches!(node, Expression::Identifier { value, .. } if value.as_str() == binding) {
                 referenced = true;
             }
         },
-        &mut |pattern| {
+        &mut |pattern, _| {
             shadowed |= pattern_binds(pattern, binding);
         },
     );

--- a/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
@@ -1,8 +1,8 @@
 use diagnostics::LocalSink;
-use syntax::ast::{Expression, Generic, Pattern, Span};
+use syntax::ast::{Expression, Generic, Pattern, RestPattern, Span};
 
 use crate::passes::lints::ast_walk::casing::{is_snake_case, to_pascal_case, to_snake_case};
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{FunctionRole, NodeCtx, PatternRole};
 
 use super::helpers::first_param_is_self;
 
@@ -61,6 +61,17 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
                     "non_pascal_case_enum_variant",
                     sink,
                 );
+
+                if !is_d_lis && variant.fields.is_struct() {
+                    for field in variant.fields.iter() {
+                        check_snake_case(
+                            &field.name,
+                            &field.name_span,
+                            "non_snake_case_enum_field",
+                            sink,
+                        );
+                    }
+                }
             }
         }
 
@@ -103,20 +114,24 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
             params,
             ..
         } => {
-            if !is_d_lis && !first_param_is_self(params) {
+            let is_go_method = match ctx.function_role.get() {
+                FunctionRole::InterfaceMethod => true,
+                FunctionRole::ImplMethod => first_param_is_self(params),
+                FunctionRole::Free => false,
+            };
+            let exempt = is_go_method && name.chars().next().is_some_and(char::is_uppercase);
+            if !is_d_lis && !exempt {
                 check_snake_case(name, name_span, "non_snake_case_function", sink);
             }
 
             for generic in generics {
                 check_type_parameter(generic, sink);
             }
+        }
 
-            if !is_d_lis {
-                for param in params {
-                    if let Pattern::Identifier { identifier, span } = &param.pattern {
-                        check_snake_case(identifier, span, "non_snake_case_parameter", sink);
-                    }
-                }
+        Expression::ImplBlock { generics, .. } => {
+            for generic in generics {
+                check_type_parameter(generic, sink);
             }
         }
 
@@ -128,9 +143,22 @@ pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
     if ctx.is_d_lis {
         return;
     }
-    if let Pattern::Identifier { identifier, span } = pattern {
-        check_snake_case(identifier, span, "non_snake_case_variable", ctx.sink);
-    }
+    let (name, span) = match pattern {
+        Pattern::Identifier { identifier, span } => (identifier, span),
+        Pattern::AsBinding {
+            name, name_span, ..
+        } => (name, name_span),
+        Pattern::Slice {
+            rest: RestPattern::Bind { name, span },
+            ..
+        } => (name, span),
+        _ => return,
+    };
+    let code = match ctx.pattern_role.get() {
+        PatternRole::Parameter => "non_snake_case_parameter",
+        PatternRole::Binding => "non_snake_case_variable",
+    };
+    check_snake_case(name, span, code, ctx.sink);
 }
 
 fn check_type_parameter(generic: &Generic, sink: &LocalSink) {

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -160,7 +160,7 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_negated_logical_operand, &[Binary]),
             (
                 check_expression_naming,
-                &[Struct, Enum, TypeAlias, Interface, Function],
+                &[Struct, Enum, TypeAlias, Interface, Function, ImplBlock],
             ),
             (check_enum_variant_names, &[Enum]),
             (check_self_named_constructors, &[ImplBlock]),
@@ -186,7 +186,14 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
                 &[PatternKind::Literal],
             ),
             (check_invisible_in_string_pattern, &[PatternKind::Literal]),
-            (check_pattern_naming, &[PatternKind::Identifier]),
+            (
+                check_pattern_naming,
+                &[
+                    PatternKind::Identifier,
+                    PatternKind::AsBinding,
+                    PatternKind::Slice,
+                ],
+            ),
         ],
     )
 });
@@ -258,6 +265,8 @@ fn run_module(
             is_d_lis: file.is_d_lis(),
             sink: &file_sink,
             claimed_spans: Default::default(),
+            function_role: Default::default(),
+            pattern_role: Default::default(),
         };
         walk_nodes(&file.items, &ctx, &LINT_CHECKS);
 

--- a/crates/passes/src/passes/lints/ast_walk/suppression.rs
+++ b/crates/passes/src/passes/lints/ast_walk/suppression.rs
@@ -8,13 +8,13 @@ pub(super) fn collect_declaration_allows(items: &[Expression]) -> Vec<(Span, Vec
     let mut out = Vec::new();
     visit_ast(
         items,
-        &mut |expression| {
+        &mut |expression, _| {
             let flags = allow_flags(expression);
             if !flags.is_empty() {
                 out.push((expression.get_span(), flags));
             }
         },
-        &mut |_| {},
+        &mut |_, _| {},
     );
     out
 }

--- a/crates/passes/src/passes/walk.rs
+++ b/crates/passes/src/passes/walk.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use diagnostics::LocalSink;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -21,6 +21,23 @@ pub(crate) struct NodeCtx<'a> {
     /// Node spans already claimed by an enclosing node, so a check does not also
     /// judge them standalone (e.g. the nested `&&` of an outer comparison chain).
     pub claimed_spans: RefCell<HashSet<Span>>,
+    pub function_role: Cell<FunctionRole>,
+    pub pattern_role: Cell<PatternRole>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PatternRole {
+    Parameter,
+    #[default]
+    Binding,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FunctionRole {
+    InterfaceMethod,
+    ImplMethod,
+    #[default]
+    Free,
 }
 
 pub(crate) type NodeCheck = fn(&Expression, &NodeCtx);
@@ -60,12 +77,14 @@ impl CheckTable {
 pub(crate) fn walk_nodes(ast: &[Expression], ctx: &NodeCtx, checks: &CheckTable) {
     visit_ast(
         ast,
-        &mut |expression| {
+        &mut |expression, role| {
+            ctx.function_role.set(role);
             for check in &checks.expression_buckets[expression.kind() as usize] {
                 check(expression, ctx);
             }
         },
-        &mut |pattern| {
+        &mut |pattern, role| {
+            ctx.pattern_role.set(role);
             for check in &checks.pattern_buckets[pattern.kind() as usize] {
                 check(pattern, ctx);
             }
@@ -75,60 +94,87 @@ pub(crate) fn walk_nodes(ast: &[Expression], ctx: &NodeCtx, checks: &CheckTable)
 
 pub fn visit_ast<E, P>(ast: &[Expression], expression_visitor: &mut E, pattern_visitor: &mut P)
 where
-    E: FnMut(&Expression),
-    P: FnMut(&Pattern),
+    E: FnMut(&Expression, FunctionRole),
+    P: FnMut(&Pattern, PatternRole),
 {
     for expression in ast {
-        visit_node(expression, expression_visitor, pattern_visitor);
+        visit_node(
+            expression,
+            FunctionRole::Free,
+            expression_visitor,
+            pattern_visitor,
+        );
     }
 }
 
-fn visit_node<E, P>(expression: &Expression, expression_visitor: &mut E, pattern_visitor: &mut P)
-where
-    E: FnMut(&Expression),
-    P: FnMut(&Pattern),
+fn visit_node<E, P>(
+    expression: &Expression,
+    role: FunctionRole,
+    expression_visitor: &mut E,
+    pattern_visitor: &mut P,
+) where
+    E: FnMut(&Expression, FunctionRole),
+    P: FnMut(&Pattern, PatternRole),
 {
-    expression_visitor(expression);
+    expression_visitor(expression, role);
 
     match expression {
         Expression::Function { params, .. } | Expression::Lambda { params, .. } => {
             for param in params {
-                visit_pattern(&param.pattern, pattern_visitor);
+                visit_pattern(&param.pattern, PatternRole::Parameter, pattern_visitor);
             }
         }
         Expression::Let { binding, .. } | Expression::For { binding, .. } => {
-            visit_pattern(&binding.pattern, pattern_visitor);
+            visit_pattern(&binding.pattern, PatternRole::Binding, pattern_visitor);
         }
         Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
-            visit_pattern(pattern, pattern_visitor);
+            visit_pattern(pattern, PatternRole::Binding, pattern_visitor);
         }
         Expression::Match { arms, .. } => {
             for arm in arms {
-                visit_pattern(&arm.pattern, pattern_visitor);
+                visit_pattern(&arm.pattern, PatternRole::Binding, pattern_visitor);
             }
         }
         Expression::Select { arms, .. } => {
             for arm in arms {
-                if let SelectArmPattern::MatchReceive {
-                    arms: match_arms, ..
-                } = &arm.pattern
-                {
-                    for match_arm in match_arms {
-                        visit_pattern(&match_arm.pattern, pattern_visitor);
+                match &arm.pattern {
+                    SelectArmPattern::Receive { binding, .. } => {
+                        visit_pattern(binding, PatternRole::Binding, pattern_visitor);
                     }
+                    SelectArmPattern::MatchReceive {
+                        arms: match_arms, ..
+                    } => {
+                        for match_arm in match_arms {
+                            visit_pattern(
+                                &match_arm.pattern,
+                                PatternRole::Binding,
+                                pattern_visitor,
+                            );
+                        }
+                    }
+                    SelectArmPattern::Send { .. } | SelectArmPattern::WildCard { .. } => {}
                 }
             }
         }
         _ => {}
     }
 
+    let child_role = match expression {
+        Expression::Interface { .. } => FunctionRole::InterfaceMethod,
+        Expression::ImplBlock { .. } => FunctionRole::ImplMethod,
+        _ => FunctionRole::Free,
+    };
     for child in expression.children() {
-        visit_node(child, expression_visitor, pattern_visitor);
+        visit_node(child, child_role, expression_visitor, pattern_visitor);
     }
 }
 
-fn visit_pattern<F: FnMut(&Pattern)>(pattern: &Pattern, visitor: &mut F) {
-    visitor(pattern);
+fn visit_pattern<F: FnMut(&Pattern, PatternRole)>(
+    pattern: &Pattern,
+    role: PatternRole,
+    visitor: &mut F,
+) {
+    visitor(pattern, role);
 
     match pattern {
         Pattern::Literal { .. }
@@ -138,25 +184,25 @@ fn visit_pattern<F: FnMut(&Pattern)>(pattern: &Pattern, visitor: &mut F) {
 
         Pattern::EnumVariant { fields, .. } => {
             for field in fields {
-                visit_pattern(field, visitor);
+                visit_pattern(field, role, visitor);
             }
         }
 
         Pattern::Struct { fields, .. } => {
             for field in fields {
-                visit_pattern(&field.value, visitor);
+                visit_pattern(&field.value, role, visitor);
             }
         }
 
         Pattern::Tuple { elements, .. } => {
             for element in elements {
-                visit_pattern(element, visitor);
+                visit_pattern(element, role, visitor);
             }
         }
 
         Pattern::Slice { prefix, rest, .. } => {
             for p in prefix {
-                visit_pattern(p, visitor);
+                visit_pattern(p, role, visitor);
             }
             if let RestPattern::Bind { .. } = rest {
                 // rest binding is not a pattern itself
@@ -165,12 +211,12 @@ fn visit_pattern<F: FnMut(&Pattern)>(pattern: &Pattern, visitor: &mut F) {
 
         Pattern::Or { patterns, .. } => {
             for p in patterns {
-                visit_pattern(p, visitor);
+                visit_pattern(p, role, visitor);
             }
         }
 
         Pattern::AsBinding { pattern, .. } => {
-            visit_pattern(pattern, visitor);
+            visit_pattern(pattern, role, visitor);
         }
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -185,11 +185,12 @@ impl InferCtx<'_, '_> {
             Pattern::AsBinding {
                 pattern,
                 name,
+                name_span,
                 span,
             } => {
                 if name.chars().next().is_some_and(|c| c.is_uppercase()) {
                     self.sink
-                        .push(diagnostics::infer::uppercase_binding(span, &name));
+                        .push(diagnostics::infer::uppercase_binding(name_span, &name));
                 }
                 match pattern.as_ref() {
                     Pattern::Identifier { identifier, .. } => {
@@ -222,11 +223,6 @@ impl InferCtx<'_, '_> {
                     is_struct_field,
                 );
                 let alias_ty = inner.get_type().unwrap_or_else(|| expected_ty.clone());
-                let name_span = Span::new(
-                    span.file_id,
-                    span.byte_offset + span.byte_length - name.len() as u32,
-                    name.len() as u32,
-                );
                 self.bind_name_in_scope(
                     name.to_string(),
                     name_span,
@@ -240,6 +236,7 @@ impl InferCtx<'_, '_> {
                     Pattern::AsBinding {
                         pattern: Box::new(inner),
                         name,
+                        name_span,
                         span,
                     },
                     typed,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -286,6 +286,7 @@ pub enum Pattern {
     AsBinding {
         pattern: Box<Self>,
         name: EcoString,
+        name_span: Span,
         span: Span,
     },
 }
@@ -318,10 +319,11 @@ pub fn collect_pattern_bindings(pattern: &Pattern) -> Vec<(String, Span)> {
         Pattern::AsBinding {
             pattern,
             name,
-            span,
+            name_span,
+            ..
         } => {
             let mut bindings = collect_pattern_bindings(pattern);
-            bindings.push((name.to_string(), *span));
+            bindings.push((name.to_string(), *name_span));
             bindings
         }
         Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => vec![],

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -46,10 +46,12 @@ impl<'source> Parser<'source> {
                 self.next();
             } else {
                 let name: EcoString = self.current_token().text.into();
+                let name_span = self.span_from_token(self.current_token());
                 self.next();
                 result = Pattern::AsBinding {
                     pattern: Box::new(result),
                     name,
+                    name_span,
                     span: self.span_from_tokens(start),
                 };
             }
@@ -362,20 +364,14 @@ impl<'source> Parser<'source> {
         let mut rest = RestPattern::Absent;
 
         while self.is_not(RightSquareBracket) {
-            if let Some((binding, rest_start)) = self.try_parse_rest() {
+            if let Some(parsed_rest) = self.try_parse_rest() {
                 if rest.is_present() {
                     self.track_error(
                         "multiple rest patterns in slice pattern",
                         "Only one `..` or `..rest` is allowed.",
                     );
                 } else {
-                    rest = match binding {
-                        Some(name) => RestPattern::Bind {
-                            name,
-                            span: self.span_from_tokens(rest_start),
-                        },
-                        None => RestPattern::Discard(self.span_from_tokens(rest_start)),
-                    };
+                    rest = parsed_rest;
                 }
                 self.expect_comma_or(RightSquareBracket);
                 continue;
@@ -712,29 +708,35 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn try_parse_rest(&mut self) -> Option<(Option<EcoString>, Token<'source>)> {
+    fn try_parse_rest(&mut self) -> Option<RestPattern> {
         if self.is(DotDot) {
             let rest_start = self.current_token();
             self.ensure(DotDot);
             if self.is(Identifier) {
-                let name: EcoString = self.current_token().text.into();
+                let name_token = self.current_token();
+                let name: EcoString = name_token.text.into();
                 self.next();
-                return Some((Some(name), rest_start));
+                return Some(RestPattern::Bind {
+                    name,
+                    span: self.span_from_token(name_token),
+                });
             }
-            return Some((None, rest_start));
+            return Some(RestPattern::Discard(self.span_from_tokens(rest_start)));
         }
 
         if self.is(Identifier) {
-            let text = self.current_token().text;
-            if let Some(binding) = text.strip_prefix("..") {
-                let rest_start = self.current_token();
+            let token = self.current_token();
+            if let Some(binding) = token.text.strip_prefix("..") {
                 self.next();
-                let name = if binding.is_empty() {
-                    None
-                } else {
-                    Some(EcoString::from(binding))
-                };
-                return Some((name, rest_start));
+                if binding.is_empty() {
+                    return Some(RestPattern::Discard(self.span_from_token(token)));
+                }
+                let name_span =
+                    Span::new(self.file_id, token.byte_offset + 2, binding.len() as u32);
+                return Some(RestPattern::Bind {
+                    name: EcoString::from(binding),
+                    span: name_span,
+                });
             }
         }
 

--- a/tests/spec/parse/snapshots/slice_pattern_suffix.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_suffix.snap
@@ -86,8 +86,8 @@ description: |
                                     name: "init",
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 6,
+                                        byte_offset: 53,
+                                        byte_length: 4,
                                     },
                                 },
                                 element_ty: Var {

--- a/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
@@ -152,8 +152,8 @@ description: |
                                     name: "rest",
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 84,
-                                        byte_length: 6,
+                                        byte_offset: 86,
+                                        byte_length: 4,
                                     },
                                 },
                                 element_ty: Var {

--- a/tests/ui/errors/snapshots/infer_duplicate_binding_in_slice_rest_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_duplicate_binding_in_slice_rest_pattern.snap
@@ -5,8 +5,8 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:3:8]
  2 │ fn main() {
  3 │   let [x, ..x] = [1, 2, 3];
-   ·        ┬  ─┬─
-   ·        │   ╰── used again
+   ·        ┬    ┬
+   ·        │    ╰── used again
    ·        ╰── first use of `x`
  4 │ }
    ╰────

--- a/tests/ui/errors/snapshots/infer_uppercase_as_alias.snap
+++ b/tests/ui/errors/snapshots/infer_uppercase_as_alias.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid binding name
-   ╭─[test.lis:6:5]
+   ╭─[test.lis:6:24]
  5 │   match p {
  6 │     Point { x, .. } as P => x,
-   ·     ──────────┬─────────
-   ·               ╰── binding names must start with a lowercase letter
+   ·                        ┬
+   ·                        ╰── binding names must start with a lowercase letter
  7 │   }
    ╰────
   help: Use a lowercase name instead of `P` · code: [infer.uppercase_binding]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -8261,6 +8261,240 @@ fn main() {
 }
 
 #[test]
+fn non_snake_case_method() {
+    assert_lint_snapshot!(
+        r#"
+struct Snake { parts: int }
+
+impl Snake {
+  fn addPart(self: Ref<Snake>, x: int) {
+    self.parts += x
+  }
+}
+
+fn main() {
+  let s = &Snake { parts: 0 }
+  s.addPart(1)
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_interface_method() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Doer {
+  fn doThing(self) -> int
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_associated_function() {
+    assert_lint_snapshot!(
+        r#"
+struct Widget { n: int }
+
+impl Widget {
+  fn newWidget(n: int) -> Widget { Widget { n: n } }
+  fn val(self) -> int { self.n }
+}
+
+fn main() {
+  let w = Widget.newWidget(1)
+  let _ = w.val()
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_pascal_associated_function() {
+    assert_lint_snapshot!(
+        r#"
+struct Widget { n: int }
+
+impl Widget {
+  fn NewWidget(n: int) -> Widget { Widget { n: n } }
+  fn val(self) -> int { self.n }
+}
+
+fn main() {
+  let w = Widget.NewWidget(1)
+  let _ = w.val()
+}
+"#
+    );
+}
+
+#[test]
+fn snake_case_method_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct Snake { parts: int }
+
+impl Snake {
+  fn add_part(self: Ref<Snake>, x: int) {
+    self.parts += x
+  }
+}
+
+fn main() {
+  let s = &Snake { parts: 0 }
+  s.add_part(1)
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_free_function_with_self_param() {
+    assert_lint_snapshot!(
+        r#"
+fn Error(self: int) -> int { self }
+
+fn main() {
+  let _ = Error(1)
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_select_receive_binding() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let ch = Channel.new<int>()
+  ch.send(1)
+  let _ = select {
+    let Some(headItem) = ch.receive() => headItem,
+    _ => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn function_parameter_reported_once() {
+    let warnings = crate::_harness::lint::lint(
+        r#"
+fn greet(userId: int) {
+  let _ = userId;
+}
+
+fn main() {
+  greet(42);
+}
+"#,
+    );
+    let miscasings = warnings
+        .iter()
+        .filter(|w| w.code_str() == Some("lint.non_snake_case_parameter"))
+        .count();
+    assert_eq!(
+        miscasings, 1,
+        "a miscased parameter must be reported exactly once, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn non_snake_case_nested_destructure_parameter() {
+    assert_lint_snapshot!(
+        r#"
+fn add((leftHand, right): (int, int)) -> int { leftHand + right }
+
+fn main() {
+  let _ = add((1, 2))
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_enum_field() {
+    assert_lint_snapshot!(
+        r#"
+enum Shape {
+  Rect { widthPx: int, height_px: int },
+}
+
+fn main() {
+  let _ = Shape.Rect { widthPx: 1, height_px: 2 }
+}
+"#
+    );
+}
+
+#[test]
+fn snake_case_enum_field_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+enum Shape {
+  Rect { width_px: int, height_px: int },
+}
+
+fn main() {
+  let _ = Shape.Rect { width_px: 1, height_px: 2 }
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_as_binding() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = match Some(1) {
+    Some(_) as wholeThing => wholeThing,
+    None => None,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn non_snake_case_slice_rest_binding() {
+    assert_lint_snapshot!(
+        r#"
+fn head_and_tail(xs: Slice<int>) -> int {
+  match xs {
+    [first, ..tailItems] => first + tailItems.length(),
+    [] => 0,
+  }
+}
+
+fn main() {
+  let _ = head_and_tail([1, 2, 3])
+}
+"#
+    );
+}
+
+#[test]
+fn snake_case_slice_rest_binding_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn head_and_tail(xs: Slice<int>) -> int {
+  match xs {
+    [first, ..tail_items] => first + tail_items.length(),
+    [] => 0,
+  }
+}
+
+fn main() {
+  let _ = head_and_tail([1, 2, 3])
+}
+"#
+    );
+}
+
+#[test]
 fn non_snake_case_variable() {
     assert_lint_snapshot!(
         r#"
@@ -8417,6 +8651,23 @@ fn identity<T>(x: T) -> T { x }
 
 fn main() {
   let _ = identity(42);
+}
+"#
+    );
+}
+
+#[test]
+fn non_pascal_case_impl_block_type_parameter() {
+    assert_lint_snapshot!(
+        r#"
+struct Box<T> { value: T }
+
+impl<t> Box<t> {
+  fn get(self) -> t { self.value }
+}
+
+fn main() {
+  let _ = Box { value: 1 }.get()
 }
 "#
     );
@@ -10376,6 +10627,17 @@ impl MyError {
 fn main() {
   let e = MyError { message: "fail" };
   let _ = e.Error();
+}
+"#
+    );
+}
+
+#[test]
+fn interface_method_pascal_case_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Stringer {
+  fn String() -> string
 }
 "#
     );

--- a/tests/ui/lint/snapshots/non_pascal_case_impl_block_type_parameter.snap
+++ b/tests/ui/lint/snapshots/non_pascal_case_impl_block_type_parameter.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:4:6]
+ 3 │ 
+ 4 │ impl<t> Box<t> {
+   ·      ┬
+   ·      ╰── expected PascalCase
+ 5 │   fn get(self) -> t { self.value }
+   ╰────
+  help: Rename to `T` · code: [lint.non_pascal_case_type_parameter]

--- a/tests/ui/lint/snapshots/non_snake_case_as_binding.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_as_binding.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:4:16]
+ 3 │   let _ = match Some(1) {
+ 4 │     Some(_) as wholeThing => wholeThing,
+   ·                ─────┬────
+   ·                     ╰── expected snake_case
+ 5 │     None => None,
+   ╰────
+  help: Rename to `whole_thing` · code: [lint.non_snake_case_variable]

--- a/tests/ui/lint/snapshots/non_snake_case_associated_function.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_associated_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:5:6]
+ 4 │ impl Widget {
+ 5 │   fn newWidget(n: int) -> Widget { Widget { n: n } }
+   ·      ────┬────
+   ·          ╰── expected snake_case
+ 6 │   fn val(self) -> int { self.n }
+   ╰────
+  help: Rename to `new_widget` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/non_snake_case_enum_field.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_enum_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:3:10]
+ 2 │ enum Shape {
+ 3 │   Rect { widthPx: int, height_px: int },
+   ·          ───┬───
+   ·             ╰── expected snake_case
+ 4 │ }
+   ╰────
+  help: Rename to `width_px` · code: [lint.non_snake_case_enum_field]

--- a/tests/ui/lint/snapshots/non_snake_case_free_function_with_self_param.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_free_function_with_self_param.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:2:4]
+ 1 │ 
+ 2 │ fn Error(self: int) -> int { self }
+   ·    ──┬──
+   ·      ╰── expected snake_case
+ 3 │ 
+   ╰────
+  help: Rename to `error` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/non_snake_case_interface_method.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_interface_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:3:6]
+ 2 │ pub interface Doer {
+ 3 │   fn doThing(self) -> int
+   ·      ───┬───
+   ·         ╰── expected snake_case
+ 4 │ }
+   ╰────
+  help: Rename to `do_thing` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/non_snake_case_method.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:5:6]
+ 4 │ impl Snake {
+ 5 │   fn addPart(self: Ref<Snake>, x: int) {
+   ·      ───┬───
+   ·         ╰── expected snake_case
+ 6 │     self.parts += x
+   ╰────
+  help: Rename to `add_part` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/non_snake_case_nested_destructure_parameter.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_nested_destructure_parameter.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:2:9]
+ 1 │ 
+ 2 │ fn add((leftHand, right): (int, int)) -> int { leftHand + right }
+   ·         ────┬───
+   ·             ╰── expected snake_case
+ 3 │ 
+   ╰────
+  help: Rename to `left_hand` · code: [lint.non_snake_case_parameter]

--- a/tests/ui/lint/snapshots/non_snake_case_pascal_associated_function.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_pascal_associated_function.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:5:6]
+ 4 │ impl Widget {
+ 5 │   fn NewWidget(n: int) -> Widget { Widget { n: n } }
+   ·      ────┬────
+   ·          ╰── expected snake_case
+ 6 │   fn val(self) -> int { self.n }
+   ╰────
+  help: Rename to `new_widget` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/non_snake_case_select_receive_binding.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_select_receive_binding.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:6:14]
+ 5 │   let _ = select {
+ 6 │     let Some(headItem) = ch.receive() => headItem,
+   ·              ────┬───
+   ·                  ╰── expected snake_case
+ 7 │     _ => 0,
+   ╰────
+  help: Rename to `head_item` · code: [lint.non_snake_case_variable]

--- a/tests/ui/lint/snapshots/non_snake_case_slice_rest_binding.snap
+++ b/tests/ui/lint/snapshots/non_snake_case_slice_rest_binding.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:4:15]
+ 3 │   match xs {
+ 4 │     [first, ..tailItems] => first + tailItems.length(),
+   ·               ────┬────
+   ·                   ╰── expected snake_case
+ 5 │     [] => 0,
+   ╰────
+  help: Rename to `tail_items` · code: [lint.non_snake_case_variable]


### PR DESCRIPTION
The snake_case and PascalCase naming lints now fire on methods and a number of other declaration and binding psitions they were skipping.

```rs
impl Snake {
  fn addPart(self: Ref<Snake>, x: int) { self.parts += x }  // expected snake_case
}
```

Fix #876
