### PR TITLE
fix: silence unused `mut` warning inside erroring functions

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -468,6 +468,10 @@ impl LisetteDiagnostic {
         self.labels.first().map(|l| l.offset()).unwrap_or(0)
     }
 
+    pub fn label_offsets(&self) -> Vec<usize> {
+        self.labels.iter().map(|l| l.offset()).collect()
+    }
+
     pub fn location_offset(&self) -> Option<usize> {
         self.labels
             .iter()

--- a/crates/diagnostics/src/sink.rs
+++ b/crates/diagnostics/src/sink.rs
@@ -22,6 +22,20 @@ impl LocalSink {
         self.diagnostics.borrow().iter().any(|d| d.is_error())
     }
 
+    pub fn error_label_points(&self) -> Vec<(Option<u32>, usize)> {
+        self.diagnostics
+            .borrow()
+            .iter()
+            .filter(|d| d.is_error())
+            .flat_map(|d| {
+                let file_id = d.file_id();
+                d.label_offsets()
+                    .into_iter()
+                    .map(move |offset| (file_id, offset))
+            })
+            .collect()
+    }
+
     pub fn len(&self) -> usize {
         self.diagnostics.borrow().len()
     }

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -80,7 +80,14 @@ pub(crate) fn run(
     let mut diagnostics: Vec<LisetteDiagnostic> = Vec::new();
     let sources = source_by_file(analysis);
 
-    collect_bindings(facts, unused, &sources, &mut diagnostics);
+    let erroring_functions = erroring_function_spans(facts, sink);
+    collect_bindings(
+        facts,
+        unused,
+        &sources,
+        &erroring_functions,
+        &mut diagnostics,
+    );
     collect_dead_code(facts, &mut diagnostics);
     collect_pattern_issues(facts, &mut diagnostics);
     collect_unused_expressions(facts, &mut diagnostics);
@@ -131,10 +138,38 @@ fn fstring_inner<'a>(sources: &HashMap<u32, &'a str>, span: Span) -> Option<&'a 
     Some(inner.strip_prefix('{')?.strip_suffix('}')?.trim())
 }
 
+fn erroring_function_spans(facts: &Facts, sink: &LocalSink) -> Vec<Span> {
+    let error_points = sink.error_label_points();
+    if error_points.is_empty() {
+        return Vec::new();
+    }
+    facts
+        .function_spans
+        .iter()
+        .filter(|function_span| {
+            error_points.iter().any(|(file_id, offset)| {
+                *file_id == Some(function_span.file_id)
+                    && function_span.byte_offset as usize <= *offset
+                    && *offset < function_span.end() as usize
+            })
+        })
+        .copied()
+        .collect()
+}
+
+fn within_any(function_spans: &[Span], span: Span) -> bool {
+    function_spans.iter().any(|function_span| {
+        function_span.file_id == span.file_id
+            && function_span.byte_offset <= span.byte_offset
+            && span.end() <= function_span.end()
+    })
+}
+
 fn collect_bindings(
     facts: &Facts,
     unused: &mut UnusedInfo,
     sources: &HashMap<u32, &str>,
+    erroring_functions: &[Span],
     out: &mut Vec<LisetteDiagnostic>,
 ) {
     for b in facts.bindings.values() {
@@ -159,7 +194,7 @@ fn collect_bindings(
             unused.mark_binding_unused(b.span);
         }
 
-        if b.kind.is_mutable() && !b.mutated {
+        if b.kind.is_mutable() && !b.mutated && !within_any(erroring_functions, b.span) {
             let mut diagnostic = diagnostics::lint::unused_mut(&b.span);
             if let Some(deletion) = mut_keyword_deletion(sources, b.span) {
                 diagnostic =

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -211,6 +211,8 @@ impl InferCtx<'_, '_> {
 
         self.unify(expected_ty, &fn_ty, &span);
 
+        self.facts.add_function_span(span);
+
         Expression::Function {
             doc,
             attributes,
@@ -400,6 +402,7 @@ impl InferCtx<'_, '_> {
             &param_mutability,
             &callee_expression,
         );
+
         self.check_range_to_for_variadic(&new_args, &variadic_elem_ty);
 
         if let Some(idx) = substring_range_idx
@@ -407,6 +410,11 @@ impl InferCtx<'_, '_> {
         {
             self.validate_substring_range_arg(arg);
         }
+
+        let callee_is_unresolved = callee_expression
+            .get_type()
+            .resolve_in(&self.env)
+            .is_error();
 
         let new_spread = (*spread).map(|spread_expr| match variadic_elem_ty {
             Some(elem_ty) => {
@@ -425,8 +433,10 @@ impl InferCtx<'_, '_> {
                 inferred
             }
             None => {
-                self.sink
-                    .push(diagnostics::infer::spread_on_non_variadic(span));
+                if !callee_is_unresolved {
+                    self.sink
+                        .push(diagnostics::infer::spread_on_non_variadic(span));
+                }
                 self.with_value_context(|s| s.infer_expression(spread_expr, &Type::Error))
             }
         });

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -69,6 +69,10 @@ pub struct Facts {
     /// Spans of binary expressions the checker rejected, so lints can skip them.
     pub type_error_spans: HashSet<Span>,
 
+    /// Span of every inferred function, so lints can attribute errors to
+    /// the containing function.
+    pub function_spans: Vec<Span>,
+
     /// Resolved type for each generic-bound annotation, keyed by the
     /// annotation's span. Lets emit render bounds from the resolved type
     /// instead of re-resolving the annotation.
@@ -129,6 +133,7 @@ impl Facts {
             select_exhaustiveness_checks: Vec::new(),
             or_pattern_error_spans: HashSet::default(),
             type_error_spans: HashSet::default(),
+            function_spans: Vec::new(),
             usages: Vec::new(),
             usage_set: HashSet::default(),
             interface_satisfied_methods: HashMap::default(),
@@ -184,6 +189,10 @@ impl Facts {
             fact.mutated = true;
             fact.alias_mutated = true;
         }
+    }
+
+    pub fn add_function_span(&mut self, span: Span) {
+        self.function_spans.push(span);
     }
 
     pub fn binding_checkpoint(&self) -> BindingId {
@@ -286,6 +295,7 @@ impl Facts {
             select_exhaustiveness_checks,
             or_pattern_error_spans,
             type_error_spans,
+            function_spans,
             usages,
             usage_set: _,
             interface_satisfied_methods,
@@ -319,6 +329,7 @@ impl Facts {
             .extend(select_exhaustiveness_checks);
         self.or_pattern_error_spans.extend(or_pattern_error_spans);
         self.type_error_spans.extend(type_error_spans);
+        self.function_spans.extend(function_spans);
 
         self.usages.reserve(usages.len());
         self.usage_set.reserve(usages.len());

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -91,10 +91,6 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
         let typed_expression =
             InferCtx::new(&mut checker, &store).infer_expression(expression, &type_var);
         typed_ast.push(typed_expression);
-
-        if checker.failed() {
-            break;
-        }
     }
 
     {
@@ -110,10 +106,6 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     typed_ast =
         semantics::checker::freeze::FreezeFolder::new(&checker.env, &store).freeze_items(typed_ast);
 
-    if checker.failed() {
-        return vec![];
-    }
-
     let typed_file = File {
         id: file_id,
         module_id: TEST_MODULE_ID.to_string(),
@@ -126,11 +118,32 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     store.store_file(TEST_MODULE_ID, typed_file);
     store.build_closed_domains();
 
+    let inference_len = sink.len();
+
     let analysis = semantics::context::AnalysisContext::new(&store, &checker.ufcs_methods);
     let mut unused = UnusedInfo::default();
     passes::run(&analysis, &mut checker.facts, &sink, &mut unused, true);
 
-    sink.take()
+    // Deferred inference errors surface during passes::run, mixed in with
+    // the error-severity lint diagnostics the tests assert on.
+    let deferred_codes = [
+        "infer.statement_as_tail",
+        "infer.type_not_inferred",
+        "infer.missing_type_argument",
+    ];
+    let mut all_diagnostics = sink.take();
+    let pass_diagnostics = all_diagnostics.split_off(inference_len);
+    let mut diagnostics: Vec<LisetteDiagnostic> = all_diagnostics
+        .into_iter()
+        .filter(|diagnostic| !diagnostic.is_error())
+        .collect();
+    diagnostics.extend(pass_diagnostics.into_iter().filter(|diagnostic| {
+        !diagnostic.is_error()
+            || !diagnostic
+                .code_str()
+                .is_some_and(|code| deferred_codes.contains(&code))
+    }));
+    diagnostics
 }
 
 pub fn apply_lint_fixes(source: &str) -> String {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -10898,6 +10898,21 @@ fn test(args: Slice<int>) {
 }
 
 #[test]
+fn spread_on_unresolved_callee_not_judged_non_variadic() {
+    let input = r#"
+fn test(args: Slice<int>) {
+  nofn(args...)
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        !has_code(&result, "spread_on_non_variadic"),
+        "an unresolved callee's variadic-ness is unknowable, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn infer_variadic_param_not_last() {
     let input = r#"
 fn test(rest: VarArgs<int>, trailing: int) -> int {

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -127,6 +127,84 @@ fn main() {
 }
 
 #[test]
+fn erroring_function_suppresses_unnecessary_mut() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut file_names: Slice<string> = []
+  file_names.add("x")
+}
+"#
+    );
+}
+
+#[test]
+fn erroring_function_suppresses_unnecessary_mut_for_unrelated_binding() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut n = 1
+  let _ = n
+  nofn()
+}
+"#
+    );
+}
+
+#[test]
+fn erroring_function_suppression_is_function_scoped() {
+    assert_lint_snapshot!(
+        r#"
+fn broken() {
+  let mut a = 1
+  a.nope()
+}
+
+fn clean() {
+  let mut b = 2
+  let _ = b
+}
+
+fn main() {
+  broken()
+  clean()
+}
+"#
+    );
+}
+
+#[test]
+fn deferred_error_suppresses_unnecessary_mut() {
+    assert_no_lint_warnings!(
+        r#"
+fn f() {
+  let mut x = 1
+  let _ = x
+  let empty = []
+  let _ = empty
+}
+
+fn main() {
+  f()
+}
+"#
+    );
+}
+
+#[test]
+fn lambda_error_suppresses_enclosing_function_unnecessary_mut() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut n = 5
+  let _ = [1].map(|x| x.gone())
+  let _ = n
+}
+"#
+    );
+}
+
+#[test]
 fn mut_param_no_unnecessary_mut_warning() {
     assert_no_lint_warnings!(
         r#"
@@ -7806,7 +7884,8 @@ struct User {
 
 fn main() {
   let u = User { id: 1, name: "Alice" }
-  u.id + u.name.len() as int
+  let _ = u.id
+  let _ = u.name
 }
 "#
     );

--- a/tests/ui/lint/snapshots/erroring_function_suppression_is_function_scoped.snap
+++ b/tests/ui/lint/snapshots/erroring_function_suppression_is_function_scoped.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused `mut`
+   ╭─[test.lis:8:11]
+ 7 │ fn clean() {
+ 8 │   let mut b = 2
+   ·           ┬
+   ·           ╰── declared as mutable
+ 9 │   let _ = b
+   ╰────
+  help: Remove `mut` from the declaration if you do not need to mutate the variable · code: [lint.unnecessary_mut]


### PR DESCRIPTION
The `unnecessary_mut` lint no longer fires inside a function whose body has a type or resolution error, since the failed expression may have been the mutation.