### PR TITLE
feat: autofix seven more lints

### DIFF
--- a/crates/passes/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
@@ -1,5 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
+
+use super::helpers::span_text;
 
 pub fn check_excess_parens_on_condition(expression: &Expression, ctx: &NodeCtx) {
     let (condition, keyword) = match expression {
@@ -10,8 +13,17 @@ pub fn check_excess_parens_on_condition(expression: &Expression, ctx: &NodeCtx) 
         _ => return,
     };
 
-    if let Expression::Paren { span, .. } = condition {
-        ctx.sink
-            .push(diagnostics::lint::unnecessary_parens(span, keyword));
+    if let Expression::Paren {
+        span, expression, ..
+    } = condition
+    {
+        let mut diagnostic = diagnostics::lint::unnecessary_parens(span, keyword);
+        if let Some(inner) = span_text(ctx.source, expression) {
+            diagnostic = diagnostic.with_fix(Fix::new(
+                "Remove redundant parentheses",
+                Edit::replacement(*span, inner),
+            ));
+        }
+        ctx.sink.push(diagnostic);
     }
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
@@ -1,7 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::wrapped_single_arg;
+use super::helpers::{span_text, wrapped_single_arg};
 
 pub fn check_needless_question_mark(expression: &Expression, ctx: &NodeCtx) {
     match expression {
@@ -79,8 +80,13 @@ fn flag_needless(value: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::needless_question_mark(
-        &value.get_span(),
-        wrapper,
-    ));
+    let span = value.get_span();
+    let mut diagnostic = diagnostics::lint::needless_question_mark(&span, wrapper);
+    if let Some(inner_text) = span_text(ctx.source, inner) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{inner_text}`"),
+            Edit::replacement(span, inner_text),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
@@ -1,5 +1,6 @@
 use super::helpers::{signed_integer_literal, span_text};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
 pub fn check_needless_splitn(expression: &Expression, ctx: &NodeCtx) {
@@ -51,13 +52,20 @@ pub fn check_needless_splitn(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::needless_splitn(
-        span,
-        member.as_str(),
-        target,
-        namespace_text,
-        s_text,
-        sep_text,
-        count_text,
-    ));
+    let replacement = format!("{namespace_text}.{target}({s_text}, {sep_text})");
+    ctx.sink.push(
+        diagnostics::lint::needless_splitn(
+            span,
+            member.as_str(),
+            target,
+            namespace_text,
+            s_text,
+            sep_text,
+            count_text,
+        )
+        .with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
 
 use super::helpers::{signed_integer_literal, span_text};
@@ -57,5 +58,11 @@ pub fn check_neg_multiply(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::neg_multiply(span, text));
+    let replacement = format!("-{text}");
+    ctx.sink.push(
+        diagnostics::lint::neg_multiply(span, text).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement.clone()),
+        )),
+    );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_raw_string.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_raw_string.rs
@@ -1,5 +1,6 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{Expression, Literal, Pattern};
+use diagnostics::{Edit, Fix};
+use syntax::ast::{Expression, Literal, Pattern, Span};
 
 pub fn check_unnecessary_raw_string_expression(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Literal {
@@ -11,8 +12,12 @@ pub fn check_unnecessary_raw_string_expression(expression: &Expression, ctx: &No
         return;
     };
     if !value.contains('\\') {
-        ctx.sink
-            .push(diagnostics::lint::unnecessary_raw_string(span));
+        ctx.sink.push(
+            diagnostics::lint::unnecessary_raw_string(span).with_fix(Fix::new(
+                "Remove the `r` prefix",
+                Edit::deletion(Span::new(span.file_id, span.byte_offset, 1)),
+            )),
+        );
     }
 }
 
@@ -26,7 +31,11 @@ pub fn check_unnecessary_raw_string_pattern(pattern: &Pattern, ctx: &NodeCtx) {
         return;
     };
     if !value.contains('\\') {
-        ctx.sink
-            .push(diagnostics::lint::unnecessary_raw_string(span));
+        ctx.sink.push(
+            diagnostics::lint::unnecessary_raw_string(span).with_fix(Fix::new(
+                "Remove the `r` prefix",
+                Edit::deletion(Span::new(span.file_id, span.byte_offset, 1)),
+            )),
+        );
     }
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/wildcard_in_or_patterns.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/wildcard_in_or_patterns.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Pattern, collect_pattern_bindings};
 
 pub fn check_wildcard_in_or_patterns(pattern: &Pattern, ctx: &NodeCtx) {
@@ -22,6 +23,8 @@ pub fn check_wildcard_in_or_patterns(pattern: &Pattern, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::wildcard_in_or_patterns(span));
+    ctx.sink.push(
+        diagnostics::lint::wildcard_in_or_patterns(span)
+            .with_fix(Fix::new("Replace with `_`", Edit::replacement(*span, "_"))),
+    );
 }

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -2,7 +2,9 @@ use rustc_hash::FxHashSet as HashSet;
 
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
+use diagnostics::{Edit, Fix};
 use semantics::facts::Facts;
+use syntax::ast::Span;
 use syntax::program::UnusedInfo;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -149,10 +151,14 @@ fn collect_discarded_tail_expressions(facts: &Facts, out: &mut Vec<LisetteDiagno
 
 fn collect_overused_references(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
     for fact in &facts.overused_references {
-        out.push(diagnostics::lint::unnecessary_reference(
-            &fact.span,
-            fact.name.as_deref(),
-        ));
+        out.push(
+            diagnostics::lint::unnecessary_reference(&fact.span, fact.name.as_deref()).with_fix(
+                Fix::new(
+                    "Remove the redundant `&`",
+                    Edit::deletion(Span::new(fact.span.file_id, fact.span.byte_offset, 1)),
+                ),
+            ),
+        );
     }
 }
 

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -368,3 +368,90 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn fix_unnecessary_raw_string() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let msg = r"hello";
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn fix_excess_parens_on_condition() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  if (x > 0) {
+    let _ = x;
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_wildcard_in_or_patterns() {
+    assert_fix_snapshot!(
+        r#"
+pub fn test(n: int) -> int {
+  match n {
+    0 | _ => 1,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_question_mark() {
+    assert_fix_snapshot!(
+        r#"
+fn consume() -> Option<int> {
+  let x: Option<int> = Some(1)
+  Some(x?)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_neg_multiply() {
+    assert_fix_snapshot!(
+        r#"
+fn negate(x: int) -> int {
+  x * -1
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_splitn() {
+    assert_fix_snapshot!(
+        r#"
+import "go:strings"
+
+fn main() {
+  let s = "a,b,c"
+  let _ = strings.SplitN(s, ",", -1)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_reference() {
+    assert_fix_snapshot!(
+        r#"
+pub fn foo(x: Ref<int>) {
+  let _ = &x;
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/fix_excess_parens_on_condition.snap
+++ b/tests/ui/lint/snapshots/fix_excess_parens_on_condition.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let x = 5;
+  if (x > 0) {
+    let _ = x;
+  }
+}
+=== fixed ===
+fn main() {
+  let x = 5;
+  if x > 0 {
+    let _ = x;
+  }
+}

--- a/tests/ui/lint/snapshots/fix_needless_question_mark.snap
+++ b/tests/ui/lint/snapshots/fix_needless_question_mark.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn consume() -> Option<int> {
+  let x: Option<int> = Some(1)
+  Some(x?)
+}
+=== fixed ===
+fn consume() -> Option<int> {
+  let x: Option<int> = Some(1)
+  x
+}

--- a/tests/ui/lint/snapshots/fix_needless_splitn.snap
+++ b/tests/ui/lint/snapshots/fix_needless_splitn.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:strings"
+
+fn main() {
+  let s = "a,b,c"
+  let _ = strings.SplitN(s, ",", -1)
+}
+=== fixed ===
+import "go:strings"
+
+fn main() {
+  let s = "a,b,c"
+  let _ = strings.Split(s, ",")
+}

--- a/tests/ui/lint/snapshots/fix_neg_multiply.snap
+++ b/tests/ui/lint/snapshots/fix_neg_multiply.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn negate(x: int) -> int {
+  x * -1
+}
+=== fixed ===
+fn negate(x: int) -> int {
+  -x
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_raw_string.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_raw_string.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let msg = r"hello";
+  let _ = msg
+}
+=== fixed ===
+fn main() {
+  let msg = "hello";
+  let _ = msg
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_reference.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_reference.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn foo(x: Ref<int>) {
+  let _ = &x;
+}
+=== fixed ===
+pub fn foo(x: Ref<int>) {
+  let _ = x;
+}

--- a/tests/ui/lint/snapshots/fix_wildcard_in_or_patterns.snap
+++ b/tests/ui/lint/snapshots/fix_wildcard_in_or_patterns.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn test(n: int) -> int {
+  match n {
+    0 | _ => 1,
+  }
+}
+=== fixed ===
+pub fn test(n: int) -> int {
+  match n {
+    _ => 1,
+  }
+}


### PR DESCRIPTION
Adds autofixes for seven more lints:

- `unnecessary_raw_string`
- `excess_parens_on_condition`
- `wildcard_in_or_patterns`
- `needless_question_mark`
- `neg_multiply`
- `needless_splitn`
- `unnecessary_reference`

Follow-up to #930
