### PR TITLE
fix: allow `mut` parsing in function types

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -87,12 +87,21 @@ fn annotation_to_string(ann: &Annotation) -> String {
         }
         Annotation::Function {
             params,
+            param_mutability,
             return_type,
             ..
         } => {
             let params_str = params
                 .iter()
-                .map(annotation_to_string)
+                .enumerate()
+                .map(|(index, param)| {
+                    let rendered = annotation_to_string(param);
+                    if param_mutability.get(index).copied().unwrap_or(false) {
+                        format!("mut {}", rendered)
+                    } else {
+                        rendered
+                    }
+                })
                 .collect::<Vec<_>>()
                 .join(", ");
             let ret = annotation_to_string(return_type);

--- a/crates/emit/src/names/constraints.rs
+++ b/crates/emit/src/names/constraints.rs
@@ -165,16 +165,19 @@ fn annotations_equivalent(a: &Annotation, b: &Annotation) -> bool {
         (
             Annotation::Function {
                 params: a_params,
+                param_mutability: a_mutability,
                 return_type: a_return,
                 ..
             },
             Annotation::Function {
                 params: b_params,
+                param_mutability: b_mutability,
                 return_type: b_return,
                 ..
             },
         ) => {
-            annotation_lists_equivalent(a_params, b_params)
+            a_mutability == b_mutability
+                && annotation_lists_equivalent(a_params, b_params)
                 && annotations_equivalent(a_return, b_return)
         }
         (
@@ -290,6 +293,26 @@ mod tests {
         assert!(s.add_explicit(parent_int(Span::new(0, 0, 1))));
         assert!(!s.add_explicit(parent_int(Span::new(0, 5, 1))));
         assert_eq!(s.explicit.len(), 1);
+    }
+
+    #[test]
+    fn add_explicit_keeps_function_bounds_differing_only_in_mut() {
+        let fn_bound = |mutability: Vec<bool>, span| {
+            ConstraintAtom::Named(Annotation::Function {
+                params: vec![Annotation::Constructor {
+                    name: "T".into(),
+                    params: vec![],
+                    span,
+                }],
+                param_mutability: mutability,
+                return_type: Box::new(Annotation::unit()),
+                span,
+            })
+        };
+        let mut s = set("F");
+        assert!(s.add_explicit(fn_bound(vec![false], Span::new(0, 0, 1))));
+        assert!(s.add_explicit(fn_bound(vec![true], Span::new(0, 5, 1))));
+        assert_eq!(s.explicit.len(), 2);
     }
 
     #[test]

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -507,10 +507,22 @@ impl<'a> Formatter<'a> {
             }
             Annotation::Function {
                 params,
+                param_mutability,
                 return_type,
                 ..
             } => {
-                let param_docs: Vec<_> = params.iter().map(Self::annotation).collect();
+                let param_docs: Vec<_> = params
+                    .iter()
+                    .enumerate()
+                    .map(|(index, param)| {
+                        let doc = Self::annotation(param);
+                        if param_mutability.get(index).copied().unwrap_or(false) {
+                            Document::str("mut ").append(doc)
+                        } else {
+                            doc
+                        }
+                    })
+                    .collect();
                 Document::str("fn(")
                     .append(join(param_docs, Document::str(", ")))
                     .append(") -> ")

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -302,7 +302,7 @@ impl InferCtx<'_, '_> {
                 .iter()
                 .map(|p| p.pattern.get_identifier())
                 .collect(),
-            vec![false; new_params.len()],
+            new_params.iter().map(|p| p.mutable).collect(),
             vec![],
             return_ty.clone().into(),
         );

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -46,6 +46,7 @@ impl TaskState<'_> {
 
             Annotation::Function {
                 params,
+                param_mutability,
                 return_type,
                 ..
             } => {
@@ -69,10 +70,9 @@ impl TaskState<'_> {
                     self.convert_to_type(store, return_type, span)
                 };
 
-                let param_mutability = vec![false; new_params.len()];
                 Type::function(
                     new_params,
-                    param_mutability,
+                    param_mutability.clone(),
                     Default::default(),
                     new_return_type.into(),
                 )

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -631,6 +631,7 @@ pub enum Annotation {
     },
     Function {
         params: Vec<Self>,
+        param_mutability: Vec<bool>,
         return_type: Box<Self>,
         span: Span,
     },

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -172,8 +172,10 @@ impl<'source> Parser<'source> {
         self.ensure(LeftParen);
 
         let mut params = vec![];
+        let mut param_mutability = vec![];
 
         while self.is_not(RightParen) {
+            param_mutability.push(self.advance_if(Mut));
             params.push(self.parse_annotation());
             self.expect_comma_or(RightParen);
         }
@@ -184,6 +186,7 @@ impl<'source> Parser<'source> {
 
         Annotation::Function {
             params,
+            param_mutability,
             return_type: return_type.into(),
             span: self.span_from_tokens(start),
         }

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -868,7 +868,10 @@ impl<'source> Parser<'source> {
         let mut params = vec![];
 
         while self.is_not(Pipe) {
-            params.push(self.parse_binding());
+            let is_mut = self.advance_if(Mut);
+            let mut binding = self.parse_binding();
+            binding.mutable = is_mut;
+            params.push(binding);
             self.expect_comma_or(Pipe);
         }
 
@@ -1808,7 +1811,7 @@ impl<'source> Parser<'source> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{BinaryOperator, Expression};
+    use crate::ast::{Annotation, BinaryOperator, Expression};
     use crate::build_ast;
 
     fn count_nodes(expression: &Expression) -> usize {
@@ -1845,6 +1848,58 @@ mod tests {
         assert!(
             matches!(value.as_ref(), Expression::Literal { .. }),
             "value should hold only the rhs, not a duplicated `x + 5`: {value:?}"
+        );
+    }
+
+    #[test]
+    fn function_type_annotation_captures_per_param_mutability() {
+        let result = build_ast("fn run(action: fn(mut Bar, Baz) -> ()) {}", 0);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        let Some(Expression::Function { params, .. }) = result
+            .ast
+            .iter()
+            .find(|item| matches!(item, Expression::Function { .. }))
+        else {
+            unreachable!("expected a top-level function")
+        };
+        let Some(Annotation::Function {
+            param_mutability, ..
+        }) = &params[0].annotation
+        else {
+            panic!(
+                "expected a function-type annotation, got {:?}",
+                params[0].annotation
+            )
+        };
+
+        assert_eq!(param_mutability, &vec![true, false]);
+    }
+
+    #[test]
+    fn lambda_parameter_can_be_mut() {
+        let result = build_ast("fn f() {\n  let g = |mut x: int| x\n  let _ = g\n}", 0);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        fn find_lambda(expression: &Expression) -> Option<&Expression> {
+            if matches!(expression, Expression::Lambda { .. }) {
+                return Some(expression);
+            }
+            expression
+                .children()
+                .iter()
+                .find_map(|child| find_lambda(child))
+        }
+
+        let Some(Expression::Lambda { params, .. }) = result.ast.iter().find_map(find_lambda)
+        else {
+            unreachable!("expected a lambda")
+        };
+
+        assert_eq!(params.len(), 1);
+        assert!(
+            params[0].mutable,
+            "`mut x` lambda parameter should be mutable"
         );
     }
 

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -453,6 +453,7 @@ fn format_annotation(ann: &ast::Annotation) -> std::string::String {
         }
         ast::Annotation::Function {
             params,
+            param_mutability,
             return_type,
             ..
         } => {
@@ -460,7 +461,15 @@ fn format_annotation(ann: &ast::Annotation) -> std::string::String {
                 "fn({}) -> {}",
                 params
                     .iter()
-                    .map(format_annotation)
+                    .enumerate()
+                    .map(|(index, param)| {
+                        let rendered = format_annotation(param);
+                        if param_mutability.get(index).copied().unwrap_or(false) {
+                            format!("mut {}", rendered)
+                        } else {
+                            rendered
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", "),
                 format_annotation(return_type)

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -583,6 +583,45 @@ fn test() -> int {
 }
 
 #[test]
+fn function_type_with_mut_parameter() {
+    let input = r#"
+struct Counter { times_called: int }
+
+fn run(counter: Counter, action: fn(mut Counter) -> ()) {
+  action(counter)
+}
+
+fn bump(mut counter: Counter) {
+  counter.times_called += 1
+}
+
+fn test() {
+  let counter = Counter { times_called: 0 }
+  run(counter, bump)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn lambda_with_mut_parameter() {
+    let input = r#"
+fn apply(f: fn(mut int) -> int, x: int) -> int {
+  f(x)
+}
+
+fn test() -> int {
+  let bump = |mut x: int| {
+    x += 1
+    x
+  }
+  apply(bump, 41)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn function_type_as_return() {
     let input = r#"
 fn make_adder(n: int) -> fn(int) -> int {

--- a/tests/spec/emit/snapshots/function_type_with_mut_parameter.snap
+++ b/tests/spec/emit/snapshots/function_type_with_mut_parameter.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Counter { times_called: int }
+  
+  fn run(counter: Counter, action: fn(mut Counter) -> ()) {
+    action(counter)
+  }
+  
+  fn bump(mut counter: Counter) {
+    counter.times_called += 1
+  }
+  
+  fn test() {
+    let counter = Counter { times_called: 0 }
+    run(counter, bump)
+  }
+---
+package main
+
+type Counter struct {
+	times_called int
+}
+
+func run(counter Counter, action func(Counter)) {
+	action(counter)
+}
+
+func bump(counter Counter) {
+	counter.times_called++
+}
+
+func test() {
+	counter := Counter{times_called: 0}
+	run(counter, bump)
+}

--- a/tests/spec/emit/snapshots/lambda_with_mut_parameter.snap
+++ b/tests/spec/emit/snapshots/lambda_with_mut_parameter.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn apply(f: fn(mut int) -> int, x: int) -> int {
+    f(x)
+  }
+  
+  fn test() -> int {
+    let bump = |mut x: int| {
+      x += 1
+      x
+    }
+    apply(bump, 41)
+  }
+---
+package main
+
+func apply(f func(int) int, x int) int {
+	return f(x)
+}
+
+func test() int {
+	bump := func(x int) int {
+		x++
+		return x
+	}
+	return apply(bump, 41)
+}

--- a/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
+++ b/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
@@ -83,6 +83,10 @@ description: |
                                     },
                                 },
                             ],
+                            param_mutability: [
+                                false,
+                                false,
+                            ],
                             return_type: Constructor {
                                 name: "int",
                                 params: [],

--- a/tests/spec/parse/snapshots/lambda_no_params_after_let.snap
+++ b/tests/spec/parse/snapshots/lambda_no_params_after_let.snap
@@ -24,6 +24,7 @@ description: |
         params: [],
         return_annotation: Function {
             params: [],
+            param_mutability: [],
             return_type: Constructor {
                 name: "int",
                 params: [],

--- a/tests/spec/parse/snapshots/lambda_no_params_expr_after_let.snap
+++ b/tests/spec/parse/snapshots/lambda_no_params_expr_after_let.snap
@@ -21,6 +21,7 @@ description: |
         params: [],
         return_annotation: Function {
             params: [],
+            param_mutability: [],
             return_type: Constructor {
                 name: "int",
                 params: [],

--- a/tests/spec/parse/snapshots/type_function.snap
+++ b/tests/spec/parse/snapshots/type_function.snap
@@ -36,6 +36,10 @@ description: |
                     },
                 },
             ],
+            param_mutability: [
+                false,
+                false,
+            ],
             return_type: Constructor {
                 name: "bool",
                 params: [],


### PR DESCRIPTION
Fix #913
