### PR TITLE
fix: missing write-back for bare-statement slice append/extend

### DIFF
--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -223,6 +223,9 @@ impl Planner<'_> {
         }
 
         if let Expression::Call { .. } = unwrapped {
+            if let Some(statements) = self.lower_append_statement_writeback(unwrapped) {
+                return statements;
+            }
             let mut statements: Vec<LoweredStatement> = Vec::new();
             if let Some(raw) = self.emit_go_call_discarded(&mut statements, unwrapped) {
                 statements.push(LoweredStatement::RawGo(format!("{}\n", raw)));
@@ -546,6 +549,52 @@ impl Planner<'_> {
         };
 
         statements.push(simple_assign(var, ValuePlan::Operand(value)));
+        Some(statements)
+    }
+
+    fn lower_append_statement_writeback(
+        &mut self,
+        expression: &Expression,
+    ) -> Option<Vec<LoweredStatement>> {
+        let Expression::Call {
+            expression: func,
+            args,
+            spread,
+            ..
+        } = expression
+        else {
+            return None;
+        };
+        if !self.is_slice_append_or_extend(func) {
+            return None;
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = func.as_ref()
+        else {
+            return None;
+        };
+        let unwrapped = receiver.unwrap_parens();
+        if !is_lvalue_chain(unwrapped) || self.contains_newtype_access(unwrapped) {
+            return None;
+        }
+
+        let is_extend = member == "extend";
+        let (args_setup, args_str) =
+            self.lower_append_args(func, args, (**spread).as_ref(), is_extend);
+        let rhs_has_setup = !args_setup.is_empty()
+            || args.iter().any(contains_call)
+            || (**spread).as_ref().is_some_and(contains_call);
+
+        let mut statements: Vec<LoweredStatement> = Vec::new();
+        let receiver_lv = self.emit_left_value_capturing(&mut statements, unwrapped, rhs_has_setup);
+        statements.extend(args_setup);
+        statements.push(simple_assign(
+            &receiver_lv,
+            ValuePlan::Operand(format!("append({}, {})", receiver_lv, args_str)),
+        ));
         Some(statements)
     }
 

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -3297,6 +3297,18 @@ fn main() {
 }
 
 #[test]
+fn append_bare_statement_writes_back_to_local() {
+    let input = r#"
+fn main() {
+  let mut items: Slice<int> = []
+  items.append(1)
+  let _ = items
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn ref_call_field_assignment() {
     let input = r#"
 struct Item { x: int }

--- a/tests/spec/emit/snapshots/append_bare_statement_writes_back_to_local.snap
+++ b/tests/spec/emit/snapshots/append_bare_statement_writes_back_to_local.snap
@@ -2,28 +2,16 @@
 source: tests/spec/emit/expressions.rs
 description: |
   
-  fn bump(i: Ref<int>) -> int {
-    i.* = 1
-    10
-  }
-  
   fn main() {
-    let mut i = 0
     let mut items: Slice<int> = []
-    items.append(i, bump(&i))
+    items.append(1)
     let _ = items
   }
 ---
 package main
 
-func bump(i *int) int {
-	*i = 1
-	return 10
-}
-
 func main() {
-	i := 0
 	items := ([]int)(nil)
-	items = append(items, i, bump(&i))
+	items = append(items, 1)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
@@ -32,6 +32,6 @@ func arg() int {
 }
 
 func main() {
-	recv_1 := *get()
-	_ = append(recv_1, arg())
+	ref_1 := get()
+	*ref_1 = append(*ref_1, arg())
 }

--- a/tests/spec/emit/snapshots/ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_slice_append_expr_position.snap
@@ -13,5 +13,5 @@ package main
 func main() {
 	s := []int{1}
 	r := &s
-	_ = append(*r, 2)
+	*r = append(*r, 2)
 }

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -15,7 +15,6 @@ func noop() {}
 
 func test() {
 	xs := ([]struct{})(nil)
-	_arg_1 := xs
 	noop()
-	_ = append(_arg_1, struct{}{})
+	xs = append(xs, struct{}{})
 }


### PR DESCRIPTION
Calling `.append()` or `.extend()` on a `Slice` as a standalone statement now grows the slice, instead of silently discarding the result. I'll be adding e2e tests for all prelude methods to prevent issues like this in future.