### PR TITLE
feat: autocomplete struct field names

### DIFF
--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -219,22 +219,7 @@ pub(crate) fn get_instance_completions(
         return items;
     }
 
-    if let Some(syntax::program::Definition {
-        body: syntax::program::DefinitionBody::Struct { fields, .. },
-        ..
-    }) = snapshot.definitions().get(type_id)
-    {
-        for field in fields {
-            if same_module || field.visibility.is_public() {
-                items.push(CompletionItem {
-                    label: field.name.to_string(),
-                    kind: Some(CompletionItemKind::FIELD),
-                    detail: Some(field.ty.to_string()),
-                    ..Default::default()
-                });
-            }
-        }
-    }
+    struct_field_completions(type_id, snapshot, same_module, &mut items);
 
     let method_prefix = format!("{type_id}.");
     for (qname, definition) in snapshot.definitions().iter() {
@@ -256,6 +241,75 @@ pub(crate) fn get_instance_completions(
         }
     }
 
+    items
+}
+
+/// A struct's own field completions, honoring visibility. No methods.
+pub(crate) fn struct_field_completions(
+    type_id: &str,
+    snapshot: &AnalysisSnapshot,
+    same_module: bool,
+    items: &mut Vec<CompletionItem>,
+) {
+    if let Some(syntax::program::Definition {
+        body: syntax::program::DefinitionBody::Struct { fields, .. },
+        ..
+    }) = snapshot.definitions().get(type_id)
+    {
+        for field in fields {
+            if same_module || field.visibility.is_public() {
+                items.push(CompletionItem {
+                    label: field.name.to_string(),
+                    kind: Some(CompletionItemKind::FIELD),
+                    detail: Some(field.ty.to_string()),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+}
+
+/// The struct literal and its assignments when `offset` is at a field name.
+pub(crate) fn detect_struct_literal_field_context(
+    file: &syntax::program::File,
+    offset: u32,
+) -> Option<(&Type, &[syntax::ast::StructFieldAssignment])> {
+    let tokens = Lexer::new(&file.source, 0).lex().tokens;
+    let split = tokens.partition_point(|t| (t.byte_offset as usize) < offset as usize);
+    if !in_field_name_position(&tokens[..split]) {
+        return None;
+    }
+
+    let Expression::StructCall {
+        ty,
+        field_assignments,
+        ..
+    } = find_expression_at(&file.items, offset)?
+    else {
+        return None;
+    };
+    Some((ty, field_assignments))
+}
+
+/// Whether the token before any partial name is `{` or `,` (field name), not `:` (value).
+fn in_field_name_position(before: &[Token]) -> bool {
+    let end = match before.last() {
+        Some(t) if t.kind == Tk::Identifier => before.len() - 1,
+        _ => before.len(),
+    };
+    end >= 1 && matches!(before[end - 1].kind, Tk::LeftCurlyBrace | Tk::Comma)
+}
+
+/// A struct literal body's completions: unassigned fields, no methods.
+pub(crate) fn get_struct_literal_completions(
+    type_id: &str,
+    snapshot: &AnalysisSnapshot,
+    same_module: bool,
+    assigned: &[syntax::ast::StructFieldAssignment],
+) -> Vec<CompletionItem> {
+    let mut items = Vec::new();
+    struct_field_completions(type_id, snapshot, same_module, &mut items);
+    items.retain(|item| !assigned.iter().any(|fa| fa.name.as_str() == item.label));
     items
 }
 
@@ -324,7 +378,7 @@ pub(crate) fn get_type_completions(
     items
 }
 
-fn id_is_in_module(qualified_id: &str, module: &str) -> bool {
+pub(crate) fn id_is_in_module(qualified_id: &str, module: &str) -> bool {
     qualified_id.starts_with(module) && qualified_id.as_bytes().get(module.len()) == Some(&b'.')
 }
 

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -269,11 +269,11 @@ pub(crate) fn struct_field_completions(
     }
 }
 
-/// The struct literal and its assignments when `offset` is at a field name.
+/// The struct literal's name, type, and assignments when `offset` is at a field name.
 pub(crate) fn detect_struct_literal_field_context(
     file: &syntax::program::File,
     offset: u32,
-) -> Option<(&Type, &[syntax::ast::StructFieldAssignment])> {
+) -> Option<(&str, &Type, &[syntax::ast::StructFieldAssignment])> {
     let tokens = Lexer::new(&file.source, 0).lex().tokens;
     let split = tokens.partition_point(|t| (t.byte_offset as usize) < offset as usize);
     if !in_field_name_position(&tokens[..split]) {
@@ -281,14 +281,23 @@ pub(crate) fn detect_struct_literal_field_context(
     }
 
     let Expression::StructCall {
+        name,
         ty,
         field_assignments,
+        spread,
         ..
     } = find_expression_at(&file.items, offset)?
     else {
         return None;
     };
-    Some((ty, field_assignments))
+
+    if let Some(spread_span) = spread.span()
+        && offset >= spread_span.byte_offset
+    {
+        return None;
+    }
+
+    Some((name.as_str(), ty, field_assignments))
 }
 
 /// Whether the token before any partial name is `{` or `,` (field name), not `:` (value).
@@ -300,17 +309,57 @@ fn in_field_name_position(before: &[Token]) -> bool {
     end >= 1 && matches!(before[end - 1].kind, Tk::LeftCurlyBrace | Tk::Comma)
 }
 
-/// A struct literal body's completions: unassigned fields, no methods.
+/// A struct or enum-variant literal's unset fields, plus the one being typed. No methods.
 pub(crate) fn get_struct_literal_completions(
     type_id: &str,
+    call_name: &str,
     snapshot: &AnalysisSnapshot,
     same_module: bool,
     assigned: &[syntax::ast::StructFieldAssignment],
+    offset: u32,
 ) -> Vec<CompletionItem> {
     let mut items = Vec::new();
     struct_field_completions(type_id, snapshot, same_module, &mut items);
-    items.retain(|item| !assigned.iter().any(|fa| fa.name.as_str() == item.label));
+    enum_variant_field_completions(type_id, call_name, snapshot, &mut items);
+    items.retain(|item| {
+        !assigned
+            .iter()
+            .any(|fa| fa.name.as_str() == item.label && !cursor_on_name(fa, offset))
+    });
     items
+}
+
+/// An enum struct-variant's fields, resolved from the literal's `Enum.Variant` name.
+fn enum_variant_field_completions(
+    type_id: &str,
+    call_name: &str,
+    snapshot: &AnalysisSnapshot,
+    items: &mut Vec<CompletionItem>,
+) {
+    let Some(syntax::program::Definition {
+        body: syntax::program::DefinitionBody::Enum { variants, .. },
+        ..
+    }) = snapshot.definitions().get(type_id)
+    else {
+        return;
+    };
+    let variant_name = call_name.rsplit_once('.').map_or(call_name, |(_, v)| v);
+    let Some(variant) = variants.iter().find(|v| v.name == variant_name) else {
+        return;
+    };
+    for field in variant.fields.iter() {
+        items.push(CompletionItem {
+            label: field.name.to_string(),
+            kind: Some(CompletionItemKind::FIELD),
+            detail: Some(field.ty.to_string()),
+            ..Default::default()
+        });
+    }
+}
+
+fn cursor_on_name(fa: &syntax::ast::StructFieldAssignment, offset: u32) -> bool {
+    let start = fa.name_span.byte_offset;
+    offset >= start && offset <= start + fa.name_span.byte_length
 }
 
 fn collect_interface_methods(

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1238,11 +1238,18 @@ impl LanguageServer for Backend {
         }
 
         // In a struct literal's field-name position, offer the unassigned fields.
-        if let Some((ty, assigned)) = detect_struct_literal_field_context(file, offset)
+        if let Some((name, ty, assigned)) = detect_struct_literal_field_context(file, offset)
             && let Some(type_id) = type_name(ty)
         {
             let same_module = id_is_in_module(&type_id, &file.module_id);
-            let items = get_struct_literal_completions(&type_id, &snapshot, same_module, assigned);
+            let items = get_struct_literal_completions(
+                &type_id,
+                name,
+                &snapshot,
+                same_module,
+                assigned,
+                offset,
+            );
             return Ok(Some(CompletionResponse::Array(items)));
         }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -22,7 +22,8 @@ use tower_lsp::lsp_types::*;
 use crate::analysis::{offset_in_span, type_name};
 use crate::completion::{
     DotContext, attribute_completions, definition_to_completion_kind, detect_dot_context,
-    get_instance_completions, get_module_prefix, get_type_completions, resolve_variable_type,
+    detect_struct_literal_field_context, get_instance_completions, get_module_prefix,
+    get_struct_literal_completions, get_type_completions, id_is_in_module, resolve_variable_type,
 };
 use crate::definition::{
     find_struct_field_span, is_generated_typedef_span, lookup_definition_span,
@@ -1183,8 +1184,7 @@ impl LanguageServer for Backend {
         if let Some(ctx) = detect_dot_context(file, offset, &snapshot) {
             let items = match ctx {
                 DotContext::Instance(type_id) => {
-                    let same_module = type_id.starts_with(file.module_id.as_str())
-                        && type_id.as_bytes().get(file.module_id.len()) == Some(&b'.');
+                    let same_module = id_is_in_module(&type_id, &file.module_id);
                     get_instance_completions(&type_id, &snapshot, same_module)
                 }
                 DotContext::TypeLevel(type_id) => {
@@ -1228,14 +1228,22 @@ impl LanguageServer for Backend {
                 if let Some(type_id) =
                     resolve_variable_type(prefix, file, offset, &snapshot, indexed)
                 {
-                    let same_module = type_id.starts_with(file.module_id.as_str())
-                        && type_id.as_bytes().get(file.module_id.len()) == Some(&b'.');
+                    let same_module = id_is_in_module(&type_id, &file.module_id);
                     let items = get_instance_completions(&type_id, &snapshot, same_module);
                     return Ok(Some(CompletionResponse::Array(items)));
                 }
             }
 
             return Ok(Some(CompletionResponse::Array(vec![])));
+        }
+
+        // In a struct literal's field-name position, offer the unassigned fields.
+        if let Some((ty, assigned)) = detect_struct_literal_field_context(file, offset)
+            && let Some(type_id) = type_name(ty)
+        {
+            let same_module = id_is_in_module(&type_id, &file.module_id);
+            let items = get_struct_literal_completions(&type_id, &snapshot, same_module, assigned);
+            return Ok(Some(CompletionResponse::Array(items)));
         }
 
         let mut items = Vec::new();

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1334,6 +1334,194 @@ fn main() {
 }
 
 #[tokio::test]
+async fn completion_struct_literal_offers_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+impl Point {
+  pub fn sum(self) -> int { self.x + self.y }
+}
+fn main() {
+  let s = Point {  }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Cursor inside the literal body on line 5: `  let s = Point { | }`.
+    let response = client.completion(TEST_URI, 5, 18).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+    // A literal body wants fields only — not the struct's methods.
+    assert!(!labels.contains(&"sum".to_string()), "got: {labels:?}");
+    assert!(
+        !labels.iter().any(|l| l == "fn" || l == "let"),
+        "got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_value_position_offers_no_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point { x: 1 }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Cursor right after the colon, before the value: `  let s = Point { x:| 1 }`.
+    let response = client.completion(TEST_URI, 2, 20).await;
+    let labels = completion_labels(&response.expect("completions"));
+
+    // A value position is not a field-name position: no fields, fall through to general completions.
+    assert!(!labels.contains(&"y".to_string()), "got: {labels:?}");
+    assert!(labels.iter().any(|l| l == "let"), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_nested_resolves_inner_struct() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Inner { a: int, b: int }
+struct Outer { inner: Inner }
+fn main() {
+  let s = Outer { inner: Inner {  } }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Cursor inside the nested literal: `… Outer { inner: Inner { | } }` on line 3.
+    let response = client.completion(TEST_URI, 3, 33).await;
+    let labels = completion_labels(&response.expect("nested struct literal field completions"));
+
+    // The inner literal offers Inner's fields, not Outer's.
+    assert!(labels.contains(&"a".to_string()), "got: {labels:?}");
+    assert!(labels.contains(&"b".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"inner".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_ignores_comma_in_comment() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    // A comma inside a comment is not a field separator: the field name detection
+    // is token-based, so it must not treat this as a field-name position.
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point { x: 1 //,
+  }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Cursor before the closing brace on line 3: `  |}`.
+    let response = client.completion(TEST_URI, 3, 2).await;
+    let labels = completion_labels(&response.expect("completions"));
+
+    assert!(!labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"y".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_omits_assigned_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point { x: 1,  }
+}";
+    client.open(TEST_URI, source).await;
+
+    // Cursor after `x: 1, ` on line 2: `  let s = Point { x: 1, | }`.
+    let response = client.completion(TEST_URI, 2, 24).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"x".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_respects_field_visibility() {
+    let mut client = TestClient::new().await;
+
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path();
+
+    std::fs::write(
+        root_path.join("lisette.toml"),
+        "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/shapes")).unwrap();
+    std::fs::write(
+        root_path.join("src/shapes/shapes.lis"),
+        "pub struct Box { pub w: int, h: int }\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
+    std::fs::write(
+        root_path.join("src/main/main.lis"),
+        "import \"shapes\"\nfn main() {\n  let b = shapes.Box {  }\n}\n",
+    )
+    .unwrap();
+
+    client.initialize_with_root(root_path).await;
+
+    let shapes_uri = format!(
+        "file://{}",
+        root_path.join("src/shapes/shapes.lis").display()
+    );
+    let main_uri = format!("file://{}", root_path.join("src/main/main.lis").display());
+
+    client
+        .open(
+            &shapes_uri,
+            &std::fs::read_to_string(root_path.join("src/shapes/shapes.lis")).unwrap(),
+        )
+        .await;
+    client
+        .open(
+            &main_uri,
+            &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        )
+        .await;
+
+    // Cursor inside the cross-module literal body: `  let b = shapes.Box { | }`.
+    let response = client.completion(&main_uri, 2, 23).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(
+        labels.contains(&"w".to_string()),
+        "public field, got: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"h".to_string()),
+        "private field, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_dot_on_for_loop_variable() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1522,6 +1522,140 @@ async fn completion_struct_literal_respects_field_visibility() {
 }
 
 #[tokio::test]
+async fn completion_struct_literal_enum_variant_offers_variant_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+enum Action { Move { x: int, y: int }, Stop }
+fn main() {
+  let a = Action.Move {  }
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 23).await;
+    let labels = completion_labels(&response.expect("enum variant field completions"));
+
+    assert!(labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"Stop".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"Move".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_keeps_field_being_typed() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point { x }
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 19).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(
+        labels.contains(&"x".to_string()),
+        "field being typed must remain, got: {labels:?}"
+    );
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_unclosed_brace_offers_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point {
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 18).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_no_space_after_brace_offers_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let s = Point {}
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 2, 17).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_after_spread_offers_no_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let base = Point { x: 1, y: 2 }
+  let s = Point { ..base,  }
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 3, 26).await;
+    let labels = completion_labels(&response.expect("completions"));
+
+    assert!(!labels.contains(&"x".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"y".to_string()), "got: {labels:?}");
+    assert!(labels.iter().any(|l| l == "let"), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn completion_struct_literal_before_spread_offers_fields() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Point { x: int, y: int }
+fn main() {
+  let base = Point { x: 1, y: 2 }
+  let s = Point { x: 1, ..base }
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 3, 23).await;
+    let labels = completion_labels(&response.expect("struct literal field completions"));
+
+    assert!(labels.contains(&"y".to_string()), "got: {labels:?}");
+    assert!(!labels.contains(&"x".to_string()), "got: {labels:?}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_dot_on_for_loop_variable() {
     let mut client = TestClient::new().await;
     client.initialize().await;


### PR DESCRIPTION
This change adds support for the lsp to autocomplete struct fields (when initialising).

Eg.

```rust
struct Event { name: string, duration: int, date: string } 

Event { n|  } // ac shows "name"
Event { name: "foo", d|  } // ac shows "date, duration"
Event { name: "foo", date: "foo", d|  } // ac shows "duration"
```
