### PR TITLE
refactor: reduce cyclomatic complexity in emit crate

### DIFF
--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -1,7 +1,9 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, emit as emit_diag};
-use syntax::ast::{Expression, ImportAlias, Pattern, Span, StructKind, VariantFields, Visibility};
+use syntax::ast::{
+    EnumVariant, Expression, ImportAlias, Pattern, Span, StructKind, VariantFields, Visibility,
+};
 use syntax::program::File;
 
 use crate::Planner;
@@ -56,343 +58,442 @@ impl Planner<'_> {
         diagnostics: &mut Vec<LisetteDiagnostic>,
     ) {
         match item {
-            Expression::Function {
-                name,
-                name_span,
-                visibility,
-                generics,
-                attributes,
-                ..
-            } => {
-                if self.facts.is_unused_definition(name_span) {
-                    return;
-                }
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-                let go = self.free_function_go_name(name, visibility);
-                self.check_reserved_prefix(&go, name_span, diagnostics);
-                package_block.entry(go).or_default().push(*name_span);
-                if syntax::attributes::has_test_attribute(attributes) {
-                    let wrapper = go_name::go_test_function_name(name);
-                    package_block.entry(wrapper).or_default().push(*name_span);
-                }
+            Expression::Function { .. } => self.collect_function(item, package_block, diagnostics),
+            Expression::Const { .. } => self.collect_const(item, package_block, diagnostics),
+            Expression::TypeAlias { .. } => {
+                self.collect_type_alias(item, package_block, diagnostics)
             }
-            Expression::Const {
-                identifier,
-                identifier_span,
-                ..
-            } => {
-                let go = self.const_go_name(identifier);
-                self.check_reserved_prefix(&go, identifier_span, diagnostics);
-                package_block.entry(go).or_default().push(*identifier_span);
+            Expression::Struct { .. } => {
+                self.collect_struct(item, package_block, selectors, diagnostics)
             }
-            Expression::TypeAlias {
-                name,
-                name_span,
-                generics,
-                ..
-            } => {
-                let go = go_name::escape_keyword(name).into_owned();
-                self.check_reserved_prefix(&go, name_span, diagnostics);
-                self.check_reserved_qualifier(&go, name_span, diagnostics);
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-                package_block.entry(go).or_default().push(*name_span);
+            Expression::Enum { .. } => {
+                self.collect_enum(item, package_block, selectors, diagnostics)
             }
-            Expression::Struct {
-                name,
-                name_span,
-                fields,
-                kind,
-                attributes,
-                generics,
-                ..
-            } => {
-                let type_go = go_name::escape_keyword(name).into_owned();
-                self.check_reserved_prefix(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-                package_block
-                    .entry(type_go.clone())
-                    .or_default()
-                    .push(*name_span);
-
-                let members = selectors.entry(type_go).or_default();
-                match kind {
-                    StructKind::Record => {
-                        for field in fields {
-                            let field_go = struct_field_go_name(field, attributes);
-                            members.entry(field_go).or_default().push(field.name_span);
-                        }
-                    }
-                    StructKind::Tuple => {
-                        // A single-field tuple with no generics is a newtype (a Go
-                        // scalar type, no struct fields); empty tuples have none.
-                        let is_newtype = fields.len() == 1 && generics.is_empty();
-                        if !fields.is_empty() && !is_newtype {
-                            for (index, field) in fields.iter().enumerate() {
-                                members
-                                    .entry(format!("F{}", index))
-                                    .or_default()
-                                    .push(field.name_span);
-                            }
-                        }
-                    }
-                }
-                if let Some(stringer) = self.stringer_method_name(name, attributes) {
-                    members
-                        .entry(stringer.to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.should_synthesize_to_string(name, attributes) {
-                    members
-                        .entry(self.to_string_method_go_name())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.should_synthesize_equals(name) {
-                    members
-                        .entry(self.equals_method_go_name())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
-                    members
-                        .entry(DEBUG_STRING_METHOD.to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
+            Expression::Interface { .. } => {
+                self.collect_interface(item, package_block, interfaces, diagnostics)
             }
-            Expression::Enum {
-                name,
-                name_span,
-                variants,
-                attributes,
-                visibility,
-                generics,
-                ..
-            } => {
-                let type_go = go_name::escape_keyword(name).into_owned();
-                self.check_reserved_prefix(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-
-                if attributes
-                    .iter()
-                    .any(|attribute| attribute.name == "iterate")
-                {
-                    let variants_fn =
-                        self.variants_go_name(name, matches!(visibility, Visibility::Public));
-                    package_block
-                        .entry(variants_fn)
-                        .or_default()
-                        .push(*name_span);
-                }
-
-                package_block
-                    .entry(type_go.clone())
-                    .or_default()
-                    .push(*name_span);
-                package_block
-                    .entry(format!("{}Tag", name))
-                    .or_default()
-                    .push(*name_span);
-                for variant in variants {
-                    let tag_constant = if variant.name.as_str() == ENUM_TAG_FIELD {
-                        format!("{}Tag_", name)
-                    } else {
-                        format!("{}{}", name, variant.name)
-                    };
-                    package_block
-                        .entry(tag_constant)
-                        .or_default()
-                        .push(variant.name_span);
-                    let constructor =
-                        format!("Make{}{}", go_name::escape_keyword(name), variant.name);
-                    package_block
-                        .entry(constructor)
-                        .or_default()
-                        .push(variant.name_span);
-                }
-
-                let members = selectors.entry(type_go).or_default();
-                members
-                    .entry(ENUM_TAG_FIELD.to_string())
-                    .or_default()
-                    .push(*name_span);
-                let synthesize = should_synthesize_stringer(attributes);
-                let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
-                if synthesize && !has_user_string {
-                    members
-                        .entry(ENUM_STRINGER_METHOD.to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if synthesize && !has_user_go_string {
-                    members
-                        .entry(ENUM_GO_STRINGER_METHOD.to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.should_synthesize_to_string(name, attributes) {
-                    members
-                        .entry(self.to_string_method_go_name())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.should_synthesize_equals(name) {
-                    members
-                        .entry(self.equals_method_go_name())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
-                    members
-                        .entry(DEBUG_STRING_METHOD.to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
-                if attributes.iter().any(|attribute| attribute.name == "json") {
-                    members
-                        .entry("MarshalJSON".to_string())
-                        .or_default()
-                        .push(*name_span);
-                    members
-                        .entry("UnmarshalJSON".to_string())
-                        .or_default()
-                        .push(*name_span);
-                }
-                // Enum payload fields share the type's selector namespace. They
-                // are coalesced by Go name across variants, so each distinct
-                // name is recorded once (coalescing is intentional, not a
-                // collision). Within one variant, two fields landing on the
-                // same Go name would assign one struct field twice, so each
-                // struct variant's fields are also grouped on their own.
-                let qualified = self.facts.qualified_current(name);
-                if let Some(layout) = self.enum_layout(&qualified) {
-                    let mut seen: HashSet<&str> = HashSet::default();
-                    for (variant, layout_variant) in variants.iter().zip(&layout.variants) {
-                        for field in &layout_variant.fields {
-                            if seen.insert(field.go_name.as_str()) {
-                                members
-                                    .entry(field.go_name.clone())
-                                    .or_default()
-                                    .push(variant.name_span);
-                            }
-                        }
-                        if let VariantFields::Struct(fields) = &variant.fields {
-                            let mut variant_fields: SpanMap = HashMap::default();
-                            for (field, layout_field) in fields.iter().zip(&layout_variant.fields) {
-                                variant_fields
-                                    .entry(layout_field.go_name.clone())
-                                    .or_default()
-                                    .push(field.name_span);
-                            }
-                            report_collisions(variant_fields, diagnostics);
-                        }
-                    }
-                }
-            }
-            Expression::Interface {
-                name,
-                name_span,
-                method_signatures,
-                visibility,
-                generics,
-                ..
-            } => {
-                let type_go = go_name::escape_keyword(name).into_owned();
-                self.check_reserved_prefix(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier(&type_go, name_span, diagnostics);
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-                package_block
-                    .entry(type_go.clone())
-                    .or_default()
-                    .push(*name_span);
-
-                let is_public = matches!(visibility, Visibility::Public);
-                let methods = interfaces.entry(type_go).or_default();
-                for signature in method_signatures {
-                    if let Expression::Function {
-                        name: method_name,
-                        name_span: method_span,
-                        generics: method_generics,
-                        ..
-                    } = signature
-                    {
-                        self.check_reserved_qualifier_generics(method_generics, diagnostics);
-                        let method_go = if is_public || self.method_needs_export(method_name) {
-                            go_name::snake_to_camel(method_name)
-                        } else {
-                            go_name::escape_keyword(method_name).into_owned()
-                        };
-                        methods.entry(method_go).or_default().push(*method_span);
-                    }
-                }
-            }
-            Expression::ImplBlock {
-                receiver_name,
-                methods,
-                generics,
-                ..
-            } => {
-                self.check_reserved_qualifier_generics(generics, diagnostics);
-                let type_go = go_name::escape_keyword(receiver_name).into_owned();
-                let qualified_type = self.facts.qualified_current(receiver_name);
-                for method in methods {
-                    let Expression::Function {
-                        name,
-                        name_span,
-                        visibility,
-                        params,
-                        generics: method_generics,
-                        ..
-                    } = method
-                    else {
-                        continue;
-                    };
-                    if self.facts.is_unused_definition(name_span) {
-                        continue;
-                    }
-                    self.check_reserved_qualifier_generics(method_generics, diagnostics);
-                    let has_self = params.first().is_some_and(|binding| {
-                        matches!(&binding.pattern, Pattern::Identifier { identifier, .. } if identifier == "self")
-                    });
-                    let is_ufcs = self.facts.is_ufcs_method(&qualified_type, name);
-                    let should_export =
-                        matches!(visibility, Visibility::Public) || self.method_needs_export(name);
-                    if has_self && !is_ufcs {
-                        // Go receiver method: lives in the type's selector set.
-                        let method_go = if should_export {
-                            go_name::snake_to_camel(name)
-                        } else {
-                            go_name::escape_keyword(name).into_owned()
-                        };
-                        self.check_reserved_prefix(&method_go, name_span, diagnostics);
-                        selectors
-                            .entry(type_go.clone())
-                            .or_default()
-                            .entry(method_go)
-                            .or_default()
-                            .push(*name_span);
-                    } else {
-                        // self-less or UFCS method: package-level free function.
-                        let method_go = if should_export {
-                            go_name::snake_to_camel(name)
-                        } else {
-                            name.to_string()
-                        };
-                        let base = format!("{}_{}", receiver_name, method_go);
-                        let go = self
-                            .module
-                            .escape_remap(&base)
-                            .map(str::to_string)
-                            .unwrap_or_else(|| go_name::escape_reserved(&base).into_owned());
-                        self.check_reserved_prefix(&go, name_span, diagnostics);
-                        package_block.entry(go).or_default().push(*name_span);
-                    }
-                }
+            Expression::ImplBlock { .. } => {
+                self.collect_impl_block(item, package_block, selectors, diagnostics)
             }
             _ => {}
+        }
+    }
+
+    fn collect_function(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::Function {
+            name,
+            name_span,
+            visibility,
+            generics,
+            attributes,
+            ..
+        } = item
+        else {
+            return;
+        };
+        if self.facts.is_unused_definition(name_span) {
+            return;
+        }
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+        let go = self.free_function_go_name(name, visibility);
+        self.check_reserved_prefix(&go, name_span, diagnostics);
+        package_block.entry(go).or_default().push(*name_span);
+        if syntax::attributes::has_test_attribute(attributes) {
+            let wrapper = go_name::go_test_function_name(name);
+            package_block.entry(wrapper).or_default().push(*name_span);
+        }
+    }
+
+    fn collect_const(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::Const {
+            identifier,
+            identifier_span,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let go = self.const_go_name(identifier);
+        self.check_reserved_prefix(&go, identifier_span, diagnostics);
+        package_block.entry(go).or_default().push(*identifier_span);
+    }
+
+    fn collect_type_alias(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::TypeAlias {
+            name,
+            name_span,
+            generics,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let go = go_name::escape_keyword(name).into_owned();
+        self.check_reserved_prefix(&go, name_span, diagnostics);
+        self.check_reserved_qualifier(&go, name_span, diagnostics);
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+        package_block.entry(go).or_default().push(*name_span);
+    }
+
+    fn collect_struct(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        selectors: &mut HashMap<String, SpanMap>,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::Struct {
+            name,
+            name_span,
+            fields,
+            kind,
+            attributes,
+            generics,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let type_go = go_name::escape_keyword(name).into_owned();
+        self.check_reserved_prefix(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+        package_block
+            .entry(type_go.clone())
+            .or_default()
+            .push(*name_span);
+
+        let members = selectors.entry(type_go).or_default();
+        match kind {
+            StructKind::Record => {
+                for field in fields {
+                    let field_go = struct_field_go_name(field, attributes);
+                    members.entry(field_go).or_default().push(field.name_span);
+                }
+            }
+            StructKind::Tuple => {
+                // A single-field tuple with no generics is a newtype (a Go
+                // scalar type, no struct fields); empty tuples have none.
+                let is_newtype = fields.len() == 1 && generics.is_empty();
+                if !fields.is_empty() && !is_newtype {
+                    for (index, field) in fields.iter().enumerate() {
+                        members
+                            .entry(format!("F{}", index))
+                            .or_default()
+                            .push(field.name_span);
+                    }
+                }
+            }
+        }
+        if let Some(stringer) = self.stringer_method_name(name, attributes) {
+            members
+                .entry(stringer.to_string())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.should_synthesize_to_string(name, attributes) {
+            members
+                .entry(self.to_string_method_go_name())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.should_synthesize_equals(name) {
+            members
+                .entry(self.equals_method_go_name())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
+            members
+                .entry(DEBUG_STRING_METHOD.to_string())
+                .or_default()
+                .push(*name_span);
+        }
+    }
+
+    fn collect_enum(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        selectors: &mut HashMap<String, SpanMap>,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::Enum {
+            name,
+            name_span,
+            variants,
+            attributes,
+            visibility,
+            generics,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let type_go = go_name::escape_keyword(name).into_owned();
+        self.check_reserved_prefix(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+
+        if attributes
+            .iter()
+            .any(|attribute| attribute.name == "iterate")
+        {
+            let variants_fn = self.variants_go_name(name, matches!(visibility, Visibility::Public));
+            package_block
+                .entry(variants_fn)
+                .or_default()
+                .push(*name_span);
+        }
+
+        package_block
+            .entry(type_go.clone())
+            .or_default()
+            .push(*name_span);
+        package_block
+            .entry(format!("{}Tag", name))
+            .or_default()
+            .push(*name_span);
+        for variant in variants {
+            let tag_constant = if variant.name.as_str() == ENUM_TAG_FIELD {
+                format!("{}Tag_", name)
+            } else {
+                format!("{}{}", name, variant.name)
+            };
+            package_block
+                .entry(tag_constant)
+                .or_default()
+                .push(variant.name_span);
+            let constructor = format!("Make{}{}", go_name::escape_keyword(name), variant.name);
+            package_block
+                .entry(constructor)
+                .or_default()
+                .push(variant.name_span);
+        }
+
+        let members = selectors.entry(type_go).or_default();
+        members
+            .entry(ENUM_TAG_FIELD.to_string())
+            .or_default()
+            .push(*name_span);
+        let synthesize = should_synthesize_stringer(attributes);
+        let (has_user_string, has_user_go_string) = self.stringer_overrides(name);
+        if synthesize && !has_user_string {
+            members
+                .entry(ENUM_STRINGER_METHOD.to_string())
+                .or_default()
+                .push(*name_span);
+        }
+        if synthesize && !has_user_go_string {
+            members
+                .entry(ENUM_GO_STRINGER_METHOD.to_string())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.should_synthesize_to_string(name, attributes) {
+            members
+                .entry(self.to_string_method_go_name())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.should_synthesize_equals(name) {
+            members
+                .entry(self.equals_method_go_name())
+                .or_default()
+                .push(*name_span);
+        }
+        if self.facts.emit_tests_enabled() && !self.debug_string_override(name) {
+            members
+                .entry(DEBUG_STRING_METHOD.to_string())
+                .or_default()
+                .push(*name_span);
+        }
+        if attributes.iter().any(|attribute| attribute.name == "json") {
+            members
+                .entry("MarshalJSON".to_string())
+                .or_default()
+                .push(*name_span);
+            members
+                .entry("UnmarshalJSON".to_string())
+                .or_default()
+                .push(*name_span);
+        }
+        self.collect_enum_payload_fields(name, variants, members, diagnostics);
+    }
+
+    /// Record enum payload-field Go names in the type's selector namespace.
+    /// Names are coalesced across variants (each distinct Go name once, which is
+    /// intentional, not a collision). Within a single struct variant, two fields
+    /// landing on the same Go name would assign one struct field twice, so each
+    /// variant's own fields are additionally grouped and reported.
+    fn collect_enum_payload_fields(
+        &self,
+        name: &str,
+        variants: &[EnumVariant],
+        members: &mut SpanMap,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let qualified = self.facts.qualified_current(name);
+        let Some(layout) = self.enum_layout(&qualified) else {
+            return;
+        };
+        let mut seen: HashSet<&str> = HashSet::default();
+        for (variant, layout_variant) in variants.iter().zip(&layout.variants) {
+            for field in &layout_variant.fields {
+                if seen.insert(field.go_name.as_str()) {
+                    members
+                        .entry(field.go_name.clone())
+                        .or_default()
+                        .push(variant.name_span);
+                }
+            }
+            if let VariantFields::Struct(fields) = &variant.fields {
+                let mut variant_fields: SpanMap = HashMap::default();
+                for (field, layout_field) in fields.iter().zip(&layout_variant.fields) {
+                    variant_fields
+                        .entry(layout_field.go_name.clone())
+                        .or_default()
+                        .push(field.name_span);
+                }
+                report_collisions(variant_fields, diagnostics);
+            }
+        }
+    }
+
+    fn collect_interface(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        interfaces: &mut HashMap<String, SpanMap>,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::Interface {
+            name,
+            name_span,
+            method_signatures,
+            visibility,
+            generics,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let type_go = go_name::escape_keyword(name).into_owned();
+        self.check_reserved_prefix(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier(&type_go, name_span, diagnostics);
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+        package_block
+            .entry(type_go.clone())
+            .or_default()
+            .push(*name_span);
+
+        let is_public = matches!(visibility, Visibility::Public);
+        let methods = interfaces.entry(type_go).or_default();
+        for signature in method_signatures {
+            if let Expression::Function {
+                name: method_name,
+                name_span: method_span,
+                generics: method_generics,
+                ..
+            } = signature
+            {
+                self.check_reserved_qualifier_generics(method_generics, diagnostics);
+                let method_go = if is_public || self.method_needs_export(method_name) {
+                    go_name::snake_to_camel(method_name)
+                } else {
+                    go_name::escape_keyword(method_name).into_owned()
+                };
+                methods.entry(method_go).or_default().push(*method_span);
+            }
+        }
+    }
+
+    fn collect_impl_block(
+        &self,
+        item: &Expression,
+        package_block: &mut SpanMap,
+        selectors: &mut HashMap<String, SpanMap>,
+        diagnostics: &mut Vec<LisetteDiagnostic>,
+    ) {
+        let Expression::ImplBlock {
+            receiver_name,
+            methods,
+            generics,
+            ..
+        } = item
+        else {
+            return;
+        };
+        self.check_reserved_qualifier_generics(generics, diagnostics);
+        let type_go = go_name::escape_keyword(receiver_name).into_owned();
+        let qualified_type = self.facts.qualified_current(receiver_name);
+        for method in methods {
+            let Expression::Function {
+                name,
+                name_span,
+                visibility,
+                params,
+                generics: method_generics,
+                ..
+            } = method
+            else {
+                continue;
+            };
+            if self.facts.is_unused_definition(name_span) {
+                continue;
+            }
+            self.check_reserved_qualifier_generics(method_generics, diagnostics);
+            let has_self = params.first().is_some_and(|binding| {
+                        matches!(&binding.pattern, Pattern::Identifier { identifier, .. } if identifier == "self")
+                    });
+            let is_ufcs = self.facts.is_ufcs_method(&qualified_type, name);
+            let should_export =
+                matches!(visibility, Visibility::Public) || self.method_needs_export(name);
+            if has_self && !is_ufcs {
+                // Go receiver method: lives in the type's selector set.
+                let method_go = if should_export {
+                    go_name::snake_to_camel(name)
+                } else {
+                    go_name::escape_keyword(name).into_owned()
+                };
+                self.check_reserved_prefix(&method_go, name_span, diagnostics);
+                selectors
+                    .entry(type_go.clone())
+                    .or_default()
+                    .entry(method_go)
+                    .or_default()
+                    .push(*name_span);
+            } else {
+                // self-less or UFCS method: package-level free function.
+                let method_go = if should_export {
+                    go_name::snake_to_camel(name)
+                } else {
+                    name.to_string()
+                };
+                let base = format!("{}_{}", receiver_name, method_go);
+                let go = self
+                    .module
+                    .escape_remap(&base)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| go_name::escape_reserved(&base).into_owned());
+                self.check_reserved_prefix(&go, name_span, diagnostics);
+                package_block.entry(go).or_default().push(*name_span);
+            }
         }
     }
 

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -312,52 +312,7 @@ impl Planner<'_> {
                 }
                 _ => format!("{}{{}}", self.go_type_string(ty)),
             },
-            Type::Nominal { id, params, .. } => {
-                if id.as_str() == "prelude.Option" {
-                    let inner = params
-                        .first()
-                        .map(|a| self.go_type_string(a))
-                        .unwrap_or_else(|| "any".to_string());
-                    self.require_stdlib();
-                    return format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, inner);
-                }
-                if go_name::is_go_import(id.as_str()) {
-                    return self.go_imported_zero(ty, id.as_str());
-                }
-
-                if let Some(underlying) = self.get_newtype_underlying(ty) {
-                    let go_ty = self.go_type_string(ty);
-                    let inner = self.lisette_zero(&underlying);
-                    return format!("{}({})", go_ty, inner);
-                }
-
-                if let Some(fields) =
-                    self.lookup_unspecified_fields(ty, "", None, &HashSet::default())
-                {
-                    let go_ty = self.go_type_string(ty);
-                    let is_tuple = self.is_tuple_struct_type(ty);
-                    let pairs: Vec<(String, String)> = fields
-                        .into_iter()
-                        .enumerate()
-                        .filter(|(_, (_, field_ty))| !field_ty.is_slice())
-                        .map(|(index, (name, field_ty))| {
-                            let go_name = if is_tuple {
-                                format!("F{}", index)
-                            } else if self.struct_field_is_exported(ty, &name) {
-                                go_name::make_exported(&name)
-                            } else {
-                                go_name::escape_keyword(&name).into_owned()
-                            };
-                            (go_name, self.lisette_zero(&field_ty))
-                        })
-                        .collect();
-                    return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
-                }
-                if let Some(underlying) = ty.get_underlying() {
-                    return self.lisette_zero(underlying);
-                }
-                format!("{}{{}}", self.go_type_string(ty))
-            }
+            Type::Nominal { id, params, .. } => self.lisette_zero_nominal(ty, id.as_str(), params),
             Type::Tuple(elements) => {
                 let parts: Vec<String> = elements.iter().map(|e| self.lisette_zero(e)).collect();
                 self.require_stdlib();
@@ -370,6 +325,49 @@ impl Planner<'_> {
             }
             _ => format!("{}{{}}", self.go_type_string(ty)),
         }
+    }
+
+    fn lisette_zero_nominal(&mut self, ty: &Type, id: &str, params: &[Type]) -> String {
+        if id == "prelude.Option" {
+            let inner = params
+                .first()
+                .map(|a| self.go_type_string(a))
+                .unwrap_or_else(|| "any".to_string());
+            self.require_stdlib();
+            return format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, inner);
+        }
+        if go_name::is_go_import(id) {
+            return self.go_imported_zero(ty, id);
+        }
+        if let Some(underlying) = self.get_newtype_underlying(ty) {
+            let go_ty = self.go_type_string(ty);
+            let inner = self.lisette_zero(&underlying);
+            return format!("{}({})", go_ty, inner);
+        }
+        if let Some(fields) = self.lookup_unspecified_fields(ty, "", None, &HashSet::default()) {
+            let go_ty = self.go_type_string(ty);
+            let is_tuple = self.is_tuple_struct_type(ty);
+            let pairs: Vec<(String, String)> = fields
+                .into_iter()
+                .enumerate()
+                .filter(|(_, (_, field_ty))| !field_ty.is_slice())
+                .map(|(index, (name, field_ty))| {
+                    let go_name = if is_tuple {
+                        format!("F{}", index)
+                    } else if self.struct_field_is_exported(ty, &name) {
+                        go_name::make_exported(&name)
+                    } else {
+                        go_name::escape_keyword(&name).into_owned()
+                    };
+                    (go_name, self.lisette_zero(&field_ty))
+                })
+                .collect();
+            return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
+        }
+        if let Some(underlying) = ty.get_underlying() {
+            return self.lisette_zero(underlying);
+        }
+        format!("{}{{}}", self.go_type_string(ty))
     }
 
     /// Address a struct-call field stored behind a compiler-inserted pointer

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -6,7 +6,7 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
-use syntax::ast::{FormatStringPart, Literal};
+use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::types::{SimpleKind, Type};
 
 impl Planner<'_> {
@@ -49,55 +49,67 @@ impl Planner<'_> {
                 value
             }
             Literal::Slice(elements) => {
-                let element_lisette_ty = ty
-                    .get_type_params()
-                    .expect("Slice type must have type args")
-                    .first()
-                    .expect("Slice type must have element type")
-                    .clone();
-                let element_ty = self.go_type_string(&element_lisette_ty);
-
-                if elements.is_empty() {
-                    // Parens around the slice type disambiguate the conversion when
-                    // the element type itself ends in `)` (e.g. `func(int)`); Go
-                    // otherwise parses `[]func(int)(nil)` as a call expression.
-                    format!("([]{})(nil)", element_ty)
-                } else {
-                    let stages: Vec<StagedExpression> = elements
-                        .iter()
-                        .map(|e| self.stage_composite(e, ExpressionContext::value()))
-                        .collect();
-                    let (slice_setup, rendered) = self.sequence_structured(stages, "_v");
-                    setup.extend(slice_setup);
-
-                    let mut wrapped: Vec<String> = Vec::with_capacity(rendered.len());
-                    for (expr, emitted) in elements.iter().zip(rendered) {
-                        let coercion = Coercion::resolve(
-                            self,
-                            &expr.get_type(),
-                            &element_lisette_ty,
-                            CoercionDirection::Internal,
-                        );
-                        let (coercion_setup, coerced) = coercion.lower(self, emitted);
-                        setup.extend(coercion_setup);
-                        wrapped.push(coerced);
-                    }
-                    let elements = wrapped;
-
-                    if elements.len() > 1 && elements.iter().any(|e| e.len() > 30) {
-                        let indented = elements
-                            .iter()
-                            .map(|e| format!("\t{}", e))
-                            .collect::<Vec<_>>()
-                            .join(",\n");
-                        format!("[]{}{{\n{},\n}}", element_ty, indented)
-                    } else {
-                        format!("[]{}{{ {} }}", element_ty, elements.join(", "))
-                    }
-                }
+                let (slice_setup, slice_value) = self.emit_slice_literal(elements, ty);
+                setup = slice_setup;
+                slice_value
             }
         };
         value_plan_from_statements(setup, value)
+    }
+
+    fn emit_slice_literal(
+        &mut self,
+        elements: &[Expression],
+        ty: &Type,
+    ) -> (Vec<LoweredStatement>, String) {
+        let element_lisette_ty = ty
+            .get_type_params()
+            .expect("Slice type must have type args")
+            .first()
+            .expect("Slice type must have element type")
+            .clone();
+        let element_ty = self.go_type_string(&element_lisette_ty);
+
+        if elements.is_empty() {
+            // Parens around the slice type disambiguate the conversion when
+            // the element type itself ends in `)` (e.g. `func(int)`); Go
+            // otherwise parses `[]func(int)(nil)` as a call expression.
+            return (Vec::new(), format!("([]{})(nil)", element_ty));
+        }
+
+        let mut setup: Vec<LoweredStatement> = Vec::new();
+        let stages: Vec<StagedExpression> = elements
+            .iter()
+            .map(|e| self.stage_composite(e, ExpressionContext::value()))
+            .collect();
+        let (slice_setup, rendered) = self.sequence_structured(stages, "_v");
+        setup.extend(slice_setup);
+
+        let mut wrapped: Vec<String> = Vec::with_capacity(rendered.len());
+        for (expr, emitted) in elements.iter().zip(rendered) {
+            let coercion = Coercion::resolve(
+                self,
+                &expr.get_type(),
+                &element_lisette_ty,
+                CoercionDirection::Internal,
+            );
+            let (coercion_setup, coerced) = coercion.lower(self, emitted);
+            setup.extend(coercion_setup);
+            wrapped.push(coerced);
+        }
+        let elements = wrapped;
+
+        let value = if elements.len() > 1 && elements.iter().any(|e| e.len() > 30) {
+            let indented = elements
+                .iter()
+                .map(|e| format!("\t{}", e))
+                .collect::<Vec<_>>()
+                .join(",\n");
+            format!("[]{}{{\n{},\n}}", element_ty, indented)
+        } else {
+            format!("[]{}{{ {} }}", element_ty, elements.join(", "))
+        };
+        (setup, value)
     }
 
     fn emit_format_string(
@@ -136,15 +148,7 @@ impl Planner<'_> {
                     }
                 }
                 FormatStringPart::Expression(expression) => {
-                    let format_verb = match expression.get_type().as_simple() {
-                        Some(SimpleKind::Rune) => "%c",
-                        Some(SimpleKind::String) => "%s",
-                        Some(SimpleKind::Bool) => "%t",
-                        Some(k) if k.is_signed_int() || k.is_unsigned_int() => "%d",
-                        Some(k) if k.is_float() => "%g",
-                        _ => "%v",
-                    };
-                    format_string.push_str(format_verb);
+                    format_string.push_str(format_verb_for(&expression.get_type()));
                     args.push(
                         emitted
                             .next()
@@ -172,6 +176,18 @@ impl Planner<'_> {
             setup,
             format!("fmt.Sprintf(\"{}\", {})", format_string, args.join(", ")),
         )
+    }
+}
+
+/// The `fmt` printf verb for interpolating a value of `ty` into an f-string.
+fn format_verb_for(ty: &Type) -> &'static str {
+    match ty.as_simple() {
+        Some(SimpleKind::Rune) => "%c",
+        Some(SimpleKind::String) => "%s",
+        Some(SimpleKind::Bool) => "%t",
+        Some(k) if k.is_signed_int() || k.is_unsigned_int() => "%d",
+        Some(k) if k.is_float() => "%g",
+        _ => "%v",
     }
 }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -80,62 +80,71 @@ impl GlobalEmitData {
 
         for (key, definition) in definitions.iter() {
             let is_go = go_name::is_go_import(key);
-
-            if is_go
-                && let Type::Function(f) = match definition.ty() {
-                    Type::Forall { body, .. } => body.as_ref(),
-                    other => other,
-                }
-                && let Some(strategy) =
-                    classify_go_return_type(definitions, &f.return_type, definition.go_hints())
-            {
-                globals.go_call_strategies.insert(key.to_string(), strategy);
-            }
-
-            match &definition.body {
-                DefinitionBody::Interface {
-                    definition: iface, ..
-                } if definition.visibility.is_public() => {
-                    for method_name in iface.methods.keys() {
-                        globals
-                            .exported_method_names
-                            .insert(method_name.to_string());
-                    }
-                }
-                DefinitionBody::Value { .. }
-                    if definition.visibility.is_public()
-                        && !is_go
-                        && !key.starts_with(go_name::PRELUDE_PREFIX)
-                        && key.chars().filter(|c| *c == '.').count() >= 2 =>
-                {
-                    let method_name = go_name::unqualified_name(key);
-                    globals
-                        .exported_method_names
-                        .insert(method_name.to_string());
-                }
-                _ => {}
-            }
-
-            if definition.visibility.is_public() && definition.is_display() {
-                globals
-                    .exported_method_names
-                    .insert("to_string".to_string());
-            }
-
-            if let Definition {
-                name: Some(name),
-                body: DefinitionBody::Enum { variants, .. },
-                ..
-            } = definition
-                && PreludeType::from_name(name).is_none()
-            {
-                for (constructor, make_fn) in user_enum_make_function_entries(name, variants) {
-                    globals.make_function_names.insert(constructor, make_fn);
-                }
-            }
+            globals.register_go_call_strategy(definitions, key, definition, is_go);
+            globals.register_exported_methods(key, definition, is_go);
+            globals.register_enum_make_functions(definition);
         }
 
         globals
+    }
+
+    fn register_go_call_strategy(
+        &mut self,
+        definitions: &HashMap<Symbol, Definition>,
+        key: &Symbol,
+        definition: &Definition,
+        is_go: bool,
+    ) {
+        if is_go
+            && let Type::Function(f) = match definition.ty() {
+                Type::Forall { body, .. } => body.as_ref(),
+                other => other,
+            }
+            && let Some(strategy) =
+                classify_go_return_type(definitions, &f.return_type, definition.go_hints())
+        {
+            self.go_call_strategies.insert(key.to_string(), strategy);
+        }
+    }
+
+    fn register_exported_methods(&mut self, key: &Symbol, definition: &Definition, is_go: bool) {
+        match &definition.body {
+            DefinitionBody::Interface {
+                definition: iface, ..
+            } if definition.visibility.is_public() => {
+                for method_name in iface.methods.keys() {
+                    self.exported_method_names.insert(method_name.to_string());
+                }
+            }
+            DefinitionBody::Value { .. }
+                if definition.visibility.is_public()
+                    && !is_go
+                    && !key.starts_with(go_name::PRELUDE_PREFIX)
+                    && key.chars().filter(|c| *c == '.').count() >= 2 =>
+            {
+                let method_name = go_name::unqualified_name(key);
+                self.exported_method_names.insert(method_name.to_string());
+            }
+            _ => {}
+        }
+
+        if definition.visibility.is_public() && definition.is_display() {
+            self.exported_method_names.insert("to_string".to_string());
+        }
+    }
+
+    fn register_enum_make_functions(&mut self, definition: &Definition) {
+        if let Definition {
+            name: Some(name),
+            body: DefinitionBody::Enum { variants, .. },
+            ..
+        } = definition
+            && PreludeType::from_name(name).is_none()
+        {
+            for (constructor, make_fn) in user_enum_make_function_entries(name, variants) {
+                self.make_function_names.insert(constructor, make_fn);
+            }
+        }
     }
 }
 

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -207,19 +207,15 @@ impl Planner<'_> {
                 alternative,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan =
                     self.lower_if(condition, consequence, alternative, &PlacePlan::Statement);
-                directed(directive, LoweredStatement::If(plan))
+                self.directed_at(expression, LoweredStatement::If(plan))
             }
             Expression::Loop {
                 body, needs_label, ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
-                directed(
-                    directive,
-                    LoweredStatement::Loop(self.lower_infinite_loop(body, *needs_label)),
-                )
+                let plan = self.lower_infinite_loop(body, *needs_label);
+                self.directed_at(expression, LoweredStatement::Loop(plan))
             }
             Expression::While {
                 condition,
@@ -227,11 +223,8 @@ impl Planner<'_> {
                 needs_label,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
-                directed(
-                    directive,
-                    LoweredStatement::Loop(self.lower_while(condition, body, *needs_label)),
-                )
+                let plan = self.lower_while(condition, body, *needs_label);
+                self.directed_at(expression, LoweredStatement::Loop(plan))
             }
             Expression::Block { .. } => {
                 self.enter_scope();
@@ -241,29 +234,18 @@ impl Planner<'_> {
             }
             Expression::For { .. } => self.lower_for_statement(expression),
             Expression::Continue { .. } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
-                directed(
-                    directive,
-                    LoweredStatement::Continue {
-                        label: self.current_loop_label().map(str::to_string),
-                    },
-                )
+                let label = self.current_loop_label().map(str::to_string);
+                self.directed_at(expression, LoweredStatement::Continue { label })
             }
             Expression::Break { value: None, .. } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
-                directed(
-                    directive,
-                    LoweredStatement::Break {
-                        label: self.current_loop_label().map(str::to_string),
-                    },
-                )
+                let label = self.current_loop_label().map(str::to_string);
+                self.directed_at(expression, LoweredStatement::Break { label })
             }
             Expression::Break {
                 value: Some(value), ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.build_break_value_plan(value);
-                directed(directive, LoweredStatement::BreakValue(plan))
+                self.directed_at(expression, LoweredStatement::BreakValue(plan))
             }
             Expression::Const {
                 identifier,
@@ -271,16 +253,14 @@ impl Planner<'_> {
                 ty,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.build_const_plan(identifier, value, ty);
-                directed(directive, LoweredStatement::Const(plan))
+                self.directed_at(expression, LoweredStatement::Const(plan))
             }
             Expression::Return {
                 expression: value, ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.build_return_plan(value);
-                directed(directive, LoweredStatement::Return(plan))
+                self.directed_at(expression, LoweredStatement::Return(plan))
             }
             Expression::Let {
                 binding,
@@ -290,10 +270,9 @@ impl Planner<'_> {
                 assert,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan =
                     self.build_let_plan(binding, value, else_block.as_deref(), *mutable, *assert);
-                directed(directive, LoweredStatement::Let(plan))
+                self.directed_at(expression, LoweredStatement::Let(plan))
             }
             Expression::Assignment {
                 target,
@@ -301,9 +280,8 @@ impl Planner<'_> {
                 compound_operator,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.build_assignment_plan(target, value, compound_operator.as_ref());
-                directed(directive, LoweredStatement::Assign(plan))
+                self.directed_at(expression, LoweredStatement::Assign(plan))
             }
             Expression::IfLet {
                 pattern,
@@ -313,26 +291,23 @@ impl Planner<'_> {
                 typed_pattern,
                 ..
             } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
                 let body = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Statement);
-                directed(
-                    directive,
+                self.directed_at(
+                    expression,
                     LoweredStatement::Match(MatchStatementPlan { body }),
                 )
             }
             Expression::Match { subject, arms, .. } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let body = self.lower_match_to_block(subject, arms, &PlacePlan::Statement);
-                directed(
-                    directive,
+                self.directed_at(
+                    expression,
                     LoweredStatement::Match(MatchStatementPlan { body }),
                 )
             }
             Expression::Select { arms, .. } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
                 let plan = self.lower_select(arms, &PlacePlan::Statement);
-                directed(directive, LoweredStatement::Select(plan))
+                self.directed_at(expression, LoweredStatement::Select(plan))
             }
             Expression::WhileLet { .. } => self.lower_while_let_statement(expression),
             Expression::Assert { .. } => self.lower_assert_statement(expression),
@@ -359,6 +334,12 @@ impl Planner<'_> {
             }
             _ => self.lower_expression_statement(expression),
         }
+    }
+
+    /// Wrap a lowered statement with `expression`'s source-line directive when
+    /// sourcemaps are enabled (a no-op wrapper otherwise).
+    fn directed_at(&self, expression: &Expression, stmt: LoweredStatement) -> LoweredStatement {
+        directed(self.maybe_line_directive(&expression.get_span()), stmt)
     }
 
     /// Lower the statement-position fall-through: Task/Defer (async value),

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -31,38 +31,7 @@ impl Planner<'_> {
         }
 
         if let Some((op, rhs)) = detect_compound_assignment(target, value, compound_operator) {
-            let is_inc_dec = is_literal_one(rhs)
-                && matches!(op, BinaryOperator::Addition | BinaryOperator::Subtraction);
-            let (kind, rhs_has_setup) = if is_inc_dec {
-                let kind = if *op == BinaryOperator::Addition {
-                    CompoundKind::Increment
-                } else {
-                    CompoundKind::Decrement
-                };
-                (kind, false)
-            } else {
-                let staged = self.stage_operand(rhs, ExpressionContext::value());
-                let rhs_has_setup =
-                    !staged.setup.is_empty() || self.rhs_contains_effectful_call(rhs);
-                let kind = CompoundKind::OpAssign {
-                    op_text: format!("{}", op),
-                    rhs: value_plan_from_statements(staged.setup, staged.value),
-                };
-                (kind, rhs_has_setup)
-            };
-            let mut target_capture: Vec<LoweredStatement> = Vec::new();
-            let target_str = if is_order_sensitive(target) {
-                self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
-            } else {
-                self.emit_left_value(&mut target_capture, target)
-            };
-            return AssignPlan {
-                form: AssignForm::Compound {
-                    target_capture,
-                    target_str,
-                    kind,
-                },
-            };
+            return self.build_compound_assignment_plan(target, op, rhs);
         }
 
         if self.target_binds_to_discard(target) {
@@ -87,12 +56,7 @@ impl Planner<'_> {
             && target_ty.resolves_to_unknown()
             && value.is_none_literal()
         {
-            let mut target_capture: Vec<LoweredStatement> = Vec::new();
-            let target_str = if is_order_sensitive(target) {
-                self.emit_left_value_capturing(&mut target_capture, target, false)
-            } else {
-                self.emit_left_value(&mut target_capture, target)
-            };
+            let (target_capture, target_str) = self.capture_assignment_target(target, false);
             return AssignPlan {
                 form: AssignForm::NilClear {
                     target_capture,
@@ -106,12 +70,7 @@ impl Planner<'_> {
         // setup + coercion setup into the value plan in emission order.
         let rhs_staged = self.stage_composite(value, ExpressionContext::value());
         let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
-        let mut target_capture: Vec<LoweredStatement> = Vec::new();
-        let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
-        } else {
-            self.emit_left_value(&mut target_capture, target)
-        };
+        let (target_capture, target_str) = self.capture_assignment_target(target, rhs_has_setup);
         let mut value_setup = rhs_staged.setup;
         let coercion = if let Some(target_ty) = go_field_ty {
             Coercion::resolve(
@@ -137,6 +96,58 @@ impl Planner<'_> {
                 value: value_plan_from_statements(value_setup, final_value),
             },
         }
+    }
+
+    /// Build a compound assignment plan (`+=`, `-=`, `++`, etc.), staging the
+    /// right-hand side and capturing the target in evaluation order.
+    fn build_compound_assignment_plan(
+        &mut self,
+        target: &Expression,
+        op: &BinaryOperator,
+        rhs: &Expression,
+    ) -> AssignPlan {
+        let is_inc_dec = is_literal_one(rhs)
+            && matches!(op, BinaryOperator::Addition | BinaryOperator::Subtraction);
+        let (kind, rhs_has_setup) = if is_inc_dec {
+            let kind = if *op == BinaryOperator::Addition {
+                CompoundKind::Increment
+            } else {
+                CompoundKind::Decrement
+            };
+            (kind, false)
+        } else {
+            let staged = self.stage_operand(rhs, ExpressionContext::value());
+            let rhs_has_setup = !staged.setup.is_empty() || self.rhs_contains_effectful_call(rhs);
+            let kind = CompoundKind::OpAssign {
+                op_text: format!("{}", op),
+                rhs: value_plan_from_statements(staged.setup, staged.value),
+            };
+            (kind, rhs_has_setup)
+        };
+        let (target_capture, target_str) = self.capture_assignment_target(target, rhs_has_setup);
+        AssignPlan {
+            form: AssignForm::Compound {
+                target_capture,
+                target_str,
+                kind,
+            },
+        }
+    }
+
+    /// Emit a left-value target, capturing order-sensitive sub-expressions into
+    /// preceding statements when the target reads must be pinned before the RHS.
+    fn capture_assignment_target(
+        &mut self,
+        target: &Expression,
+        rhs_has_setup: bool,
+    ) -> (Vec<LoweredStatement>, String) {
+        let mut target_capture: Vec<LoweredStatement> = Vec::new();
+        let target_str = if is_order_sensitive(target) {
+            self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
+        } else {
+            self.emit_left_value(&mut target_capture, target)
+        };
+        (target_capture, target_str)
     }
 
     pub(crate) fn rhs_contains_effectful_call(&self, expression: &Expression) -> bool {


### PR DESCRIPTION
Decomposes the highest cyclomatic-complexity sections in the emit crate into focused single-purpose methods.
