### PR TITLE
fix: parenthesize nested negation to avoid Go decrement token

### DIFF
--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -27,6 +27,14 @@ pub(crate) enum ValuePlan {
     },
 }
 
+pub(crate) fn render_unary(op: &str, value: &str) -> String {
+    if op == "-" && value.starts_with('-') {
+        format!("-({value})")
+    } else {
+        format!("{op}{value}")
+    }
+}
+
 /// Build a `ValuePlan`: `Operand` when there is no setup, otherwise
 /// `Composite`.
 pub(crate) fn value_plan_from_statements(setup: Vec<LoweredStatement>, value: String) -> ValuePlan {
@@ -61,7 +69,7 @@ impl ValuePlan {
             }
             ValuePlan::Unary { op, inner } => {
                 let (setup, value) = inner.into_parts();
-                (setup, format!("{op}{value}"))
+                (setup, render_unary(op, &value))
             }
         }
     }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -6,7 +6,7 @@ use crate::plan::bodies::{
 };
 #[cfg(debug_assertions)]
 use crate::plan::invariants;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{ValuePlan, render_unary};
 use crate::render::Renderer;
 use crate::write_line;
 
@@ -451,7 +451,7 @@ impl Renderer {
             }
             ValuePlan::Unary { op, inner } => {
                 let inner_text = self.render_value(output, inner);
-                format!("{}{}", op, inner_text)
+                render_unary(op, &inner_text)
             }
         }
     }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -195,6 +195,16 @@ fn test() -> int {
 }
 
 #[test]
+fn unary_double_negation_cannot_lex_as_decrement() {
+    let input = r#"
+fn test(x: int) -> int {
+  - -x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unary_logical_not() {
     let input = r#"
 fn test() -> bool {

--- a/tests/spec/emit/snapshots/unary_double_negation_cannot_lex_as_decrement.snap
+++ b/tests/spec/emit/snapshots/unary_double_negation_cannot_lex_as_decrement.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn test(x: int) -> int {
+    - -x
+  }
+---
+package main
+
+func test(x int) int {
+	return -(-x)
+}


### PR DESCRIPTION
Negating a negation without parens as in `- -x` emitted `--x`, which Go lexes as its decrement token, so the build aborted with a gofmt error. The emitter now parenthesizes the inner operand: `-(-x)`.

```rs
fn main() {
  let x = 5
  let y = - -x // was: gofmt error: expected operand, found '--'
}
```
