### PR TITLE
feat: autofix 25 more lints

### DIFF
--- a/crates/diagnostics/src/fix.rs
+++ b/crates/diagnostics/src/fix.rs
@@ -30,18 +30,26 @@ impl Edit {
     }
 }
 
-/// A single applicable fix for one diagnostic.
+/// An applicable fix for one diagnostic, carrying one or more edits that are
+/// applied together as a unit.
 #[derive(Debug, Clone)]
 pub struct Fix {
     message: String,
-    edit: Edit,
+    edits: Vec<Edit>,
 }
 
 impl Fix {
     pub fn new(message: impl Into<String>, edit: Edit) -> Self {
         Self {
             message: message.into(),
-            edit,
+            edits: vec![edit],
+        }
+    }
+
+    pub fn multi(message: impl Into<String>, edits: Vec<Edit>) -> Self {
+        Self {
+            message: message.into(),
+            edits,
         }
     }
 
@@ -49,8 +57,8 @@ impl Fix {
         &self.message
     }
 
-    pub fn edit(&self) -> &Edit {
-        &self.edit
+    pub fn edits(&self) -> &[Edit] {
+        &self.edits
     }
 }
 
@@ -60,37 +68,57 @@ pub struct FixApplicationOutcome {
     pub applied: usize,
 }
 
-/// Apply `fixes` to `source` in a single left-to-right pass.
-///
-/// Fixes are sorted by span. A fix whose edit starts at or before the last
-/// applied edit ended is skipped (boundary-adjacent spans count as overlapping)
-/// and stays reported as a diagnostic on the next run.
+/// Apply `fixes` to `source`, each fix atomically. A fix applies only when all of
+/// its edits are mutually non-overlapping and clear of every already-applied edit
+/// (boundary adjacency counts as overlap), else the whole fix is skipped and stays
+/// reported on the next run.
 pub fn apply_fixes(source: &str, mut fixes: Vec<&Fix>) -> FixApplicationOutcome {
-    fixes.sort_by_key(|fix| {
-        let span = fix.edit().span();
-        (span.byte_offset, span.end())
-    });
+    fixes.sort_by_key(|fix| fix.edits().iter().map(|edit| edit.span().byte_offset).min());
 
-    let mut out = String::with_capacity(source.len());
-    let mut last_end: Option<u32> = None;
+    let mut accepted: Vec<&Edit> = Vec::new();
     let mut applied = 0;
 
     for fix in fixes {
-        let span = fix.edit().span();
-        if last_end.is_some_and(|end| span.byte_offset <= end) {
-            continue;
+        let edits = fix.edits();
+        // A fix's own edits are authored together, so adjacent ones concatenate.
+        // Only edits that share a byte genuinely conflict.
+        let internally_clear = edits.iter().enumerate().all(|(i, a)| {
+            edits[i + 1..]
+                .iter()
+                .all(|b| !spans_share_byte(a.span(), b.span()))
+        });
+        let clear_of_accepted = edits.iter().all(|edit| {
+            accepted
+                .iter()
+                .all(|other| !spans_overlap(edit.span(), other.span()))
+        });
+        if internally_clear && clear_of_accepted {
+            accepted.extend(edits);
+            applied += 1;
         }
-        out.push_str(&source[last_end.unwrap_or(0) as usize..span.byte_offset as usize]);
-        out.push_str(fix.edit().content());
-        last_end = Some(span.end());
-        applied += 1;
     }
 
-    out.push_str(&source[last_end.unwrap_or(0) as usize..]);
+    accepted.sort_by_key(|edit| edit.span().byte_offset);
+    let mut out = String::with_capacity(source.len());
+    let mut cursor = 0usize;
+    for edit in accepted {
+        let start = edit.span().byte_offset as usize;
+        out.push_str(&source[cursor..start]);
+        out.push_str(edit.content());
+        cursor = edit.span().end() as usize;
+    }
+    out.push_str(&source[cursor..]);
     FixApplicationOutcome {
         source: out,
         applied,
     }
+}
+
+fn spans_overlap(a: Span, b: Span) -> bool {
+    a.byte_offset <= b.end() && b.byte_offset <= a.end()
+}
+fn spans_share_byte(a: Span, b: Span) -> bool {
+    a.byte_offset < b.end() && b.byte_offset < a.end()
 }
 
 #[cfg(test)]
@@ -140,6 +168,49 @@ mod tests {
         let b = Fix::new("b", Edit::replacement(span(2, 2), "Y"));
         let applied = apply_fixes("abcd", vec![&a, &b]);
         assert_eq!(applied.source, "Xcd");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn applies_all_edits_of_a_multi_edit_fix() {
+        let fix = Fix::multi(
+            "m",
+            vec![
+                Edit::replacement(span(0, 1), "A"),
+                Edit::replacement(span(4, 1), "E"),
+            ],
+        );
+        let applied = apply_fixes("abcde", vec![&fix]);
+        assert_eq!(applied.source, "AbcdE");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn applies_adjacent_edits_within_one_fix() {
+        let fix = Fix::multi(
+            "m",
+            vec![
+                Edit::replacement(span(0, 1), "X"),
+                Edit::deletion(span(1, 2)),
+            ],
+        );
+        let applied = apply_fixes("abcd", vec![&fix]);
+        assert_eq!(applied.source, "Xd");
+        assert_eq!(applied.applied, 1);
+    }
+
+    #[test]
+    fn skips_whole_multi_edit_fix_when_one_edit_conflicts() {
+        let blocker = Fix::new("b", Edit::replacement(span(0, 1), "Z"));
+        let multi = Fix::multi(
+            "m",
+            vec![
+                Edit::replacement(span(0, 1), "A"),
+                Edit::replacement(span(4, 1), "E"),
+            ],
+        );
+        let applied = apply_fixes("abcde", vec![&blocker, &multi]);
+        assert_eq!(applied.source, "Zbcde");
         assert_eq!(applied.applied, 1);
     }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1157,14 +1157,17 @@ impl LanguageServer for Backend {
                 continue;
             }
 
-            let edit = fix.edit();
-            let text_edit = TextEdit {
-                range: line_index.span_to_range(edit.span()),
-                new_text: edit.content().to_string(),
-            };
+            let text_edits: Vec<TextEdit> = fix
+                .edits()
+                .iter()
+                .map(|edit| TextEdit {
+                    range: line_index.span_to_range(edit.span()),
+                    new_text: edit.content().to_string(),
+                })
+                .collect();
 
             let mut changes = std::collections::HashMap::new();
-            changes.insert(uri.clone(), vec![text_edit]);
+            changes.insert(uri.clone(), text_edits);
 
             actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                 title: fix.message().to_string(),

--- a/crates/passes/src/passes/comparison.rs
+++ b/crates/passes/src/passes/comparison.rs
@@ -158,6 +158,19 @@ pub(crate) fn flip_comparison(operator: BinaryOperator) -> BinaryOperator {
     }
 }
 
+pub(crate) fn negate_comparison(operator: BinaryOperator) -> Option<&'static str> {
+    use BinaryOperator::*;
+    Some(match operator {
+        Equal => "!=",
+        NotEqual => "==",
+        LessThan => ">=",
+        LessThanOrEqual => ">",
+        GreaterThan => "<=",
+        GreaterThanOrEqual => "<",
+        _ => return None,
+    })
+}
+
 pub(crate) fn is_side_effect_free(expression: &Expression) -> bool {
     match expression.unwrap_parens() {
         Expression::Identifier { .. } | Expression::Literal { .. } => true,

--- a/crates/passes/src/passes/lints/ast_walk/checks/bind_instead_of_map.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/bind_instead_of_map.rs
@@ -1,7 +1,11 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::{has_escaping_control_flow, method_call, unary_lambda, wrapped_single_arg};
+use super::helpers::{
+    as_tight_operand, has_escaping_control_flow, lambda_is_annotated, method_call,
+    reads_as_method_call, span_text, unary_lambda, wrapped_single_arg,
+};
 
 pub fn check_bind_instead_of_map(expression: &Expression, ctx: &NodeCtx) {
     let Some((receiver, args, span)) = method_call(expression, "and_then") else {
@@ -10,7 +14,7 @@ pub fn check_bind_instead_of_map(expression: &Expression, ctx: &NodeCtx) {
     let [closure] = args else {
         return;
     };
-    let Some((_, body)) = unary_lambda(closure) else {
+    let Some((param, body)) = unary_lambda(closure) else {
         return;
     };
 
@@ -36,6 +40,22 @@ pub fn check_bind_instead_of_map(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::bind_instead_of_map(span, wrapper));
+    let mut diagnostic = diagnostics::lint::bind_instead_of_map(span, wrapper);
+    if !lambda_is_annotated(closure)
+        && reads_as_method_call(receiver, args)
+        && let (Some(receiver_text), Some(wrapped_text)) = (
+            span_text(ctx.source, receiver),
+            span_text(ctx.source, wrapped),
+        )
+    {
+        let replacement = format!(
+            "{}.map(|{param}| {wrapped_text})",
+            as_tight_operand(receiver_text, receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
@@ -1,8 +1,9 @@
 use crate::passes::comparison::{in_scope_comparison, is_side_effect_free};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 
-use super::helpers::expressions_equivalent;
+use super::helpers::{expressions_equivalent, span_text};
 
 /// Inspects a single `&&`/`||` of two directly-joined comparisons over the same
 /// operands; flattened chains and swapped-operand forms are out of scope.
@@ -43,8 +44,18 @@ pub fn check_double_comparison(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink
-        .push(diagnostics::lint::double_comparison(span, combined));
+    let mut diagnostic = diagnostics::lint::double_comparison(span, combined);
+    if let (Some(lhs), Some(rhs)) = (
+        span_text(ctx.source, left_lhs),
+        span_text(ctx.source, left_rhs),
+    ) {
+        let replacement = format!("{lhs} {combined} {rhs}");
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 /// True only when the operand's type is known to have a non-float underlying

--- a/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
@@ -10,7 +10,8 @@ use crate::passes::walk::visit_ast;
 use semantics::store::Store;
 
 pub(super) use crate::passes::comparison::{
-    expressions_equivalent, flip_comparison, is_side_effect_free, signed_integer_literal,
+    expressions_equivalent, flip_comparison, is_side_effect_free, negate_comparison,
+    signed_integer_literal,
 };
 
 pub(super) fn first_param_is_self(params: &[Binding]) -> bool {
@@ -225,6 +226,52 @@ fn literal_is_pure(literal: &Literal, store: &Store) -> bool {
 pub(super) fn span_text<'a>(source: &'a str, expression: &Expression) -> Option<&'a str> {
     let span = expression.get_span();
     source.get(span.byte_offset as usize..span.end() as usize)
+}
+
+/// Whether `expression` binds at least as tightly as a postfix operator.
+pub(super) fn is_postfix_tight(expression: &Expression) -> bool {
+    match expression {
+        Expression::Identifier { .. }
+        | Expression::Literal { .. }
+        | Expression::DotAccess { .. }
+        | Expression::IndexedAccess { .. }
+        | Expression::Paren { .. }
+        | Expression::Propagate { .. } => true,
+        // A `|>` pipeline desugars to a `Call` with its piped arg before the callee.
+        Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } => args
+            .iter()
+            .all(|arg| arg.get_span().byte_offset >= callee.get_span().byte_offset),
+        _ => false,
+    }
+}
+
+pub(super) fn lambda_is_annotated(expression: &Expression) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::Lambda { params, return_annotation, .. }
+            if !return_annotation.is_unknown()
+                || params.iter().any(|param| param.annotation.is_some())
+    )
+}
+
+pub(super) fn as_tight_operand(text: &str, expression: &Expression) -> String {
+    if is_postfix_tight(expression) {
+        text.to_string()
+    } else {
+        format!("({text})")
+    }
+}
+
+/// Whether every argument sits after `receiver` in source, distinguishing a
+/// written `receiver.method(args)` from a `|>` pipeline (piped value before it).
+pub(super) fn reads_as_method_call(receiver: &Expression, args: &[Expression]) -> bool {
+    let receiver_end = receiver.get_span().end();
+    args.iter()
+        .all(|arg| arg.get_span().byte_offset >= receiver_end)
 }
 
 // The single identifier bound by a one-field enum-variant pattern such as

--- a/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
@@ -1,5 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Pattern};
+
+use super::helpers::span_text;
 
 pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Block { items, .. } = expression else {
@@ -12,6 +15,7 @@ pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
 
     let Expression::Let {
         binding,
+        value: bound_value,
         mutable: false,
         else_block: None,
         span,
@@ -39,5 +43,13 @@ pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::let_and_return(span));
+    let mut diagnostic = diagnostics::lint::let_and_return(span);
+    if let Some(value_text) = span_text(ctx.source, bound_value) {
+        let edit_span = span.merge(tail.get_span());
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{value_text}`"),
+            Edit::replacement(edit_span, value_text.to_string()),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_contains.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_contains.rs
@@ -1,8 +1,10 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{BinaryOperator, Expression};
 
 use super::helpers::{
-    expression_is_pure, is_bare_identifier, mentions_identifier, method_call, unary_lambda,
+    as_tight_operand, expression_is_pure, is_bare_identifier, lambda_is_annotated,
+    mentions_identifier, method_call, reads_as_method_call, span_text, unary_lambda,
 };
 
 pub fn check_manual_contains(expression: &Expression, ctx: &NodeCtx) {
@@ -57,5 +59,22 @@ pub fn check_manual_contains(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::manual_contains(span));
+    let mut diagnostic = diagnostics::lint::manual_contains(span);
+    if !lambda_is_annotated(closure)
+        && reads_as_method_call(receiver, args)
+        && let (Some(receiver_text), Some(value_text)) = (
+            span_text(ctx.source, receiver),
+            span_text(ctx.source, value),
+        )
+    {
+        let replacement = format!(
+            "{}.contains({value_text})",
+            as_tight_operand(receiver_text, receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
@@ -1,5 +1,8 @@
-use super::helpers::{expression_is_pure, is_zero_literal, span_text};
+use super::helpers::{
+    as_tight_operand, expression_is_pure, is_zero_literal, reads_as_method_call, span_text,
+};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use semantics::store::Store;
 use syntax::ast::{Expression, Span};
 use syntax::program::{CallKind, NativeTypeKind};
@@ -29,11 +32,18 @@ pub fn check_manual_find(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::manual_find(
-        span,
-        receiver_text,
-        predicate_text,
-    ));
+    let mut diagnostic = diagnostics::lint::manual_find(span, receiver_text, predicate_text);
+    if reads_as_method_call(receiver, std::slice::from_ref(predicate)) {
+        let replacement = format!(
+            "{}.find({predicate_text})",
+            as_tight_operand(receiver_text, receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 fn native_slice_method<'a>(

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_option_zip.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_option_zip.rs
@@ -1,8 +1,12 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
+use syntax::types::Type;
 
 use super::helpers::{
-    is_bare_identifier, is_side_effect_free, mentions_identifier, method_call, unary_lambda,
+    as_tight_operand, expression_is_pure, is_bare_identifier, is_side_effect_free,
+    lambda_is_annotated, mentions_identifier, method_call, reads_as_method_call, span_text,
+    unary_lambda,
 };
 
 pub fn check_manual_option_zip(expression: &Expression, ctx: &NodeCtx) {
@@ -48,12 +52,58 @@ pub fn check_manual_option_zip(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    // `zip` evaluates its argument eagerly and outside the outer closure, so the
-    // second option must be side-effect-free and independent of the captured
-    // binding.
-    if !is_side_effect_free(inner_receiver) || mentions_identifier(inner_receiver, outer_param) {
+    // `zip` evaluates the second option eagerly and outside the outer closure, so
+    // it must not depend on the binding or panic where the lazy `and_then` would not.
+    if !is_side_effect_free(inner_receiver)
+        || mentions_identifier(inner_receiver, outer_param)
+        || !expression_is_pure(inner_receiver, ctx.store)
+    {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::manual_option_zip(span));
+    // `and_then`/`map` can adapt the tuple elements against the result type, which
+    // `zip` (fixing them from the receivers) would not, so require a matching type.
+    let outer_ty = outer_receiver.get_type();
+    let inner_ty = inner_receiver.get_type();
+    let result_ty = expression.get_type();
+    let (Some(first_ty), Some(second_ty), Some(result_inner)) = (
+        option_inner(&outer_ty),
+        option_inner(&inner_ty),
+        option_inner(&result_ty),
+    ) else {
+        return;
+    };
+    if *result_inner != Type::Tuple(vec![first_ty.clone(), second_ty.clone()]) {
+        return;
+    }
+
+    let mut diagnostic = diagnostics::lint::manual_option_zip(span);
+    if !lambda_is_annotated(outer_closure)
+        && !lambda_is_annotated(inner_closure)
+        && reads_as_method_call(outer_receiver, outer_args)
+        && let (Some(receiver_text), Some(other_text)) = (
+            span_text(ctx.source, outer_receiver),
+            span_text(ctx.source, inner_receiver),
+        )
+    {
+        let replacement = format!(
+            "{}.zip({other_text})",
+            as_tight_operand(receiver_text, outer_receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
+}
+
+fn option_inner(ty: &Type) -> Option<&Type> {
+    if !ty.is_option() {
+        return None;
+    }
+    match ty {
+        Type::Nominal { params, .. } => params.first(),
+        _ => None,
+    }
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
@@ -1,4 +1,6 @@
+use crate::passes::lints::span_edit::match_arm_deletion;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use ecow::EcoString;
 use syntax::ast::{Expression, Literal, MatchArm, TypedPattern, collect_pattern_bindings};
 use syntax::types::unqualified_name;
@@ -49,16 +51,28 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
             continue;
         };
         let earlier_span = earlier.pattern.get_span();
-        let Some(earlier_text) = ctx
-            .source
-            .get(earlier_span.byte_offset as usize..earlier_span.end() as usize)
-        else {
+        let later_span = later.pattern.get_span();
+        let (Some(earlier_text), Some(later_text)) = (
+            ctx.source
+                .get(earlier_span.byte_offset as usize..earlier_span.end() as usize),
+            ctx.source
+                .get(later_span.byte_offset as usize..later_span.end() as usize),
+        ) else {
             continue;
         };
-        ctx.sink.push(diagnostics::lint::match_same_arms(
-            &later.pattern.get_span(),
-            earlier_text,
-        ));
+
+        let merged = format!("{earlier_text} | {later_text}");
+        let arm_span = later_span.merge(later.expression.get_span());
+        let deletion = match_arm_deletion(ctx.source, arm_span);
+        ctx.sink.push(
+            diagnostics::lint::match_same_arms(&later_span, earlier_text).with_fix(Fix::multi(
+                format!("Merge into `{merged}`"),
+                vec![
+                    Edit::replacement(earlier_span, merged),
+                    Edit::deletion(deletion),
+                ],
+            )),
+        );
     }
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_match.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_match.rs
@@ -1,8 +1,10 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, MatchArm, Span};
 
 use super::helpers::{
-    enum_variant_binding, is_bare_identifier, is_none_pattern, span_text, wraps_binding,
+    as_tight_operand, enum_variant_binding, is_bare_identifier, is_none_pattern, span_text,
+    wraps_binding,
 };
 
 pub fn check_needless_match(expression: &Expression, ctx: &NodeCtx) {
@@ -34,15 +36,24 @@ pub fn check_needless_match(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
+    // A differing result type means the arms adapt the subject,
+    // so the match is not needless.
+    if subject_ty != result_ty {
+        return;
+    }
+
     let Some(subject_text) = span_text(ctx.source, subject) else {
         return;
     };
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    ctx.sink.push(diagnostics::lint::needless_match(
-        &match_keyword_span,
-        subject_text,
-    ));
+    let replacement = as_tight_operand(subject_text, subject);
+    ctx.sink.push(
+        diagnostics::lint::needless_match(&match_keyword_span, subject_text).with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        )),
+    );
 }
 
 fn option_passthrough(a: &MatchArm, b: &MatchArm) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_update.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_update.rs
@@ -2,8 +2,10 @@ use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Span, StructSpread};
 use syntax::types::Type;
 
-use super::helpers::{is_side_effect_free, struct_field_names};
+use super::helpers::{expression_is_pure, is_side_effect_free, struct_field_names};
+use crate::passes::lints::span_edit::list_item_deletion;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 
 pub fn check_needless_update(expression: &Expression, ctx: &NodeCtx) {
     let Expression::StructCall {
@@ -20,7 +22,7 @@ pub fn check_needless_update(expression: &Expression, ctx: &NodeCtx) {
     let StructSpread::From(base) = spread else {
         return;
     };
-    if !is_side_effect_free(base) {
+    if !is_side_effect_free(base) || !expression_is_pure(base, ctx.store) {
         return;
     }
     if is_go_imported(ty) {
@@ -44,8 +46,13 @@ pub fn check_needless_update(expression: &Expression, ctx: &NodeCtx) {
         .source
         .get(base_span.byte_offset as usize..base_span.end() as usize)
         .unwrap_or("");
-    ctx.sink
-        .push(diagnostics::lint::needless_update(&span, base_text));
+    let deletion = list_item_deletion(ctx.source, span);
+    ctx.sink.push(
+        diagnostics::lint::needless_update(&span, base_text).with_fix(Fix::new(
+            "Remove the redundant `..` update",
+            Edit::deletion(deletion),
+        )),
+    );
 }
 
 fn is_go_imported(ty: &Type) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/nested_fstring.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/nested_fstring.rs
@@ -32,7 +32,13 @@ pub fn check_nested_fstring(expression: &Expression, ctx: &NodeCtx) {
         let has_interpolation = inner_parts
             .iter()
             .any(|part| matches!(part, FormatStringPart::Expression(_)));
-        if !has_interpolation || ctx.facts.expression_only_fstrings.contains(inner_span) {
+        if !has_interpolation
+            || ctx
+                .facts
+                .expression_only_fstrings
+                .iter()
+                .any(|fact| fact.span == *inner_span)
+        {
             continue;
         }
         ctx.sink.push(diagnostics::lint::nested_fstring(inner_span));

--- a/crates/passes/src/passes/lints/ast_walk/checks/or_fn_call.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/or_fn_call.rs
@@ -1,8 +1,9 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 use syntax::program::CallKind;
 
-use super::helpers::has_escaping_control_flow;
+use super::helpers::{as_tight_operand, has_escaping_control_flow, span_text};
 
 pub fn check_or_fn_call(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
@@ -63,11 +64,33 @@ pub fn check_or_fn_call(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink.push(diagnostics::lint::or_fn_call(
-        &eager_argument.get_span(),
-        eager,
-        lazy,
-    ));
+    let mut diagnostic = diagnostics::lint::or_fn_call(&eager_argument.get_span(), eager, lazy);
+    // `Result`/`Partial` lazy callbacks take the error value, `Option`'s take none.
+    let closure_head = if receiver_ty.is_result() || receiver_ty.is_partial() {
+        "|_|"
+    } else {
+        "||"
+    };
+    let arg_texts: Option<Vec<&str>> = args.iter().map(|arg| span_text(ctx.source, arg)).collect();
+    if let Some(receiver_text) = span_text(ctx.source, receiver)
+        && let Some(arg_texts) = arg_texts
+        && let [first, rest @ ..] = arg_texts.as_slice()
+    {
+        let mut call_args = format!("{closure_head} {first}");
+        for extra in rest {
+            call_args.push_str(", ");
+            call_args.push_str(extra);
+        }
+        let replacement = format!(
+            "{}.{lazy}({call_args})",
+            as_tight_operand(receiver_text, receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(expression.get_span(), replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 // Descends through cheap wrappers (arithmetic, field reads, value constructors),

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
@@ -1,6 +1,8 @@
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Pattern};
 use syntax::program::{CallKind, DotAccessKind};
 
+use super::helpers::lambda_is_annotated;
 use crate::passes::walk::NodeCtx;
 use semantics::facts::Facts;
 
@@ -57,8 +59,14 @@ pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink
-        .push(diagnostics::lint::redundant_closure(span, &callee_name));
+    let mut diagnostic = diagnostics::lint::redundant_closure(span, &callee_name);
+    if !lambda_is_annotated(expression) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{callee_name}`"),
+            Edit::replacement(*span, callee_name.clone()),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 fn lambda_body(body: &Expression) -> &Expression {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure_call.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure_call.rs
@@ -1,7 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::has_escaping_control_flow;
+use super::helpers::{has_escaping_control_flow, is_postfix_tight, span_text};
 
 pub fn check_redundant_closure_call(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
@@ -23,6 +24,7 @@ pub fn check_redundant_closure_call(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Lambda {
         params,
         body,
+        return_annotation,
         span: lambda_span,
         ..
     } = callee.unwrap_parens()
@@ -42,6 +44,28 @@ pub fn check_redundant_closure_call(expression: &Expression, ctx: &NodeCtx) {
     // Claim the closure so `redundant_closure` does not also advise on it.
     ctx.claimed_spans.borrow_mut().insert(*lambda_span);
 
-    ctx.sink
-        .push(diagnostics::lint::redundant_closure_call(span));
+    let mut diagnostic = diagnostics::lint::redundant_closure_call(span);
+    if return_annotation.is_unknown()
+        && let Some(inner) = inlinable_value(body)
+        && let Some(text) = span_text(ctx.source, inner)
+    {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{text}`"),
+            Edit::replacement(*span, text.to_string()),
+        ));
+    }
+    ctx.sink.push(diagnostic);
+}
+
+fn inlinable_value(body: &Expression) -> Option<&Expression> {
+    let inner = match body.unwrap_parens() {
+        Expression::Block { items, .. } => {
+            let [single] = items.as_slice() else {
+                return None;
+            };
+            single.unwrap_parens()
+        }
+        other => other,
+    };
+    is_postfix_tight(inner).then_some(inner)
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_fstring_conversion.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_fstring_conversion.rs
@@ -1,5 +1,6 @@
 use super::helpers::span_text;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::types::SimpleKind;
 
@@ -28,12 +29,13 @@ pub fn check_redundant_fstring_conversion(expression: &Expression, ctx: &NodeCtx
         let Some(arg_text) = span_text(ctx.source, arg) else {
             continue;
         };
-        ctx.sink
-            .push(diagnostics::lint::redundant_fstring_conversion(
-                &call.get_span(),
-                method,
-                arg_text,
-            ));
+        ctx.sink.push(
+            diagnostics::lint::redundant_fstring_conversion(&call.get_span(), method, arg_text)
+                .with_fix(Fix::new(
+                    format!("Replace with `{arg_text}`"),
+                    Edit::replacement(call.get_span(), arg_text.to_string()),
+                )),
+        );
     }
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_guards.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_guards.rs
@@ -1,5 +1,6 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BinaryOperator, Expression, Literal, MatchArm, Pattern};
+use diagnostics::{Edit, Fix};
+use syntax::ast::{BinaryOperator, Expression, Literal, MatchArm, Pattern, Span};
 
 use syntax::ast::collect_pattern_bindings;
 
@@ -65,11 +66,22 @@ fn check_arm(arm: &MatchArm, ctx: &NodeCtx) {
         return;
     };
 
-    ctx.sink.push(diagnostics::lint::redundant_guards(
-        span,
-        binding,
-        literal_text,
-    ));
+    let mut diagnostic = diagnostics::lint::redundant_guards(span, binding, literal_text);
+    if let Some((_, binding_span)) = bindings.iter().find(|(name, _)| name == binding)
+        && !binding_in_struct(&arm.pattern, binding)
+    {
+        let pattern_end = arm.pattern.get_span().end();
+        let guard_end = guard.get_span().end();
+        let guard_deletion = Span::new(span.file_id, pattern_end, guard_end - pattern_end);
+        diagnostic = diagnostic.with_fix(Fix::multi(
+            format!("Fold `{binding} == {literal_text}` into the pattern"),
+            vec![
+                Edit::replacement(*binding_span, literal_text.to_string()),
+                Edit::deletion(guard_deletion),
+            ],
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 fn binding_name(expression: &Expression) -> Option<&str> {
@@ -88,6 +100,22 @@ fn foldable_literal(expression: &Expression) -> bool {
             ..
         }
     )
+}
+
+// A struct-bound `x` would swap to invalid `{ 5 }`, not `{ x: 5 }`, so skip it.
+fn binding_in_struct(pattern: &Pattern, name: &str) -> bool {
+    match pattern {
+        Pattern::Struct { fields, .. } => fields
+            .iter()
+            .any(|field| binds_as_identifier(&field.value, name)),
+        Pattern::EnumVariant { fields, .. }
+        | Pattern::Tuple {
+            elements: fields, ..
+        } => fields.iter().any(|field| binding_in_struct(field, name)),
+        Pattern::Slice { prefix, .. } => prefix.iter().any(|p| binding_in_struct(p, name)),
+        Pattern::AsBinding { pattern, .. } => binding_in_struct(pattern, name),
+        _ => false,
+    }
 }
 
 fn binds_as_identifier(pattern: &Pattern, name: &str) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
@@ -1,8 +1,9 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::unqualified_name;
 
-use super::helpers::bool_literal;
+use super::helpers::{as_tight_operand, bool_literal, span_text};
 
 pub fn check_redundant_pattern_matching(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
@@ -50,11 +51,22 @@ pub fn check_redundant_pattern_matching(expression: &Expression, ctx: &NodeCtx) 
         _ => return,
     };
 
+    // A bool newtype (`Flag(bool)`) result adapts the arms, which `.is_some()` loses.
+    if !expression.get_type().is_boolean() {
+        return;
+    }
+
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    ctx.sink.push(diagnostics::lint::redundant_pattern_matching(
-        &match_keyword_span,
-        predicate,
-    ));
+    let mut diagnostic =
+        diagnostics::lint::redundant_pattern_matching(&match_keyword_span, predicate);
+    if let Some(subject_text) = span_text(ctx.source, subject) {
+        let replacement = format!("{}.{predicate}()", as_tight_operand(subject_text, subject));
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 fn arm_variant_bool(arm: &MatchArm) -> Option<(&str, bool)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
@@ -1,4 +1,6 @@
+use crate::passes::lints::span_edit::statement_deletion;
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Pattern};
 
 /// Flags `let x = x`, an immutable rebinding of a variable to itself.
@@ -64,6 +66,11 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::redundant_rebinding(span, identifier));
+    let deletion = statement_deletion(ctx.source, *span);
+    ctx.sink.push(
+        diagnostics::lint::redundant_rebinding(span, identifier).with_fix(Fix::new(
+            "Remove the redundant rebinding",
+            Edit::deletion(deletion),
+        )),
+    );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/rest_only_slice_pattern.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/rest_only_slice_pattern.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Pattern, RestPattern};
 
 pub fn check_rest_only_slice_pattern(pattern: &Pattern, ctx: &NodeCtx) {
@@ -15,14 +16,17 @@ pub fn check_rest_only_slice_pattern(pattern: &Pattern, ctx: &NodeCtx) {
         && prefix.is_empty()
         && !matches!(rest, RestPattern::Absent)
     {
-        let help = match rest {
-            RestPattern::Bind { name, .. } => {
-                format!("Use `let {}` instead", name)
-            }
-            _ => "Use `let _` instead".to_string(),
+        let replacement = match rest {
+            RestPattern::Bind { name, .. } => name.to_string(),
+            _ => "_".to_string(),
         };
+        let help = format!("Use `let {replacement}` instead");
 
-        ctx.sink
-            .push(diagnostics::lint::rest_only_slice_pattern(span, help));
+        ctx.sink.push(
+            diagnostics::lint::rest_only_slice_pattern(span, help).with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement),
+            )),
+        );
     }
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
@@ -1,10 +1,12 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::Expression;
+use diagnostics::{Edit, Fix};
+use syntax::ast::{BinaryOperator, Expression};
 
-use super::helpers::bool_literal;
+use super::helpers::{as_tight_operand, bool_literal, negate_comparison, span_text};
 
 pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
+        condition,
         consequence,
         alternative,
         span,
@@ -26,8 +28,57 @@ pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::unnecessary_bool(span, then_value));
+    let condition = condition.unwrap_parens();
+    // A bool newtype (`Flag(bool)`) result or condition is not plain-bool redundancy.
+    if !expression.get_type().is_boolean() || !condition.get_type().is_boolean() {
+        return;
+    }
+
+    let mut diagnostic = diagnostics::lint::unnecessary_bool(span, then_value);
+    let replacement = if then_value {
+        span_text(ctx.source, condition).map(|text| as_tight_operand(text, condition))
+    } else {
+        negated_condition(ctx.source, condition)
+    };
+    if let Some(replacement) = replacement {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
+}
+
+/// Source text negating `condition`: flip a comparison operator, else prefix `!`.
+fn negated_condition(source: &str, condition: &Expression) -> Option<String> {
+    if let Expression::Binary {
+        operator,
+        left,
+        right,
+        ..
+    } = condition
+        && let Some(negated) = negate_comparison(*operator)
+        && flip_preserves_nan(*operator, left, right)
+    {
+        let lhs = span_text(source, left)?;
+        let rhs = span_text(source, right)?;
+        return Some(format!("({lhs} {negated} {rhs})"));
+    }
+    let text = span_text(source, condition)?;
+    Some(format!("(!{})", as_tight_operand(text, condition)))
+}
+
+// Ordered flips are not NaN-safe (`!(a < b)` is not `a >= b`), only `==`/`!=` are.
+fn flip_preserves_nan(operator: BinaryOperator, left: &Expression, right: &Expression) -> bool {
+    matches!(operator, BinaryOperator::Equal | BinaryOperator::NotEqual)
+        || (is_non_float(left) && is_non_float(right))
+}
+
+fn is_non_float(expression: &Expression) -> bool {
+    expression
+        .get_type()
+        .underlying_simple_kind()
+        .is_some_and(|kind| !kind.is_float())
 }
 
 fn block_single_bool(expression: &Expression) -> Option<bool> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_lazy_evaluations.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_lazy_evaluations.rs
@@ -1,7 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
-use super::helpers::constant_closure_value;
+use super::helpers::{as_tight_operand, constant_closure_value, expression_is_pure, span_text};
 
 pub fn check_unnecessary_lazy_evaluations(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Call {
@@ -44,7 +45,11 @@ pub fn check_unnecessary_lazy_evaluations(expression: &Expression, ctx: &NodeCtx
         _ => return,
     };
 
-    if constant_closure_value(lazy_argument).is_none() {
+    let Some(constant) = constant_closure_value(lazy_argument) else {
+        return;
+    };
+
+    if !expression_is_pure(constant, ctx.store) {
         return;
     }
 
@@ -56,10 +61,30 @@ pub fn check_unnecessary_lazy_evaluations(expression: &Expression, ctx: &NodeCtx
         return;
     }
 
-    ctx.sink
-        .push(diagnostics::lint::unnecessary_lazy_evaluations(
-            &lazy_argument.get_span(),
-            lazy,
-            eager,
+    let mut diagnostic =
+        diagnostics::lint::unnecessary_lazy_evaluations(&lazy_argument.get_span(), lazy, eager);
+    let rest_texts: Option<Vec<&str>> = args[1..]
+        .iter()
+        .map(|arg| span_text(ctx.source, arg))
+        .collect();
+    if let (Some(receiver_text), Some(constant_text), Some(rest_texts)) = (
+        span_text(ctx.source, receiver),
+        span_text(ctx.source, constant),
+        rest_texts,
+    ) {
+        let mut call_args = constant_text.to_string();
+        for extra in rest_texts {
+            call_args.push_str(", ");
+            call_args.push_str(extra);
+        }
+        let replacement = format!(
+            "{}.{eager}({call_args})",
+            as_tight_operand(receiver_text, receiver)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(expression.get_span(), replacement),
         ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
@@ -1,8 +1,11 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::Expression;
+use diagnostics::{Edit, Fix};
+use semantics::store::Store;
+use syntax::ast::{Expression, Span};
 
 use super::helpers::{
-    is_eager_safe, is_identity_lambda, is_pure_mapper, method_call, wrapped_single_arg,
+    as_tight_operand, expression_is_pure, is_identity_lambda, method_call, reads_as_method_call,
+    span_text, wrapped_single_arg,
 };
 
 pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeCtx) {
@@ -28,11 +31,8 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
             "Some" => container.is_option(),
             _ => container.is_result(),
         };
-        if confirmed && reorder_safe(payload, mapper) {
-            ctx.sink
-                .push(diagnostics::lint::unnecessary_map_on_constructor(
-                    span, variant, "map",
-                ));
+        if confirmed && reorder_safe(payload, mapper, ctx.store) {
+            push_map_on_constructor(ctx, span, receiver, args, variant, "map", payload, mapper);
         }
         return;
     }
@@ -45,21 +45,50 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
         let Some(payload) = wrapped_single_arg(receiver, "Err") else {
             return;
         };
-        if receiver.get_type().is_result() && reorder_safe(payload, mapper) {
-            ctx.sink
-                .push(diagnostics::lint::unnecessary_map_on_constructor(
-                    span, "Err", "map_err",
-                ));
+        if receiver.get_type().is_result() && reorder_safe(payload, mapper, ctx.store) {
+            push_map_on_constructor(ctx, span, receiver, args, "Err", "map_err", payload, mapper);
         }
     }
 }
 
-// `Constructor(p).map(f)` becomes `Constructor(f(p))`, swapping evaluation of
-// `p` and `f`. Invisible when `f` is a lambda literal, or when both are
-// side-effect-free.
-fn reorder_safe(payload: &Expression, mapper: &Expression) -> bool {
-    if !is_pure_mapper(mapper) {
-        return false;
+#[allow(clippy::too_many_arguments)]
+fn push_map_on_constructor(
+    ctx: &NodeCtx,
+    span: &Span,
+    receiver: &Expression,
+    args: &[Expression],
+    variant: &str,
+    method: &str,
+    payload: &Expression,
+    mapper: &Expression,
+) {
+    let mut diagnostic = diagnostics::lint::unnecessary_map_on_constructor(span, variant, method);
+    // A lambda mapper needs beta-reduction to inline, so it reports without a fix.
+    if !matches!(mapper.unwrap_parens(), Expression::Lambda { .. })
+        && reads_as_method_call(receiver, args)
+        && let (Some(mapper_text), Some(payload_text)) = (
+            span_text(ctx.source, mapper),
+            span_text(ctx.source, payload),
+        )
+    {
+        let replacement = format!(
+            "{variant}({}({payload_text}))",
+            as_tight_operand(mapper_text, mapper)
+        );
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
     }
-    matches!(mapper.unwrap_parens(), Expression::Lambda { .. }) || is_eager_safe(payload)
+    ctx.sink.push(diagnostic);
+}
+
+// `Constructor(p).map(f)` to `Constructor(f(p))` swaps evaluation of `p` and `f`.
+// A lambda defers its body, otherwise both must be non-panicking for the swap to
+// be invisible.
+fn reorder_safe(payload: &Expression, mapper: &Expression, store: &Store) -> bool {
+    if matches!(mapper.unwrap_parens(), Expression::Lambda { .. }) {
+        return true;
+    }
+    expression_is_pure(payload, store) && expression_is_pure(mapper, store)
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
@@ -1,9 +1,13 @@
 use crate::passes::comparison::{MinMaxOp, prelude_min_max};
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 use syntax::types::SimpleKind;
 
-use super::helpers::{expressions_equivalent, is_side_effect_free, signed_integer_literal};
+use super::helpers::{
+    as_tight_operand, expressions_equivalent, is_side_effect_free, signed_integer_literal,
+    span_text,
+};
 
 pub fn check_unnecessary_min_or_max(expression: &Expression, ctx: &NodeCtx) {
     let Some(call) = prelude_min_max(expression) else {
@@ -19,30 +23,31 @@ pub fn check_unnecessary_min_or_max(expression: &Expression, ctx: &NodeCtx) {
         MinMaxOp::Max => "max",
     };
 
-    if expressions_equivalent(call.left, call.right) && is_side_effect_free(call.left) {
-        ctx.sink.push(diagnostics::lint::unnecessary_min_or_max(
-            &expression.get_span(),
-            op,
-        ));
-        return;
-    }
+    let survivor =
+        if expressions_equivalent(call.left, call.right) && is_side_effect_free(call.left) {
+            call.left
+        } else if let Some((value_operand, literal)) = split_one_literal(call.left, call.right)
+            && let Some(kind) = value_operand.get_type().as_simple()
+            && (match call.op {
+                MinMaxOp::Min => max_bound(kind),
+                MinMaxOp::Max => min_bound(kind),
+            }) == Some(literal)
+        {
+            value_operand
+        } else {
+            return;
+        };
 
-    let Some((value_operand, literal)) = split_one_literal(call.left, call.right) else {
-        return;
-    };
-    let Some(kind) = value_operand.get_type().as_simple() else {
-        return;
-    };
-    let no_op_bound = match call.op {
-        MinMaxOp::Min => max_bound(kind),
-        MinMaxOp::Max => min_bound(kind),
-    };
-    if no_op_bound == Some(literal) {
-        ctx.sink.push(diagnostics::lint::unnecessary_min_or_max(
-            &expression.get_span(),
-            op,
+    let span = expression.get_span();
+    let mut diagnostic = diagnostics::lint::unnecessary_min_or_max(&span, op);
+    if let Some(text) = span_text(ctx.source, survivor) {
+        let replacement = as_tight_operand(text, survivor);
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(span, replacement),
         ));
     }
+    ctx.sink.push(diagnostic);
 }
 
 fn split_one_literal<'a>(a: &'a Expression, b: &'a Expression) -> Option<(&'a Expression, i128)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_return.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_return.rs
@@ -1,6 +1,7 @@
 use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
-use syntax::ast::Expression;
+use diagnostics::{Edit, Fix};
+use syntax::ast::{Expression, Span};
 
 pub fn check_unnecessary_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Function { body, .. } = expression else {
@@ -22,7 +23,15 @@ fn flag_tail_returns(expression: &Expression, sink: &LocalSink) {
             // Bare `return` is excluded: dropping it can change the block's
             // type when a preceding statement is non-unit.
             if !matches!(value.as_ref(), Expression::Unit { .. }) {
-                sink.push(diagnostics::lint::unnecessary_return(span));
+                let prefix = Span::new(
+                    span.file_id,
+                    span.byte_offset,
+                    value.get_span().byte_offset - span.byte_offset,
+                );
+                sink.push(
+                    diagnostics::lint::unnecessary_return(span)
+                        .with_fix(Fix::new("Drop `return`", Edit::deletion(prefix))),
+                );
             }
         }
         Expression::Block { items, .. } => {

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -1,8 +1,10 @@
+use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use diagnostics::{Edit, Fix};
+use semantics::context::AnalysisContext;
 use semantics::facts::Facts;
 use syntax::ast::Span;
 use syntax::program::UnusedInfo;
@@ -69,10 +71,16 @@ impl LintConfig {
     }
 }
 
-pub(crate) fn run(facts: &Facts, unused: &mut UnusedInfo, sink: &LocalSink) {
+pub(crate) fn run(
+    analysis: &AnalysisContext,
+    facts: &Facts,
+    unused: &mut UnusedInfo,
+    sink: &LocalSink,
+) {
     let mut diagnostics: Vec<LisetteDiagnostic> = Vec::new();
+    let sources = source_by_file(analysis);
 
-    collect_bindings(facts, unused, &mut diagnostics);
+    collect_bindings(facts, unused, &sources, &mut diagnostics);
     collect_dead_code(facts, &mut diagnostics);
     collect_pattern_issues(facts, &mut diagnostics);
     collect_unused_expressions(facts, &mut diagnostics);
@@ -81,13 +89,54 @@ pub(crate) fn run(facts: &Facts, unused: &mut UnusedInfo, sink: &LocalSink) {
     collect_unused_type_params(facts, &mut diagnostics);
     collect_type_params_only_in_bound(facts, &mut diagnostics);
     collect_always_failing_try_blocks(facts, &mut diagnostics);
-    collect_expression_only_fstrings(facts, &mut diagnostics);
+    collect_expression_only_fstrings(facts, &sources, &mut diagnostics);
 
     diagnostics.sort_by(LisetteDiagnostic::sort_key);
     sink.extend(diagnostics);
 }
 
-fn collect_bindings(facts: &Facts, unused: &mut UnusedInfo, out: &mut Vec<LisetteDiagnostic>) {
+fn source_by_file<'a>(analysis: &AnalysisContext<'a>) -> HashMap<u32, &'a str> {
+    let mut sources = HashMap::default();
+    for module in analysis.store.modules.values() {
+        for (file_id, file) in &module.files {
+            sources.insert(*file_id, file.source.as_str());
+        }
+    }
+    sources
+}
+
+fn mut_keyword_deletion(sources: &HashMap<u32, &str>, name: Span) -> Option<Span> {
+    let source = sources.get(&name.file_id)?;
+    let name_start = name.byte_offset as usize;
+    let before = source.get(..name_start)?.trim_end();
+    let mut_start = before.strip_suffix("mut")?.len();
+    let preceded_by_word = before[..mut_start]
+        .bytes()
+        .last()
+        .is_some_and(|b| b.is_ascii_alphanumeric() || b == b'_');
+    if preceded_by_word {
+        return None;
+    }
+    Some(Span::new(
+        name.file_id,
+        mut_start as u32,
+        (name_start - mut_start) as u32,
+    ))
+}
+
+fn fstring_inner<'a>(sources: &HashMap<u32, &'a str>, span: Span) -> Option<&'a str> {
+    let source = sources.get(&span.file_id)?;
+    let text = source.get(span.byte_offset as usize..span.end() as usize)?;
+    let inner = text.strip_prefix("f\"")?.strip_suffix('"')?.trim();
+    Some(inner.strip_prefix('{')?.strip_suffix('}')?.trim())
+}
+
+fn collect_bindings(
+    facts: &Facts,
+    unused: &mut UnusedInfo,
+    sources: &HashMap<u32, &str>,
+    out: &mut Vec<LisetteDiagnostic>,
+) {
     for b in facts.bindings.values() {
         let is_anon = b.name.starts_with('_');
         let written_but_not_read = b.kind.is_mutable() && b.mutated && !b.used && !is_anon;
@@ -111,7 +160,12 @@ fn collect_bindings(facts: &Facts, unused: &mut UnusedInfo, out: &mut Vec<Lisett
         }
 
         if b.kind.is_mutable() && !b.mutated {
-            out.push(diagnostics::lint::unused_mut(&b.span));
+            let mut diagnostic = diagnostics::lint::unused_mut(&b.span);
+            if let Some(deletion) = mut_keyword_deletion(sources, b.span) {
+                diagnostic =
+                    diagnostic.with_fix(Fix::new("Remove `mut`", Edit::deletion(deletion)));
+            }
+            out.push(diagnostic);
         }
 
         if written_but_not_read {
@@ -182,8 +236,24 @@ fn collect_always_failing_try_blocks(facts: &Facts, out: &mut Vec<LisetteDiagnos
     }
 }
 
-fn collect_expression_only_fstrings(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
-    for span in &facts.expression_only_fstrings {
-        out.push(diagnostics::lint::expression_only_fstring(span));
+fn collect_expression_only_fstrings(
+    facts: &Facts,
+    sources: &HashMap<u32, &str>,
+    out: &mut Vec<LisetteDiagnostic>,
+) {
+    for fact in &facts.expression_only_fstrings {
+        let mut diagnostic = diagnostics::lint::expression_only_fstring(&fact.span);
+        if let Some(inner) = fstring_inner(sources, fact.span) {
+            let replacement = if fact.needs_parens {
+                format!("({inner})")
+            } else {
+                inner.to_string()
+            };
+            diagnostic = diagnostic.with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(fact.span, replacement),
+            ));
+        }
+        out.push(diagnostic);
     }
 }

--- a/crates/passes/src/passes/lints/mod.rs
+++ b/crates/passes/src/passes/lints/mod.rs
@@ -14,5 +14,6 @@
 pub(crate) mod ast_walk;
 pub(crate) mod from_facts;
 pub(crate) mod ref_graph;
+pub(crate) mod span_edit;
 
 pub use from_facts::Lint;

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -7,8 +7,10 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 
 use crate::passes::PARALLEL_THRESHOLD;
+use crate::passes::lints::span_edit::statement_deletion;
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
+use diagnostics::{Edit, Fix};
 use semantics::context::AnalysisContext;
 use semantics::facts::Facts;
 use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
@@ -220,7 +222,16 @@ fn run_ref_lints(
             if info.kind == ItemKind::Function {
                 unused_definition_spans.push(info.span);
             }
-            if let Some(diagnostic) = create_unused_diagnostic(info.kind, &info.span, config) {
+            if let Some(mut diagnostic) = create_unused_diagnostic(info.kind, &info.span, config) {
+                if let Some(statement_span) = info.statement_span
+                    && let Some(file) = files.get(&statement_span.file_id)
+                {
+                    let deletion = statement_deletion(&file.source, statement_span);
+                    diagnostic = diagnostic.with_fix(Fix::new(
+                        "Remove the unused import",
+                        Edit::deletion(deletion),
+                    ));
+                }
                 diagnostics.push(diagnostic);
             }
         }
@@ -278,7 +289,7 @@ fn collect_items(
 
                     if let Some(effective) = file_import.effective_alias(go_package_names) {
                         let id = ModuleItemId::new(&effective);
-                        graph.add_import(id, *name_span);
+                        graph.add_import(id, *name_span, *span);
                     }
                 }
                 Expression::Function {

--- a/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
@@ -98,19 +98,27 @@ impl ReferenceGraph {
 
     pub fn add_item(&mut self, id: ModuleItemId, span: Span, kind: ItemKind, is_entry_point: bool) {
         self.nodes.insert(id.clone());
-        self.items.insert(id.clone(), ItemInfo { span, kind });
+        self.items.insert(
+            id.clone(),
+            ItemInfo {
+                span,
+                kind,
+                statement_span: None,
+            },
+        );
         if is_entry_point {
             self.entrypoints.insert(id);
         }
     }
 
-    pub fn add_import(&mut self, id: ModuleItemId, span: Span) {
+    pub fn add_import(&mut self, id: ModuleItemId, span: Span, statement_span: Span) {
         self.nodes.insert(id.clone());
         self.items.insert(
             id,
             ItemInfo {
                 span,
                 kind: ItemKind::Import,
+                statement_span: Some(statement_span),
             },
         );
     }
@@ -228,4 +236,5 @@ pub enum ItemKind {
 pub struct ItemInfo {
     pub span: Span,
     pub kind: ItemKind,
+    pub statement_span: Option<Span>,
 }

--- a/crates/passes/src/passes/lints/span_edit.rs
+++ b/crates/passes/src/passes/lints/span_edit.rs
@@ -1,0 +1,139 @@
+use syntax::ast::Span;
+
+pub(crate) fn statement_deletion(source: &str, stmt: Span) -> Span {
+    line_aware_deletion(source, stmt, b';')
+}
+
+pub(crate) fn match_arm_deletion(source: &str, arm: Span) -> Span {
+    line_aware_deletion(source, arm, b',')
+}
+
+/// Deletes `item` and its trailing `separator`, widening to the whole physical
+/// line when `item` is alone on it so no indented blank line is left behind.
+fn line_aware_deletion(source: &str, item: Span, separator: u8) -> Span {
+    let bytes = source.as_bytes();
+    let start = item.byte_offset as usize;
+    let end = item.end() as usize;
+
+    let mut after = end;
+    while after < bytes.len() && matches!(bytes[after], b' ' | b'\t') {
+        after += 1;
+    }
+    let has_separator = after < bytes.len() && bytes[after] == separator;
+    if has_separator {
+        after += 1;
+    }
+
+    let mut line_tail = after;
+    while line_tail < bytes.len() && matches!(bytes[line_tail], b' ' | b'\t') {
+        line_tail += 1;
+    }
+    let trailing_blank = line_tail >= bytes.len() || bytes[line_tail] == b'\n';
+
+    let line_start = source[..start].rfind('\n').map_or(0, |i| i + 1);
+    let leading_blank = source[line_start..start]
+        .bytes()
+        .all(|b| matches!(b, b' ' | b'\t'));
+
+    if leading_blank && trailing_blank {
+        let line_end = if line_tail < bytes.len() && bytes[line_tail] == b'\n' {
+            line_tail + 1
+        } else {
+            line_tail
+        };
+        Span::new(
+            item.file_id,
+            line_start as u32,
+            (line_end - line_start) as u32,
+        )
+    } else if has_separator {
+        Span::new(item.file_id, start as u32, (after - start) as u32)
+    } else {
+        item
+    }
+}
+
+/// Deletes `item` with its separating comma: trailing (`item, rest`) if present,
+/// else leading (`rest, item`), else the item alone.
+pub(crate) fn list_item_deletion(source: &str, item: Span) -> Span {
+    let bytes = source.as_bytes();
+    let start = item.byte_offset as usize;
+    let end = item.end() as usize;
+
+    let mut after = end;
+    while after < bytes.len() && matches!(bytes[after], b' ' | b'\t' | b'\n') {
+        after += 1;
+    }
+    if after < bytes.len() && bytes[after] == b',' {
+        let mut trail = after + 1;
+        while trail < bytes.len() && matches!(bytes[trail], b' ' | b'\t') {
+            trail += 1;
+        }
+        return Span::new(item.file_id, start as u32, (trail - start) as u32);
+    }
+
+    let mut before = start;
+    while before > 0 && matches!(bytes[before - 1], b' ' | b'\t' | b'\n') {
+        before -= 1;
+    }
+    if before > 0 && bytes[before - 1] == b',' {
+        let new_start = before - 1;
+        return Span::new(item.file_id, new_start as u32, (end - new_start) as u32);
+    }
+
+    item
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(source: &str, needle: &str) -> Span {
+        let offset = source.find(needle).unwrap();
+        Span::new(0, offset as u32, needle.len() as u32)
+    }
+
+    fn deleted(source: &str, span: Span) -> String {
+        let mut out = source.to_string();
+        out.replace_range(span.byte_offset as usize..span.end() as usize, "");
+        out
+    }
+
+    #[test]
+    fn statement_alone_on_line_removes_the_line() {
+        let src = "a\n  let x = x;\n  b\n";
+        let span = at(src, "let x = x");
+        assert_eq!(deleted(src, statement_deletion(src, span)), "a\n  b\n");
+    }
+
+    #[test]
+    fn statement_sharing_a_line_keeps_the_rest() {
+        let src = "let x = x; foo()\n";
+        let span = at(src, "let x = x");
+        assert_eq!(deleted(src, statement_deletion(src, span)), " foo()\n");
+    }
+
+    #[test]
+    fn list_item_consumes_trailing_comma() {
+        let src = "f(a, b, c)";
+        let span = at(src, "a");
+        assert_eq!(deleted(src, list_item_deletion(src, span)), "f(b, c)");
+    }
+
+    #[test]
+    fn list_item_consumes_leading_comma_for_last() {
+        let src = "f(a, b, c)";
+        let span = at(src, "c");
+        assert_eq!(deleted(src, list_item_deletion(src, span)), "f(a, b)");
+    }
+
+    #[test]
+    fn match_arm_alone_on_line_removes_the_line() {
+        let src = "match n {\n  1 => a,\n  2 => b,\n  3 => c,\n}\n";
+        let span = at(src, "2 => b");
+        assert_eq!(
+            deleted(src, match_arm_deletion(src, span)),
+            "match n {\n  1 => a,\n  3 => c,\n}\n"
+        );
+    }
+}

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -58,7 +58,7 @@ pub fn run(
     sink.extend(checks_diagnostics);
     deferred::run(facts, sink);
     if run_lints {
-        lints::from_facts::run(facts, unused, sink);
+        lints::from_facts::run(analysis, facts, unused, sink);
     }
     if let Some((ast_walk_diagnostics, (ref_graph_diagnostics, ref_graph_unused))) = lint_outputs {
         sink.extend(ast_walk_diagnostics);

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -173,7 +173,8 @@ impl InferCtx<'_, '_> {
                     && let Some(FormatStringPart::Expression(expression)) = new_parts.first()
                     && expression.get_type().resolve_in(&self.env).is_string()
                 {
-                    self.facts.add_expression_only_fstring(span);
+                    self.facts
+                        .add_expression_only_fstring(span, fstring_inner_needs_parens(expression));
                 }
 
                 let string_ty = self.type_string();
@@ -194,6 +195,28 @@ impl InferCtx<'_, '_> {
         self.unify(&new_ty, &unit_ty, &span);
         self.unify(expected_ty, &new_ty, &span);
         Expression::Unit { ty: new_ty, span }
+    }
+}
+
+/// Whether `expr` must be parenthesized to replace its f-string: true unless it
+/// binds at least as tightly as a postfix operator.
+fn fstring_inner_needs_parens(expression: &Expression) -> bool {
+    match expression {
+        Expression::Identifier { .. }
+        | Expression::Literal { .. }
+        | Expression::DotAccess { .. }
+        | Expression::IndexedAccess { .. }
+        | Expression::Paren { .. }
+        | Expression::Propagate { .. } => false,
+        // A `|>` pipeline desugars to a `Call` with its piped arg before the callee.
+        Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } => !args
+            .iter()
+            .all(|arg| arg.get_span().byte_offset >= callee.get_span().byte_offset),
+        _ => true,
     }
 }
 

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -45,7 +45,7 @@ pub struct Facts {
     pub unused_type_params: Vec<UnusedTypeParamFact>,
     pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
     pub always_failing_try_blocks: Vec<Span>,
-    pub expression_only_fstrings: Vec<Span>,
+    pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<String>>,
     pub equality_derivations: Vec<String>,
     pub test_functions: Vec<TestFunction>,
@@ -197,8 +197,9 @@ impl Facts {
         self.always_failing_try_blocks.push(span);
     }
 
-    pub fn add_expression_only_fstring(&mut self, span: Span) {
-        self.expression_only_fstrings.push(span);
+    pub fn add_expression_only_fstring(&mut self, span: Span, needs_parens: bool) {
+        self.expression_only_fstrings
+            .push(ExpressionOnlyFstringFact { span, needs_parens });
     }
 
     pub fn add_usage(&mut self, usage_span: Span, definition_span: Span) {
@@ -381,6 +382,12 @@ impl LocalFacts {
         self.type_params_only_in_bound
             .push(TypeParamOnlyInBoundFact { name, span });
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ExpressionOnlyFstringFact {
+    pub span: Span,
+    pub needs_parens: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -394,8 +394,8 @@ impl<'source> Parser<'source> {
             self.expect_comma_or(RightSquareBracket);
         }
 
-        let span = self.span_from_tokens(start);
         self.ensure(RightSquareBracket);
+        let span = self.span_from_tokens(start);
 
         Pattern::Slice {
             prefix: elements,

--- a/tests/spec/parse/snapshots/slice_pattern_empty.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_empty.snap
@@ -89,7 +89,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 50,
-                                    byte_length: 1,
+                                    byte_length: 2,
                                 },
                             },
                             expression: Call {

--- a/tests/spec/parse/snapshots/slice_pattern_rest_only.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_rest_only.snap
@@ -94,7 +94,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 50,
-                                    byte_length: 3,
+                                    byte_length: 4,
                                 },
                             },
                             expression: Call {

--- a/tests/spec/parse/snapshots/slice_pattern_single.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_single.snap
@@ -98,7 +98,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 50,
-                                    byte_length: 2,
+                                    byte_length: 3,
                                 },
                             },
                             expression: Call {

--- a/tests/spec/parse/snapshots/slice_pattern_suffix.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_suffix.snap
@@ -96,7 +96,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 50,
-                                    byte_length: 13,
+                                    byte_length: 14,
                                 },
                             },
                             expression: Call {
@@ -166,7 +166,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 96,
-                                    byte_length: 1,
+                                    byte_length: 2,
                                 },
                             },
                             expression: Call {

--- a/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
@@ -89,7 +89,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 50,
-                                    byte_length: 1,
+                                    byte_length: 2,
                                 },
                             },
                             expression: Call {
@@ -162,7 +162,7 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 76,
-                                    byte_length: 14,
+                                    byte_length: 15,
                                 },
                             },
                             expression: Call {

--- a/tests/ui/errors/snapshots/infer_refutable_slice_pattern_in_let.snap
+++ b/tests/ui/errors/snapshots/infer_refutable_slice_pattern_in_let.snap
@@ -5,8 +5,8 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:3:7]
  2 │ fn test(slice: Slice<int>) {
  3 │   let [a, b] = slice;
-   ·       ──┬──
-   ·         ╰── only matches 2 elements
+   ·       ───┬──
+   ·          ╰── only matches 2 elements
  4 │ }
    ╰────
   help: Use `match` to handle slices of any length:

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -1,5 +1,5 @@
 use crate::_harness::lint::apply_lint_fixes;
-use crate::{assert_fix_snapshot, assert_no_fix};
+use crate::{assert_fix_snapshot, assert_no_fix, assert_no_lint_warnings};
 
 #[test]
 fn fix_bool_literal_comparison_eq_true() {
@@ -451,6 +451,687 @@ fn fix_unnecessary_reference() {
         r#"
 pub fn foo(x: Ref<int>) {
   let _ = &x;
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_return() {
+    assert_fix_snapshot!(
+        r#"
+fn five() -> int {
+  return 5
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_rebinding() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let a = 5;
+  let a = a;
+  let _ = a
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_mut() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let mut x = 5
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
+fn fix_expression_only_fstring() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let name = "world"
+  let _ = f"{name}"
+}
+"#
+    );
+}
+
+#[test]
+fn fix_expression_only_fstring_parenthesizes_binary() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let a = "x"
+  let b = "y"
+  let _ = f"{a + b}".length()
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unused_import() {
+    assert_fix_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let _ = 5
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unused_import_with_alias() {
+    assert_fix_snapshot!(
+        r#"
+import f "go:fmt"
+
+fn main() {
+  let _ = 5
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_update() {
+    assert_fix_snapshot!(
+        r#"
+struct Config { debug: bool, port: int }
+
+fn read(c: Config) -> int { if c.debug { c.port } else { 0 } }
+
+fn rebuild(base: Config) -> Config {
+  Config { debug: true, port: 80, ..base }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_rest_only_slice_pattern_wildcard() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3]
+  let [..] = xs
+}
+"#
+    );
+}
+
+#[test]
+fn fix_rest_only_slice_pattern_bind() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let xs = [1, 2, 3]
+  let [..rest] = xs
+  let _ = rest
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_positive() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(c: bool) -> bool {
+  if c { true } else { false }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_negated() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(c: bool) -> bool {
+  if c { false } else { true }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_negates_comparison() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: int, b: int) -> bool {
+  if a == b { false } else { true }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_parenthesizes_loose_condition() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: int, b: int) -> bool {
+  if a > b { true } else { false }
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_bool_newtype_condition_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Flag(bool)
+
+pub fn f(flag: Flag) -> bool {
+  if flag { true } else { false }
+}
+"#
+    );
+}
+
+#[test]
+fn unnecessary_bool_bool_newtype_result_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Flag(bool)
+
+pub fn f(c: bool) -> Flag {
+  if c { true } else { false }
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_pattern_matching_bool_newtype_result_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub struct Flag(bool)
+
+pub fn f(o: Option<int>) -> Flag {
+  match o { Some(_) => true, None => false }
+}
+"#
+    );
+}
+
+#[test]
+fn needless_match_interface_adaptation_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Face { fn tag(self) -> int }
+pub struct Impl {}
+impl Impl { fn tag(self) -> int { 1 } }
+
+pub fn f(o: Option<Impl>) -> Option<Face> {
+  match o { Some(x) => Some(x), None => None }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_pattern_matching_is_some() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> bool {
+  match o { Some(_) => true, None => false }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_pattern_matching_is_err() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(r: Result<int, string>) -> bool {
+  match r { Ok(_) => false, Err(_) => true }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_match_option() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> Option<int> {
+  match o { Some(x) => Some(x), None => None }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_needless_match_result() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(r: Result<int, string>) -> Result<int, string> {
+  match r { Ok(x) => Ok(x), Err(e) => Err(e) }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_closure() {
+    assert_fix_snapshot!(
+        r#"
+pub fn apply(xs: Slice<int>) -> Slice<int> {
+  xs.map(|x| double(x))
+}
+
+fn double(n: int) -> int { n * 2 }
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_with_return_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn apply(xs: Slice<int>) -> Slice<int> {
+  xs.map(|x| -> int { double(x) })
+}
+
+fn double(n: int) -> int { n * 2 }
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_closure_call() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f() -> int {
+  (|| compute())()
+}
+
+fn compute() -> int { 42 }
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_closure_call_single_item_block() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f() -> int {
+  (|| { compute() })()
+}
+
+fn compute() -> int { 42 }
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_call_multi_statement_block_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f() -> int {
+  (|| {
+    let a = 1
+    a + 1
+  })()
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_call_with_return_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f() -> int {
+  (|| -> int { compute() })()
+}
+
+fn compute() -> int { 42 }
+"#
+    );
+}
+
+#[test]
+fn fix_double_comparison() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: int, b: int) -> bool {
+  a < b || a == b
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_min_or_max() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(x: int) -> int {
+  min(x, x)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_fstring_conversion() {
+    assert_fix_snapshot!(
+        r#"
+import "go:strconv"
+
+pub fn f(x: int) -> string {
+  f"n={strconv.Itoa(x)}"
+}
+"#
+    );
+}
+
+#[test]
+fn manual_contains_with_param_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f(xs: Slice<int>, v: int) -> bool {
+  xs.any(|x: int| x == v)
+}
+"#
+    );
+}
+
+#[test]
+fn manual_option_zip_with_param_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f(a: Option<int>, b: Option<string>) -> Option<(int, string)> {
+  a.and_then(|x: int| b.map(|y| (x, y)))
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_with_param_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f(o: Option<int>) -> Option<int> {
+  o.and_then(|x: int| Some(x))
+}
+"#
+    );
+}
+
+#[test]
+fn bind_instead_of_map_with_param_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn g(o: Option<int>) -> Option<int> {
+  o.and_then(|x: int| Some(x + 1))
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_contains() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(xs: Slice<int>, v: int) -> bool {
+  xs.any(|x| x == v)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_find() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(xs: Slice<int>) -> Option<int> {
+  xs.filter(|x| x > 0).get(0)
+}
+"#
+    );
+}
+
+#[test]
+fn manual_option_zip_result_adaptation_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Face { fn tag(self) -> int }
+pub struct Impl {}
+impl Impl { fn tag(self) -> int { 1 } }
+
+pub fn f(a: Option<Impl>, b: Option<Impl>) -> Option<(Face, Face)> {
+  a.and_then(|x| b.map(|y| (x, y)))
+}
+"#
+    );
+}
+
+#[test]
+fn fix_manual_option_zip() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: Option<int>, b: Option<string>) -> Option<(int, string)> {
+  a.and_then(|x| b.map(|y| (x, y)))
+}
+"#
+    );
+}
+
+#[test]
+fn bind_instead_of_map_with_return_annotation_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f(o: Option<int>) -> Option<int> {
+  o.and_then(|x| -> Option<int> { Some(x + 1) })
+}
+"#
+    );
+}
+
+#[test]
+fn fix_bind_instead_of_map() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> Option<int> {
+  o.and_then(|x| Some(x + 1))
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_map_on_constructor() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(x: int) -> Option<int> {
+  Some(x).map(triple)
+}
+
+fn triple(n: int) -> int { n * 3 }
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_map_on_constructor_non_nilable_field() {
+    assert_fix_snapshot!(
+        r#"
+struct A { field: int }
+
+pub fn f(a: A) -> Option<int> {
+  Some(a.field).map(triple)
+}
+
+fn triple(n: int) -> int { n * 3 }
+"#
+    );
+}
+
+#[test]
+fn unnecessary_map_on_constructor_lambda_mapper_has_no_fix() {
+    assert_no_fix!(
+        r#"
+pub fn f(x: int) -> Option<int> {
+  Some(x).map(|y| y + 1)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_let_and_return() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f() -> int {
+  let x = compute()
+  x
+}
+
+fn compute() -> int { 42 }
+"#
+    );
+}
+
+#[test]
+fn fix_or_fn_call() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or(fallback())
+}
+
+fn fallback() -> int { 7 }
+"#
+    );
+}
+
+#[test]
+fn fix_or_fn_call_result_callback_takes_error() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(r: Result<int, string>) -> int {
+  r.unwrap_or(fallback())
+}
+
+fn fallback() -> int { 7 }
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_lazy_evaluations() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or_else(|| 5)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_guards() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(o: Option<int>) -> int {
+  match o {
+    Some(x) if x == 5 => 1,
+    _ => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_float_ordering_negates_with_not() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: float64, b: float64) -> bool {
+  if a < b { false } else { true }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_unnecessary_bool_parenthesizes_pipeline_condition() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(x: int) -> bool {
+  if x |> pred { false } else { true }
+}
+
+fn pred(n: int) -> bool { n > 0 }
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_pattern_matching_parenthesizes_pipeline_subject() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(x: int) -> bool {
+  match x |> maybe { Some(_) => true, None => false }
+}
+
+fn maybe(n: int) -> Option<int> { Some(n) }
+"#
+    );
+}
+
+#[test]
+fn fix_expression_only_fstring_parenthesizes_pipeline() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(x: int) -> string {
+  f"{x |> label}"
+}
+
+fn label(n: int) -> string { "n" }
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_guards_bare_binding() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(n: int) -> int {
+  match n {
+    x if x == 5 => 1,
+    _ => 0,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_match_same_arms() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(n: int) -> string {
+  match n {
+    1 => "a",
+    2 => "b",
+    3 => "a",
+    _ => "z",
+  }
 }
 "#
     );

--- a/tests/ui/lint/snapshots/fix_bind_instead_of_map.snap
+++ b/tests/ui/lint/snapshots/fix_bind_instead_of_map.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> Option<int> {
+  o.and_then(|x| Some(x + 1))
+}
+=== fixed ===
+pub fn f(o: Option<int>) -> Option<int> {
+  o.map(|x| x + 1)
+}

--- a/tests/ui/lint/snapshots/fix_double_comparison.snap
+++ b/tests/ui/lint/snapshots/fix_double_comparison.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: int, b: int) -> bool {
+  a < b || a == b
+}
+=== fixed ===
+pub fn f(a: int, b: int) -> bool {
+  a <= b
+}

--- a/tests/ui/lint/snapshots/fix_expression_only_fstring.snap
+++ b/tests/ui/lint/snapshots/fix_expression_only_fstring.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let name = "world"
+  let _ = f"{name}"
+}
+=== fixed ===
+fn main() {
+  let name = "world"
+  let _ = name
+}

--- a/tests/ui/lint/snapshots/fix_expression_only_fstring_parenthesizes_binary.snap
+++ b/tests/ui/lint/snapshots/fix_expression_only_fstring_parenthesizes_binary.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let a = "x"
+  let b = "y"
+  let _ = f"{a + b}".length()
+}
+=== fixed ===
+fn main() {
+  let a = "x"
+  let b = "y"
+  let _ = (a + b).length()
+}

--- a/tests/ui/lint/snapshots/fix_expression_only_fstring_parenthesizes_pipeline.snap
+++ b/tests/ui/lint/snapshots/fix_expression_only_fstring_parenthesizes_pipeline.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(x: int) -> string {
+  f"{x |> label}"
+}
+
+fn label(n: int) -> string { "n" }
+=== fixed ===
+pub fn f(x: int) -> string {
+  (x |> label)
+}
+
+fn label(n: int) -> string { "n" }

--- a/tests/ui/lint/snapshots/fix_let_and_return.snap
+++ b/tests/ui/lint/snapshots/fix_let_and_return.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f() -> int {
+  let x = compute()
+  x
+}
+
+fn compute() -> int { 42 }
+=== fixed ===
+pub fn f() -> int {
+  compute()
+}
+
+fn compute() -> int { 42 }

--- a/tests/ui/lint/snapshots/fix_manual_contains.snap
+++ b/tests/ui/lint/snapshots/fix_manual_contains.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(xs: Slice<int>, v: int) -> bool {
+  xs.any(|x| x == v)
+}
+=== fixed ===
+pub fn f(xs: Slice<int>, v: int) -> bool {
+  xs.contains(v)
+}

--- a/tests/ui/lint/snapshots/fix_manual_find.snap
+++ b/tests/ui/lint/snapshots/fix_manual_find.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(xs: Slice<int>) -> Option<int> {
+  xs.filter(|x| x > 0).get(0)
+}
+=== fixed ===
+pub fn f(xs: Slice<int>) -> Option<int> {
+  xs.find(|x| x > 0)
+}

--- a/tests/ui/lint/snapshots/fix_manual_option_zip.snap
+++ b/tests/ui/lint/snapshots/fix_manual_option_zip.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: Option<int>, b: Option<string>) -> Option<(int, string)> {
+  a.and_then(|x| b.map(|y| (x, y)))
+}
+=== fixed ===
+pub fn f(a: Option<int>, b: Option<string>) -> Option<(int, string)> {
+  a.zip(b)
+}

--- a/tests/ui/lint/snapshots/fix_match_same_arms.snap
+++ b/tests/ui/lint/snapshots/fix_match_same_arms.snap
@@ -1,0 +1,19 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(n: int) -> string {
+  match n {
+    1 => "a",
+    2 => "b",
+    3 => "a",
+    _ => "z",
+  }
+}
+=== fixed ===
+pub fn f(n: int) -> string {
+  match n {
+    1 | 3 => "a",
+    2 => "b",
+    _ => "z",
+  }
+}

--- a/tests/ui/lint/snapshots/fix_needless_match_option.snap
+++ b/tests/ui/lint/snapshots/fix_needless_match_option.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> Option<int> {
+  match o { Some(x) => Some(x), None => None }
+}
+=== fixed ===
+pub fn f(o: Option<int>) -> Option<int> {
+  o
+}

--- a/tests/ui/lint/snapshots/fix_needless_match_result.snap
+++ b/tests/ui/lint/snapshots/fix_needless_match_result.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(r: Result<int, string>) -> Result<int, string> {
+  match r { Ok(x) => Ok(x), Err(e) => Err(e) }
+}
+=== fixed ===
+pub fn f(r: Result<int, string>) -> Result<int, string> {
+  r
+}

--- a/tests/ui/lint/snapshots/fix_needless_update.snap
+++ b/tests/ui/lint/snapshots/fix_needless_update.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+struct Config { debug: bool, port: int }
+
+fn read(c: Config) -> int { if c.debug { c.port } else { 0 } }
+
+fn rebuild(base: Config) -> Config {
+  Config { debug: true, port: 80, ..base }
+}
+=== fixed ===
+struct Config { debug: bool, port: int }
+
+fn read(c: Config) -> int { if c.debug { c.port } else { 0 } }
+
+fn rebuild(base: Config) -> Config {
+  Config { debug: true, port: 80 }
+}

--- a/tests/ui/lint/snapshots/fix_or_fn_call.snap
+++ b/tests/ui/lint/snapshots/fix_or_fn_call.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or(fallback())
+}
+
+fn fallback() -> int { 7 }
+=== fixed ===
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or_else(|| fallback())
+}
+
+fn fallback() -> int { 7 }

--- a/tests/ui/lint/snapshots/fix_or_fn_call_result_callback_takes_error.snap
+++ b/tests/ui/lint/snapshots/fix_or_fn_call_result_callback_takes_error.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(r: Result<int, string>) -> int {
+  r.unwrap_or(fallback())
+}
+
+fn fallback() -> int { 7 }
+=== fixed ===
+pub fn f(r: Result<int, string>) -> int {
+  r.unwrap_or_else(|_| fallback())
+}
+
+fn fallback() -> int { 7 }

--- a/tests/ui/lint/snapshots/fix_redundant_closure.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_closure.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn apply(xs: Slice<int>) -> Slice<int> {
+  xs.map(|x| double(x))
+}
+
+fn double(n: int) -> int { n * 2 }
+=== fixed ===
+pub fn apply(xs: Slice<int>) -> Slice<int> {
+  xs.map(double)
+}
+
+fn double(n: int) -> int { n * 2 }

--- a/tests/ui/lint/snapshots/fix_redundant_closure_call.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_closure_call.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f() -> int {
+  (|| compute())()
+}
+
+fn compute() -> int { 42 }
+=== fixed ===
+pub fn f() -> int {
+  compute()
+}
+
+fn compute() -> int { 42 }

--- a/tests/ui/lint/snapshots/fix_redundant_closure_call_single_item_block.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_closure_call_single_item_block.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f() -> int {
+  (|| { compute() })()
+}
+
+fn compute() -> int { 42 }
+=== fixed ===
+pub fn f() -> int {
+  compute()
+}
+
+fn compute() -> int { 42 }

--- a/tests/ui/lint/snapshots/fix_redundant_fstring_conversion.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_fstring_conversion.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:strconv"
+
+pub fn f(x: int) -> string {
+  f"n={strconv.Itoa(x)}"
+}
+=== fixed ===
+import "go:strconv"
+
+pub fn f(x: int) -> string {
+  f"n={x}"
+}

--- a/tests/ui/lint/snapshots/fix_redundant_guards.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_guards.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> int {
+  match o {
+    Some(x) if x == 5 => 1,
+    _ => 0,
+  }
+}
+=== fixed ===
+pub fn f(o: Option<int>) -> int {
+  match o {
+    Some(5) => 1,
+    _ => 0,
+  }
+}

--- a/tests/ui/lint/snapshots/fix_redundant_guards_bare_binding.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_guards_bare_binding.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(n: int) -> int {
+  match n {
+    x if x == 5 => 1,
+    _ => 0,
+  }
+}
+=== fixed ===
+pub fn f(n: int) -> int {
+  match n {
+    5 => 1,
+    _ => 0,
+  }
+}

--- a/tests/ui/lint/snapshots/fix_redundant_pattern_matching_is_err.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_pattern_matching_is_err.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(r: Result<int, string>) -> bool {
+  match r { Ok(_) => false, Err(_) => true }
+}
+=== fixed ===
+pub fn f(r: Result<int, string>) -> bool {
+  r.is_err()
+}

--- a/tests/ui/lint/snapshots/fix_redundant_pattern_matching_is_some.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_pattern_matching_is_some.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> bool {
+  match o { Some(_) => true, None => false }
+}
+=== fixed ===
+pub fn f(o: Option<int>) -> bool {
+  o.is_some()
+}

--- a/tests/ui/lint/snapshots/fix_redundant_pattern_matching_parenthesizes_pipeline_subject.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_pattern_matching_parenthesizes_pipeline_subject.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(x: int) -> bool {
+  match x |> maybe { Some(_) => true, None => false }
+}
+
+fn maybe(n: int) -> Option<int> { Some(n) }
+=== fixed ===
+pub fn f(x: int) -> bool {
+  (x |> maybe).is_some()
+}
+
+fn maybe(n: int) -> Option<int> { Some(n) }

--- a/tests/ui/lint/snapshots/fix_redundant_rebinding.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_rebinding.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let a = 5;
+  let a = a;
+  let _ = a
+}
+=== fixed ===
+fn main() {
+  let a = 5;
+  let _ = a
+}

--- a/tests/ui/lint/snapshots/fix_rest_only_slice_pattern_bind.snap
+++ b/tests/ui/lint/snapshots/fix_rest_only_slice_pattern_bind.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let xs = [1, 2, 3]
+  let [..rest] = xs
+  let _ = rest
+}
+=== fixed ===
+fn main() {
+  let xs = [1, 2, 3]
+  let rest = xs
+  let _ = rest
+}

--- a/tests/ui/lint/snapshots/fix_rest_only_slice_pattern_wildcard.snap
+++ b/tests/ui/lint/snapshots/fix_rest_only_slice_pattern_wildcard.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let xs = [1, 2, 3]
+  let [..] = xs
+}
+=== fixed ===
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_float_ordering_negates_with_not.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_float_ordering_negates_with_not.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: float64, b: float64) -> bool {
+  if a < b { false } else { true }
+}
+=== fixed ===
+pub fn f(a: float64, b: float64) -> bool {
+  (!(a < b))
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_negated.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_negated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(c: bool) -> bool {
+  if c { false } else { true }
+}
+=== fixed ===
+pub fn f(c: bool) -> bool {
+  (!c)
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_negates_comparison.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_negates_comparison.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: int, b: int) -> bool {
+  if a == b { false } else { true }
+}
+=== fixed ===
+pub fn f(a: int, b: int) -> bool {
+  (a != b)
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_parenthesizes_loose_condition.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_parenthesizes_loose_condition.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: int, b: int) -> bool {
+  if a > b { true } else { false }
+}
+=== fixed ===
+pub fn f(a: int, b: int) -> bool {
+  (a > b)
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_parenthesizes_pipeline_condition.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_parenthesizes_pipeline_condition.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(x: int) -> bool {
+  if x |> pred { false } else { true }
+}
+
+fn pred(n: int) -> bool { n > 0 }
+=== fixed ===
+pub fn f(x: int) -> bool {
+  (!(x |> pred))
+}
+
+fn pred(n: int) -> bool { n > 0 }

--- a/tests/ui/lint/snapshots/fix_unnecessary_bool_positive.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_bool_positive.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(c: bool) -> bool {
+  if c { true } else { false }
+}
+=== fixed ===
+pub fn f(c: bool) -> bool {
+  c
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_lazy_evaluations.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_lazy_evaluations.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or_else(|| 5)
+}
+=== fixed ===
+pub fn f(o: Option<int>) -> int {
+  o.unwrap_or(5)
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_map_on_constructor.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_map_on_constructor.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(x: int) -> Option<int> {
+  Some(x).map(triple)
+}
+
+fn triple(n: int) -> int { n * 3 }
+=== fixed ===
+pub fn f(x: int) -> Option<int> {
+  Some(triple(x))
+}
+
+fn triple(n: int) -> int { n * 3 }

--- a/tests/ui/lint/snapshots/fix_unnecessary_map_on_constructor_non_nilable_field.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_map_on_constructor_non_nilable_field.snap
@@ -1,0 +1,18 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+struct A { field: int }
+
+pub fn f(a: A) -> Option<int> {
+  Some(a.field).map(triple)
+}
+
+fn triple(n: int) -> int { n * 3 }
+=== fixed ===
+struct A { field: int }
+
+pub fn f(a: A) -> Option<int> {
+  Some(triple(a.field))
+}
+
+fn triple(n: int) -> int { n * 3 }

--- a/tests/ui/lint/snapshots/fix_unnecessary_min_or_max.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_min_or_max.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(x: int) -> int {
+  min(x, x)
+}
+=== fixed ===
+pub fn f(x: int) -> int {
+  x
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_mut.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_mut.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let mut x = 5
+  let _ = x
+}
+=== fixed ===
+fn main() {
+  let x = 5
+  let _ = x
+}

--- a/tests/ui/lint/snapshots/fix_unnecessary_return.snap
+++ b/tests/ui/lint/snapshots/fix_unnecessary_return.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn five() -> int {
+  return 5
+}
+=== fixed ===
+fn five() -> int {
+  5
+}

--- a/tests/ui/lint/snapshots/fix_unused_import.snap
+++ b/tests/ui/lint/snapshots/fix_unused_import.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import "go:fmt"
+
+fn main() {
+  let _ = 5
+}
+=== fixed ===
+fn main() {
+  let _ = 5
+}

--- a/tests/ui/lint/snapshots/fix_unused_import_with_alias.snap
+++ b/tests/ui/lint/snapshots/fix_unused_import_with_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import f "go:fmt"
+
+fn main() {
+  let _ = 5
+}
+=== fixed ===
+fn main() {
+  let _ = 5
+}

--- a/tests/ui/lint/snapshots/rest_only_slice_pattern_bind.snap
+++ b/tests/ui/lint/snapshots/rest_only_slice_pattern_bind.snap
@@ -5,8 +5,8 @@ source: tests/ui/lint/mod.rs
    ╭─[test.lis:3:7]
  2 │ pub fn test(slice: Slice<int>) {
  3 │   let [..rest] = slice;
-   ·       ───┬───
-   ·          ╰── always matches
+   ·       ────┬───
+   ·           ╰── always matches
  4 │   let _ = rest
    ╰────
   help: Use `let rest` instead · code: [lint.rest_only_slice_pattern]

--- a/tests/ui/lint/snapshots/rest_only_slice_pattern_discard.snap
+++ b/tests/ui/lint/snapshots/rest_only_slice_pattern_discard.snap
@@ -5,8 +5,8 @@ source: tests/ui/lint/mod.rs
    ╭─[test.lis:3:7]
  2 │ pub fn test(slice: Slice<int>) {
  3 │   let [..] = slice;
-   ·       ─┬─
-   ·        ╰── always matches
+   ·       ──┬─
+   ·         ╰── always matches
  4 │ }
    ╰────
   help: Use `let _` instead · code: [lint.rest_only_slice_pattern]


### PR DESCRIPTION
Adds autofixes for 25 more lints:

- `unnecessary_return`
- `redundant_rebinding`
- `needless_update`
- `unnecessary_mut`
- `expression_only_fstring`
- `unused_import`
- `rest_only_slice_pattern`
- `unnecessary_bool`
- `redundant_pattern_matching`
- `needless_match`
- `redundant_closure`
- `redundant_closure_call`
- `double_comparison`
- `unnecessary_min_or_max`
- `redundant_fstring_conversion`
- `manual_contains`
- `manual_find`
- `manual_option_zip`
- `bind_instead_of_map`
- `unnecessary_map_on_constructor`
- `let_and_return`
- `or_fn_call`
- `unnecessary_lazy_evaluations`
- `redundant_guards`
- `match_same_arms`

Follow-up to #932
