### PR TITLE
feat: add `.lis` file icon to VSCode and IntelliJ extensions

### DIFF
--- a/editors/intellij/src/main/kotlin/run/lisette/intellij/LisetteFileType.kt
+++ b/editors/intellij/src/main/kotlin/run/lisette/intellij/LisetteFileType.kt
@@ -1,6 +1,7 @@
 package run.lisette.intellij
 
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.util.IconLoader
 import org.jetbrains.plugins.textmate.TextMateBackedFileType
 import javax.swing.Icon
 
@@ -8,5 +9,5 @@ object LisetteFileType : LanguageFileType(LisetteLanguage), TextMateBackedFileTy
     override fun getName(): String = "Lisette"
     override fun getDescription(): String = "Lisette source file"
     override fun getDefaultExtension(): String = "lis"
-    override fun getIcon(): Icon? = null
+    override fun getIcon(): Icon = IconLoader.getIcon("/icons/lisette.svg", LisetteFileType::class.java)
 }

--- a/editors/intellij/src/main/resources/icons/lisette.svg
+++ b/editors/intellij/src/main/resources/icons/lisette.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="42" fill="#9b7ed9"/></svg>

--- a/editors/vscode/icons/lisette.svg
+++ b/editors/vscode/icons/lisette.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="42" fill="#9b7ed9"/></svg>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lisette",
   "displayName": "Lisette",
   "description": "Language support for Lisette",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "ivov",
   "license": "MIT",
   "repository": "https://github.com/ivov/lisette",
@@ -19,7 +19,11 @@
         "id": "lisette",
         "aliases": ["Lisette"],
         "extensions": [".lis", ".d.lis"],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "light": "./icons/lisette.svg",
+          "dark": "./icons/lisette.svg"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
Lis has no logo, but this should do for now.

Only for VSCode and Goland, because
- Zed has no per-language icon: https://github.com/zed-industries/zed/discussions/24204
- nvim icons belong to the user's devicons plugin: https://github.com/nvim-tree/nvim-web-devicons

Close #900

## Screenshot

<img width="339" height="588" alt="Capture 2026-06-27 at 19 43 49@2x" src="https://github.com/user-attachments/assets/fc9548ff-0af9-43ac-b859-8b2f29580447" />


