### PR TITLE
feat: report all missing cases and redundant match arms

### DIFF
--- a/crates/diagnostics/src/pattern.rs
+++ b/crates/diagnostics/src/pattern.rs
@@ -10,19 +10,28 @@ pub struct PatternIssue {
 }
 
 pub fn non_exhaustive(match_span: Span, cases: &[String]) -> LisetteDiagnostic {
-    let listed = cases
+    let arms: Vec<String> = cases
         .iter()
-        .map(|case| format!("`{}`", case))
-        .collect::<Vec<_>>()
-        .join(", ");
+        .map(|case| format!("`{} => {{ ... }}`", case))
+        .collect();
     let noun = if cases.len() == 1 { "case" } else { "cases" };
     LisetteDiagnostic::error("`match` is not exhaustive")
         .with_infer_code("non_exhaustive")
         .with_span_label(&match_span, "not all patterns covered")
         .with_help(format!(
-            "Handle the missing {} {}, e.g. `{} => {{ ... }}`",
-            noun, listed, cases[0]
+            "Handle the missing {} by adding {}",
+            noun,
+            join_and(&arms)
         ))
+}
+
+fn join_and(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => format!("{} and {}", first, second),
+        [rest @ .., last] => format!("{}, and {}", rest.join(", "), last),
+    }
 }
 
 pub fn irrefutable_while_let(pattern_span: Span) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/pattern.rs
+++ b/crates/diagnostics/src/pattern.rs
@@ -9,13 +9,19 @@ pub struct PatternIssue {
     pub kind: IssueKind,
 }
 
-pub fn non_exhaustive(match_span: Span, case: &str) -> LisetteDiagnostic {
+pub fn non_exhaustive(match_span: Span, cases: &[String]) -> LisetteDiagnostic {
+    let listed = cases
+        .iter()
+        .map(|case| format!("`{}`", case))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let noun = if cases.len() == 1 { "case" } else { "cases" };
     LisetteDiagnostic::error("`match` is not exhaustive")
         .with_infer_code("non_exhaustive")
         .with_span_label(&match_span, "not all patterns covered")
         .with_help(format!(
-            "Handle the missing case `{}`, e.g. `{} => {{ ... }}`",
-            case, case
+            "Handle the missing {} {}, e.g. `{} => {{ ... }}`",
+            noun, listed, cases[0]
         ))
 }
 

--- a/crates/passes/src/passes/checks/pattern_analysis/mod.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/mod.rs
@@ -206,8 +206,10 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
                 .collect();
 
             if let Err(witnesses) = check_exhaustiveness(&unguarded_rows, &unions) {
-                let first_witness = witnesses.first().expect("witnesses should not be empty");
-                let case = witness::format_witness(first_witness);
+                let mut cases: Vec<String> =
+                    witnesses.iter().map(witness::format_witness).collect();
+                cases.sort();
+                cases.dedup();
 
                 let subject_span = subject.get_span();
                 let match_span = Span::new(
@@ -216,7 +218,7 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
                     (subject_span.byte_offset + subject_span.byte_length) - span.byte_offset,
                 );
 
-                sink.push(diagnostics::pattern::non_exhaustive(match_span, &case));
+                sink.push(diagnostics::pattern::non_exhaustive(match_span, &cases));
                 return;
             }
 
@@ -390,6 +392,7 @@ fn check_redundancy_with_guards(
     sink: &LocalSink,
 ) -> bool {
     let mut unguarded_previous: Vec<(usize, Row)> = vec![];
+    let mut found_redundant = false;
 
     for (index, arm) in arms.iter().enumerate() {
         let current_rows = normalize_arm(arm, unions, norm_ctx);
@@ -450,7 +453,7 @@ fn check_redundancy_with_guards(
                 };
 
                 sink.push(diagnostics::pattern::redundant_arm(span, label, help));
-                return false;
+                found_redundant = true;
             }
 
             current_arm_rows.push(current_row.clone());
@@ -465,7 +468,7 @@ fn check_redundancy_with_guards(
         }
     }
 
-    true
+    !found_redundant
 }
 
 fn check_if_let(

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -326,6 +326,10 @@ impl InferResult {
         self.assert_code_count(&format!("infer.{}", code), 1)
     }
 
+    pub fn assert_infer_code_count(self, code: &str, count: usize) -> Self {
+        self.assert_code_count(&format!("infer.{}", code), count)
+    }
+
     fn assert_code_count(self, expected_code: &str, expected: usize) -> Self {
         let count = self
             .errors
@@ -422,7 +426,25 @@ fn is_slice_with_type_var(ty: &Type) -> bool {
     }
 }
 
+/// A consistent one-to-one renaming between the type variables of the two
+/// types being compared, so `fn(a) -> a` and `fn(a) -> b` are not conflated.
+#[derive(Default)]
+struct VarBijection {
+    forward: std::collections::HashMap<u32, u32>,
+    backward: std::collections::HashMap<u32, u32>,
+}
+
+impl VarBijection {
+    fn unify(&mut self, a: u32, b: u32) -> bool {
+        *self.forward.entry(a).or_insert(b) == b && *self.backward.entry(b).or_insert(a) == a
+    }
+}
+
 fn types_equal(t1: &Type, t2: &Type) -> bool {
+    types_equal_with(t1, t2, &mut VarBijection::default())
+}
+
+fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
     if let (Some(n1), Some(n2)) = (t1.get_name(), t2.get_name())
         && n1 == n2
     {
@@ -432,7 +454,7 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
             && args1
                 .iter()
                 .zip(args2.iter())
-                .all(|(a1, a2)| types_equal(a1, a2))
+                .all(|(a1, a2)| types_equal_with(a1, a2, vars))
         {
             return true;
         }
@@ -446,7 +468,7 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
                 return args
                     .iter()
                     .zip(params.iter())
-                    .all(|(x, y)| types_equal(x, y));
+                    .all(|(x, y)| types_equal_with(x, y, vars));
             }
         }
         (Type::Simple(kind), Type::Nominal { id, params, .. })
@@ -463,7 +485,7 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
         underlying_ty: Some(u),
         ..
     } = t1
-        && types_equal(u, t2)
+        && types_equal_with(u, t2, vars)
     {
         return true;
     }
@@ -471,13 +493,13 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
         underlying_ty: Some(u),
         ..
     } = t2
-        && types_equal(t1, u)
+        && types_equal_with(t1, u, vars)
     {
         return true;
     }
 
     match (t1, t2) {
-        (Type::Var { .. }, Type::Var { .. }) => true,
+        (Type::Var { id: a, .. }, Type::Var { id: b, .. }) => vars.unify(a.0, b.0),
 
         (
             Type::Nominal {
@@ -498,12 +520,12 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
                 && args1
                     .iter()
                     .zip(args2.iter())
-                    .all(|(a1, a2)| types_equal(a1, a2))
+                    .all(|(a1, a2)| types_equal_with(a1, a2, vars))
             {
                 return true;
             }
             if let Some(u) = u1
-                && types_equal(u, t2)
+                && types_equal_with(u, t2, vars)
             {
                 return true;
             }
@@ -516,8 +538,8 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
                     .params
                     .iter()
                     .zip(f2.params.iter())
-                    .all(|(a1, a2)| types_equal(a1, a2))
-                && types_equal(&f1.return_type, &f2.return_type)
+                    .all(|(a1, a2)| types_equal_with(a1, a2, vars))
+                && types_equal_with(&f1.return_type, &f2.return_type, vars)
         }
 
         (Type::Tuple(elems1), Type::Tuple(elems2)) => {
@@ -525,7 +547,7 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
                 && elems1
                     .iter()
                     .zip(elems2.iter())
-                    .all(|(e1, e2)| types_equal(e1, e2))
+                    .all(|(e1, e2)| types_equal_with(e1, e2, vars))
         }
 
         (Type::Simple(k1), Type::Simple(k2)) => k1 == k2,
@@ -533,7 +555,10 @@ fn types_equal(t1: &Type, t2: &Type) -> bool {
         (Type::Compound { kind: k1, args: a1 }, Type::Compound { kind: k2, args: a2 }) => {
             k1 == k2
                 && a1.len() == a2.len()
-                && a1.iter().zip(a2.iter()).all(|(x, y)| types_equal(x, y))
+                && a1
+                    .iter()
+                    .zip(a2.iter())
+                    .all(|(x, y)| types_equal_with(x, y, vars))
         }
 
         _ => false,

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -250,6 +250,21 @@ fn test(opt: Option<int>) -> int {
 }
 
 #[test]
+fn test_reports_every_redundant_arm() {
+    let input = r#"
+fn test(opt: Option<int>) -> int {
+  match opt {
+    Option.Some(x) => x,
+    Option.None => 0,
+    Option.Some(y) => y,
+    Option.None => 1,
+  }
+}
+"#;
+    infer(input).assert_infer_code_count("redundant_arm", 2);
+}
+
+#[test]
 fn test_redundant_wildcard() {
     let input = r#"
 match true {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2695,6 +2695,24 @@ fn test() {
 }
 
 #[test]
+fn match_non_exhaustive_lists_all_missing_cases() {
+    let input = r#"
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+fn test(c: Color) -> int {
+  match c {
+    Color.Red => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn match_non_exhaustive_tuple_struct_field_literal() {
     let input = r#"
 struct MP(int, string)

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2713,6 +2713,25 @@ fn test(c: Color) -> int {
 }
 
 #[test]
+fn match_non_exhaustive_three_missing_cases_uses_oxford_comma() {
+    let input = r#"
+enum Suit {
+  Hearts,
+  Diamonds,
+  Clubs,
+  Spades,
+}
+
+fn test(s: Suit) -> int {
+  match s {
+    Suit.Hearts => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn match_non_exhaustive_tuple_struct_field_literal() {
     let input = r#"
 struct MP(int, string)

--- a/tests/ui/errors/snapshots/match_non_exhaustive.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·      ╰── not all patterns covered
  5 │     Ok(x) => x,
    ╰────
-  help: Handle the missing case `Result.Err(_)`, e.g. `Result.Err(_) => { ... }` · code: [infer.non_exhaustive]
+  help: Handle the missing case by adding `Result.Err(_) => { ... }` · code: [infer.non_exhaustive]

--- a/tests/ui/errors/snapshots/match_non_exhaustive_lists_all_missing_cases.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_lists_all_missing_cases.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·      ╰── not all patterns covered
  10 │     Color.Red => 1,
     ╰────
-  help: Handle the missing cases `Color.Blue`, `Color.Green`, e.g. `Color.Blue => { ... }` · code: [infer.non_exhaustive]
+  help: Handle the missing cases by adding `Color.Blue => { ... }` and `Color.Green => { ... }` · code: [infer.non_exhaustive]

--- a/tests/ui/errors/snapshots/match_non_exhaustive_lists_all_missing_cases.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_lists_all_missing_cases.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `match` is not exhaustive
+    ╭─[test.lis:9:3]
+  8 │ fn test(c: Color) -> int {
+  9 │   match c {
+    ·   ───┬───
+    ·      ╰── not all patterns covered
+ 10 │     Color.Red => 1,
+    ╰────
+  help: Handle the missing cases `Color.Blue`, `Color.Green`, e.g. `Color.Blue => { ... }` · code: [infer.non_exhaustive]

--- a/tests/ui/errors/snapshots/match_non_exhaustive_partial.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_partial.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·      ╰── not all patterns covered
  4 │     Partial.Ok(n) => n,
    ╰────
-  help: Handle the missing case `Partial.Both(_, _)`, e.g. `Partial.Both(_, _) => { ... }` · code: [infer.non_exhaustive]
+  help: Handle the missing case by adding `Partial.Both(_, _) => { ... }` · code: [infer.non_exhaustive]

--- a/tests/ui/errors/snapshots/match_non_exhaustive_three_missing_cases_uses_oxford_comma.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_three_missing_cases_uses_oxford_comma.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `match` is not exhaustive
+    ╭─[test.lis:10:3]
+  9 │ fn test(s: Suit) -> int {
+ 10 │   match s {
+    ·   ───┬───
+    ·      ╰── not all patterns covered
+ 11 │     Suit.Hearts => 1,
+    ╰────
+  help: Handle the missing cases by adding `Suit.Clubs => { ... }`, `Suit.Diamonds => { ... }`, and `Suit.Spades => { ... }` · code: [infer.non_exhaustive]

--- a/tests/ui/errors/snapshots/match_non_exhaustive_tuple_struct_field_literal.snap
+++ b/tests/ui/errors/snapshots/match_non_exhaustive_tuple_struct_field_literal.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·      ╰── not all patterns covered
  6 │     MP(0, _) => 1,
    ╰────
-  help: Handle the missing case `MP(_, _)`, e.g. `MP(_, _) => { ... }` · code: [infer.non_exhaustive]
+  help: Handle the missing case by adding `MP(_, _) => { ... }` · code: [infer.non_exhaustive]


### PR DESCRIPTION
Non-exhaustive `match` errors now list every missing case, and unreachable-pattern errors report every redundant arm, instead of stopping at the first of each.

```
  ✕ `match` is not exhaustive
    ╭─[test.lis:10:3]
  9 │ fn test(s: Suit) -> int {
 10 │   match s {
    ·   ───┬───
    ·      ╰── not all patterns covered
 11 │     Suit.Hearts => 1,
    ╰────
  help: Handle the missing cases by adding `Suit.Clubs => { ... }`, `Suit.Diamonds => { ... }`, and `Suit.Spades => { ... }` · code: [infer.non_exhaustive]
```
