### PR TITLE
feat: inline subscript assignment targets

### DIFF
--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -8,6 +8,7 @@ use crate::is_order_sensitive;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::types::native::NativeGoType;
+use crate::utils::contains_call;
 
 impl Planner<'_> {
     /// Plan an index/slice access. Range-literal and range-typed-variable
@@ -43,12 +44,29 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, value);
         }
 
-        let index_staged = self.stage_composite(index, ExpressionContext::value());
-        let (setup, values) = self.sequence_structured(vec![base_staged, index_staged], "_base");
-        value_plan_from_statements(setup, format!("{}[{}]", values[0], values[1]))
+        let (setup, value) = self.sequence_indexed_access(expression, base_staged, index, "_base");
+        value_plan_from_statements(setup, value)
     }
 
-    fn stage_base_with_deref(&mut self, expression: &Expression) -> StagedExpression {
+    pub(crate) fn sequence_indexed_access(
+        &mut self,
+        base: &Expression,
+        mut base_staged: StagedExpression,
+        index: &Expression,
+        prefix: &str,
+    ) -> (Vec<LoweredStatement>, String) {
+        let index_staged = self.stage_composite(index, ExpressionContext::value());
+        if base_staged.setup.is_empty()
+            && is_order_sensitive(base)
+            && (contains_call(base) || contains_call(index))
+        {
+            self.pin_staged(&mut base_staged, prefix);
+        }
+        let (setup, values) = self.sequence_structured(vec![base_staged, index_staged], prefix);
+        (setup, format!("{}[{}]", values[0], values[1]))
+    }
+
+    pub(crate) fn stage_base_with_deref(&mut self, expression: &Expression) -> StagedExpression {
         let Some(inner) = expression.deref_inner() else {
             return self.stage_operand(expression, ExpressionContext::value());
         };

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -399,9 +399,10 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         let rhs_staged = self.stage_composite(value, ExpressionContext::value());
 
+        let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut setup, target, !rhs_staged.setup.is_empty())
+            self.emit_left_value_capturing(&mut setup, target, rhs_has_setup)
         } else {
             self.emit_left_value(&mut setup, target)
         };

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -139,7 +139,7 @@ impl Planner<'_> {
         }
     }
 
-    fn rhs_contains_effectful_call(&self, expression: &Expression) -> bool {
+    pub(crate) fn rhs_contains_effectful_call(&self, expression: &Expression) -> bool {
         match expression.unwrap_parens() {
             Expression::Call {
                 expression: callee,
@@ -338,9 +338,13 @@ impl Planner<'_> {
                 index,
                 ..
             } => {
-                let base_str = self.emit_indexed_base_lvalue(setup, base);
-                let index_str = self.emit_index_lvalue(setup, index, rhs_has_setup);
-                format!("{}[{}]", base_str, index_str)
+                if rhs_has_setup {
+                    let base_str = self.emit_indexed_base_lvalue(setup, base);
+                    let index_str = self.emit_force_capture(setup, index, "idx");
+                    format!("{}[{}]", base_str, index_str)
+                } else {
+                    self.emit_indexed_lvalue_inline(setup, base, index)
+                }
             }
             Expression::DotAccess {
                 expression: base,
@@ -372,9 +376,18 @@ impl Planner<'_> {
         }
     }
 
-    /// Emit the base of an `IndexedAccess` lvalue, peeling an explicit deref
-    /// so `(*ptr)[i]` evaluates the pointer separately from the index, and
-    /// capturing the base to a temp when ordering matters.
+    fn emit_indexed_lvalue_inline(
+        &mut self,
+        setup: &mut Vec<LoweredStatement>,
+        base: &Expression,
+        index: &Expression,
+    ) -> String {
+        let base_staged = self.stage_base_with_deref(base);
+        let (seq_setup, value) = self.sequence_indexed_access(base, base_staged, index, "base");
+        setup.extend(seq_setup);
+        value
+    }
+
     fn emit_indexed_base_lvalue(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
@@ -399,27 +412,6 @@ impl Planner<'_> {
             self.emit_force_capture(setup, expression, "base")
         } else {
             self.capture_operand_into(setup, expression)
-        }
-    }
-
-    /// Emit the index of an `IndexedAccess` lvalue, capturing to a temp when
-    /// the RHS will emit setup statements that could mutate the index variable,
-    /// or when the index expression itself is order-sensitive.
-    fn emit_index_lvalue(
-        &mut self,
-        setup: &mut Vec<LoweredStatement>,
-        index: &Expression,
-        rhs_has_setup: bool,
-    ) -> String {
-        let needs_capture = if rhs_has_setup {
-            !matches!(index.unwrap_parens(), Expression::Literal { .. })
-        } else {
-            is_order_sensitive(index)
-        };
-        if needs_capture {
-            self.emit_force_capture(setup, index, "idx")
-        } else {
-            self.capture_operand_into(setup, index)
         }
     }
 }

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -104,18 +104,31 @@ pub(crate) fn contains_call(expression: &Expression) -> bool {
     }
 }
 
-pub(crate) fn is_order_sensitive(expression: &Expression) -> bool {
-    !matches!(
+pub(crate) fn is_scalar_literal(expression: &Expression) -> bool {
+    matches!(
         expression.unwrap_parens(),
-        Expression::Literal { .. } | Expression::Identifier { .. }
+        Expression::Literal {
+            literal: Literal::Integer { .. }
+                | Literal::Float { .. }
+                | Literal::Imaginary(_)
+                | Literal::Boolean(_)
+                | Literal::String { .. }
+                | Literal::Char(_),
+            ..
+        }
     )
 }
 
-/// True for any expression except a pure literal — i.e. one whose value can
+pub(crate) fn is_order_sensitive(expression: &Expression) -> bool {
+    !(is_scalar_literal(expression)
+        || matches!(expression.unwrap_parens(), Expression::Identifier { .. }))
+}
+
+/// True for any expression except a scalar constant, i.e. one whose value can
 /// be invalidated by a later sibling's setup, or is a call we should not
 /// re-evaluate.
 pub(crate) fn observable_after_mutation(expression: &Expression) -> bool {
-    !matches!(expression.unwrap_parens(), Expression::Literal { .. })
+    !is_scalar_literal(expression)
 }
 
 pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2435,6 +2435,117 @@ fn main() {
 }
 
 #[test]
+fn indexed_field_assignment_no_temp_for_trivial_rhs() {
+    let input = r#"
+struct Pos { x: int, y: int }
+
+struct Snake {
+  parts: Slice<Pos>,
+  head:  int
+}
+
+impl Snake {
+  fn set_head(self: Ref<Snake>, x: int, y: int) {
+    self.parts[self.head].x = x
+    self.parts[self.head].y = y
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn compound_indexed_field_assignment_no_temp_for_trivial_rhs() {
+    let input = r#"
+struct Pos { x: int, y: int }
+
+struct Snake {
+  parts: Slice<Pos>,
+  head:  int
+}
+
+impl Snake {
+  fn grow(self: Ref<Snake>) {
+    self.parts[self.head].x += 1
+    self.parts[self.head].y -= 2
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_lvalue_pins_base_before_call_index() {
+    let input = r#"
+fn main() {
+  let mut xss = [[10, 11], [20, 21]]
+  let mut i = 0
+  let bump = || -> int { i += 1; i }
+  xss[i][bump()] = 9
+  let _ = xss
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_lvalue_pins_call_base_before_index() {
+    let input = r#"
+fn main() {
+  let xs = [10, 20]
+  let mut i = 0
+  let make = || -> Slice<int> { i += 1; xs }
+  make()[i] = 99
+  let _ = xs
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_index_captured_before_rhs_setup() {
+    let input = r#"
+fn main() {
+  let mut m = Map.new<string, int>()
+  m["0"] = 100
+  let mut i = 0
+  m[f"{i}"] = if true { i += 1; 7 } else { 0 }
+  let _ = m
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_lvalue_pins_call_base_before_format_string_index() {
+    let input = r#"
+fn main() {
+  let mut m = Map.new<string, int>()
+  m["0"] = 100
+  let mut i = 0
+  let make = || -> Map<string, int> { i += 1; m }
+  make()[f"{i}"] = 99
+  let _ = m
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn expr_position_indexed_assign_pins_base_before_call_rhs() {
+    let input = r#"
+fn main() {
+  let mut xss = [[10, 11], [20, 21]]
+  let mut i = 0
+  let bump = || -> int { i += 1; i }
+  let _ = if true { xss[i][0] = bump() } else {}
+  let _ = xss
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn ref_temp_var_no_collision() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -59,6 +59,8 @@ func main() {
 		Tag: CarrierC,
 		P:   &i,
 	}
-	x := first(m[i][0], []int{bump(c)}[0])
+	_arg_2 := m[i][0]
+	_base_1 := []int{bump(c)}
+	x := first(_arg_2, _base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
@@ -38,6 +38,8 @@ func main() {
 	i := 0
 	m := [][]int{[]int{10}, []int{20}}
 	c := Carrier{p: &i}
-	x := first(m[i][0], []int{bump(c)}[0])
+	_arg_2 := m[i][0]
+	_base_1 := []int{bump(c)}
+	x := first(_arg_2, _base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
@@ -32,6 +32,8 @@ func main() {
 	i := 0
 	m := [][]int{[]int{10}, []int{20}}
 	ip := &i
-	x := first(m[i][0], []int{bump(ip)}[0])
+	_arg_2 := m[i][0]
+	_base_1 := []int{bump(ip)}
+	x := first(_arg_2, _base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/compound_indexed_field_assignment_no_temp_for_trivial_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_indexed_field_assignment_no_temp_for_trivial_rhs.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Pos { x: int, y: int }
+  
+  struct Snake {
+    parts: Slice<Pos>,
+    head:  int
+  }
+  
+  impl Snake {
+    fn grow(self: Ref<Snake>) {
+      self.parts[self.head].x += 1
+      self.parts[self.head].y -= 2
+    }
+  }
+---
+package main
+
+type Pos struct {
+	x int
+	y int
+}
+
+type Snake struct {
+	parts []Pos
+	head  int
+}
+
+func (s *Snake) grow() {
+	s.parts[s.head].x++
+	s.parts[s.head].y -= 2
+}

--- a/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
@@ -11,8 +11,9 @@ package main
 
 func run(out *[]int) {
 	_arg_1 := *out
+	_arg_2 := []int{1, 2, 3}
 	defer func() {
-		_ = copy(_arg_1, []int{1, 2, 3})
+		_ = copy(_arg_1, _arg_2)
 	}()
 	*out = []int{7, 7, 7, 7, 7}
 }

--- a/tests/spec/emit/snapshots/deref_map_index_assignment.snap
+++ b/tests/spec/emit/snapshots/deref_map_index_assignment.snap
@@ -9,6 +9,5 @@ description: |
 package main
 
 func update(m *map[string]int, key string, val int) {
-	base_1 := m
-	(*base_1)[key] = val
+	(*m)[key] = val
 }

--- a/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
+++ b/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
@@ -17,12 +17,13 @@ func get_items() []int {
 
 func main() {
 	items := []int{0, 0, 0}
-	idx_2 := get_items()[0]
+	_base_2 := get_items()
+	idx_3 := _base_2[0]
 	var tmp_1 int
 	if true {
 		tmp_1 = 42
 	} else {
 		tmp_1 = 0
 	}
-	items[idx_2] = tmp_1
+	items[idx_3] = tmp_1
 }

--- a/tests/spec/emit/snapshots/expr_position_indexed_assign_pins_base_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/expr_position_indexed_assign_pins_base_before_call_rhs.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn main() {
+    let mut xss = [[10, 11], [20, 21]]
+    let mut i = 0
+    let bump = || -> int { i += 1; i }
+    let _ = if true { xss[i][0] = bump() } else {}
+    let _ = xss
+  }
+---
+package main
+
+func main() {
+	xss := [][]int{[]int{10, 11}, []int{20, 21}}
+	i := 0
+	bump := func() int {
+		i++
+		return i
+	}
+	var tmp_1 struct{}
+	if true {
+		base_2 := xss[i]
+		base_2[0] = bump()
+		tmp_1 = struct{}{}
+	}
+	_ = tmp_1
+	_ = xss
+}

--- a/tests/spec/emit/snapshots/format_string_index_captured_before_rhs_setup.snap
+++ b/tests/spec/emit/snapshots/format_string_index_captured_before_rhs_setup.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn main() {
+    let mut m = Map.new<string, int>()
+    m["0"] = 100
+    let mut i = 0
+    m[f"{i}"] = if true { i += 1; 7 } else { 0 }
+    let _ = m
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]int)
+	m["0"] = 100
+	i := 0
+	idx_2 := fmt.Sprint(i)
+	var tmp_1 int
+	if true {
+		i++
+		tmp_1 = 7
+	} else {
+		tmp_1 = 0
+	}
+	m[idx_2] = tmp_1
+	_ = m
+}

--- a/tests/spec/emit/snapshots/indexed_field_assignment_no_temp_for_trivial_rhs.snap
+++ b/tests/spec/emit/snapshots/indexed_field_assignment_no_temp_for_trivial_rhs.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Pos { x: int, y: int }
+  
+  struct Snake {
+    parts: Slice<Pos>,
+    head:  int
+  }
+  
+  impl Snake {
+    fn set_head(self: Ref<Snake>, x: int, y: int) {
+      self.parts[self.head].x = x
+      self.parts[self.head].y = y
+    }
+  }
+---
+package main
+
+type Pos struct {
+	x int
+	y int
+}
+
+type Snake struct {
+	parts []Pos
+	head  int
+}
+
+func (s *Snake) set_head(x, y int) {
+	s.parts[s.head].x = x
+	s.parts[s.head].y = y
+}

--- a/tests/spec/emit/snapshots/indexed_lvalue_pins_base_before_call_index.snap
+++ b/tests/spec/emit/snapshots/indexed_lvalue_pins_base_before_call_index.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn main() {
+    let mut xss = [[10, 11], [20, 21]]
+    let mut i = 0
+    let bump = || -> int { i += 1; i }
+    xss[i][bump()] = 9
+    let _ = xss
+  }
+---
+package main
+
+func main() {
+	xss := [][]int{[]int{10, 11}, []int{20, 21}}
+	i := 0
+	bump := func() int {
+		i++
+		return i
+	}
+	base_1 := xss[i]
+	base_1[bump()] = 9
+	_ = xss
+}

--- a/tests/spec/emit/snapshots/indexed_lvalue_pins_call_base_before_format_string_index.snap
+++ b/tests/spec/emit/snapshots/indexed_lvalue_pins_call_base_before_format_string_index.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn main() {
+    let mut m = Map.new<string, int>()
+    m["0"] = 100
+    let mut i = 0
+    let make = || -> Map<string, int> { i += 1; m }
+    make()[f"{i}"] = 99
+    let _ = m
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]int)
+	m["0"] = 100
+	i := 0
+	make_ := func() map[string]int {
+		i++
+		return m
+	}
+	base_1 := make_()
+	base_1[fmt.Sprint(i)] = 99
+	_ = m
+}

--- a/tests/spec/emit/snapshots/indexed_lvalue_pins_call_base_before_index.snap
+++ b/tests/spec/emit/snapshots/indexed_lvalue_pins_call_base_before_index.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn main() {
+    let xs = [10, 20]
+    let mut i = 0
+    let make = || -> Slice<int> { i += 1; xs }
+    make()[i] = 99
+    let _ = xs
+  }
+---
+package main
+
+func main() {
+	xs := []int{10, 20}
+	i := 0
+	make_ := func() []int {
+		i++
+		return xs
+	}
+	base_1 := make_()
+	base_1[i] = 99
+	_ = xs
+}

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -27,6 +27,5 @@ func main() {
 	r := &m
 	entry := (*r)["a"]
 	entry.items = append(entry.items, 1)
-	base_1 := r
-	(*base_1)["a"] = entry
+	(*r)["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
@@ -43,6 +43,5 @@ func main() {
 	i := make_i()
 	entry := maps_[i]["k"]
 	entry.x = 1
-	base_1 := maps_[i]
-	base_1["k"] = entry
+	maps_[i]["k"] = entry
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -25,6 +25,5 @@ func main() {
 	r := &m
 	entry := (*r)["k"]
 	entry.x = 1
-	base_1 := r
-	(*base_1)["k"] = entry
+	(*r)["k"] = entry
 }

--- a/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
+++ b/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
@@ -17,10 +17,9 @@ func noop() {}
 
 func main() {
 	m := make(map[struct{}]int)
-	idx_1 := struct{}{}
-	m[idx_1] = 7
-	_base_2 := m
+	m[struct{}{}] = 7
+	_base_1 := m
 	noop()
-	x := _base_2[struct{}{}]
+	x := _base_1[struct{}{}]
 	_ = x
 }

--- a/tests/spec/emit/snapshots/unit_call_as_map_index_key_assignment.snap
+++ b/tests/spec/emit/snapshots/unit_call_as_map_index_key_assignment.snap
@@ -15,7 +15,7 @@ func noop() {}
 
 func main() {
 	m := make(map[struct{}]int)
+	base_1 := m
 	noop()
-	idx_1 := struct{}{}
-	m[idx_1] = 7
+	base_1[struct{}{}] = 7
 }


### PR DESCRIPTION
Subscript assignment targets now emit as-is instead of spilling the base and index into temps, only when the RHS is trivial.

Close #877
