### PR TITLE
feat: autofix nine more lints

### DIFF
--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_bytes_equal.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_bytes_equal.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 
 use super::helpers::is_zero_literal;
@@ -38,13 +39,16 @@ pub fn check_manual_bytes_equal(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_bytes_equal(
-        span,
-        negated,
-        namespace_text,
-        left_text,
-        right_text,
-    ));
+    let prefix = if negated { "!" } else { "" };
+    let replacement = format!("{prefix}{namespace_text}.Equal({left_text}, {right_text})");
+
+    ctx.sink.push(
+        diagnostics::lint::manual_bytes_equal(span, negated, namespace_text, left_text, right_text)
+            .with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            )),
+    );
 }
 
 fn bytes_compare(expression: &Expression) -> Option<(&Expression, &Expression, &Expression)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_equal_fold.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_equal_fold.rs
@@ -1,5 +1,6 @@
 use super::helpers::span_text;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 
 const CASE_FUNCTIONS: &[&str] = &["ToLower", "ToUpper"];
@@ -40,13 +41,16 @@ pub fn check_manual_equal_fold(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_equal_fold(
-        span,
-        negated,
-        namespace_text,
-        left_text,
-        right_text,
-    ));
+    let prefix = if negated { "!" } else { "" };
+    let replacement = format!("{prefix}{namespace_text}.EqualFold({left_text}, {right_text})");
+
+    ctx.sink.push(
+        diagnostics::lint::manual_equal_fold(span, negated, namespace_text, left_text, right_text)
+            .with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            )),
+    );
 }
 
 fn case_conversion(expression: &Expression) -> Option<(&str, &Expression, &Expression)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_is_empty.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_is_empty.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 use syntax::types::{CompoundKind, Type};
 
@@ -49,8 +50,12 @@ pub fn check_manual_is_empty(expression: &Expression, ctx: &NodeCtx) {
 
     let replacement = format!("{receiver_text}.is_empty()");
 
-    ctx.sink
-        .push(diagnostics::lint::manual_is_empty(span, &replacement));
+    ctx.sink.push(
+        diagnostics::lint::manual_is_empty(span, &replacement).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }
 
 fn length_call_receiver(expression: &Expression) -> Option<&Expression> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_replace_all.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_replace_all.rs
@@ -1,5 +1,6 @@
 use super::helpers::{is_one_literal, span_text};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, UnaryOperator};
 
 pub fn check_manual_replace_all(expression: &Expression, ctx: &NodeCtx) {
@@ -47,13 +48,15 @@ pub fn check_manual_replace_all(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_replace_all(
-        span,
-        namespace_text,
-        s_text,
-        old_text,
-        new_text,
-    ));
+    let replacement = format!("{namespace_text}.ReplaceAll({s_text}, {old_text}, {new_text})");
+
+    ctx.sink.push(
+        diagnostics::lint::manual_replace_all(span, namespace_text, s_text, old_text, new_text)
+            .with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            )),
+    );
 }
 
 fn is_negative_one(expression: &Expression) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_time_since.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_time_since.rs
@@ -1,5 +1,6 @@
 use super::helpers::{is_side_effect_free, span_text};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 pub fn check_manual_time_since(expression: &Expression, ctx: &NodeCtx) {
@@ -44,11 +45,14 @@ pub fn check_manual_time_since(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_time_since(
-        span,
-        namespace_text,
-        arg_text,
-    ));
+    let replacement = format!("{namespace_text}.Since({arg_text})");
+
+    ctx.sink.push(
+        diagnostics::lint::manual_time_since(span, namespace_text, arg_text).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }
 
 fn time_now_namespace(expression: &Expression) -> Option<&Expression> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_time_until.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_time_until.rs
@@ -1,5 +1,6 @@
 use super::helpers::{is_side_effect_free, span_text};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 pub fn check_manual_time_until(expression: &Expression, ctx: &NodeCtx) {
@@ -51,11 +52,16 @@ pub fn check_manual_time_until(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_time_until(
-        span,
-        namespace_text,
-        receiver_text,
-    ));
+    let replacement = format!("{namespace_text}.Until({receiver_text})");
+
+    ctx.sink.push(
+        diagnostics::lint::manual_time_until(span, namespace_text, receiver_text).with_fix(
+            Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            ),
+        ),
+    );
 }
 
 fn time_now_namespace(expression: &Expression) -> Option<&Expression> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_bool_assign.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_bool_assign.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 use super::helpers::{bool_literal, expressions_equivalent, span_text};
@@ -45,12 +46,21 @@ pub fn check_needless_bool_assign(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::needless_bool_assign(
-        span,
-        target,
-        condition_text,
-        !then_value,
-    ));
+    let negate = !then_value;
+    let replacement = if negate {
+        format!("{target} = !({condition_text})")
+    } else {
+        format!("{target} = {condition_text}")
+    };
+
+    ctx.sink.push(
+        diagnostics::lint::needless_bool_assign(span, target, condition_text, negate).with_fix(
+            Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            ),
+        ),
+    );
 }
 
 fn single_bool_assignment(block: &Expression) -> Option<(&Expression, bool)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_slice_bounds.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_slice_bounds.rs
@@ -1,5 +1,6 @@
 use super::helpers::{expressions_equivalent, is_side_effect_free, is_zero_literal, span_text};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 pub fn check_redundant_slice_bounds(expression: &Expression, ctx: &NodeCtx) {
@@ -74,10 +75,13 @@ pub fn check_redundant_slice_bounds(expression: &Expression, ctx: &NodeCtx) {
         format!("{receiver_text}[{start_text}..]")
     };
 
-    ctx.sink.push(diagnostics::lint::redundant_slice_bounds(
-        span,
-        &replacement,
-    ));
+    let fix_span = receiver.get_span().merge(*span);
+    ctx.sink.push(
+        diagnostics::lint::redundant_slice_bounds(span, &replacement).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(fix_span, replacement.clone()),
+        )),
+    );
 }
 
 fn is_length_call_on(expression: &Expression, slice_receiver: &Expression) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_first_then_check.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_first_then_check.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 use super::helpers::{is_zero_literal, method_call};
@@ -52,9 +53,10 @@ pub fn check_unnecessary_first_then_check(expression: &Expression, ctx: &NodeCtx
         format!("{slice_text}.is_empty()")
     };
 
-    ctx.sink
-        .push(diagnostics::lint::unnecessary_first_then_check(
-            span,
-            &replacement,
-        ));
+    ctx.sink.push(
+        diagnostics::lint::unnecessary_first_then_check(span, &replacement).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -242,3 +242,129 @@ fn main() {
     let twice = apply_lint_fixes(&once);
     assert_eq!(once, twice);
 }
+
+#[test]
+fn fix_manual_is_empty() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs.length() == 0
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_first_then_check() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3, 4]
+  let _ = xs.get(0).is_some()
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_slice_bounds() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3, 4, 5]
+  let a = 2
+  let _ = xs[a..xs.length()]
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_bool_assign() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(c: bool) -> bool {
+  let mut x = false
+  if c {
+    x = true
+  } else {
+    x = false
+  }
+  x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_bytes_equal() {
+    assert_fix_snapshot!(
+        r#"
+import "go:bytes"
+
+fn main() {
+  let a = "hello" as Slice<byte>
+  let b = "world" as Slice<byte>
+  let _ = bytes.Compare(a, b) == 0
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_equal_fold() {
+    assert_fix_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let a = "Hello"
+  let b = "hELLO"
+  let _ = strings.ToLower(a) == strings.ToLower(b)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_replace_all() {
+    assert_fix_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "hello world"
+  let _ = strings.Replace(s, "o", "0", -1)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_time_since() {
+    assert_fix_snapshot!(
+        r#"
+import "go:time"
+
+fn main() {
+  let t = time.Now()
+  let _ = time.Now().Sub(t)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_time_until() {
+    assert_fix_snapshot!(
+        r#"
+import "go:time"
+
+fn main() {
+  let deadline = time.Now()
+  let _ = deadline.Sub(time.Now())
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/fix_manual_bytes_equal.snap
+++ b/tests/ui/lint/snapshots/fix_manual_bytes_equal.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:bytes"
+
+fn main() {
+  let a = "hello" as Slice<byte>
+  let b = "world" as Slice<byte>
+  let _ = bytes.Compare(a, b) == 0
+}
+=== fixed ===
+import "go:bytes"
+
+fn main() {
+  let a = "hello" as Slice<byte>
+  let b = "world" as Slice<byte>
+  let _ = bytes.Equal(a, b)
+}

--- a/tests/ui/lint/snapshots/fix_manual_equal_fold.snap
+++ b/tests/ui/lint/snapshots/fix_manual_equal_fold.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:strings"
+
+fn main() {
+  let a = "Hello"
+  let b = "hELLO"
+  let _ = strings.ToLower(a) == strings.ToLower(b)
+}
+=== fixed ===
+import "go:strings"
+
+fn main() {
+  let a = "Hello"
+  let b = "hELLO"
+  let _ = strings.EqualFold(a, b)
+}

--- a/tests/ui/lint/snapshots/fix_manual_is_empty.snap
+++ b/tests/ui/lint/snapshots/fix_manual_is_empty.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs.length() == 0
+}
+=== fixed ===
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs.is_empty()
+}

--- a/tests/ui/lint/snapshots/fix_manual_replace_all.snap
+++ b/tests/ui/lint/snapshots/fix_manual_replace_all.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:strings"
+
+fn main() {
+  let s = "hello world"
+  let _ = strings.Replace(s, "o", "0", -1)
+}
+=== fixed ===
+import "go:strings"
+
+fn main() {
+  let s = "hello world"
+  let _ = strings.ReplaceAll(s, "o", "0")
+}

--- a/tests/ui/lint/snapshots/fix_manual_time_since.snap
+++ b/tests/ui/lint/snapshots/fix_manual_time_since.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:time"
+
+fn main() {
+  let t = time.Now()
+  let _ = time.Now().Sub(t)
+}
+=== fixed ===
+import "go:time"
+
+fn main() {
+  let t = time.Now()
+  let _ = time.Since(t)
+}

--- a/tests/ui/lint/snapshots/fix_manual_time_until.snap
+++ b/tests/ui/lint/snapshots/fix_manual_time_until.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:time"
+
+fn main() {
+  let deadline = time.Now()
+  let _ = deadline.Sub(time.Now())
+}
+=== fixed ===
+import "go:time"
+
+fn main() {
+  let deadline = time.Now()
+  let _ = time.Until(deadline)
+}

--- a/tests/ui/lint/snapshots/fix_needless_bool_assign.snap
+++ b/tests/ui/lint/snapshots/fix_needless_bool_assign.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(c: bool) -> bool {
+  let mut x = false
+  if c {
+    x = true
+  } else {
+    x = false
+  }
+  x
+}
+=== fixed ===
+pub fn f(c: bool) -> bool {
+  let mut x = false
+  x = c
+  x
+}

--- a/tests/ui/lint/snapshots/fix_redundant_slice_bounds.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_slice_bounds.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let xs = [1, 2, 3, 4, 5]
+  let a = 2
+  let _ = xs[a..xs.length()]
+}
+=== fixed ===
+fn main() {
+  let xs = [1, 2, 3, 4, 5]
+  let a = 2
+  let _ = xs[a..]
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_first_then_check.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_first_then_check.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let xs = [1, 2, 3, 4]
+  let _ = xs.get(0).is_some()
+}
+=== fixed ===
+fn main() {
+  let xs = [1, 2, 3, 4]
+  let _ = !xs.is_empty()
+}


### PR DESCRIPTION
Adds autofixes for nine more lints:

- `manual_is_empty`
- `unnecessary_first_then_check`
- `redundant_slice_bounds`
- `needless_bool_assign`
- `manual_bytes_equal`
- `manual_equal_fold`
- `manual_replace_all`
- `manual_time_since`
- `manual_time_until`

Follow-up to #924
