### PR TITLE
perf: batch typedef generation for faster cold builds

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use crate::cli_error;
 use crate::go_cli;
 use crate::lock::acquire_target_lock;
-use crate::workspace::WorkspaceBindgen;
+use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs_batched};
 use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, Sources, TestIndex, compile};
@@ -218,6 +218,14 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> BuildOutc
     }
 
     let typedef_cache_dir = deps::typedef_cache_dir(&prep.project_path);
+
+    // Batch-warm the typedef cache so the lazy path during compile is all hits.
+    {
+        let workspace =
+            GoWorkspace::new(&prep.target_dir, &typedef_cache_dir, prep.locator.target());
+        warm_typedefs_batched(&prep.project_path, &workspace, &prep.locator);
+    }
+
     let bindgen = Arc::new(WorkspaceBindgen::new(
         prep.target_dir.clone(),
         typedef_cache_dir,

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -11,7 +11,7 @@ use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
 use crate::cli_error;
 use crate::lock::acquire_target_lock;
-use crate::workspace::WorkspaceBindgen;
+use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs_batched};
 
 pub fn check(
     path: Option<String>,
@@ -108,6 +108,13 @@ fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat) -> 
     }
 
     let typedef_cache_dir = deps::typedef_cache_dir(project_path);
+
+    // Batch-warm the typedef cache so the lazy path during compile is all hits.
+    {
+        let workspace = GoWorkspace::new(&target_dir, &typedef_cache_dir, locator.target());
+        warm_typedefs_batched(project_path, &workspace, &locator);
+    }
+
     let bindgen = Arc::new(WorkspaceBindgen::new(
         target_dir,
         typedef_cache_dir,

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -1,17 +1,13 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use stdlib::Target;
-use syntax::ast::{Expression, ImportAlias};
-use syntax::parse::Parser;
-
-use lisette::fs::collect_lis_filepaths_recursive;
 
 use crate::go_cli;
 use crate::handlers::add::find_project_root;
 use crate::lock::{acquire_mutation_lock, acquire_target_lock};
 use crate::output::print_sync_summary;
 use crate::typedef_regen::prewarm_typedef_cache;
+use crate::typedef_scan::{SourceScanError, scan_source_imports};
 use crate::workspace::WorkspaceBindgen;
 use crate::{cli_error, error};
 
@@ -155,112 +151,4 @@ pub fn sync() -> i32 {
     print_sync_summary(&trimmed, &report.promoted, &report.removed, needs_separator);
 
     prewarm_result.err().unwrap_or(0)
-}
-
-enum SourceScanError {
-    Parse {
-        path: PathBuf,
-        message: String,
-    },
-    Read {
-        path: PathBuf,
-        error: std::io::Error,
-    },
-}
-
-struct ScannedImports {
-    /// All third-party `go:` imports (blank-imports keep modules referenced).
-    all: Vec<String>,
-    /// Third-party `go:` imports excluding `_`-aliased blank ones.
-    non_blank: Vec<String>,
-}
-
-/// Collect every third-party `go:` import across `src/**/*.lis`.
-fn scan_source_imports(src_dir: &Path) -> Result<ScannedImports, SourceScanError> {
-    let mut all = Vec::new();
-    let mut non_blank = Vec::new();
-    if !src_dir.is_dir() {
-        return Ok(ScannedImports { all, non_blank });
-    }
-
-    for path in collect_lis_filepaths_recursive(src_dir) {
-        let source = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(e) => return Err(SourceScanError::Read { path, error: e }),
-        };
-        let parse_result = Parser::lex_and_parse_file(&source, 0);
-        if parse_result.failed() {
-            return Err(SourceScanError::Parse {
-                path,
-                message: parse_result.errors[0].message.clone(),
-            });
-        }
-        for expr in &parse_result.ast {
-            if let Expression::ModuleImport { name, alias, .. } = expr
-                && let Some(pkg) = name.strip_prefix("go:")
-                && deps::is_third_party(pkg)
-            {
-                all.push(pkg.to_string());
-                if !matches!(alias, Some(ImportAlias::Blank(_))) {
-                    non_blank.push(pkg.to_string());
-                }
-            }
-        }
-    }
-
-    Ok(ScannedImports { all, non_blank })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn project_src(files: &[(&str, &str)]) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("src");
-        std::fs::create_dir_all(&src).unwrap();
-        for (name, body) in files {
-            std::fs::write(src.join(name), body).unwrap();
-        }
-        dir
-    }
-
-    #[test]
-    fn scan_reports_parse_error_naming_the_file() {
-        let project = project_src(&[("main.lis", "fn broken( {\n")]);
-
-        let Err(SourceScanError::Parse { path, .. }) =
-            scan_source_imports(&project.path().join("src"))
-        else {
-            panic!("expected a parse error");
-        };
-        assert!(
-            path.ends_with("main.lis"),
-            "error must name the failing file, got {}",
-            path.display()
-        );
-    }
-
-    #[test]
-    fn scan_collects_third_party_imports_and_separates_blank_and_stdlib() {
-        let source = r#"import "go:github.com/gorilla/mux"
-import _ "go:github.com/gorilla/context"
-import "go:fmt"
-
-fn main() {}
-"#;
-        let project = project_src(&[("main.lis", source)]);
-
-        let Ok(scanned) = scan_source_imports(&project.path().join("src")) else {
-            panic!("scan must succeed on valid sources");
-        };
-
-        assert_eq!(scanned.non_blank, vec!["github.com/gorilla/mux"]);
-        let mut all = scanned.all;
-        all.sort();
-        assert_eq!(
-            all,
-            vec!["github.com/gorilla/context", "github.com/gorilla/mux"]
-        );
-    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,7 @@ mod output;
 mod panic;
 mod shell_words;
 mod typedef_regen;
+mod typedef_scan;
 mod workspace;
 
 use command::Command;

--- a/crates/cli/src/typedef_scan.rs
+++ b/crates/cli/src/typedef_scan.rs
@@ -1,0 +1,114 @@
+use std::path::{Path, PathBuf};
+
+use syntax::ast::{Expression, ImportAlias};
+use syntax::parse::Parser;
+
+use lisette::fs::collect_lis_filepaths_recursive;
+
+pub(crate) enum SourceScanError {
+    Parse {
+        path: PathBuf,
+        message: String,
+    },
+    Read {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+}
+
+pub(crate) struct ScannedImports {
+    /// All third-party `go:` imports (blank-imports keep modules referenced).
+    pub(crate) all: Vec<String>,
+    /// Third-party `go:` imports excluding `_`-aliased blank ones.
+    pub(crate) non_blank: Vec<String>,
+}
+
+/// Collect every third-party `go:` import across `src/**/*.lis`.
+pub(crate) fn scan_source_imports(src_dir: &Path) -> Result<ScannedImports, SourceScanError> {
+    let mut all = Vec::new();
+    let mut non_blank = Vec::new();
+    if !src_dir.is_dir() {
+        return Ok(ScannedImports { all, non_blank });
+    }
+
+    for path in collect_lis_filepaths_recursive(src_dir) {
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => return Err(SourceScanError::Read { path, error: e }),
+        };
+        let parse_result = Parser::lex_and_parse_file(&source, 0);
+        if parse_result.failed() {
+            return Err(SourceScanError::Parse {
+                path,
+                message: parse_result.errors[0].message.clone(),
+            });
+        }
+        for expr in &parse_result.ast {
+            if let Expression::ModuleImport { name, alias, .. } = expr
+                && let Some(pkg) = name.strip_prefix("go:")
+                && deps::is_third_party(pkg)
+            {
+                all.push(pkg.to_string());
+                if !matches!(alias, Some(ImportAlias::Blank(_))) {
+                    non_blank.push(pkg.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(ScannedImports { all, non_blank })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project_src(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        for (name, body) in files {
+            std::fs::write(src.join(name), body).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn scan_reports_parse_error_naming_the_file() {
+        let project = project_src(&[("main.lis", "fn broken( {\n")]);
+
+        let Err(SourceScanError::Parse { path, .. }) =
+            scan_source_imports(&project.path().join("src"))
+        else {
+            panic!("expected a parse error");
+        };
+        assert!(
+            path.ends_with("main.lis"),
+            "error must name the failing file, got {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn scan_collects_third_party_imports_and_separates_blank_and_stdlib() {
+        let source = r#"import "go:github.com/gorilla/mux"
+import _ "go:github.com/gorilla/context"
+import "go:fmt"
+
+fn main() {}
+"#;
+        let project = project_src(&[("main.lis", source)]);
+
+        let Ok(scanned) = scan_source_imports(&project.path().join("src")) else {
+            panic!("scan must succeed on valid sources");
+        };
+
+        assert_eq!(scanned.non_blank, vec!["github.com/gorilla/mux"]);
+        let mut all = scanned.all;
+        all.sort();
+        assert_eq!(
+            all,
+            vec!["github.com/gorilla/context", "github.com/gorilla/mux"]
+        );
+    }
+}

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -6,7 +6,9 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
-use deps::{Bindgen, BindgenFailure, BindgenSession, BindgenSetup, GoModule, GoPackage};
+use deps::{
+    Bindgen, BindgenFailure, BindgenSession, BindgenSetup, GoModule, GoPackage, TypedefLocator,
+};
 use serde::Deserialize;
 use syntax::ast::{Expression, ImportAlias};
 use syntax::parse::Parser;
@@ -693,6 +695,133 @@ impl GoWorkspace<'_> {
         }
 
         outcome
+    }
+
+    /// Write a multi-module batch to the cache, resolving each entry's module via
+    /// `locator`. Returns the count written and those typedefs' `go:` imports.
+    pub(crate) fn apply_cross_module_manifest(
+        &self,
+        manifest: &BatchManifest,
+        locator: &TypedefLocator,
+    ) -> (usize, Vec<String>) {
+        let mut written = 0;
+        let mut discovered = Vec::new();
+
+        for entry in &manifest.ok {
+            let Some((module_path, version)) = locator.module_for_package(&entry.package) else {
+                continue;
+            };
+            if validate_typedef_parses(&entry.package, &entry.content).is_err() {
+                continue;
+            }
+
+            let pkg = GoPackage {
+                module: GoModule {
+                    path: &module_path,
+                    version: &version,
+                },
+                package: &entry.package,
+            };
+            let path = pkg.typedef_path(self.typedef_cache_dir, self.target);
+
+            if let Some(parent) = path.parent()
+                && fs::create_dir_all(parent).is_err()
+            {
+                continue;
+            }
+            if atomic_write(&path, &entry.content).is_ok() {
+                written += 1;
+                discovered.extend(extract_go_imports(&entry.content));
+            }
+        }
+
+        (written, discovered)
+    }
+
+    fn typedef_cache_path(&self, locator: &TypedefLocator, package: &str) -> Option<PathBuf> {
+        let (module_path, version) = locator.module_for_package(package)?;
+        let pkg = GoPackage {
+            module: GoModule {
+                path: &module_path,
+                version: &version,
+            },
+            package,
+        };
+        Some(pkg.typedef_path(self.typedef_cache_dir, self.target))
+    }
+
+    fn typedef_cached(&self, locator: &TypedefLocator, package: &str) -> bool {
+        self.typedef_cache_path(locator, package)
+            .is_some_and(|p| p.exists())
+    }
+
+    fn read_cached_typedef(&self, locator: &TypedefLocator, package: &str) -> Option<String> {
+        let path = self.typedef_cache_path(locator, package)?;
+        fs::read_to_string(path).ok()
+    }
+}
+
+/// Best-effort batched typedef warming for `check`/`build` before analysis.
+pub(crate) fn warm_typedefs_batched(
+    project_root: &Path,
+    workspace: &GoWorkspace<'_>,
+    locator: &TypedefLocator,
+) {
+    let src_dir = project_root.join("src");
+    let Ok(scanned) = crate::typedef_scan::scan_source_imports(&src_dir) else {
+        return;
+    };
+
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut frontier: Vec<String> = scanned
+        .non_blank
+        .into_iter()
+        .filter(|pkg| locator.is_declared_go_dep(pkg))
+        .filter(|pkg| visited.insert(pkg.clone()))
+        .collect();
+
+    while !frontier.is_empty() {
+        let (cached, missing): (Vec<String>, Vec<String>) = frontier
+            .into_iter()
+            .partition(|pkg| workspace.typedef_cached(locator, pkg));
+
+        let mut discovered: Vec<String> = Vec::new();
+
+        if !missing.is_empty() {
+            crate::output::print_progress(&format!(
+                "Generating typedefs for {} Go package(s)",
+                missing.len()
+            ));
+            // Retry once: a transient `go list` failure rturns zero typedefs and
+            // would otherwise abort the whole warm into the slow lazy path.
+            let mut wrote = false;
+            for _ in 0..2 {
+                if let Ok(manifest) = workspace.run_bindgen_batch(&missing) {
+                    let (written, imports) =
+                        workspace.apply_cross_module_manifest(&manifest, locator);
+                    if written > 0 {
+                        discovered.extend(imports);
+                        wrote = true;
+                        break;
+                    }
+                }
+            }
+            if !wrote {
+                return;
+            }
+        }
+
+        for package in &cached {
+            if let Some(content) = workspace.read_cached_typedef(locator, package) {
+                discovered.extend(extract_go_imports(&content));
+            }
+        }
+
+        frontier = discovered
+            .into_iter()
+            .filter(|pkg| locator.is_declared_go_dep(pkg))
+            .filter(|pkg| visited.insert(pkg.clone()))
+            .collect();
     }
 }
 

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -166,6 +166,13 @@ impl TypedefLocator {
         find_module_for_pkg(&self.deps, package_path).is_some()
     }
 
+    /// Resolve a `go:` package path to its declared module path and version by
+    /// longest declared prefix, or `None` if no declared module contains it.
+    pub fn module_for_package(&self, package_path: &str) -> Option<(String, String)> {
+        find_module_for_pkg(&self.deps, package_path)
+            .map(|(module, dep)| (module.to_string(), dep.version.clone()))
+    }
+
     /// Classify a `go:` import path without touching the cache or bindgen.
     pub fn validate_declaration(&self, package_path: &str) -> DeclarationStatus {
         self.classify(package_path)


### PR DESCRIPTION
Cold-cache bindgen for Go deps now runs in batched passes instead of one run per package, so `lis check` and `lis build` on projects with multiple Go deps are faster from a cold typedef cache.

In a project importing 15 dragonfly packages (transitively all-in 45 typedefs), bindgen drops from ~30s to ~5s.

Fix #889