### PR TITLE
fix: keep a single lhs copy in compound assignments

### DIFF
--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -424,7 +424,7 @@ fn detect_compound_assignment<'a>(
     compound_operator: Option<&'a BinaryOperator>,
 ) -> Option<(&'a BinaryOperator, &'a Expression)> {
     if let Some(op) = compound_operator {
-        return Some((op, compound_rhs(value)));
+        return Some((op, value));
     }
     let Expression::Binary {
         left,
@@ -439,16 +439,6 @@ fn detect_compound_assignment<'a>(
         return None;
     }
     Some((operator, right.as_ref()))
-}
-
-/// Extract the original RHS from a desugared compound assignment.
-/// `x += rhs` is parsed as `Assignment { value: Binary(x, +, rhs), .. }`.
-fn compound_rhs(value: &Expression) -> &Expression {
-    if let Expression::Binary { right, .. } = value {
-        right
-    } else {
-        value
-    }
 }
 
 fn is_literal_one(expression: &Expression) -> bool {

--- a/crates/format/src/formatter/expression.rs
+++ b/crates/format/src/formatter/expression.rs
@@ -901,14 +901,13 @@ impl<'a> Formatter<'a> {
     ) -> Document<'a> {
         if let Some(op) = compound_operator
             && let Some(op_str) = op.compound_assignment_symbol()
-            && let Expression::Binary { right, .. } = value
         {
             return self
                 .expression(target)
                 .append(" ")
                 .append(op_str)
                 .append(" ")
-                .append(self.expression(right));
+                .append(self.expression(value));
         }
 
         self.expression(target)

--- a/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
@@ -14,32 +14,19 @@ pub fn check_misrefactored_assign_op(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    // A compound assignment is lowered to `target <op> rhs`, so the written
-    // right-hand side is this binary's right operand.
-    let Expression::Binary {
-        operator,
-        left,
-        right,
-        ..
-    } = value.unwrap_parens()
-    else {
-        return;
-    };
-    if operator != compound {
-        return;
-    }
-
     let target = target.unwrap_parens();
-    if !expressions_equivalent(target, left) || !is_side_effect_free(target) {
+    if !is_side_effect_free(target) {
         return;
     }
 
+    // The written right-hand side of `target <op>= rhs` is stored directly as
+    // the value. Flag the mirror form `target <op>= other <op> target`.
     let Expression::Binary {
         operator: rhs_operator,
         left: rhs_left,
         right: rhs_right,
         ..
-    } = right.unwrap_parens()
+    } = value.unwrap_parens()
     else {
         return;
     };

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -149,7 +149,7 @@ impl InferCtx<'_, '_> {
     /// Infer a binary expression where the left operand is already inferred.
     /// Returns the inferred expression and its result type.
     #[allow(clippy::too_many_arguments)]
-    fn infer_binary_with_left(
+    pub(super) fn infer_binary_with_left(
         &mut self,
         operator: BinaryOperator,
         left_inferred: Expression,

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -333,8 +333,24 @@ impl InferCtx<'_, '_> {
         // Propagates type information to the RHS (e.g., lambda params
         // get their types from a Map's value type).
         let value_expected = target_ty.resolve_in(&self.env);
-        let new_value = self.infer_expression(*value, &value_expected);
-        let value_ty = new_value.get_type();
+        let (new_value, value_ty) = if let Some(operator) = compound_operator {
+            let (binary, result_ty) = self.infer_binary_with_left(
+                operator,
+                new_target.clone(),
+                target_ty.clone(),
+                value,
+                &value_expected,
+                span,
+            );
+            let Expression::Binary { right, .. } = binary else {
+                unreachable!("infer_binary_with_left always returns a binary")
+            };
+            (*right, result_ty)
+        } else {
+            let new_value = self.infer_expression(*value, &value_expected);
+            let value_ty = new_value.get_type();
+            (new_value, value_ty)
+        };
 
         // Track mutation for binding-rooted targets. Call-based lvalues
         // (e.g., `get().*.x = ...`) have no local binding to track.

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1263,15 +1263,8 @@ impl<'source> Parser<'source> {
             self.next();
             let rhs = self.parse_expression();
             return Expression::Assignment {
-                target: lhs.clone().into(),
-                value: Expression::Binary {
-                    left: lhs.into(),
-                    operator,
-                    right: rhs.into(),
-                    ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
-                }
-                .into(),
+                target: lhs.into(),
+                value: rhs.into(),
                 compound_operator: Some(operator),
                 span: self.span_from_tokens(start),
             };
@@ -1810,5 +1803,66 @@ impl<'source> Parser<'source> {
             ty: Type::uninferred(),
             span: token_span,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::{BinaryOperator, Expression};
+    use crate::build_ast;
+
+    fn count_nodes(expression: &Expression) -> usize {
+        1 + expression.children().iter().map(count_nodes).sum::<usize>()
+    }
+
+    fn first_assignment(expression: &Expression) -> Option<&Expression> {
+        if matches!(expression, Expression::Assignment { .. }) {
+            return Some(expression);
+        }
+        expression.children().iter().find_map(first_assignment)
+    }
+
+    #[test]
+    fn compound_assignment_stores_only_the_rhs() {
+        let result = build_ast("fn f() {\n let mut x = 0\n x += 5\n}", 0);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        let assignment = result
+            .ast
+            .iter()
+            .find_map(first_assignment)
+            .expect("an assignment");
+        let Expression::Assignment {
+            value,
+            compound_operator,
+            ..
+        } = assignment
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(*compound_operator, Some(BinaryOperator::Addition));
+        assert!(
+            matches!(value.as_ref(), Expression::Literal { .. }),
+            "value should hold only the rhs, not a duplicated `x + 5`: {value:?}"
+        );
+    }
+
+    #[test]
+    fn nested_compound_assignments_stay_linear() {
+        let depth = 14;
+        let source = format!(
+            "fn f() {{ {}x{} }}",
+            "{".repeat(depth),
+            "}.f += 1".repeat(depth),
+        );
+        let result = build_ast(&source, 0);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        let nodes: usize = result.ast.iter().map(count_nodes).sum();
+        assert!(
+            nodes < 20 * depth,
+            "nested compound assignments grew super-linearly: {nodes} nodes at depth {depth}",
+        );
     }
 }

--- a/tests/spec/parse/snapshots/compound_assignment.snap
+++ b/tests/spec/parse/snapshots/compound_assignment.snap
@@ -95,42 +95,18 @@ description: |
                         binding_id: None,
                         qualified: None,
                     },
-                    value: Binary {
-                        operator: Addition,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 1,
-                            },
+                    value: Literal {
+                        literal: Integer {
+                            value: 5,
+                            text: None,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 6,
+                            byte_offset: 38,
+                            byte_length: 1,
                         },
                     },
                     compound_operator: Some(
@@ -156,42 +132,18 @@ description: |
                         binding_id: None,
                         qualified: None,
                     },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 3,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 48,
-                                byte_length: 1,
-                            },
+                    value: Literal {
+                        literal: Integer {
+                            value: 3,
+                            text: None,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 43,
-                            byte_length: 6,
+                            byte_offset: 48,
+                            byte_length: 1,
                         },
                     },
                     compound_operator: Some(
@@ -217,42 +169,18 @@ description: |
                         binding_id: None,
                         qualified: None,
                     },
-                    value: Binary {
-                        operator: Multiplication,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 53,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 2,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 58,
-                                byte_length: 1,
-                            },
+                    value: Literal {
+                        literal: Integer {
+                            value: 2,
+                            text: None,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 53,
-                            byte_length: 6,
+                            byte_offset: 58,
+                            byte_length: 1,
                         },
                     },
                     compound_operator: Some(
@@ -278,42 +206,18 @@ description: |
                         binding_id: None,
                         qualified: None,
                     },
-                    value: Binary {
-                        operator: Division,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 63,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 4,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 68,
-                                byte_length: 1,
-                            },
+                    value: Literal {
+                        literal: Integer {
+                            value: 4,
+                            text: None,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 63,
-                            byte_length: 6,
+                            byte_offset: 68,
+                            byte_length: 1,
                         },
                     },
                     compound_operator: Some(
@@ -339,42 +243,18 @@ description: |
                         binding_id: None,
                         qualified: None,
                     },
-                    value: Binary {
-                        operator: Remainder,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 73,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 3,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 78,
-                                byte_length: 1,
-                            },
+                    value: Literal {
+                        literal: Integer {
+                            value: 3,
+                            text: None,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 73,
-                            byte_length: 6,
+                            byte_offset: 78,
+                            byte_length: 1,
                         },
                     },
                     compound_operator: Some(


### PR DESCRIPTION
Parsing compound assignments no longer stores a second copy of the target in the AST, so nesting them no longer grows the tree exponentially with depth. The fuzzer found a contrived input that parses cleanly could exhaust memory while building the syntax tree.

```rs
fn f() {
  {{{ x }.f += 1 }.f += 1 }.f += 1
}
```

Fix #895
