### PR TITLE
chore: no false foreign-type errors when editing prelude source

### DIFF
--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -12706,3 +12706,32 @@ async fn inlay_hint_lambda_return_over_index_body() {
     );
     client.shutdown().await;
 }
+
+#[tokio::test]
+async fn opening_prelude_source_reports_no_foreign_type_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let prelude_src = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../stdlib/prelude.d.lis"
+    ))
+    .unwrap();
+    let path = dir.path().join("prelude.d.lis");
+    std::fs::write(&path, &prelude_src).unwrap();
+    let uri = Url::from_file_path(&path).unwrap().to_string();
+
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.open(&uri, &prelude_src).await;
+    let diagnostics = client.await_diagnostics().await;
+
+    let offenders: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("foreign type"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "opening the prelude source must not flag its own impls as foreign: {offenders:?}"
+    );
+    client.shutdown().await;
+}

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -147,7 +147,8 @@ impl TaskState<'_> {
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
 
-        if let Some(type_module) = store.module_for_qualified_name(&receiver_qualified_name)
+        if !is_d_lis
+            && let Some(type_module) = store.module_for_qualified_name(&receiver_qualified_name)
             && type_module != module_id
         {
             self.sink.push(diagnostics::infer::impl_on_foreign_type(


### PR DESCRIPTION
Opening a `.d.lis` declaration file in the editor no longer reports the file's own method impls as `impl_on_foreign_type`. This surfaced when editing the stdlib prelude, where the compiler injects the prelude as one module and analyzes the open file as another, so every `impl` on a prelude type looked foreign.