### PR TITLE
refactor: accept integer literals in type argument position

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -119,6 +119,9 @@ fn annotation_to_string(ann: &Annotation) -> String {
                 .join(", ");
             format!("({})", inner)
         }
+        Annotation::Constant { value, text, .. } => {
+            text.clone().unwrap_or_else(|| value.to_string())
+        }
         Annotation::Unknown => "Unknown".to_string(),
         Annotation::Opaque { .. } => String::new(),
     }

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -219,6 +219,13 @@ pub fn value_in_type_position(
     diag
 }
 
+pub fn integer_in_type_position(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Integer in type position")
+        .with_infer_code("integer_in_type_position")
+        .with_span_label(&span, "expected a type, found an integer literal")
+        .with_help("Integer literals are not valid type arguments.")
+}
+
 pub fn undeclared_impl_type_param(
     type_name: &str,
     annotation_span: Span,

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -535,6 +535,9 @@ impl<'a> Formatter<'a> {
                     .append(join(elem_docs, Document::str(", ")))
                     .append(")")
             }
+            Annotation::Constant { value, text, .. } => {
+                Document::string(text.clone().unwrap_or_else(|| value.to_string()))
+            }
             Annotation::Opaque { .. } => Document::Sequence(vec![]),
         }
     }

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -230,7 +230,7 @@ pub(crate) fn resolve_annotation_definition(
             .find_map(recurse)
             .or_else(|| recurse(return_type.as_ref())),
         Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),
-        Annotation::Unknown | Annotation::Opaque { .. } => None,
+        Annotation::Unknown | Annotation::Opaque { .. } | Annotation::Constant { .. } => None,
     }
 }
 

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -85,7 +85,7 @@ fn resolve_annotation_hover(
             .find_map(recurse)
             .or_else(|| recurse(return_type.as_ref())),
         Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),
-        Annotation::Unknown | Annotation::Opaque { .. } => None,
+        Annotation::Unknown | Annotation::Opaque { .. } | Annotation::Constant { .. } => None,
     }
 }
 

--- a/crates/passes/src/passes/fact_producers/generics.rs
+++ b/crates/passes/src/passes/fact_producers/generics.rs
@@ -148,6 +148,6 @@ fn annotation_remove_names(annotation: &Annotation, names: &mut HashSet<EcoStrin
                 annotation_remove_names(e, names);
             }
         }
-        Annotation::Unknown | Annotation::Opaque { .. } => {}
+        Annotation::Unknown | Annotation::Opaque { .. } | Annotation::Constant { .. } => {}
     }
 }

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -691,7 +691,7 @@ fn walk_annotation(
                 walk_annotation(module, e, graph, alias_map, from);
             }
         }
-        Annotation::Unknown | Annotation::Opaque { .. } => {}
+        Annotation::Unknown | Annotation::Opaque { .. } | Annotation::Constant { .. } => {}
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -670,20 +670,6 @@ impl InferCtx<'_, '_> {
         let is_method_only_arity =
             receiver_generics_count > 0 && type_args.len() == method_only_count;
 
-        if !is_full_arity && !is_method_only_arity {
-            let actual_types: Vec<Type> = type_args
-                .iter()
-                .map(|arg| self.convert_to_type(store, arg, span))
-                .collect();
-            let vars_as_str: Vec<String> = vars.iter().map(|s| s.to_string()).collect();
-            self.sink.push(diagnostics::infer::generics_arity_mismatch(
-                &vars_as_str,
-                type_args,
-                &actual_types,
-                *span,
-            ));
-        }
-
         let mut resolved_args: Vec<Type> = Vec::new();
         let mut instantiated = if is_method_only_arity {
             let mut map: SubstitutionMap = SubstitutionMap::default();
@@ -702,6 +688,16 @@ impl InferCtx<'_, '_> {
             resolved_args = args;
             instantiated
         };
+
+        if !is_full_arity && !is_method_only_arity {
+            let vars_as_str: Vec<String> = vars.iter().map(|s| s.to_string()).collect();
+            self.sink.push(diagnostics::infer::generics_arity_mismatch(
+                &vars_as_str,
+                type_args,
+                &resolved_args,
+                *span,
+            ));
+        }
 
         if let Expression::DotAccess { expression, .. } = callee_expression {
             let receiver_ty = expression.get_type().resolve_in(&self.env);

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -165,25 +165,21 @@ impl TaskState<'_> {
                     other => (vec![], other),
                 };
 
+                let concrete_args: Vec<Type> = params
+                    .iter()
+                    .map(|arg| self.convert_to_type(store, arg, span))
+                    .collect();
+
                 if generics.len() != params.len() {
-                    let actual_types: Vec<Type> = params
-                        .iter()
-                        .map(|arg| self.convert_to_type(store, arg, span))
-                        .collect();
                     let generics_as_str: Vec<String> =
                         generics.iter().map(|s| s.to_string()).collect();
                     self.sink.push(diagnostics::infer::generics_arity_mismatch(
                         &generics_as_str,
                         params,
-                        &actual_types,
+                        &concrete_args,
                         *span,
                     ));
                 }
-
-                let concrete_args: Vec<Type> = params
-                    .iter()
-                    .map(|arg| self.convert_to_type(store, arg, span))
-                    .collect();
                 let resolved_ty = if generics.is_empty() && concrete_args.is_empty() {
                     body
                 } else {
@@ -255,6 +251,14 @@ impl TaskState<'_> {
                     .map(|e| self.convert_to_type(store, e, span))
                     .collect();
                 Type::Tuple(element_types)
+            }
+
+            Annotation::Constant {
+                span: const_span, ..
+            } => {
+                self.sink
+                    .push(diagnostics::infer::integer_in_type_position(*const_span));
+                Type::Error
             }
 
             Annotation::Opaque { .. } => {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -643,6 +643,11 @@ pub enum Annotation {
     Opaque {
         span: Span,
     },
+    Constant {
+        value: u64,
+        text: Option<String>,
+        span: Span,
+    },
 }
 
 impl Annotation {
@@ -660,6 +665,7 @@ impl Annotation {
             Self::Function { span, .. } => *span,
             Self::Tuple { span, .. } => *span,
             Self::Opaque { span } => *span,
+            Self::Constant { span, .. } => *span,
             Self::Unknown => Span::dummy(),
         }
     }

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -1,6 +1,6 @@
 use super::{MAX_TUPLE_ARITY, ParamMode, Parser};
 use crate::EcoString;
-use crate::ast::{Annotation, Attribute, Expression, Generic, Span, Visibility};
+use crate::ast::{Annotation, Attribute, Expression, Generic, Literal, Span, Visibility};
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::types::Type;
@@ -62,8 +62,20 @@ impl<'source> Parser<'source> {
                     span,
                 }
             }
+            Integer => self.parse_constant_annotation(),
             _ => self.parse_named_annotation(),
         }
+    }
+
+    fn parse_constant_annotation(&mut self) -> Annotation {
+        let token = self.current_token();
+        let span = Span::new(self.file_id, token.byte_offset, token.byte_length);
+        let (value, text) = match self.parse_integer_text(token.text) {
+            Literal::Integer { value, text } => (value, text),
+            _ => (0, None),
+        };
+        self.next();
+        Annotation::Constant { value, text, span }
     }
 
     fn parse_named_annotation(&mut self) -> Annotation {

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -622,7 +622,10 @@ impl<'source> Parser<'source> {
     }
 
     fn can_start_annotation(&self) -> bool {
-        matches!(self.current_token().kind, Identifier | Function | LeftParen)
+        matches!(
+            self.current_token().kind,
+            Identifier | Function | LeftParen | Integer
+        )
     }
 
     fn at_item_boundary(&self) -> bool {

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -475,6 +475,9 @@ fn format_annotation(ann: &ast::Annotation) -> std::string::String {
                 format_annotation(return_type)
             )
         }
+        ast::Annotation::Constant { value, text, .. } => {
+            text.clone().unwrap_or_else(|| value.to_string())
+        }
         ast::Annotation::Unknown | ast::Annotation::Opaque { .. } => "_".to_string(),
     }
 }

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -322,6 +322,30 @@ impl InferResult {
         self
     }
 
+    pub fn assert_infer_code_once(self, code: &str) -> Self {
+        self.assert_code_count(&format!("infer.{}", code), 1)
+    }
+
+    fn assert_code_count(self, expected_code: &str, expected: usize) -> Self {
+        let count = self
+            .errors
+            .iter()
+            .filter(|err| err.code_str() == Some(expected_code))
+            .count();
+        if count != expected {
+            let actual_codes: Vec<&str> = self
+                .errors
+                .iter()
+                .filter_map(|err| err.code_str())
+                .collect();
+            panic!(
+                "Expected {} occurrence(s) of '{}', found {}. Codes: {:?}",
+                expected, expected_code, count, actual_codes
+            );
+        }
+        self
+    }
+
     pub fn assert_type_mismatch(self) -> Self {
         self.assert_error_contains("type mismatch")
     }

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -163,6 +163,13 @@ fn call_with_multiple_type_args() {
 }
 
 #[test]
+fn type_argument_integer_formats_like_value_literal() {
+    assert_format_snapshot!(
+        "fn test(a: Array<byte, 0x10>, b: Array<byte, 1_000>, c: Array<byte, 16>) {}"
+    );
+}
+
+#[test]
 fn call_with_single_closure_arg() {
     assert_format_snapshot!("fn test() { map(|x| x + 1) }");
 }

--- a/tests/spec/format/snapshots/type_argument_integer_formats_like_value_literal.snap
+++ b/tests/spec/format/snapshots/type_argument_integer_formats_like_value_literal.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test(a: Array<byte, 0x10>, b: Array<byte, 1_000>, c: Array<byte, 16>) {}"
+---
+fn test(a: Array<byte, 0x10>, b: Array<byte, 1000>, c: Array<byte, 16>) {}

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -7992,3 +7992,26 @@ fn ref_alias_satisfies_interface_with_pointer_receiver() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn integer_in_type_position_is_rejected() {
+    infer(r#"{ let x: Slice<3> = [] }"#).assert_infer_code("integer_in_type_position");
+}
+
+#[test]
+fn integer_in_type_position_not_duplicated_in_annotation() {
+    infer(r#"{ let x: Slice<int, 3> = [] }"#).assert_infer_code_once("integer_in_type_position");
+}
+
+#[test]
+fn integer_in_type_position_not_duplicated_in_call() {
+    infer(
+        r#"
+fn f<T>() {}
+fn main() {
+  f<int, 3>()
+}
+"#,
+    )
+    .assert_infer_code_once("integer_in_type_position");
+}

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -802,6 +802,14 @@ fn function_with_generic() {
 }
 
 #[test]
+fn integer_in_type_argument_position() {
+    let input = r#"
+fn test(value: Array<int, 3>) {}
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
 fn function_with_empty_body() {
     let input = r#"
 fn noop() {

--- a/tests/spec/parse/snapshots/integer_in_type_argument_position.snap
+++ b/tests/spec/parse/snapshots/integer_in_type_argument_position.snap
@@ -1,0 +1,89 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  fn test(value: Array<int, 3>) {}
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "value",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 9,
+                        byte_length: 5,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "Array",
+                        params: [
+                            Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 22,
+                                    byte_length: 3,
+                                },
+                            },
+                            Constant {
+                                value: 3,
+                                text: None,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 27,
+                                    byte_length: 1,
+                                },
+                            },
+                        ],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 16,
+                            byte_length: 13,
+                        },
+                    },
+                ),
+                typed_pattern: None,
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+        ],
+        return_annotation: Unknown,
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Block {
+            items: [],
+            ty: Var {
+                id: uninferred,
+            },
+            span: Span {
+                file_id: 0,
+                byte_offset: 31,
+                byte_length: 2,
+            },
+        },
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 32,
+        },
+    },
+]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4765,6 +4765,16 @@ fn test<T>(x: T<int>) -> T {
 }
 
 #[test]
+fn infer_integer_in_type_position() {
+    let input = r#"
+fn test() {
+  let x: Slice<3> = []
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_irrefutable_while_let() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_integer_in_type_position.snap
+++ b/tests/ui/errors/snapshots/infer_integer_in_type_position.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer in type position
+   ╭─[test.lis:3:16]
+ 2 │ fn test() {
+ 3 │   let x: Slice<3> = []
+   ·                ┬
+   ·                ╰── expected a type, found an integer literal
+ 4 │ }
+   ╰────
+  help: Integer literals are not valid type arguments · code: [infer.integer_in_type_position]


### PR DESCRIPTION
The parser now accepts an integer literal in type argument position. No type consumes a constant type argument yet, so for the time being this is reported with a dedicated error instead of a parse failure. Groundwork for `Array<T, N>`.

cc @stormpat


