### PR TITLE
feat: `lis add --replace` to substitute Go dependencies

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -43,6 +43,7 @@ pub enum Command {
     Version,
     Add {
         dependency: String,
+        replace: Option<String>,
     },
     Sync,
     Lsp,
@@ -400,22 +401,45 @@ impl Command {
 
             "version" | "--version" => Ok(Command::Version),
 
-            "add" => match arguments.next() {
-                Some(dependency) => {
-                    if let Some(extra) = arguments.next() {
+            "add" => {
+                let mut dependency = None;
+                let mut replace = None;
+
+                while let Some(arg) = arguments.next() {
+                    if arg == "--replace" {
+                        let Some(value) = arguments.next() else {
+                            return Err(ParseError::MissingArgument {
+                                command: "add",
+                                argument: "--replace <module@version>",
+                            });
+                        };
+                        replace = Some(value);
+                    } else if let Some(value) = arg.strip_prefix("--replace=") {
+                        replace = Some(value.to_string());
+                    } else if arg.starts_with('-') {
+                        return Err(ParseError::UnknownFlag(arg));
+                    } else if dependency.is_none() {
+                        dependency = Some(arg);
+                    } else {
                         return Err(ParseError::UnexpectedArgument {
-                            message: format!("unexpected argument `{}`", extra),
+                            message: format!("unexpected argument `{}`", arg),
                             reason: "`lis add` accepts a single dependency".to_string(),
                             hint: "Run `lis add` once per dep".to_string(),
                         });
                     }
-                    Ok(Command::Add { dependency })
                 }
-                None => Err(ParseError::MissingArgument {
-                    command: "add",
-                    argument: "dependency",
-                }),
-            },
+
+                match dependency {
+                    Some(dependency) => Ok(Command::Add {
+                        dependency,
+                        replace,
+                    }),
+                    None => Err(ParseError::MissingArgument {
+                        command: "add",
+                        argument: "dependency",
+                    }),
+                }
+            }
 
             "sync" => {
                 if let Some(extra) = arguments.next() {
@@ -545,6 +569,61 @@ mod tests {
     #[test]
     fn test_failed_and_filter_conflict() {
         assert!(parse(&["lis", "test", "--failed", "-f", "parse"]).is_err());
+    }
+
+    #[test]
+    fn add_without_replace_has_no_replace() {
+        let Ok(Command::Add {
+            dependency,
+            replace,
+        }) = parse(&["lis", "add", "github.com/gorilla/mux"])
+        else {
+            panic!("expected Add command");
+        };
+        assert_eq!(dependency, "github.com/gorilla/mux");
+        assert_eq!(replace, None);
+    }
+
+    #[test]
+    fn add_replace_flag_after_dependency() {
+        let Ok(Command::Add {
+            dependency,
+            replace,
+        }) = parse(&[
+            "lis",
+            "add",
+            "github.com/df-mc/dragonfly",
+            "--replace",
+            "github.com/you/dragonfly@v1.2.0",
+        ])
+        else {
+            panic!("expected Add command");
+        };
+        assert_eq!(dependency, "github.com/df-mc/dragonfly");
+        assert_eq!(replace.as_deref(), Some("github.com/you/dragonfly@v1.2.0"));
+    }
+
+    #[test]
+    fn add_replace_flag_before_dependency_and_equals_form() {
+        let Ok(Command::Add {
+            dependency,
+            replace,
+        }) = parse(&[
+            "lis",
+            "add",
+            "--replace=github.com/you/dragonfly@v1.2.0",
+            "github.com/df-mc/dragonfly",
+        ])
+        else {
+            panic!("expected Add command");
+        };
+        assert_eq!(dependency, "github.com/df-mc/dragonfly");
+        assert_eq!(replace.as_deref(), Some("github.com/you/dragonfly@v1.2.0"));
+    }
+
+    #[test]
+    fn add_replace_without_value_errors() {
+        assert!(parse(&["lis", "add", "dep", "--replace"]).is_err());
     }
 
     #[test]

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -129,9 +129,29 @@ pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> 
     let prelude_version = env!("CARGO_PKG_VERSION");
 
     let mut requires = vec![format!("\t{} v{}", PRELUDE_IMPORT_PATH, prelude_version)];
+    let mut replace_lines: Vec<String> = Vec::new();
 
     for (module_path, dep) in locator.deps() {
-        requires.push(format!("\t{} {}", module_path, dep.version));
+        match dep {
+            deps::GoDependency::Remote { version, .. } => {
+                requires.push(format!("\t{} {}", module_path, version));
+            }
+            deps::GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                ..
+            } => {
+                requires.push(format!(
+                    "\t{} {}",
+                    module_path,
+                    deps::placeholder_require_version(module_path)
+                ));
+                replace_lines.push(format!(
+                    "replace {} => {} {}",
+                    module_path, replacement_path, replacement_version
+                ));
+            }
+        }
     }
 
     let mut content = format!(
@@ -140,6 +160,10 @@ pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> 
         go_mod_version(),
         requires.join("\n"),
     );
+
+    for line in &replace_lines {
+        content.push_str(&format!("\n{}\n", line));
+    }
 
     if cfg!(debug_assertions) {
         let prelude_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../prelude");
@@ -635,6 +659,70 @@ mod tests {
     fn binary_name_uses_last_module_segment() {
         assert_eq!(binary_name("myproj", linux()), "myproj");
         assert_eq!(binary_name("github.com/u/myproj", linux()), "myproj");
+    }
+
+    fn locator_with(deps: Vec<(&str, deps::GoDependency)>) -> deps::TypedefLocator {
+        let map = deps
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        deps::TypedefLocator::new(map, None, Target::host())
+    }
+
+    #[test]
+    fn write_go_mod_emits_synthetic_require_and_replace_for_replaced_dep() {
+        let dir = tempfile::tempdir().unwrap();
+        let locator = locator_with(vec![(
+            "github.com/df-mc/dragonfly",
+            deps::GoDependency::Replaced {
+                replacement_path: "github.com/fork/dragonfly".to_string(),
+                replacement_version: "v0.0.0-20260101000000-abcdef123456".to_string(),
+                via: None,
+            },
+        )]);
+
+        write_go_mod(dir.path(), "example.com/app", &locator).unwrap();
+        let content = std::fs::read_to_string(dir.path().join("go.mod")).unwrap();
+
+        assert!(
+            content.contains("github.com/df-mc/dragonfly v0.0.0\n"),
+            "{}",
+            content
+        );
+        assert!(
+            content.contains(
+                "replace github.com/df-mc/dragonfly => github.com/fork/dragonfly v0.0.0-20260101000000-abcdef123456"
+            ),
+            "{}",
+            content
+        );
+    }
+
+    #[test]
+    fn write_go_mod_uses_major_matched_synthetic_for_v2_replaced_dep() {
+        let dir = tempfile::tempdir().unwrap();
+        let locator = locator_with(vec![(
+            "example.com/lib/v2",
+            deps::GoDependency::Replaced {
+                replacement_path: "github.com/fork/lib/v2".to_string(),
+                replacement_version: "v2.3.0".to_string(),
+                via: None,
+            },
+        )]);
+
+        write_go_mod(dir.path(), "example.com/app", &locator).unwrap();
+        let content = std::fs::read_to_string(dir.path().join("go.mod")).unwrap();
+
+        assert!(
+            content.contains("example.com/lib/v2 v2.0.0\n"),
+            "{}",
+            content
+        );
+        assert!(
+            content.contains("replace example.com/lib/v2 => github.com/fork/lib/v2 v2.3.0"),
+            "{}",
+            content
+        );
     }
 
     #[test]

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -2,12 +2,12 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use super::reconciliation::{
-    ResolvedDependency, apply_graph_to_manifest, expand_unwalked_modules,
-    rebuild_drifted_cache_entries, reconcile_module_graph, walk_typedef_cache,
+    ReplacedRoot, ReplacedRootMode, ReplacementIdentity, ResolvedDependency,
+    apply_graph_to_manifest, declared_replacements, finalize_manifest_via, reconcile_root,
 };
 use crate::go_cli;
 use crate::lock::{acquire_mutation_lock, acquire_target_lock};
-use crate::output::{print_add_success, print_preview_notice, print_progress};
+use crate::output::{print_add_success, print_preview_notice, print_progress, print_warning};
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
 use deps::GoModule;
@@ -29,9 +29,13 @@ struct ProjectContext {
     _target_lock: File,
 }
 
-pub fn add(dep_string: &str) -> i32 {
+pub fn add(dep_string: &str, replace: Option<&str>) -> i32 {
     if let Err(code) = go_cli::require_go() {
         return code;
+    }
+
+    if let Some(replace) = replace {
+        return add_replace(dep_string, replace);
     }
 
     let parsed_dep = match parse_dep_string(dep_string) {
@@ -51,29 +55,109 @@ pub fn add(dep_string: &str) -> i32 {
         Err(code) => return code,
     };
 
+    run_add_pipeline(project_ctx, resolved_dep, None)
+}
+
+/// Expand a bare `owner/repo` to `github.com/owner/repo`; keep a non-GitHub path as-is.
+fn normalize_module_path(path: &str) -> Result<String, String> {
+    if deps::is_third_party(path) {
+        Ok(path.to_string())
+    } else if path.contains('/') {
+        Ok(format!("github.com/{}", path))
+    } else {
+        Err(format!(
+            "`{}` is not a valid module path; expected something like `github.com/owner/repo`",
+            path
+        ))
+    }
+}
+
+/// `lis add <original> --replace <module>[@<version>]`: source `<original>` from another module.
+fn add_replace(original_arg: &str, replace_spec: &str) -> i32 {
+    let original = original_arg.trim();
+    if original.contains('@') {
+        cli_error!(
+            "Invalid dependency",
+            "with `--replace`, the dependency is the original module path, given without `@version`",
+            "Example: `lis add github.com/df-mc/dragonfly --replace github.com/you/dragonfly@v1.2.0`"
+        );
+        return 1;
+    }
+    let original = match normalize_module_path(original) {
+        Ok(p) => p,
+        Err(msg) => {
+            cli_error!(
+                "Invalid dependency",
+                msg,
+                "Example: `lis add github.com/df-mc/dragonfly --replace github.com/you/dragonfly@v1.2.0`"
+            );
+            return 1;
+        }
+    };
+
+    let (replace_raw, replace_query) = match replace_spec.rsplit_once('@') {
+        Some((path, version)) if !path.is_empty() && !version.is_empty() => {
+            (path.to_string(), version.to_string())
+        }
+        Some(_) => {
+            cli_error!(
+                "Invalid `--replace`",
+                format!(
+                    "`{}` is not of the form `<module>[@<version>]`",
+                    replace_spec
+                ),
+                "Example: `--replace github.com/you/dragonfly@v1.2.0`"
+            );
+            return 1;
+        }
+        None => (replace_spec.to_string(), "latest".to_string()),
+    };
+    let replacement_path = match normalize_module_path(&replace_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            cli_error!(
+                "Invalid `--replace`",
+                msg,
+                "Example: `--replace github.com/you/dragonfly@v1.2.0`"
+            );
+            return 1;
+        }
+    };
+
+    let (project_ctx, resolved_dep, replacement) =
+        match setup_project_replace(&original, &replacement_path, &replace_query) {
+            Ok(triple) => triple,
+            Err(code) => return code,
+        };
+
+    run_add_pipeline(project_ctx, resolved_dep, Some(replacement))
+}
+
+fn run_add_pipeline(
+    project_ctx: ProjectContext,
+    resolved_dep: ResolvedDependency,
+    replacement: Option<ReplacementIdentity>,
+) -> i32 {
     let workspace = GoWorkspace::new(
         &project_ctx.target_dir,
         &project_ctx.typedef_cache_dir,
         Target::host(),
     );
 
-    let mut module_graph = match reconcile_module_graph(&resolved_dep, &workspace) {
-        Ok(v) => v,
-        Err(code) => return code,
-    };
-
-    let bindgenned = match walk_typedef_cache(&resolved_dep, &workspace, &mut module_graph) {
-        Ok(v) => v,
-        Err(code) => return code,
-    };
-
-    if let Err(code) = expand_unwalked_modules(&workspace, &mut module_graph) {
-        return code;
+    let mut replacements = declared_replacements(&project_ctx.manifest);
+    match &replacement {
+        Some(replacement) => {
+            replacements.insert(resolved_dep.canonical_module.clone(), replacement.clone());
+        }
+        None => {
+            replacements.remove(&resolved_dep.canonical_module);
+        }
     }
 
-    // Expansion above may MVS-upgrade modules whose typedefs the cache walk
-    // already wrote at the old version, so refresh them at the new pin.
-    rebuild_drifted_cache_entries(&workspace, &module_graph, &bindgenned);
+    let module_graph = match reconcile_root(&resolved_dep, &workspace, &replacements) {
+        Ok(graph) => graph,
+        Err(code) => return code,
+    };
 
     let upgraded = match apply_graph_to_manifest(
         &resolved_dep.canonical_module,
@@ -82,10 +166,18 @@ pub fn add(dep_string: &str) -> i32 {
         &project_ctx.resolved_version,
         &workspace,
         &module_graph,
+        replacement.as_ref().map(|identity| ReplacedRoot {
+            identity,
+            mode: ReplacedRootMode::AddDirect,
+        }),
     ) {
         Ok(u) => u,
         Err(code) => return code,
     };
+
+    if let Err(code) = finalize_manifest_via(&project_ctx.project_root, &[]) {
+        return code;
+    }
 
     let dep_version = module_graph
         .versions
@@ -104,12 +196,17 @@ pub fn add(dep_string: &str) -> i32 {
         })
         .collect();
 
+    let replacement_label = replacement
+        .as_ref()
+        .map(|f| (f.replacement_path.as_str(), f.replacement_version.as_str()));
+
     print_add_success(
         &resolved_dep.canonical_module,
         &dep_version,
         &module_graph.edges,
         &module_graph.versions,
         &upgraded_tuples,
+        replacement_label,
     );
 
     0
@@ -215,16 +312,7 @@ fn parse_dep_string(input: &str) -> Result<ParsedDependency, String> {
         ));
     }
 
-    let requested_package = if deps::is_third_party(path) {
-        path.to_string()
-    } else if path.contains('/') {
-        format!("github.com/{}", path)
-    } else {
-        return Err(format!(
-            "`{}` is not a valid module path; expected something like `github.com/owner/repo`",
-            path
-        ));
-    };
+    let requested_package = normalize_module_path(path)?;
 
     if requested_package == PRELUDE_MODULE {
         return Err(
@@ -366,9 +454,16 @@ pub(crate) fn find_project_root() -> Option<PathBuf> {
     }
 }
 
-fn setup_project(
-    parsed_dep: ParsedDependency,
-) -> Result<(ProjectContext, ResolvedDependency), i32> {
+struct ProjectSetup {
+    project_root: PathBuf,
+    target_dir: PathBuf,
+    manifest: deps::Manifest,
+    typedef_cache_dir: PathBuf,
+    mutation_lock: File,
+    target_lock: File,
+}
+
+fn open_project_for_mutation() -> Result<ProjectSetup, i32> {
     let project_root = match find_project_root() {
         Some(root) => root,
         None => {
@@ -437,21 +532,74 @@ fn setup_project(
 
     let mutation_lock = acquire_mutation_lock(&project_target_dir)?;
     let target_lock = acquire_target_lock(&project_target_dir)?;
+    let typedef_cache_dir = deps::typedef_cache_dir(&project_root);
 
-    let locator = deps::TypedefLocator::new(
-        manifest.go_deps(),
-        Some(project_root.clone()),
-        Target::host(),
-    );
+    Ok(ProjectSetup {
+        project_root,
+        target_dir: project_target_dir,
+        manifest,
+        typedef_cache_dir,
+        mutation_lock,
+        target_lock,
+    })
+}
 
-    if let Err(msg) = go_cli::write_go_mod(&project_target_dir, &manifest.project.name, &locator) {
+/// Write `target/go.mod` from the manifest, plus one `extra` dep not yet in it.
+fn write_target_go_mod(setup: &ProjectSetup, extra: Option<(&str, deps::GoDependency)>) -> bool {
+    let mut go_deps = setup.manifest.go_deps();
+    if let Some((module, dep)) = extra {
+        go_deps.insert(module.to_string(), dep);
+    }
+    write_target_go_mod_from(setup, go_deps)
+}
+
+/// Write `target/go.mod` from an explicit dependency set.
+fn write_target_go_mod_from(
+    setup: &ProjectSetup,
+    go_deps: std::collections::BTreeMap<String, deps::GoDependency>,
+) -> bool {
+    let locator =
+        deps::TypedefLocator::new(go_deps, Some(setup.project_root.clone()), Target::host());
+    if let Err(msg) =
+        go_cli::write_go_mod(&setup.target_dir, &setup.manifest.project.name, &locator)
+    {
         error!("failed to write target/go.mod", msg);
+        return false;
+    }
+    true
+}
+
+/// Remove any declared replacement for the module that owns `package`.
+fn strip_replacement_for(
+    go_deps: &mut std::collections::BTreeMap<String, deps::GoDependency>,
+    package: &str,
+) {
+    let owner = go_deps
+        .keys()
+        .filter(|module| package == module.as_str() || package.starts_with(&format!("{module}/")))
+        .max_by_key(|module| module.len())
+        .cloned();
+    if let Some(module) = owner
+        && matches!(
+            go_deps.get(&module),
+            Some(deps::GoDependency::Replaced { .. })
+        )
+    {
+        go_deps.remove(&module);
+    }
+}
+
+fn setup_project(
+    parsed_dep: ParsedDependency,
+) -> Result<(ProjectContext, ResolvedDependency), i32> {
+    let setup = open_project_for_mutation()?;
+    let mut go_deps = setup.manifest.go_deps();
+    strip_replacement_for(&mut go_deps, &parsed_dep.requested_package);
+    if !write_target_go_mod_from(&setup, go_deps) {
         return Err(1);
     }
 
-    let typedef_cache_dir = deps::typedef_cache_dir(&project_root);
-
-    let workspace = GoWorkspace::new(&project_target_dir, &typedef_cache_dir, Target::host());
+    let workspace = GoWorkspace::new(&setup.target_dir, &setup.typedef_cache_dir, Target::host());
 
     print_progress(&format!(
         "Fetching {}@{}",
@@ -462,6 +610,7 @@ fn setup_project(
     if let Err(msg) = workspace.go_get(GoModule {
         path: &parsed_dep.requested_package,
         version: &parsed_dep.version,
+        replacement: None,
     }) {
         let enriched = enrich_with_parent_hint(&workspace, &parsed_dep.requested_package, msg);
         error!("failed to download dependency", enriched);
@@ -492,21 +641,117 @@ fn setup_project(
     };
 
     let ctx = ProjectContext {
-        project_root,
-        target_dir: project_target_dir,
-        manifest,
-        typedef_cache_dir,
+        project_root: setup.project_root,
+        target_dir: setup.target_dir,
+        manifest: setup.manifest,
+        typedef_cache_dir: setup.typedef_cache_dir,
         resolved_version: info.version,
-        _mutation_lock: mutation_lock,
-        _target_lock: target_lock,
+        _mutation_lock: setup.mutation_lock,
+        _target_lock: setup.target_lock,
     };
 
     Ok((ctx, resolved))
 }
 
+fn setup_project_replace(
+    original: &str,
+    replacement_path: &str,
+    replace_query: &str,
+) -> Result<(ProjectContext, ResolvedDependency, ReplacementIdentity), i32> {
+    let setup = open_project_for_mutation()?;
+
+    if !write_target_go_mod(&setup, None) {
+        return Err(1);
+    }
+
+    let workspace = GoWorkspace::new(&setup.target_dir, &setup.typedef_cache_dir, Target::host());
+
+    print_progress(&format!(
+        "Resolving replacement {}@{}",
+        replacement_path, replace_query
+    ));
+    let resolution = match workspace.resolve_replace(replacement_path, replace_query) {
+        Ok(r) => r,
+        Err(msg) => {
+            error!("failed to resolve replacement", msg);
+            return Err(1);
+        }
+    };
+
+    if let Err(msg) =
+        deps::check_version_matches_path(replacement_path, &resolution.resolved_version)
+    {
+        cli_error!(
+            "Replacement is not usable",
+            msg,
+            "Publish the replacement at a path whose major version matches, e.g. `<module>/vN`"
+        );
+        return Err(1);
+    }
+
+    if resolution.declared_module != original {
+        print_warning(&format!(
+            "replacement `{}@{}` declares module `{}`, not `{}`. It builds only if its own imports use `{}`",
+            replacement_path,
+            resolution.resolved_version,
+            resolution.declared_module,
+            original,
+            original
+        ));
+    }
+
+    let replaced_dep = deps::GoDependency::Replaced {
+        replacement_path: replacement_path.to_string(),
+        replacement_version: resolution.resolved_version.clone(),
+        via: None,
+    };
+    if !write_target_go_mod(&setup, Some((original, replaced_dep))) {
+        return Err(1);
+    }
+
+    let resolved = ResolvedDependency {
+        requested_package: original.to_string(),
+        canonical_module: original.to_string(),
+    };
+
+    let ctx = ProjectContext {
+        project_root: setup.project_root,
+        target_dir: setup.target_dir,
+        manifest: setup.manifest,
+        typedef_cache_dir: setup.typedef_cache_dir,
+        resolved_version: resolution.resolved_version.clone(),
+        _mutation_lock: setup.mutation_lock,
+        _target_lock: setup.target_lock,
+    };
+
+    let replacement = ReplacementIdentity {
+        replacement_path: replacement_path.to_string(),
+        replacement_version: resolution.resolved_version,
+    };
+
+    Ok((ctx, resolved, replacement))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_module_path_applies_github_shorthand() {
+        assert_eq!(
+            normalize_module_path("github.com/df-mc/dragonfly").unwrap(),
+            "github.com/df-mc/dragonfly"
+        );
+        assert_eq!(
+            normalize_module_path("df-mc/dragonfly").unwrap(),
+            "github.com/df-mc/dragonfly"
+        );
+        assert_eq!(
+            normalize_module_path("go.uber.org/zap").unwrap(),
+            "go.uber.org/zap"
+        );
+        assert!(normalize_module_path("dragonfly").is_err());
+    }
 
     #[test]
     fn returns_first_ancestor_that_resolves() {
@@ -548,5 +793,51 @@ mod tests {
         let known = ["foo", "foo/bar"];
         let parent = find_first_parent_module("foo/bar/baz/qux", 5, |p| known.contains(&p));
         assert_eq!(parent.as_deref(), Some("foo/bar"));
+    }
+
+    #[test]
+    fn strip_replacement_leaves_parent_when_child_remote_owns_package() {
+        let mut go_deps = std::collections::BTreeMap::new();
+        go_deps.insert(
+            "go.opentelemetry.io/otel".to_string(),
+            deps::GoDependency::Replaced {
+                replacement_path: "github.com/fork/otel".to_string(),
+                replacement_version: "v1.0.0".to_string(),
+                via: None,
+            },
+        );
+        go_deps.insert(
+            "go.opentelemetry.io/otel/sdk".to_string(),
+            deps::GoDependency::Remote {
+                version: "v1.0.0".to_string(),
+                via: None,
+            },
+        );
+        strip_replacement_for(&mut go_deps, "go.opentelemetry.io/otel/sdk");
+        assert!(go_deps.contains_key("go.opentelemetry.io/otel"));
+        assert!(go_deps.contains_key("go.opentelemetry.io/otel/sdk"));
+    }
+
+    #[test]
+    fn strip_replacement_removes_longest_prefix_replaced_owner() {
+        let mut go_deps = std::collections::BTreeMap::new();
+        go_deps.insert(
+            "go.opentelemetry.io/otel".to_string(),
+            deps::GoDependency::Remote {
+                version: "v1.0.0".to_string(),
+                via: None,
+            },
+        );
+        go_deps.insert(
+            "go.opentelemetry.io/otel/sdk".to_string(),
+            deps::GoDependency::Replaced {
+                replacement_path: "github.com/fork/otel-sdk".to_string(),
+                replacement_version: "v1.0.0".to_string(),
+                via: None,
+            },
+        );
+        strip_replacement_for(&mut go_deps, "go.opentelemetry.io/otel/sdk");
+        assert!(go_deps.contains_key("go.opentelemetry.io/otel"));
+        assert!(!go_deps.contains_key("go.opentelemetry.io/otel/sdk"));
     }
 }

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -63,6 +63,10 @@ fn bash_completions() -> &'static str {
             COMPREPLY=( $(compgen -W "--check" -- "$cur") )
             return 0
             ;;
+        add)
+            COMPREPLY=( $(compgen -W "--replace" -- "$cur") )
+            return 0
+            ;;
         check)
             COMPREPLY=( $(compgen -W "--errors-only --warnings-only --output" -- "$cur") )
             return 0
@@ -145,6 +149,9 @@ _lis() {
                 format)
                     _arguments '--check[Check formatting without modifying]'
                     ;;
+                add)
+                    _arguments '--replace[Source the dependency from another module]:module@version'
+                    ;;
                 check)
                     _arguments \
                         '--errors-only[Show only errors]' \
@@ -181,6 +188,7 @@ complete -c lis -n __fish_use_subcommand -a check -d 'Lint and typecheck a proje
 complete -c lis -n __fish_use_subcommand -a format -d 'Format a project'
 complete -c lis -n __fish_use_subcommand -a test -d 'Run a project\'s tests'
 complete -c lis -n __fish_use_subcommand -a add -d 'Add a third-party Go dependency'
+complete -c lis -n '__fish_seen_subcommand_from add' -l replace -d 'Source the dependency from another module'
 complete -c lis -n __fish_use_subcommand -a sync -d 'Tidy project manifest'
 complete -c lis -n __fish_use_subcommand -a version -d 'Print compiler version'
 complete -c lis -n __fish_use_subcommand -a help -d 'Show help for a command'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -183,18 +183,23 @@ Run `lis doc test` to learn how to write tests.",
         ),
 
         "add" => print_help(
-            "`lis add` <dependency> {[@version]:b}
+            "`lis add` <dependency>{[@version]:b} {[--flags]:b}
 
 Add a third-party Go module as a dependency to your Lisette project.
 
 Arguments:
     {dependency:g} {(required):d}          Go module name
 
+Options:
+    {--replace:b} {<module>:g}             Source from another module
+
 Examples:
     `lis add` {google/uuid:g}            Latest version
     `lis add` {google/uuid:g}{@v1.6.0:b}     Exact version
     `lis add` {google/uuid:g}{@2d3c2a9:b}    Exact commit hash or branch
-    `lis add` {go.uber.org/zap:g}        Full path for non-GitHub host",
+    `lis add` {go.uber.org/zap:g}        Full path for non-GitHub host
+    `lis add` {gorilla/mux:g} \\
+      {--replace:b} {you/mux:g}            Use your own fork of {gorilla/mux:g}",
         ),
 
         "sync" => print_help(

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -1,16 +1,18 @@
-//! Go dependency reconciliation engine.
+//! Go dependency reconciliation engine, shared by `lis add` and `lis sync`.
 //!
 //! The graph walk (bindgen each package, follow its imports), MVS-drift
-//! convergence, and manifest application live here, separate from the `lis add`
-//! CLI handler that drives them.
+//! convergence, replacement-closure reconciliation, and manifest application live here
+//! so neither handler owns them.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use crate::go_cli;
 use crate::output::{print_progress, print_warning};
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
-use deps::{GoModule, remove_go_dep, resolve_empty_via, trim_dead_via_parents, upsert_go_dep};
+use deps::{GoModule, resolve_empty_via, trim_dead_via_parents, upsert_go_dependency};
+use stdlib::Target;
 
 /// The dependency to reconcile, after its containing module is resolved.
 pub(crate) struct ResolvedDependency {
@@ -52,7 +54,143 @@ impl GraphResult {
     }
 }
 
-pub(crate) fn reconcile_module_graph(
+/// The replacement a `--replace` add resolves to: where its code comes from.
+#[derive(Clone)]
+pub(crate) struct ReplacementIdentity {
+    pub(crate) replacement_path: String,
+    pub(crate) replacement_version: String,
+}
+
+/// How `apply_graph_to_manifest` writes a replaced root: `AddDirect` promotes it to
+/// a direct dep, `SyncPreserveVia` keeps an existing `via` (so a replaced
+/// transitive is not silently promoted).
+pub(crate) enum ReplacedRootMode {
+    AddDirect,
+    SyncPreserveVia,
+}
+
+pub(crate) struct ReplacedRoot<'a> {
+    pub(crate) identity: &'a ReplacementIdentity,
+    pub(crate) mode: ReplacedRootMode,
+}
+
+/// Re-walk every declared replacement's closure and reconcile the manifest, for `lis sync`.
+pub(crate) fn reconcile_declared_replacements(
+    project_root: &Path,
+    target_dir: &Path,
+    manifest: &deps::Manifest,
+) -> Result<(), i32> {
+    let replaced_roots: Vec<(String, ReplacementIdentity)> = manifest
+        .go_deps()
+        .into_iter()
+        .filter_map(|(module, dep)| match dep {
+            deps::GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                ..
+            } => Some((
+                module,
+                ReplacementIdentity {
+                    replacement_path,
+                    replacement_version,
+                },
+            )),
+            deps::GoDependency::Remote { .. } => None,
+        })
+        .collect();
+
+    if replaced_roots.is_empty() {
+        return Ok(());
+    }
+
+    go_cli::require_go()?;
+
+    // Seed every declared dep so MVS picks the versions the real build sees.
+    let locator = deps::TypedefLocator::new(
+        manifest.go_deps(),
+        Some(project_root.to_path_buf()),
+        Target::host(),
+    );
+    if let Err(msg) = go_cli::write_go_mod(target_dir, &manifest.project.name, &locator) {
+        error!("failed to write target/go.mod", msg);
+        return Err(1);
+    }
+
+    let typedef_cache_dir = deps::typedef_cache_dir(project_root);
+    let workspace = GoWorkspace::new(target_dir, &typedef_cache_dir, Target::host());
+
+    // Walk all replacements before writing the manifest, so a partial failure leaves it untouched.
+    let replacements: HashMap<String, ReplacementIdentity> =
+        replaced_roots.iter().cloned().collect();
+
+    let mut walked: Vec<(String, ReplacementIdentity, GraphResult)> = Vec::new();
+    for (original, replacement) in &replaced_roots {
+        let resolved = ResolvedDependency {
+            requested_package: original.clone(),
+            canonical_module: original.clone(),
+        };
+
+        let graph = reconcile_root(&resolved, &workspace, &replacements)?;
+        walked.push((original.clone(), replacement.clone(), graph));
+    }
+
+    for (original, replacement, graph) in &walked {
+        let current = match deps::parse_manifest(project_root) {
+            Ok(m) => m,
+            Err(msg) => {
+                error!("failed to read manifest", msg);
+                return Err(1);
+            }
+        };
+        apply_graph_to_manifest(
+            original,
+            project_root,
+            &current,
+            &replacement.replacement_version,
+            &workspace,
+            graph,
+            Some(ReplacedRoot {
+                identity: replacement,
+                mode: ReplacedRootMode::SyncPreserveVia,
+            }),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// A Go resolution error that means a `replace` target is not import-compatible:
+/// its own packages do not resolve under the original module path (Go binds one
+/// module to two import paths).
+fn import_compat_hint(go_error: &str) -> Option<&'static str> {
+    go_error
+        .contains("used for two different module paths")
+        .then_some(
+            "the `replace` target is not import-compatible: keep its `module` line as the original module path so its own imports resolve",
+        )
+}
+
+/// Reconcile a root's full module graph: walk the manifest subgraph, build each
+/// package's typedefs, expand modules the walk did not reach, and rebuild any
+/// cache entry MVS drift moved to a new version. Returns the resolved graph for
+/// `apply_graph_to_manifest`, shared by `lis add` and `lis sync`.
+pub(crate) fn reconcile_root(
+    dep: &ResolvedDependency,
+    workspace: &GoWorkspace,
+    replacements: &HashMap<String, ReplacementIdentity>,
+) -> Result<GraphResult, i32> {
+    let mut graph = reconcile_module_graph(dep, workspace)?;
+    let bindgenned = walk_typedef_cache(dep, workspace, &mut graph, replacements)?;
+    expand_unwalked_modules(workspace, &mut graph)?;
+    rebuild_drifted_cache_entries(workspace, &graph, &bindgenned, replacements);
+    Ok(graph)
+}
+
+/// Manifest walk: BFS the third-party module subgraph from `dep.canonical_module`
+/// via `go list -json M/...`. Module-grained so the manifest declares every
+/// module a future subpackage import could reach; the outer loop converges
+/// MVS drift since MVS only moves upward.
+fn reconcile_module_graph(
     dep: &ResolvedDependency,
     workspace: &GoWorkspace,
 ) -> Result<GraphResult, i32> {
@@ -72,7 +210,12 @@ pub(crate) fn reconcile_module_graph(
                 Ok(v) => v,
                 Err(msg) => {
                     if is_explicit {
-                        error!("failed to resolve module version", msg);
+                        match import_compat_hint(&msg) {
+                            Some(hint) => {
+                                cli_error!("failed to resolve module version", msg, hint)
+                            }
+                            None => error!("failed to resolve module version", msg),
+                        }
                         return Err(1);
                     }
                     if failed_transitives.insert(module_path.clone()) {
@@ -97,7 +240,12 @@ pub(crate) fn reconcile_module_graph(
                 Ok(l) => l,
                 Err(msg) => {
                     if is_explicit {
-                        error!("failed to scan transitive modules", msg);
+                        match import_compat_hint(&msg) {
+                            Some(hint) => {
+                                cli_error!("failed to scan transitive modules", msg, hint)
+                            }
+                            None => error!("failed to scan transitive modules", msg),
+                        }
                         return Err(1);
                     }
                     if failed_transitives.insert(module_path.clone()) {
@@ -168,15 +316,53 @@ pub(crate) fn reconcile_module_graph(
     })
 }
 
+/// The `Replacement` a module's typedef cache is keyed by, if it is a declared replacement.
+fn replacement_for<'a>(
+    module_path: &str,
+    replacements: &'a HashMap<String, ReplacementIdentity>,
+) -> Option<deps::Replacement<'a>> {
+    replacements
+        .get(module_path)
+        .map(|identity| deps::Replacement {
+            path: &identity.replacement_path,
+            version: &identity.replacement_version,
+        })
+}
+
+/// The declared replacement redirects, keyed by original module path.
+pub(crate) fn declared_replacements(
+    manifest: &deps::Manifest,
+) -> HashMap<String, ReplacementIdentity> {
+    manifest
+        .go_deps()
+        .into_iter()
+        .filter_map(|(module, dep)| match dep {
+            deps::GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                ..
+            } => Some((
+                module,
+                ReplacementIdentity {
+                    replacement_path,
+                    replacement_version,
+                },
+            )),
+            deps::GoDependency::Remote { .. } => None,
+        })
+        .collect()
+}
+
 /// Cache walk: bindgen the requested package, then recurse into each
 /// typedef's own `go:` imports. Sibling subpackages stay cache misses for
 /// the locator to handle on first access. Returns each bindgenned
 /// `(module, version, package)` so any later MVS drift in
 /// `expand_unwalked_modules` can re-reconcile at the new pin.
-pub(crate) fn walk_typedef_cache(
+fn walk_typedef_cache(
     dep: &ResolvedDependency,
     workspace: &GoWorkspace,
     module_graph: &mut GraphResult,
+    replacements: &HashMap<String, ReplacementIdentity>,
 ) -> Result<Vec<BindgennedPackage>, i32> {
     let mut visited: HashSet<(String, String)> = HashSet::new();
     let mut queue: Vec<(String, String, String)> = Vec::new();
@@ -198,6 +384,7 @@ pub(crate) fn walk_typedef_cache(
         let module = GoModule {
             path: &module_path,
             version: &version,
+            replacement: replacement_for(&module_path, replacements),
         };
 
         match workspace.reconcile_package(module, &package_path) {
@@ -301,10 +488,11 @@ pub(crate) struct BindgennedPackage {
 }
 
 /// Re-reconcile cache entries whose module version was raised by MVS drift.
-pub(crate) fn rebuild_drifted_cache_entries(
+fn rebuild_drifted_cache_entries(
     workspace: &GoWorkspace,
     graph: &GraphResult,
     bindgenned: &[BindgennedPackage],
+    replacements: &HashMap<String, ReplacementIdentity>,
 ) {
     for entry in bindgenned {
         let Some(current) = graph.versions.get(&entry.module) else {
@@ -316,6 +504,7 @@ pub(crate) fn rebuild_drifted_cache_entries(
         let module = GoModule {
             path: &entry.module,
             version: current,
+            replacement: replacement_for(&entry.module, replacements),
         };
         match workspace.reconcile_package(module, &entry.package) {
             Ok(stubs) => warn_stubbed(&stubs),
@@ -341,10 +530,7 @@ fn warn_stubbed(stubs: &[String]) {
 /// Run the manifest walk for modules in `graph.versions` whose
 /// `find_third_party_modules` result is missing, until the graph is closed
 /// under MVS drift. Failures are warnings since these are all transitives.
-pub(crate) fn expand_unwalked_modules(
-    workspace: &GoWorkspace,
-    graph: &mut GraphResult,
-) -> Result<(), i32> {
+fn expand_unwalked_modules(workspace: &GoWorkspace, graph: &mut GraphResult) -> Result<(), i32> {
     let mut failed: HashSet<String> = HashSet::new();
 
     let mut queue: Vec<String> = graph
@@ -545,6 +731,7 @@ pub(crate) fn apply_graph_to_manifest(
     fallback_version: &str,
     workspace: &GoWorkspace,
     graph: &GraphResult,
+    replaced_root: Option<ReplacedRoot>,
 ) -> Result<Vec<DirectUpgrade>, i32> {
     let existing_deps = manifest.go_deps();
     let transitives = graph.transitive_map(added_dep);
@@ -555,7 +742,34 @@ pub(crate) fn apply_graph_to_manifest(
         .unwrap_or(fallback_version);
     let mut upgraded: Vec<DirectUpgrade> = Vec::new();
 
-    if let Err(msg) = upsert_go_dep(project_root, added_dep, added_dep_version, None) {
+    let root_result = match replaced_root {
+        Some(replaced_root) => {
+            let via = match replaced_root.mode {
+                ReplacedRootMode::SyncPreserveVia => {
+                    existing_deps.get(added_dep).and_then(|d| d.via().cloned())
+                }
+                ReplacedRootMode::AddDirect => None,
+            };
+            upsert_go_dependency(
+                project_root,
+                added_dep,
+                &deps::GoDependency::Replaced {
+                    replacement_path: replaced_root.identity.replacement_path.clone(),
+                    replacement_version: replaced_root.identity.replacement_version.clone(),
+                    via,
+                },
+            )
+        }
+        None => upsert_go_dependency(
+            project_root,
+            added_dep,
+            &deps::GoDependency::Remote {
+                version: added_dep_version.to_string(),
+                via: None,
+            },
+        ),
+    };
+    if let Err(msg) = root_result {
         error!("failed to update manifest", msg);
         return Err(1);
     }
@@ -569,27 +783,40 @@ pub(crate) fn apply_graph_to_manifest(
             None => continue,
         };
 
-        // If already a direct dep, refresh the version but keep it direct
-        if let Some(existing) = existing_deps.get(module_path.as_str())
-            && existing.via.is_none()
+        // If already a direct dep, refresh the version but keep it direct.
+        let existing = existing_deps.get(module_path.as_str());
+        if let Some(existing) = existing
+            && existing.via().is_none()
         {
-            if existing.version != version {
-                upsert_go_dep(project_root, module_path, version, None).map_err(|msg| {
+            if let deps::GoDependency::Remote {
+                version: existing_version,
+                ..
+            } = existing
+                && existing_version != version
+            {
+                upsert_go_dependency(
+                    project_root,
+                    module_path,
+                    &deps::GoDependency::Remote {
+                        version: version.to_string(),
+                        via: None,
+                    },
+                )
+                .map_err(|msg| {
                     error!("failed to update manifest", msg);
                     1
                 })?;
                 upgraded.push(DirectUpgrade {
                     path: (*module_path).clone(),
-                    old_version: existing.version.clone(),
+                    old_version: existing_version.clone(),
                     new_version: version.to_string(),
                 });
             }
             continue;
         }
 
-        let mut via: Vec<String> = existing_deps
-            .get(module_path.as_str())
-            .and_then(|d| d.via.clone())
+        let mut via: Vec<String> = existing
+            .and_then(|d| d.via().cloned())
             .unwrap_or_default()
             .into_iter()
             .filter(|p| p != added_dep)
@@ -602,7 +829,21 @@ pub(crate) fn apply_graph_to_manifest(
         }
         via.sort();
 
-        if let Err(msg) = upsert_go_dep(project_root, module_path, version, Some(via)) {
+        // A replaced transitive keeps its `replace` shape, only its `via` is reconciled.
+        let result = match existing {
+            Some(replaced @ deps::GoDependency::Replaced { .. }) => {
+                upsert_go_dependency(project_root, module_path, &replaced.with_via(Some(via)))
+            }
+            _ => upsert_go_dependency(
+                project_root,
+                module_path,
+                &deps::GoDependency::Remote {
+                    version: version.to_string(),
+                    via: Some(via),
+                },
+            ),
+        };
+        if let Err(msg) = result {
             error!("failed to update manifest", msg);
             return Err(1);
         }
@@ -616,7 +857,7 @@ pub(crate) fn apply_graph_to_manifest(
             continue;
         }
 
-        let Some(ref old_via) = dep.via else { continue };
+        let Some(old_via) = dep.via() else { continue };
 
         if !old_via.iter().any(|p| p == added_dep) {
             continue;
@@ -630,32 +871,78 @@ pub(crate) fn apply_graph_to_manifest(
         filtered.sort();
 
         if filtered.is_empty() {
-            remove_go_dep(project_root, dep_path).map_err(|msg| {
-                error!("failed to update manifest", msg);
-                1
-            })?;
+            upsert_go_dependency(project_root, dep_path, &dep.with_via(Some(Vec::new()))).map_err(
+                |msg| {
+                    error!("failed to update manifest", msg);
+                    1
+                },
+            )?;
             continue;
         }
 
-        let dep_version = workspace.query_version(dep_path).map_err(|msg| {
-            error!("failed to resolve module version", msg);
-            1
-        })?;
+        match dep {
+            deps::GoDependency::Replaced { .. } => {
+                upsert_go_dependency(project_root, dep_path, &dep.with_via(Some(filtered)))
+                    .map_err(|msg| {
+                        error!("failed to update manifest", msg);
+                        1
+                    })?;
+            }
+            deps::GoDependency::Remote { .. } => {
+                let dep_version = workspace.query_version(dep_path).map_err(|msg| {
+                    error!("failed to resolve module version", msg);
+                    1
+                })?;
+                upsert_go_dependency(
+                    project_root,
+                    dep_path,
+                    &deps::GoDependency::Remote {
+                        version: dep_version,
+                        via: Some(filtered),
+                    },
+                )
+                .map_err(|msg| {
+                    error!("failed to update manifest", msg);
+                    1
+                })?;
+            }
+        }
+    }
 
-        upsert_go_dep(project_root, dep_path, &dep_version, Some(filtered)).map_err(|msg| {
+    Ok(upgraded)
+}
+
+/// Trim dead `via` parents and promote/drop empty-`via` entries, to a fixed
+/// point (a removal can orphan another's `via`). `imported_pkgs` promotes a
+/// directly-imported transitive instead of deleting it.
+pub(crate) fn finalize_manifest_via(
+    project_root: &Path,
+    imported_pkgs: &[String],
+) -> Result<(Vec<deps::TrimmedVia>, deps::ResolveReport), i32> {
+    let mut all_trimmed = Vec::new();
+    let mut promoted = Vec::new();
+    let mut removed = Vec::new();
+
+    loop {
+        let trimmed = trim_dead_via_parents(project_root).map_err(|msg| {
             error!("failed to update manifest", msg);
             1
         })?;
+        let report = resolve_empty_via(project_root, imported_pkgs).map_err(|msg| {
+            error!("failed to update manifest", msg);
+            1
+        })?;
+
+        let changed =
+            !trimmed.is_empty() || !report.promoted.is_empty() || !report.removed.is_empty();
+        all_trimmed.extend(trimmed);
+        promoted.extend(report.promoted);
+        removed.extend(report.removed);
+
+        if !changed {
+            break;
+        }
     }
 
-    trim_dead_via_parents(project_root).map_err(|msg| {
-        error!("failed to update manifest", msg);
-        1
-    })?;
-    resolve_empty_via(project_root, &[]).map_err(|msg| {
-        error!("failed to update manifest", msg);
-        1
-    })?;
-
-    Ok(upgraded)
+    Ok((all_trimmed, deps::ResolveReport { promoted, removed }))
 }

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -4,6 +4,7 @@ use stdlib::Target;
 
 use crate::go_cli;
 use crate::handlers::add::find_project_root;
+use crate::handlers::reconciliation::{finalize_manifest_via, reconcile_declared_replacements};
 use crate::lock::{acquire_mutation_lock, acquire_target_lock};
 use crate::output::print_sync_summary;
 use crate::typedef_regen::prewarm_typedef_cache;
@@ -104,6 +105,32 @@ pub fn sync() -> i32 {
         }
     };
 
+    // Drop dead `via` entries (replaced ones included) before any go.mod write,
+    // so a stale replacement cannot poison later Go commands.
+    let (pre_trimmed, pre_report) = match finalize_manifest_via(&project_root, &scanned.all) {
+        Ok(reports) => reports,
+        Err(code) => return code,
+    };
+    let manifest = match deps::parse_manifest(&project_root) {
+        Ok(m) => m,
+        Err(msg) => {
+            error!("failed to read manifest", msg);
+            return 1;
+        }
+    };
+
+    if let Err(code) = reconcile_declared_replacements(&project_root, &target_dir, &manifest) {
+        return code;
+    }
+
+    let manifest = match deps::parse_manifest(&project_root) {
+        Ok(m) => m,
+        Err(msg) => {
+            error!("failed to read manifest", msg);
+            return 1;
+        }
+    };
+
     let mut bindgen_runner: Option<Arc<WorkspaceBindgen>> = None;
     let prewarm_result = if !scanned.non_blank.is_empty() {
         let target = Target::host();
@@ -129,26 +156,22 @@ pub fn sync() -> i32 {
         Ok(())
     };
 
-    let trimmed = match deps::trim_dead_via_parents(&project_root) {
-        Ok(t) => t,
-        Err(msg) => {
-            error!("failed to update manifest", msg);
-            return 1;
-        }
+    let (post_trimmed, post_report) = match finalize_manifest_via(&project_root, &scanned.all) {
+        Ok(reports) => reports,
+        Err(code) => return code,
     };
 
-    let report = match deps::resolve_empty_via(&project_root, &scanned.all) {
-        Ok(r) => r,
-        Err(msg) => {
-            error!("failed to update manifest", msg);
-            return 1;
-        }
-    };
+    let mut trimmed = pre_trimmed;
+    trimmed.extend(post_trimmed);
+    let mut promoted = pre_report.promoted;
+    promoted.extend(post_report.promoted);
+    let mut removed = pre_report.removed;
+    removed.extend(post_report.removed);
 
     let needs_separator = bindgen_runner
         .as_ref()
         .is_some_and(|r| r.progress_emitted());
-    print_sync_summary(&trimmed, &report.promoted, &report.removed, needs_separator);
+    print_sync_summary(&trimmed, &promoted, &removed, needs_separator);
 
     prewarm_result.err().unwrap_or(0)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -99,7 +99,10 @@ fn main() {
             handlers::help::print_version();
             0
         }
-        Command::Add { dependency } => handlers::add(&dependency),
+        Command::Add {
+            dependency,
+            replace,
+        } => handlers::add(&dependency, replace.as_deref()),
         Command::Sync => handlers::sync(),
         Command::Lsp => handlers::lsp(),
         Command::Bindgen {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -174,6 +174,7 @@ pub fn print_add_success(
     edges: &std::collections::HashMap<String, Vec<String>>,
     versions: &std::collections::HashMap<String, String>,
     upgraded_directs: &[(&str, &str, &str)],
+    replacement: Option<(&str, &str)>,
 ) {
     eprintln!();
 
@@ -194,10 +195,19 @@ pub fn print_add_success(
         eprintln!();
     }
 
-    if colored {
-        eprintln!("  ✓ Added {} {}", module_path.green(), version.blue());
-    } else {
-        eprintln!("  ✓ Added {} {}", module_path, version);
+    match replacement {
+        Some((replacement_path, replacement_version)) if colored => eprintln!(
+            "  ✓ Added {} (replaced by {} {})",
+            module_path.green(),
+            replacement_path.green(),
+            replacement_version.blue()
+        ),
+        Some((replacement_path, replacement_version)) => eprintln!(
+            "  ✓ Added {} (replaced by {} {})",
+            module_path, replacement_path, replacement_version
+        ),
+        None if colored => eprintln!("  ✓ Added {} {}", module_path.green(), version.blue()),
+        None => eprintln!("  ✓ Added {} {}", module_path, version),
     }
 
     let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();

--- a/crates/cli/src/typedef_regen.rs
+++ b/crates/cli/src/typedef_regen.rs
@@ -34,7 +34,9 @@ pub fn prewarm_typedef_cache(
             TypedefLocatorResult::UnknownStdlib | TypedefLocatorResult::UndeclaredImport => {
                 // Type-checker handles these.
             }
-            TypedefLocatorResult::MissingTypedef { module, version } => {
+            TypedefLocatorResult::MissingTypedef {
+                module, version, ..
+            } => {
                 print_warning(&format!(
                     "missing typedef for {}",
                     pkg_label(&pkg, &module, &version)

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -44,6 +44,12 @@ struct ErrorEntry {
     message: String,
 }
 
+/// A replacement's resolved version and the module path its `go.mod` declares.
+pub struct ReplaceResolution {
+    pub resolved_version: String,
+    pub declared_module: String,
+}
+
 /// Information about a Go module from `go list -m -json`.
 pub struct GoModuleInfo {
     pub path: String,
@@ -134,6 +140,39 @@ impl<'a> GoWorkspace<'a> {
             return Err(format!("`go list -m -json {}` returned no version", target));
         }
         Ok(version)
+    }
+
+    /// Resolve a replacement's exact version and the module path its `go.mod` declares.
+    pub fn resolve_replace(
+        &self,
+        replacement_path: &str,
+        query: &str,
+    ) -> Result<ReplaceResolution, String> {
+        let target = format!("{}@{}", replacement_path, query);
+        let listed = self.run_go(&["list", "-mod=mod", "-m", "-json", &target])?;
+        let listed: serde_json::Value = serde_json::from_str(&listed)
+            .map_err(|e| format!("Failed to parse Go module JSON: {}", e))?;
+        let resolved_version = listed["Version"].as_str().unwrap_or("").to_string();
+        if resolved_version.is_empty() {
+            return Err(format!("`go list -m -json {}` returned no version", target));
+        }
+        let go_mod = listed["GoMod"].as_str().unwrap_or("");
+        if go_mod.is_empty() {
+            return Err("Go did not report the replacement's go.mod path".to_string());
+        }
+
+        let edited = self.run_go(&["mod", "edit", "-json", go_mod])?;
+        let edited: serde_json::Value = serde_json::from_str(&edited)
+            .map_err(|e| format!("Failed to parse `go mod edit -json` output: {}", e))?;
+        let declared_module = edited["Module"]["Path"].as_str().unwrap_or("").to_string();
+        if declared_module.is_empty() {
+            return Err("replacement `go.mod` has no `module` directive".to_string());
+        }
+
+        Ok(ReplaceResolution {
+            resolved_version,
+            declared_module,
+        })
     }
 
     /// List all public packages in a Go module.
@@ -291,6 +330,7 @@ impl<'a> GoWorkspace<'a> {
         self.go_get(GoModule {
             path: package,
             version: module.version,
+            replacement: None,
         })?;
 
         let manifest = self.run_bindgen_batch(&[package.to_string()], BatchScope::RequestedOnly)?;
@@ -721,7 +761,9 @@ impl GoWorkspace<'_> {
         let mut written = 0;
 
         for entry in &manifest.ok {
-            let Some((module_path, version)) = locator.module_for_package(&entry.package) else {
+            let Some((module_path, version, replacement)) =
+                locator.module_for_package(&entry.package)
+            else {
                 continue;
             };
             if validate_typedef_parses(&entry.package, &entry.content).is_err() {
@@ -732,6 +774,9 @@ impl GoWorkspace<'_> {
                 module: GoModule {
                     path: &module_path,
                     version: &version,
+                    replacement: replacement
+                        .as_ref()
+                        .map(|(path, version)| deps::Replacement { path, version }),
                 },
                 package: &entry.package,
             };
@@ -818,7 +863,17 @@ fn warm_stamp_for(roots: &[String], locator: &TypedefLocator) -> String {
     let deps: Vec<String> = locator
         .deps()
         .iter()
-        .map(|(module, dep)| format!("{} {}", module, dep.version))
+        .map(|(module, dep)| {
+            let source = match dep {
+                deps::GoDependency::Remote { version, .. } => version.clone(),
+                deps::GoDependency::Replaced {
+                    replacement_path,
+                    replacement_version,
+                    ..
+                } => format!("{}@{}", replacement_path, replacement_version),
+            };
+            format!("{} {}", module, source)
+        })
         .collect();
     format!("{}\n--\n{}", roots.join("\n"), deps.join("\n"))
 }
@@ -963,6 +1018,7 @@ impl Bindgen for WorkspaceBindgen {
         let module = GoModule {
             path: pkg.module.path,
             version: pkg.module.version,
+            replacement: pkg.module.replacement,
         };
 
         match workspace.reconcile_package(module, pkg.package) {
@@ -999,6 +1055,7 @@ mod tests {
         GoModule {
             path: MODULE_PATH,
             version: MODULE_VERSION,
+            replacement: None,
         }
     }
 

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -35,7 +35,7 @@ fn typedef_home() -> Option<PathBuf> {
 pub use project_manifest::{
     GoDependency, Manifest, ResolveReport, TrimmedVia, check_no_subpackage_deps,
     check_toolchain_version, parse_manifest, remove_go_dep, resolve_empty_via,
-    trim_dead_via_parents, upsert_go_dep, validate_project_name,
+    trim_dead_via_parents, upsert_go_dependency, validate_project_name,
 };
 pub use typedef_locator::{
     Bindgen, BindgenFailure, BindgenGuard, BindgenSession, BindgenSetup, DeclarationStatus,
@@ -46,6 +46,61 @@ pub fn is_third_party(pkg: &str) -> bool {
     pkg.split('/')
         .next()
         .is_some_and(|first| first.contains('.'))
+}
+
+pub fn placeholder_require_version(module_path: &str) -> String {
+    match path_major(module_path) {
+        Some(major) => format!("v{}.0.0", major),
+        None => "v0.0.0".to_string(),
+    }
+}
+
+pub fn check_version_matches_path(module_path: &str, version: &str) -> Result<(), String> {
+    let Some(actual) = version_major(version) else {
+        return Ok(());
+    };
+    let ok = match path_major(module_path) {
+        Some(required) => actual == required,
+        None => actual <= 1,
+    };
+    if ok {
+        return Ok(());
+    }
+    let expected = match path_major(module_path) {
+        Some(required) => format!("v{}.x", required),
+        None => "v0.x or v1.x".to_string(),
+    };
+    Err(format!(
+        "version `{}` is not valid for module path `{}` (expected {})",
+        version, module_path, expected
+    ))
+}
+
+fn version_major(version: &str) -> Option<u64> {
+    version
+        .strip_prefix('v')?
+        .split(['.', '-', '+'])
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// The major a path's suffix demands: `/vN` (N >= 2), or gopkg.in `.vN` (any N).
+fn path_major(module_path: &str) -> Option<u64> {
+    let last = module_path.rsplit('/').next()?;
+    if module_path.starts_with("gopkg.in/") {
+        let (_, digits) = last.rsplit_once(".v")?;
+        return parse_major_digits(digits);
+    }
+    let digits = last.strip_prefix('v')?;
+    parse_major_digits(digits).filter(|&major| major >= 2)
+}
+
+fn parse_major_digits(digits: &str) -> Option<u64> {
+    let is_canonical = !digits.is_empty()
+        && digits.bytes().all(|b| b.is_ascii_digit())
+        && (digits.len() == 1 || !digits.starts_with('0'));
+    is_canonical.then(|| digits.parse().ok()).flatten()
 }
 
 pub fn is_stdlib(pkg: &str) -> bool {
@@ -249,12 +304,20 @@ pub fn ensure_prelude_extracted() {
     prune_stale_version_dirs(&version_dir);
 }
 
+/// The target of a replace directive: code from `path` at `version`.
+#[derive(Clone, Copy)]
+pub struct Replacement<'a> {
+    pub path: &'a str,
+    pub version: &'a str,
+}
+
 #[derive(Clone, Copy)]
 pub struct GoModule<'a> {
-    /// Module path, e.g. `github.com/gorilla/mux`.
+    /// Module path, e.g. `github.com/gorilla/mux`. For a replaced module, the original path.
     pub path: &'a str,
-    /// Module version, e.g. `v1.8.0`.
+    /// Version handed to Go commands. For a replaced module, a placeholder.
     pub version: &'a str,
+    pub replacement: Option<Replacement<'a>>,
 }
 
 /// A Go package within a module.
@@ -274,9 +337,15 @@ impl GoPackage<'_> {
     /// <project>/target/.lisette/typedefs/lis@v0.1.6/darwin_arm64/github.com/gorilla/mux@v1.8.0/middleware/middleware.d.lis
     /// ```
     pub fn typedef_path(&self, base_dir: &Path, target: Target) -> PathBuf {
-        let module_dir = base_dir
-            .join(target.cache_segment())
-            .join(format!("{}@{}", self.module.path, self.module.version));
+        let target_dir = base_dir.join(target.cache_segment());
+        let module_dir = match self.module.replacement {
+            Some(replacement) => target_dir
+                .join("replaced")
+                .join(self.module.path)
+                .join("module")
+                .join(format!("{}@{}", replacement.path, replacement.version)),
+            None => target_dir.join(format!("{}@{}", self.module.path, self.module.version)),
+        };
 
         let relative = if self.package == self.module.path {
             ""
@@ -327,6 +396,65 @@ mod tests {
         );
         assert!(completed.exists(), "the completed target dir is kept");
         assert!(other_target_tmp.exists(), "another target's temp is kept");
+    }
+
+    #[test]
+    fn typedef_path_uses_replaced_layout_keyed_by_replacement_identity() {
+        let target = Target::new("linux", "amd64");
+        let pkg = GoPackage {
+            module: GoModule {
+                path: "example.com/dragon",
+                version: "v0.0.0",
+                replacement: Some(Replacement {
+                    path: "fork.example/dragon",
+                    version: "v1.2.0",
+                }),
+            },
+            package: "example.com/dragon/server",
+        };
+        let path = pkg.typedef_path(Path::new("/base"), target);
+        assert_eq!(
+            path,
+            Path::new(
+                "/base/linux_amd64/replaced/example.com/dragon/module/fork.example/dragon@v1.2.0/server/server.d.lis"
+            )
+        );
+    }
+
+    #[test]
+    fn check_version_matches_path_enforces_major_suffix() {
+        // /vN path requires vN
+        assert!(check_version_matches_path("example.com/lib/v2", "v2.3.0").is_ok());
+        assert!(check_version_matches_path("example.com/lib/v2", "v1.0.0").is_err());
+        // gopkg.in .vN path requires vN
+        assert!(check_version_matches_path("gopkg.in/yaml.v3", "v3.1.0").is_ok());
+        assert!(check_version_matches_path("gopkg.in/yaml.v3", "v2.0.0").is_err());
+        // plain path requires v0/v1 (incl. pseudo-versions)
+        assert!(check_version_matches_path("github.com/you/mux", "v1.5.0").is_ok());
+        assert!(
+            check_version_matches_path("github.com/you/mux", "v0.0.0-20260101000000-abc").is_ok()
+        );
+        assert!(check_version_matches_path("github.com/you/mux", "v3.1.0").is_err());
+    }
+
+    #[test]
+    fn synthetic_require_version_is_major_matched() {
+        assert_eq!(
+            placeholder_require_version("github.com/df-mc/dragonfly"),
+            "v0.0.0"
+        );
+        assert_eq!(placeholder_require_version("example.com/lib/v2"), "v2.0.0");
+        assert_eq!(
+            placeholder_require_version("example.com/lib/v10"),
+            "v10.0.0"
+        );
+        assert_eq!(placeholder_require_version("example.com/lib/v1"), "v0.0.0");
+        assert_eq!(placeholder_require_version("example.com/vault"), "v0.0.0");
+        assert_eq!(placeholder_require_version("gopkg.in/yaml.v2"), "v2.0.0");
+        assert_eq!(
+            placeholder_require_version("gopkg.in/user/pkg.v3"),
+            "v3.0.0"
+        );
     }
 
     #[test]

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -30,9 +30,42 @@ pub struct Dependencies {
 }
 
 #[derive(Debug, Clone)]
-pub struct GoDependency {
-    pub version: String,
-    pub via: Option<Vec<String>>,
+pub enum GoDependency {
+    Remote {
+        version: String,
+        via: Option<Vec<String>>,
+    },
+    Replaced {
+        replacement_path: String,
+        replacement_version: String,
+        via: Option<Vec<String>>,
+    },
+}
+
+impl GoDependency {
+    pub fn via(&self) -> Option<&Vec<String>> {
+        match self {
+            GoDependency::Remote { via, .. } | GoDependency::Replaced { via, .. } => via.as_ref(),
+        }
+    }
+
+    pub fn with_via(&self, via: Option<Vec<String>>) -> GoDependency {
+        match self {
+            GoDependency::Remote { version, .. } => GoDependency::Remote {
+                version: version.clone(),
+                via,
+            },
+            GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                ..
+            } => GoDependency::Replaced {
+                replacement_path: replacement_path.clone(),
+                replacement_version: replacement_version.clone(),
+                via,
+            },
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for GoDependency {
@@ -46,38 +79,75 @@ impl<'de> Deserialize<'de> for GoDependency {
             type Value = GoDependency;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("a version string or a table with `version` and optional `via`")
+                f.write_str(
+                    "a version string, a table with `version` (and optional `via`), or a table with `replace` (and optional `via`)",
+                )
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<GoDependency, E> {
-                Ok(GoDependency {
+                Ok(GoDependency::Remote {
                     version: v.to_string(),
                     via: None,
                 })
             }
 
             fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<GoDependency, M::Error> {
-                let mut version = None;
-                let mut via = None;
+                let mut version: Option<String> = None;
+                let mut replacement: Option<String> = None;
+                let mut via: Option<Vec<String>> = None;
 
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "version" => version = Some(map.next_value()?),
+                        "replacement" => replacement = Some(map.next_value()?),
                         "via" => via = Some(map.next_value()?),
                         other => {
-                            return Err(de::Error::unknown_field(other, &["version", "via"]));
+                            return Err(de::Error::unknown_field(
+                                other,
+                                &["version", "replacement", "via"],
+                            ));
                         }
                     }
                 }
 
-                let version = version.ok_or_else(|| de::Error::missing_field("version"))?;
-
-                Ok(GoDependency { version, via })
+                match (version, replacement) {
+                    (Some(version), None) => Ok(GoDependency::Remote { version, via }),
+                    (None, Some(replacement)) => {
+                        let (replacement_path, replacement_version) =
+                            split_replacement(&replacement).map_err(de::Error::custom)?;
+                        Ok(GoDependency::Replaced {
+                            replacement_path,
+                            replacement_version,
+                            via,
+                        })
+                    }
+                    (Some(_), Some(_)) => Err(de::Error::custom(
+                        "a Go dependency cannot set both `version` and `replacement`",
+                    )),
+                    (None, None) => Err(de::Error::custom(
+                        "a Go dependency table needs either `version` or `replacement`",
+                    )),
+                }
             }
         }
 
         deserializer.deserialize_any(GoDependencyVisitor)
     }
+}
+
+/// Split a `replacement` value of the form `<module-path>@<version>` into its parts.
+fn split_replacement(replacement: &str) -> Result<(String, String), String> {
+    let err = || {
+        format!(
+            "`replacement` must be of the form `<module-path>@<version>`, got `{}`",
+            replacement
+        )
+    };
+    let (path, version) = replacement.rsplit_once('@').ok_or_else(err)?;
+    if path.is_empty() || version.is_empty() {
+        return Err(err());
+    }
+    Ok((path.to_string(), version.to_string()))
 }
 
 impl Manifest {
@@ -97,7 +167,36 @@ pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
     let content =
         strip_bom_to_str(&bytes).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))?;
 
-    toml::from_str(content).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))
+    let manifest: Manifest =
+        toml::from_str(content).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))?;
+    validate_go_dep_paths(&manifest)?;
+    Ok(manifest)
+}
+
+/// A replaced entry's key (the original module) and its `replace` target must
+/// both be third-party module paths, or resolution silently misclassifies them.
+fn validate_go_dep_paths(manifest: &Manifest) -> Result<(), String> {
+    for (key, dep) in &manifest.go_deps() {
+        let GoDependency::Replaced {
+            replacement_path, ..
+        } = dep
+        else {
+            continue;
+        };
+        if !crate::is_third_party(key) {
+            return Err(format!(
+                "`{}` in `[dependencies.go]` has a `replace` but is not a third-party module path (its first path segment needs a dot)",
+                key
+            ));
+        }
+        if !crate::is_third_party(replacement_path) {
+            return Err(format!(
+                "the `replace` target `{}` for `{}` is not a third-party module path",
+                replacement_path, key
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub fn validate_project_name(name: &str) -> Result<(), String> {
@@ -134,7 +233,7 @@ pub fn check_toolchain_version(manifest: &Manifest) -> Result<(), String> {
 
 pub fn check_no_subpackage_deps(manifest: &Manifest) -> Result<(), String> {
     let deps = manifest.go_deps();
-    let has_via = |d: &GoDependency| d.via.as_ref().is_some_and(|v| !v.is_empty());
+    let has_via = |d: &GoDependency| d.via().is_some_and(|v| !v.is_empty());
 
     for (key, dep) in &deps {
         let Some((parent, parent_dep)) = deps
@@ -201,44 +300,69 @@ fn save_manifest(
     .map_err(|e| format!("Failed to write `lisette.toml`: {}", e))
 }
 
-/// Add or update a Go dependency in `lisette.toml`.
-///
-/// ```text
-/// "github.com/gorilla/mux" = "v1.8.0"
-/// "github.com/gorilla/context" = { version = "v1.1.1", via = ["github.com/gorilla/mux"] }
-/// ```
-pub fn upsert_go_dep(
+/// Add or update a Go dependency in `lisette.toml`, written in the shape matching its variant.
+pub fn upsert_go_dependency(
     project_root: &Path,
     module_path: &str,
-    version: &str,
-    via: Option<Vec<String>>,
+    dep: &GoDependency,
 ) -> Result<(), String> {
     let path = project_root.join("lisette.toml");
     let (encoding, mut manifest) = open_manifest(&path)?;
     let go = ensure_go_deps_table(&mut manifest)?;
 
-    match via {
-        Some(mut via_list) => {
-            via_list.sort();
-            via_list.dedup();
-            let mut inline = toml_edit::InlineTable::new();
-            inline.insert("version", version.into());
-            let mut arr = toml_edit::Array::new();
-            for v in &via_list {
-                arr.push(v.as_str());
+    let via = dep.via().map(|via_list| {
+        let mut sorted = via_list.clone();
+        sorted.sort();
+        sorted.dedup();
+        sorted
+    });
+
+    match dep {
+        GoDependency::Remote { version, .. } => match via {
+            Some(via_list) => {
+                let mut inline = toml_edit::InlineTable::new();
+                inline.insert("version", version.as_str().into());
+                inline.insert("via", via_array(&via_list));
+                go.insert(
+                    module_path,
+                    toml_edit::value(toml_edit::Value::InlineTable(inline)),
+                );
             }
-            inline.insert("via", toml_edit::Value::Array(arr));
+            None => {
+                go.insert(module_path, toml_edit::value(version.as_str()));
+            }
+        },
+        GoDependency::Replaced {
+            replacement_path,
+            replacement_version,
+            ..
+        } => {
+            let mut inline = toml_edit::InlineTable::new();
+            inline.insert(
+                "replacement",
+                format!("{}@{}", replacement_path, replacement_version)
+                    .as_str()
+                    .into(),
+            );
+            if let Some(via_list) = via {
+                inline.insert("via", via_array(&via_list));
+            }
             go.insert(
                 module_path,
                 toml_edit::value(toml_edit::Value::InlineTable(inline)),
             );
         }
-        None => {
-            go.insert(module_path, toml_edit::value(version));
-        }
     }
 
     save_manifest(&path, &encoding, &manifest)
+}
+
+fn via_array(via_list: &[String]) -> toml_edit::Value {
+    let mut arr = toml_edit::Array::new();
+    for v in via_list {
+        arr.push(v.as_str());
+    }
+    toml_edit::Value::Array(arr)
 }
 
 pub fn remove_go_dep(project_root: &Path, go_dep_path: &str) -> Result<(), String> {
@@ -277,7 +401,7 @@ pub fn trim_dead_via_parents(project_root: &Path) -> Result<Vec<TrimmedVia>, Str
     let mut trimmed = Vec::new();
 
     for (dep_path, dep) in &live_deps {
-        let Some(ref via) = dep.via else { continue };
+        let Some(via) = dep.via() else { continue };
 
         let removed_parents: Vec<String> = via
             .iter()
@@ -297,7 +421,7 @@ pub fn trim_dead_via_parents(project_root: &Path) -> Result<Vec<TrimmedVia>, Str
         canonical.sort();
         canonical.dedup();
 
-        upsert_go_dep(project_root, dep_path, &dep.version, Some(canonical))?;
+        upsert_go_dependency(project_root, dep_path, &dep.with_via(Some(canonical)))?;
         trimmed.push(TrimmedVia {
             module_path: dep_path.clone(),
             removed_parents,
@@ -332,13 +456,13 @@ pub fn resolve_empty_via(
     let mut removed = Vec::new();
 
     for (dep_path, dep) in &live_deps {
-        let Some(ref via) = dep.via else { continue };
+        let Some(via) = dep.via() else { continue };
         if !via.is_empty() {
             continue;
         }
 
         if matched.contains(dep_path.as_str()) {
-            upsert_go_dep(project_root, dep_path, &dep.version, None)?;
+            upsert_go_dependency(project_root, dep_path, &dep.with_via(None))?;
             promoted.push(dep_path.clone());
         } else {
             remove_go_dep(project_root, dep_path)?;
@@ -520,14 +644,14 @@ version = "0.1.0"
         let mut deps = BTreeMap::new();
         deps.insert(
             "k8s.io".to_string(),
-            GoDependency {
+            GoDependency::Remote {
                 version: "v0.0.0".to_string(),
                 via: None,
             },
         );
         deps.insert(
             "k8s.io/api".to_string(),
-            GoDependency {
+            GoDependency::Remote {
                 version: "v0.30.0".to_string(),
                 via: None,
             },
@@ -555,6 +679,126 @@ version = "0.1.0"
         let error = check_no_subpackage_deps(&manifest).unwrap_err();
         assert!(error.contains("`github.com/gorilla/mux/middleware`"));
         assert!(error.contains("subpackage of `github.com/gorilla/mux`"));
+    }
+
+    fn replacement_manifest(entry: &str) -> TempDir {
+        project_with(&format!(
+            "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies.go]\n{}\n",
+            entry
+        ))
+    }
+
+    #[test]
+    fn parses_replacement_entry() {
+        let dir = replacement_manifest(
+            r#""github.com/df-mc/dragonfly" = { replacement = "github.com/fork/dragonfly@v1.2.0" }"#,
+        );
+        let manifest = parse_manifest(dir.path()).unwrap();
+        match &manifest.go_deps()["github.com/df-mc/dragonfly"] {
+            GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                via,
+            } => {
+                assert_eq!(replacement_path, "github.com/fork/dragonfly");
+                assert_eq!(replacement_version, "v1.2.0");
+                assert!(via.is_none());
+            }
+            other => panic!("expected Replaced, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_replacement_with_via() {
+        let dir = replacement_manifest(
+            r#""github.com/df-mc/dragonfly" = { replacement = "github.com/fork/dragonfly@v0.0.0-20260101000000-abcdef123456", via = ["github.com/x/y"] }"#,
+        );
+        let manifest = parse_manifest(dir.path()).unwrap();
+        match &manifest.go_deps()["github.com/df-mc/dragonfly"] {
+            GoDependency::Replaced {
+                replacement_version,
+                via,
+                ..
+            } => {
+                assert_eq!(replacement_version, "v0.0.0-20260101000000-abcdef123456");
+                assert_eq!(
+                    via.as_deref(),
+                    Some(["github.com/x/y".to_string()].as_slice())
+                );
+            }
+            other => panic!("expected Replaced, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_replacement_without_version() {
+        let dir = replacement_manifest(
+            r#""github.com/df-mc/dragonfly" = { replacement = "github.com/fork/dragonfly" }"#,
+        );
+        let error = parse_manifest(dir.path()).unwrap_err();
+        assert!(error.contains("<module-path>@<version>"), "{}", error);
+    }
+
+    #[test]
+    fn rejects_replacement_with_non_third_party_key() {
+        let dir =
+            replacement_manifest(r#""dragon" = { replacement = "fork.example/dragon@v1.2.0" }"#);
+        let error = parse_manifest(dir.path()).unwrap_err();
+        assert!(error.contains("not a third-party module path"), "{}", error);
+    }
+
+    #[test]
+    fn rejects_replacement_with_non_third_party_replacement_path() {
+        let dir =
+            replacement_manifest(r#""example.com/dragon" = { replacement = "localfork@v1.2.0" }"#);
+        let error = parse_manifest(dir.path()).unwrap_err();
+        assert!(
+            error.contains("`localfork`") && error.contains("not a third-party"),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn rejects_both_version_and_replacement() {
+        let dir = replacement_manifest(
+            r#""github.com/df-mc/dragonfly" = { version = "v1.0.0", replacement = "github.com/fork/dragonfly@v1.2.0" }"#,
+        );
+        let error = parse_manifest(dir.path()).unwrap_err();
+        assert!(
+            error.contains("both `version` and `replacement`"),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn upsert_go_dependency_round_trips_replacement_shape() {
+        let dir = replacement_manifest("");
+        upsert_go_dependency(
+            dir.path(),
+            "github.com/df-mc/dragonfly",
+            &GoDependency::Replaced {
+                replacement_path: "github.com/fork/dragonfly".to_string(),
+                replacement_version: "v1.2.0".to_string(),
+                via: Some(vec!["github.com/x/y".to_string()]),
+            },
+        )
+        .unwrap();
+        let after = manifest_text(&dir);
+        assert!(
+            after.contains(
+                r#""github.com/df-mc/dragonfly" = { replacement = "github.com/fork/dragonfly@v1.2.0", via = ["github.com/x/y"] }"#
+            ),
+            "{}",
+            after
+        );
+
+        let reparsed = parse_manifest(dir.path()).unwrap();
+        assert!(matches!(
+            reparsed.go_deps()["github.com/df-mc/dragonfly"],
+            GoDependency::Replaced { .. }
+        ));
     }
 
     #[test]

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -11,6 +11,9 @@ use crate::project_manifest::{
 };
 use crate::{GoModule, GoPackage, typedef_cache_dir};
 
+/// `(module path, version to hand Go, optional (replacement path, version))`.
+type ResolvedModule = (String, String, Option<(String, String)>);
+
 #[derive(Debug)]
 pub enum TypedefLocatorResult {
     Found {
@@ -22,7 +25,11 @@ pub enum TypedefLocatorResult {
     /// Has a domain-style path but is not declared in the manifest.
     UndeclaredImport,
     /// Declared in the manifest but no `.d.lis` on disk and no bindgen runner.
-    MissingTypedef { module: String, version: String },
+    MissingTypedef {
+        module: String,
+        version: String,
+        replacement_path: Option<String>,
+    },
     /// Typedef file exists but could not be read.
     UnreadableTypedef { path: PathBuf, error: String },
     /// The bindgen runner ran on cache miss but failed.
@@ -47,7 +54,15 @@ pub enum BindgenFailure {
 #[derive(Debug)]
 pub enum DeclarationStatus {
     Stdlib,
-    DeclaredThirdParty { module: String, version: String },
+    DeclaredThirdParty {
+        module: String,
+        version: String,
+    },
+    DeclaredReplacement {
+        module: String,
+        replacement_path: String,
+        replacement_version: String,
+    },
     UnknownStdlib,
     UndeclaredImport,
 }
@@ -166,11 +181,27 @@ impl TypedefLocator {
         find_module_for_pkg(&self.deps, package_path).is_some()
     }
 
-    /// Resolve a `go:` package path to its declared module path and version by
-    /// longest declared prefix, or `None` if no declared module contains it.
-    pub fn module_for_package(&self, package_path: &str) -> Option<(String, String)> {
-        find_module_for_pkg(&self.deps, package_path)
-            .map(|(module, dep)| (module.to_string(), dep.version.clone()))
+    /// Resolve a `go:` package path to its declared module, the version to hand
+    /// Go, and its replacement if any, by longest declared prefix. `None` if no
+    /// declared module contains it.
+    pub fn module_for_package(&self, package_path: &str) -> Option<ResolvedModule> {
+        let (module, dep) = find_module_for_pkg(&self.deps, package_path)?;
+        let module = module.to_string();
+        Some(match dep {
+            GoDependency::Remote { version, .. } => (module, version.clone(), None),
+            GoDependency::Replaced {
+                replacement_path,
+                replacement_version,
+                ..
+            } => {
+                let synthetic = crate::placeholder_require_version(&module);
+                (
+                    module,
+                    synthetic,
+                    Some((replacement_path.clone(), replacement_version.clone())),
+                )
+            }
+        })
     }
 
     /// Classify a `go:` import path without touching the cache or bindgen.
@@ -187,9 +218,23 @@ impl TypedefLocator {
         }
 
         match find_module_for_pkg(&self.deps, package_path) {
-            Some((module_path, dep)) => DeclarationStatus::DeclaredThirdParty {
+            Some((module_path, GoDependency::Remote { version, .. })) => {
+                DeclarationStatus::DeclaredThirdParty {
+                    module: module_path.to_string(),
+                    version: version.clone(),
+                }
+            }
+            Some((
+                module_path,
+                GoDependency::Replaced {
+                    replacement_path,
+                    replacement_version,
+                    ..
+                },
+            )) => DeclarationStatus::DeclaredReplacement {
                 module: module_path.to_string(),
-                version: dep.version.clone(),
+                replacement_path: replacement_path.clone(),
+                replacement_version: replacement_version.clone(),
             },
             None => DeclarationStatus::UndeclaredImport,
         }
@@ -197,7 +242,7 @@ impl TypedefLocator {
 
     /// Resolve a `go:` package: stdlib -> on-disk cache -> bindgen runner if set.
     pub fn find_typedef_content(&self, package_path: &str) -> TypedefLocatorResult {
-        let (module_path, version) = match self.classify(package_path) {
+        let (module_path, version, replacement) = match self.classify(package_path) {
             DeclarationStatus::Stdlib => {
                 let source = stdlib::get_go_stdlib_typedef(package_path, self.target)
                     .expect("Stdlib classification implies an embedded typedef");
@@ -214,13 +259,33 @@ impl TypedefLocator {
             }
             DeclarationStatus::UnknownStdlib => return TypedefLocatorResult::UnknownStdlib,
             DeclarationStatus::UndeclaredImport => return TypedefLocatorResult::UndeclaredImport,
-            DeclarationStatus::DeclaredThirdParty { module, version } => (module, version),
+            DeclarationStatus::DeclaredThirdParty { module, version } => (module, version, None),
+            DeclarationStatus::DeclaredReplacement {
+                module,
+                replacement_path,
+                replacement_version,
+            } => {
+                let synthetic = crate::placeholder_require_version(&module);
+                (
+                    module,
+                    synthetic,
+                    Some((replacement_path, replacement_version)),
+                )
+            }
         };
+
+        let display_version = match &replacement {
+            Some((_, replacement_version)) => replacement_version.clone(),
+            None => version.clone(),
+        };
+
+        let replacement_path = replacement.as_ref().map(|(path, _)| path.clone());
 
         let Some(project_root) = &self.project_root else {
             return TypedefLocatorResult::MissingTypedef {
                 module: module_path,
-                version,
+                version: display_version,
+                replacement_path,
             };
         };
 
@@ -228,6 +293,9 @@ impl TypedefLocator {
             module: GoModule {
                 path: &module_path,
                 version: &version,
+                replacement: replacement
+                    .as_ref()
+                    .map(|(path, version)| crate::Replacement { path, version }),
             },
             package: package_path,
         };
@@ -246,7 +314,8 @@ impl TypedefLocator {
             ReadOutcome::Missing => match &self.bindgen {
                 None => TypedefLocatorResult::MissingTypedef {
                     module: module_path,
-                    version,
+                    version: display_version,
+                    replacement_path,
                 },
                 Some(runner) => match runner.run(&pkg) {
                     Ok(()) => match read_typedef(&typedef_path) {
@@ -260,7 +329,7 @@ impl TypedefLocator {
                         },
                         ReadOutcome::Missing => TypedefLocatorResult::BindgenFailed {
                             module: module_path,
-                            version,
+                            version: display_version,
                             package: package_path.to_string(),
                             kind: BindgenFailure::InvocationFailed {
                                 stderr: format!(
@@ -272,7 +341,7 @@ impl TypedefLocator {
                     },
                     Err(kind) => TypedefLocatorResult::BindgenFailed {
                         module: module_path,
-                        version,
+                        version: display_version,
                         package: package_path.to_string(),
                         kind,
                     },
@@ -293,5 +362,41 @@ fn read_typedef(path: &Path) -> ReadOutcome {
         Ok(s) => ReadOutcome::Found(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReadOutcome::Missing,
         Err(e) => ReadOutcome::Unreadable(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn replace_diagnostic_shows_replacement_version_not_synthetic() {
+        let mut deps = BTreeMap::new();
+        deps.insert(
+            "github.com/df-mc/dragonfly".to_string(),
+            GoDependency::Replaced {
+                replacement_path: "github.com/you/dragonfly".to_string(),
+                replacement_version: "v1.9.0".to_string(),
+                via: None,
+            },
+        );
+        let locator = TypedefLocator::new(deps, None, Target::host());
+
+        match locator.find_typedef_content("github.com/df-mc/dragonfly") {
+            TypedefLocatorResult::MissingTypedef {
+                module,
+                version,
+                replacement_path,
+            } => {
+                assert_eq!(module, "github.com/df-mc/dragonfly");
+                assert_eq!(version, "v1.9.0");
+                assert_eq!(
+                    replacement_path.as_deref(),
+                    Some("github.com/you/dragonfly")
+                );
+            }
+            other => panic!("expected MissingTypedef, got {:?}", other),
+        }
     }
 }

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -120,13 +120,33 @@ pub fn undeclared_go_import(go_pkg: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn undeclared_go_import_via_replace(
+    go_pkg: &str,
+    replaced_module: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Undeclared Go dependency")
+        .with_resolve_code("undeclared_go_import")
+        .with_span_label(&span, "not in lisette.toml")
+        .with_help(format!(
+            "`{}` is a dependency of the replaced module `{}`. Run `lis sync` to reconcile the replacement's dependencies, or `lis add {}` to add it directly",
+            go_pkg, replaced_module, go_pkg
+        ))
+}
+
 pub fn missing_go_typedef(
     go_pkg: &str,
     module: &str,
     version: &str,
+    replacement_path: Option<&str>,
     span: Span,
 ) -> LisetteDiagnostic {
-    let help = if go_pkg == module {
+    let help = if let Some(replacement_path) = replacement_path {
+        format!(
+            "Module `{}` is sourced via `replace` from `{}@{}` but has no typedef. Run `lis sync` to regenerate it.",
+            module, replacement_path, version
+        )
+    } else if go_pkg == module {
         format!(
             "Module `{}` {} is declared but no typedef was found. Run `lis check` to regenerate all typedefs, or `lis add {}@{}` to regenerate this one.",
             module, version, module, version

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1090,6 +1090,7 @@ async fn goto_definition_on_third_party_go_function_navigates_to_cache() {
         module: deps::GoModule {
             path: "github.com/example/lib",
             version: "v1.0.0",
+            replacement: None,
         },
         package: "github.com/example/lib",
     };

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 use rustc_hash::FxHashMap as HashMap;
 
 use deps::TypedefLocator;
+
+use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use syntax::ast::{
     Annotation, Attribute, AttributeArg, Binding, EnumVariant, Expression, Generic, Span,
     StructKind, Visibility as SyntacticVisibility,
@@ -303,6 +305,13 @@ impl TaskState<'_> {
 
         let imports = file.imports();
 
+        let replace_importer = module_id.strip_prefix("go:").filter(|pkg| {
+            matches!(
+                locator.validate_declaration(pkg),
+                deps::DeclarationStatus::DeclaredReplacement { .. }
+            )
+        });
+
         for import in &imports {
             if let Some(go_pkg) = import.name.strip_prefix("go:") {
                 if matches!(import.alias, Some(syntax::ast::ImportAlias::Blank(_))) {
@@ -326,13 +335,16 @@ impl TaskState<'_> {
                         );
                     }
                     other => {
-                        crate::diagnostics::emit_for_locator_result(
+                        emit_for_locator_result(
                             &other,
-                            &import.name,
-                            go_pkg,
-                            Some(import.name_span),
-                            locator.target(),
-                            false,
+                            &GoImportSite {
+                                import_name: &import.name,
+                                go_pkg,
+                                name_span: Some(import.name_span),
+                                target: locator.target(),
+                                standalone_mode: false,
+                                replace_importer,
+                            },
                             self.sink,
                         );
                     }

--- a/crates/semantics/src/diagnostics.rs
+++ b/crates/semantics/src/diagnostics.rs
@@ -3,15 +3,30 @@ use diagnostics::LocalSink;
 use stdlib::Target;
 use syntax::ast::Span;
 
+/// The import site a typedef-resolution diagnostic refers to.
+pub struct GoImportSite<'a> {
+    pub import_name: &'a str,
+    pub go_pkg: &'a str,
+    pub name_span: Option<Span>,
+    pub target: Target,
+    pub standalone_mode: bool,
+    /// Set when reached through a replaced module's typedef, so the hint points at `lis sync`.
+    pub replace_importer: Option<&'a str>,
+}
+
 pub fn emit_for_locator_result(
     result: &TypedefLocatorResult,
-    import_name: &str,
-    go_pkg: &str,
-    name_span: Option<Span>,
-    target: Target,
-    standalone_mode: bool,
+    site: &GoImportSite,
     sink: &LocalSink,
 ) -> bool {
+    let GoImportSite {
+        import_name,
+        go_pkg,
+        name_span,
+        target,
+        standalone_mode,
+        replace_importer,
+    } = *site;
     let span = name_span.unwrap_or_else(|| Span::new(0, 0, 0));
     match result {
         TypedefLocatorResult::Found { .. } => return true,
@@ -19,11 +34,26 @@ pub fn emit_for_locator_result(
             emit_unknown_stdlib(import_name, go_pkg, span, target, standalone_mode, sink);
         }
         TypedefLocatorResult::UndeclaredImport => {
-            emit_undeclared(import_name, go_pkg, span, standalone_mode, sink);
+            emit_undeclared(
+                import_name,
+                go_pkg,
+                span,
+                standalone_mode,
+                replace_importer,
+                sink,
+            );
         }
-        TypedefLocatorResult::MissingTypedef { module, version } => {
+        TypedefLocatorResult::MissingTypedef {
+            module,
+            version,
+            replacement_path,
+        } => {
             sink.push(diagnostics::module_graph::missing_go_typedef(
-                go_pkg, module, version, span,
+                go_pkg,
+                module,
+                version,
+                replacement_path.as_deref(),
+                span,
             ));
         }
         TypedefLocatorResult::UnreadableTypedef { path, error } => {
@@ -63,7 +93,9 @@ pub fn emit_for_declaration_status(
     sink: &LocalSink,
 ) -> bool {
     match status {
-        DeclarationStatus::Stdlib | DeclarationStatus::DeclaredThirdParty { .. } => true,
+        DeclarationStatus::Stdlib
+        | DeclarationStatus::DeclaredThirdParty { .. }
+        | DeclarationStatus::DeclaredReplacement { .. } => true,
         DeclarationStatus::UnknownStdlib => {
             emit_unknown_stdlib(
                 import_name,
@@ -76,7 +108,7 @@ pub fn emit_for_declaration_status(
             false
         }
         DeclarationStatus::UndeclaredImport => {
-            emit_undeclared(import_name, go_pkg, name_span, standalone_mode, sink);
+            emit_undeclared(import_name, go_pkg, name_span, standalone_mode, None, sink);
             false
         }
     }
@@ -113,6 +145,7 @@ fn emit_undeclared(
     go_pkg: &str,
     span: Span,
     standalone_mode: bool,
+    replace_importer: Option<&str>,
     sink: &LocalSink,
 ) {
     if standalone_mode {
@@ -122,6 +155,12 @@ fn emit_undeclared(
             false,
             true,
             None,
+        ));
+    } else if let Some(replaced_module) = replace_importer {
+        sink.push(diagnostics::module_graph::undeclared_go_import_via_replace(
+            go_pkg,
+            replaced_module,
+            span,
         ));
     } else {
         sink.push(diagnostics::module_graph::undeclared_go_import(

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -18,7 +18,7 @@ use crate::cache::{
 };
 use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
-use crate::diagnostics::emit_for_locator_result;
+use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use crate::facts::{BindingIdAllocator, Facts};
 use crate::loader::Loader;
 use crate::module_graph::build_module_graph;
@@ -391,11 +391,14 @@ fn register_go_module(
         other => {
             emit_for_locator_result(
                 &other,
-                module_id,
-                go_pkg,
-                None,
-                locator.target(),
-                standalone_mode,
+                &GoImportSite {
+                    import_name: module_id,
+                    go_pkg,
+                    name_span: None,
+                    target: locator.target(),
+                    standalone_mode,
+                    replace_importer: None,
+                },
                 sink,
             );
         }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -6,7 +6,7 @@ use deps::TypedefLocator;
 use syntax::ast::{ImportAlias, Span};
 use syntax::program::File;
 
-use crate::diagnostics::{emit_for_declaration_status, emit_for_locator_result};
+use crate::diagnostics::{GoImportSite, emit_for_declaration_status, emit_for_locator_result};
 use crate::loader as semantics_loader;
 use crate::loader::Loader;
 use crate::store::Store;
@@ -345,11 +345,14 @@ fn process_file_imports(
                 let result = locator.find_typedef_content(go_pkg);
                 emit_for_locator_result(
                     &result,
-                    &file_import.name,
-                    go_pkg,
-                    Some(file_import.name_span),
-                    locator.target(),
-                    standalone_mode,
+                    &GoImportSite {
+                        import_name: &file_import.name,
+                        go_pkg,
+                        name_span: Some(file_import.name_span),
+                        target: locator.target(),
+                        standalone_mode,
+                        replace_importer: None,
+                    },
                     sink,
                 )
             };

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -391,6 +391,29 @@ To remove a dependency:
 - Delete the entry from `lisette.toml`
 - Run `lis sync`
 
+### Replacing a dependency
+
+The `--replace` flag adds a dependency under its usual name but sources it from a different module. This is how Lisette exposes Go's [replace directive](https://go.dev/ref/mod#go-mod-file-replace). Use this flag to source a dependency from a fork, to override a version another dependency pulls in, or to redirect to a mirror.
+
+```sh
+lis add gorilla/mux --replace you/mux
+```
+
+The replacement is recorded in the manifest:
+
+```toml
+[dependencies.go]
+"github.com/gorilla/mux" = { replacement = "github.com/you/mux@v1.9.0" }
+```
+
+The substitution is transparent to your code:
+
+```rs
+import "go:github.com/gorilla/mux"
+```
+
+To undo the replacement, re-add the dependency without `--replace`.
+
 <br>
 
 <table><tr>

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -122,7 +122,7 @@ pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLoc
     let mut go_deps = std::collections::BTreeMap::new();
     go_deps.insert(
         module_path.to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: version.to_string(),
             via: None,
         },

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -271,7 +271,7 @@ fn graph_declared_dep_missing_typedef() {
     let mut go_deps = BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: "v1.8.0".to_string(),
             via: None,
         },
@@ -321,7 +321,7 @@ fn graph_subpackage_missing_typedef_points_at_add() {
     let mut go_deps = BTreeMap::new();
     go_deps.insert(
         "k8s.io/api".to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: "v0.30.0".to_string(),
             via: None,
         },
@@ -497,7 +497,7 @@ fn resolver_root_vs_subpackage_typedef_lookup() {
     let mut go_deps = BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: "v1.8.0".to_string(),
             via: None,
         },
@@ -551,7 +551,7 @@ fn third_party_go_struct_impl_methods_registered() {
     let mut go_deps = std::collections::BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: "v1.8.0".to_string(),
             via: None,
         },
@@ -641,7 +641,7 @@ fn stdlib_cache_save_load_excludes_third_party() {
     let mut go_deps = std::collections::BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
-        deps::GoDependency {
+        deps::GoDependency::Remote {
             version: "v1.8.0".to_string(),
             via: None,
         },


### PR DESCRIPTION
Introduces `lis add --replace`, which sources a Go dependency from a different module while your code keeps importing the original path, based on Go's [`replace`](https://go.dev/ref/mod#go-mod-file-replace) directive. Use it to swap in a fork, pin a version to dodge a broken release, or redirect to a mirror.

```sh
lis add github.com/gorilla/mux --replace github.com/you/mux
```

The redirect is recorded in the manifest as: 

```toml
"github.com/gorilla/mux" = { replacement = "github.com/you/mux@v1.9.0" }
```

Re-adding the dependency without `--replace` reverts this.

Close #859
