### PR TITLE
feat: `lis check --fix` to autofix diagnostics

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -29,6 +29,7 @@ pub enum Command {
         errors_only: bool,
         warnings_only: bool,
         format: OutputFormat,
+        fix: bool,
     },
     Test {
         path: Option<String>,
@@ -270,11 +271,13 @@ impl Command {
                 let mut errors_only = false;
                 let mut warnings_only = false;
                 let mut format = OutputFormat::Graphical;
+                let mut fix = false;
 
                 while let Some(arg) = arguments.next() {
                     match arg.as_str() {
                         "--errors-only" => errors_only = true,
                         "--warnings-only" => warnings_only = true,
+                        "--fix" => fix = true,
                         "--output" => {
                             let Some(value) = arguments.next() else {
                                 return Err(ParseError::MissingArgument {
@@ -308,6 +311,7 @@ impl Command {
                     errors_only,
                     warnings_only,
                     format,
+                    fix,
                 })
             }
 

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -1,11 +1,13 @@
 use rustc_hash::FxHashMap as HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
 use deps::TypedefLocator;
 use diagnostics::render::{self, Filter, OutputFormat};
+use diagnostics::{Fix, apply_fixes};
 use lisette::fs::LocalFileSystem;
 use lisette::pipeline::{CompileConfig, CompilePhase, CompileResult, compile};
 
@@ -18,6 +20,7 @@ pub fn check(
     errors_only: bool,
     warnings_only: bool,
     format: OutputFormat,
+    fix: bool,
 ) -> i32 {
     let target = path.unwrap_or_else(|| ".".to_string());
     let target_path = Path::new(&target);
@@ -43,17 +46,18 @@ pub fn check(
             false,
             TypedefLocator::default(),
             format,
+            fix,
         );
     }
 
     if target_path.join("lisette.toml").exists() {
-        return check_project(target_path, &filter, format);
+        return check_project(target_path, &filter, format, fix);
     }
 
-    check_loose_dir(target_path, &filter, format)
+    check_loose_dir(target_path, &filter, format, fix)
 }
 
-fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat) -> i32 {
+fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat, fix: bool) -> i32 {
     let root_main = project_path.join("main.lis");
     let src_main = project_path.join("src/main.lis");
 
@@ -122,7 +126,7 @@ fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat) -> 
     ));
     let locator = locator.with_bindgen(bindgen);
 
-    let result = check_single_file(&src_main, filter, true, locator, format);
+    let result = check_single_file(&src_main, filter, true, locator, format, fix);
     drop(target_lock);
     result
 }
@@ -133,6 +137,7 @@ fn check_single_file(
     load_siblings: bool,
     locator: TypedefLocator,
     format: OutputFormat,
+    fix: bool,
 ) -> i32 {
     let start = Instant::now();
     let unix = matches!(format, OutputFormat::Unix);
@@ -143,6 +148,14 @@ fn check_single_file(
     else {
         return 1; // Read error already reported by compile_single_file
     };
+
+    if fix {
+        let mut summary = FixSummary::default();
+        apply_result_fixes(&result, &mut summary);
+        print_fix_summary(&summary, start.elapsed());
+        return i32::from(summary.write_failures > 0);
+    }
+
     let get_source = |file_id: u32| {
         result
             .sources
@@ -228,7 +241,7 @@ fn compile_single_file(
     Some((result, source, entry_display))
 }
 
-fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
+fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool) -> i32 {
     let mut files = lisette::fs::collect_lis_filepaths_recursive(dir);
     files.sort();
 
@@ -262,6 +275,8 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
         eprintln!();
     }
 
+    let mut fix_summary = FixSummary::default();
+
     for dir_files in dirs.values() {
         let mut compiled = None;
         let mut dir_read_failures = 0;
@@ -277,6 +292,12 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
             read_failures += dir_read_failures;
             continue;
         };
+
+        if fix {
+            apply_result_fixes(&result, &mut fix_summary);
+            continue;
+        }
+
         let get_source = |file_id: u32| {
             result
                 .sources
@@ -314,10 +335,101 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat) -> i32 {
 
     let elapsed = start.elapsed();
 
+    if fix {
+        print_fix_summary(&fix_summary, elapsed);
+        return i32::from(fix_summary.write_failures > 0);
+    }
+
     let all_errors = total_errors + read_failures;
     if !unix {
         render::print_summary(total_files, elapsed, all_errors, total_warnings, total_info);
     }
 
     all_errors
+}
+
+#[derive(Default)]
+struct FixSummary {
+    applied: usize,
+    files_changed: usize,
+    write_failures: usize,
+}
+
+fn apply_result_fixes(result: &CompileResult, summary: &mut FixSummary) {
+    let mut by_file: HashMap<u32, Vec<&Fix>> = HashMap::default();
+    for lint in &result.lints {
+        let Some(fix) = lint.fix() else {
+            continue;
+        };
+        let Some(file_id) = lint.file_id() else {
+            continue;
+        };
+        by_file.entry(file_id).or_default().push(fix);
+    }
+
+    for (file_id, fixes) in by_file {
+        let Some(info) = result.sources.get(&file_id) else {
+            continue;
+        };
+        let path = Path::new(&info.filename);
+        if !path.is_file() {
+            continue;
+        }
+
+        let applied = apply_fixes(&info.source, fixes);
+        if applied.applied == 0 {
+            continue;
+        }
+
+        if !syntax::build_ast(&applied.source, file_id)
+            .errors
+            .is_empty()
+        {
+            cli_error!(
+                "Skipped a fix",
+                format!(
+                    "Applying fixes to `{}` would produce invalid syntax",
+                    info.filename
+                ),
+                "Re-run `lis check` to see the remaining diagnostics"
+            );
+            summary.write_failures += 1;
+            continue;
+        }
+
+        match fs::File::create(path).and_then(|mut file| file.write_all(applied.source.as_bytes()))
+        {
+            Ok(()) => {
+                summary.applied += applied.applied;
+                summary.files_changed += 1;
+            }
+            Err(e) => {
+                cli_error!(
+                    "Failed to write fix",
+                    format!("Failed to write `{}`: {}", info.filename, e),
+                    "Check file permissions"
+                );
+                summary.write_failures += 1;
+            }
+        }
+    }
+}
+
+fn print_fix_summary(summary: &FixSummary, elapsed: std::time::Duration) {
+    let time_display = crate::output::format_elapsed(elapsed);
+
+    if summary.files_changed == 0 {
+        eprintln!("  ✓ No fixes applied {}", time_display);
+    } else {
+        let fix_word = if summary.applied == 1 { "fix" } else { "fixes" };
+        let location = if summary.files_changed == 1 {
+            "in 1 file".to_string()
+        } else {
+            format!("across {} files", summary.files_changed)
+        };
+        eprintln!(
+            "  ✓ Applied {} {} {} {}",
+            summary.applied, fix_word, location, time_display
+        );
+    }
 }

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -64,7 +64,7 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         check)
-            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --output" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --fix --output" -- "$cur") )
             return 0
             ;;
         --output)
@@ -149,6 +149,7 @@ _lis() {
                     _arguments \
                         '--errors-only[Show only errors]' \
                         '--warnings-only[Show only warnings]' \
+                        '--fix[Apply lint fixes in place]' \
                         '--output[Machine-readable output]:output:(unix)'
                     ;;
                 doc)
@@ -200,6 +201,7 @@ complete -c lis -n '__fish_seen_subcommand_from test' -l go-flags -r -d 'Flags p
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'
+complete -c lis -n '__fish_seen_subcommand_from check' -l fix -d 'Apply lint fixes in place'
 complete -c lis -n '__fish_seen_subcommand_from check' -l output -r -a unix -d 'Machine-readable output'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'
 complete -c lis -n '__fish_seen_subcommand_from complete' -a 'bash zsh fish' -d 'Shell type'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -151,12 +151,14 @@ Arguments:
 Flags:
     {--errors-only:b}                Show only errors
     {--warnings-only:b}              Show only warnings
+    {--fix:b}                        Apply lint fixes in place
     {--output:b} {unix}                Machine-readable output
 
 Examples:
     `lis check`                    Check project in current dir
     `lis check` {~/projects/demo:g}    Check project in specific dir
     `lis check` {script.lis:g}         Check single file
+    `lis check` {--fix:b}              Fix all lints in the project
     `lis check` {--output:b} {unix}      One diagnostic per line",
         ),
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -77,7 +77,8 @@ fn main() {
             errors_only,
             warnings_only,
             format,
-        } => handlers::check(path, errors_only, warnings_only, format),
+            fix,
+        } => handlers::check(path, errors_only, warnings_only, format, fix),
         Command::Test {
             path,
             go_flags,

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -188,6 +188,7 @@ pub struct LisetteDiagnostic {
     file_id: Option<u32>,
     use_color: bool,
     label_accent: Option<Style>,
+    fix: Option<crate::Fix>,
 }
 
 impl fmt::Display for LisetteDiagnostic {
@@ -339,6 +340,7 @@ impl LisetteDiagnostic {
             file_id: None,
             use_color: false,
             label_accent: None,
+            fix: None,
         }
     }
 
@@ -393,6 +395,15 @@ impl LisetteDiagnostic {
     pub fn with_note(mut self, note: impl Into<String>) -> Self {
         self.note = Some(note.into());
         self
+    }
+
+    pub fn with_fix(mut self, fix: crate::Fix) -> Self {
+        self.fix = Some(fix);
+        self
+    }
+
+    pub fn fix(&self) -> Option<&crate::Fix> {
+        self.fix.as_ref()
     }
 
     pub fn with_lex_code(mut self, code: &str) -> Self {

--- a/crates/diagnostics/src/fix.rs
+++ b/crates/diagnostics/src/fix.rs
@@ -1,0 +1,156 @@
+use syntax::ast::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Edit {
+    span: Span,
+    content: Box<str>,
+}
+
+impl Edit {
+    pub fn replacement(span: Span, content: impl Into<Box<str>>) -> Self {
+        Self {
+            span,
+            content: content.into(),
+        }
+    }
+
+    pub fn deletion(span: Span) -> Self {
+        Self {
+            span,
+            content: Box::from(""),
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+/// A single applicable fix for one diagnostic.
+#[derive(Debug, Clone)]
+pub struct Fix {
+    message: String,
+    edit: Edit,
+}
+
+impl Fix {
+    pub fn new(message: impl Into<String>, edit: Edit) -> Self {
+        Self {
+            message: message.into(),
+            edit,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn edit(&self) -> &Edit {
+        &self.edit
+    }
+}
+
+#[derive(Debug)]
+pub struct FixApplicationOutcome {
+    pub source: String,
+    pub applied: usize,
+}
+
+/// Apply `fixes` to `source` in a single left-to-right pass.
+///
+/// Fixes are sorted by span. A fix whose edit starts at or before the last
+/// applied edit ended is skipped (boundary-adjacent spans count as overlapping)
+/// and stays reported as a diagnostic on the next run.
+pub fn apply_fixes(source: &str, mut fixes: Vec<&Fix>) -> FixApplicationOutcome {
+    fixes.sort_by_key(|fix| {
+        let span = fix.edit().span();
+        (span.byte_offset, span.end())
+    });
+
+    let mut out = String::with_capacity(source.len());
+    let mut last_end: Option<u32> = None;
+    let mut applied = 0;
+
+    for fix in fixes {
+        let span = fix.edit().span();
+        if last_end.is_some_and(|end| span.byte_offset <= end) {
+            continue;
+        }
+        out.push_str(&source[last_end.unwrap_or(0) as usize..span.byte_offset as usize]);
+        out.push_str(fix.edit().content());
+        last_end = Some(span.end());
+        applied += 1;
+    }
+
+    out.push_str(&source[last_end.unwrap_or(0) as usize..]);
+    FixApplicationOutcome {
+        source: out,
+        applied,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(offset: u32, len: u32) -> Span {
+        Span::new(0, offset, len)
+    }
+
+    #[test]
+    fn applies_single_replacement() {
+        let fix = Fix::new("x", Edit::replacement(span(0, 5), "y"));
+        let applied = apply_fixes("hello world", vec![&fix]);
+        assert_eq!(applied.source, "y world");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn applies_deletion() {
+        let fix = Fix::new("drop", Edit::deletion(span(5, 6)));
+        let applied = apply_fixes("hello world!", vec![&fix]);
+        assert_eq!(applied.source, "hello!");
+    }
+
+    #[test]
+    fn applies_non_overlapping_fixes_left_to_right() {
+        let a = Fix::new("a", Edit::replacement(span(0, 1), "A"));
+        let b = Fix::new("b", Edit::replacement(span(2, 1), "C"));
+        let applied = apply_fixes("abc", vec![&b, &a]);
+        assert_eq!(applied.source, "AbC");
+        assert_eq!(applied.applied, 2);
+    }
+
+    #[test]
+    fn skips_overlapping_fix() {
+        let a = Fix::new("a", Edit::replacement(span(0, 3), "X"));
+        let b = Fix::new("b", Edit::replacement(span(2, 3), "Y"));
+        let applied = apply_fixes("abcdef", vec![&a, &b]);
+        assert_eq!(applied.source, "Xdef");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn treats_boundary_adjacent_as_overlap() {
+        let a = Fix::new("a", Edit::replacement(span(0, 2), "X"));
+        let b = Fix::new("b", Edit::replacement(span(2, 2), "Y"));
+        let applied = apply_fixes("abcd", vec![&a, &b]);
+        assert_eq!(applied.source, "Xcd");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn malformed_fix_output_is_caught_by_reparse() {
+        let fix = Fix::new("bad", Edit::replacement(span(0, 1), "((("));
+        let applied = apply_fixes("x", vec![&fix]);
+        assert_eq!(applied.source, "(((");
+        assert!(
+            !syntax::build_ast(&applied.source, 0).errors.is_empty(),
+            "the CLI write-gate relies on build_ast rejecting malformed fix output"
+        );
+    }
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -1,4 +1,5 @@
 mod diagnostic;
+mod fix;
 mod result;
 mod sink;
 
@@ -12,6 +13,7 @@ pub mod pattern;
 pub mod render;
 
 pub use diagnostic::{IndexedSource, LisetteDiagnostic, Report};
+pub use fix::{Edit, Fix, FixApplicationOutcome, apply_fixes};
 pub use result::SemanticResult;
 pub use sink::LocalSink;
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,7 +19,7 @@ use tower_lsp::LanguageServer;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
-use crate::analysis::{offset_in_span, type_name};
+use crate::analysis::{convert_diagnostic, offset_in_span, type_name};
 use crate::completion::{
     DotContext, attribute_completions, definition_to_completion_kind, detect_dot_context,
     detect_struct_literal_field_context, get_instance_completions, get_module_prefix,
@@ -82,6 +82,7 @@ impl LanguageServer for Backend {
                 definition_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 rename_provider: Some(OneOf::Right(RenameOptions {
                     prepare_provider: Some(true),
                     work_done_progress_options: Default::default(),
@@ -1128,6 +1129,63 @@ impl LanguageServer for Backend {
         }))
     }
 
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        let uri = &params.text_document.uri;
+
+        let Some(snapshot) = self.get_snapshot(uri).await else {
+            return Ok(None);
+        };
+        let Some(file_id) = snapshot.get_file_id(uri) else {
+            return Ok(None);
+        };
+        let Some(line_index) = snapshot.get_line_index(file_id) else {
+            return Ok(None);
+        };
+
+        let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+
+        for diagnostic in &snapshot.result.lints {
+            if diagnostic.file_id() != Some(file_id) {
+                continue;
+            }
+            let Some(fix) = diagnostic.fix() else {
+                continue;
+            };
+
+            let lsp_diagnostic = convert_diagnostic(diagnostic, line_index);
+            if !ranges_overlap(params.range, lsp_diagnostic.range) {
+                continue;
+            }
+
+            let edit = fix.edit();
+            let text_edit = TextEdit {
+                range: line_index.span_to_range(edit.span()),
+                new_text: edit.content().to_string(),
+            };
+
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(uri.clone(), vec![text_edit]);
+
+            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                title: fix.message().to_string(),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(vec![lsp_diagnostic]),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                is_preferred: Some(true),
+                ..Default::default()
+            }));
+        }
+
+        if actions.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(actions))
+    }
+
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
@@ -1386,6 +1444,11 @@ impl LanguageServer for Backend {
     }
 }
 
+fn ranges_overlap(a: Range, b: Range) -> bool {
+    let position_le = |x: Position, y: Position| (x.line, x.character) <= (y.line, y.character);
+    position_le(a.start, b.end) && position_le(b.start, a.end)
+}
+
 /// Narrows a usage span to just the trailing member token, dropping any
 /// qualifier (`Color.Red`) and any payload (`Red(x)`).
 fn trailing_segment_span(
@@ -1451,7 +1514,24 @@ pub(crate) fn head_extent(text: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::member_token_range;
+    use super::{member_token_range, ranges_overlap};
+    use tower_lsp::lsp_types::{Position, Range};
+
+    fn range(sl: u32, sc: u32, el: u32, ec: u32) -> Range {
+        Range {
+            start: Position::new(sl, sc),
+            end: Position::new(el, ec),
+        }
+    }
+
+    #[test]
+    fn ranges_overlap_detects_intersection() {
+        assert!(ranges_overlap(range(0, 0, 0, 5), range(0, 3, 0, 8)));
+        assert!(ranges_overlap(range(1, 4, 1, 4), range(1, 0, 1, 10)));
+        assert!(ranges_overlap(range(0, 5, 0, 5), range(0, 0, 0, 5)));
+        assert!(!ranges_overlap(range(0, 0, 0, 2), range(0, 3, 0, 5)));
+        assert!(!ranges_overlap(range(0, 0, 0, 9), range(1, 0, 1, 1)));
+    }
 
     #[test]
     fn member_token_range_extracts_trailing_token() {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -569,6 +569,68 @@ async fn rename_local_variable() {
 }
 
 #[tokio::test]
+async fn code_action_capability_advertised() {
+    let mut client = TestClient::new().await;
+    let result = client.initialize().await;
+    assert!(result.capabilities.code_action_provider.is_some());
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn code_action_offers_quick_fix() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn main() {\n  let x = true\n  let _ = x == true\n}",
+        )
+        .await;
+
+    let actions = client
+        .code_action(TEST_URI, (2, 12), (2, 12))
+        .await
+        .expect("expected code actions");
+
+    let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+        panic!("expected a CodeAction");
+    };
+    assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+    assert_eq!(action.is_preferred, Some(true));
+
+    let edits = action
+        .edit
+        .as_ref()
+        .unwrap()
+        .changes
+        .as_ref()
+        .unwrap()
+        .get(&Url::parse(TEST_URI).unwrap())
+        .unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "x");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn code_action_absent_away_from_diagnostic() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client
+        .open(
+            TEST_URI,
+            "fn main() {\n  let x = true\n  let _ = x == true\n}",
+        )
+        .await;
+
+    let actions = client.code_action(TEST_URI, (0, 0), (0, 0)).await;
+    assert!(actions.is_none() || actions.unwrap().is_empty());
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn rename_rejects_keywords() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -328,6 +328,26 @@ impl TestClient {
         .await
     }
 
+    pub async fn code_action(
+        &mut self,
+        uri: &str,
+        start: (u32, u32),
+        end: (u32, u32),
+    ) -> Option<CodeActionResponse> {
+        self.request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": start.0, "character": start.1},
+                    "end": {"line": end.0, "character": end.1}
+                },
+                "context": {"diagnostics": []}
+            }),
+        )
+        .await
+    }
+
     pub async fn formatting(&mut self, uri: &str) -> Option<Vec<TextEdit>> {
         self.request(
             "textDocument/formatting",

--- a/crates/passes/src/passes/lints/ast_walk/checks/bool_literal_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/bool_literal_comparison.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 
 use super::helpers::bool_literal;
@@ -46,8 +47,10 @@ pub fn check_bool_literal_comparison(expression: &Expression, ctx: &NodeCtx) {
         other_text
     };
 
-    ctx.sink.push(diagnostics::lint::bool_literal_comparison(
-        span,
-        &replacement,
-    ));
+    ctx.sink.push(
+        diagnostics::lint::bool_literal_comparison(span, &replacement).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/double_negation.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/double_negation.rs
@@ -1,5 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Span, UnaryOperator};
+
+use super::helpers::span_text;
 
 pub fn check_double_negation(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Unary {
@@ -14,6 +17,7 @@ pub fn check_double_negation(expression: &Expression, ctx: &NodeCtx) {
 
     let Expression::Unary {
         operator: inner_op,
+        expression: inner_operand,
         span: inner_span,
         ..
     } = operand.unwrap_parens()
@@ -36,6 +40,14 @@ pub fn check_double_negation(expression: &Expression, ctx: &NodeCtx) {
     );
 
     let is_bool = *operator == UnaryOperator::Not;
-    ctx.sink
-        .push(diagnostics::lint::double_negation(&operators_span, is_bool));
+    let mut diagnostic = diagnostics::lint::double_negation(&operators_span, is_bool);
+
+    if let Some(text) = span_text(ctx.source, inner_operand) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            "Remove double negation",
+            Edit::replacement(*outer_span, text),
+        ));
+    }
+
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
@@ -1,7 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::{expressions_equivalent, is_side_effect_free};
+use super::helpers::{expressions_equivalent, is_side_effect_free, span_text};
 
 pub fn check_manual_compound_assignment(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Assignment {
@@ -14,7 +15,13 @@ pub fn check_manual_compound_assignment(expression: &Expression, ctx: &NodeCtx) 
         return;
     };
 
-    let Expression::Binary { operator, left, .. } = value.unwrap_parens() else {
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        ..
+    } = value.unwrap_parens()
+    else {
         return;
     };
 
@@ -26,6 +33,17 @@ pub fn check_manual_compound_assignment(expression: &Expression, ctx: &NodeCtx) 
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::manual_compound_assignment(span, symbol));
+    let mut diagnostic = diagnostics::lint::manual_compound_assignment(span, symbol);
+
+    if let (Some(target_text), Some(rhs_text)) =
+        (span_text(ctx.source, target), span_text(ctx.source, right))
+    {
+        let replacement = format!("{target_text} {symbol} {rhs_text}");
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Use `{symbol}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/map_identity.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/map_identity.rs
@@ -1,7 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::{is_identity_lambda, method_call};
+use super::helpers::{is_identity_lambda, method_call, span_text};
 
 pub fn check_map_identity(expression: &Expression, ctx: &NodeCtx) {
     let Some((receiver, args, span)) = method_call(expression, "map") else {
@@ -26,5 +27,12 @@ pub fn check_map_identity(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::map_identity(span));
+    let mut diagnostic = diagnostics::lint::map_identity(span);
+    if let Some(text) = span_text(ctx.source, receiver) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            "Remove identity map",
+            Edit::replacement(*span, text),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/negated_equality.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/negated_equality.rs
@@ -1,5 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
+
+use super::helpers::span_text;
 
 pub fn check_negated_equality(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Unary {
@@ -12,16 +15,31 @@ pub fn check_negated_equality(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    let Expression::Binary { operator, .. } = operand.unwrap_parens() else {
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        ..
+    } = operand.unwrap_parens()
+    else {
         return;
     };
 
-    let is_equal = match operator {
-        BinaryOperator::Equal => true,
-        BinaryOperator::NotEqual => false,
+    let (is_equal, flipped) = match operator {
+        BinaryOperator::Equal => (true, "!="),
+        BinaryOperator::NotEqual => (false, "=="),
         _ => return,
     };
 
-    ctx.sink
-        .push(diagnostics::lint::negated_equality(span, is_equal));
+    let mut diagnostic = diagnostics::lint::negated_equality(span, is_equal);
+
+    if let (Some(lhs), Some(rhs)) = (span_text(ctx.source, left), span_text(ctx.source, right)) {
+        let replacement = format!("{lhs} {flipped} {rhs}");
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_field_names.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_field_names.rs
@@ -2,6 +2,7 @@ use syntax::ast::{Expression, Span, StructFieldAssignment};
 
 use super::helpers::struct_field_names;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 
 pub fn check_redundant_field_names(expression: &Expression, ctx: &NodeCtx) {
     let Expression::StructCall {
@@ -33,10 +34,12 @@ pub fn check_redundant_field_names(expression: &Expression, ctx: &NodeCtx) {
             continue;
         };
         let span = assignment.name_span.merge(value_span);
-        ctx.sink.push(diagnostics::lint::redundant_field_names(
-            &span,
-            &assignment.name,
-        ));
+        ctx.sink.push(
+            diagnostics::lint::redundant_field_names(&span, &assignment.name).with_fix(Fix::new(
+                format!("Use shorthand `{}`", assignment.name),
+                Edit::replacement(span, assignment.name.to_string()),
+            )),
+        );
     }
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_operation.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_operation.rs
@@ -1,14 +1,23 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 use syntax::types::Type;
 
-use super::helpers::{bool_literal, is_one_literal, is_side_effect_free, is_zero_literal};
+use super::helpers::{
+    bool_literal, is_one_literal, is_side_effect_free, is_zero_literal, span_text,
+};
 
 enum Outcome {
     /// The operation returns its other operand unchanged (`x + 0`, `x && true`).
     Identity,
     /// The operation always evaluates to a constant (`x * 0`, `x && false`).
     Constant(&'static str),
+}
+
+#[derive(Clone, Copy)]
+enum Side {
+    Left,
+    Right,
 }
 
 pub fn check_redundant_operation(expression: &Expression, ctx: &NodeCtx) {
@@ -23,103 +32,118 @@ pub fn check_redundant_operation(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    let left = left.unwrap_parens();
-    let right = right.unwrap_parens();
+    let unwrapped_left = left.unwrap_parens();
+    let unwrapped_right = right.unwrap_parens();
 
-    let Some((other, outcome)) = classify(*operator, left, right) else {
+    let Some((side, outcome)) = classify(*operator, unwrapped_left, unwrapped_right) else {
         return;
+    };
+
+    let (other, other_source) = match side {
+        Side::Left => (unwrapped_left, left.as_ref()),
+        Side::Right => (unwrapped_right, right.as_ref()),
     };
 
     if let Outcome::Constant(value) = outcome {
         if !is_side_effect_free(other) {
             return;
         }
-        ctx.sink
-            .push(diagnostics::lint::redundant_operation(span, Some(value)));
+        ctx.sink.push(
+            diagnostics::lint::redundant_operation(span, Some(value)).with_fix(Fix::new(
+                format!("Replace with `{value}`"),
+                Edit::replacement(*span, value),
+            )),
+        );
     } else {
-        ctx.sink
-            .push(diagnostics::lint::redundant_operation(span, None));
+        let mut diagnostic = diagnostics::lint::redundant_operation(span, None);
+        if let Some(text) = span_text(ctx.source, other_source) {
+            diagnostic = diagnostic.with_fix(Fix::new(
+                format!("Replace with `{text}`"),
+                Edit::replacement(*span, text),
+            ));
+        }
+        ctx.sink.push(diagnostic);
     }
 }
 
-fn classify<'a>(
+fn classify(
     operator: BinaryOperator,
-    left: &'a Expression,
-    right: &'a Expression,
-) -> Option<(&'a Expression, Outcome)> {
+    left: &Expression,
+    right: &Expression,
+) -> Option<(Side, Outcome)> {
     use BinaryOperator::*;
 
     if let And | Or = operator {
         return classify_boolean(operator, left, right);
     }
 
-    let (other, outcome) = match operator {
+    let (side, outcome) = match operator {
         Addition => {
             if is_zero_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else if is_zero_literal(left) {
-                (right, Outcome::Identity)
+                (Side::Right, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Subtraction => {
             if is_zero_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Multiplication => {
             if is_one_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else if is_one_literal(left) {
-                (right, Outcome::Identity)
+                (Side::Right, Outcome::Identity)
             } else if is_zero_literal(right) {
-                (left, Outcome::Constant("0"))
+                (Side::Left, Outcome::Constant("0"))
             } else if is_zero_literal(left) {
-                (right, Outcome::Constant("0"))
+                (Side::Right, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         Division => {
             if is_one_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else {
                 return None;
             }
         }
         Remainder => {
             if is_one_literal(right) {
-                (left, Outcome::Constant("0"))
+                (Side::Left, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         BitwiseOr | BitwiseXor => {
             if is_zero_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else if is_zero_literal(left) {
-                (right, Outcome::Identity)
+                (Side::Right, Outcome::Identity)
             } else {
                 return None;
             }
         }
         BitwiseAnd => {
             if is_zero_literal(right) {
-                (left, Outcome::Constant("0"))
+                (Side::Left, Outcome::Constant("0"))
             } else if is_zero_literal(left) {
-                (right, Outcome::Constant("0"))
+                (Side::Right, Outcome::Constant("0"))
             } else {
                 return None;
             }
         }
         BitwiseAndNot => {
             if is_zero_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else if is_zero_literal(left) {
-                (right, Outcome::Constant("0"))
+                (Side::Right, Outcome::Constant("0"))
             } else {
                 return None;
             }
@@ -128,7 +152,7 @@ fn classify<'a>(
             // `0 << n` is not folded to `0`: a negative `n` panics at runtime,
             // so the result is not unconditionally `0`.
             if is_zero_literal(right) {
-                (left, Outcome::Identity)
+                (Side::Left, Outcome::Identity)
             } else {
                 return None;
             }
@@ -136,38 +160,46 @@ fn classify<'a>(
         _ => return None,
     };
 
+    let other = match side {
+        Side::Left => left,
+        Side::Right => right,
+    };
     if !is_integer(&other.get_type()) {
         return None;
     }
-    Some((other, outcome))
+    Some((side, outcome))
 }
 
-fn classify_boolean<'a>(
+fn classify_boolean(
     operator: BinaryOperator,
-    left: &'a Expression,
-    right: &'a Expression,
-) -> Option<(&'a Expression, Outcome)> {
+    left: &Expression,
+    right: &Expression,
+) -> Option<(Side, Outcome)> {
     let is_and = matches!(operator, BinaryOperator::And);
-    let (other, outcome) = if let Some(value) = bool_literal(right) {
-        boolean_outcome(left, value, is_and)
+    let (side, outcome) = if let Some(value) = bool_literal(right) {
+        (Side::Left, boolean_outcome(value, is_and))
     } else if let Some(value) = bool_literal(left) {
-        boolean_outcome(right, value, is_and)
+        (Side::Right, boolean_outcome(value, is_and))
     } else {
         return None;
+    };
+    let other = match side {
+        Side::Left => left,
+        Side::Right => right,
     };
     if !other.get_type().is_boolean() {
         return None;
     }
-    Some((other, outcome))
+    Some((side, outcome))
 }
 
-fn boolean_outcome(other: &Expression, literal: bool, is_and: bool) -> (&Expression, Outcome) {
+fn boolean_outcome(literal: bool, is_and: bool) -> Outcome {
     if is_and == literal {
-        (other, Outcome::Identity)
+        Outcome::Identity
     } else if is_and {
-        (other, Outcome::Constant("false"))
+        Outcome::Constant("false")
     } else {
-        (other, Outcome::Constant("true"))
+        Outcome::Constant("true")
     }
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_sprintf.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_sprintf.rs
@@ -1,5 +1,6 @@
 use super::helpers::span_text;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Literal};
 
 pub fn check_redundant_sprintf(expression: &Expression, ctx: &NodeCtx) {
@@ -60,9 +61,10 @@ pub fn check_redundant_sprintf(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::redundant_sprintf(
-        span,
-        namespace_text,
-        value_text,
-    ));
+    ctx.sink.push(
+        diagnostics::lint::redundant_sprintf(span, namespace_text, value_text).with_fix(Fix::new(
+            format!("Replace with `{value_text}`"),
+            Edit::replacement(*span, value_text),
+        )),
+    );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, FormatStringPart, Literal};
 
 pub fn check_uninterpolated_fstring(expression: &Expression, ctx: &NodeCtx) {
@@ -15,8 +16,23 @@ pub fn check_uninterpolated_fstring(expression: &Expression, ctx: &NodeCtx) {
         .iter()
         .any(|p| matches!(p, FormatStringPart::Expression(_)));
 
-    if !has_interpolation {
-        ctx.sink
-            .push(diagnostics::lint::uninterpolated_fstring(span));
+    if has_interpolation {
+        return;
     }
+
+    let mut diagnostic = diagnostics::lint::uninterpolated_fstring(span);
+
+    if let Some(source) = ctx
+        .source
+        .get(span.byte_offset as usize..span.end() as usize)
+        && let Some(without_prefix) = source.strip_prefix('f')
+    {
+        let replacement = without_prefix.replace("{{", "{").replace("}}", "}");
+        diagnostic = diagnostic.with_fix(Fix::new(
+            "Convert to a regular string",
+            Edit::replacement(*span, replacement),
+        ));
+    }
+
+    ctx.sink.push(diagnostic);
 }

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -4,6 +4,7 @@
 
 - Syntax highlighting
 - Diagnostics
+- Quick fixes (lint autofixes)
 - Hover
 - Completions
 - Go-to-definition

--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -6,6 +6,7 @@ Neovim language support for [Lisette](https://github.com/ivov/lisette). Requires
 
 - Syntax highlighting
 - Diagnostics
+- Quick fixes (lint autofixes)
 - Hover
 - Completions
 - Go-to-definition

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,6 +6,7 @@ VSCode language support for [Lisette](https://github.com/ivov/lisette).
 
 - Syntax highlighting
 - Diagnostics
+- Quick fixes (lint autofixes)
 - Hover
 - Completions
 - Go-to-definition

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -6,6 +6,7 @@ Zed language support for [Lisette](https://github.com/ivov/lisette).
 
 - Syntax highlighting
 - Diagnostics
+- Quick fixes (lint autofixes)
 - Hover
 - Completions
 - Go-to-definition

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -1,4 +1,4 @@
-use diagnostics::{LisetteDiagnostic, LocalSink};
+use diagnostics::{Fix, LisetteDiagnostic, LocalSink, apply_fixes};
 use semantics::{checker::TaskState, checker::infer::InferCtx, store::Store};
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
@@ -131,4 +131,19 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     passes::run(&analysis, &mut checker.facts, &sink, &mut unused, true);
 
     sink.take()
+}
+
+pub fn apply_lint_fixes(source: &str) -> String {
+    let lints = lint(source);
+    let fixes: Vec<&Fix> = lints.iter().filter_map(LisetteDiagnostic::fix).collect();
+    let fixed = apply_fixes(source, fixes).source;
+
+    let reparsed = syntax::build_ast(&fixed, 0);
+    if !reparsed.errors.is_empty() {
+        panic!(
+            "Applied fix produced source that no longer parses:\n{fixed}\nerrors: {:?}",
+            reparsed.errors
+        );
+    }
+    fixed
 }

--- a/tests/_harness/macros.rs
+++ b/tests/_harness/macros.rs
@@ -262,6 +262,37 @@ macro_rules! assert_lint_snapshot {
 }
 
 #[macro_export]
+macro_rules! assert_fix_snapshot {
+    ($source:expr) => {
+        let fixed = $crate::_harness::lint::apply_lint_fixes($source);
+        if fixed == $source {
+            panic!("Expected a fix to change the source but it was unchanged");
+        }
+        let combined = format!(
+            "{}\n=== fixed ===\n{}",
+            $source.trim_matches('\n'),
+            fixed.trim_matches('\n'),
+        );
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+        }, {
+            insta::assert_snapshot!(combined);
+        });
+    };
+}
+
+#[macro_export]
+macro_rules! assert_no_fix {
+    ($source:expr) => {
+        let fixed = $crate::_harness::lint::apply_lint_fixes($source);
+        if fixed != $source {
+            panic!("Expected no fix but the source changed to:\n{fixed}");
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! assert_no_lint_warnings {
     ($source:expr) => {
         let warnings = $crate::_harness::lint::lint($source);

--- a/tests/spec/desugar/mod.rs
+++ b/tests/spec/desugar/mod.rs
@@ -1,6 +1,40 @@
 use crate::assert_desugar_snapshot;
 
 #[test]
+fn desugar_only_rewrites_pipelines() {
+    let source = r#"
+fn main() {
+  let a = if let Some(v) = opt { v } else { 0 }
+  let b = match n { 1 => "a", _ => "b" }
+  let c = Point { x: 1, y: 2 }
+  let d = !!flag
+  let e = first + second * third - 0
+  let g = obj.method(arg).field
+  let h = f"hello {name} world"
+  for item in items { print(item) }
+  while cond { break }
+}
+"#;
+
+    let lexed = syntax::lex::Lexer::new(source, 0).lex();
+    assert!(!lexed.failed(), "lex failed: {:?}", lexed.errors);
+    let parsed = syntax::parse::Parser::new(lexed.tokens, source).parse();
+    assert!(!parsed.failed(), "parse failed: {:?}", parsed.errors);
+
+    let before = parsed.ast.clone();
+    let desugared = syntax::desugar::desugar(parsed.ast);
+    assert!(
+        desugared.errors.is_empty(),
+        "desugar errors: {:?}",
+        desugared.errors
+    );
+    assert_eq!(
+        desugared.ast, before,
+        "desugar rewrote a non-pipeline construct, breaking the lint-autofix source-provenance contract"
+    );
+}
+
+#[test]
 fn pipeline_simple() {
     let input = "fn test() { x |> func; }";
     assert_desugar_snapshot!(input);

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -1,0 +1,244 @@
+use crate::_harness::lint::apply_lint_fixes;
+use crate::{assert_fix_snapshot, assert_no_fix};
+
+#[test]
+fn fix_bool_literal_comparison_eq_true() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = true;
+  let _ = x == true
+}
+"#
+    );
+}
+
+#[test]
+fn fix_bool_literal_comparison_ne_true() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = true;
+  let _ = x != true
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_operation_identity() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = 0 + x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_operation_constant() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = x * 0
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_operation_keeps_operand_parens() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let a = 1
+  let b = 2
+  let c = 3
+  let _ = (a + b) * 1 * c
+}
+"#
+    );
+}
+
+#[test]
+fn fix_double_bool_negation() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = true;
+  let _ = !!x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_double_bool_negation_with_parens() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = true;
+  let _ = !(!x)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_double_int_negation() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = --x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_negated_equality_equal() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = !(a == b)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_negated_equality_not_equal() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = !(a != b)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_sprintf() {
+    assert_fix_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let s = "hello"
+  let _ = fmt.Sprintf("%s", s)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_map_identity_option() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = o.map(|x| x)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_compound_assignment() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let mut x = 5;
+  x = x + 1;
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_field_names() {
+    assert_fix_snapshot!(
+        r#"
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int) -> Point {
+  Point { x: x, y: 0 }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_field_names_multiple() {
+    assert_fix_snapshot!(
+        r#"
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int, y: int) -> Point {
+  Point { x: x, y: y }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_uninterpolated_fstring() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let msg = f"hello world";
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn fix_uninterpolated_fstring_collapses_brace_escapes() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let msg = f"a {{ b }}";
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn self_comparison_has_no_fix() {
+    assert_no_fix!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x == x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_is_idempotent() {
+    let source = r#"
+fn main() {
+  let x = true;
+  let _ = x == true
+}
+"#;
+    let once = apply_lint_fixes(source);
+    let twice = apply_lint_fixes(&once);
+    assert_eq!(once, twice);
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -1,3 +1,5 @@
+mod fixes;
+
 use crate::_harness::build::compile_check;
 use crate::_harness::filesystem::MockFileSystem;
 use crate::{assert_lint_snapshot, assert_no_lint_warnings};

--- a/tests/ui/lint/snapshots/fix_bool_literal_comparison_eq_true.snap
+++ b/tests/ui/lint/snapshots/fix_bool_literal_comparison_eq_true.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = true;
+  let _ = x == true
+}
+=== fixed ===
+fn main() {
+  let x = true;
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_bool_literal_comparison_ne_true.snap
+++ b/tests/ui/lint/snapshots/fix_bool_literal_comparison_ne_true.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = true;
+  let _ = x != true
+}
+=== fixed ===
+fn main() {
+  let x = true;
+  let _ = !x
+}

--- a/tests/ui/lint/snapshots/fix_double_bool_negation.snap
+++ b/tests/ui/lint/snapshots/fix_double_bool_negation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = true;
+  let _ = !!x
+}
+=== fixed ===
+fn main() {
+  let x = true;
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_double_bool_negation_with_parens.snap
+++ b/tests/ui/lint/snapshots/fix_double_bool_negation_with_parens.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = true;
+  let _ = !(!x)
+}
+=== fixed ===
+fn main() {
+  let x = true;
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_double_int_negation.snap
+++ b/tests/ui/lint/snapshots/fix_double_int_negation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = 5;
+  let _ = --x
+}
+=== fixed ===
+fn main() {
+  let x = 5;
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_manual_compound_assignment.snap
+++ b/tests/ui/lint/snapshots/fix_manual_compound_assignment.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let mut x = 5;
+  x = x + 1;
+  let _ = x
+}
+=== fixed ===
+fn main() {
+  let mut x = 5;
+  x += 1;
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_map_identity_option.snap
+++ b/tests/ui/lint/snapshots/fix_map_identity_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = o.map(|x| x)
+}
+=== fixed ===
+fn main() {
+  let o: Option<int> = Some(1)
+  let _ = o
+}

--- a/tests/ui/lint/snapshots/fix_negated_equality_equal.snap
+++ b/tests/ui/lint/snapshots/fix_negated_equality_equal.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = !(a == b)
+}
+=== fixed ===
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = a != b
+}

--- a/tests/ui/lint/snapshots/fix_negated_equality_not_equal.snap
+++ b/tests/ui/lint/snapshots/fix_negated_equality_not_equal.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = !(a != b)
+}
+=== fixed ===
+fn main() {
+  let a = true;
+  let b = false;
+  let _ = a == b
+}

--- a/tests/ui/lint/snapshots/fix_redundant_field_names.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_field_names.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int) -> Point {
+  Point { x: x, y: 0 }
+}
+=== fixed ===
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int) -> Point {
+  Point { x, y: 0 }
+}

--- a/tests/ui/lint/snapshots/fix_redundant_field_names_multiple.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_field_names_multiple.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int, y: int) -> Point {
+  Point { x: x, y: y }
+}
+=== fixed ===
+struct Point { x: int, y: int }
+
+fn read(p: Point) -> int { p.x + p.y }
+
+fn make(x: int, y: int) -> Point {
+  Point { x, y }
+}

--- a/tests/ui/lint/snapshots/fix_redundant_operation_constant.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_operation_constant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = 5
+  let _ = x * 0
+}
+=== fixed ===
+fn main() {
+  let x = 5
+  let _ = 0
+}

--- a/tests/ui/lint/snapshots/fix_redundant_operation_identity.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_operation_identity.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = 5
+  let _ = 0 + x
+}
+=== fixed ===
+fn main() {
+  let x = 5
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_redundant_operation_keeps_operand_parens.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_operation_keeps_operand_parens.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let a = 1
+  let b = 2
+  let c = 3
+  let _ = (a + b) * 1 * c
+}
+=== fixed ===
+fn main() {
+  let a = 1
+  let b = 2
+  let c = 3
+  let _ = (a + b) * c
+}

--- a/tests/ui/lint/snapshots/fix_redundant_sprintf.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_sprintf.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:fmt"
+
+fn main() {
+  let s = "hello"
+  let _ = fmt.Sprintf("%s", s)
+}
+=== fixed ===
+import "go:fmt"
+
+fn main() {
+  let s = "hello"
+  let _ = s
+}

--- a/tests/ui/lint/snapshots/fix_uninterpolated_fstring.snap
+++ b/tests/ui/lint/snapshots/fix_uninterpolated_fstring.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let msg = f"hello world";
+  let _ = msg
+}
+=== fixed ===
+fn main() {
+  let msg = "hello world";
+  let _ = msg
+}

--- a/tests/ui/lint/snapshots/fix_uninterpolated_fstring_collapses_brace_escapes.snap
+++ b/tests/ui/lint/snapshots/fix_uninterpolated_fstring_collapses_brace_escapes.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let msg = f"a {{ b }}";
+  let _ = msg
+}
+=== fixed ===
+fn main() {
+  let msg = "a { b }";
+  let _ = msg
+}


### PR DESCRIPTION
Adds autofixes for lint diagnostics, applied in bulk with `lis check --fix`, and offered as quick fixes via LSP.

For example, given:

```rs
let _ = n + 0
let _ = !!flag
total = total + 1
```

`lis check --fix` rewrites them to:

```rs
let _ = n
let _ = flag
total += 1
```

Only _safe_ fixes are applied, i.e. those that preserve both behavior and intent.

Initially, nine lints carry an autofix. Follow-ups will bring additional safe autofixes for other lints.
