### PR TITLE
fix: reject map bracket reads when type has no zero value

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -892,6 +892,33 @@ pub fn field_no_zero(
         .with_help(main)
 }
 
+pub fn map_read_no_zero(value_ty: &Type, receiver: &str, span: Span) -> LisetteDiagnostic {
+    let (label, help) = if matches!(value_ty, Type::Parameter(_)) {
+        (
+            format!("`{value_ty}` is not guaranteed to have a zero value"),
+            format!(
+                "Bracket reads can return a zero value when the key is missing, but the type \
+                 parameter `{value_ty}` can be instantiated with a type that has no zero value, \
+                 such as `Ref<T>`, so this bracket read is disallowed. Use \
+                 `{receiver}.get(key)` instead"
+            ),
+        )
+    } else {
+        (
+            format!("`{value_ty}` has no zero value"),
+            format!(
+                "Bracket reads can return a zero value when the key is missing, but \
+                 `{value_ty}` has no zero value, so this bracket read is disallowed. Use \
+                 `{receiver}.get(key)` instead"
+            ),
+        )
+    };
+    LisetteDiagnostic::error("No zero value for missing key")
+        .with_infer_code("map_read_no_zero")
+        .with_span_label(&span, label)
+        .with_help(help)
+}
+
 pub fn unresolved_receiver_type(member: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot infer receiver type")
         .with_infer_code("unresolved_receiver_type")

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -65,6 +65,7 @@ impl InferCtx<'_, '_> {
                     .collect();
 
                 ctx.check_reference_sibling_aliasing(&inferred_items);
+                ctx.check_map_bracket_reads(&inferred_items);
                 ctx.resolve_branch_subsumptions();
                 ctx.resolve_select_exhaustiveness();
 

--- a/crates/semantics/src/checker/infer/validation/map_reads.rs
+++ b/crates/semantics/src/checker/infer/validation/map_reads.rs
@@ -1,0 +1,73 @@
+use syntax::ast::{Expression, Span};
+use syntax::types::CompoundKind;
+
+use crate::checker::EnvResolve;
+use crate::checker::infer::InferCtx;
+
+impl InferCtx<'_, '_> {
+    /// Reject map bracket reads whose value type has no zero value. A missing
+    /// key surfaces the Go zero value, which for types like `Ref<T>` is a nil
+    /// pointer with no Lisette equivalent.
+    pub fn check_map_bracket_reads(&mut self, items: &[Expression]) {
+        for item in items {
+            self.walk_map_bracket_reads(item, false);
+        }
+    }
+
+    fn walk_map_bracket_reads(&mut self, expression: &Expression, is_write_target: bool) {
+        match expression {
+            Expression::Assignment {
+                target,
+                value,
+                compound_operator,
+                ..
+            } => {
+                // `m[k] = v` never reads the entry. Compound assignments do.
+                self.walk_map_bracket_reads(target, compound_operator.is_none());
+                self.walk_map_bracket_reads(value, false);
+            }
+            Expression::Paren { expression, .. } => {
+                self.walk_map_bracket_reads(expression, is_write_target);
+            }
+            Expression::IndexedAccess {
+                expression: collection,
+                index,
+                span,
+                ..
+            } => {
+                if !is_write_target {
+                    self.check_map_bracket_read(collection, *span);
+                }
+                self.walk_map_bracket_reads(collection, false);
+                self.walk_map_bracket_reads(index, false);
+            }
+            _ => {
+                for child in expression.children() {
+                    self.walk_map_bracket_reads(child, false);
+                }
+            }
+        }
+    }
+
+    fn check_map_bracket_read(&mut self, collection: &Expression, span: Span) {
+        let store = self.store;
+        let collection_ty = store.peel_alias(&collection.get_type().resolve_in(&self.env));
+        let Some((CompoundKind::Map, args)) = collection_ty.as_compound() else {
+            return;
+        };
+        let Some(value_ty) = args.get(1) else {
+            return;
+        };
+        if value_ty.is_error() || value_ty.is_variable() {
+            return;
+        }
+        let from_module = self.cursor.module_id.clone();
+        if self.has_zero(value_ty, &from_module).is_err() {
+            let receiver = collection.root_identifier().unwrap_or("m");
+            let full_span = collection.get_span().merge(span);
+            self.sink.push(diagnostics::infer::map_read_no_zero(
+                value_ty, receiver, full_span,
+            ));
+        }
+    }
+}

--- a/crates/semantics/src/checker/infer/validation/mod.rs
+++ b/crates/semantics/src/checker/infer/validation/mod.rs
@@ -1,6 +1,7 @@
 mod casts;
 mod const_cycles;
 mod control_flow;
+mod map_reads;
 mod numeric;
 mod references;
 mod select;

--- a/docs/reference/03-operators.md
+++ b/docs/reference/03-operators.md
@@ -158,7 +158,9 @@ ages["Alice"] = 20
 let age = ages["Alice"]      // 20
 ```
 
-Bracket access panics if the index is out of bounds (slices) or returns the zero value if the key is missing (maps). For safe access that returns `Option<T>`, use `.get()`. See [`safety.md`](../intro/safety.md)
+Bracket access on a slice panics if the index is out of bounds; bracket access on maps returns the zero value if the key is missing. If the map's value type has no zero value (e.g. `Ref<T>`), bracket reads are rejected at compile time. 
+
+For safe access that returns `Option<T>`, use `.get()`:
 
 ```rust
 let safe = nums.get(0)       // Some(10)

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -198,6 +198,7 @@ impl CompiledTest {
 
             {
                 let mut ctx = InferCtx::new(&mut checker, &store);
+                ctx.check_map_bracket_reads(&typed_ast);
                 ctx.resolve_branch_subsumptions();
                 ctx.resolve_select_exhaustiveness();
             }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1685,7 +1685,8 @@ impl Counter {
 }
 
 fn test(m: Map<string, Ref<Counter>>) {
-  m["a"].*.increment()
+  let Some(c) = m.get("a") else { return; };
+  c.*.increment()
 }
 "#;
     assert_emit_snapshot!(input);
@@ -3489,7 +3490,8 @@ fn main() {
   let mut items = [1]
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer { items: &items }
-  m["a"].items.* = m["a"].items.*.append(2)
+  let Some(o) = m.get("a") else { return; };
+  o.items.* = o.items.*.append(2)
   let _ = items
 }
 "#;
@@ -3505,7 +3507,8 @@ fn main() {
   let mut w = Wrap(1)
   let mut m = Map.new<string, Ref<Wrap>>()
   m["a"] = &w
-  m["a"].* = Wrap(2)
+  let Some(r) = m.get("a") else { return; };
+  r.* = Wrap(2)
   let _ = w
 }
 "#;
@@ -3522,9 +3525,10 @@ fn main() {
   let mut w = Wrap(Inner { x: 0 })
   let mut m = Map.new<string, Ref<Wrap>>()
   m["a"] = &w
-  let mut inner = m["a"].0
+  let Some(r) = m.get("a") else { return; };
+  let mut inner = r.0
   inner.x = 1
-  m["a"].* = Wrap(inner)
+  r.* = Wrap(inner)
   let _ = w
 }
 "#;
@@ -3540,7 +3544,8 @@ fn main() {
   let mut w = Wrap([1])
   let mut m = Map.new<string, Ref<Wrap>>()
   m["a"] = &w
-  m["a"].* = Wrap(m["a"].0.append(2))
+  let Some(r) = m.get("a") else { return; };
+  r.* = Wrap(r.0.append(2))
   let _ = w
 }
 "#;
@@ -3557,9 +3562,10 @@ fn main() {
   let mut w = Wrap(Inner { items: [1] })
   let mut m = Map.new<string, Ref<Wrap>>()
   m["a"] = &w
-  let mut inner = m["a"].0
+  let Some(r) = m.get("a") else { return; };
+  let mut inner = r.0
   inner.items = inner.items.append(2)
-  m["a"].* = Wrap(inner)
+  r.* = Wrap(inner)
   let _ = w
 }
 "#;
@@ -3575,7 +3581,8 @@ fn main() {
   let mut items = [1]
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer { items: &items }
-  let _ = { m["a"].items.*.append(2) }
+  let Some(o) = m.get("a") else { return; };
+  let _ = { o.items.*.append(2) }
   let _ = items
 }
 "#;
@@ -3593,9 +3600,10 @@ fn main() {
   let mut w = Wrap(Inner { x: 0 })
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer { w: &w }
-  let mut inner = m["a"].w.0
+  let Some(o) = m.get("a") else { return; };
+  let mut inner = o.w.0
   inner.x = 2
-  m["a"].w.* = Wrap(inner)
+  o.w.* = Wrap(inner)
   let _ = w
 }
 "#;
@@ -3613,9 +3621,10 @@ fn main() {
   let mut w = Wrap(Inner { items: [1] })
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer { w: &w }
-  let mut inner = m["a"].w.0
+  let Some(o) = m.get("a") else { return; };
+  let mut inner = o.w.0
   inner.items = inner.items.append(2)
-  m["a"].w.* = Wrap(inner)
+  o.w.* = Wrap(inner)
   let _ = w
 }
 "#;

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -560,10 +560,12 @@ struct Holder { f: fn(string) -> Result<int, error> }
 fn main() {
   let mut m = Map.new<string, Holder>()
   m["a"] = Holder { f: strconv.Atoi }
-  let mut entry = m["a"]
+  let Some(found) = m.get("a") else { return; };
+  let mut entry = found
   entry.f = strconv.Atoi
   m["a"] = entry
-  let r = m["a"].f("1")
+  let Some(h) = m.get("a") else { return; };
+  let r = h.f("1")
   match r {
     Ok(v) => { let _ = v },
     Err(_) => { let _ = 0 },

--- a/tests/spec/emit/snapshots/deref_map_value_method_call.snap
+++ b/tests/spec/emit/snapshots/deref_map_value_method_call.snap
@@ -11,10 +11,13 @@ description: |
   }
   
   fn test(m: Map<string, Ref<Counter>>) {
-    m["a"].*.increment()
+    let Some(c) = m.get("a") else { return; };
+    c.*.increment()
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Counter struct {
 	count int
@@ -25,5 +28,10 @@ func (c *Counter) increment() {
 }
 
 func test(m map[string]*Counter) {
-	m["a"].increment()
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	c := subject_1.SomeVal
+	c.increment()
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -9,10 +9,12 @@ description: |
   fn main() {
     let mut m = Map.new<string, Holder>()
     m["a"] = Holder { f: strconv.Atoi }
-    let mut entry = m["a"]
+    let Some(found) = m.get("a") else { return; };
+    let mut entry = found
     entry.f = strconv.Atoi
     m["a"] = entry
-    let r = m["a"].f("1")
+    let Some(h) = m.get("a") else { return; };
+    let r = h.f("1")
     match r {
       Ok(v) => { let _ = v },
       Err(_) => { let _ = 0 },
@@ -33,17 +35,27 @@ type Holder struct {
 func main() {
 	m := make(map[string]Holder)
 	m["a"] = Holder{f: strconv.Atoi}
-	entry := m["a"]
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	found := subject_1.SomeVal
+	entry := found
 	entry.f = strconv.Atoi
 	m["a"] = entry
-	ret_1, ret_2 := m["a"].f("1")
-	var result_3 lisette.Result[int, error]
-	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	subject_2 := lisette.MapGet(m, "a")
+	if subject_2.Tag != lisette.OptionSome {
+		return
 	}
-	r := result_3
+	h := subject_2.SomeVal
+	ret_3, ret_4 := h.f("1")
+	var result_5 lisette.Result[int, error]
+	if ret_4 != nil {
+		result_5 = lisette.MakeResultErr[int, error](ret_4)
+	} else {
+		result_5 = lisette.MakeResultOk[int, error](ret_3)
+	}
+	r := result_5
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	} else {

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -8,11 +8,14 @@ description: |
     let mut items = [1]
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer { items: &items }
-    m["a"].items.* = m["a"].items.*.append(2)
+    let Some(o) = m.get("a") else { return; };
+    o.items.* = o.items.*.append(2)
     let _ = items
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Outer struct {
 	items *[]int
@@ -22,7 +25,12 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	ref_1 := m["a"].items
-	*ref_1 = append(*m["a"].items, 2)
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	o := subject_1.SomeVal
+	ref_2 := o.items
+	*ref_2 = append(*o.items, 2)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
@@ -8,11 +8,14 @@ description: |
     let mut items = [1]
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer { items: &items }
-    let _ = { m["a"].items.*.append(2) }
+    let Some(o) = m.get("a") else { return; };
+    let _ = { o.items.*.append(2) }
     let _ = items
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Outer struct {
 	items *[]int
@@ -22,8 +25,13 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	var tmp_1 []int
-	tmp_1 = append(*m["a"].items, 2)
-	_ = tmp_1
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	o := subject_1.SomeVal
+	var tmp_2 []int
+	tmp_2 = append(*o.items, 2)
+	_ = tmp_2
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
@@ -8,11 +8,14 @@ description: |
     let mut w = Wrap(1)
     let mut m = Map.new<string, Ref<Wrap>>()
     m["a"] = &w
-    m["a"].* = Wrap(2)
+    let Some(r) = m.get("a") else { return; };
+    r.* = Wrap(2)
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Wrap int
 
@@ -20,6 +23,11 @@ func main() {
 	w := Wrap(1)
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	*m["a"] = Wrap(2)
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	r := subject_1.SomeVal
+	*r = Wrap(2)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
@@ -10,13 +10,16 @@ description: |
     let mut w = Wrap(Inner { items: [1] })
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer { w: &w }
-    let mut inner = m["a"].w.0
+    let Some(o) = m.get("a") else { return; };
+    let mut inner = o.w.0
     inner.items = inner.items.append(2)
-    m["a"].w.* = Wrap(inner)
+    o.w.* = Wrap(inner)
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Inner struct {
 	items []int
@@ -32,8 +35,13 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	inner := Inner(*m["a"].w)
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	o := subject_1.SomeVal
+	inner := Inner(*o.w)
 	inner.items = append(inner.items, 2)
-	*m["a"].w = Wrap(inner)
+	*o.w = Wrap(inner)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
@@ -10,13 +10,16 @@ description: |
     let mut w = Wrap(Inner { x: 0 })
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer { w: &w }
-    let mut inner = m["a"].w.0
+    let Some(o) = m.get("a") else { return; };
+    let mut inner = o.w.0
     inner.x = 2
-    m["a"].w.* = Wrap(inner)
+    o.w.* = Wrap(inner)
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Inner struct {
 	x int
@@ -32,8 +35,13 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	inner := Inner(*m["a"].w)
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	o := subject_1.SomeVal
+	inner := Inner(*o.w)
 	inner.x = 2
-	*m["a"].w = Wrap(inner)
+	*o.w = Wrap(inner)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
@@ -9,13 +9,16 @@ description: |
     let mut w = Wrap(Inner { items: [1] })
     let mut m = Map.new<string, Ref<Wrap>>()
     m["a"] = &w
-    let mut inner = m["a"].0
+    let Some(r) = m.get("a") else { return; };
+    let mut inner = r.0
     inner.items = inner.items.append(2)
-    m["a"].* = Wrap(inner)
+    r.* = Wrap(inner)
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Inner struct {
 	items []int
@@ -27,8 +30,13 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	inner := Inner(*m["a"])
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	r := subject_1.SomeVal
+	inner := Inner(*r)
 	inner.items = append(inner.items, 2)
-	*m["a"] = Wrap(inner)
+	*r = Wrap(inner)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
@@ -9,13 +9,16 @@ description: |
     let mut w = Wrap(Inner { x: 0 })
     let mut m = Map.new<string, Ref<Wrap>>()
     m["a"] = &w
-    let mut inner = m["a"].0
+    let Some(r) = m.get("a") else { return; };
+    let mut inner = r.0
     inner.x = 1
-    m["a"].* = Wrap(inner)
+    r.* = Wrap(inner)
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Inner struct {
 	x int
@@ -27,8 +30,13 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	inner := Inner(*m["a"])
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	r := subject_1.SomeVal
+	inner := Inner(*r)
 	inner.x = 1
-	*m["a"] = Wrap(inner)
+	*r = Wrap(inner)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -8,11 +8,14 @@ description: |
     let mut w = Wrap([1])
     let mut m = Map.new<string, Ref<Wrap>>()
     m["a"] = &w
-    m["a"].* = Wrap(m["a"].0.append(2))
+    let Some(r) = m.get("a") else { return; };
+    r.* = Wrap(r.0.append(2))
     let _ = w
   }
 ---
 package main
+
+import lisette "github.com/ivov/lisette/prelude"
 
 type Wrap []int
 
@@ -20,7 +23,12 @@ func main() {
 	w := Wrap([]int{1})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	ref_1 := m["a"]
-	*ref_1 = Wrap(append([]int(*m["a"]), 2))
+	subject_1 := lisette.MapGet(m, "a")
+	if subject_1.Tag != lisette.OptionSome {
+		return
+	}
+	r := subject_1.SomeVal
+	ref_2 := r
+	*ref_2 = Wrap(append([]int(*r), 2))
 	_ = w
 }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1977,6 +1977,128 @@ fn test() {
 }
 
 #[test]
+fn infer_map_read_no_zero_for_ref_value() {
+    let input = r#"
+fn test() {
+  let m = Map.new<string, Ref<int>>()
+  let _r = m["missing"]
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_read_no_zero_for_generic_value() {
+    let input = r#"
+fn pick<K, V>(m: Map<K, V>, k: K) -> V {
+  m[k]
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_read_no_zero_through_alias() {
+    let input = r#"
+type Registry = Map<string, Ref<int>>
+
+fn test(regs: Registry) {
+  let _r = regs["x"]
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read through a map alias must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_for_struct_with_ref_field() {
+    let input = r#"
+struct Holder { pub r: Ref<int> }
+
+fn test(holders: Map<string, Holder>) {
+  let _h = holders["x"]
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read yielding a struct with a Ref field must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_in_deref_write() {
+    let input = r#"
+fn test() {
+  let mut m = Map.new<string, Ref<int>>()
+  m["k"].* = 5
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "writing through a bracket-read entry still reads the entry, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_nested_in_write_target() {
+    let input = r#"
+fn test() {
+  let m = Map.new<string, Ref<int>>()
+  let mut counts = Map.new<int, string>()
+  counts[m["j"].*] = "x"
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read inside an assignment target index must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_bracket_write_of_no_zero_value_allowed() {
+    let input = r#"
+fn test() {
+  let x = 5
+  let mut m = Map.new<string, Ref<int>>()
+  m["k"] = &x
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "a bracket write never reads the entry, so it must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_with_zero_value_allowed() {
+    let input = r#"
+fn test(ages: Map<string, int>, opts: Map<string, Option<Ref<int>>>, rows: Slice<Ref<int>>) {
+  let _age = ages["missing"]
+  let _opt = opts["missing"]
+  let _row = rows[0]
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "reads of zero-valued map entries and slice indexing must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn infer_struct_zero_fill_function_alias_field() {
     let input = r#"
 type F = fn() -> int

--- a/tests/ui/errors/snapshots/infer_map_read_no_zero_for_generic_value.snap
+++ b/tests/ui/errors/snapshots/infer_map_read_no_zero_for_generic_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ No zero value for missing key
+   ╭─[test.lis:3:3]
+ 2 │ fn pick<K, V>(m: Map<K, V>, k: K) -> V {
+ 3 │   m[k]
+   ·   ──┬─
+   ·     ╰── `V` is not guaranteed to have a zero value
+ 4 │ }
+   ╰────
+  help: Bracket reads can return a zero value when the key is missing, but the type parameter `V` can be instantiated with a type that has no zero value, such as `Ref<T>`, so this bracket read is disallowed. Use `m.get(key)` instead · code: [infer.map_read_no_zero]

--- a/tests/ui/errors/snapshots/infer_map_read_no_zero_for_ref_value.snap
+++ b/tests/ui/errors/snapshots/infer_map_read_no_zero_for_ref_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ No zero value for missing key
+   ╭─[test.lis:4:12]
+ 3 │   let m = Map.new<string, Ref<int>>()
+ 4 │   let _r = m["missing"]
+   ·            ──────┬─────
+   ·                  ╰── `Ref<int>` has no zero value
+ 5 │ }
+   ╰────
+  help: Bracket reads can return a zero value when the key is missing, but `Ref<int>` has no zero value, so this bracket read is disallowed. Use `m.get(key)` instead · code: [infer.map_read_no_zero]


### PR DESCRIPTION
Bracket reads on a map whose value type has no zero value are now rejected at compile time. Reading a missing key returns the value type's Go zero value, and for `Ref<T>` that zero value is a nil pointer, so a bracket read could forge a null reference.

```rs
fn main() {
  let m = Map.new<string, Ref<int>>()
  let r = m["missing"] // previously compiled, then crashed with SIGSEGV
  fmt.Println(r.*)
}
```

This now fails to compile:

```
  ✕ No zero value for missing key
   ╭─[test.lis:4:12]
 3 │   let m = Map.new<string, Ref<int>>()
 4 │   let _r = m["missing"]
   ·            ──────┬─────
   ·                  ╰── `Ref<int>` has no zero value
 5 │ }
   ╰────
  help: Bracket reads can return a zero value when the key is missing, but `Ref<int>` has no zero value, so this bracket read is disallowed. Use `m.get(key)` instead · code: [infer.map_read_no_zero]
```
