### PR TITLE
feat: extend `mut` aliasing protection to collection wrappers

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -529,21 +529,59 @@ pub fn mut_binding_aliases(
     binding_name: &str,
     source: &str,
     addressable: bool,
+    clone_severs: bool,
     span: Span,
 ) -> LisetteDiagnostic {
-    let help = if addressable {
-        format!(
-            "Mutating `{binding_name}` would implicitly mutate `{source}`. Either use `{source}.clone()` to make a copy or `&{source}` to take a reference."
-        )
-    } else {
-        format!(
-            "Mutating `{binding_name}` would implicitly mutate `{source}`. Use `{source}.clone()` to make a copy."
-        )
+    let target = mutation_target(binding_name, source);
+    let help = match (clone_severs, addressable) {
+        (true, true) => format!(
+            "Mutating `{binding_name}` would implicitly mutate {target}. Either use `{source}.clone()` to make a copy or `&{source}` to take a reference."
+        ),
+        (true, false) => format!(
+            "Mutating `{binding_name}` would implicitly mutate {target}. Use `{source}.clone()` to make a copy."
+        ),
+        (false, true) => format!(
+            "Mutating `{binding_name}` would implicitly mutate {target}. Either use `&{source}` to take a reference or construct a new value to mutate independently."
+        ),
+        (false, false) => format!(
+            "Mutating `{binding_name}` would implicitly mutate {target}. Construct a new value to mutate independently."
+        ),
     };
     LisetteDiagnostic::error(format!("Cannot make a mutable binding to `{source}`"))
         .with_infer_code("mut_binding_aliases")
         .with_span_label(&span, "would be mutated implicitly")
         .with_help(help)
+}
+
+pub fn mut_binding_clone_does_not_sever(
+    binding_name: &str,
+    source: &str,
+    addressable: bool,
+    span: Span,
+) -> LisetteDiagnostic {
+    let target = mutation_target(binding_name, source);
+    let help = if addressable {
+        format!(
+            "`{source}.clone()` leaves collections inside struct or enum values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Either use `&{source}` to take a reference or construct a new value to mutate independently."
+        )
+    } else {
+        format!(
+            "`{source}.clone()` leaves collections inside struct or enum values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Construct a new value to mutate independently."
+        )
+    };
+    LisetteDiagnostic::error(format!("Cannot make a mutable binding to `{source}`"))
+        .with_infer_code("mut_binding_aliases")
+        .with_span_label(&span, "does not make an independent copy")
+        .with_help(help)
+}
+
+/// A same-name source means the new binding shadows the one it aliases.
+fn mutation_target(binding_name: &str, source: &str) -> String {
+    if binding_name == source {
+        format!("the shadowed `{source}`")
+    } else {
+        format!("`{source}`")
+    }
 }
 
 pub fn uppercase_binding(span: Span, name: &str) -> LisetteDiagnostic {
@@ -3227,6 +3265,20 @@ pub fn immutable_argument_to_mut_param(
     LisetteDiagnostic::error("Immutable argument passed to `mut` parameter")
         .with_infer_code("immutable_arg_to_mut_param")
         .with_span_label(&span, "expected mutable, found immutable")
+        .with_help(help)
+}
+
+pub fn mut_arg_clone_does_not_sever(
+    source: &str,
+    callee_label: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    let help = format!(
+        "`{source}.clone()` leaves collections inside struct or enum values shared, so {callee_label} could still mutate one shared with `{source}`. Construct a new value to pass instead."
+    );
+    LisetteDiagnostic::error("Aliasing argument passed to `mut` parameter")
+        .with_infer_code("mut_arg_clone_does_not_sever")
+        .with_span_label(&span, "does not make an independent copy")
         .with_help(help)
 }
 

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -1,0 +1,103 @@
+use syntax::parse::TUPLE_FIELDS;
+use syntax::types::{CompoundKind, Type};
+
+use crate::Planner;
+use crate::names::go_name;
+
+impl Planner<'_> {
+    pub(crate) fn render_clone(&mut self, value: &str, ty: &Type) -> String {
+        let peeled = self.facts.peel_alias(ty);
+        match &peeled {
+            Type::Compound {
+                kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
+                args,
+            } => match args.first().and_then(|elem| self.element_clone(elem)) {
+                Some(clone) => {
+                    self.require_stdlib();
+                    format!(
+                        "{}.SliceCloneFunc({value}, {clone})",
+                        go_name::GO_STDLIB_PKG
+                    )
+                }
+                None => {
+                    self.require_slices();
+                    format!("slices.Clone({value})")
+                }
+            },
+            Type::Compound {
+                kind: CompoundKind::Map,
+                args,
+            } => match args.get(1).and_then(|v| self.element_clone(v)) {
+                Some(clone) => {
+                    self.require_stdlib();
+                    format!("{}.MapCloneFunc({value}, {clone})", go_name::GO_STDLIB_PKG)
+                }
+                None => {
+                    self.require_maps();
+                    format!("maps.Clone({value})")
+                }
+            },
+            _ => value.to_string(),
+        }
+    }
+
+    fn element_clone(&mut self, ty: &Type) -> Option<String> {
+        if !self.needs_clone(ty) {
+            return None;
+        }
+        let peeled = self.facts.peel_alias(ty);
+        let go_ty = self.go_type_string(ty);
+        match &peeled {
+            Type::Tuple(elems) => {
+                let var = self.fresh_var(Some("e"));
+                let statements = self.tuple_clone_statements(&var, elems);
+                Some(format!(
+                    "func({var} {go_ty}) {go_ty} {{\n{}\nreturn {var}\n}}",
+                    statements.join("\n")
+                ))
+            }
+            _ => {
+                let var = self.fresh_var(Some("e"));
+                let body = self.render_clone(&var, ty);
+                Some(format!("func({var} {go_ty}) {go_ty} {{ return {body} }}"))
+            }
+        }
+    }
+
+    fn tuple_clone_statements(&mut self, place: &str, elems: &[Type]) -> Vec<String> {
+        let mut statements = Vec::new();
+        for (index, elem) in elems.iter().enumerate() {
+            let Some(field) = TUPLE_FIELDS.get(index) else {
+                break;
+            };
+            let field_place = format!("{place}.{field}");
+            let peeled = self.facts.peel_alias(elem);
+            match &peeled {
+                Type::Compound {
+                    kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice | CompoundKind::Map,
+                    ..
+                } => statements.push(format!(
+                    "{field_place} = {}",
+                    self.render_clone(&field_place, elem)
+                )),
+                Type::Tuple(inner) if self.needs_clone(elem) => {
+                    statements.extend(self.tuple_clone_statements(&field_place, inner))
+                }
+                _ => {}
+            }
+        }
+        statements
+    }
+
+    fn needs_clone(&self, ty: &Type) -> bool {
+        let peeled = self.facts.peel_alias(ty);
+        match &peeled {
+            Type::Compound {
+                kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice | CompoundKind::Map,
+                ..
+            } => true,
+            Type::Tuple(elems) => elems.iter().any(|e| self.needs_clone(e)),
+            _ => false,
+        }
+    }
+}

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -1,3 +1,4 @@
+mod clone;
 pub(crate) mod dispatch;
 pub(crate) mod go_interop;
 mod native;

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -9,14 +9,13 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::types::native::NativeGoType;
 use crate::utils::{contains_call, reads_mutable_operand};
 use syntax::ast::Expression;
-use syntax::types::{Type, peel_to_range_type};
+use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
 #[derive(Clone, Copy)]
 pub(super) enum InlineImport {
     None,
     Slices,
     Strings,
-    Maps,
     Stdlib,
 }
 
@@ -81,22 +80,6 @@ static INLINE_METHODS: &[InlineRule] = &[
         template: "{r}",
         negated_template: None,
         import: InlineImport::None,
-    },
-    InlineRule {
-        types: &[N::Slice],
-        method: "clone",
-        arity: 0,
-        template: "slices.Clone({r})",
-        negated_template: None,
-        import: InlineImport::Slices,
-    },
-    InlineRule {
-        types: &[N::Map],
-        method: "clone",
-        arity: 0,
-        template: "maps.Clone({r})",
-        negated_template: None,
-        import: InlineImport::Maps,
     },
     InlineRule {
         types: &[N::String],
@@ -338,6 +321,15 @@ impl Planner<'_> {
             }
         }
 
+        if ctx.method == "clone" {
+            let receiver_ty = self.facts.strip_and_peel(&expression.get_type());
+            if is_cloneable_container(&receiver_ty) {
+                let (setup, receiver, _) = self.stage_native_dot_access_call(ctx);
+                let body = self.render_clone(&receiver, &receiver_ty);
+                return (setup, body);
+            }
+        }
+
         let (setup, receiver, emitted_args) = self.stage_native_dot_access_call(ctx);
 
         if let Some(inlined) = apply_inline_lookup(
@@ -464,6 +456,19 @@ impl Planner<'_> {
                 if emitted_args.len() >= 2 {
                     let body =
                         self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty);
+                    return (setup, body);
+                }
+            }
+        }
+
+        if ctx.method == "clone"
+            && let Some(receiver_expr) = ctx.args.first()
+        {
+            let receiver_ty = self.facts.strip_and_peel(&receiver_expr.get_type());
+            if is_cloneable_container(&receiver_ty) {
+                let (setup, emitted_args) = self.stage_native_identifier_args(ctx);
+                if let Some(receiver) = emitted_args.first() {
+                    let body = self.render_clone(receiver, &receiver_ty);
                     return (setup, body);
                 }
             }
@@ -640,6 +645,16 @@ impl Planner<'_> {
     }
 }
 
+fn is_cloneable_container(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Compound {
+            kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice | CompoundKind::Map,
+            ..
+        }
+    )
+}
+
 fn format_substring_call(receiver: &str, start: Option<&str>, end: Option<&str>) -> String {
     let pkg = go_name::GO_STDLIB_PKG;
     match (start, end) {
@@ -654,7 +669,6 @@ pub(super) fn apply_inline_import(planner: &Planner, import: InlineImport) {
     match import {
         InlineImport::Slices => planner.require_slices(),
         InlineImport::Strings => planner.require_strings(),
-        InlineImport::Maps => planner.require_maps(),
         InlineImport::Stdlib => planner.require_stdlib(),
         InlineImport::None => {}
     }

--- a/crates/semantics/src/checker/infer/carry_mut.rs
+++ b/crates/semantics/src/checker/infer/carry_mut.rs
@@ -21,6 +21,68 @@ pub(super) fn can_carry_mutation_across_fn_boundary(
     can_carry_mutation(ty, env, store, &mut visited)
 }
 
+/// Whether `.clone()` on `ty` fully severs. Only built-in container clones
+/// qualify, and they leave collections inside a nominal element shared, so a
+/// container of such elements does not sever.
+pub(super) fn clone_severs_alias(ty: &Type, env: &TypeEnv, store: &Store) -> bool {
+    let resolved = store.peel_alias(&ty.resolve_in(env));
+    match &resolved {
+        Type::Compound {
+            kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
+            args,
+        } => args
+            .first()
+            .is_some_and(|elem| element_severed(elem, env, store)),
+        Type::Compound {
+            kind: CompoundKind::Map,
+            args,
+        } => args
+            .get(1)
+            .is_some_and(|value| element_severed(value, env, store)),
+        _ => false,
+    }
+}
+
+/// Whether the built-in clone fully copies this element: scalars and nested
+/// containers/tuples do, a carry-mut nominal does not (it copies shallowly).
+fn element_severed(ty: &Type, env: &TypeEnv, store: &Store) -> bool {
+    let resolved = store.peel_alias(&ty.resolve_in(env));
+    if !can_carry_mutation_across_fn_boundary(&resolved, env, store) {
+        return true;
+    }
+    match &resolved {
+        Type::Compound {
+            kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
+            args,
+        } => args
+            .first()
+            .is_some_and(|elem| element_severed(elem, env, store)),
+        Type::Compound {
+            kind: CompoundKind::Map,
+            args,
+        } => args
+            .get(1)
+            .is_some_and(|value| element_severed(value, env, store)),
+        Type::Tuple(elems) => elems.iter().all(|e| element_severed(e, env, store)),
+        Type::Forall { body, .. } => element_severed(body, env, store),
+        _ => false,
+    }
+}
+
+/// Whether `.clone()` on `ty` is a built-in container clone (depth the
+/// compiler controls). A nominal `.clone()` is user-written, so it is treated
+/// as an ordinary call producing a fresh value.
+pub(super) fn clone_recipe_is_known(ty: &Type, env: &TypeEnv, store: &Store) -> bool {
+    let resolved = store.peel_alias(&ty.resolve_in(env));
+    matches!(
+        resolved,
+        Type::Compound {
+            kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice | CompoundKind::Map,
+            ..
+        }
+    )
+}
+
 fn can_carry_mutation(
     ty: &Type,
     env: &TypeEnv,

--- a/crates/semantics/src/checker/infer/expressions/aliasing.rs
+++ b/crates/semantics/src/checker/infer/expressions/aliasing.rs
@@ -1,42 +1,123 @@
 use syntax::ast::{Expression, Literal, UnaryOperator};
-use syntax::types::{CompoundKind, Type};
+use syntax::program::CallKind;
 
-use crate::checker::EnvResolve;
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::addressability::check_is_non_addressable;
+use crate::checker::infer::carry_mut::{
+    can_carry_mutation_across_fn_boundary, clone_recipe_is_known, clone_severs_alias,
+};
 
 impl InferCtx<'_, '_> {
-    /// A mutable binding initialized or reassigned from a place expression of
-    /// a directly aliasable type would share the source's backing storage, so
-    /// writes through the binding would also be visible through the source.
+    /// Reject a mutable binding that would alias a carry-mut place. A
+    /// `clone()` of the place is exempt only when the clone actually severs.
     pub(super) fn check_mut_binding_alias(&mut self, binding_name: &str, value: &Expression) {
-        let place = value.unwrap_parens();
+        let expr = value.unwrap_parens();
+        let (place, via_clone) = match clone_call_receiver(expr) {
+            Some(receiver) => (receiver.unwrap_parens(), true),
+            None => (expr, false),
+        };
         if !is_aliasing_place(place) {
             return;
         }
-        if !self.is_directly_aliasable(&value.get_type()) {
+        let rooted_in_binding = place_root_name(place)
+            .is_some_and(|root| self.scopes.lookup_binding_id(&root).is_some());
+        if !rooted_in_binding {
+            return;
+        }
+        let ty = if via_clone {
+            place.get_type()
+        } else {
+            value.get_type()
+        };
+        if !can_carry_mutation_across_fn_boundary(&ty, &self.env, self.store) {
+            return;
+        }
+        if via_clone && !clone_recipe_is_known(&ty, &self.env, self.store) {
+            return;
+        }
+        let clone_severs = clone_severs_alias(&ty, &self.env, self.store);
+        if via_clone && clone_severs {
             return;
         }
         let source = render_place(place);
         let addressable = check_is_non_addressable(place, &self.env).is_none();
-        self.sink.push(diagnostics::infer::mut_binding_aliases(
-            binding_name,
-            &source,
-            addressable,
-            value.get_span(),
-        ));
+        let diagnostic = if via_clone {
+            diagnostics::infer::mut_binding_clone_does_not_sever(
+                binding_name,
+                &source,
+                addressable,
+                value.get_span(),
+            )
+        } else {
+            diagnostics::infer::mut_binding_aliases(
+                binding_name,
+                &source,
+                addressable,
+                clone_severs,
+                value.get_span(),
+            )
+        };
+        self.sink.push(diagnostic);
     }
 
-    fn is_directly_aliasable(&self, ty: &Type) -> bool {
-        let resolved = ty.resolve_in(&self.env);
-        let peeled = self.store.peel_alias(&resolved);
-        matches!(
-            peeled,
-            Type::Compound {
-                kind: CompoundKind::Slice | CompoundKind::Map | CompoundKind::EnumeratedSlice,
-                ..
-            }
-        )
+    /// Source of a `.clone()` of a local carry-mut place that the clone does
+    /// not fully sever, or `None` when the clone is fresh, opaque, or severing.
+    pub(super) fn non_severing_clone_source(&self, value: &Expression) -> Option<String> {
+        let receiver = clone_call_receiver(value.unwrap_parens())?;
+        let place = receiver.unwrap_parens();
+        if !is_aliasing_place(place) {
+            return None;
+        }
+        let root = place_root_name(place)?;
+        self.scopes.lookup_binding_id(&root)?;
+        let ty = place.get_type();
+        if !can_carry_mutation_across_fn_boundary(&ty, &self.env, self.store) {
+            return None;
+        }
+        if !clone_recipe_is_known(&ty, &self.env, self.store) {
+            return None;
+        }
+        if clone_severs_alias(&ty, &self.env, self.store) {
+            return None;
+        }
+        Some(render_place(place))
+    }
+}
+
+/// The receiver of a `clone()` call written as `x.clone()`, `Type.clone(x)`,
+/// or `Slice.clone(x)`. `None` for a free function named `clone` (UFCS).
+pub(super) fn clone_call_receiver(expression: &Expression) -> Option<&Expression> {
+    let Expression::Call {
+        expression: callee,
+        args,
+        call_kind,
+        ..
+    } = expression
+    else {
+        return None;
+    };
+    match callee.unwrap_parens() {
+        Expression::DotAccess {
+            expression, member, ..
+        } if member == "clone"
+            && args.is_empty()
+            && !matches!(call_kind, Some(CallKind::UfcsMethod)) =>
+        {
+            Some(expression)
+        }
+        Expression::Identifier { .. }
+            if args.len() == 1
+                && matches!(
+                    call_kind,
+                    Some(CallKind::NativeMethodIdentifier(_) | CallKind::ReceiverMethodUfcs { .. })
+                )
+                && callee
+                    .get_var_name()
+                    .is_some_and(|name| name.ends_with(".clone")) =>
+        {
+            args.first()
+        }
+        _ => None,
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1445,6 +1445,15 @@ impl InferCtx<'_, '_> {
         if !can_carry_mutation_across_fn_boundary(param_ty, &self.env, store) {
             return;
         }
+        if let Some(source) = self.non_severing_clone_source(arg) {
+            self.sink
+                .push(diagnostics::infer::mut_arg_clone_does_not_sever(
+                    &source,
+                    callee_label,
+                    arg.get_span(),
+                ));
+            return;
+        }
         let Some(var_name) = arg.get_var_name() else {
             return;
         };

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -411,8 +411,12 @@ impl InferCtx<'_, '_> {
                     .push(diagnostics::infer::self_reference_in_assignment(span));
             }
 
-            let self_sourced = super::aliasing::place_root_name(new_value.unwrap_parens())
-                .is_some_and(|root| root == var_name);
+            let value_expr = new_value.unwrap_parens();
+            let value_place = super::aliasing::clone_call_receiver(value_expr)
+                .map(|receiver| receiver.unwrap_parens())
+                .unwrap_or(value_expr);
+            let self_sourced =
+                super::aliasing::place_root_name(value_place).is_some_and(|root| root == var_name);
             if compound_operator.is_none() && is_simple_target && is_mutable && !self_sourced {
                 self.check_mut_binding_alias(&var_name, &new_value);
             }

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -328,7 +328,7 @@ impl<T> Slice<T> {
   /// Returns an enumerated slice for indexed iteration.
   fn enumerate(self) -> EnumeratedSlice<T>
 
-  /// Returns a shallow copy of the slice.
+  /// Returns a copy, including any nested slices, maps, and tuples.
   fn clone(self) -> Slice<T>
 }
 
@@ -344,6 +344,10 @@ impl<T> EnumeratedSlice<T> {
   fn fold<U>(self, accumulator: U, f: fn(U, (int, T)) -> U) -> U
 
   fn find(self, f: fn((int, T)) -> bool) -> Option<(int, T)>
+
+  /// Returns a copy of the underlying slice, including any nested slices,
+  /// maps, and tuples.
+  fn clone(self) -> EnumeratedSlice<T>
 }
 
 impl Slice<string> {
@@ -378,7 +382,7 @@ impl<K, V> Map<K, V> {
   /// Creates a map from a slice of key-value pairs.
   fn from(pairs: Slice<(K, V)>) -> Map<K, V>
 
-  /// Returns a shallow copy of the map.
+  /// Returns a copy, including any nested slices, maps, and tuples.
   fn clone(self) -> Map<K, V>
 
   /// Returns `true` if this map has the same keys and values as `other`.

--- a/docs/intro/safety.md
+++ b/docs/intro/safety.md
@@ -302,7 +302,7 @@ b := a
 b[0] = 99 // `a` is now [99 2 3]
 ```
 
-In Lisette, a mutable binding must own its value. Creating one from an existing binding, field, or index of a slice or map is a compile error:
+In Lisette, a mutable binding must own its value. Creating one from an existing binding, field, or element whose type holds a slice or map (directly, or nested inside a struct, tuple, or enum) is a compile error:
 
 ```
   ✕ Cannot make a mutable binding to `a`

--- a/docs/reference/02-types.md
+++ b/docs/reference/02-types.md
@@ -274,7 +274,7 @@ let mut count = 0
 count += 1
 ```
 
-A mutable binding must own its value. Initializing or reassigning a mutable binding from an existing binding, field, or index of a `Slice` or `Map` would share the source's backing storage, so the compiler rejects it. Use `.clone()` for an independent copy, or `&` to share the value intentionally through a reference.
+A mutable binding must own its value. Initializing or reassigning one from an existing binding, field, or element whose type holds a `Slice` or `Map` (directly, or nested inside a struct, tuple, or enum) would share the source's backing storage, so the compiler rejects it. Use `.clone()` for an independent copy, or `&` to share the value intentionally through a reference.
 
 ```rust
 let a = [1, 2, 3]

--- a/prelude/map.go
+++ b/prelude/map.go
@@ -15,3 +15,14 @@ func MapFrom[K comparable, V any](pairs []Tuple2[K, V]) map[K]V {
 	}
 	return result
 }
+
+func MapCloneFunc[M ~map[K]V, K comparable, V any](m M, clone func(V) V) M {
+	if m == nil {
+		return nil
+	}
+	out := make(M, len(m))
+	for k, v := range m {
+		out[k] = clone(v)
+	}
+	return out
+}

--- a/prelude/slice.go
+++ b/prelude/slice.go
@@ -98,3 +98,14 @@ func SliceToAny[T any](s []T) []any {
 	}
 	return out
 }
+
+func SliceCloneFunc[S ~[]E, E any](s S, clone func(E) E) S {
+	if s == nil {
+		return nil
+	}
+	out := make(S, len(s))
+	for i, v := range s {
+		out[i] = clone(v)
+	}
+	return out
+}

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -225,3 +225,19 @@ fn map_equals() {
   let c = Map.from([("x", 2)])
   assert a.equals(b) && !a.equals(c)
 }
+
+#[test]
+fn nested_slice_clone_severs() {
+  let a = [[1, 2], [3, 4]]
+  let mut b = a.clone()
+  b[0][0] = 9
+  assert a[0][0] == 1 && b[0][0] == 9
+}
+
+#[test]
+fn map_slice_values_clone_severs() {
+  let m = Map.from([("k", [1, 2])])
+  let mut m2 = m.clone()
+  m2["k"][0] = 9
+  assert m["k"][0] == 1 && m2["k"][0] == 9
+}

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2372,7 +2372,7 @@ struct Box {
 fn main() {
   let mut m = Map.new<string, Box>()
   m["a"] = Box { items: [] }
-  let mut entry = m["a"]
+  let mut entry = Box { items: m["a"].items.clone() }
   entry.items = entry.items.append(1)
   m["a"] = entry
 }
@@ -2403,7 +2403,7 @@ fn map_entry_slice_append_tuple_field() {
 fn main() {
   let mut m = Map.new<string, (Slice<int>, int)>()
   m["a"] = ([1], 2)
-  let mut entry = m["a"]
+  let mut entry = (m["a"].0.clone(), m["a"].1)
   entry.0 = entry.0.append(3)
   m["a"] = entry
 }
@@ -2419,7 +2419,7 @@ struct Wrap(Slice<int>, int)
 fn main() {
   let mut m = Map.new<string, Wrap>()
   m["a"] = Wrap([], 0)
-  let mut entry = m["a"]
+  let mut entry = Wrap(m["a"].0.clone(), m["a"].1)
   entry.0 = entry.0.append(2)
   m["a"] = entry
 }
@@ -2452,7 +2452,7 @@ struct Wrap(Inner)
 fn main() {
   let mut m = Map.new<string, Wrap>()
   m["a"] = Wrap(Inner { items: [] })
-  let mut inner = m["a"].0
+  let mut inner = Inner { items: m["a"].0.items.clone() }
   inner.items = inner.items.append(1)
   m["a"] = Wrap(inner)
 }
@@ -2475,7 +2475,7 @@ fn main() {
   let mut m = Map.new<string, Box>()
   m["a"] = Box { items: [] }
   let mut map = get_map(m)
-  let mut entry = map["a"]
+  let mut entry = Box { items: map["a"].items.clone() }
   entry.items = entry.items.append(1)
   map["a"] = entry
 }
@@ -2494,7 +2494,7 @@ fn main() {
   let mut m = Map.new<string, Box>()
   m["a"] = Box { items: [] }
   let r = &m
-  let mut entry = r.*["a"]
+  let mut entry = Box { items: r.*["a"].items.clone() }
   entry.items = entry.items.append(1)
   r.*["a"] = entry
 }
@@ -3433,7 +3433,7 @@ struct Wrap(Pair)
 
 fn main() {
   let mut w = Wrap(Pair([1], 0))
-  let mut p = w.0
+  let mut p = Pair(w.0.0.clone(), w.0.1)
   p.0 = p.0.append(2)
   w = Wrap(p)
   let _ = w
@@ -3563,7 +3563,7 @@ fn main() {
   let mut m = Map.new<string, Ref<Wrap>>()
   m["a"] = &w
   let Some(r) = m.get("a") else { return; };
-  let mut inner = r.0
+  let mut inner = Inner { items: r.0.items.clone() }
   inner.items = inner.items.append(2)
   r.* = Wrap(inner)
   let _ = w
@@ -3622,7 +3622,7 @@ fn main() {
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer { w: &w }
   let Some(o) = m.get("a") else { return; };
-  let mut inner = o.w.0
+  let mut inner = Inner { items: o.w.0.items.clone() }
   inner.items = inner.items.append(2)
   o.w.* = Wrap(inner)
   let _ = w
@@ -3790,7 +3790,7 @@ fn main() {
   let mut m = Map.new<string, Outer>()
   m["a"] = Outer{ items: [1] }
   let k = key()
-  let mut entry = m[k]
+  let mut entry = Outer { items: m[k].items.clone() }
   entry.items = entry.items.append(2)
   m[k] = entry
 }

--- a/tests/spec/emit/snapshots/block_expr_append_map_entry_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_map_entry_no_double_eval.snap
@@ -10,12 +10,14 @@ description: |
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer{ items: [1] }
     let k = key()
-    let mut entry = m[k]
+    let mut entry = Outer { items: m[k].items.clone() }
     entry.items = entry.items.append(2)
     m[k] = entry
   }
 ---
 package main
+
+import "slices"
 
 type Outer struct {
 	items []int
@@ -29,7 +31,7 @@ func main() {
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: []int{1}}
 	k := key()
-	entry := m[k]
+	entry := Outer{items: slices.Clone(m[k].items)}
 	entry.items = append(entry.items, 2)
 	m[k] = entry
 }

--- a/tests/spec/emit/snapshots/clone_container_of_user_clone_stays_shallow.snap
+++ b/tests/spec/emit/snapshots/clone_container_of_user_clone_stays_shallow.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Doc { tags: Slice<string> }
+  
+  impl Doc {
+    fn clone(self) -> Doc {
+      Doc { tags: self.tags.clone() }
+    }
+  }
+  
+  fn main() {
+    let docs = [Doc { tags: ["x"] }]
+    let copy = docs.clone()
+    let _ = docs
+    let _ = copy
+  }
+---
+package main
+
+import "slices"
+
+type Doc struct {
+	tags []string
+}
+
+func (d Doc) clone() Doc {
+	return Doc{tags: slices.Clone(d.tags)}
+}
+
+func main() {
+	docs := []Doc{Doc{tags: []string{"x"}}}
+	copy_ := slices.Clone(docs)
+	_ = docs
+	_ = copy_
+}

--- a/tests/spec/emit/snapshots/clone_enumerated_slice.snap
+++ b/tests/spec/emit/snapshots/clone_enumerated_slice.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn main() {
+    let s = [1, 2, 3]
+    let e = s.enumerate()
+    let mut e2 = e.clone()
+    e2 = s.enumerate()
+    let _ = e
+    let _ = e2
+  }
+---
+package main
+
+import "slices"
+
+func main() {
+	s := []int{1, 2, 3}
+	e := s
+	e2 := slices.Clone(e)
+	e2 = s
+	_ = e
+	_ = e2
+}

--- a/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
+++ b/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn main() {
+    let m = Map.from([("k", [1, 2])])
+    let mut m2 = m.clone()
+    m2["k"] = [9]
+    let _ = m
+    let _ = m2
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
+
+func main() {
+	m := lisette.MapFrom([]lisette.Tuple2[string, []int]{lisette.MakeTuple2("k", []int{1, 2})})
+	m2 := lisette.MapCloneFunc(m, func(e_1 []int) []int { return slices.Clone(e_1) })
+	m2["k"] = []int{9}
+	_ = m
+	_ = m2
+}

--- a/tests/spec/emit/snapshots/clone_nested_slice_deep.snap
+++ b/tests/spec/emit/snapshots/clone_nested_slice_deep.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn main() {
+    let a = [[1, 2], [3, 4]]
+    let mut b = a.clone()
+    b[0][0] = 9
+    let _ = a
+    let _ = b
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
+
+func main() {
+	a := [][]int{[]int{1, 2}, []int{3, 4}}
+	b := lisette.SliceCloneFunc(a, func(e_1 []int) []int { return slices.Clone(e_1) })
+	b[0][0] = 9
+	_ = a
+	_ = b
+}

--- a/tests/spec/emit/snapshots/clone_slice_of_tuples_deep.snap
+++ b/tests/spec/emit/snapshots/clone_slice_of_tuples_deep.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn main() {
+    let a = [(1, [2, 3])]
+    let mut b = a.clone()
+    b[0] = (4, [5])
+    let _ = a
+    let _ = b
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
+
+func main() {
+	a := []lisette.Tuple2[int, []int]{lisette.MakeTuple2(1, []int{2, 3})}
+	b := lisette.SliceCloneFunc(a, func(e_1 lisette.Tuple2[int, []int]) lisette.Tuple2[int, []int] {
+		e_1.Second = slices.Clone(e_1.Second)
+		return e_1
+	})
+	b[0] = lisette.MakeTuple2(4, []int{5})
+	_ = a
+	_ = b
+}

--- a/tests/spec/emit/snapshots/clone_user_method_dispatched.snap
+++ b/tests/spec/emit/snapshots/clone_user_method_dispatched.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Doc { tags: Slice<string> }
+  
+  impl Doc {
+    fn clone(self) -> Doc {
+      Doc { tags: self.tags.clone() }
+    }
+  }
+  
+  fn main() {
+    let d1 = Doc { tags: ["x"] }
+    let mut d2 = d1.clone()
+    d2.tags[0] = "y"
+    let _ = d1
+    let _ = d2
+  }
+---
+package main
+
+import "slices"
+
+type Doc struct {
+	tags []string
+}
+
+func (d Doc) clone() Doc {
+	return Doc{tags: slices.Clone(d.tags)}
+}
+
+func main() {
+	d1 := Doc{tags: []string{"x"}}
+	d2 := d1.clone()
+	d2.tags[0] = "y"
+	_ = d1
+	_ = d2
+}

--- a/tests/spec/emit/snapshots/map_entry_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append.snap
@@ -9,12 +9,14 @@ description: |
   fn main() {
     let mut m = Map.new<string, Box>()
     m["a"] = Box { items: [] }
-    let mut entry = m["a"]
+    let mut entry = Box { items: m["a"].items.clone() }
     entry.items = entry.items.append(1)
     m["a"] = entry
   }
 ---
 package main
+
+import "slices"
 
 type Box struct {
 	items []int
@@ -23,7 +25,7 @@ type Box struct {
 func main() {
 	m := make(map[string]Box)
 	m["a"] = Box{}
-	entry := m["a"]
+	entry := Box{items: slices.Clone(m["a"].items)}
 	entry.items = append(entry.items, 1)
 	m["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -10,12 +10,14 @@ description: |
     let mut m = Map.new<string, Box>()
     m["a"] = Box { items: [] }
     let r = &m
-    let mut entry = r.*["a"]
+    let mut entry = Box { items: r.*["a"].items.clone() }
     entry.items = entry.items.append(1)
     r.*["a"] = entry
   }
 ---
 package main
+
+import "slices"
 
 type Box struct {
 	items []int
@@ -25,7 +27,7 @@ func main() {
 	m := make(map[string]Box)
 	m["a"] = Box{}
 	r := &m
-	entry := (*r)["a"]
+	entry := Box{items: slices.Clone((*r)["a"].items)}
 	entry.items = append(entry.items, 1)
 	(*r)["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
@@ -14,12 +14,14 @@ description: |
     let mut m = Map.new<string, Box>()
     m["a"] = Box { items: [] }
     let mut map = get_map(m)
-    let mut entry = map["a"]
+    let mut entry = Box { items: map["a"].items.clone() }
     entry.items = entry.items.append(1)
     map["a"] = entry
   }
 ---
 package main
+
+import "slices"
 
 type Box struct {
 	items []int
@@ -33,7 +35,7 @@ func main() {
 	m := make(map[string]Box)
 	m["a"] = Box{}
 	map_ := get_map(m)
-	entry := map_["a"]
+	entry := Box{items: slices.Clone(map_["a"].items)}
 	entry.items = append(entry.items, 1)
 	map_["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
@@ -10,12 +10,14 @@ description: |
   fn main() {
     let mut m = Map.new<string, Wrap>()
     m["a"] = Wrap(Inner { items: [] })
-    let mut inner = m["a"].0
+    let mut inner = Inner { items: m["a"].0.items.clone() }
     inner.items = inner.items.append(1)
     m["a"] = Wrap(inner)
   }
 ---
 package main
+
+import "slices"
 
 type Inner struct {
 	items []int
@@ -26,7 +28,7 @@ type Wrap Inner
 func main() {
 	m := make(map[string]Wrap)
 	m["a"] = Wrap(Inner{})
-	inner := Inner(m["a"])
+	inner := Inner{items: slices.Clone(Inner(m["a"]).items)}
 	inner.items = append(inner.items, 1)
 	m["a"] = Wrap(inner)
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_field.snap
@@ -5,19 +5,22 @@ description: |
   fn main() {
     let mut m = Map.new<string, (Slice<int>, int)>()
     m["a"] = ([1], 2)
-    let mut entry = m["a"]
+    let mut entry = (m["a"].0.clone(), m["a"].1)
     entry.0 = entry.0.append(3)
     m["a"] = entry
   }
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
 
 func main() {
 	m := make(map[string]lisette.Tuple2[[]int, int])
 	m["a"] = lisette.MakeTuple2([]int{1}, 2)
-	entry := m["a"]
+	entry := lisette.MakeTuple2(slices.Clone(m["a"].First), m["a"].Second)
 	entry.First = append(entry.First, 3)
 	m["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
@@ -7,12 +7,14 @@ description: |
   fn main() {
     let mut m = Map.new<string, Wrap>()
     m["a"] = Wrap([], 0)
-    let mut entry = m["a"]
+    let mut entry = Wrap(m["a"].0.clone(), m["a"].1)
     entry.0 = entry.0.append(2)
     m["a"] = entry
   }
 ---
 package main
+
+import "slices"
 
 type Wrap struct {
 	F0 []int
@@ -25,7 +27,10 @@ func main() {
 		F0: ([]int)(nil),
 		F1: 0,
 	}
-	entry := m["a"]
+	entry := Wrap{
+		F0: slices.Clone(m["a"].F0),
+		F1: m["a"].F1,
+	}
 	entry.F0 = append(entry.F0, 2)
 	m["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
@@ -11,7 +11,7 @@ description: |
     let mut m = Map.new<string, Outer>()
     m["a"] = Outer { w: &w }
     let Some(o) = m.get("a") else { return; };
-    let mut inner = o.w.0
+    let mut inner = Inner { items: o.w.0.items.clone() }
     inner.items = inner.items.append(2)
     o.w.* = Wrap(inner)
     let _ = w
@@ -19,7 +19,10 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
 
 type Inner struct {
 	items []int
@@ -40,7 +43,7 @@ func main() {
 		return
 	}
 	o := subject_1.SomeVal
-	inner := Inner(*o.w)
+	inner := Inner{items: slices.Clone(Inner(*o.w).items)}
 	inner.items = append(inner.items, 2)
 	*o.w = Wrap(inner)
 	_ = w

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
@@ -10,7 +10,7 @@ description: |
     let mut m = Map.new<string, Ref<Wrap>>()
     m["a"] = &w
     let Some(r) = m.get("a") else { return; };
-    let mut inner = r.0
+    let mut inner = Inner { items: r.0.items.clone() }
     inner.items = inner.items.append(2)
     r.* = Wrap(inner)
     let _ = w
@@ -18,7 +18,10 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
 
 type Inner struct {
 	items []int
@@ -35,7 +38,7 @@ func main() {
 		return
 	}
 	r := subject_1.SomeVal
-	inner := Inner(*r)
+	inner := Inner{items: slices.Clone(Inner(*r).items)}
 	inner.items = append(inner.items, 2)
 	*r = Wrap(inner)
 	_ = w

--- a/tests/spec/emit/snapshots/newtype_tuple_field_append.snap
+++ b/tests/spec/emit/snapshots/newtype_tuple_field_append.snap
@@ -7,13 +7,15 @@ description: |
   
   fn main() {
     let mut w = Wrap(Pair([1], 0))
-    let mut p = w.0
+    let mut p = Pair(w.0.0.clone(), w.0.1)
     p.0 = p.0.append(2)
     w = Wrap(p)
     let _ = w
   }
 ---
 package main
+
+import "slices"
 
 type Pair struct {
 	F0 []int
@@ -27,7 +29,10 @@ func main() {
 		F0: []int{1},
 		F1: 0,
 	})
-	p := Pair(w)
+	p := Pair{
+		F0: slices.Clone(Pair(w).F0),
+		F1: Pair(w).F1,
+	}
 	p.F0 = append(p.F0, 2)
 	w = Wrap(p)
 	_ = w

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -4314,3 +4314,103 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn clone_nested_slice_deep() {
+    let input = r#"
+fn main() {
+  let a = [[1, 2], [3, 4]]
+  let mut b = a.clone()
+  b[0][0] = 9
+  let _ = a
+  let _ = b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn clone_map_slice_values_deep() {
+    let input = r#"
+fn main() {
+  let m = Map.from([("k", [1, 2])])
+  let mut m2 = m.clone()
+  m2["k"] = [9]
+  let _ = m
+  let _ = m2
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn clone_slice_of_tuples_deep() {
+    let input = r#"
+fn main() {
+  let a = [(1, [2, 3])]
+  let mut b = a.clone()
+  b[0] = (4, [5])
+  let _ = a
+  let _ = b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn clone_user_method_dispatched() {
+    let input = r#"
+struct Doc { tags: Slice<string> }
+
+impl Doc {
+  fn clone(self) -> Doc {
+    Doc { tags: self.tags.clone() }
+  }
+}
+
+fn main() {
+  let d1 = Doc { tags: ["x"] }
+  let mut d2 = d1.clone()
+  d2.tags[0] = "y"
+  let _ = d1
+  let _ = d2
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn clone_enumerated_slice() {
+    let input = r#"
+fn main() {
+  let s = [1, 2, 3]
+  let e = s.enumerate()
+  let mut e2 = e.clone()
+  e2 = s.enumerate()
+  let _ = e
+  let _ = e2
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn clone_container_of_user_clone_stays_shallow() {
+    let input = r#"
+struct Doc { tags: Slice<string> }
+
+impl Doc {
+  fn clone(self) -> Doc {
+    Doc { tags: self.tags.clone() }
+  }
+}
+
+fn main() {
+  let docs = [Doc { tags: ["x"] }]
+  let copy = docs.clone()
+  let _ = docs
+  let _ = copy
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -2047,6 +2047,219 @@ fn mut_binding_self_shrink_reassignment_no_error() {
 }
 
 #[test]
+fn mut_binding_from_struct_place_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Doc { tags: Slice<string> }
+
+    fn main() {
+      let d1 = Doc { tags: ["x"] }
+      let mut d2 = d1
+      d2.tags[0] = "y"
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_scalar_struct_no_error() {
+    infer(
+        r#"
+    struct Point { x: int, y: int }
+
+    fn main() {
+      let p1 = Point { x: 1, y: 2 }
+      let mut p2 = p1
+      p2.x = 3
+      let _ = p1
+      let _ = p2
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_tuple_place_single_diagnostic() {
+    let result = infer(
+        r#"
+    fn main() {
+      let t1 = (["x"], 1)
+      let mut t2 = t1
+      t2.0[0] = "y"
+      let _ = t1
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_enum_place_single_diagnostic() {
+    let result = infer(
+        r#"
+    enum Holder { Tags(Slice<string>), Empty }
+
+    fn main() {
+      let h1 = Holder.Tags(["x"])
+      let mut h2 = h1
+      h2 = Holder.Empty
+      let _ = h1
+      let _ = h2
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_nested_slice_clone_no_error() {
+    infer(r#"{ let a = [[1], [2]]; let mut b = a.clone(); b[0][0] = 9; let _ = a; let _ = b }"#)
+        .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_specialized_clone_opaque_no_error() {
+    infer(
+        r#"
+    struct Box<T> { items: Slice<T> }
+
+    impl Box<int> {
+      fn clone(self) -> Box<int> {
+        Box { items: self.items.clone() }
+      }
+    }
+
+    fn main() {
+      let g1 = Box { items: [1] }
+      let mut g2 = g1.clone()
+      g2.items[0] = 9
+      let _ = g1
+      let _ = g2
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_specialized_clone_not_trusted_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Box<T> { items: Slice<T> }
+
+    impl Box<int> {
+      fn clone(self) -> Box<int> {
+        Box { items: self.items.clone() }
+      }
+    }
+
+    fn main() {
+      let g1 = Box { items: ["x"] }
+      let mut g2 = g1
+      g2.items[0] = "y"
+      let _ = g1
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_shadowing_severing_clone_no_error() {
+    infer(
+        r#"
+    fn test() {
+      let a = [[1]]
+      {
+        let mut a = a.clone()
+        a[0][0] = 9
+        let _ = a
+      }
+      let _ = a
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_reassign_own_clone_no_error() {
+    infer(r#"{ let mut b = [[1]]; b = b.clone(); let _ = b }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_user_clone_opaque_no_error() {
+    infer(
+        r#"
+    struct Doc { tags: Slice<string> }
+
+    impl Doc {
+      fn clone(self) -> Doc {
+        Doc { tags: self.tags.clone() }
+      }
+    }
+
+    fn main() {
+      let d1 = Doc { tags: ["x"] }
+      let mut d2 = d1.clone()
+      d2.tags[0] = "y"
+      let _ = d1
+      let _ = d2
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_user_clone_not_vouched_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Doc { tags: Slice<string> }
+
+    impl Doc {
+      fn clone(self) -> Doc {
+        self
+      }
+    }
+
+    fn main() {
+      let d1 = Doc { tags: ["x"] }
+      let mut d2 = d1
+      d2.tags[0] = "y"
+      let _ = d1
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_container_of_user_clone_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Doc { tags: Slice<string> }
+
+    impl Doc {
+      fn clone(self) -> Doc {
+        self
+      }
+    }
+
+    fn main() {
+      let docs = [Doc { tags: ["x"] }]
+      let mut copy = docs.clone()
+      copy[0].tags[0] = "y"
+      let _ = docs
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
 fn float_remainder_by_zero_single_diagnostic() {
     let result = infer(
         r#"

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2220,6 +2220,88 @@ fn my_sort(items: Slice<int>) {
 }
 
 #[test]
+fn mut_param_non_severing_clone_arg_rejected() {
+    infer(
+        r#"
+struct Doc { tags: Slice<string> }
+
+fn touch(mut docs: Slice<Doc>) {
+  docs[0] = Doc { tags: ["z"] }
+}
+
+fn main() {
+  let items = [Doc { tags: ["x"] }]
+  touch(items.clone())
+  let _ = items
+}
+"#,
+    )
+    .assert_infer_code("mut_arg_clone_does_not_sever");
+}
+
+#[test]
+fn mut_param_severing_clone_arg_accepted() {
+    infer(
+        r#"
+fn touch(mut m: Slice<Slice<int>>) {
+  m[0][0] = 9
+}
+
+fn main() {
+  let a = [[1]]
+  touch(a.clone())
+  let _ = a
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_param_user_clone_arg_accepted() {
+    infer(
+        r#"
+struct Box { items: Slice<int> }
+
+impl Box {
+  fn clone(self) -> Box { self }
+}
+
+fn touch(mut b: Box) {
+  b.items[0] = 9
+}
+
+fn main() {
+  let b1 = Box { items: [1] }
+  touch(b1.clone())
+  let _ = b1
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_param_fresh_clone_arg_accepted() {
+    infer(
+        r#"
+fn make() -> Slice<Slice<int>> {
+  [[1]]
+}
+
+fn touch(mut m: Slice<Slice<int>>) {
+  m[0][0] = 9
+}
+
+fn main() {
+  touch(make().clone())
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn mut_int_param_does_not_require_mut_arg() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2445,6 +2445,82 @@ fn test(m: Map<string, Slice<int>>) {
 }
 
 #[test]
+fn infer_mut_binding_aliases_struct() {
+    let input = r#"
+struct Doc { tags: Slice<string> }
+
+fn test(d1: Doc) {
+  let mut d2 = d1
+  d2.tags[0] = "y"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_tuple() {
+    let input = r#"
+fn test(t1: (Slice<string>, int)) {
+  let mut t2 = t1
+  t2.0[0] = "y"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_enum() {
+    let input = r#"
+enum Holder { Tags(Slice<string>), Empty }
+
+fn test(h1: Holder) {
+  let mut h2 = h1
+  h2 = Holder.Empty
+  let _ = h2
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_generic_param_fed() {
+    let input = r#"
+struct Box<T> { items: Slice<T> }
+
+fn test(b1: Box<Slice<int>>) {
+  let mut b2 = b1
+  b2.items[0][0] = 9
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_clone_does_not_sever() {
+    let input = r#"
+struct Doc { tags: Slice<string> }
+
+fn test(docs: Slice<Doc>) {
+  let mut copy = docs.clone()
+  copy[0].tags[0] = "y"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_option() {
+    let input = r#"
+fn test(o1: Option<Slice<int>>) {
+  let mut o2 = o1
+  o2 = None
+  let _ = o2
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_subslice_not_addressable() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_enum.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_enum.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `h1`
+   ╭─[test.lis:5:16]
+ 4 │ fn test(h1: Holder) {
+ 5 │   let mut h2 = h1
+   ·                ─┬
+   ·                 ╰── would be mutated implicitly
+ 6 │   h2 = Holder.Empty
+   ╰────
+  help: Mutating `h2` would implicitly mutate `h1`. Either use `&h1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_generic_param_fed.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_generic_param_fed.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `b1`
+   ╭─[test.lis:5:16]
+ 4 │ fn test(b1: Box<Slice<int>>) {
+ 5 │   let mut b2 = b1
+   ·                ─┬
+   ·                 ╰── would be mutated implicitly
+ 6 │   b2.items[0][0] = 9
+   ╰────
+  help: Mutating `b2` would implicitly mutate `b1`. Either use `&b1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_option.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `o1`
+   ╭─[test.lis:3:16]
+ 2 │ fn test(o1: Option<Slice<int>>) {
+ 3 │   let mut o2 = o1
+   ·                ─┬
+   ·                 ╰── would be mutated implicitly
+ 4 │   o2 = None
+   ╰────
+  help: Mutating `o2` would implicitly mutate `o1`. Either use `&o1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_struct.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `d1`
+   ╭─[test.lis:5:16]
+ 4 │ fn test(d1: Doc) {
+ 5 │   let mut d2 = d1
+   ·                ─┬
+   ·                 ╰── would be mutated implicitly
+ 6 │   d2.tags[0] = "y"
+   ╰────
+  help: Mutating `d2` would implicitly mutate `d1`. Either use `&d1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_tuple.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_tuple.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `t1`
+   ╭─[test.lis:3:16]
+ 2 │ fn test(t1: (Slice<string>, int)) {
+ 3 │   let mut t2 = t1
+   ·                ─┬
+   ·                 ╰── would be mutated implicitly
+ 4 │   t2.0[0] = "y"
+   ╰────
+  help: Mutating `t2` would implicitly mutate `t1`. Either use `&t1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_clone_does_not_sever.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_clone_does_not_sever.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `docs`
+   ╭─[test.lis:5:18]
+ 4 │ fn test(docs: Slice<Doc>) {
+ 5 │   let mut copy = docs.clone()
+   ·                  ──────┬─────
+   ·                        ╰── does not make an independent copy
+ 6 │   copy[0].tags[0] = "y"
+   ╰────
+  help: `docs.clone()` leaves collections inside struct or enum values shared, so mutating one through `copy` could still implicitly mutate `docs`. Either use `&docs` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]


### PR DESCRIPTION
The rule that a mutable binding must own its value now covers collections wrapped in a struct, tuple, or enum.

```
 ✕ Cannot make a mutable binding to `d1`
   ╭─[test.lis:5:16]
 4 │ fn test(d1: Doc) {
 5 │   let mut d2 = d1
   ·                ─┬
   ·                 ╰── would be mutated implicitly
 6 │   d2.tags[0] = "y"
   ╰────
  help: Mutating `d2` would implicitly mutate `d1`. Either use `&d1` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]
```

Follow-up to #951
