### PR TITLE
feat: autofix five more lints

### DIFF
--- a/crates/passes/src/passes/lints/ast_walk/checks/collapsible_else_if.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/collapsible_else_if.rs
@@ -1,5 +1,8 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, Span};
+
+use super::helpers::replacement_drops_comment;
 
 pub fn check_collapsible_else_if(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
@@ -28,7 +31,17 @@ pub fn check_collapsible_else_if(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let inner_if_keyword_span = Span::new(inner_span.file_id, inner_span.byte_offset, 2);
-    ctx.sink.push(diagnostics::lint::collapsible_else_if(
-        &inner_if_keyword_span,
-    ));
+    let mut diagnostic = diagnostics::lint::collapsible_else_if(&inner_if_keyword_span);
+    let alternative_span = alternative.get_span();
+    if let Some(inner_text) = ctx
+        .source
+        .get(inner_span.byte_offset as usize..inner_span.end() as usize)
+        && !replacement_drops_comment(ctx.source, alternative_span, inner_text)
+    {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            "Collapse into `else if`",
+            Edit::replacement(alternative_span, inner_text.to_string()),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/collapsible_if.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/collapsible_if.rs
@@ -1,11 +1,15 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{Expression, Span};
+use diagnostics::{Edit, Fix};
+use syntax::ast::{BinaryOperator, Expression, Span};
+
+use super::helpers::{replacement_drops_comment, span_text};
 
 pub fn check_collapsible_if(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
         condition,
         consequence,
         alternative,
+        span,
         ..
     } = expression
     else {
@@ -22,6 +26,7 @@ pub fn check_collapsible_if(expression: &Expression, ctx: &NodeCtx) {
     let [
         Expression::If {
             condition: inner_condition,
+            consequence: inner_consequence,
             alternative: inner_alternative,
             span: inner_span,
             ..
@@ -39,8 +44,49 @@ pub fn check_collapsible_if(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let inner_if_keyword_span = Span::new(inner_span.file_id, inner_span.byte_offset, 2);
-    ctx.sink
-        .push(diagnostics::lint::collapsible_if(&inner_if_keyword_span));
+    let mut diagnostic = diagnostics::lint::collapsible_if(&inner_if_keyword_span);
+    if let (Some(outer), Some(inner), Some(body)) = (
+        as_and_operand(ctx.source, condition),
+        as_and_operand(ctx.source, inner_condition),
+        span_text(ctx.source, inner_consequence),
+    ) {
+        let replacement = format!("if {outer} && {inner} {body}");
+        if !replacement_drops_comment(ctx.source, *span, &replacement) {
+            diagnostic = diagnostic.with_fix(Fix::new(
+                format!("Collapse into `if {outer} && {inner}`"),
+                Edit::replacement(*span, replacement),
+            ));
+        }
+    }
+    ctx.sink.push(diagnostic);
+}
+
+fn as_and_operand(source: &str, condition: &Expression) -> Option<String> {
+    let inner = condition.unwrap_parens();
+    let text = span_text(source, inner)?;
+    let parenthesize = binds_looser_than_and(inner);
+    Some(if parenthesize {
+        format!("({text})")
+    } else {
+        text.to_string()
+    })
+}
+
+fn binds_looser_than_and(expression: &Expression) -> bool {
+    match expression {
+        Expression::Binary {
+            operator: BinaryOperator::Or,
+            ..
+        } => true,
+        Expression::Call {
+            expression: callee,
+            args,
+            ..
+        } => args
+            .iter()
+            .any(|arg| arg.get_span().byte_offset < callee.get_span().byte_offset),
+        _ => false,
+    }
 }
 
 fn is_missing_else(alternative: &Expression) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/equatable_if_let.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/equatable_if_let.rs
@@ -1,8 +1,9 @@
 use crate::passes::walk::NodeCtx;
+use diagnostics::{Edit, Fix};
 use semantics::checker::{TypeEnv, check_not_comparable};
 use syntax::ast::{Expression, Pattern, Span};
 
-use super::helpers::{enum_has_multiple_variants, span_text};
+use super::helpers::{enum_has_multiple_variants, replacement_drops_comment, span_text};
 
 pub fn check_equatable_if_let(expression: &Expression, ctx: &NodeCtx) {
     let Expression::IfLet {
@@ -60,11 +61,21 @@ pub fn check_equatable_if_let(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let if_keyword_span = Span::new(span.file_id, span.byte_offset, 2);
-    ctx.sink.push(diagnostics::lint::equatable_if_let(
-        &if_keyword_span,
-        pattern_text,
-        subject_text,
-    ));
+    let condition_span = Span::new(
+        span.file_id,
+        span.byte_offset,
+        scrutinee.get_span().end() - span.byte_offset,
+    );
+    let replacement = format!("if {subject_text} == {pattern_text}");
+    let mut diagnostic =
+        diagnostics::lint::equatable_if_let(&if_keyword_span, pattern_text, subject_text);
+    if !replacement_drops_comment(ctx.source, condition_span, &replacement) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(condition_span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 // Fielded variants and literals are excluded: an inner value can mismatch its

--- a/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
@@ -228,6 +228,13 @@ pub(super) fn span_text<'a>(source: &'a str, expression: &Expression) -> Option<
     source.get(span.byte_offset as usize..span.end() as usize)
 }
 
+pub(super) fn replacement_drops_comment(source: &str, span: Span, replacement: &str) -> bool {
+    let Some(original) = source.get(span.byte_offset as usize..span.end() as usize) else {
+        return false;
+    };
+    original.matches("//").count() > replacement.matches("//").count()
+}
+
 /// Whether `expression` binds at least as tightly as a postfix operator.
 pub(super) fn is_postfix_tight(expression: &Expression) -> bool {
     match expression {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_else.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_else.rs
@@ -1,6 +1,7 @@
-use super::helpers::is_empty_block;
+use super::helpers::{is_empty_block, mentions_identifier, replacement_drops_comment};
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{Expression, Span};
+use diagnostics::{Edit, Fix};
+use syntax::ast::{Expression, Pattern, Span};
 
 pub fn check_redundant_else(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Block { items, .. } = expression else {
@@ -10,14 +11,16 @@ pub fn check_redundant_else(expression: &Expression, ctx: &NodeCtx) {
     // Only a non-tail `if` is in statement position; the block's tail item is a
     // value, where the idiomatic form is `if c { a } else { b }` and dropping the
     // `else` would conflict with the `unnecessary_return` advice on the branch.
-    let Some((_, leading)) = items.split_last() else {
+    if items.len() < 2 {
         return;
-    };
+    }
+    let leading = &items[..items.len() - 1];
 
-    for item in leading {
+    for (index, item) in leading.iter().enumerate() {
         let Expression::If {
             consequence,
             alternative,
+            span: if_span,
             ..
         } = item
         else {
@@ -42,8 +45,107 @@ pub fn check_redundant_else(expression: &Expression, ctx: &NodeCtx) {
         };
 
         let else_span = Span::new(consequence_span.file_id, else_offset, 4);
-        ctx.sink.push(diagnostics::lint::redundant_else(&else_span));
+        let mut diagnostic = diagnostics::lint::redundant_else(&else_span);
+        if let Some(fix) = denest_fix(
+            ctx.source,
+            if_span,
+            consequence_span,
+            alternative,
+            &items[index + 1..],
+        ) {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        ctx.sink.push(diagnostic);
     }
+}
+
+fn denest_fix(
+    source: &str,
+    if_span: &Span,
+    consequence_span: Span,
+    alternative: &Expression,
+    following: &[Expression],
+) -> Option<Fix> {
+    let Expression::Block { items, .. } = alternative else {
+        return None;
+    };
+    if else_body_leaks_binding(items, following) {
+        return None;
+    }
+    let alternative_span = alternative.get_span();
+    let inner = source
+        .get(alternative_span.byte_offset as usize + 1..alternative_span.end() as usize - 1)?;
+    let if_indent = line_indent(source, if_span.byte_offset);
+    let body = reindent(inner, if_indent)?;
+
+    let removed = Span::new(
+        consequence_span.file_id,
+        consequence_span.end(),
+        alternative_span.end() - consequence_span.end(),
+    );
+    let replacement = format!("\n{body}");
+    if replacement_drops_comment(source, removed, &replacement) {
+        return None;
+    }
+    Some(Fix::new(
+        "Drop the `else` and lift its body out",
+        Edit::replacement(removed, replacement),
+    ))
+}
+
+fn else_body_leaks_binding(else_items: &[Expression], following: &[Expression]) -> bool {
+    else_items.iter().any(|item| match item {
+        Expression::Let { binding, .. } => match &binding.pattern {
+            Pattern::Identifier { identifier, .. } => following
+                .iter()
+                .any(|after| mentions_identifier(after, identifier)),
+            _ => true,
+        },
+        Expression::Const { .. } | Expression::Function { .. } => true,
+        _ => false,
+    })
+}
+
+fn line_indent(source: &str, offset: u32) -> &str {
+    let bytes = source.as_bytes();
+    let mut start = offset as usize;
+    while start > 0 && bytes[start - 1] != b'\n' {
+        start -= 1;
+    }
+    let prefix = &source[start..offset as usize];
+    &prefix[..prefix.len() - prefix.trim_start().len()]
+}
+
+fn reindent(inner: &str, target_indent: &str) -> Option<String> {
+    let lines: Vec<&str> = inner
+        .lines()
+        .skip_while(|line| line.trim().is_empty())
+        .collect();
+    let end = lines
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .map(|index| index + 1)?;
+    let content = &lines[..end];
+
+    let common = content
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()?;
+
+    Some(
+        content
+            .iter()
+            .map(|line| {
+                if line.trim().is_empty() {
+                    String::new()
+                } else {
+                    format!("{target_indent}{}", line[common..].trim_end())
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }
 
 /// Offset of the `else` keyword between a consequence and its alternative, or

--- a/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_zero_fill.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_zero_fill.rs
@@ -1,8 +1,10 @@
+use diagnostics::{Edit, Fix};
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Literal, Span, StructFieldAssignment, StructSpread};
 use syntax::program::DefinitionBody;
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
+use super::helpers::replacement_drops_comment;
 use crate::passes::walk::NodeCtx;
 use semantics::store::Store;
 use semantics::zero::has_zero;
@@ -45,11 +47,19 @@ pub fn check_replaceable_with_zero_fill(expression: &Expression, ctx: &NodeCtx) 
 
     let kept = render_kept_fields(ctx.source, field_assignments);
     let owner_span = Span::new(span.file_id, span.byte_offset, name.len() as u32);
-    ctx.sink.push(diagnostics::lint::replaceable_with_zero_fill(
-        &owner_span,
-        &kept,
-        name,
-    ));
+    let replacement = if kept.is_empty() {
+        format!("{name} {{ .. }}")
+    } else {
+        format!("{name} {{ {kept}, .. }}")
+    };
+    let mut diagnostic = diagnostics::lint::replaceable_with_zero_fill(&owner_span, &kept, name);
+    if !replacement_drops_comment(ctx.source, *span, &replacement) {
+        diagnostic = diagnostic.with_fix(Fix::new(
+            format!("Replace with `{replacement}`"),
+            Edit::replacement(*span, replacement),
+        ));
+    }
+    ctx.sink.push(diagnostic);
 }
 
 fn render_kept_fields(source: &str, fields: &[StructFieldAssignment]) -> String {

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -1136,3 +1136,192 @@ pub fn f(n: int) -> string {
 "#
     );
 }
+
+#[test]
+fn fix_equatable_if_let() {
+    assert_fix_snapshot!(
+        r#"
+enum Sig { A, B }
+
+pub fn f(s: Sig) -> int {
+  if let Sig.A = s { 1 } else { 0 }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_collapsible_else_if() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: int) -> int {
+  if a > 0 { 1 } else { if a < 0 { 2 } else { 3 } }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_collapsible_if() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: bool, b: bool) -> int {
+  if a { if b { 1 } }
+  0
+}
+"#
+    );
+}
+
+#[test]
+fn fix_collapsible_if_parenthesizes_or_operand() {
+    assert_fix_snapshot!(
+        r#"
+pub fn f(a: bool, b: bool, c: bool) -> int {
+  if a || b { if c { 1 } }
+  0
+}
+"#
+    );
+}
+
+#[test]
+fn fix_replaceable_with_zero_fill() {
+    assert_fix_snapshot!(
+        r#"
+struct Cfg { a: int, b: int, c: int, d: int }
+
+pub fn f() -> Cfg {
+  Cfg { a: 5, b: 0, c: 0, d: 0 }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_else() {
+    assert_fix_snapshot!(
+        r#"
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  } else {
+    let y = x + 1
+    log(y)
+  }
+  log(x)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_else_single_line() {
+    assert_fix_snapshot!(
+        r#"
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 { return } else { log(x) }
+  log(0)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_else_nested_body() {
+    assert_fix_snapshot!(
+        r#"
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  } else {
+    if x < -5 {
+      log(1)
+    }
+    log(2)
+  }
+  log(3)
+}
+"#
+    );
+}
+
+#[test]
+fn fix_collapsible_if_parenthesizes_pipeline_operand() {
+    assert_fix_snapshot!(
+        r#"
+fn is_even(n: int) -> bool { n % 2 == 0 }
+fn work() {}
+
+pub fn f(x: int, b: bool) {
+  if x |> is_even { if b { work() } }
+}
+"#
+    );
+}
+
+#[test]
+fn fix_collapsible_if_keeps_comparison_unparenthesized() {
+    assert_fix_snapshot!(
+        r#"
+fn work() {}
+
+pub fn f(x: int, y: int) {
+  if x > 0 { if y > 0 { work() } }
+}
+"#
+    );
+}
+
+#[test]
+fn collapsible_if_with_dropped_comment_has_no_fix() {
+    assert_no_fix!(
+        r#"
+fn work() {}
+fn other() {}
+
+pub fn f(a: bool, b: bool) {
+  if a {
+    // keep me
+    if b { work() }
+  }
+  other()
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_else_leaking_binding_has_no_fix() {
+    assert_no_fix!(
+        r#"
+fn log(n: int) {}
+
+pub fn f(cond: bool) -> int {
+  let y = 0
+  if cond { return 9 } else { let y = 1; log(y) }
+  y
+}
+"#
+    );
+}
+
+#[test]
+fn fix_redundant_else_lifts_binding_used_only_inside() {
+    assert_fix_snapshot!(
+        r#"
+fn log(n: int) {}
+
+pub fn f(cond: bool) {
+  if cond { return } else { let y = 1; log(y) }
+  log(0)
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/fix_collapsible_else_if.snap
+++ b/tests/ui/lint/snapshots/fix_collapsible_else_if.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: int) -> int {
+  if a > 0 { 1 } else { if a < 0 { 2 } else { 3 } }
+}
+=== fixed ===
+pub fn f(a: int) -> int {
+  if a > 0 { 1 } else if a < 0 { 2 } else { 3 }
+}

--- a/tests/ui/lint/snapshots/fix_collapsible_if.snap
+++ b/tests/ui/lint/snapshots/fix_collapsible_if.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: bool, b: bool) -> int {
+  if a { if b { 1 } }
+  0
+}
+=== fixed ===
+pub fn f(a: bool, b: bool) -> int {
+  if a && b { 1 }
+  0
+}

--- a/tests/ui/lint/snapshots/fix_collapsible_if_keeps_comparison_unparenthesized.snap
+++ b/tests/ui/lint/snapshots/fix_collapsible_if_keeps_comparison_unparenthesized.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn work() {}
+
+pub fn f(x: int, y: int) {
+  if x > 0 { if y > 0 { work() } }
+}
+=== fixed ===
+fn work() {}
+
+pub fn f(x: int, y: int) {
+  if x > 0 && y > 0 { work() }
+}

--- a/tests/ui/lint/snapshots/fix_collapsible_if_parenthesizes_or_operand.snap
+++ b/tests/ui/lint/snapshots/fix_collapsible_if_parenthesizes_or_operand.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+pub fn f(a: bool, b: bool, c: bool) -> int {
+  if a || b { if c { 1 } }
+  0
+}
+=== fixed ===
+pub fn f(a: bool, b: bool, c: bool) -> int {
+  if (a || b) && c { 1 }
+  0
+}

--- a/tests/ui/lint/snapshots/fix_collapsible_if_parenthesizes_pipeline_operand.snap
+++ b/tests/ui/lint/snapshots/fix_collapsible_if_parenthesizes_pipeline_operand.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn is_even(n: int) -> bool { n % 2 == 0 }
+fn work() {}
+
+pub fn f(x: int, b: bool) {
+  if x |> is_even { if b { work() } }
+}
+=== fixed ===
+fn is_even(n: int) -> bool { n % 2 == 0 }
+fn work() {}
+
+pub fn f(x: int, b: bool) {
+  if (x |> is_even) && b { work() }
+}

--- a/tests/ui/lint/snapshots/fix_equatable_if_let.snap
+++ b/tests/ui/lint/snapshots/fix_equatable_if_let.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+enum Sig { A, B }
+
+pub fn f(s: Sig) -> int {
+  if let Sig.A = s { 1 } else { 0 }
+}
+=== fixed ===
+enum Sig { A, B }
+
+pub fn f(s: Sig) -> int {
+  if s == Sig.A { 1 } else { 0 }
+}

--- a/tests/ui/lint/snapshots/fix_redundant_else.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_else.snap
@@ -1,0 +1,25 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  } else {
+    let y = x + 1
+    log(y)
+  }
+  log(x)
+}
+=== fixed ===
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  }
+  let y = x + 1
+  log(y)
+  log(x)
+}

--- a/tests/ui/lint/snapshots/fix_redundant_else_lifts_binding_used_only_inside.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_else_lifts_binding_used_only_inside.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn log(n: int) {}
+
+pub fn f(cond: bool) {
+  if cond { return } else { let y = 1; log(y) }
+  log(0)
+}
+=== fixed ===
+fn log(n: int) {}
+
+pub fn f(cond: bool) {
+  if cond { return }
+  let y = 1; log(y)
+  log(0)
+}

--- a/tests/ui/lint/snapshots/fix_redundant_else_nested_body.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_else_nested_body.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  } else {
+    if x < -5 {
+      log(1)
+    }
+    log(2)
+  }
+  log(3)
+}
+=== fixed ===
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 {
+    return
+  }
+  if x < -5 {
+    log(1)
+  }
+  log(2)
+  log(3)
+}

--- a/tests/ui/lint/snapshots/fix_redundant_else_single_line.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_else_single_line.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 { return } else { log(x) }
+  log(0)
+}
+=== fixed ===
+fn log(n: int) {}
+
+pub fn f(x: int) {
+  if x > 0 { return }
+  log(x)
+  log(0)
+}

--- a/tests/ui/lint/snapshots/fix_replaceable_with_zero_fill.snap
+++ b/tests/ui/lint/snapshots/fix_replaceable_with_zero_fill.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+struct Cfg { a: int, b: int, c: int, d: int }
+
+pub fn f() -> Cfg {
+  Cfg { a: 5, b: 0, c: 0, d: 0 }
+}
+=== fixed ===
+struct Cfg { a: int, b: int, c: int, d: int }
+
+pub fn f() -> Cfg {
+  Cfg { a: 5, .. }
+}


### PR DESCRIPTION
Adds autofixes for five more lints:

- `collapsible_if`
- `collapsible_else_if`
- `equatable_if_let`
- `redundant_else`
- `replaceable_with_zero_fill`

Follow-up to #941
