### PR TITLE
fix: preserve NaN semantics in negated comparisons

### DIFF
--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -186,6 +186,7 @@ impl Planner<'_> {
             ..
         } = target
             && let Some(flipped) = flip_comparison(cmp)
+            && flip_preserves_nan(cmp, left, right)
         {
             let plan = self.plan_binary(&flipped, left, right, ctx);
             let (setup, value) = plan.into_parts();
@@ -231,6 +232,18 @@ impl Planner<'_> {
         let result = format!("{} {} {}", left_string, operator, right_string);
         value_plan_from_statements(setup, result)
     }
+}
+
+fn flip_preserves_nan(operator: &BinaryOperator, left: &Expression, right: &Expression) -> bool {
+    matches!(operator, BinaryOperator::Equal | BinaryOperator::NotEqual)
+        || (is_non_float(left) && is_non_float(right))
+}
+
+fn is_non_float(expression: &Expression) -> bool {
+    expression
+        .get_type()
+        .underlying_simple_kind()
+        .is_some_and(|kind| !kind.is_float())
 }
 
 fn flip_comparison(operator: &BinaryOperator) -> Option<BinaryOperator> {

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -205,6 +205,48 @@ fn test() -> bool {
 }
 
 #[test]
+fn negated_float_comparison_keeps_not() {
+    let input = r#"
+type Score = float64
+
+fn test(a: float64, b: float64, c: Score, d: Score) -> bool {
+  !(a < b) && !(c <= d)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn negated_generic_comparison_keeps_not() {
+    let input = r#"
+fn test<T: Ordered>(a: T, b: T) -> bool {
+  !(a > b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn negated_int_comparison_flips() {
+    let input = r#"
+fn test(a: int, b: int, s: string, t: string) -> bool {
+  !(a < b) && !(s < t)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn negated_float_equality_flips() {
+    let input = r#"
+fn test(a: float64, b: float64) -> bool {
+  !(a == b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unary_not_skips_operator_text_inside_string_literal() {
     let input = r#"
 fn test(s: string) -> bool {

--- a/tests/spec/emit/snapshots/negated_float_comparison_keeps_not.snap
+++ b/tests/spec/emit/snapshots/negated_float_comparison_keeps_not.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  type Score = float64
+  
+  fn test(a: float64, b: float64, c: Score, d: Score) -> bool {
+    !(a < b) && !(c <= d)
+  }
+---
+package main
+
+type Score = float64
+
+func test(a, b float64, c, d Score) bool {
+	return !(a < b) && !(c <= d)
+}

--- a/tests/spec/emit/snapshots/negated_float_equality_flips.snap
+++ b/tests/spec/emit/snapshots/negated_float_equality_flips.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn test(a: float64, b: float64) -> bool {
+    !(a == b)
+  }
+---
+package main
+
+func test(a, b float64) bool {
+	return (a != b)
+}

--- a/tests/spec/emit/snapshots/negated_generic_comparison_keeps_not.snap
+++ b/tests/spec/emit/snapshots/negated_generic_comparison_keeps_not.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn test<T: Ordered>(a: T, b: T) -> bool {
+    !(a > b)
+  }
+---
+package main
+
+import "cmp"
+
+func test[T cmp.Ordered](a, b T) bool {
+	return !(a > b)
+}

--- a/tests/spec/emit/snapshots/negated_int_comparison_flips.snap
+++ b/tests/spec/emit/snapshots/negated_int_comparison_flips.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn test(a: int, b: int, s: string, t: string) -> bool {
+    !(a < b) && !(s < t)
+  }
+---
+package main
+
+func test(a, b int, s, t string) bool {
+	return (a >= b) && (s >= t)
+}


### PR DESCRIPTION
Emitted Go rewrote `!(a < b)` as `a >= b`. For integers and strings the two are equivalent, but for floats they are not, because with a NaN operand both `a < b` and `a >= b` are false, so the negated comparison returned the wrong result.

This PR ensures the rewrite is applied only where it is exact: `==` and `!=` everywhere, ordered comparisons only when both operands are provably non-float. Float type aliases and `T: Ordered` type parameters keep the written negation.
