### PR TITLE
feat: mutable bindings must own their value

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -525,6 +525,27 @@ pub fn self_reference_in_assignment(span: Span) -> LisetteDiagnostic {
         .with_help("Separate the reassignment from reference taking, or use a different variable")
 }
 
+pub fn mut_binding_aliases(
+    binding_name: &str,
+    source: &str,
+    addressable: bool,
+    span: Span,
+) -> LisetteDiagnostic {
+    let help = if addressable {
+        format!(
+            "Mutating `{binding_name}` would implicitly mutate `{source}`. Either use `{source}.clone()` to make a copy or `&{source}` to take a reference."
+        )
+    } else {
+        format!(
+            "Mutating `{binding_name}` would implicitly mutate `{source}`. Use `{source}.clone()` to make a copy."
+        )
+    };
+    LisetteDiagnostic::error(format!("Cannot make a mutable binding to `{source}`"))
+        .with_infer_code("mut_binding_aliases")
+        .with_span_label(&span, "would be mutated implicitly")
+        .with_help(help)
+}
+
 pub fn uppercase_binding(span: Span, name: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid binding name")
         .with_infer_code("uppercase_binding")

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -8,9 +8,8 @@ use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
 use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CalleePlan;
 use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
-use crate::types::native::NativeGoType;
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
-use syntax::types::{Type, peel_to_range_type};
+use syntax::types::Type;
 
 #[derive(Clone, Copy)]
 pub(crate) struct LetSpec<'a> {
@@ -70,45 +69,6 @@ fn is_fn_alias_nominal(ty: &Type) -> bool {
         return false;
     };
     matches!(inner.unwrap_forall(), Type::Function(_))
-}
-
-/// `let mut x = arr[range]` would otherwise alias the backing array.
-fn maybe_clone_subslice(
-    planner: &mut Planner,
-    value: &Expression,
-    mutable: bool,
-    expression: String,
-) -> String {
-    if !is_mutable_subslice(planner, value, mutable) {
-        return expression;
-    }
-    planner.require_slices();
-    format!("slices.Clone({})", expression)
-}
-
-fn is_mutable_subslice(planner: &Planner, value: &Expression, mutable: bool) -> bool {
-    if !mutable {
-        return false;
-    }
-    let value = value.unwrap_parens();
-    let Expression::IndexedAccess {
-        expression, index, ..
-    } = value
-    else {
-        return false;
-    };
-    let is_range_index = matches!(**index, Expression::Range { .. })
-        || peel_to_range_type(&index.get_type()).is_some();
-    if !is_range_index {
-        return false;
-    }
-    let collection_ty = if let Some(inner) = expression.deref_inner() {
-        let inner_ty = inner.get_type();
-        inner_ty.inner().unwrap_or(inner_ty)
-    } else {
-        expression.get_type()
-    };
-    planner.is_native_shape(&collection_ty, NativeGoType::Slice)
 }
 
 /// Pick the Go type for a `let` binding's `var X T` temp. Diverging values
@@ -300,7 +260,6 @@ impl Planner<'_> {
         );
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
         statements.extend(coercion_setup);
-        let value_expression = maybe_clone_subslice(self, value, mutable, value_expression);
 
         let go_identifier = self.scope.bind(identifier, raw_go_name);
         let is_new = self.try_declare(&go_identifier);

--- a/crates/semantics/src/checker/infer/addressability.rs
+++ b/crates/semantics/src/checker/infer/addressability.rs
@@ -1,4 +1,5 @@
 use syntax::ast::{Expression, UnaryOperator};
+use syntax::types::peel_to_range_type;
 
 use crate::checker::EnvResolve;
 use crate::checker::TypeEnv;
@@ -20,7 +21,14 @@ pub(crate) fn check_is_non_addressable(
                 check_is_non_addressable(expression, env)
             }
         }
-        Expression::IndexedAccess { expression, .. } => {
+        Expression::IndexedAccess {
+            expression, index, ..
+        } => {
+            let is_range_index = matches!(index.unwrap_parens(), Expression::Range { .. })
+                || peel_to_range_type(&index.get_type()).is_some();
+            if is_range_index {
+                return Some("sub-slice expression");
+            }
             let expression_ty = expression.get_type().resolve_in(env);
             if let Some(name) = expression_ty.get_name() {
                 if name == "Map" {

--- a/crates/semantics/src/checker/infer/expressions/aliasing.rs
+++ b/crates/semantics/src/checker/infer/expressions/aliasing.rs
@@ -1,0 +1,146 @@
+use syntax::ast::{Expression, Literal, UnaryOperator};
+use syntax::types::{CompoundKind, Type};
+
+use crate::checker::EnvResolve;
+use crate::checker::infer::InferCtx;
+use crate::checker::infer::addressability::check_is_non_addressable;
+
+impl InferCtx<'_, '_> {
+    /// A mutable binding initialized or reassigned from a place expression of
+    /// a directly aliasable type would share the source's backing storage, so
+    /// writes through the binding would also be visible through the source.
+    pub(super) fn check_mut_binding_alias(&mut self, binding_name: &str, value: &Expression) {
+        let place = value.unwrap_parens();
+        if !is_aliasing_place(place) {
+            return;
+        }
+        if !self.is_directly_aliasable(&value.get_type()) {
+            return;
+        }
+        let source = render_place(place);
+        let addressable = check_is_non_addressable(place, &self.env).is_none();
+        self.sink.push(diagnostics::infer::mut_binding_aliases(
+            binding_name,
+            &source,
+            addressable,
+            value.get_span(),
+        ));
+    }
+
+    fn is_directly_aliasable(&self, ty: &Type) -> bool {
+        let resolved = ty.resolve_in(&self.env);
+        let peeled = self.store.peel_alias(&resolved);
+        matches!(
+            peeled,
+            Type::Compound {
+                kind: CompoundKind::Slice | CompoundKind::Map | CompoundKind::EnumeratedSlice,
+                ..
+            }
+        )
+    }
+}
+
+/// Name of the identifier a place expression is rooted at.
+pub(super) fn place_root_name(expression: &Expression) -> Option<String> {
+    match expression {
+        Expression::Identifier { .. } => expression.get_var_name(),
+        Expression::DotAccess {
+            expression: inner, ..
+        }
+        | Expression::IndexedAccess {
+            expression: inner, ..
+        }
+        | Expression::Unary {
+            operator: UnaryOperator::Deref,
+            expression: inner,
+            ..
+        } => place_root_name(inner.unwrap_parens()),
+        _ => None,
+    }
+}
+
+/// Identifiers, field accesses, indexed accesses, and derefs rooted at one of
+/// these.
+fn is_aliasing_place(expression: &Expression) -> bool {
+    match expression {
+        Expression::Identifier { .. } => true,
+        Expression::DotAccess {
+            expression: inner, ..
+        } => is_aliasing_place(inner.unwrap_parens()),
+        Expression::IndexedAccess {
+            expression: inner, ..
+        } => is_aliasing_place(inner.unwrap_parens()),
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            expression: inner,
+            ..
+        } => is_aliasing_place(inner.unwrap_parens()),
+        _ => false,
+    }
+}
+
+/// Reconstructed source text for a place expression. Indexes that are not
+/// literals or identifiers render as `..` placeholders.
+fn render_place(expression: &Expression) -> String {
+    match expression {
+        Expression::Identifier { .. } => expression.get_var_name().unwrap_or_default(),
+        Expression::DotAccess {
+            expression: inner,
+            member,
+            ..
+        } => format!("{}.{member}", render_place(inner.unwrap_parens())),
+        Expression::IndexedAccess {
+            expression: inner,
+            index,
+            ..
+        } => format!(
+            "{}[{}]",
+            render_place(inner.unwrap_parens()),
+            render_index(index.unwrap_parens())
+        ),
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            expression: inner,
+            ..
+        } => format!("{}.*", render_place(inner.unwrap_parens())),
+        _ => String::new(),
+    }
+}
+
+fn render_index(index: &Expression) -> String {
+    match index {
+        Expression::Range {
+            start,
+            end,
+            inclusive,
+            ..
+        } => {
+            let endpoint = |e: &Option<Box<Expression>>| match e {
+                None => Some(String::new()),
+                Some(e) => render_scalar(e.unwrap_parens()),
+            };
+            match (endpoint(start), endpoint(end)) {
+                (Some(s), Some(e)) => {
+                    format!("{s}{}{e}", if *inclusive { "..=" } else { ".." })
+                }
+                _ => "..".to_string(),
+            }
+        }
+        other => render_scalar(other).unwrap_or_else(|| "..".to_string()),
+    }
+}
+
+fn render_scalar(expression: &Expression) -> Option<String> {
+    match expression {
+        Expression::Identifier { .. } => expression.get_var_name(),
+        Expression::Literal { literal, .. } => match literal {
+            Literal::Integer { value, text } => {
+                Some(text.clone().unwrap_or_else(|| value.to_string()))
+            }
+            Literal::String { value, .. } => Some(format!("{value:?}")),
+            Literal::Boolean(value) => Some(value.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -190,6 +190,13 @@ impl InferCtx<'_, '_> {
             ));
         }
 
+        if mutable
+            && new_binding.pattern.is_identifier()
+            && let Some(ref name) = binding_name
+        {
+            self.check_mut_binding_alias(name, &new_value);
+        }
+
         // Reject enum type bindings: `let c = utils.Color`
         if let Expression::DotAccess {
             expression: inner,

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -1,3 +1,4 @@
+pub mod aliasing;
 pub mod bindings;
 pub mod comparison;
 pub mod control_flow;

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -410,6 +410,12 @@ impl InferCtx<'_, '_> {
                 self.sink
                     .push(diagnostics::infer::self_reference_in_assignment(span));
             }
+
+            let self_sourced = super::aliasing::place_root_name(new_value.unwrap_parens())
+                .is_some_and(|root| root == var_name);
+            if compound_operator.is_none() && is_simple_target && is_mutable && !self_sourced {
+                self.check_mut_binding_alias(&var_name, &new_value);
+            }
         }
 
         // Only unify if the RHS type is still a variable (not yet resolved).

--- a/docs/intro/safety.md
+++ b/docs/intro/safety.md
@@ -118,12 +118,12 @@ let sub = source[1..3]        // compiles to source[1:3:3], cap = 2
 let sub = sub.append(99)      // allocates new array, source untouched
 ```
 
-In addition, when a sub-slice is bound with `let mut`, Lisette clones the sub-slice to sever the backing array alias entirely. This prevents writes through the sub-slice from mutating the original:
+In addition, binding a sub-slice with `let mut` requires an explicit `.clone()`, which severs the backing array alias entirely. This prevents writes through the sub-slice from mutating the original:
 
 ```rust
 let source = [1, 2, 3, 4, 5]
-let mut sub = source[1..3]    // cloned - fresh backing array
-sub[0] = 99                   // only sub is affected, source unchanged
+let mut sub = source[1..3].clone()  // fresh backing array
+sub[0] = 99                         // only sub is affected, source unchanged
 ```
 
 Immutable sub-slices with `let` remain zero-copy since element writes are not permitted on them.
@@ -291,6 +291,33 @@ In Lisette, functions that mutate their parameters in a way observable to the ca
 ```
 
 📚 See [`05-functions.md`](../reference/05-functions.md#mutable-parameters)
+
+### Aliased collections
+
+In Go, assigning a slice or map copies only a small header, so two variables silently share the same backing storage:
+
+```go
+a := []int{1, 2, 3}
+b := a
+b[0] = 99 // `a` is now [99 2 3]
+```
+
+In Lisette, a mutable binding must own its value. Creating one from an existing binding, field, or index of a slice or map is a compile error:
+
+```
+  ✕ Cannot make a mutable binding to `a`
+   ╭─[example.lis:3:15]
+ 2 │   let a = [1, 2, 3]
+ 3 │   let mut b = a
+   ·               ┬
+   ·               ╰── would be mutated implicitly
+ 4 │   b[0] = 99
+   ╰────
+  help: Mutating `b` would implicitly mutate `a`. Either use `a.clone()` to
+        make a copy or `&a` to take a reference.
+```
+
+Fresh values (literals, call results, constructed values) bind without ceremony. Immutable `let` bindings remain zero-copy views, as element writes are not permitted on them.
 
 ## Zero values
 

--- a/docs/reference/02-types.md
+++ b/docs/reference/02-types.md
@@ -274,6 +274,15 @@ let mut count = 0
 count += 1
 ```
 
+A mutable binding must own its value. Initializing or reassigning a mutable binding from an existing binding, field, or index of a `Slice` or `Map` would share the source's backing storage, so the compiler rejects it. Use `.clone()` for an independent copy, or `&` to share the value intentionally through a reference.
+
+```rust
+let a = [1, 2, 3]
+let mut b = a          // error: mutating `b` would implicitly mutate `a`
+let mut c = a.clone()  // independent copy
+let r = &a             // shared intentionally
+```
+
 `const` defines a compile-time constant. As in Go, only primitive values are allowed: `bool`, `int`, `float`, `string`. The initializer must be a literal or an expression built from literals. `const` bindings are immutable and unaddressable.
 
 ```rust

--- a/tests/e2e_smoke_project/src/control_flow.test.lis
+++ b/tests/e2e_smoke_project/src/control_flow.test.lis
@@ -135,7 +135,7 @@ fn subslice_append_no_alias() {
 #[test]
 fn mutable_subslice_element_write_no_alias() {
   let source = [1, 2, 3, 4, 5]
-  let mut sub = source[1..3]
+  let mut sub = source[1..3].clone()
   sub[0] = 99
   let result = source[1]
   assert result == 2

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -232,7 +232,7 @@ fn test(s: Slice<int>, flag: bool) -> Slice<int> {
 fn slice_append_reassign() {
     let input = r#"
 fn test(items: Slice<int>) {
-  let mut s = items
+  let mut s = items.clone()
   s = s.append(1, 2, 3)
 }
 "#;
@@ -243,7 +243,7 @@ fn test(items: Slice<int>) {
 fn slice_append_statement() {
     let input = r#"
 fn test(items: Slice<int>) -> Slice<int> {
-  let mut s = items
+  let mut s = items.clone()
   s = s.append(4)
   s
 }
@@ -1105,7 +1105,7 @@ fn mut_subslice_clones_for_aliased_range() {
     let input = r#"
 type Prefix = Range<int>
 fn test(arr: Slice<int>, r: Prefix) -> Slice<int> {
-  let mut owned = arr[r]
+  let mut owned = arr[r].clone()
   owned[0] = 99
   owned
 }

--- a/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
+++ b/tests/spec/emit/snapshots/mut_subslice_clones_for_aliased_range.snap
@@ -4,7 +4,7 @@ description: |
   
   type Prefix = Range<int>
   fn test(arr: Slice<int>, r: Prefix) -> Slice<int> {
-    let mut owned = arr[r]
+    let mut owned = arr[r].clone()
     owned[0] = 99
     owned
   }

--- a/tests/spec/emit/snapshots/mutable_subslice_cloned.snap
+++ b/tests/spec/emit/snapshots/mutable_subslice_cloned.snap
@@ -4,7 +4,7 @@ description: |
   
   fn test(arr: Slice<int>) {
     let view = arr[1..4]
-    let mut owned = arr[1..4]
+    let mut owned = arr[1..4].clone()
     owned[0] = 99
     let _ = view
   }

--- a/tests/spec/emit/snapshots/mutable_subslice_through_alias_cloned.snap
+++ b/tests/spec/emit/snapshots/mutable_subslice_through_alias_cloned.snap
@@ -6,7 +6,7 @@ description: |
   
   fn test() {
     let xs: Numbers = [1, 2, 3]
-    let mut part = xs[0..2]
+    let mut part = xs[0..2].clone()
     part[0] = 99
     let _ = xs
   }

--- a/tests/spec/emit/snapshots/slice_append_reassign.snap
+++ b/tests/spec/emit/snapshots/slice_append_reassign.snap
@@ -3,13 +3,15 @@ source: tests/spec/emit/prelude.rs
 description: |
   
   fn test(items: Slice<int>) {
-    let mut s = items
+    let mut s = items.clone()
     s = s.append(1, 2, 3)
   }
 ---
 package main
 
+import "slices"
+
 func test(items []int) {
-	s := items
+	s := slices.Clone(items)
 	s = append(s, 1, 2, 3)
 }

--- a/tests/spec/emit/snapshots/slice_append_statement.snap
+++ b/tests/spec/emit/snapshots/slice_append_statement.snap
@@ -3,15 +3,17 @@ source: tests/spec/emit/prelude.rs
 description: |
   
   fn test(items: Slice<int>) -> Slice<int> {
-    let mut s = items
+    let mut s = items.clone()
     s = s.append(4)
     s
   }
 ---
 package main
 
+import "slices"
+
 func test(items []int) []int {
-	s := items
+	s := slices.Clone(items)
 	s = append(s, 4)
 	return s
 }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1263,7 +1263,7 @@ fn mutable_subslice_cloned() {
     let input = r#"
 fn test(arr: Slice<int>) {
   let view = arr[1..4]
-  let mut owned = arr[1..4]
+  let mut owned = arr[1..4].clone()
   owned[0] = 99
   let _ = view
 }
@@ -1278,7 +1278,7 @@ type Numbers = Slice<int>
 
 fn test() {
   let xs: Numbers = [1, 2, 3]
-  let mut part = xs[0..2]
+  let mut part = xs[0..2].clone()
   part[0] = 99
   let _ = xs
 }

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1989,3 +1989,59 @@ fn assignment_type_mismatch_single_diagnostic() {
     let result = infer(r#"{ let mut x = 0; x = true; let _ = x }"#);
     assert_eq!(result.errors.len(), 1);
 }
+
+#[test]
+fn mut_binding_from_clone_no_error() {
+    infer(r#"{ let a = [1, 2]; let mut b = a.clone(); b = b.append(3); let _ = b; let _ = a }"#)
+        .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_call_no_error() {
+    infer(r#"{ let mut b = Slice.new<int>(); b = b.append(1); let _ = b }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_literal_no_error() {
+    infer(r#"{ let mut b = [1, 2]; b = b.append(3); let _ = b }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_subslice_clone_no_error() {
+    infer(r#"{ let a = [1, 2, 3]; let mut b = a[1..3].clone(); b[0] = 9; let _ = b; let _ = a }"#)
+        .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_subslice_single_diagnostic() {
+    let result =
+        infer(r#"{ let a = [1, 2, 3]; let mut b = a[1..3]; b[0] = 9; let _ = b; let _ = a }"#);
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn immutable_binding_from_binding_no_error() {
+    infer(r#"{ let a = [1, 2]; let b = a; let _ = b }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_ref_no_error() {
+    infer(r#"{ let a = 1; let r = &a; let mut r2 = r; r2 = &a; let _ = r2 }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_scalar_element_no_error() {
+    infer(r#"{ let xs = [1, 2]; let mut x = xs[0]; x += 1; let _ = x }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_binding_single_diagnostic() {
+    let result =
+        infer(r#"{ let a = [1, 2]; let mut b = a; b = b.append(3); let _ = b; let _ = a }"#);
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_self_shrink_reassignment_no_error() {
+    infer(r#"{ let mut it = Slice.new<int>(); it = it[1..]; let _ = it }"#).assert_no_errors();
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2238,6 +2238,103 @@ fn test() {
 }
 
 #[test]
+fn infer_mut_binding_aliases_slice() {
+    let input = r#"
+fn test() {
+  let a = [1, 2, 3]
+  let mut b = a
+  b = b.append(4)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_map() {
+    let input = r#"
+fn test() {
+  let m = Map.from([("a", 1)])
+  let mut m2 = m
+  m2["b"] = 2
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_reassignment() {
+    let input = r#"
+fn test(a: Slice<int>) {
+  let mut b = [0]
+  b = a
+  b = b.append(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_struct_field() {
+    let input = r#"
+struct Doc { tags: Slice<string> }
+
+fn test(d: Doc) {
+  let mut t = d.tags
+  t = t.append("x")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_map_index() {
+    let input = r#"
+fn test(m: Map<string, Slice<int>>) {
+  let mut s = m["k"]
+  s = s.append(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_subslice() {
+    let input = r#"
+fn test() {
+  let a = [1, 2, 3]
+  let mut b = a[1..3]
+  b[0] = 9
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_computed_index() {
+    let input = r#"
+fn key() -> string { "k" }
+
+fn test(m: Map<string, Slice<int>>) {
+  let mut s = m[key()]
+  s = s.append(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_subslice_not_addressable() {
+    let input = r#"
+fn test() {
+  let a = [1, 2, 3]
+  let r = &a[1..3]
+  let _ = r
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_value_receiver_not_mutable() {
     let input = r#"
 struct Counter { count: int }

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_computed_index.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_computed_index.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `m[..]`
+   ╭─[test.lis:5:16]
+ 4 │ fn test(m: Map<string, Slice<int>>) {
+ 5 │   let mut s = m[key()]
+   ·                ───┬───
+   ·                   ╰── would be mutated implicitly
+ 6 │   s = s.append(1)
+   ╰────
+  help: Mutating `s` would implicitly mutate `m[..]`. Use `m[..].clone()` to make a copy · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_map.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_map.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `m`
+   ╭─[test.lis:4:16]
+ 3 │   let m = Map.from([("a", 1)])
+ 4 │   let mut m2 = m
+   ·                ┬
+   ·                ╰── would be mutated implicitly
+ 5 │   m2["b"] = 2
+   ╰────
+  help: Mutating `m2` would implicitly mutate `m`. Either use `m.clone()` to make a copy or `&m` to take a reference · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_map_index.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_map_index.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `m["k"]`
+   ╭─[test.lis:3:16]
+ 2 │ fn test(m: Map<string, Slice<int>>) {
+ 3 │   let mut s = m["k"]
+   ·                ──┬──
+   ·                  ╰── would be mutated implicitly
+ 4 │   s = s.append(1)
+   ╰────
+  help: Mutating `s` would implicitly mutate `m["k"]`. Use `m["k"].clone()` to make a copy · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_reassignment.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_reassignment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `a`
+   ╭─[test.lis:4:7]
+ 3 │   let mut b = [0]
+ 4 │   b = a
+   ·       ┬
+   ·       ╰── would be mutated implicitly
+ 5 │   b = b.append(1)
+   ╰────
+  help: Mutating `b` would implicitly mutate `a`. Either use `a.clone()` to make a copy or `&a` to take a reference · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_slice.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `a`
+   ╭─[test.lis:4:15]
+ 3 │   let a = [1, 2, 3]
+ 4 │   let mut b = a
+   ·               ┬
+   ·               ╰── would be mutated implicitly
+ 5 │   b = b.append(4)
+   ╰────
+  help: Mutating `b` would implicitly mutate `a`. Either use `a.clone()` to make a copy or `&a` to take a reference · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_struct_field.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `d.tags`
+   ╭─[test.lis:5:15]
+ 4 │ fn test(d: Doc) {
+ 5 │   let mut t = d.tags
+   ·               ───┬──
+   ·                  ╰── would be mutated implicitly
+ 6 │   t = t.append("x")
+   ╰────
+  help: Mutating `t` would implicitly mutate `d.tags`. Either use `d.tags.clone()` to make a copy or `&d.tags` to take a reference · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_subslice.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_subslice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `a[1..3]`
+   ╭─[test.lis:4:16]
+ 3 │   let a = [1, 2, 3]
+ 4 │   let mut b = a[1..3]
+   ·                ───┬──
+   ·                   ╰── would be mutated implicitly
+ 5 │   b[0] = 9
+   ╰────
+  help: Mutating `b` would implicitly mutate `a[1..3]`. Use `a[1..3].clone()` to make a copy · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_subslice_not_addressable.snap
+++ b/tests/ui/errors/snapshots/infer_subslice_not_addressable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Non-addressable expression
+   ╭─[test.lis:4:11]
+ 3 │   let a = [1, 2, 3]
+ 4 │   let r = &a[1..3]
+   ·           ────┬───
+   ·               ╰── cannot take address of sub-slice expression
+ 5 │   let _ = r
+   ╰────
+  help: Assign the value to a variable first, then take its address · code: [infer.non_addressable_expression]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -19466,7 +19466,7 @@ fn while_let_loop() {
 import "go:fmt"
 
 pub fn drain(xs: Slice<int>) {
-  let mut it = xs
+  let mut it = xs.clone()
   loop {
     match it.get(0) {
       Some(v) => {

--- a/tests/ui/lint/snapshots/while_let_loop.snap
+++ b/tests/ui/lint/snapshots/while_let_loop.snap
@@ -3,7 +3,7 @@ source: tests/ui/lint/mod.rs
 ---
   ● Manual `while let`
    ╭─[test.lis:6:3]
- 5 │   let mut it = xs
+ 5 │   let mut it = xs.clone()
  6 │   loop {
    ·   ──┬─
    ·     ╰── can be a `while let`


### PR DESCRIPTION
A mutable binding must now own its value. Initializing or reassigning a `let mut` binding from an existing binding, field, or index of a `Slice` or `Map` is a compile error, since writes through the new binding would implicitly mutate the source.

```rs
let a = [1, 2, 3]

// error: mutating `b` would implicitly mutate `a`
let mut b = a 

// independent copy
let mut c = a.clone()  

// shared intentionally
let r = &a             
```

Sub-slices follow the same rule. Self-rebinding like `it = it[1..]` stays legal, and immutable `let` bindings remain zero-copy.
