### PR TITLE
fix: enforce left-to-right eval order

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -630,7 +630,7 @@ fn emit_lowered_tuple_tail(
                 Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
                     let mut setup = Vec::new();
                     let value = lower_nullable_slot_value(planner, &mut setup, e, slot_ty);
-                    StagedExpression::from_typed_setup(setup, value, e)
+                    planner.staged_from_typed_setup(setup, value, e)
                 }
                 _ => planner.stage_composite(e, ExpressionContext::value()),
             })

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -163,6 +163,10 @@ impl<'a> EmitFacts<'a> {
         self.mutations.is_mutated(id)
     }
 
+    pub(crate) fn is_alias_mutated(&self, id: BindingId) -> bool {
+        self.mutations.is_alias_mutated(id)
+    }
+
     pub(crate) fn is_ufcs_method(&self, qualified_type: &str, method: &str) -> bool {
         self.ufcs_methods
             .contains(&(qualified_type.to_string(), method.to_string()))

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -428,7 +428,7 @@ impl<'a> Planner<'a> {
             .enumerate()
             .map(|(i, arg)| {
                 let (setup, value) = self.lower_call_arg(arg, i, ctx);
-                StagedExpression::from_typed_setup(setup, value, arg)
+                self.staged_from_typed_setup(setup, value, arg)
             })
             .collect();
 
@@ -727,7 +727,7 @@ impl<'a> Planner<'a> {
             loop_cb, src_var, body
         )));
 
-        Some(StagedExpression::from_typed_setup(setup, adapted, spread))
+        Some(self.staged_from_typed_setup(setup, adapted, spread))
     }
 
     /// Detect whether a Go-call argument needs a callback wrapper. Returns

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -201,7 +201,7 @@ impl Planner<'_> {
         };
         let mut setup: Vec<LoweredStatement> = Vec::new();
         if let Some(value) = self.try_adapt_lowered_fn_arg_shape(&mut setup, arg, Some(declared)) {
-            return StagedExpression::from_typed_setup(setup, value, arg);
+            return self.staged_from_typed_setup(setup, value, arg);
         }
         self.stage_composite(arg, ExpressionContext::value())
     }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,7 +1,6 @@
 use crate::Planner;
 use crate::Renderer;
 use crate::context::expression::ExpressionContext;
-use crate::is_order_sensitive;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
 use crate::plan::bodies::{LoopPlan, LoweredBlock, LoweredStatement, directed};
@@ -470,7 +469,11 @@ impl Planner<'_> {
         let end_expression = end
             .as_ref()
             .map(|e| self.force_capture_into(&mut prologue, e, "_bound"));
-        if prologue.len() > checkpoint && start.as_ref().is_some_and(|s| is_order_sensitive(s)) {
+        if prologue.len() > checkpoint
+            && start
+                .as_ref()
+                .is_some_and(|s| observable_after_mutation(s) && !self.is_unmutated_identifier(s))
+        {
             // The end bound's capture inserted statements after the start value;
             // hoist start into its own temp before them so it evaluates first.
             let var = self.fresh_var(Some("start"));
@@ -573,18 +576,6 @@ impl Planner<'_> {
             "go:iter.Seq" => Some(1),
             "go:iter.Seq2" => Some(2),
             _ => None,
-        }
-    }
-
-    fn is_unmutated_identifier(&self, expression: &Expression) -> bool {
-        if let Expression::Identifier {
-            binding_id: Some(id),
-            ..
-        } = expression
-        {
-            !self.facts.is_mutated(*id)
-        } else {
-            false
         }
     }
 }

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -30,13 +30,16 @@ impl Planner<'_> {
             return value_plan_from_statements(setup, value);
         }
 
-        let base_staged = self.stage_base_with_deref(expression);
+        let mut base_staged = self.stage_base_with_deref(expression);
 
         // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`,
         // or `r: Prefix` where `type Prefix = RangeTo<int>`).
         let index_ty = index.get_type();
         if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
             let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
+            if base_staged.has_call {
+                self.pin_staged(&mut base_staged, "_base");
+            }
             let index_staged = self.stage_or_capture(index, "range");
             let (setup, values) =
                 self.sequence_structured(vec![base_staged, index_staged], "_base");
@@ -76,6 +79,9 @@ impl Planner<'_> {
             setup: s.setup,
             capture: s.capture,
             non_literal: s.non_literal,
+            has_call: s.has_call,
+            has_effectful_call: s.has_effectful_call,
+            call_pin_exempt: false,
         }
     }
 

--- a/crates/emit/src/expressions/emission.rs
+++ b/crates/emit/src/expressions/emission.rs
@@ -2,15 +2,15 @@ use syntax::ast::Expression;
 
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::ValuePlan;
-use crate::utils::observable_after_mutation;
+use crate::utils::{contains_call, observable_after_mutation};
 
 /// Whether an inline-valued emission needs to be captured to a temp when a
-/// later sibling produces setup statements. Setup-bearing emissions are
-/// already pinned and use `Never`.
+/// later sibling produces setup statements or contains a call. Setup-bearing
+/// emissions are already pinned and use `Never`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CapturePolicy {
     Never,
-    IfLaterSetup,
+    IfLaterEffect,
 }
 
 /// Result of staging a sub-expression to a separate buffer.
@@ -19,24 +19,34 @@ pub(crate) struct StagedExpression {
     pub value: String,
     pub capture: CapturePolicy,
     pub non_literal: bool,
+    pub has_call: bool,
+    /// `has_call` refined down by the planner for pure calls.
+    pub has_effectful_call: bool,
+    /// A value no later sibling call can invalidate. Planner-computed,
+    /// since it depends on the lowered value.
+    pub call_pin_exempt: bool,
 }
 
 impl StagedExpression {
-    /// Derive the capture policy and observability flag from `expression`,
+    /// Derive the capture policy and observability flags from `expression`,
     /// given already-structured setup and value text. The single place those
-    /// two fields are computed.
+    /// fields are computed.
     fn build(setup: Vec<LoweredStatement>, value: String, expression: &Expression) -> Self {
         let non_literal = observable_after_mutation(expression);
         let capture = if setup.is_empty() && non_literal {
-            CapturePolicy::IfLaterSetup
+            CapturePolicy::IfLaterEffect
         } else {
             CapturePolicy::Never
         };
+        let has_call = contains_call(expression);
         Self {
             setup,
             value,
             capture,
             non_literal,
+            has_call,
+            has_effectful_call: has_call,
+            call_pin_exempt: false,
         }
     }
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -4,10 +4,11 @@ use crate::abi::transition::lower_arg_to_tagged;
 use crate::calls::effective_param_type;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::{CapturePolicy, StagedExpression};
+use crate::expressions::values::is_plain_go_call;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::utils::observable_after_mutation;
-use syntax::ast::Expression;
+use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::types::Type;
 
 /// Folds `f(leading, spread...)` into `f(append([]T{leading}, spread...)...)` — Go rejects the former.
@@ -39,6 +40,9 @@ impl Planner<'_> {
             value: temp_var,
             capture: CapturePolicy::Never,
             non_literal: false,
+            has_call: false,
+            has_effectful_call: false,
+            call_pin_exempt: false,
         }
     }
 
@@ -49,6 +53,8 @@ impl Planner<'_> {
         let tmp = self.hoist_tmp_value_statement(&mut staged.setup, prefix, &value);
         staged.value = tmp;
         staged.capture = CapturePolicy::Never;
+        staged.has_call = false;
+        staged.has_effectful_call = false;
     }
 
     pub(crate) fn emit_force_capture(
@@ -75,7 +81,9 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> StagedExpression {
         let plan = self.plan_operand(expression, ctx);
-        StagedExpression::from_plan(plan, expression)
+        let mut staged = StagedExpression::from_plan(plan, expression);
+        self.refine_stage_flags(&mut staged, expression);
+        staged
     }
 
     /// Stage an expression as a composite value, capturing typed setup.
@@ -85,7 +93,172 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> StagedExpression {
         let plan = self.lower_composite_value(expression, ctx);
-        StagedExpression::from_plan(plan, expression)
+        let mut staged = StagedExpression::from_plan(plan, expression);
+        self.refine_stage_flags(&mut staged, expression);
+        staged
+    }
+
+    /// From typed setup + value, with the exemption refinement applied.
+    pub(crate) fn staged_from_typed_setup(
+        &self,
+        setup: Vec<LoweredStatement>,
+        value: String,
+        expression: &Expression,
+    ) -> StagedExpression {
+        let mut staged = StagedExpression::from_typed_setup(setup, value, expression);
+        self.refine_stage_flags(&mut staged, expression);
+        staged
+    }
+
+    /// Exempt reads of never-mutated bindings (casts are pure conversions)
+    /// and values lowering to plain Go calls, which Go orders lexically.
+    /// Constructor calls are excluded: they can lower to a conversion or
+    /// struct literal, whose operand reads Go does not order.
+    fn refine_stage_flags(&self, staged: &mut StagedExpression, expression: &Expression) {
+        staged.has_effectful_call = staged.has_call && self.contains_effectful_call(expression);
+        let mut inner = expression.unwrap_parens();
+        while let Expression::Cast { expression, .. } = inner {
+            inner = expression.unwrap_parens();
+        }
+        if self.identifier_immune_to_calls(inner) {
+            staged.call_pin_exempt = true;
+            return;
+        }
+        if let Expression::Call {
+            expression: callee, ..
+        } = inner
+            && is_plain_go_call(&staged.value)
+            && !self.callee_lowers_to_type_construction(callee)
+        {
+            staged.call_pin_exempt = true;
+        }
+    }
+
+    /// `Some`/`Ok`/`Err` lower to prelude constructor calls (their non-call
+    /// nilable-slot form already fails the syntactic check).
+    fn callee_lowers_to_type_construction(&self, callee: &Expression) -> bool {
+        let name = match callee.unwrap_parens() {
+            Expression::Identifier { value, .. } => Some(value.as_str()),
+            Expression::DotAccess { member, .. } => Some(member.as_str()),
+            _ => None,
+        };
+        if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
+            return false;
+        }
+        self.callee_definition(callee)
+            .is_some_and(|definition| definition.is_type_definition())
+    }
+
+    /// Whether evaluating `expression` can mutate observable state.
+    pub(crate) fn contains_effectful_call(&self, expression: &Expression) -> bool {
+        match expression.unwrap_parens() {
+            Expression::Call {
+                expression: callee,
+                args,
+                spread,
+                call_kind,
+                ..
+            } => {
+                if self.is_pure_constructor_callee(callee) {
+                    args.iter().any(|a| self.contains_effectful_call(a))
+                        || (**spread)
+                            .as_ref()
+                            .is_some_and(|s| self.contains_effectful_call(s))
+                } else if is_pure_native_method(callee, call_kind) {
+                    self.contains_effectful_call(callee)
+                        || args.iter().any(|a| self.contains_effectful_call(a))
+                } else {
+                    true
+                }
+            }
+            Expression::Binary { left, right, .. } => {
+                self.contains_effectful_call(left) || self.contains_effectful_call(right)
+            }
+            Expression::Unary { expression, .. }
+            | Expression::DotAccess { expression, .. }
+            | Expression::Cast { expression, .. }
+            | Expression::Reference { expression, .. } => self.contains_effectful_call(expression),
+            Expression::IndexedAccess {
+                expression, index, ..
+            } => self.contains_effectful_call(expression) || self.contains_effectful_call(index),
+            Expression::Tuple { elements, .. } => {
+                elements.iter().any(|e| self.contains_effectful_call(e))
+            }
+            Expression::StructCall {
+                field_assignments,
+                spread,
+                ..
+            } => {
+                field_assignments
+                    .iter()
+                    .any(|f| self.contains_effectful_call(&f.value))
+                    || spread
+                        .as_expression()
+                        .is_some_and(|s| self.contains_effectful_call(s))
+            }
+            Expression::Literal {
+                literal: Literal::Slice(elements),
+                ..
+            } => elements.iter().any(|e| self.contains_effectful_call(e)),
+            Expression::Literal {
+                literal: Literal::FormatString(parts),
+                ..
+            } => parts.iter().any(|part| match part {
+                FormatStringPart::Expression(e) => self.contains_effectful_call(e),
+                FormatStringPart::Text(_) => false,
+            }),
+            Expression::Range { start, end, .. } => {
+                start
+                    .as_deref()
+                    .is_some_and(|e| self.contains_effectful_call(e))
+                    || end
+                        .as_deref()
+                        .is_some_and(|e| self.contains_effectful_call(e))
+            }
+            _ => false,
+        }
+    }
+
+    fn is_pure_constructor_callee(&self, callee: &Expression) -> bool {
+        let name = match callee.unwrap_parens() {
+            Expression::Identifier { value, .. } => Some(value.as_str()),
+            Expression::DotAccess { member, .. } => Some(member.as_str()),
+            _ => None,
+        };
+        if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
+            return true;
+        }
+        self.callee_definition(callee)
+            .is_some_and(|definition| definition.is_type_definition())
+    }
+
+    /// No binding id means a top-level definition, which is immutable.
+    pub(crate) fn is_unmutated_identifier(&self, expression: &Expression) -> bool {
+        match expression {
+            Expression::Identifier {
+                binding_id: Some(id),
+                ..
+            } => !self.facts.is_mutated(*id),
+            Expression::Identifier {
+                binding_id: None, ..
+            } => true,
+            _ => false,
+        }
+    }
+
+    /// Only a binding mutated through an alias can be rebound by a call, so
+    /// reads of alias-free bindings commute with sibling calls.
+    pub(crate) fn identifier_immune_to_calls(&self, expression: &Expression) -> bool {
+        match expression {
+            Expression::Identifier {
+                binding_id: Some(id),
+                ..
+            } => !self.facts.is_alias_mutated(*id),
+            Expression::Identifier {
+                binding_id: None, ..
+            } => true,
+            _ => false,
+        }
     }
 
     pub(crate) fn stage_prelude_arg(
@@ -104,9 +277,9 @@ impl Planner<'_> {
             if let Some(tagged) =
                 self.try_lower_arg_to_tagged(&mut setup, expression, &staged.value, param_ty)
             {
-                return StagedExpression::from_typed_setup(setup, tagged, expression);
+                return self.staged_from_typed_setup(setup, tagged, expression);
             }
-            return StagedExpression::from_typed_setup(setup, staged.value, expression);
+            return self.staged_from_typed_setup(setup, staged.value, expression);
         }
 
         staged
@@ -212,8 +385,9 @@ impl Planner<'_> {
 
     /// Sequence N staged emissions preserving left-to-right eval order,
     /// accumulating setup into a `Vec<LoweredStatement>` so a value plan can
-    /// carry it as structured setup. A later sibling with setup forces an
-    /// earlier inline-but-observable value to be captured to a `TempBind`.
+    /// carry it as structured setup. A later sibling with setup or a call
+    /// forces an earlier inline-but-observable value to be captured to a
+    /// `TempBind`, since Go otherwise reads it after the call runs.
     /// Returns `(setup_statements, values)`.
     pub(crate) fn sequence_structured(
         &mut self,
@@ -221,24 +395,45 @@ impl Planner<'_> {
         prefix: &str,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let eager = self.function_state.eager_operand_capture();
-        if !eager && stages.iter().all(|s| s.setup.is_empty()) {
+        if !eager
+            && stages
+                .iter()
+                .all(|s| s.setup.is_empty() && !s.has_effectful_call)
+        {
             return (Vec::new(), stages.into_iter().map(|s| s.value).collect());
+        }
+
+        // Pinning hoists evaluation into setup, so a call left inline must
+        // also pin when a later sibling pins or carries setup. A value
+        // already reduced to a temp by its own setup evaluates nothing
+        // inline and needs no ordering pin.
+        let mut pins = vec![false; stages.len()];
+        let mut later_has_setup = false;
+        let mut later_effectful = false;
+        let mut later_pins = false;
+        for i in (0..stages.len()).rev() {
+            let stage = &stages[i];
+            let base_pin = matches!(stage.capture, CapturePolicy::IfLaterEffect)
+                && (later_has_setup || (later_effectful && !stage.call_pin_exempt));
+            let value_still_evaluates = stage.value.contains('(') || stage.value.contains("<-");
+            let ordering_pin =
+                stage.has_call && value_still_evaluates && (later_has_setup || later_pins);
+            pins[i] = base_pin || ordering_pin;
+            later_pins |= pins[i];
+            later_has_setup |= !stage.setup.is_empty();
+            later_effectful |= stage.has_effectful_call;
         }
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let mut results = Vec::with_capacity(stages.len());
         for i in 0..stages.len() {
-            let later_has_setup = stages[i + 1..].iter().any(|s| !s.setup.is_empty());
-            let s_capture = stages[i].capture;
             let s_non_literal = stages[i].non_literal;
             let s_value = std::mem::take(&mut stages[i].value);
             let s_setup = std::mem::take(&mut stages[i].setup);
 
             setup.extend(s_setup);
 
-            let capture_for_later =
-                later_has_setup && matches!(s_capture, CapturePolicy::IfLaterSetup);
-            if capture_for_later || (eager && s_non_literal) {
+            if pins[i] || (eager && s_non_literal) {
                 let tmp = self.fresh_var(Some(prefix));
                 self.declare(&tmp);
                 setup.push(LoweredStatement::TempBind {
@@ -302,4 +497,17 @@ impl Planner<'_> {
         }
         self.sequence_with_spread_structured(stages, spread, wrap_to_any, "_arg", combine)
     }
+}
+
+fn is_pure_native_method(
+    callee: &Expression,
+    call_kind: &Option<syntax::program::CallKind>,
+) -> bool {
+    if !matches!(call_kind, Some(syntax::program::CallKind::NativeMethod(_))) {
+        return false;
+    }
+    matches!(
+        callee.unwrap_parens(),
+        Expression::DotAccess { member, .. } if matches!(member.as_str(), "length" | "capacity")
+    )
 }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -399,10 +399,13 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         let rhs_staged = self.stage_composite(value, ExpressionContext::value());
 
-        let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
+        let rhs = crate::statements::assignments::RhsEffects {
+            has_setup: !rhs_staged.setup.is_empty(),
+            has_effectful_call: self.contains_effectful_call(value),
+        };
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut setup, target, rhs_has_setup)
+            self.emit_left_value_capturing(&mut setup, target, rhs)
         } else {
             self.emit_left_value(&mut setup, target)
         };
@@ -611,10 +614,12 @@ fn needs_iife_for_async(expression: &Expression, emitted: &str) -> bool {
     if !is_native_method_call(expression) {
         return false;
     }
-    !is_valid_go_async_target(emitted)
+    !is_plain_go_call(emitted)
 }
 
-fn is_valid_go_async_target(emitted: &str) -> bool {
+/// Whether emitted Go text is a plain non-builtin call. Valid as a `go` or
+/// `defer` target, and evaluated in lexical order among sibling operands.
+pub(crate) fn is_plain_go_call(emitted: &str) -> bool {
     let trimmed = emitted.trim();
     if !trimmed.ends_with(')') {
         return false;

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -233,10 +233,12 @@ pub(crate) enum AssignForm {
 pub(crate) enum CompoundKind {
     Increment,
     Decrement,
-    /// `target op= rhs`. `op_text` is the rendered Go operator.
+    /// `target op= rhs`. An effectful RHS forces the target's prior value
+    /// into `pinned_left`, rendered as `target = pinned_left op rhs`.
     OpAssign {
         op_text: String,
         rhs: ValuePlan,
+        pinned_left: Option<String>,
     },
 }
 

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -10,9 +10,8 @@ use crate::plan::bodies::{
 };
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
-use crate::statements::assignments::is_lvalue_chain;
+use crate::statements::assignments::{RhsEffects, is_lvalue_chain};
 use crate::types::native::NativeGoType;
-use crate::utils::contains_call;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
 
@@ -527,12 +526,15 @@ impl Planner<'_> {
 
         let (value, mut statements) = if receiver_is_lvalue {
             let (args_setup, args_str) = self.lower_append_args(func, args, (**spread).as_ref());
-            let rhs_has_setup = !args_setup.is_empty()
-                || args.iter().any(contains_call)
-                || (**spread).as_ref().is_some_and(contains_call);
+            let rhs = RhsEffects {
+                has_setup: !args_setup.is_empty(),
+                has_effectful_call: args.iter().any(|a| self.contains_effectful_call(a))
+                    || (**spread)
+                        .as_ref()
+                        .is_some_and(|s| self.contains_effectful_call(s)),
+            };
             let mut capture: Vec<LoweredStatement> = Vec::new();
-            let receiver_lv =
-                self.emit_left_value_capturing(&mut capture, unwrapped, rhs_has_setup);
+            let receiver_lv = self.emit_left_value_capturing(&mut capture, unwrapped, rhs);
             capture.extend(args_setup);
             let value = if args_str.is_empty() {
                 receiver_lv

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -258,9 +258,25 @@ impl Renderer {
                 match kind {
                     CompoundKind::Increment => write_line!(output, "{}++", target_str),
                     CompoundKind::Decrement => write_line!(output, "{}--", target_str),
-                    CompoundKind::OpAssign { op_text, rhs } => {
+                    CompoundKind::OpAssign {
+                        op_text,
+                        rhs,
+                        pinned_left,
+                    } => {
                         let rhs_text = self.render_value(output, rhs);
-                        write_line!(output, "{} {}= {}", target_str, op_text, rhs_text);
+                        match pinned_left {
+                            Some(left) => write_line!(
+                                output,
+                                "{} = {} {} {}",
+                                target_str,
+                                left,
+                                op_text,
+                                rhs_text
+                            ),
+                            None => {
+                                write_line!(output, "{} {}= {}", target_str, op_text, rhs_text)
+                            }
+                        }
                     }
                 }
             }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -7,9 +7,23 @@ use crate::plan::bodies::{AssignForm, AssignPlan, CompoundKind, LoweredBlock, Lo
 use crate::plan::values::value_plan_from_statements;
 use crate::state::bindings::BindingValue;
 use crate::utils::observable_after_mutation;
-use syntax::ast::{BinaryOperator, Expression, FormatStringPart, Literal, UnaryOperator};
+use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
+
+/// Splits the two pin triggers: setup can mutate any binding directly,
+/// calls can only rebind aliased bindings.
+#[derive(Clone, Copy)]
+pub(crate) struct RhsEffects {
+    pub has_setup: bool,
+    pub has_effectful_call: bool,
+}
+
+impl RhsEffects {
+    pub(crate) fn any(self) -> bool {
+        self.has_setup || self.has_effectful_call
+    }
+}
 
 impl Planner<'_> {
     /// Build an `AssignPlan`, dispatching on shape: never-typed, compound,
@@ -56,7 +70,13 @@ impl Planner<'_> {
             && target_ty.resolves_to_unknown()
             && value.is_none_literal()
         {
-            let (target_capture, target_str) = self.capture_assignment_target(target, false);
+            let (target_capture, target_str) = self.capture_assignment_target(
+                target,
+                RhsEffects {
+                    has_setup: false,
+                    has_effectful_call: false,
+                },
+            );
             return AssignPlan {
                 form: AssignForm::NilClear {
                     target_capture,
@@ -69,8 +89,11 @@ impl Planner<'_> {
         // whether RHS produced setup), capture the target, then fold RHS
         // setup + coercion setup into the value plan in emission order.
         let rhs_staged = self.stage_composite(value, ExpressionContext::value());
-        let rhs_has_setup = !rhs_staged.setup.is_empty() || self.rhs_contains_effectful_call(value);
-        let (target_capture, target_str) = self.capture_assignment_target(target, rhs_has_setup);
+        let rhs = RhsEffects {
+            has_setup: !rhs_staged.setup.is_empty(),
+            has_effectful_call: self.contains_effectful_call(value),
+        };
+        let (target_capture, target_str) = self.capture_assignment_target(target, rhs);
         let mut value_setup = rhs_staged.setup;
         let coercion = if let Some(target_ty) = go_field_ty {
             Coercion::resolve(
@@ -108,23 +131,57 @@ impl Planner<'_> {
     ) -> AssignPlan {
         let is_inc_dec = is_literal_one(rhs)
             && matches!(op, BinaryOperator::Addition | BinaryOperator::Subtraction);
-        let (kind, rhs_has_setup) = if is_inc_dec {
+        if is_inc_dec {
             let kind = if *op == BinaryOperator::Addition {
                 CompoundKind::Increment
             } else {
                 CompoundKind::Decrement
             };
-            (kind, false)
-        } else {
-            let staged = self.stage_operand(rhs, ExpressionContext::value());
-            let rhs_has_setup = !staged.setup.is_empty() || self.rhs_contains_effectful_call(rhs);
-            let kind = CompoundKind::OpAssign {
-                op_text: format!("{}", op),
-                rhs: value_plan_from_statements(staged.setup, staged.value),
+            let (target_capture, target_str) = self.capture_assignment_target(
+                target,
+                RhsEffects {
+                    has_setup: false,
+                    has_effectful_call: false,
+                },
+            );
+            return AssignPlan {
+                form: AssignForm::Compound {
+                    target_capture,
+                    target_str,
+                    kind,
+                },
             };
-            (kind, rhs_has_setup)
+        }
+
+        let staged = self.stage_operand(rhs, ExpressionContext::value());
+        let rhs_effects = RhsEffects {
+            has_setup: !staged.setup.is_empty(),
+            has_effectful_call: self.contains_effectful_call(rhs),
         };
-        let (target_capture, target_str) = self.capture_assignment_target(target, rhs_has_setup);
+        let (mut target_capture, target_str) = self.capture_assignment_target(target, rhs_effects);
+        let needs_left_pin = rhs_effects.has_setup
+            || (rhs_effects.has_effectful_call
+                && !self.identifier_immune_to_calls(target.unwrap_parens()));
+        let pinned_left = needs_left_pin.then(|| {
+            let tmp = self.fresh_var(Some("_left"));
+            self.declare(&tmp);
+            target_capture.push(LoweredStatement::TempBind {
+                name: tmp.clone(),
+                value: target_str.clone(),
+            });
+            tmp
+        });
+        let rhs_value =
+            if pinned_left.is_some() && matches!(rhs.unwrap_parens(), Expression::Binary { .. }) {
+                format!("({})", staged.value)
+            } else {
+                staged.value
+            };
+        let kind = CompoundKind::OpAssign {
+            op_text: format!("{}", op),
+            rhs: value_plan_from_statements(staged.setup, rhs_value),
+            pinned_left,
+        };
         AssignPlan {
             form: AssignForm::Compound {
                 target_capture,
@@ -139,98 +196,15 @@ impl Planner<'_> {
     fn capture_assignment_target(
         &mut self,
         target: &Expression,
-        rhs_has_setup: bool,
+        rhs: RhsEffects,
     ) -> (Vec<LoweredStatement>, String) {
         let mut target_capture: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
-            self.emit_left_value_capturing(&mut target_capture, target, rhs_has_setup)
+            self.emit_left_value_capturing(&mut target_capture, target, rhs)
         } else {
             self.emit_left_value(&mut target_capture, target)
         };
         (target_capture, target_str)
-    }
-
-    pub(crate) fn rhs_contains_effectful_call(&self, expression: &Expression) -> bool {
-        match expression.unwrap_parens() {
-            Expression::Call {
-                expression: callee,
-                args,
-                spread,
-                ..
-            } => {
-                if self.is_pure_constructor_callee(callee) {
-                    args.iter().any(|a| self.rhs_contains_effectful_call(a))
-                        || (**spread)
-                            .as_ref()
-                            .is_some_and(|s| self.rhs_contains_effectful_call(s))
-                } else {
-                    true
-                }
-            }
-            Expression::Binary { left, right, .. } => {
-                self.rhs_contains_effectful_call(left) || self.rhs_contains_effectful_call(right)
-            }
-            Expression::Unary { expression, .. }
-            | Expression::DotAccess { expression, .. }
-            | Expression::Cast { expression, .. }
-            | Expression::Reference { expression, .. } => {
-                self.rhs_contains_effectful_call(expression)
-            }
-            Expression::IndexedAccess {
-                expression, index, ..
-            } => {
-                self.rhs_contains_effectful_call(expression)
-                    || self.rhs_contains_effectful_call(index)
-            }
-            Expression::Tuple { elements, .. } => {
-                elements.iter().any(|e| self.rhs_contains_effectful_call(e))
-            }
-            Expression::StructCall {
-                field_assignments,
-                spread,
-                ..
-            } => {
-                field_assignments
-                    .iter()
-                    .any(|f| self.rhs_contains_effectful_call(&f.value))
-                    || spread
-                        .as_expression()
-                        .is_some_and(|s| self.rhs_contains_effectful_call(s))
-            }
-            Expression::Literal {
-                literal: Literal::Slice(elements),
-                ..
-            } => elements.iter().any(|e| self.rhs_contains_effectful_call(e)),
-            Expression::Literal {
-                literal: Literal::FormatString(parts),
-                ..
-            } => parts.iter().any(|part| match part {
-                FormatStringPart::Expression(e) => self.rhs_contains_effectful_call(e),
-                FormatStringPart::Text(_) => false,
-            }),
-            Expression::Range { start, end, .. } => {
-                start
-                    .as_deref()
-                    .is_some_and(|e| self.rhs_contains_effectful_call(e))
-                    || end
-                        .as_deref()
-                        .is_some_and(|e| self.rhs_contains_effectful_call(e))
-            }
-            _ => false,
-        }
-    }
-
-    fn is_pure_constructor_callee(&self, callee: &Expression) -> bool {
-        let name = match callee.unwrap_parens() {
-            Expression::Identifier { value, .. } => Some(value.as_str()),
-            Expression::DotAccess { member, .. } => Some(member.as_str()),
-            _ => None,
-        };
-        if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
-            return true;
-        }
-        self.callee_definition(callee)
-            .is_some_and(|definition| definition.is_type_definition())
     }
 
     fn target_binds_to_discard(&self, target: &Expression) -> bool {
@@ -340,7 +314,7 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        rhs_has_setup: bool,
+        rhs: RhsEffects,
     ) -> String {
         let expression = expression.unwrap_parens();
         match expression {
@@ -349,8 +323,8 @@ impl Planner<'_> {
                 index,
                 ..
             } => {
-                if rhs_has_setup {
-                    let base_str = self.emit_indexed_base_lvalue(setup, base);
+                if rhs.any() {
+                    let base_str = self.emit_indexed_base_lvalue(setup, base, rhs);
                     let index_str = self.emit_force_capture(setup, index, "idx");
                     format!("{}[{}]", base_str, index_str)
                 } else {
@@ -363,14 +337,14 @@ impl Planner<'_> {
                 ..
             } => {
                 let base_str = if let Some(inner) = base.deref_inner() {
-                    if rhs_has_setup {
+                    if rhs.any() {
                         self.emit_force_capture(setup, inner, "ref")
                     } else {
                         self.capture_operand_into(setup, inner)
                     }
                 } else if is_order_sensitive(base) {
-                    self.emit_left_value_capturing(setup, base, rhs_has_setup)
-                } else if rhs_has_setup && base.get_type().is_ref() {
+                    self.emit_left_value_capturing(setup, base, rhs)
+                } else if rhs.any() && base.get_type().is_ref() {
                     self.emit_force_capture(setup, base, "ref")
                 } else {
                     self.emit_left_value(setup, base)
@@ -382,7 +356,7 @@ impl Planner<'_> {
                 operator: UnaryOperator::Deref,
                 expression: inner,
                 ..
-            } => self.emit_deref_lvalue(setup, inner, rhs_has_setup),
+            } => self.emit_deref_lvalue(setup, inner, rhs.any()),
             _ => self.emit_left_value(setup, expression),
         }
     }
@@ -403,12 +377,14 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         base: &Expression,
+        rhs: RhsEffects,
     ) -> String {
-        let force = is_order_sensitive(base);
         if let Some(inner) = base.deref_inner() {
-            let inner_str = self.emit_base_operand(setup, inner, force);
+            let inner_str = self.emit_base_operand(setup, inner, true);
             format!("(*{})", inner_str)
         } else {
+            let force = observable_after_mutation(base)
+                && (rhs.has_setup || !self.identifier_immune_to_calls(base.unwrap_parens()));
             self.emit_base_operand(setup, base, force)
         }
     }

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -48,7 +48,9 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
 
     let mut mutations = MutationInfo::default();
     for (&binding_id, b) in facts.bindings.iter() {
-        if b.mutated {
+        if b.alias_mutated {
+            mutations.mark_binding_alias_mutated(binding_id);
+        } else if b.mutated {
             mutations.mark_binding_mutated(binding_id);
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -996,7 +996,7 @@ impl InferCtx<'_, '_> {
         };
 
         if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
-            self.facts.mark_mutated(binding_id);
+            self.facts.mark_alias_mutated(binding_id);
         }
         let is_deref = contains_deref(receiver_expression);
         let binding_is_ref = self

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1387,7 +1387,7 @@ impl InferCtx<'_, '_> {
             return;
         };
         if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
-            self.facts.mark_mutated(binding_id);
+            self.facts.mark_alias_mutated(binding_id);
         }
         let is_deref = contains_deref(receiver);
         let binding_is_ref = self
@@ -1457,7 +1457,7 @@ impl InferCtx<'_, '_> {
                 ));
         }
         if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
-            self.facts.mark_mutated(binding_id);
+            self.facts.mark_alias_mutated(binding_id);
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -209,7 +209,7 @@ impl InferCtx<'_, '_> {
             if let Some(var_name) = new_expression.get_var_name()
                 && let Some(binding_id) = self.scopes.lookup_binding_id(&var_name)
             {
-                self.facts.mark_mutated(binding_id);
+                self.facts.mark_alias_mutated(binding_id);
             }
         }
 
@@ -361,7 +361,11 @@ impl InferCtx<'_, '_> {
                 if compound_operator.is_some() {
                     self.facts.mark_used(binding_id);
                 }
-                self.facts.mark_mutated(binding_id);
+                if self.scopes.binding_crosses_function_boundary(&var_name) {
+                    self.facts.mark_alias_mutated(binding_id);
+                } else {
+                    self.facts.mark_mutated(binding_id);
+                }
             }
 
             let is_mutable = self.scopes.lookup_mutable(&var_name);

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -250,6 +250,20 @@ impl Scopes {
         None
     }
 
+    /// Whether resolving `name` crosses a function scope, meaning captured.
+    pub fn binding_crosses_function_boundary(&self, name: &str) -> bool {
+        let mut crossed = false;
+        for scope in self.stack.iter().rev() {
+            if scope.name_to_binding.contains_key(name) {
+                return crossed;
+            }
+            if scope.fn_return_type.is_some() {
+                crossed = true;
+            }
+        }
+        false
+    }
+
     /// Look up a type parameter by walking the scope stack from top to bottom.
     pub fn lookup_type_param(&self, name: &str) -> Option<usize> {
         for scope in self.stack.iter().rev() {

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -156,6 +156,7 @@ impl Facts {
                 kind,
                 used: false,
                 mutated: false,
+                alias_mutated: false,
                 is_typedef,
                 is_struct_field,
                 is_as_alias,
@@ -173,6 +174,15 @@ impl Facts {
     pub fn mark_mutated(&mut self, id: BindingId) {
         if let Some(fact) = self.bindings.get_mut(&id) {
             fact.mutated = true;
+        }
+    }
+
+    /// The binding is mutated through an alias (address taken, mutable
+    /// capture, mut argument or receiver), so a call can rebind it.
+    pub fn mark_alias_mutated(&mut self, id: BindingId) {
+        if let Some(fact) = self.bindings.get_mut(&id) {
+            fact.mutated = true;
+            fact.alias_mutated = true;
         }
     }
 
@@ -390,6 +400,7 @@ pub struct BindingFact {
     pub kind: BindingKind,
     pub used: bool,
     pub mutated: bool,
+    pub alias_mutated: bool,
     pub is_typedef: bool,
     /// If true, this binding is a shorthand in a struct pattern (e.g., `Point { x }`)
     pub is_struct_field: bool,

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -201,6 +201,7 @@ impl EqualityIndex {
 #[derive(Debug, Clone, Default)]
 pub struct MutationInfo {
     bindings: HashSet<AstBindingId>,
+    alias_bindings: HashSet<AstBindingId>,
 }
 
 impl MutationInfo {
@@ -208,8 +209,18 @@ impl MutationInfo {
         self.bindings.insert(id);
     }
 
+    /// The binding is mutated through an alias, so a call can rebind it.
+    pub fn mark_binding_alias_mutated(&mut self, id: AstBindingId) {
+        self.bindings.insert(id);
+        self.alias_bindings.insert(id);
+    }
+
     pub fn is_mutated(&self, id: AstBindingId) -> bool {
         self.bindings.contains(&id)
+    }
+
+    pub fn is_alias_mutated(&self, id: AstBindingId) -> bool {
+        self.alias_bindings.contains(&id)
     }
 }
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -278,7 +278,9 @@ impl CompiledTest {
                 if !b.used {
                     unused.mark_binding_unused(b.span);
                 }
-                if b.mutated {
+                if b.alias_mutated {
+                    mutations.mark_binding_alias_mutated(binding_id);
+                } else if b.mutated {
                     mutations.mark_binding_mutated(binding_id);
                 }
             }

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_merge_constraints.snap
@@ -20,7 +20,8 @@ type Container[T any] struct {
 }
 
 func Container_display[T Printable](self Container[T]) string {
-	return fmt.Sprintf("[%s] %s", self.label, self.value.PrintVal())
+	_fmtarg_1 := self.label
+	return fmt.Sprintf("[%s] %s", _fmtarg_1, self.value.PrintVal())
 }
 
 func Container_total[T Summable](self Container[T]) int {

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -82,7 +82,8 @@ type Tagged[T traits.Showable] struct {
 }
 
 func (t Tagged[T]) Show() string {
-	return fmt.Sprintf("[%s] %s", t.Label, t.Value.Show())
+	_fmtarg_1 := t.Label
+	return fmt.Sprintf("[%s] %s", _fmtarg_1, t.Value.Show())
 }
 
 func (t Tagged[T]) Display() string {

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -733,6 +733,22 @@ fn test() -> int {
 }
 
 #[test]
+fn for_loop_range_start_frozen_before_call_bound() {
+    let input = r#"
+fn test() -> int {
+  let mut n = 1
+  let consume = || -> int { n = 5; 4 }
+  let mut sum = 0
+  for i in n..consume() {
+    sum += i
+  }
+  sum
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_loop_range_from_call() {
     let input = r#"
 fn get_range() -> Range<int> { 0..5 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4593,6 +4593,194 @@ fn run() -> int {
 }
 
 #[test]
+fn compound_identifier_target_reads_before_call_rhs() {
+    let input = r#"
+fn run() -> int {
+  let mut x = 1
+  let bump = || -> int { x = 100; 5 }
+  x += bump()
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn inline_call_pins_when_later_operand_pins() {
+    let input = r#"
+fn run() -> int {
+  let mut x = 1
+  let setx = || -> int { x = 50; 100 }
+  let bump = |v: int| -> int { x += 7; v }
+  let r = [setx(), x, bump(5)]
+  r[0] + r[1] + r[2]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_free_target_keeps_compound_assign_with_call_rhs() {
+    let input = r#"
+fn pure_add(a: int) -> int { a + 100 }
+
+fn run() -> int {
+  let mut x = 5
+  x += pure_add(1)
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_free_base_not_pinned_before_call_rhs() {
+    let input = r#"
+fn pure_add(a: int) -> int { a + 100 }
+
+fn run() -> int {
+  let mut ws = [1, 2, 3]
+  ws[0] = pure_add(7)
+  ws[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn alias_free_operand_not_pinned_before_call() {
+    let input = r#"
+fn bump(a: int) -> int { a + 1 }
+
+fn run() -> int {
+  let mut items: Slice<int> = []
+  let mut i = 0
+  let ibump = || -> int { i = 1; 10 }
+  items = items.append(i, ibump())
+  items[0] + items[1]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pure_constructor_does_not_force_sibling_pins() {
+    let input = r#"
+struct Wrap(int)
+
+fn run() -> int {
+  let pair = (Wrap(9), Wrap(8))
+  pair.0.0 + pair.1.0
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pure_constructor_with_mutable_read_pins_when_later_operand_pins() {
+    let input = r#"
+fn run() -> int {
+  let mut x = 1
+  let bump = || -> int { x = 20; 2 }
+  let elems = [Some(x), Some(x + bump()), Some(x)]
+  elems[0].unwrap_or(-1) + elems[1].unwrap_or(-1) + elems[2].unwrap_or(-1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn setup_bearing_call_pins_when_later_operand_pins() {
+    let input = r#"
+fn foo(a: int, b: int) -> int { a + b }
+
+fn run() -> int {
+  let mut x = 1
+  let setx = || -> int { x = 50; 100 }
+  let bump = |v: int| -> int { x += 7; v }
+  let r = [foo(x, setx()), x, bump(5)]
+  r[0] + r[1] + r[2]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn constructor_lowered_to_conversion_pins_before_call() {
+    let input = r#"
+struct Box(int)
+
+fn run() -> int {
+  let mut x = 1
+  let bump = |v: int| -> int { x = 50; v }
+  let r = (Box(x), bump(5))
+  r.0.0 + r.1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn top_level_reference_not_pinned_before_call() {
+    let input = r#"
+const BASE = 10
+
+fn eff(x: Ref<int>) -> int {
+  x.* = 1
+  2
+}
+
+fn run() -> int {
+  let mut i = 0
+  let r = [BASE, eff(&i)]
+  r[0] + r[1]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn compound_binary_rhs_keeps_grouping_when_left_pinned() {
+    let input = r#"
+fn run() -> int {
+  let mut x = 2
+  let mut y = 3
+  let bump = || -> int { y = 10; 4 }
+  x *= y + bump()
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn index_assignment_base_frozen_before_call_rhs() {
+    let input = r#"
+fn run() -> int {
+  let mut xs = [1, 2, 3]
+  let swap = || -> int { xs = [7, 8, 9]; 42 }
+  xs[0] = swap()
+  xs[0]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn range_variable_slice_base_call_evaluated_once() {
+    let input = r#"
+fn make() -> Slice<int> { [1, 2, 3] }
+
+fn run() -> int {
+  let r = 1..
+  let s = make()[r]
+  s.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn selector_callee_eval_order_captured() {
     let input = r#"
 fn f0(x: int) -> int { x + 10 }

--- a/tests/spec/emit/snapshots/alias_free_base_not_pinned_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/alias_free_base_not_pinned_before_call_rhs.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn pure_add(a: int) -> int { a + 100 }
+  
+  fn run() -> int {
+    let mut ws = [1, 2, 3]
+    ws[0] = pure_add(7)
+    ws[0]
+  }
+---
+package main
+
+func pure_add(a int) int {
+	return a + 100
+}
+
+func run() int {
+	ws := []int{1, 2, 3}
+	ws[0] = pure_add(7)
+	return ws[0]
+}

--- a/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn bump(a: int) -> int { a + 1 }
+  
+  fn run() -> int {
+    let mut items: Slice<int> = []
+    let mut i = 0
+    let ibump = || -> int { i = 1; 10 }
+    items = items.append(i, ibump())
+    items[0] + items[1]
+  }
+---
+package main
+
+func bump(a int) int {
+	return a + 1
+}
+
+func run() int {
+	items := ([]int)(nil)
+	i := 0
+	ibump := func() int {
+		i = 1
+		return 10
+	}
+	_arg_1 := i
+	items = append(items, _arg_1, ibump())
+	return items[0] + items[1]
+}

--- a/tests/spec/emit/snapshots/alias_free_target_keeps_compound_assign_with_call_rhs.snap
+++ b/tests/spec/emit/snapshots/alias_free_target_keeps_compound_assign_with_call_rhs.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn pure_add(a: int) -> int { a + 100 }
+  
+  fn run() -> int {
+    let mut x = 5
+    x += pure_add(1)
+    x
+  }
+---
+package main
+
+func pure_add(a int) int {
+	return a + 100
+}
+
+func run() int {
+	x := 5
+	x += pure_add(1)
+	return x
+}

--- a/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
@@ -24,6 +24,7 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	items := ([]int)(nil)
-	items = append(items, i, bump(&i))
+	_arg_1 := i
+	items = append(items, _arg_1, bump(&i))
 	_ = items
 }

--- a/tests/spec/emit/snapshots/assignment_lvalue_side_effects_with_temp_rhs.snap
+++ b/tests/spec/emit/snapshots/assignment_lvalue_side_effects_with_temp_rhs.snap
@@ -22,12 +22,13 @@ func make_b() int {
 
 func main() {
 	s := []int{0, 0, 0}
-	idx_2 := make_a()
+	base_2 := s
+	idx_3 := make_a()
 	var tmp_1 int
 	if true {
 		tmp_1 = make_b()
 	} else {
 		tmp_1 = 0
 	}
-	s[idx_2] = tmp_1
+	base_2[idx_3] = tmp_1
 }

--- a/tests/spec/emit/snapshots/binary_left_hoisted_when_right_is_call.snap
+++ b/tests/spec/emit/snapshots/binary_left_hoisted_when_right_is_call.snap
@@ -22,6 +22,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	z := i + bump(&i)
+	_left_1 := i
+	z := _left_1 + bump(&i)
 	_ = z
 }

--- a/tests/spec/emit/snapshots/call_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/call_args_eval_order_captured.snap
@@ -28,6 +28,7 @@ func sum(a, b int) int {
 
 func main() {
 	i := 0
-	z := sum(i, bump(&i))
+	_arg_1 := i
+	z := sum(_arg_1, bump(&i))
 	_ = z
 }

--- a/tests/spec/emit/snapshots/compound_binary_rhs_keeps_grouping_when_left_pinned.snap
+++ b/tests/spec/emit/snapshots/compound_binary_rhs_keeps_grouping_when_left_pinned.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn run() -> int {
+    let mut x = 2
+    let mut y = 3
+    let bump = || -> int { y = 10; 4 }
+    x *= y + bump()
+    x
+  }
+---
+package main
+
+func run() int {
+	x := 2
+	y := 3
+	bump := func() int {
+		y = 10
+		return 4
+	}
+	_left_2 := x
+	_left_1 := y
+	x = _left_2 * (_left_1 + bump())
+	return x
+}

--- a/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
+++ b/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
@@ -36,7 +36,8 @@ func main() {
 	b := 2
 	h := H{ptr: &a}
 	ref_1 := h.ptr
-	*ref_1 += h.repoint(&b)
+	_left_2 := *ref_1
+	*ref_1 = _left_2 + h.repoint(&b)
 	_ = a
 	_ = b
 }

--- a/tests/spec/emit/snapshots/compound_identifier_target_reads_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_identifier_target_reads_before_call_rhs.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn run() -> int {
+    let mut x = 1
+    let bump = || -> int { x = 100; 5 }
+    x += bump()
+    x
+  }
+---
+package main
+
+func run() int {
+	x := 1
+	bump := func() int {
+		x = 100
+		return 5
+	}
+	_left_1 := x
+	x = _left_1 + bump()
+	return x
+}

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
@@ -20,6 +20,7 @@ func run() int {
 		return 5
 	}
 	idx_1 := i
-	xs[idx_1] += bump()
+	_left_2 := xs[idx_1]
+	xs[idx_1] = _left_2 + bump()
 	return xs[0]
 }

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
@@ -24,11 +24,13 @@ func run() lisette.Result[struct{}, string] {
 		i = 1
 		return lisette.MakeResultOk[int, string](5)
 	}
-	idx_2 := i
+	base_2 := xs
+	idx_3 := i
+	_left_4 := base_2[idx_3]
 	check_1 := bump()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
 	}
-	xs[idx_2] += check_1.OkVal
+	base_2[idx_3] = _left_4 + check_1.OkVal
 	return lisette.MakeResultOk[struct{}, string](struct{}{})
 }

--- a/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
+++ b/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Box(int)
+  
+  fn run() -> int {
+    let mut x = 1
+    let bump = |v: int| -> int { x = 50; v }
+    let r = (Box(x), bump(5))
+    r.0.0 + r.1
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box int
+
+func run() int {
+	x := 1
+	bump := func(v int) int {
+		x = 50
+		return v
+	}
+	_v_1 := Box(x)
+	r := lisette.MakeTuple2(_v_1, bump(5))
+	return int(r.First) + r.Second
+}

--- a/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
+++ b/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
@@ -17,13 +17,14 @@ func get_items() []int {
 
 func main() {
 	items := []int{0, 0, 0}
-	_base_2 := get_items()
-	idx_3 := _base_2[0]
+	base_2 := items
+	_base_3 := get_items()
+	idx_4 := _base_3[0]
 	var tmp_1 int
 	if true {
 		tmp_1 = 42
 	} else {
 		tmp_1 = 0
 	}
-	items[idx_3] = tmp_1
+	base_2[idx_4] = tmp_1
 }

--- a/tests/spec/emit/snapshots/eval_order_assignment_index_target_if_value.snap
+++ b/tests/spec/emit/snapshots/eval_order_assignment_index_target_if_value.snap
@@ -14,7 +14,8 @@ package main
 func main() {
 	items := []int{10, 20}
 	i := 0
-	idx_2 := i
+	base_2 := items
+	idx_3 := i
 	var tmp_1 int
 	if true {
 		i = 1
@@ -22,6 +23,6 @@ func main() {
 	} else {
 		tmp_1 = 0
 	}
-	items[idx_2] = tmp_1
+	base_2[idx_3] = tmp_1
 	_ = items
 }

--- a/tests/spec/emit/snapshots/expr_position_assign_preserves_lvalue.snap
+++ b/tests/spec/emit/snapshots/expr_position_assign_preserves_lvalue.snap
@@ -29,13 +29,14 @@ func cond() bool {
 
 func main() {
 	s := []int{1}
-	idx_2 := idx()
+	base_2 := s
+	idx_3 := idx()
 	var tmp_1 int
 	if cond() {
 		tmp_1 = 2
 	} else {
 		tmp_1 = 3
 	}
-	s[idx_2] = tmp_1
+	base_2[idx_3] = tmp_1
 	fmt.Println(s[0])
 }

--- a/tests/spec/emit/snapshots/for_loop_range_start_frozen_before_call_bound.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_start_frozen_before_call_bound.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test() -> int {
+    let mut n = 1
+    let consume = || -> int { n = 5; 4 }
+    let mut sum = 0
+    for i in n..consume() {
+      sum += i
+    }
+    sum
+  }
+---
+package main
+
+func test() int {
+	n := 1
+	consume := func() int {
+		n = 5
+		return 4
+	}
+	sum := 0
+	start_2 := n
+	_bound_1 := consume()
+	for i := start_2; i < _bound_1; i++ {
+		sum += i
+	}
+	return sum
+}

--- a/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
@@ -24,6 +24,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	s := fmt.Sprintf("%d,%d", i, bump(&i))
+	_fmtarg_1 := i
+	s := fmt.Sprintf("%d,%d", _fmtarg_1, bump(&i))
 	_ = s
 }

--- a/tests/spec/emit/snapshots/format_string_index_captured_before_rhs_setup.snap
+++ b/tests/spec/emit/snapshots/format_string_index_captured_before_rhs_setup.snap
@@ -18,7 +18,8 @@ func main() {
 	m := make(map[string]int)
 	m["0"] = 100
 	i := 0
-	idx_2 := fmt.Sprint(i)
+	base_2 := m
+	idx_3 := fmt.Sprint(i)
 	var tmp_1 int
 	if true {
 		i++
@@ -26,6 +27,6 @@ func main() {
 	} else {
 		tmp_1 = 0
 	}
-	m[idx_2] = tmp_1
+	base_2[idx_3] = tmp_1
 	_ = m
 }

--- a/tests/spec/emit/snapshots/index_assignment_base_frozen_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/index_assignment_base_frozen_before_call_rhs.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn run() -> int {
+    let mut xs = [1, 2, 3]
+    let swap = || -> int { xs = [7, 8, 9]; 42 }
+    xs[0] = swap()
+    xs[0]
+  }
+---
+package main
+
+func run() int {
+	xs := []int{1, 2, 3}
+	swap := func() int {
+		xs = []int{7, 8, 9}
+		return 42
+	}
+	base_1 := xs
+	base_1[0] = swap()
+	return xs[0]
+}

--- a/tests/spec/emit/snapshots/inline_call_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/inline_call_pins_when_later_operand_pins.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn run() -> int {
+    let mut x = 1
+    let setx = || -> int { x = 50; 100 }
+    let bump = |v: int| -> int { x += 7; v }
+    let r = [setx(), x, bump(5)]
+    r[0] + r[1] + r[2]
+  }
+---
+package main
+
+func run() int {
+	x := 1
+	setx := func() int {
+		x = 50
+		return 100
+	}
+	bump := func(v int) int {
+		x += 7
+		return v
+	}
+	_v_1 := setx()
+	_v_2 := x
+	r := []int{_v_1, _v_2, bump(5)}
+	return r[0] + r[1] + r[2]
+}

--- a/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
+++ b/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
@@ -31,5 +31,6 @@ func main() {
 	empty := slices.Concat[[]byte, byte]()
 	value := slices.Clone[[]byte, byte]
 	out := apply(slices.Clone[[]byte, byte], empty)
-	fmt.Println(len(empty), len(value(empty)), len(out))
+	_arg_1 := len(empty)
+	fmt.Println(_arg_1, len(value(empty)), len(out))
 }

--- a/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
+++ b/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
@@ -28,12 +28,13 @@ func make_i() int {
 
 func main() {
 	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(0, 0)}
-	idx_2 := make_i()
+	base_2 := items
+	idx_3 := make_i()
 	var tmp_1 int
 	if true {
 		tmp_1 = 1
 	} else {
 		tmp_1 = 2
 	}
-	items[idx_2].First = tmp_1
+	base_2[idx_3].First = tmp_1
 }

--- a/tests/spec/emit/snapshots/pure_constructor_does_not_force_sibling_pins.snap
+++ b/tests/spec/emit/snapshots/pure_constructor_does_not_force_sibling_pins.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Wrap(int)
+  
+  fn run() -> int {
+    let pair = (Wrap(9), Wrap(8))
+    pair.0.0 + pair.1.0
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Wrap int
+
+func run() int {
+	pair := lisette.MakeTuple2(Wrap(9), Wrap(8))
+	return int(pair.First) + int(pair.Second)
+}

--- a/tests/spec/emit/snapshots/pure_constructor_with_mutable_read_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/pure_constructor_with_mutable_read_pins_when_later_operand_pins.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn run() -> int {
+    let mut x = 1
+    let bump = || -> int { x = 20; 2 }
+    let elems = [Some(x), Some(x + bump()), Some(x)]
+    elems[0].unwrap_or(-1) + elems[1].unwrap_or(-1) + elems[2].unwrap_or(-1)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func run() int {
+	x := 1
+	bump := func() int {
+		x = 20
+		return 2
+	}
+	_v_2 := lisette.MakeOptionSome(x)
+	_left_1 := x
+	elems := []lisette.Option[int]{
+		_v_2,
+		lisette.MakeOptionSome(_left_1 + bump()),
+		lisette.MakeOptionSome(x),
+	}
+	_left_3 := elems[0].UnwrapOr(-1) + elems[1].UnwrapOr(-1)
+	return _left_3 + elems[2].UnwrapOr(-1)
+}

--- a/tests/spec/emit/snapshots/range_value_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/range_value_eval_order_captured.snap
@@ -24,8 +24,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
+	_range_1 := i
 	r := lisette.Range[int]{
-		Start: i,
+		Start: _range_1,
 		End:   bump(&i),
 	}
 	_ = r

--- a/tests/spec/emit/snapshots/range_variable_slice_base_call_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/range_variable_slice_base_call_evaluated_once.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn make() -> Slice<int> { [1, 2, 3] }
+  
+  fn run() -> int {
+    let r = 1..
+    let s = make()[r]
+    s.length()
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func make_() []int {
+	return []int{1, 2, 3}
+}
+
+func run() int {
+	r := lisette.RangeFrom[int]{Start: 1}
+	_base_1 := make_()
+	s := _base_1[r.Start:len(_base_1):len(_base_1)]
+	return len(s)
+}

--- a/tests/spec/emit/snapshots/setup_bearing_call_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/setup_bearing_call_pins_when_later_operand_pins.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn foo(a: int, b: int) -> int { a + b }
+  
+  fn run() -> int {
+    let mut x = 1
+    let setx = || -> int { x = 50; 100 }
+    let bump = |v: int| -> int { x += 7; v }
+    let r = [foo(x, setx()), x, bump(5)]
+    r[0] + r[1] + r[2]
+  }
+---
+package main
+
+func foo(a, b int) int {
+	return a + b
+}
+
+func run() int {
+	x := 1
+	setx := func() int {
+		x = 50
+		return 100
+	}
+	bump := func(v int) int {
+		x += 7
+		return v
+	}
+	_arg_1 := x
+	_v_2 := foo(_arg_1, setx())
+	_v_3 := x
+	r := []int{_v_2, _v_3, bump(5)}
+	return r[0] + r[1] + r[2]
+}

--- a/tests/spec/emit/snapshots/slice_literal_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/slice_literal_eval_order_captured.snap
@@ -22,6 +22,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	s := []int{i, bump(&i)}
+	_v_1 := i
+	s := []int{_v_1, bump(&i)}
 	_ = s
 }

--- a/tests/spec/emit/snapshots/slice_range_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/slice_range_eval_order_captured.snap
@@ -24,7 +24,8 @@ func bump(i *int) int {
 func main() {
 	items := []int{10, 20, 30, 40, 50}
 	i := 1
-	end_1 := bump(&i)
-	s := items[i:end_1:end_1]
+	_base_1 := i
+	end_2 := bump(&i)
+	s := items[_base_1:end_2:end_2]
 	_ = s
 }

--- a/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
@@ -40,8 +40,8 @@ func make_range() lisette.Range[int] {
 }
 
 func main() {
-	_base_2 := make_items()
-	range_1 := make_range()
-	xs := _base_2[range_1.Start:range_1.End:range_1.End]
+	_base_1 := make_items()
+	range_2 := make_range()
+	xs := _base_1[range_2.Start:range_2.End:range_2.End]
 	fmt.Println(len(xs))
 }

--- a/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
@@ -29,8 +29,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
+	_field_1 := i
 	p := Pair{
-		a: i,
+		a: _field_1,
 		b: bump(&i),
 	}
 	_ = p

--- a/tests/spec/emit/snapshots/top_level_reference_not_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/top_level_reference_not_pinned_before_call.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  const BASE = 10
+  
+  fn eff(x: Ref<int>) -> int {
+    x.* = 1
+    2
+  }
+  
+  fn run() -> int {
+    let mut i = 0
+    let r = [BASE, eff(&i)]
+    r[0] + r[1]
+  }
+---
+package main
+
+const BASE int = 10
+
+func eff(x *int) int {
+	*x = 1
+	return 2
+}
+
+func run() int {
+	i := 0
+	r := []int{BASE, eff(&i)}
+	return r[0] + r[1]
+}

--- a/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
@@ -24,6 +24,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	t := lisette.MakeTuple2(i, bump(&i))
+	_v_1 := i
+	t := lisette.MakeTuple2(_v_1, bump(&i))
 	_ = t
 }

--- a/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
@@ -29,8 +29,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
+	_arg_1 := i
 	p := Pair{
-		F0: i,
+		F0: _arg_1,
 		F1: bump(&i),
 	}
 	_ = p

--- a/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
@@ -40,6 +40,7 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	adder := Adder{base: 5}
-	v := adder.add(i, bump(&i))
+	_arg_1 := i
+	v := adder.add(_arg_1, bump(&i))
 	_ = v
 }

--- a/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
+++ b/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
@@ -24,7 +24,11 @@ func bump(i *int) int {
 
 func test() {
 	i := 0
-	for lisette.MakeTuple2(i < 3, bump(&i)).First {
+	for {
+		_v_1 := i < 3
+		if !(lisette.MakeTuple2(_v_1, bump(&i)).First) {
+			break
+		}
 		_ = i
 	}
 }


### PR DESCRIPTION
Lisette guarantees left-to-right evaluation of subexpressions. The emitted Go did not, e.g. an operand read to the left of a side-effecting call was read after the call had run.

```rs
let mut x = 1
let bump = |v: int| -> int {
  x += 100
  v
}

let r = x + bump(5) // want 6, got 106
```

The emitter now pins an earlier operand to a temp before a later operand that can interfere with it. Pinning is kept to a minimum: reads of bindings no call can reach, plain calls (which Go already orders), and pure constructors such as `Some(...)` stay inline.
