### PR TITLE
fix: correct division-by-zero help text for float divisors

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1257,11 +1257,16 @@ pub fn missing_bound_on_param(
         ))
 }
 
-pub fn division_by_zero(span: Span) -> LisetteDiagnostic {
+pub fn division_by_zero(span: Span, ieee: bool) -> LisetteDiagnostic {
+    let help = if ieee {
+        "This operation evaluates to `+Inf`, `-Inf`, or `NaN` at runtime, which is almost never intended"
+    } else {
+        "This operation will panic at runtime"
+    };
     LisetteDiagnostic::error("Division by zero")
         .with_infer_code("division_by_zero")
         .with_span_label(&span, "cannot divide by zero")
-        .with_help("This operation will panic at runtime")
+        .with_help(help)
 }
 
 pub fn incompatible_named_types(underlying_ty: &Type, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -158,22 +158,8 @@ impl InferCtx<'_, '_> {
         expected_ty: &Type,
         span: Span,
     ) -> (Expression, Type) {
-        if matches!(operator, Division | Remainder) {
-            let is_zero = match right_operand.unwrap_parens() {
-                Expression::Literal {
-                    literal: Literal::Integer { value: 0, .. },
-                    ..
-                } => true,
-                Expression::Literal {
-                    literal: Literal::Float { value, .. },
-                    ..
-                } => *value == 0.0,
-                _ => false,
-            };
-            if is_zero {
-                self.sink.push(diagnostics::infer::division_by_zero(span));
-            }
-        }
+        let divisor_is_zero =
+            matches!(operator, Division | Remainder) && is_zero_literal(&right_operand);
 
         let left_operand_ty = left_ty;
         let right_operand_ty = self.new_type_var();
@@ -190,6 +176,10 @@ impl InferCtx<'_, '_> {
             }
             s.infer_expression(*right_operand, &right_operand_ty)
         });
+
+        if divisor_is_zero {
+            self.report_zero_divisor(operator, &right_operand_ty, span);
+        }
 
         if matches!(operator, And | Or)
             && let Some(span) = Self::find_propagate(&new_right_operand)
@@ -234,22 +224,8 @@ impl InferCtx<'_, '_> {
         expected_ty: &Type,
         span: Span,
     ) -> Expression {
-        if matches!(operator, Division | Remainder) {
-            let is_zero = match right_operand.unwrap_parens() {
-                Expression::Literal {
-                    literal: Literal::Integer { value: 0, .. },
-                    ..
-                } => true,
-                Expression::Literal {
-                    literal: Literal::Float { value, .. },
-                    ..
-                } => *value == 0.0,
-                _ => false,
-            };
-            if is_zero {
-                self.sink.push(diagnostics::infer::division_by_zero(span));
-            }
-        }
+        let divisor_is_zero =
+            matches!(operator, Division | Remainder) && is_zero_literal(&right_operand);
 
         let left_operand_ty = self.new_type_var();
         let right_operand_ty = self.new_type_var();
@@ -288,6 +264,10 @@ impl InferCtx<'_, '_> {
                 (left, right)
             }
         });
+
+        if divisor_is_zero {
+            self.report_zero_divisor(operator, &right_operand_ty, span);
+        }
 
         if matches!(operator, And | Or)
             && let Some(span) = Self::find_propagate(&new_right_operand)
@@ -833,6 +813,30 @@ impl InferCtx<'_, '_> {
             ty: result_ty,
             span,
         }
+    }
+
+    fn report_zero_divisor(&mut self, operator: BinaryOperator, divisor_ty: &Type, span: Span) {
+        let resolved = divisor_ty.resolve_in(&self.env);
+        let ieee = resolved.is_float() || resolved.is_complex();
+        if ieee && matches!(operator, Remainder) {
+            return;
+        }
+        self.sink
+            .push(diagnostics::infer::division_by_zero(span, ieee));
+    }
+}
+
+fn is_zero_literal(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Literal {
+            literal: Literal::Integer { value: 0, .. },
+            ..
+        } => true,
+        Expression::Literal {
+            literal: Literal::Float { value, .. },
+            ..
+        } => *value == 0.0,
+        _ => false,
     }
 }
 

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -2045,3 +2045,29 @@ fn mut_binding_from_binding_single_diagnostic() {
 fn mut_binding_self_shrink_reassignment_no_error() {
     infer(r#"{ let mut it = Slice.new<int>(); it = it[1..]; let _ = it }"#).assert_no_errors();
 }
+
+#[test]
+fn float_remainder_by_zero_single_diagnostic() {
+    let result = infer(
+        r#"
+    fn main() {
+      let x = 3.5;
+      let _ = x % 0.0;
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn complex_division_by_zero_rejected() {
+    infer(
+        r#"
+    fn main() {
+      let z: complex128 = 1.0 + 2.0i;
+      let _ = z / 0.0;
+    }
+        "#,
+    )
+    .assert_infer_code("division_by_zero");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6104,6 +6104,29 @@ fn main() {
 }
 
 #[test]
+fn infer_float_division_by_zero() {
+    let input = r#"
+fn main() {
+  let x = 1.0 / 0.0;
+  x
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_float_division_by_adapted_zero() {
+    let input = r#"
+fn main() {
+  let x = 3.5;
+  let y = x / 0;
+  y
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn parse_uppercase_binding_in_function_param() {
     let input = r#"
 fn scale(X: int, Y: int) -> int {

--- a/tests/ui/errors/snapshots/infer_float_division_by_adapted_zero.snap
+++ b/tests/ui/errors/snapshots/infer_float_division_by_adapted_zero.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Division by zero
+   ╭─[test.lis:4:11]
+ 3 │   let x = 3.5;
+ 4 │   let y = x / 0;
+   ·           ──┬──
+   ·             ╰── cannot divide by zero
+ 5 │   y
+   ╰────
+  help: This operation evaluates to `+Inf`, `-Inf`, or `NaN` at runtime, which is almost never intended · code: [infer.division_by_zero]

--- a/tests/ui/errors/snapshots/infer_float_division_by_zero.snap
+++ b/tests/ui/errors/snapshots/infer_float_division_by_zero.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Division by zero
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let x = 1.0 / 0.0;
+   ·           ────┬────
+   ·               ╰── cannot divide by zero
+ 4 │   x
+   ╰────
+  help: This operation evaluates to `+Inf`, `-Inf`, or `NaN` at runtime, which is almost never intended · code: [infer.division_by_zero]


### PR DESCRIPTION
A user pointed out the division-by-zero error claims every such operation panics at runtime, but that is true for integers only, whereas float and complex division by zero follows IEEE semantics. The help text now matches the divisor's type.