### PR TITLE
fix: `#[json(omitempty)]` on `Option` fields

### DIFF
--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -132,8 +132,8 @@ impl Planner<'_> {
         }
 
         let tag_configs = interpret_field_attributes(f, struct_attrs);
-        let needs_omitzero = is_option_type(&f.ty);
-        let tag_string = format_tag_string(&f.name, &tag_configs, needs_omitzero);
+        let is_option = is_option_type(&f.ty);
+        let tag_string = format_tag_string(&f.name, &tag_configs, is_option);
 
         let has_tags = !tag_configs.is_empty();
         let field_name = struct_field_go_name(f, struct_attrs);
@@ -453,13 +453,8 @@ pub(crate) fn debug_verb(is_function: bool) -> &'static str {
 
 fn is_option_type(ty: &Type) -> bool {
     match ty {
-        Type::Nominal {
-            id, underlying_ty, ..
-        } => {
-            if id == "Option" || id.ends_with(".Option") {
-                return true;
-            }
-            underlying_ty.as_deref().is_some_and(is_option_type)
+        Type::Nominal { underlying_ty, .. } => {
+            ty.is_option() || underlying_ty.as_deref().is_some_and(is_option_type)
         }
         _ => false,
     }

--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -258,7 +258,7 @@ fn interpret_tag_attribute(attribute: &Attribute) -> Option<TagConfig> {
 pub(super) fn format_tag_string(
     field_name: &str,
     configs: &[TagConfig],
-    needs_omitzero: bool,
+    is_option: bool,
 ) -> Option<String> {
     if configs.is_empty() {
         return None;
@@ -269,7 +269,7 @@ pub(super) fn format_tag_string(
 
     let parts: Vec<String> = sorted_configs
         .iter()
-        .filter_map(|config| format_single_tag(field_name, config, needs_omitzero))
+        .filter_map(|config| format_single_tag(field_name, config, is_option))
         .collect();
 
     if parts.is_empty() {
@@ -291,7 +291,7 @@ fn tag_sort_key(config: &TagConfig) -> (u8, &str) {
     }
 }
 
-fn format_single_tag(field_name: &str, config: &TagConfig, needs_omitzero: bool) -> Option<String> {
+fn format_single_tag(field_name: &str, config: &TagConfig, is_option: bool) -> Option<String> {
     if let Some(ref raw) = config.raw_value {
         let key_prefix = format!("{}:", config.key);
         if raw.starts_with(&key_prefix) {
@@ -312,10 +312,11 @@ fn format_single_tag(field_name: &str, config: &TagConfig, needs_omitzero: bool)
 
     let mut options = Vec::new();
     if config.omitempty {
-        options.push("omitempty");
-        if needs_omitzero {
-            options.push("omitzero");
-        }
+        options.push(if is_option && config.key == "json" {
+            "omitzero"
+        } else {
+            "omitempty"
+        });
     }
     if config.string_encoding {
         options.push("string");

--- a/docs/index.html
+++ b/docs/index.html
@@ -1033,7 +1033,7 @@
   <span class="pl">account_id</span><span class="pn">:</span> <span class="ty">int</span><span class="pn">,</span> <span class="cm">// =&gt; `json:"userID"`</span>
 
   <span class="pn">#[json(omitempty)]</span>
-  <span class="pl">bio</span><span class="pn">:</span> <span class="ty">Option</span><span class="pn">&lt;</span><span class="ty">string</span><span class="pn">&gt;,</span> <span class="cm">// =&gt; `json:"bio,omitempty"`</span>
+  <span class="pl">bio</span><span class="pn">:</span> <span class="ty">Option</span><span class="pn">&lt;</span><span class="ty">string</span><span class="pn">&gt;,</span> <span class="cm">// =&gt; `json:"bio,omitzero"`</span>
 
   <span class="pn">#[json(string)]</span>
   <span class="pl">score</span><span class="pn">:</span> <span class="ty">int64</span><span class="pn">,</span> <span class="cm">// =&gt; `json:"score,string"`</span>

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -52,6 +52,8 @@ struct Config {
 }
 ```
 
+On `Option` fields, `omitempty` compiles to the `omitzero` JSON tag option, which omits `None` values.
+
 Or override the serialized field name:
 
 ```rust

--- a/prelude/option.go
+++ b/prelude/option.go
@@ -10,8 +10,8 @@ import (
 type OptionTag int
 
 const (
-	OptionSome OptionTag = iota
-	OptionNone
+	OptionNone OptionTag = iota
+	OptionSome
 )
 
 type Option[T any] struct {
@@ -124,11 +124,15 @@ func (opt Option[T]) MarshalJSON() ([]byte, error) {
 
 func (opt *Option[T]) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
-		opt.Tag = OptionNone
+		*opt = Option[T]{Tag: OptionNone}
 		return nil
 	}
-	opt.Tag = OptionSome
-	return json.Unmarshal(data, &opt.SomeVal)
+	value := opt.SomeVal
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*opt = Option[T]{Tag: OptionSome, SomeVal: value}
+	return nil
 }
 
 func (opt *Option[T]) Scan(src any) error {

--- a/prelude/option_test.go
+++ b/prelude/option_test.go
@@ -146,6 +146,72 @@ func TestOptionJSON(t *testing.T) {
 	}
 }
 
+func TestOptionZeroValueIsNone(t *testing.T) {
+	var opt Option[int]
+	if !opt.IsNone() {
+		t.Fatal("expected zero value to be None")
+	}
+}
+
+func TestOptionStructFieldRoundTrip(t *testing.T) {
+	type user struct {
+		Name   string           `json:"name,omitempty"`
+		Emails Option[[]string] `json:"emails,omitzero"`
+	}
+
+	var u user
+	if err := json.Unmarshal([]byte(`{"name":"alice"}`), &u); err != nil {
+		t.Fatal(err)
+	}
+	if !u.Emails.IsNone() {
+		t.Fatal("expected missing key to unmarshal as None")
+	}
+
+	out, err := json.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `{"name":"alice"}` {
+		t.Fatalf("expected None field to be omitted, got %s", out)
+	}
+}
+
+func TestOptionUnmarshalNullResetsValue(t *testing.T) {
+	opt := MakeOptionSome(42)
+	if err := json.Unmarshal([]byte("null"), &opt); err != nil {
+		t.Fatal(err)
+	}
+	if opt != MakeOptionNone[int]() {
+		t.Fatalf("expected canonical None, got %#v", opt)
+	}
+}
+
+func TestOptionUnmarshalErrorLeavesValue(t *testing.T) {
+	some := MakeOptionSome(42)
+	if err := json.Unmarshal([]byte(`"nope"`), &some); err == nil {
+		t.Fatal("expected error")
+	}
+	if some != MakeOptionSome(42) {
+		t.Fatalf("expected Some(42) preserved, got %#v", some)
+	}
+
+	none := MakeOptionNone[int]()
+	if err := json.Unmarshal([]byte(`"nope"`), &none); err == nil {
+		t.Fatal("expected error")
+	}
+	if none != MakeOptionNone[int]() {
+		t.Fatalf("expected None preserved, got %#v", none)
+	}
+
+	noneSlice := MakeOptionNone[[]string]()
+	if err := json.Unmarshal([]byte(`"nope"`), &noneSlice); err == nil {
+		t.Fatal("expected error")
+	}
+	if !noneSlice.IsNone() {
+		t.Fatalf("expected None tag preserved, got %#v", noneSlice)
+	}
+}
+
 func TestOptionMap(t *testing.T) {
 	some := MakeOptionSome(21)
 	mapped := OptionMap(some, func(v int) int { return v * 2 })

--- a/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_option_alias_omitempty.snap
@@ -17,6 +17,6 @@ import lisette "github.com/ivov/lisette/prelude"
 type Maybe[T any] = lisette.Option[T]
 
 type User struct {
-	Name  Maybe[string]          `json:"name,omitempty,omitzero"`
-	Email lisette.Option[string] `json:"email,omitempty,omitzero"`
+	Name  Maybe[string]          `json:"name,omitzero"`
+	Email lisette.Option[string] `json:"email,omitzero"`
 }

--- a/tests/spec/emit/snapshots/struct_with_tag_json_omitempty_option.snap
+++ b/tests/spec/emit/snapshots/struct_with_tag_json_omitempty_option.snap
@@ -2,9 +2,8 @@
 source: tests/spec/emit/types.rs
 description: |
   
-  #[json(omitempty)]
   struct User {
-    name: string,
+    #[tag("json", omitempty)]
     email: Option<string>,
   }
 ---
@@ -13,6 +12,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 type User struct {
-	Name  string                 `json:"name,omitempty"`
 	Email lisette.Option[string] `json:"email,omitzero"`
 }

--- a/tests/spec/emit/snapshots/struct_with_yaml_option_omitempty.snap
+++ b/tests/spec/emit/snapshots/struct_with_yaml_option_omitempty.snap
@@ -2,7 +2,7 @@
 source: tests/spec/emit/types.rs
 description: |
   
-  #[json(omitempty)]
+  #[yaml(omitempty)]
   struct User {
     name: string,
     email: Option<string>,
@@ -13,6 +13,6 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 type User struct {
-	Name  string                 `json:"name,omitempty"`
-	Email lisette.Option[string] `json:"email,omitzero"`
+	Name  string                 `yaml:"name,omitempty"`
+	Email lisette.Option[string] `yaml:"email,omitempty"`
 }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1831,6 +1831,29 @@ struct User {
 }
 
 #[test]
+fn struct_with_tag_json_omitempty_option() {
+    let input = r#"
+struct User {
+  #[tag("json", omitempty)]
+  email: Option<string>,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_with_yaml_option_omitempty() {
+    let input = r#"
+#[yaml(omitempty)]
+struct User {
+  name: string,
+  email: Option<string>,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn struct_with_multiple_raw_tags() {
     let input = r#"
 #[tag("validate")]


### PR DESCRIPTION
`#[json(omitempty)]` on `Option` fields now omits `None` from marshaled JSON.

```rs
#[json(omitempty)]
struct User {
  name: string,
  emails: Option<Slice<string>>,
}
```

Previously, a missing `"emails"` key decoded to `Some(nil)`, so marshaling wrote `"emails": null`, and the emitted tag carried a dead `omitempty` that gopls flagged on struct-typed fields. The field now emits `json:"emails,omitzero"`, a missing key decodes to `None`, and `None` marshals to no key at all, so this round-trips cleanly.

Fix #937
