### PR TITLE
fix: reject polymorphic recursion

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1752,6 +1752,27 @@ pub fn unconstrained_type_param(param_name: &str, span: Span) -> LisetteDiagnost
         ))
 }
 
+pub fn instantiation_cycle(
+    param_name: &str,
+    type_arg: &Type,
+    target_fn_name: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Growing type argument")
+        .with_infer_code("instantiation_cycle")
+        .with_span_label(
+            &span,
+            format!(
+                "`{}` becomes `{}` in this recursive call",
+                param_name, type_arg
+            ),
+        )
+        .with_help(format!(
+            "Each recursive call would need a new version of `{}` at a larger type, so compilation would never finish. Keep type arguments fixed across recursive calls",
+            target_fn_name
+        ))
+}
+
 pub fn slice_index_type_mismatch(index_ty: &Type, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Type mismatch")
         .with_infer_code("slice_index_type_mismatch")

--- a/crates/passes/src/passes/checks/instantiation_cycle.rs
+++ b/crates/passes/src/passes/checks/instantiation_cycle.rs
@@ -1,0 +1,485 @@
+//! Rejects recursion that regrows a generic type argument, mirroring the Go
+//! compiler's instantiation-cycle rule so the failure surfaces as a Lisette
+//! diagnostic instead of leaking from `go build`.
+
+use diagnostics::LocalSink;
+use ecow::EcoString;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use syntax::ast::{Binding, Expression, Pattern, Span};
+use syntax::program::DotAccessKind;
+use syntax::types::{CompoundKind, FunctionType, Symbol, Type};
+
+use semantics::store::Store;
+
+pub(crate) fn run(store: &Store, sink: &LocalSink) {
+    let targets = collect_generic_targets(store);
+    if targets.list.is_empty() {
+        return;
+    }
+
+    let mut collector = EdgeCollector {
+        targets: &targets,
+        adjacency: vec![Vec::new(); targets.node_count],
+        growing: Vec::new(),
+        current: 0,
+    };
+    for index in 0..targets.list.len() {
+        collector.current = index;
+        collector.walk(targets.list[index].body);
+    }
+
+    let mut reported_spans: HashSet<Span> = HashSet::default();
+    for edge in &collector.growing {
+        if !reaches(&collector.adjacency, edge.target, edge.source) {
+            continue;
+        }
+        if !reported_spans.insert(edge.span) {
+            continue;
+        }
+        sink.push(diagnostics::infer::instantiation_cycle(
+            &edge.var,
+            &edge.type_arg,
+            &edge.target_name,
+            edge.span,
+        ));
+    }
+}
+
+struct GenericTarget<'a> {
+    name: &'a EcoString,
+    vars: Vec<&'a EcoString>,
+    declared_self: Option<&'a Type>,
+    declared_params: Vec<&'a Type>,
+    declared_return: &'a Type,
+    body: &'a Expression,
+    first_node: usize,
+}
+
+#[derive(Default)]
+struct Targets<'a> {
+    list: Vec<GenericTarget<'a>>,
+    functions: HashMap<EcoString, usize>,
+    methods: HashMap<(EcoString, EcoString), usize>,
+    node_count: usize,
+}
+
+impl<'a> Targets<'a> {
+    fn add(&mut self, mut target: GenericTarget<'a>) -> usize {
+        let index = self.list.len();
+        target.first_node = self.node_count;
+        self.node_count += target.vars.len();
+        self.list.push(target);
+        index
+    }
+}
+
+fn collect_generic_targets(store: &Store) -> Targets<'_> {
+    let mut module_ids: Vec<&str> = store.modules.keys().map(String::as_str).collect();
+    module_ids.sort_unstable();
+
+    let mut targets = Targets::default();
+    for module_id in module_ids {
+        let module = &store.modules[module_id];
+        let mut files: Vec<_> = module.files.values().collect();
+        files.sort_unstable_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+        for file in files {
+            for item in &file.items {
+                match item {
+                    Expression::Function {
+                        name,
+                        generics,
+                        params,
+                        return_type,
+                        body,
+                        ..
+                    } if !generics.is_empty() => {
+                        let index = targets.add(GenericTarget {
+                            name,
+                            vars: generics.iter().map(|g| &g.name).collect(),
+                            declared_self: None,
+                            declared_params: params.iter().map(|p| &p.ty).collect(),
+                            declared_return: return_type,
+                            body,
+                            first_node: 0,
+                        });
+                        let qualified = Symbol::from_parts(module_id, name).as_eco().clone();
+                        targets.functions.insert(qualified, index);
+                    }
+                    Expression::ImplBlock {
+                        receiver_name,
+                        generics: impl_generics,
+                        methods,
+                        ..
+                    } => {
+                        for method in methods {
+                            collect_method(
+                                method,
+                                impl_generics,
+                                receiver_name,
+                                module_id,
+                                &mut targets,
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    targets
+}
+
+fn collect_method<'a>(
+    method: &'a Expression,
+    impl_generics: &'a [syntax::ast::Generic],
+    receiver_name: &EcoString,
+    module_id: &str,
+    targets: &mut Targets<'a>,
+) {
+    let Expression::Function {
+        name,
+        generics,
+        params,
+        return_type,
+        body,
+        ..
+    } = method
+    else {
+        return;
+    };
+    let vars: Vec<&EcoString> = impl_generics
+        .iter()
+        .chain(generics)
+        .map(|g| &g.name)
+        .collect();
+    if vars.is_empty() {
+        return;
+    }
+    let (declared_self, declared_params) = split_self_param(params);
+    let receiver_id = declared_self.and_then(receiver_type_id).unwrap_or_else(|| {
+        Symbol::from_parts(module_id, receiver_name)
+            .as_eco()
+            .clone()
+    });
+    let index = targets.add(GenericTarget {
+        name,
+        vars,
+        declared_self,
+        declared_params,
+        declared_return: return_type,
+        body,
+        first_node: 0,
+    });
+    // Static-style references collapse to a plain identifier qualified as
+    // `module.Type.method`.
+    let qualified = Symbol::from_raw(receiver_id.clone())
+        .with_segment(name)
+        .as_eco()
+        .clone();
+    targets.functions.insert(qualified, index);
+    targets.methods.insert((receiver_id, name.clone()), index);
+}
+
+fn split_self_param(params: &[Binding]) -> (Option<&Type>, Vec<&Type>) {
+    match params.split_first() {
+        Some((first, rest)) if is_self_binding(first) => {
+            (Some(&first.ty), rest.iter().map(|p| &p.ty).collect())
+        }
+        _ => (None, params.iter().map(|p| &p.ty).collect()),
+    }
+}
+
+fn is_self_binding(binding: &Binding) -> bool {
+    matches!(&binding.pattern, Pattern::Identifier { identifier, .. } if identifier == "self")
+}
+
+fn receiver_type_id(ty: &Type) -> Option<EcoString> {
+    match ty {
+        Type::Compound {
+            kind: CompoundKind::Ref,
+            args,
+        } => args.first().and_then(receiver_type_id),
+        Type::Nominal { id, .. } => Some(id.as_eco().clone()),
+        _ => None,
+    }
+}
+
+struct GrowingEdge {
+    source: usize,
+    target: usize,
+    span: Span,
+    var: EcoString,
+    type_arg: Type,
+    target_name: EcoString,
+}
+
+struct EdgeCollector<'s, 'a> {
+    targets: &'s Targets<'a>,
+    adjacency: Vec<Vec<usize>>,
+    growing: Vec<GrowingEdge>,
+    current: usize,
+}
+
+impl<'a> EdgeCollector<'_, 'a> {
+    fn walk(&mut self, expression: &'a Expression) {
+        match expression {
+            // A nested function declaration is a hard error elsewhere, and its
+            // type parameters shadow the enclosing ones, so references in its
+            // body must not be attributed to the enclosing generic context.
+            Expression::Function { .. } => {}
+            Expression::Call {
+                expression: callee,
+                args,
+                spread,
+                span,
+                ..
+            } => {
+                match callee.as_ref() {
+                    reference @ (Expression::Identifier { .. } | Expression::DotAccess { .. }) => {
+                        self.process_reference(reference, *span);
+                        if let Expression::DotAccess {
+                            expression: base, ..
+                        } = reference
+                        {
+                            self.walk(base);
+                        }
+                    }
+                    other => self.walk(other),
+                }
+                for argument in args {
+                    self.walk(argument);
+                }
+                if let Some(spread) = spread.as_ref() {
+                    self.walk(spread);
+                }
+            }
+            Expression::Identifier { span, .. } => self.process_reference(expression, *span),
+            Expression::DotAccess {
+                expression: base,
+                span,
+                ..
+            } => {
+                self.process_reference(expression, *span);
+                self.walk(base);
+            }
+            _ => {
+                for child in expression.children() {
+                    self.walk(child);
+                }
+            }
+        }
+    }
+
+    fn process_reference(&mut self, reference: &'a Expression, span: Span) {
+        match reference {
+            Expression::Identifier {
+                qualified: Some(qualified),
+                ty,
+                ..
+            } => {
+                if let Some(&target_index) = self.targets.functions.get(qualified)
+                    && let Type::Function(instantiated) = ty
+                {
+                    self.match_and_emit(target_index, None, instantiated, span);
+                }
+            }
+            Expression::DotAccess {
+                expression: base,
+                member,
+                ty,
+                dot_access_kind,
+                ..
+            } => self.process_method_reference(base, member, ty, dot_access_kind, span),
+            _ => {}
+        }
+    }
+
+    fn process_method_reference(
+        &mut self,
+        base: &'a Expression,
+        member: &EcoString,
+        ty: &'a Type,
+        dot_access_kind: &Option<DotAccessKind>,
+        span: Span,
+    ) {
+        let is_instance = match dot_access_kind {
+            Some(DotAccessKind::InstanceMethod { .. })
+            | Some(DotAccessKind::InstanceMethodValue { .. }) => true,
+            Some(DotAccessKind::StaticMethod { .. }) => false,
+            _ => return,
+        };
+        let base_ty = base.get_type();
+        let receiver_id = receiver_type_id(&base_ty).or_else(|| match base {
+            Expression::Identifier {
+                qualified: Some(qualified),
+                ..
+            } => Some(qualified.clone()),
+            _ => None,
+        });
+        let Some(receiver_id) = receiver_id else {
+            return;
+        };
+        let Some(&target_index) = self.targets.methods.get(&(receiver_id, member.clone())) else {
+            return;
+        };
+        let Type::Function(instantiated) = ty else {
+            return;
+        };
+        let receiver = is_instance.then_some(&base_ty);
+        self.match_and_emit(target_index, receiver, instantiated, span);
+    }
+
+    fn match_and_emit(
+        &mut self,
+        target_index: usize,
+        receiver: Option<&Type>,
+        instantiated: &FunctionType,
+        span: Span,
+    ) {
+        let targets = self.targets;
+        let target = &targets.list[target_index];
+        let declared_self = target.declared_self.map(Type::strip_refs);
+        let receiver = receiver.map(Type::strip_refs);
+
+        let mut bindings: HashMap<EcoString, &Type> = HashMap::default();
+        let actual_params: &[Type] = if instantiated.params.len() == target.declared_params.len() {
+            if let (Some(declared_self), Some(receiver)) = (&declared_self, &receiver) {
+                bind_type_arguments(declared_self, receiver, &target.vars, &mut bindings);
+            }
+            &instantiated.params
+        } else if instantiated.params.len() == target.declared_params.len() + 1
+            && declared_self.is_some()
+        {
+            // Method used with an explicit receiver slot, for example as a
+            // first-class value. The receiver is the first parameter.
+            if let Some(declared_self) = &declared_self {
+                bind_type_arguments(
+                    declared_self,
+                    &instantiated.params[0],
+                    &target.vars,
+                    &mut bindings,
+                );
+            }
+            &instantiated.params[1..]
+        } else {
+            return;
+        };
+        for (declared, actual) in target.declared_params.iter().zip(actual_params) {
+            bind_type_arguments(declared, actual, &target.vars, &mut bindings);
+        }
+        bind_type_arguments(
+            target.declared_return,
+            &instantiated.return_type,
+            &target.vars,
+            &mut bindings,
+        );
+
+        let source = &targets.list[self.current];
+        for (target_position, var) in target.vars.iter().enumerate() {
+            let Some(&type_arg) = bindings.get(*var) else {
+                continue;
+            };
+            let target_node = target.first_node + target_position;
+            for (source_position, source_var) in source.vars.iter().enumerate() {
+                let is_same = matches!(type_arg, Type::Parameter(name) if name == *source_var);
+                if !is_same && !mentions_parameter(type_arg, source_var) {
+                    continue;
+                }
+                let source_node = source.first_node + source_position;
+                self.adjacency[source_node].push(target_node);
+                if !is_same {
+                    self.growing.push(GrowingEdge {
+                        source: source_node,
+                        target: target_node,
+                        span,
+                        var: (*var).clone(),
+                        type_arg: type_arg.clone(),
+                        target_name: target.name.clone(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Recovers the type argument bound to each of the target's type parameters
+/// by walking the declared and instantiated signatures in parallel.
+fn bind_type_arguments<'t>(
+    declared: &Type,
+    actual: &'t Type,
+    vars: &[&EcoString],
+    bindings: &mut HashMap<EcoString, &'t Type>,
+) {
+    if let Type::Parameter(name) = declared {
+        if vars.contains(&name) {
+            bindings.entry(name.clone()).or_insert(actual);
+        }
+        return;
+    }
+    if !same_shape(declared, actual) {
+        return;
+    }
+    let declared_children = structural_children(declared);
+    let actual_children = structural_children(actual);
+    if declared_children.len() == actual_children.len() {
+        for (declared, actual) in declared_children.into_iter().zip(actual_children) {
+            bind_type_arguments(declared, actual, vars, bindings);
+        }
+    }
+}
+
+fn same_shape(declared: &Type, actual: &Type) -> bool {
+    match (declared, actual) {
+        (Type::Compound { kind: declared, .. }, Type::Compound { kind: actual, .. }) => {
+            declared == actual
+        }
+        (Type::Nominal { id: declared, .. }, Type::Nominal { id: actual, .. }) => {
+            declared == actual
+        }
+        (Type::Function(_), Type::Function(_)) | (Type::Tuple(_), Type::Tuple(_)) => true,
+        _ => false,
+    }
+}
+
+/// Child positions matched pairwise between the declared and instantiated
+/// sides. Excludes `Nominal.underlying_ty`, which can be present on only one
+/// side.
+fn structural_children(ty: &Type) -> Vec<&Type> {
+    match ty {
+        Type::Compound { args, .. } => args.iter().collect(),
+        Type::Nominal { params, .. } => params.iter().collect(),
+        Type::Function(function) => function
+            .params
+            .iter()
+            .chain(std::iter::once(function.return_type.as_ref()))
+            .collect(),
+        Type::Tuple(elements) => elements.iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn mentions_parameter(ty: &Type, name: &EcoString) -> bool {
+    match ty {
+        Type::Parameter(parameter) => parameter == name,
+        _ => ty
+            .children()
+            .iter()
+            .any(|child| mentions_parameter(child, name)),
+    }
+}
+
+fn reaches(adjacency: &[Vec<usize>], from: usize, to: usize) -> bool {
+    let mut visited = vec![false; adjacency.len()];
+    let mut stack = vec![from];
+    while let Some(node) = stack.pop() {
+        if node == to {
+            return true;
+        }
+        if visited[node] {
+            continue;
+        }
+        visited[node] = true;
+        stack.extend(adjacency[node].iter().copied());
+    }
+    false
+}

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod enum_variant_value;
 pub(crate) mod generics;
 pub(crate) mod impossible_comparison;
 pub(crate) mod index_out_of_bounds;
+pub(crate) mod instantiation_cycle;
 pub(crate) mod interpolation_stringer;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
@@ -56,6 +57,7 @@ pub(crate) fn run_all(
         visibility::run_module(module_id, store, &sink);
         json_methods::run_module(module_id, store, &sink);
     }
+    instantiation_cycle::run(store, &sink);
 
     let mut work: Vec<(&Module, &File)> = store
         .modules

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1858,6 +1858,344 @@ fn unconstrained_bounded_type_param_produces_error() {
 }
 
 #[test]
+fn polymorphic_recursion_growing_slice_produces_error() {
+    infer(
+        r#"
+    fn depth<T>(x: T, n: int) -> int {
+      if n > 0 { depth([x], n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = depth(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn polymorphic_recursion_growing_option_produces_error() {
+    infer(
+        r#"
+    fn nest<T>(x: T, n: int) -> int {
+      if n > 0 { nest(Some(x), n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = nest(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn polymorphic_recursion_explicit_type_args_produces_error() {
+    infer(
+        r#"
+    fn explicit<T>(x: T, n: int) -> int {
+      if n > 0 { explicit<Slice<T>>([x], n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = explicit(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn polymorphic_recursion_through_reference_produces_error() {
+    infer(
+        r#"
+    fn indirect<T>(x: T, n: int) -> int {
+      if n > 0 {
+        let recurse: fn(Slice<T>, int) -> int = indirect
+        recurse([x], n - 1)
+      } else {
+        0
+      }
+    }
+
+    fn main() {
+      let _ = indirect(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn mutual_polymorphic_recursion_produces_error() {
+    infer(
+        r#"
+    fn ping<T>(x: T, n: int) -> int {
+      if n > 0 { pong([x], n - 1) } else { 0 }
+    }
+
+    fn pong<U>(x: U, n: int) -> int {
+      ping(x, n)
+    }
+
+    fn main() {
+      let _ = ping(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn polymorphic_recursion_growing_swap_produces_error() {
+    infer(
+        r#"
+    fn grow<A, B>(a: A, b: B, n: int) -> int {
+      if n > 0 { grow(b, [a], n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = grow(1, "x", 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn generic_recursion_with_fixed_type_args_is_valid() {
+    infer(
+        r#"
+    fn countdown<T>(x: T, n: int) -> int {
+      if n > 0 { countdown(x, n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = countdown("a", 3)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_recursion_with_swapped_type_args_is_valid() {
+    infer(
+        r#"
+    fn swap_rec<A, B>(a: A, b: B, n: int) -> int {
+      if n > 0 { swap_rec(b, a, n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = swap_rec(1, "x", 3)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn one_way_growing_generic_call_is_valid() {
+    infer(
+        r#"
+    fn wrap_once<T>(x: T, n: int) -> int {
+      measure([x], n)
+    }
+
+    fn measure<U>(x: U, n: int) -> int {
+      if n > 0 { measure(x, n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = wrap_once(1, 3)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_method_polymorphic_recursion_produces_error() {
+    infer(
+        r#"
+    struct Counter {}
+
+    impl Counter {
+      fn depth<T>(self, x: T, n: int) -> int {
+        if n > 0 { self.depth([x], n - 1) } else { 0 }
+      }
+    }
+
+    fn main() {
+      let c = Counter {}
+      let _ = c.depth(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn static_method_polymorphic_recursion_produces_error() {
+    infer(
+        r#"
+    struct Tool {}
+
+    impl Tool {
+      fn measure<T>(x: T, n: int) -> int {
+        if n > 0 { Tool.measure([x], n - 1) } else { 0 }
+      }
+    }
+
+    fn main() {
+      let _ = Tool.measure(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn impl_receiver_growth_recursion_produces_error() {
+    infer(
+        r#"
+    struct Box<U> { value: U }
+
+    impl<U> Box<U> {
+      fn deep(self, n: int) -> int {
+        if n > 0 {
+          let bigger = Box { value: self }
+          bigger.deep(n - 1)
+        } else {
+          0
+        }
+      }
+    }
+
+    fn main() {
+      let b = Box { value: 1 }
+      let _ = b.deep(3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn generic_method_recursion_with_fixed_receiver_is_valid() {
+    infer(
+        r#"
+    struct Box<U> { value: U }
+
+    impl<U> Box<U> {
+      fn count(self, n: int) -> int {
+        if n > 0 { self.count(n - 1) } else { 0 }
+      }
+    }
+
+    fn main() {
+      let b = Box { value: 1 }
+      let _ = b.count(3)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn nested_function_shadowed_generic_produces_no_cycle_error() {
+    infer(
+        r#"
+    fn outer<T>(x: T, n: int) -> int {
+      fn helper<T>(y: T) -> int {
+        outer([y], 1)
+      }
+      n
+    }
+
+    fn main() {
+      let _ = outer(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code("nested_function")
+    .assert_infer_code_count("instantiation_cycle", 0);
+}
+
+#[test]
+fn static_method_recursion_through_alias_produces_error() {
+    infer(
+        r#"
+    struct Tool {}
+
+    type Gadget = Tool
+
+    impl Tool {
+      fn measure<T>(x: T, n: int) -> int {
+        if n > 0 { Gadget.measure([x], n - 1) } else { 0 }
+      }
+    }
+
+    fn main() {
+      let _ = Tool.measure(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn imported_module_polymorphic_recursion_produces_error() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "helpers",
+        "lib.lis",
+        r#"
+pub fn tally<T>(x: T, n: int) -> int {
+  if n > 0 { tally([x], n - 1) } else { 0 }
+}
+"#,
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "helpers"
+
+fn main() {
+  let _ = helpers.tally(1, 3)
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
+fn function_method_polymorphic_recursion_cycle_produces_error() {
+    infer(
+        r#"
+    struct Helper {}
+
+    impl Helper {
+      fn bounce<T>(self, x: T, n: int) -> int {
+        trampoline(x, n)
+      }
+    }
+
+    fn trampoline<T>(x: T, n: int) -> int {
+      if n > 0 { Helper {}.bounce([x], n - 1) } else { 0 }
+    }
+
+    fn main() {
+      let _ = trampoline(1, 3)
+    }
+        "#,
+    )
+    .assert_infer_code_once("instantiation_cycle");
+}
+
+#[test]
 fn constrained_bounded_type_param_is_valid() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2528,6 +2528,20 @@ fn main() {
 }
 
 #[test]
+fn infer_instantiation_cycle() {
+    let input = r#"
+fn depth<T>(x: T, n: int) -> int {
+  if n > 0 { depth([x], n - 1) } else { 0 }
+}
+
+fn main() {
+  let _ = depth(1, 3)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_option_where_inner_expected() {
     let input = r#"
 fn process(x: int) -> int { x }

--- a/tests/ui/errors/snapshots/infer_instantiation_cycle.snap
+++ b/tests/ui/errors/snapshots/infer_instantiation_cycle.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Growing type argument
+   ╭─[test.lis:3:14]
+ 2 │ fn depth<T>(x: T, n: int) -> int {
+ 3 │   if n > 0 { depth([x], n - 1) } else { 0 }
+   ·              ────────┬────────
+   ·                      ╰── `T` becomes `Slice<T>` in this recursive call
+ 4 │ }
+   ╰────
+  help: Each recursive call would need a new version of `depth` at a larger type, so compilation would never finish. Keep type arguments fixed across recursive calls · code: [infer.instantiation_cycle]


### PR DESCRIPTION
Generic recursion that grows a type arg is now rejected, instead offailing at Go's instantiation cycle error.

```
  ✕ Growing type argument
   ╭─[test.lis:3:14]
 2 │ fn depth<T>(x: T, n: int) -> int {
 3 │   if n > 0 { depth([x], n - 1) } else { 0 }
   ·              ────────┬────────
   ·                      ╰── `T` becomes `Slice<T>` in this recursive call
 4 │ }
   ╰────
  help: Each recursive call would need a new version of `depth` at a larger type, so compilation would never finish. Keep type arguments fixed across recursive calls · code: [infer.instantiation_cycle]
```

The error matches Go exactly: mutual recursion, generic methods, and receiver growth through impl generics are rejected, while recursion at fixed or swapped type arguments stays legal.
