### PR TITLE
refactor: share Go name computation between checker and emit

### DIFF
--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -5,10 +5,7 @@ use crate::names::go_name;
 use crate::utils::receiver_name;
 use syntax::ast::{EnumVariant, Generic};
 
-pub(crate) const ENUM_TAG_FIELD: &str = "Tag";
-
-pub(crate) const ENUM_STRINGER_METHOD: &str = "String";
-pub(crate) const ENUM_GO_STRINGER_METHOD: &str = "GoString";
+pub(crate) use syntax::go_names::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, ENUM_TAG_FIELD};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EnumLayout {
@@ -95,7 +92,7 @@ impl EnumLayout {
                     fi.to_string()
                 };
 
-                let go_name = Self::compute_field_go_name(
+                let go_name = syntax::go_names::enum_field_go_name(
                     &variant.name,
                     &field.name,
                     fi,
@@ -127,47 +124,6 @@ impl EnumLayout {
             is_struct_variant: is_struct,
             fields,
             doc: variant.doc.clone(),
-        }
-    }
-
-    fn compute_field_go_name(
-        variant_name: &str,
-        field_name: &str,
-        field_index: usize,
-        is_struct: bool,
-        single_field: bool,
-        enum_name: &str,
-    ) -> String {
-        if is_struct {
-            let base = go_name::snake_to_camel(field_name);
-            if base == ENUM_TAG_FIELD
-                || base == ENUM_STRINGER_METHOD
-                || base == ENUM_GO_STRINGER_METHOD
-            {
-                go_name::escape_keyword(&format!("{}{}", variant_name, base)).into_owned()
-            } else {
-                go_name::escape_keyword(&base).into_owned()
-            }
-        } else if single_field {
-            let base = variant_name.to_string();
-            if base == ENUM_TAG_FIELD
-                || base == ENUM_STRINGER_METHOD
-                || base == ENUM_GO_STRINGER_METHOD
-            {
-                format!("{}{}_", enum_name, base)
-            } else {
-                base
-            }
-        } else {
-            let base = format!("{}{}", variant_name, field_index);
-            if base == ENUM_TAG_FIELD
-                || base == ENUM_STRINGER_METHOD
-                || base == ENUM_GO_STRINGER_METHOD
-            {
-                format!("{}{}_{}", enum_name, variant_name, field_index)
-            } else {
-                base
-            }
         }
     }
 

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::definitions::enum_layout::ENUM_TAG_FIELD;
+use syntax::go_names::ENUM_TAG_FIELD;
 use syntax::types::Type;
 
 pub(crate) const GO_IMPORT_PREFIX: &str = "go:";
@@ -40,25 +40,14 @@ pub(crate) const TEST_PRELUDE_MODULE: &str = "**test_prelude";
 pub const TESTKIT_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude/testkit";
 pub(crate) const TESTKIT_PKG: &str = "testkit";
 
+pub(crate) use syntax::go_names::{GO_KEYWORDS, escape_keyword, snake_to_camel};
 pub(crate) use syntax::types::unqualified_name;
-
-pub(crate) fn capitalize_first(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
-    }
-}
 
 /// Convert a Lisette identifier to its exported Go form: snake_case becomes
 /// PascalCase (`user_id` → `UserId`), already-Pascal names pass through, and
 /// the result is escaped if it collides with a Go keyword.
 pub(crate) fn make_exported(name: &str) -> String {
     escape_keyword(&snake_to_camel(name)).into_owned()
-}
-
-pub(crate) fn snake_to_camel(s: &str) -> String {
-    s.split('_').map(capitalize_first).collect()
 }
 
 pub fn go_test_function_name(fn_name: &str) -> String {
@@ -107,36 +96,6 @@ pub(crate) fn sanitize_package_name(name: &str) -> Cow<'_, str> {
 
     Cow::Owned(result)
 }
-
-/// Go reserved keywords that cannot be used as identifiers.
-/// See: https://go.dev/ref/spec#Keywords
-const GO_KEYWORDS: &[&str] = &[
-    "break",
-    "case",
-    "chan",
-    "const",
-    "continue",
-    "default",
-    "defer",
-    "else",
-    "fallthrough",
-    "for",
-    "func",
-    "go",
-    "goto",
-    "if",
-    "import",
-    "interface",
-    "map",
-    "package",
-    "range",
-    "return",
-    "select",
-    "struct",
-    "switch",
-    "type",
-    "var",
-];
 
 pub(crate) struct ResolvedName {
     pub(crate) name: String,
@@ -275,14 +234,6 @@ const GO_BUILTINS: &[&str] = &[
     "nil",
     "true",
 ];
-
-pub(crate) fn escape_keyword(name: &str) -> Cow<'_, str> {
-    if GO_KEYWORDS.contains(&name) {
-        Cow::Owned(format!("{}_", name))
-    } else {
-        Cow::Borrowed(name)
-    }
-}
 
 /// Go builtins re-exposed by the Lisette prelude under the same name. The
 /// `prelude_function_shadowed` diagnostic forbids user code from declaring

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -133,9 +133,8 @@ impl TaskState<'_> {
 
     /// Check for Go-level field name collisions across enum variants.
     ///
-    /// Computes the Go field name for every variant field (struct fields get
-    /// capitalized, single-tuple fields use the variant name, multi-tuple fields
-    /// use variant name + index) and rejects same-name-different-type conflicts.
+    /// Computes each field's Go name via the shared authority in
+    /// `syntax::go_names` and rejects same-name-different-type conflicts.
     fn check_enum_field_type_conflicts(&mut self, name: &str, variants: &[EnumVariant]) {
         if self.cursor.module_id == "prelude" {
             return;
@@ -150,18 +149,14 @@ impl TaskState<'_> {
             let single_field = variant.fields.len() == 1;
 
             for (fi, field) in variant.fields.iter().enumerate() {
-                // Mirror the Go field name logic from enum_layout.rs
-                let go_name = if is_struct {
-                    let mut chars = field.name.chars();
-                    match chars.next() {
-                        None => String::new(),
-                        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
-                    }
-                } else if single_field {
-                    variant.name.to_string()
-                } else {
-                    format!("{}{}", variant.name, fi)
-                };
+                let go_name = syntax::go_names::enum_field_go_name(
+                    &variant.name,
+                    &field.name,
+                    fi,
+                    is_struct,
+                    single_field,
+                    name,
+                );
 
                 let resolved = field.ty.resolve_in(&self.env);
                 let annotation_span = field.annotation.get_span();

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -1,0 +1,158 @@
+//! Go identifier computation shared by the checker and the emitter, so
+//! neither has to mirror the other's naming policy.
+
+use std::borrow::Cow;
+
+/// Go reserved keywords that cannot be used as identifiers.
+/// See: https://go.dev/ref/spec#Keywords
+pub const GO_KEYWORDS: &[&str] = &[
+    "break",
+    "case",
+    "chan",
+    "const",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "for",
+    "func",
+    "go",
+    "goto",
+    "if",
+    "import",
+    "interface",
+    "map",
+    "package",
+    "range",
+    "return",
+    "select",
+    "struct",
+    "switch",
+    "type",
+    "var",
+];
+
+pub const ENUM_TAG_FIELD: &str = "Tag";
+
+pub const ENUM_STRINGER_METHOD: &str = "String";
+pub const ENUM_GO_STRINGER_METHOD: &str = "GoString";
+
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+pub fn snake_to_camel(s: &str) -> String {
+    s.split('_').map(capitalize_first).collect()
+}
+
+pub fn escape_keyword(name: &str) -> Cow<'_, str> {
+    if GO_KEYWORDS.contains(&name) {
+        Cow::Owned(format!("{}_", name))
+    } else {
+        Cow::Borrowed(name)
+    }
+}
+
+/// Go struct field name for an enum variant field. Emit's enum layout and
+/// the checker's cross-variant conflict check must both use this single
+/// authority so their notions of a field's Go name cannot drift.
+pub fn enum_field_go_name(
+    variant_name: &str,
+    field_name: &str,
+    field_index: usize,
+    is_struct: bool,
+    single_field: bool,
+    enum_name: &str,
+) -> String {
+    if is_struct {
+        let base = snake_to_camel(field_name);
+        if base == ENUM_TAG_FIELD || base == ENUM_STRINGER_METHOD || base == ENUM_GO_STRINGER_METHOD
+        {
+            escape_keyword(&format!("{}{}", variant_name, base)).into_owned()
+        } else {
+            escape_keyword(&base).into_owned()
+        }
+    } else if single_field {
+        let base = variant_name.to_string();
+        if base == ENUM_TAG_FIELD || base == ENUM_STRINGER_METHOD || base == ENUM_GO_STRINGER_METHOD
+        {
+            format!("{}{}_", enum_name, base)
+        } else {
+            base
+        }
+    } else {
+        let base = format!("{}{}", variant_name, field_index);
+        if base == ENUM_TAG_FIELD || base == ENUM_STRINGER_METHOD || base == ENUM_GO_STRINGER_METHOD
+        {
+            format!("{}{}_{}", enum_name, variant_name, field_index)
+        } else {
+            base
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snake_to_camel_converts_and_normalizes() {
+        assert_eq!(snake_to_camel("user_id"), "UserId");
+        assert_eq!(snake_to_camel("foo_bar"), "FooBar");
+        assert_eq!(snake_to_camel("fooBar"), "FooBar");
+        assert_eq!(snake_to_camel("x"), "X");
+        assert_eq!(snake_to_camel("x_"), "X");
+    }
+
+    #[test]
+    fn escape_keyword_appends_underscore() {
+        assert_eq!(escape_keyword("type"), "type_");
+        assert_eq!(escape_keyword("Type"), "Type");
+        assert_eq!(escape_keyword("target"), "target");
+    }
+
+    #[test]
+    fn enum_field_go_name_struct_fields() {
+        assert_eq!(
+            enum_field_go_name("Click", "target_id", 0, true, true, "Event"),
+            "TargetId"
+        );
+        assert_eq!(
+            enum_field_go_name("Click", "tag", 0, true, true, "Event"),
+            "ClickTag"
+        );
+        assert_eq!(
+            enum_field_go_name("Click", "string", 0, true, true, "Event"),
+            "ClickString"
+        );
+        assert_eq!(
+            enum_field_go_name("Click", "go_string", 0, true, true, "Event"),
+            "ClickGoString"
+        );
+    }
+
+    #[test]
+    fn enum_field_go_name_tuple_fields() {
+        assert_eq!(
+            enum_field_go_name("Click", "0", 0, false, true, "Event"),
+            "Click"
+        );
+        assert_eq!(
+            enum_field_go_name("Tag", "0", 0, false, true, "Event"),
+            "EventTag_"
+        );
+        assert_eq!(
+            enum_field_go_name("String", "0", 0, false, true, "Event"),
+            "EventString_"
+        );
+        assert_eq!(
+            enum_field_go_name("Click", "1", 1, false, false, "Event"),
+            "Click1"
+        );
+    }
+}

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ast_folder;
 pub mod attributes;
 pub mod desugar;
 mod display;
+pub mod go_names;
 pub mod lex;
 pub mod parse;
 pub mod program;

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8343,6 +8343,28 @@ enum Shape {
 }
 
 #[test]
+fn infer_enum_field_type_conflict_snake_vs_camel() {
+    let input = r#"
+enum Event {
+  Click { foo_bar: int },
+  Hover { fooBar: string },
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_enum_field_type_conflict_trailing_underscore() {
+    let input = r#"
+enum Event {
+  Click { x_: int },
+  Hover { x: string },
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_native_method_value() {
     let input = r#"
 fn apply(f: fn(Slice<int>, VarArgs<int>) -> Slice<int>) {

--- a/tests/ui/errors/snapshots/infer_enum_field_type_conflict_snake_vs_camel.snap
+++ b/tests/ui/errors/snapshots/infer_enum_field_type_conflict_snake_vs_camel.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Conflicting field types across enum variants
+   ╭─[test.lis:4:19]
+ 3 │   Click { foo_bar: int },
+ 4 │   Hover { fooBar: string },
+   ·                   ───┬──
+   ·                      ╰── field type mismatch
+ 5 │ }
+   ╰────
+  help: `Event.Click.foo_bar` is `int` but `Event.Hover.fooBar` is `string`. Rename one of the fields or align their types · code: [infer.enum_field_type_conflict]

--- a/tests/ui/errors/snapshots/infer_enum_field_type_conflict_trailing_underscore.snap
+++ b/tests/ui/errors/snapshots/infer_enum_field_type_conflict_trailing_underscore.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Conflicting field types across enum variants
+   ╭─[test.lis:4:14]
+ 3 │   Click { x_: int },
+ 4 │   Hover { x: string },
+   ·              ───┬──
+   ·                 ╰── field type mismatch
+ 5 │ }
+   ╰────
+  help: `Event.Click.x_` is `int` but `Event.Hover.x` is `string`. Rename one of the fields or align their types · code: [infer.enum_field_type_conflict]


### PR DESCRIPTION
The checker and the emitter now derive Go enum field names from a single shared function, instead of the checker mirroring the emitter's naming by hand.