### PR TITLE
fix: flag public PascalCase methods in snake_case lint

### DIFF
--- a/crates/passes/src/passes/checks/node_walk.rs
+++ b/crates/passes/src/passes/checks/node_walk.rs
@@ -69,6 +69,6 @@ static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
     )
 });
 
-pub(crate) fn run(items: &[Expression], ctx: &NodeCtx) {
+pub(crate) fn run<'a>(items: &'a [Expression], ctx: &NodeCtx<'a>) {
     walk_nodes(items, ctx, &NODE_CHECKS);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
@@ -1,5 +1,5 @@
 use diagnostics::LocalSink;
-use syntax::ast::{Expression, Generic, Pattern, RestPattern, Span};
+use syntax::ast::{Binding, Expression, Generic, Pattern, RestPattern, Span, Visibility};
 
 use crate::passes::lints::ast_walk::casing::{is_snake_case, to_pascal_case, to_snake_case};
 use crate::passes::walk::{FunctionRole, NodeCtx, PatternRole};
@@ -112,14 +112,10 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
             name_span,
             generics,
             params,
+            visibility,
             ..
         } => {
-            let is_go_method = match ctx.function_role.get() {
-                FunctionRole::InterfaceMethod => true,
-                FunctionRole::ImplMethod => first_param_is_self(params),
-                FunctionRole::Free => false,
-            };
-            let exempt = is_go_method && name.chars().next().is_some_and(char::is_uppercase);
+            let exempt = go_method_name_exempt(ctx, params, *visibility, name);
             if !is_d_lis && !exempt {
                 check_snake_case(name, name_span, "non_snake_case_function", sink);
             }
@@ -159,6 +155,47 @@ pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
         PatternRole::Binding => "non_snake_case_variable",
     };
     check_snake_case(name, span, code, ctx.sink);
+}
+
+/// Whether a method is exempt from the snake_case lint because a rename would change
+/// its exported Go name or break interface conformance (matched by source name).
+fn go_method_name_exempt(
+    ctx: &NodeCtx,
+    params: &[Binding],
+    visibility: Visibility,
+    name: &str,
+) -> bool {
+    let (is_method, public, impl_type) = match ctx.function_role.get() {
+        FunctionRole::InterfaceMethod { public } => (true, public, None),
+        FunctionRole::ImplMethod { type_name } => (
+            first_param_is_self(params),
+            visibility.is_public(),
+            Some(type_name),
+        ),
+        FunctionRole::Free => (false, false, None),
+    };
+    if !is_method {
+        return false;
+    }
+    if is_builtin_interface_method(name) {
+        return true;
+    }
+    if let Some(type_name) = impl_type
+        && ctx
+            .facts
+            .method_satisfies_interface(ctx.module_id, name, type_name)
+    {
+        return true;
+    }
+    if public {
+        to_pascal_case(&to_snake_case(name)) != to_pascal_case(name)
+    } else {
+        name.chars().next().is_some_and(char::is_uppercase)
+    }
+}
+
+fn is_builtin_interface_method(name: &str) -> bool {
+    matches!(name, "Error" | "String")
 }
 
 fn check_type_parameter(generic: &Generic, sink: &LocalSink) {

--- a/crates/passes/src/passes/walk.rs
+++ b/crates/passes/src/passes/walk.rs
@@ -21,7 +21,7 @@ pub(crate) struct NodeCtx<'a> {
     /// Node spans already claimed by an enclosing node, so a check does not also
     /// judge them standalone (e.g. the nested `&&` of an outer comparison chain).
     pub claimed_spans: RefCell<HashSet<Span>>,
-    pub function_role: Cell<FunctionRole>,
+    pub function_role: Cell<FunctionRole<'a>>,
     pub pattern_role: Cell<PatternRole>,
 }
 
@@ -33,9 +33,13 @@ pub enum PatternRole {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum FunctionRole {
-    InterfaceMethod,
-    ImplMethod,
+pub enum FunctionRole<'a> {
+    InterfaceMethod {
+        public: bool,
+    },
+    ImplMethod {
+        type_name: &'a str,
+    },
     #[default]
     Free,
 }
@@ -74,7 +78,7 @@ impl CheckTable {
     }
 }
 
-pub(crate) fn walk_nodes(ast: &[Expression], ctx: &NodeCtx, checks: &CheckTable) {
+pub(crate) fn walk_nodes<'a>(ast: &'a [Expression], ctx: &NodeCtx<'a>, checks: &CheckTable) {
     visit_ast(
         ast,
         &mut |expression, role| {
@@ -92,9 +96,12 @@ pub(crate) fn walk_nodes(ast: &[Expression], ctx: &NodeCtx, checks: &CheckTable)
     );
 }
 
-pub fn visit_ast<E, P>(ast: &[Expression], expression_visitor: &mut E, pattern_visitor: &mut P)
-where
-    E: FnMut(&Expression, FunctionRole),
+pub fn visit_ast<'a, E, P>(
+    ast: &'a [Expression],
+    expression_visitor: &mut E,
+    pattern_visitor: &mut P,
+) where
+    E: FnMut(&Expression, FunctionRole<'a>),
     P: FnMut(&Pattern, PatternRole),
 {
     for expression in ast {
@@ -107,13 +114,13 @@ where
     }
 }
 
-fn visit_node<E, P>(
-    expression: &Expression,
-    role: FunctionRole,
+fn visit_node<'a, E, P>(
+    expression: &'a Expression,
+    role: FunctionRole<'a>,
     expression_visitor: &mut E,
     pattern_visitor: &mut P,
 ) where
-    E: FnMut(&Expression, FunctionRole),
+    E: FnMut(&Expression, FunctionRole<'a>),
     P: FnMut(&Pattern, PatternRole),
 {
     expression_visitor(expression, role);
@@ -160,8 +167,12 @@ fn visit_node<E, P>(
     }
 
     let child_role = match expression {
-        Expression::Interface { .. } => FunctionRole::InterfaceMethod,
-        Expression::ImplBlock { .. } => FunctionRole::ImplMethod,
+        Expression::Interface { visibility, .. } => FunctionRole::InterfaceMethod {
+            public: visibility.is_public(),
+        },
+        Expression::ImplBlock { receiver_name, .. } => FunctionRole::ImplMethod {
+            type_name: receiver_name.as_str(),
+        },
         _ => FunctionRole::Free,
     };
     for child in expression.children() {

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -222,6 +222,19 @@ impl Facts {
             .push(impl_type_name);
     }
 
+    /// Whether `type_name`'s `method_name` was found to satisfy an interface method,
+    /// so the naming lint keeps its conformance-required spelling.
+    pub fn method_satisfies_interface(
+        &self,
+        module_id: &str,
+        method_name: &str,
+        type_name: &str,
+    ) -> bool {
+        self.interface_satisfied_methods
+            .get(&(module_id.to_string(), method_name.to_string()))
+            .is_some_and(|types| types.iter().any(|t| t == type_name))
+    }
+
     pub fn absorb_local_facts(&mut self, local: LocalFacts) {
         let LocalFacts {
             unused_expressions,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -10613,7 +10613,7 @@ fn main() {
 }
 
 #[test]
-fn impl_method_pascal_case_no_warning() {
+fn private_impl_method_pascal_case_no_warning() {
     assert_no_lint_warnings!(
         r#"
 struct MyError { message: string }
@@ -10638,6 +10638,159 @@ fn interface_method_pascal_case_no_warning() {
         r#"
 pub interface Stringer {
   fn String() -> string
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_pascal_case_warns() {
+    assert_lint_snapshot!(
+        r#"
+pub struct Service { count: int }
+
+impl Service {
+  pub fn DefaultRole(self) -> int {
+    self.count
+  }
+}
+
+fn main() {
+  let s = Service { count: 0 };
+  let _ = s.DefaultRole();
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_pascal_case_acronym_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Server {}
+
+impl Server {
+  pub fn ServeHTTP(self) -> int {
+    200
+  }
+}
+
+fn main() {
+  let s = Server {};
+  let _ = s.ServeHTTP();
+}
+"#
+    );
+}
+
+#[test]
+fn pub_interface_method_pascal_case_warns() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Repository {
+  fn List(self) -> int
+}
+"#
+    );
+}
+
+#[test]
+fn builtin_interface_method_names_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Printable {
+  fn String(self) -> string
+  fn Error(self) -> string
+}
+"#
+    );
+}
+
+#[test]
+fn pub_interface_non_builtin_pascal_method_warns() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Device {
+  fn Read(self) -> int
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_builtin_interface_method_name_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct MyError { message: string }
+
+impl MyError {
+  pub fn Error(self) -> string {
+    self.message
+  }
+}
+
+fn main() {
+  let e = MyError { message: "fail" };
+  let _ = e.Error();
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_satisfying_go_interface_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:encoding"
+
+pub struct Widget {}
+
+impl Widget {
+  pub fn MarshalText(self) -> Result<Slice<byte>, error> {
+    Ok("custom" as Slice<byte>)
+  }
+}
+
+fn main() {
+  let w = Widget {}
+  let _: encoding.TextMarshaler = w
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_camel_case_initialism_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Client {}
+
+impl Client {
+  pub fn parseURL(self) -> int { 1 }
+}
+
+fn main() {
+  let c = Client {}
+  let _ = c.parseURL()
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_allow_suppresses_conformance_name_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Widget {}
+
+impl Widget {
+  #[allow(non_snake_case_function)]
+  pub fn MarshalText(self) -> int { 1 }
+}
+
+fn main() {
+  let w = Widget {}
+  let _ = w.MarshalText()
 }
 "#
     );
@@ -11300,11 +11453,11 @@ fn interface_method_allow_unused_value_suppresses_lint() {
         r#"
 pub interface Router {
   #[allow(unused_value)]
-  fn Get(self, path: string) -> Router
+  fn get(self, path: string) -> Router
 }
 
 pub fn register(r: Router) {
-  r.Get("/ping")
+  r.get("/ping")
 }
 
 fn main() {
@@ -11319,11 +11472,11 @@ fn interface_method_without_allow_warns_on_discard() {
     assert_lint_snapshot!(
         r#"
 pub interface Router {
-  fn Get(self, path: string) -> Router
+  fn get(self, path: string) -> Router
 }
 
 pub fn register(r: Router) {
-  r.Get("/ping")
+  r.get("/ping")
 }
 
 fn main() {

--- a/tests/ui/lint/snapshots/interface_method_without_allow_warns_on_discard.snap
+++ b/tests/ui/lint/snapshots/interface_method_without_allow_warns_on_discard.snap
@@ -7,7 +7,7 @@ source: tests/ui/lint/mod.rs
  6 │ pub fn register(r: Router) {
    ·                            ┬
    ·                            ╰── has `()` as implicit return type
- 7 │   r.Get("/ping")
+ 7 │   r.get("/ping")
    ·   ───────┬──────
    ·          ╰── returns `Router`
  8 │ }

--- a/tests/ui/lint/snapshots/pub_impl_method_pascal_case_warns.snap
+++ b/tests/ui/lint/snapshots/pub_impl_method_pascal_case_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:5:10]
+ 4 │ impl Service {
+ 5 │   pub fn DefaultRole(self) -> int {
+   ·          ─────┬─────
+   ·               ╰── expected snake_case
+ 6 │     self.count
+   ╰────
+  help: Rename to `default_role` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/pub_interface_method_pascal_case_warns.snap
+++ b/tests/ui/lint/snapshots/pub_interface_method_pascal_case_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:3:6]
+ 2 │ pub interface Repository {
+ 3 │   fn List(self) -> int
+   ·      ──┬─
+   ·        ╰── expected snake_case
+ 4 │ }
+   ╰────
+  help: Rename to `list` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/pub_interface_non_builtin_pascal_method_warns.snap
+++ b/tests/ui/lint/snapshots/pub_interface_non_builtin_pascal_method_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:3:6]
+ 2 │ pub interface Device {
+ 3 │   fn Read(self) -> int
+   ·      ──┬─
+   ·        ╰── expected snake_case
+ 4 │ }
+   ╰────
+  help: Rename to `read` · code: [lint.non_snake_case_function]


### PR DESCRIPTION
Linting now flags methods written in PascalCase that should be snake_case. The `non_snake_case_function` lint previously skipped methods, so PascalCase method names slipped through.

```rs
impl Service {
  pub fn DefaultRole(self) -> Role { ... } // warns: rename to `default_role`
  pub fn Error(self) -> string { ... } // exempt: satisfies the `error` interface
}
```

A method stays exempt whenever renaming it would change its emitted Go name or break interface conformance, so Go interop is never pushed toward a broken state.

Fix #899
