### PR TITLE
perf: one-pass typedef generation for Go dependencies

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -19,6 +19,8 @@ import (
 type GeneratePkgResult struct {
 	Content string
 	Summary string
+	// ExternalImports are the third-party `go:` packages this typedef references.
+	ExternalImports []string
 }
 
 var lisVersion = "dev"
@@ -256,8 +258,14 @@ func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goV
 
 	emitter.EmitImplBlocks()
 
+	externalImports := make([]string, 0, len(converter.ExternalPkgs()))
+	for path := range converter.ExternalPkgs() {
+		externalImports = append(externalImports, path)
+	}
+
 	return GeneratePkgResult{
-		Content: emitter.String(),
-		Summary: emitter.Summary(),
+		Content:         emitter.String(),
+		Summary:         emitter.Summary(),
+		ExternalImports: externalImports,
 	}
 }

--- a/bindgen/internal/cli/generate_pkgs.go
+++ b/bindgen/internal/cli/generate_pkgs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/ivov/lisette/bindgen/internal/config"
@@ -47,8 +48,9 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 	fs := flag.NewFlagSet("pkgs", flag.ExitOnError)
 	configPath := fs.String("config", "", "path to bindgen config file")
 	versionOverride := fs.String("version", "", "override Lisette version in generated headers")
+	transitive := fs.Bool("transitive", false, "also emit the requested packages' transitive re-exports")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: bindgen pkgs [-config <path>] [-version <ver>]\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: bindgen pkgs [-config <path>] [-version <ver>] [-transitive]\n\n")
 		fmt.Fprintf(os.Stderr, "Generates .d.lis type definitions for many Go packages in one shared\n")
 		fmt.Fprintf(os.Stderr, "type-check pass. Reads package paths from stdin, one per line. Emits a\n")
 		fmt.Fprintf(os.Stderr, "JSON manifest on stdout with embedded content.\n")
@@ -73,7 +75,7 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 		effectiveVersion = *versionOverride
 	}
 
-	manifest := GeneratePkgs(pkgPaths, effectiveVersion, goVersion, &cfg)
+	manifest := GeneratePkgs(pkgPaths, effectiveVersion, goVersion, &cfg, *transitive)
 
 	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
 		fmt.Fprintf(os.Stderr, "bindgen: failed to encode manifest: %v\n", err)
@@ -81,7 +83,7 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 	}
 }
 
-func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *config.Config) Manifest {
+func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *config.Config, transitive bool) Manifest {
 	manifest := Manifest{
 		Ok:     make([]ManifestOk, 0, len(pkgPaths)),
 		Errors: make([]ManifestError, 0),
@@ -103,25 +105,28 @@ func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *conf
 		return manifest
 	}
 
-	byPath := make(map[string]*packages.Package, len(pkgs))
-	for _, pkg := range pkgs {
-		if pkg == nil {
-			continue
+	// In transitive mode, index the full graph so re-exports generate from this Load.
+	byPath := make(map[string]*packages.Package)
+	var indexGraph func(pkg *packages.Package)
+	indexGraph = func(pkg *packages.Package) {
+		if pkg == nil || byPath[pkg.PkgPath] != nil {
+			return
 		}
 		byPath[pkg.PkgPath] = pkg
+		if transitive {
+			for _, imp := range pkg.Imports {
+				indexGraph(imp)
+			}
+		}
+	}
+	for _, pkg := range pkgs {
+		indexGraph(pkg)
 	}
 
-	// Pre-allocated per-input slot avoids a mutex around append. Indices with
-	// no enqueued goroutine stay at the zero value and are filtered out below.
-	results := make([]ManifestOk, len(pkgPaths))
-	enqueued := make([]bool, len(pkgPaths))
-
-	g := new(errgroup.Group)
-	g.SetLimit(runtime.NumCPU())
-
-	for i, input := range pkgPaths {
+	visited := make(map[string]bool)
+	frontier := make([]string, 0, len(pkgPaths))
+	for _, input := range pkgPaths {
 		pkg := byPath[input]
-
 		if pkg == nil {
 			manifest.Errors = append(manifest.Errors, ManifestError{
 				Package: input,
@@ -130,35 +135,78 @@ func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *conf
 			})
 			continue
 		}
-
 		if hardErr := firstHardError(pkg); hardErr != nil {
 			manifest.Errors = append(manifest.Errors, *hardErr)
 			continue
 		}
-
-		i, input, pkg := i, input, pkg
-		enqueued[i] = true
-		g.Go(func() error {
-			if len(pkg.Errors) > 0 {
-				stub := generateUnloadableStub(input, pkg, lisetteVersion, goVersion)
-				results[i] = ManifestOk{Package: input, Content: stub.Content, Stubbed: true}
-			} else {
-				result := generateFromPackage(pkg, input, lisetteVersion, goVersion, cfg)
-				results[i] = ManifestOk{Package: input, Content: result.Content, Stubbed: false}
-			}
-			return nil
-		})
-	}
-
-	_ = g.Wait()
-
-	for i, ok := range enqueued {
-		if ok {
-			manifest.Ok = append(manifest.Ok, results[i])
+		if !visited[input] {
+			visited[input] = true
+			frontier = append(frontier, input)
 		}
 	}
 
+	for len(frontier) > 0 {
+		type waveResult struct {
+			ok      ManifestOk
+			imports []string
+		}
+		wave := make([]waveResult, len(frontier))
+
+		g := new(errgroup.Group)
+		g.SetLimit(runtime.NumCPU())
+		for i, pkgPath := range frontier {
+			i, pkgPath := i, pkgPath
+			pkg := byPath[pkgPath]
+			g.Go(func() error {
+				if len(pkg.Errors) > 0 {
+					stub := generateUnloadableStub(pkgPath, pkg, lisetteVersion, goVersion)
+					wave[i] = waveResult{ok: ManifestOk{Package: pkgPath, Content: stub.Content, Stubbed: true}}
+				} else {
+					result := generateFromPackage(pkg, pkgPath, lisetteVersion, goVersion, cfg)
+					wave[i] = waveResult{
+						ok:      ManifestOk{Package: pkgPath, Content: result.Content, Stubbed: false},
+						imports: result.ExternalImports,
+					}
+				}
+				return nil
+			})
+		}
+		_ = g.Wait()
+
+		var next []string
+		for _, w := range wave {
+			manifest.Ok = append(manifest.Ok, w.ok)
+			if !transitive {
+				continue
+			}
+			for _, imp := range w.imports {
+				if visited[imp] || !isThirdPartyPackage(imp) || extract.IsInternalPackagePath(imp) {
+					continue
+				}
+				pkg := byPath[imp]
+				if pkg == nil || firstHardError(pkg) != nil {
+					continue
+				}
+				visited[imp] = true
+				next = append(next, imp)
+			}
+		}
+		frontier = next
+	}
+
+	sort.Slice(manifest.Ok, func(i, j int) bool {
+		return manifest.Ok[i].Package < manifest.Ok[j].Package
+	})
+
 	return manifest
+}
+
+func isThirdPartyPackage(path string) bool {
+	first := path
+	if before, _, ok := strings.Cut(path, "/"); ok {
+		first = before
+	}
+	return strings.Contains(first, ".")
 }
 
 func firstHardError(pkg *packages.Package) *ManifestError {

--- a/bindgen/tests/bindgen_test.go
+++ b/bindgen/tests/bindgen_test.go
@@ -149,7 +149,7 @@ func TestGeneratePkgs_FullEmit(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
-	manifest := cli.GeneratePkgs([]string{"fmt", "os"}, "0.0.0", "0.0.0", nil)
+	manifest := cli.GeneratePkgs([]string{"fmt", "os"}, "0.0.0", "0.0.0", nil, false)
 
 	if len(manifest.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", manifest.Errors)
@@ -172,7 +172,7 @@ func TestGeneratePkgs_HardFail(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
-	manifest := cli.GeneratePkgs([]string{"definitely/nonexistent/foo"}, "0.0.0", "0.0.0", nil)
+	manifest := cli.GeneratePkgs([]string{"definitely/nonexistent/foo"}, "0.0.0", "0.0.0", nil, false)
 
 	if len(manifest.Ok) != 0 {
 		t.Errorf("expected no ok entries, got %d", len(manifest.Ok))
@@ -192,7 +192,7 @@ func TestGeneratePkgs_MixedBatch(t *testing.T) {
 
 	manifest := cli.GeneratePkgs(
 		[]string{"fmt", "definitely/nonexistent/foo"},
-		"0.0.0", "0.0.0", nil,
+		"0.0.0", "0.0.0", nil, false,
 	)
 
 	if len(manifest.Ok) != 1 {
@@ -204,7 +204,7 @@ func TestGeneratePkgs_MixedBatch(t *testing.T) {
 }
 
 func TestGeneratePkgs_Empty(t *testing.T) {
-	manifest := cli.GeneratePkgs(nil, "0.0.0", "0.0.0", nil)
+	manifest := cli.GeneratePkgs(nil, "0.0.0", "0.0.0", nil, false)
 	if len(manifest.Ok) != 0 || len(manifest.Errors) != 0 {
 		t.Errorf("expected empty manifest, got %v", manifest)
 	}

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use crate::cli_error;
 use crate::go_cli;
 use crate::lock::acquire_target_lock;
-use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs_batched};
+use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 use diagnostics::render::{self, Filter};
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files};
 use lisette::pipeline::{CompileConfig, CompilePhase, Sources, TestIndex, compile};
@@ -223,7 +223,7 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> BuildOutc
     {
         let workspace =
             GoWorkspace::new(&prep.target_dir, &typedef_cache_dir, prep.locator.target());
-        warm_typedefs_batched(&prep.project_path, &workspace, &prep.locator);
+        warm_typedefs(&prep.project_path, &workspace, &prep.locator);
     }
 
     let bindgen = Arc::new(WorkspaceBindgen::new(

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -11,7 +11,7 @@ use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
 use crate::cli_error;
 use crate::lock::acquire_target_lock;
-use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs_batched};
+use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 
 pub fn check(
     path: Option<String>,
@@ -112,7 +112,7 @@ fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat) -> 
     // Batch-warm the typedef cache so the lazy path during compile is all hits.
     {
         let workspace = GoWorkspace::new(&target_dir, &typedef_cache_dir, locator.target());
-        warm_typedefs_batched(project_path, &workspace, &locator);
+        warm_typedefs(project_path, &workspace, &locator);
     }
 
     let bindgen = Arc::new(WorkspaceBindgen::new(

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -22,6 +22,14 @@ pub(crate) struct BatchManifest {
     errors: Vec<ErrorEntry>,
 }
 
+/// Whether a `bindgen pkgs` batch emits only the requested packages or also
+/// their transitive re-exports.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BatchScope {
+    RequestedOnly,
+    Transitive,
+}
+
 #[derive(Debug, Deserialize)]
 struct OkEntry {
     package: String,
@@ -228,6 +236,7 @@ impl<'a> GoWorkspace<'a> {
     pub(crate) fn run_bindgen_batch(
         &self,
         package_paths: &[String],
+        scope: BatchScope,
     ) -> Result<BatchManifest, String> {
         if package_paths.is_empty() {
             return Ok(BatchManifest {
@@ -236,8 +245,13 @@ impl<'a> GoWorkspace<'a> {
             });
         }
 
-        let mut child = self
-            .bindgen_command("pkgs")
+        let mut command = self.bindgen_command("pkgs");
+
+        if scope == BatchScope::Transitive {
+            command.arg("-transitive");
+        }
+
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -279,7 +293,7 @@ impl<'a> GoWorkspace<'a> {
             version: module.version,
         })?;
 
-        let manifest = self.run_bindgen_batch(&[package.to_string()])?;
+        let manifest = self.run_bindgen_batch(&[package.to_string()], BatchScope::RequestedOnly)?;
         let outcome = self.apply_batch_manifest(&manifest, module);
 
         if !outcome.failures.is_empty() {
@@ -697,15 +711,14 @@ impl GoWorkspace<'_> {
         outcome
     }
 
-    /// Write a multi-module batch to the cache, resolving each entry's module via
-    /// `locator`. Returns the count written and those typedefs' `go:` imports.
-    pub(crate) fn apply_cross_module_manifest(
+    /// Write each generated typedef to the cache under its own module, returning
+    /// the count written.
+    pub(crate) fn cache_typedefs(
         &self,
         manifest: &BatchManifest,
         locator: &TypedefLocator,
-    ) -> (usize, Vec<String>) {
+    ) -> usize {
         let mut written = 0;
-        let mut discovered = Vec::new();
 
         for entry in &manifest.ok {
             let Some((module_path, version)) = locator.module_for_package(&entry.package) else {
@@ -731,38 +744,34 @@ impl GoWorkspace<'_> {
             }
             if atomic_write(&path, &entry.content).is_ok() {
                 written += 1;
-                discovered.extend(extract_go_imports(&entry.content));
             }
         }
 
-        (written, discovered)
+        written
     }
 
-    fn typedef_cache_path(&self, locator: &TypedefLocator, package: &str) -> Option<PathBuf> {
-        let (module_path, version) = locator.module_for_package(package)?;
-        let pkg = GoPackage {
-            module: GoModule {
-                path: &module_path,
-                version: &version,
-            },
-            package,
-        };
-        Some(pkg.typedef_path(self.typedef_cache_dir, self.target))
+    fn warm_stamp_path(&self) -> PathBuf {
+        self.typedef_cache_dir
+            .join(self.target.cache_segment())
+            .join(".warm-stamp")
     }
 
-    fn typedef_cached(&self, locator: &TypedefLocator, package: &str) -> bool {
-        self.typedef_cache_path(locator, package)
-            .is_some_and(|p| p.exists())
+    fn warm_stamp_matches(&self, content: &str) -> bool {
+        fs::read_to_string(self.warm_stamp_path()).is_ok_and(|existing| existing == content)
     }
 
-    fn read_cached_typedef(&self, locator: &TypedefLocator, package: &str) -> Option<String> {
-        let path = self.typedef_cache_path(locator, package)?;
-        fs::read_to_string(path).ok()
+    fn write_warm_stamp(&self, content: &str) {
+        let path = self.warm_stamp_path();
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(path, content);
     }
 }
 
-/// Best-effort batched typedef warming for `check`/`build` before analysis.
-pub(crate) fn warm_typedefs_batched(
+/// Generate all needed Go typedefs in one pass before compiling, skipping when
+/// the cache is already up to date. Best-effort, falling back to the lazy path.
+pub(crate) fn warm_typedefs(
     project_root: &Path,
     workspace: &GoWorkspace<'_>,
     locator: &TypedefLocator,
@@ -772,57 +781,46 @@ pub(crate) fn warm_typedefs_batched(
         return;
     };
 
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut frontier: Vec<String> = scanned
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut roots: Vec<String> = scanned
         .non_blank
         .into_iter()
         .filter(|pkg| locator.is_declared_go_dep(pkg))
-        .filter(|pkg| visited.insert(pkg.clone()))
+        .filter(|pkg| seen.insert(pkg.clone()))
         .collect();
-
-    while !frontier.is_empty() {
-        let (cached, missing): (Vec<String>, Vec<String>) = frontier
-            .into_iter()
-            .partition(|pkg| workspace.typedef_cached(locator, pkg));
-
-        let mut discovered: Vec<String> = Vec::new();
-
-        if !missing.is_empty() {
-            crate::output::print_progress(&format!(
-                "Generating typedefs for {} Go package(s)",
-                missing.len()
-            ));
-            // Retry once: a transient `go list` failure rturns zero typedefs and
-            // would otherwise abort the whole warm into the slow lazy path.
-            let mut wrote = false;
-            for _ in 0..2 {
-                if let Ok(manifest) = workspace.run_bindgen_batch(&missing) {
-                    let (written, imports) =
-                        workspace.apply_cross_module_manifest(&manifest, locator);
-                    if written > 0 {
-                        discovered.extend(imports);
-                        wrote = true;
-                        break;
-                    }
-                }
-            }
-            if !wrote {
-                return;
-            }
-        }
-
-        for package in &cached {
-            if let Some(content) = workspace.read_cached_typedef(locator, package) {
-                discovered.extend(extract_go_imports(&content));
-            }
-        }
-
-        frontier = discovered
-            .into_iter()
-            .filter(|pkg| locator.is_declared_go_dep(pkg))
-            .filter(|pkg| visited.insert(pkg.clone()))
-            .collect();
+    if roots.is_empty() {
+        return;
     }
+    roots.sort();
+
+    let stamp = warm_stamp_for(&roots, locator);
+    if workspace.warm_stamp_matches(&stamp) {
+        return;
+    }
+
+    crate::output::print_progress(&format!(
+        "Generating typedefs for {} Go import(s)",
+        roots.len()
+    ));
+
+    // Retry once to ride over a transient `go list` failure (else falls to lazy).
+    for _ in 0..2 {
+        if let Ok(manifest) = workspace.run_bindgen_batch(&roots, BatchScope::Transitive)
+            && workspace.cache_typedefs(&manifest, locator) > 0
+        {
+            workspace.write_warm_stamp(&stamp);
+            return;
+        }
+    }
+}
+
+fn warm_stamp_for(roots: &[String], locator: &TypedefLocator) -> String {
+    let deps: Vec<String> = locator
+        .deps()
+        .iter()
+        .map(|(module, dep)| format!("{} {}", module, dep.version))
+        .collect();
+    format!("{}\n--\n{}", roots.join("\n"), deps.join("\n"))
 }
 
 fn atomic_write(path: &Path, content: &str) -> Result<(), String> {


### PR DESCRIPTION
Generating the typedefs for a Go dep now resolves that package and everything it re-exports in a single pass, instead of reloading and re-type-checking the dep graph once per layer. 

On a project importing 15 dragonfly packages (which expand to 45 typedefs), a cold build dropped by ~30%. Savings grow with the size of the dependency graph.

Follow-up to #897