### PR TITLE
fix: label continue in select arms to target user loop

### DIFF
--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -3,7 +3,7 @@ use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::{
-    self, AnnotatedPattern, PatternSubject, TypedSubject, is_some_pattern, unwrap_some_pattern,
+    self, AnnotatedPattern, PatternSubject, TypedSubject, unwrap_some_pattern,
     unwrap_some_typed_pattern,
 };
 use crate::plan::bodies::{
@@ -43,7 +43,7 @@ impl Planner<'_> {
         place: &PlacePlan,
     ) -> SelectStatementPlan {
         let needs_retry_loop = arms.iter().any(|arm| {
-            matches!(&arm.pattern, SelectArmPattern::Receive { binding, .. } if is_some_pattern(binding))
+            matches!(&arm.pattern, SelectArmPattern::Receive { binding, .. } if binding.is_some_pattern())
         });
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
@@ -162,7 +162,7 @@ impl Planner<'_> {
                 } => {
                     let channel_has_call = channel_expression_has_call(receive_expression);
                     let ch = self.lower_channel_operand(setup, receive_expression);
-                    if is_some_pattern(binding) && needs_retry_loop {
+                    if binding.is_some_pattern() && needs_retry_loop {
                         let shadow = self.hoist_tmp_value_statement(setup, "ch", &ch);
                         channel_operands.push(Some(ch));
                         channel_shadows.push(Some(shadow));
@@ -366,7 +366,7 @@ impl Planner<'_> {
         let inner_typed = unwrap_some_typed_pattern(typed_pattern);
 
         self.scope.push_binding_frame();
-        if is_some_pattern(binding) {
+        if binding.is_some_pattern() {
             self.lower_receive_arm_with_ok_check(effective_pattern, inner_typed, ctx)
         } else {
             self.lower_receive_arm_simple(effective_pattern, inner_typed, ctx)

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -715,20 +715,6 @@ pub(crate) fn lower_none_arm_body(
     }
 }
 
-/// True when `Some(_)`-shaped (peeling any outer `as`-binding), with exactly
-/// one payload field.
-pub(crate) fn is_some_pattern(pattern: &Pattern) -> bool {
-    let pattern = peel_as_binding(pattern);
-    if let Pattern::EnumVariant {
-        identifier, fields, ..
-    } = pattern
-    {
-        let variant_name = go_name::unqualified_name(identifier);
-        return variant_name == "Some" && fields.len() == 1;
-    }
-    false
-}
-
 /// Peel `Some(inner)` to expose `inner`; returns the original pattern when
 /// the outer is not `Some(_)`.
 pub(crate) fn unwrap_some_pattern(pattern: &Pattern) -> &Pattern {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -427,13 +427,13 @@ impl InferCtx<'_, '_> {
                     &result_ty
                 };
                 let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-                let saved_in_guarded = self.scopes.set_in_guarded_match_arm(
-                    self.scopes.is_in_guarded_match_arm() || match_has_guard,
-                );
+                let saved_in_retry_loop_arm = self
+                    .scopes
+                    .set_in_retry_loop_arm(self.scopes.is_in_retry_loop_arm() || match_has_guard);
                 // Arm body is a tail-like context where Never calls are valid.
                 self.scopes.set_in_subexpression(false);
                 let new_expression = self.infer_expression(*a.expression, arm_expected);
-                self.scopes.set_in_guarded_match_arm(saved_in_guarded);
+                self.scopes.set_in_retry_loop_arm(saved_in_retry_loop_arm);
                 self.scopes.set_in_match_arm(saved_in_match_arm);
 
                 self.scopes.pop();
@@ -952,7 +952,7 @@ impl InferCtx<'_, '_> {
         self.check_continue_in_recover_block(span);
         self.check_continue_in_defer_block(span);
 
-        if self.scopes.is_in_guarded_match_arm() {
+        if self.scopes.is_in_retry_loop_arm() {
             self.scopes.mark_current_loop_needs_label();
         }
 

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -48,6 +48,10 @@ impl InferCtx<'_, '_> {
         self.check_multiple_select_receives(&arms);
         self.check_duplicate_select_defaults(&arms);
 
+        let has_retry_loop = arms.iter().any(|arm| {
+            matches!(&arm.pattern, SelectArmPattern::Receive { binding, .. } if binding.is_some_pattern())
+        });
+
         let result_ty = self.new_type_var();
         self.unify(expected_ty, &result_ty, &span);
 
@@ -84,12 +88,18 @@ impl InferCtx<'_, '_> {
                         receive_expression,
                         body,
                         ..
-                    } => self.infer_select_receive(binding, receive_expression, body, arm_target),
+                    } => self.infer_select_receive(
+                        binding,
+                        receive_expression,
+                        body,
+                        arm_target,
+                        has_retry_loop,
+                    ),
 
                     SelectArmPattern::Send {
                         send_expression,
                         body,
-                    } => self.infer_select_send(send_expression, body, arm_target),
+                    } => self.infer_select_send(send_expression, body, arm_target, has_retry_loop),
 
                     SelectArmPattern::MatchReceive {
                         receive_expression,
@@ -99,10 +109,11 @@ impl InferCtx<'_, '_> {
                         match_arms,
                         arm_target,
                         value_position,
+                        has_retry_loop,
                     ),
 
                     SelectArmPattern::WildCard { body } => {
-                        self.infer_select_wildcard(body, arm_target)
+                        self.infer_select_wildcard(body, arm_target, has_retry_loop)
                     }
                 };
 
@@ -150,12 +161,30 @@ impl InferCtx<'_, '_> {
         }
     }
 
+    fn infer_select_arm_body(
+        &mut self,
+        body: Expression,
+        expected_ty: &Type,
+        has_retry_loop: bool,
+    ) -> Expression {
+        let saved_in_match_arm = self.scopes.set_in_match_arm(true);
+        let saved_in_retry_loop_arm = self
+            .scopes
+            .set_in_retry_loop_arm(self.scopes.is_in_retry_loop_arm() || has_retry_loop);
+        self.scopes.set_in_subexpression(false);
+        let new_body = self.infer_expression(body, expected_ty);
+        self.scopes.set_in_retry_loop_arm(saved_in_retry_loop_arm);
+        self.scopes.set_in_match_arm(saved_in_match_arm);
+        new_body
+    }
+
     fn infer_select_receive(
         &mut self,
         binding: Box<Pattern>,
         receive_expression: Box<Expression>,
         body: Box<Expression>,
         result_ty: &Type,
+        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let receive_ty = self.new_type_var();
         let new_receive_expression = self.infer_expression(*receive_expression, &receive_ty);
@@ -226,10 +255,7 @@ impl InferCtx<'_, '_> {
             syntax::ast::BindingKind::Let { mutable: false },
         );
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
-        self.scopes.set_in_match_arm(saved_in_match_arm);
+        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
 
         SelectArmPattern::Receive {
             binding: Box::new(new_binding),
@@ -244,6 +270,7 @@ impl InferCtx<'_, '_> {
         send_expression: Box<Expression>,
         body: Box<Expression>,
         result_ty: &Type,
+        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let send_ty = self.new_type_var();
         let new_send_expression = self.infer_expression(*send_expression, &send_ty);
@@ -258,10 +285,7 @@ impl InferCtx<'_, '_> {
             ));
         }
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
-        self.scopes.set_in_match_arm(saved_in_match_arm);
+        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
 
         SelectArmPattern::Send {
             send_expression: Box::new(new_send_expression),
@@ -275,6 +299,7 @@ impl InferCtx<'_, '_> {
         match_arms: Vec<MatchArm>,
         result_ty: &Type,
         value_position: bool,
+        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let receive_ty = self.new_type_var();
         let new_receive_expression = self.infer_expression(*receive_expression, &receive_ty);
@@ -331,10 +356,8 @@ impl InferCtx<'_, '_> {
                     result_ty
                 };
 
-                let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-                self.scopes.set_in_subexpression(false);
-                let new_expression = self.infer_expression(*match_arm.expression, arm_expected);
-                self.scopes.set_in_match_arm(saved_in_match_arm);
+                let new_expression =
+                    self.infer_select_arm_body(*match_arm.expression, arm_expected, has_retry_loop);
 
                 if needs_reconciliation {
                     arm_expression_types.push(arm_expected.clone());
@@ -376,11 +399,9 @@ impl InferCtx<'_, '_> {
         &mut self,
         body: Box<Expression>,
         result_ty: &Type,
+        has_retry_loop: bool,
     ) -> SelectArmPattern {
-        let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
-        self.scopes.set_in_match_arm(saved_in_match_arm);
+        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
         SelectArmPattern::WildCard {
             body: Box::new(new_body),
         }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -127,12 +127,13 @@ pub struct Scopes {
     /// True when inferring a match/select arm body. Consumed by `infer_break`:
     /// a Go `break` inside a switch case escapes only the switch.
     in_match_arm: Cell<bool>,
-    /// True inside a guarded match arm, which lowers to an inner retry `for`
-    /// loop. Consumed by `infer_continue`: a `continue` there needs a label to
-    /// target the outer loop rather than the retry loop.
-    in_guarded_match_arm: Cell<bool>,
-    /// One entry per enclosing loop; set to `true` by a `break` in a match arm
-    /// or a `continue` in a guarded match arm. The top is popped by the loop's
+    /// True inside an arm whose body lowers into a synthetic retry `for` loop:
+    /// a guarded match arm, or any arm of a `select` with a shorthand receive.
+    /// Consumed by `infer_continue`: a `continue` there needs a label to
+    /// target the user loop rather than the retry loop.
+    in_retry_loop_arm: Cell<bool>,
+    /// One entry per enclosing loop. Set to `true` by a `break` in a match arm
+    /// or a `continue` in a retry-loop arm. The top is popped by the loop's
     /// inference function and recorded on the Loop/While/For/WhileLet AST node.
     loop_needs_label_stack: std::cell::RefCell<Vec<bool>>,
     /// True when inferring inside a compound expression (call arg, binary
@@ -164,7 +165,7 @@ impl Scopes {
         Scopes {
             stack: vec![Scope::new()],
             in_match_arm: Cell::new(false),
-            in_guarded_match_arm: Cell::new(false),
+            in_retry_loop_arm: Cell::new(false),
             loop_needs_label_stack: std::cell::RefCell::new(Vec::new()),
             in_subexpression: Cell::new(false),
             dot_access_base: Cell::new(false),
@@ -207,7 +208,7 @@ impl Scopes {
         self.stack.clear();
         self.stack.push(Scope::new());
         self.in_match_arm.set(false);
-        self.in_guarded_match_arm.set(false);
+        self.in_retry_loop_arm.set(false);
         self.loop_needs_label_stack.borrow_mut().clear();
         self.in_subexpression.set(false);
         self.dot_access_base.set(false);
@@ -463,12 +464,12 @@ impl Scopes {
         self.in_match_arm.replace(value)
     }
 
-    pub fn is_in_guarded_match_arm(&self) -> bool {
-        self.in_guarded_match_arm.get()
+    pub fn is_in_retry_loop_arm(&self) -> bool {
+        self.in_retry_loop_arm.get()
     }
 
-    pub fn set_in_guarded_match_arm(&self, value: bool) -> bool {
-        self.in_guarded_match_arm.replace(value)
+    pub fn set_in_retry_loop_arm(&self, value: bool) -> bool {
+        self.in_retry_loop_arm.replace(value)
     }
 
     pub fn push_loop_needs_label(&self) {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -407,6 +407,15 @@ impl Pattern {
             _ => None,
         }
     }
+
+    pub fn is_some_pattern(&self) -> bool {
+        let peeled = match self {
+            Pattern::AsBinding { pattern, .. } => pattern.as_ref(),
+            p => p,
+        };
+        matches!(peeled, Pattern::EnumVariant { identifier, fields, .. }
+            if crate::types::unqualified_name(identifier) == "Some" && fields.len() == 1)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -635,6 +635,95 @@ fn main() {
 }
 
 #[test]
+fn select_continue_in_loop_needs_label() {
+    let input = r#"
+fn main() {
+  let ch = Channel.buffered<int>(4)
+  ch.send(-1)
+  ch.send(10)
+  ch.send(20)
+  ch.close()
+  let mut processed = ""
+  for _ in 0..2 {
+    select {
+      let Some(x) = ch.receive() => {
+        if x < 0 {
+          continue
+        }
+        processed += f"{x},"
+      },
+      _ => {
+        processed += "none,"
+      },
+    }
+  }
+  if processed != "10," {
+    panic(f"expected 10, got {processed}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn select_continue_in_default_arm_needs_label() {
+    let input = r#"
+fn main() {
+  let ch = Channel.buffered<int>(1)
+  let mut skipped = 0
+  for i in 0..2 {
+    if i == 1 {
+      ch.send(7)
+    }
+    select {
+      let Some(_x) = ch.receive() => {},
+      _ => {
+        skipped += 1
+        continue
+      },
+    }
+  }
+  if skipped != 1 {
+    panic(f"expected 1 skip, got {skipped}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn select_continue_without_retry_loop_unlabeled() {
+    let input = r#"
+fn main() {
+  let ch = Channel.buffered<int>(2)
+  ch.send(1)
+  ch.send(2)
+  let mut total = 0
+  for _ in 0..2 {
+    select {
+      match ch.receive() {
+        Some(x) => {
+          if x == 1 {
+            continue
+          }
+          total += x
+        },
+        None => {},
+      },
+      _ => {
+        total += 100
+      },
+    }
+  }
+  if total != 2 {
+    panic(f"expected 2, got {total}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn select_arm_binding_does_not_leak() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
@@ -1,0 +1,58 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: |
+  
+  fn main() {
+    let ch = Channel.buffered<int>(1)
+    let mut skipped = 0
+    for i in 0..2 {
+      if i == 1 {
+        ch.send(7)
+      }
+      select {
+        let Some(_x) = ch.receive() => {},
+        _ => {
+          skipped += 1
+          continue
+        },
+      }
+    }
+    if skipped != 1 {
+      panic(f"expected 1 skip, got {skipped}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ch := make(chan int, 1)
+	skipped := 0
+loop_1:
+	for i := 0; i < 2; i++ {
+		if i == 1 {
+			_ = lisette.ChannelSend(ch, 7)
+		}
+		ch_2 := ch
+		for {
+			select {
+			case _, ok := <-ch_2:
+				if !ok {
+					ch_2 = nil
+					continue
+				}
+			default:
+				skipped++
+				continue loop_1
+			}
+			break
+		}
+	}
+	if skipped != 1 {
+		panic(fmt.Sprintf("expected 1 skip, got %d", skipped))
+	}
+}

--- a/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
@@ -1,0 +1,68 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: |
+  
+  fn main() {
+    let ch = Channel.buffered<int>(4)
+    ch.send(-1)
+    ch.send(10)
+    ch.send(20)
+    ch.close()
+    let mut processed = ""
+    for _ in 0..2 {
+      select {
+        let Some(x) = ch.receive() => {
+          if x < 0 {
+            continue
+          }
+          processed += f"{x},"
+        },
+        _ => {
+          processed += "none,"
+        },
+      }
+    }
+    if processed != "10," {
+      panic(f"expected 10, got {processed}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ch := make(chan int, 4)
+	_ = lisette.ChannelSend(ch, -1)
+	_ = lisette.ChannelSend(ch, 10)
+	_ = lisette.ChannelSend(ch, 20)
+	lisette.ChannelClose(ch)
+	processed := ""
+loop_1:
+	for _i_2 := 0; _i_2 < 2; _i_2++ {
+		ch_3 := ch
+		for {
+			select {
+			case x, ok := <-ch_3:
+				if ok {
+					if x < 0 {
+						continue loop_1
+					}
+					processed += fmt.Sprintf("%d,", x)
+				} else {
+					ch_3 = nil
+					continue
+				}
+			default:
+				processed += "none,"
+			}
+			break
+		}
+	}
+	if processed != "10," {
+		panic(fmt.Sprintf("expected 10, got %s", processed))
+	}
+}

--- a/tests/spec/emit/snapshots/select_continue_without_retry_loop_unlabeled.snap
+++ b/tests/spec/emit/snapshots/select_continue_without_retry_loop_unlabeled.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: |
+  
+  fn main() {
+    let ch = Channel.buffered<int>(2)
+    ch.send(1)
+    ch.send(2)
+    let mut total = 0
+    for _ in 0..2 {
+      select {
+        match ch.receive() {
+          Some(x) => {
+            if x == 1 {
+              continue
+            }
+            total += x
+          },
+          None => {},
+        },
+        _ => {
+          total += 100
+        },
+      }
+    }
+    if total != 2 {
+      panic(f"expected 2, got {total}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ch := make(chan int, 2)
+	_ = lisette.ChannelSend(ch, 1)
+	_ = lisette.ChannelSend(ch, 2)
+	total := 0
+	for _i_1 := 0; _i_1 < 2; _i_1++ {
+		select {
+		case x, ok := <-ch:
+			if ok {
+				if x == 1 {
+					continue
+				}
+				total += x
+			}
+		default:
+			total += 100
+		}
+	}
+	if total != 2 {
+		panic(fmt.Sprintf("expected 2, got %d", total))
+	}
+}


### PR DESCRIPTION
A `continue` inside a `select` arm now targets the enclosing loop.

```rs
for i in 0..jobs {
  select {
    let Some(x) = ch.receive() => {
      if x < 0 {
        continue
      }
      process(x)
    },
    _ => {},
  }
}
```

Previously, when the select had a shorthand `let Some(x)` receive arm, the `continue` bound to a hidden retry loop in the emitted Go and re-ran the select inside the same iteration. This silently consumed an extra channel message. `break` in the same position already targeted the enclosing loop correctly.
