### PR TITLE
fix: interpolate rune type aliases as characters

### DIFF
--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -148,7 +148,8 @@ impl Planner<'_> {
                     }
                 }
                 FormatStringPart::Expression(expression) => {
-                    format_string.push_str(format_verb_for(&expression.get_type()));
+                    let peeled = self.facts.peel_alias(&expression.get_type());
+                    format_string.push_str(format_verb_for(&peeled));
                     args.push(
                         emitted
                             .next()
@@ -179,7 +180,8 @@ impl Planner<'_> {
     }
 }
 
-/// The `fmt` printf verb for interpolating a value of `ty` into an f-string.
+/// The `fmt` printf verb for interpolating a value of alias-peeled `ty` into
+/// an f-string.
 fn format_verb_for(ty: &Type) -> &'static str {
     match ty.as_simple() {
         Some(SimpleKind::Rune) => "%c",

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -814,6 +814,39 @@ fn test() {
 }
 
 #[test]
+fn format_string_rune_alias() {
+    let input = r#"
+import "go:fmt"
+
+type Ch = rune
+
+fn test() {
+  let c: Ch = 'A';
+  fmt.Print(f"{c}")
+  fmt.Print(f"char: {c}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_display_rune_newtype_keeps_stringer() {
+    let input = r#"
+import "go:fmt"
+
+#[display]
+struct Grade(rune)
+
+fn test() {
+  let g = Grade('B');
+  fmt.Print(f"{g}")
+  fmt.Print(f"grade: {g}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn compound_assignment() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/format_string_display_rune_newtype_keeps_stringer.snap
+++ b/tests/spec/emit/snapshots/format_string_display_rune_newtype_keeps_stringer.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  #[display]
+  struct Grade(rune)
+  
+  fn test() {
+    let g = Grade('B');
+    fmt.Print(f"{g}")
+    fmt.Print(f"grade: {g}")
+  }
+---
+package main
+
+import "fmt"
+
+type Grade rune
+
+func (g Grade) String() string {
+	return fmt.Sprintf("Grade(%v)", rune(g))
+}
+
+func (g Grade) to_string() string {
+	return g.String()
+}
+
+func test() {
+	g := Grade('B')
+	fmt.Print(fmt.Sprint(g))
+	fmt.Printf("grade: %v", g)
+}

--- a/tests/spec/emit/snapshots/format_string_rune_alias.snap
+++ b/tests/spec/emit/snapshots/format_string_rune_alias.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  type Ch = rune
+  
+  fn test() {
+    let c: Ch = 'A';
+    fmt.Print(f"{c}")
+    fmt.Print(f"char: {c}")
+  }
+---
+package main
+
+import "fmt"
+
+type Ch = rune
+
+func test() {
+	c := 'A'
+	fmt.Printf("%c", c)
+	fmt.Printf("char: %c", c)
+}


### PR DESCRIPTION
Interpolating a rune through a type alias printed the integer codepoint instead of the character. The f-string verb is now selected from the type behind the alias, so aliases of rune get `%c` like a bare rune.

```rs
import "go:fmt"

type Ch = rune

fn show(c: Ch) -> string {
  f"{c}"
}

fn main() {
  fmt.Println(show('A')) // printed 65, now prints A
}
```
