### PR TITLE
fix: reject type names in value position

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3193,6 +3193,13 @@ pub fn record_struct_value(name: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn type_used_as_value(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot use a type as a value")
+        .with_infer_code("type_used_as_value")
+        .with_span_label(&span, "type names are not runtime values")
+        .with_help(format!("`{name}` refers to a type, not a value"))
+}
+
 pub fn namespace_alias_used_as_value(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot use a module or enum-type alias as a value")
         .with_infer_code("namespace_alias_used_as_value")

--- a/crates/passes/src/passes/checks/native_value_usage.rs
+++ b/crates/passes/src/passes/checks/native_value_usage.rs
@@ -181,13 +181,7 @@ fn resolves_to_struct_kind(qualified: &str, kind: StructKind, store: &Store) -> 
             ty: alias_ty,
             body: DefinitionBody::TypeAlias { .. },
             ..
-        }) => {
-            if let Type::Nominal { id, .. } = alias_ty.unwrap_forall() {
-                store.struct_kind(id) == Some(kind)
-            } else {
-                false
-            }
-        }
+        }) => store.deep_struct_kind(alias_ty.unwrap_forall()) == Some(kind),
         _ => false,
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -341,12 +341,19 @@ impl InferCtx<'_, '_> {
                 .get_definition(qname)
                 .is_some_and(Definition::is_type_definition),
             Expression::DotAccess {
-                expression: inner, ..
-            } => inner
-                .get_type()
-                .shallow_resolve_in(&self.env)
-                .as_import_namespace()
-                .is_some(),
+                expression: inner,
+                member,
+                ..
+            } => {
+                let inner_ty = inner.get_type().shallow_resolve_in(&self.env);
+                let Some(module_id) = inner_ty.as_import_namespace() else {
+                    return false;
+                };
+                let qualified = Symbol::from_parts(module_id, member.as_str());
+                store
+                    .get_definition(&qualified)
+                    .is_some_and(Definition::is_type_definition)
+            }
             _ => false,
         }
     }
@@ -687,6 +694,40 @@ impl InferCtx<'_, '_> {
                         *args.span,
                     ));
             }
+
+            if !self.scopes.is_callee_context()
+                && !self.scopes.is_dot_access_base()
+                && let Some(definition) = store.get_definition(&qualified_name)
+            {
+                let display_name = format!("{}.{}", type_name, args.member_name);
+                match &definition.body {
+                    DefinitionBody::TypeAlias { .. } => {
+                        let diagnostic = match store.deep_struct_kind(definition.ty.unwrap_forall())
+                        {
+                            Some(StructKind::Record) => {
+                                diagnostics::infer::record_struct_value(&display_name, *args.span)
+                            }
+                            Some(StructKind::Tuple) => {
+                                diagnostics::infer::native_constructor_value(
+                                    &display_name,
+                                    *args.span,
+                                )
+                            }
+                            None => {
+                                diagnostics::infer::type_used_as_value(&display_name, *args.span)
+                            }
+                        };
+                        self.sink.push(diagnostic);
+                    }
+                    DefinitionBody::Interface { .. } => {
+                        self.sink.push(diagnostics::infer::type_used_as_value(
+                            &display_name,
+                            *args.span,
+                        ));
+                    }
+                    _ => {}
+                }
+            }
         }
 
         let (module_ty, _) = self.instantiate(&module_ty);
@@ -736,6 +777,13 @@ impl InferCtx<'_, '_> {
             self.as_method_value(args, &mut method_ty, is_exported)
         {
             return Some((expression, value_kind));
+        }
+
+        if self.scopes.is_callee_context() && self.is_type_level_receiver(args.expression) {
+            self.sink.push(diagnostics::infer::type_used_as_value(
+                &args.expression.as_dotted_path().unwrap_or_default(),
+                args.expression.get_span(),
+            ));
         }
 
         let Type::Function(ref mut f) = method_ty else {

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -258,15 +258,17 @@ impl InferCtx<'_, '_> {
                 self.sink
                     .push(diagnostics::infer::test_function_not_callable(span, &value));
             }
-            if let DefinitionBody::TypeAlias { .. } = &definition.body
-                && !self.scopes.is_callee_context()
-                && !self.scopes.is_dot_access_base()
+            let names_a_type = match &definition.body {
+                DefinitionBody::Enum { .. } | DefinitionBody::Interface { .. } => true,
+                DefinitionBody::TypeAlias { .. } => store
+                    .deep_struct_kind(definition.ty.unwrap_forall())
+                    .is_none(),
+                _ => false,
+            };
+            if names_a_type && !self.scopes.is_callee_context() && !self.scopes.is_dot_access_base()
             {
-                let underlying = definition.ty.unwrap_forall();
-                if self.is_enum_type(store, underlying) {
-                    self.sink
-                        .push(diagnostics::infer::namespace_alias_used_as_value(span));
-                }
+                self.sink
+                    .push(diagnostics::infer::type_used_as_value(&value, span));
             }
         }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -437,6 +437,10 @@ impl Store {
         }
     }
 
+    pub fn deep_struct_kind(&self, ty: &Type) -> Option<syntax::ast::StructKind> {
+        self.struct_kind(self.deep_resolve_alias(ty).get_qualified_id()?)
+    }
+
     pub fn struct_constructor(&self, qualified_name: &str) -> Option<&Type> {
         match &self.get_definition(qualified_name)?.body {
             DefinitionBody::Struct { constructor, .. } => constructor.as_ref(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9532,6 +9532,517 @@ fn main() {
 }
 
 #[test]
+fn infer_bare_enum_as_value() {
+    let input = r#"
+enum Color { Red, Blue }
+
+fn main() {
+  let c = Color
+  let _ = c
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_alias_of_collection_as_value() {
+    let input = r#"
+type Rows = Slice<Slice<int>>
+
+fn main() {
+  let c = Rows
+  let _ = c
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_instance_method_called_on_type_alias() {
+    let input = r#"
+type Rows = Slice<Slice<int>>
+
+fn main() {
+  let n = Rows.length()
+  let _ = n
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_scalar_alias_as_value() {
+    let input = r#"
+type Id = int
+
+fn main() {
+  let c = Id
+  let _ = c
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "a scalar type alias in value position must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_struct_names_stay_owned_by_native_value_pass() {
+    let input = r#"
+struct Coord { x: int, y: int }
+type Alias = Coord
+
+fn main() {
+  let a = Coord
+  let b = Alias
+  let _ = a
+  let _ = b
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "record_struct_value"),
+        "bare struct and struct-alias names must be rejected by the native_value_usage pass, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "struct names must not double-fire type_used_as_value from infer_identifier, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_multi_hop_struct_alias_stays_struct_diagnostic() {
+    let input = r#"
+struct Coord { x: int, y: int }
+type A = Coord
+type B = A
+
+fn main() {
+  let b = B
+  let _ = b
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "record_struct_value"),
+        "a multi-hop struct alias must get the struct-literal diagnostic, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "a multi-hop struct alias must not fall through to the generic type diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_struct_alias_stays_struct_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Point { pub x: int, pub y: int }
+pub type P = Point
+"#,
+    );
+    let source = r#"
+import "geo"
+
+fn main() {
+  let x = geo.P
+  let _ = x
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "record_struct_value"),
+        "an imported struct alias must get the struct-literal diagnostic, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "an imported struct alias must not fall through to the generic type diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_tuple_struct_alias_stays_constructor_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Pair(int, int)
+pub type P = Pair
+"#,
+    );
+    let source = r#"
+import "geo"
+
+fn main() {
+  let x = geo.P
+  let _ = x
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "native_constructor_value"),
+        "an imported tuple-struct alias must get the constructor diagnostic, got: {:?}",
+        result.errors
+    );
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "an imported tuple-struct alias must not fall through to the generic type diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_enum_alias_as_value() {
+    let input = r#"
+enum E { A, B }
+type C = E
+
+fn main() {
+  let c = C
+  let _ = c
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "an enum alias in value position must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_clone_called_on_type_alias() {
+    let input = r#"
+type Rows = Slice<Slice<int>>
+
+fn main() {
+  let k = Rows.clone()
+  let _ = k
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert_eq!(
+        result
+            .errors
+            .iter()
+            .filter(|d| d
+                .code_str()
+                .is_some_and(|c| c.contains("type_used_as_value")))
+            .count(),
+        1,
+        "clone on a type alias must raise exactly one type-in-value error, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_is_empty_called_on_type_alias() {
+    let input = r#"
+type Rows = Slice<Slice<int>>
+
+fn main() {
+  let e = Rows.is_empty()
+  let _ = e
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "is_empty on a type alias must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_static_constructor_and_enum_variant_allowed() {
+    let input = r#"
+enum Color { Red, Blue }
+
+fn main() {
+  let xs = Slice.new<int>()
+  let c = Color.Red
+  let _ = xs
+  let _ = c
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "static constructors and enum variant constructors must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_value_receiver_instance_method_allowed() {
+    let input = r#"
+fn main() {
+  let xs = [1, 2, 3]
+  let n = xs.length()
+  let k = xs.clone()
+  let _ = n
+  let _ = k
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "instance methods on value receivers must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_instance_method_value_allowed() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Point { pub x: int, pub y: int }
+
+impl Point {
+  pub fn sum(self) -> int { self.x + self.y }
+}
+"#,
+    );
+
+    let source = r#"
+import "geo"
+
+fn main() {
+  let p = geo.Point { x: 1, y: 2 }
+  let f = geo.Point.sum
+  let _ = f(p)
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "taking a cross-module instance method as a value must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_instance_method_called_on_cross_module_type() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Point { pub x: int, pub y: int }
+impl Point { pub fn sum(self) -> int { self.x + self.y } }
+"#,
+    );
+    let source = r#"
+import "geo"
+
+fn main() {
+  let s = geo.Point.sum()
+  let _ = s
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "an instance method called on a cross-module type name must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_struct_literal_via_alias_allowed() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "lib.lis",
+        r#"
+pub struct Foo { pub x: int }
+pub type P = Foo
+"#,
+    );
+    let source = r#"
+import "shapes"
+
+fn main() {
+  let a = shapes.P { x: 1 }
+  let _ = a
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        result.errors.is_empty(),
+        "constructing a struct through a cross-module alias must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_variant_via_alias_allowed() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "palette",
+        "lib.lis",
+        r#"
+pub enum Color { Red, Blue }
+pub type C = Color
+"#,
+    );
+    let source = r#"
+import "palette"
+
+fn main() {
+  let a = palette.C.Red
+  let _ = a
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "constructing an enum variant through a cross-module alias must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_bare_interface_as_value() {
+    let input = r#"
+interface Greeter { fn greet(self) -> string }
+
+fn main() {
+  let x = Greeter
+  let _ = x
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "a bare interface name in value position must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_imported_value_member_method_call_allowed() {
+    let input = r#"
+import "go:time"
+import "go:fmt"
+
+fn main() {
+  fmt.Println(time.Second.String())
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "a method call on an imported value member must stay legal, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_collection_alias_as_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "grid",
+        "lib.lis",
+        r#"
+pub type Rows = Slice<Slice<int>>
+"#,
+    );
+    let source = r#"
+import "grid"
+
+fn main() {
+  let x = grid.Rows
+  let _ = x
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "a cross-module collection alias in value position must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_interface_as_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "svc",
+        "lib.lis",
+        r#"
+pub interface Greeter { fn greet(self) -> string }
+"#,
+    );
+    let source = r#"
+import "svc"
+
+fn main() {
+  let x = svc.Greeter
+  let _ = x
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        has_code(&result, "type_used_as_value"),
+        "a cross-module interface in value position must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_cross_module_const_value_allowed() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "conf",
+        "lib.lis",
+        r#"
+pub const LIMIT = 100
+"#,
+    );
+    let source = r#"
+import "conf"
+
+fn main() {
+  let x = conf.LIMIT
+  let _ = x
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        !has_code(&result, "type_used_as_value"),
+        "an imported const value must not be rejected as a type, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn iterate_on_payload_variant() {
     let input = r#"
 #[iterate]

--- a/tests/ui/errors/snapshots/infer_bare_enum_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_bare_enum_as_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot use a type as a value
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let c = Color
+   ·           ──┬──
+   ·             ╰── type names are not runtime values
+ 6 │   let _ = c
+   ╰────
+  help: `Color` refers to a type, not a value · code: [infer.type_used_as_value]

--- a/tests/ui/errors/snapshots/infer_instance_method_called_on_type_alias.snap
+++ b/tests/ui/errors/snapshots/infer_instance_method_called_on_type_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot use a type as a value
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let n = Rows.length()
+   ·           ──┬─
+   ·             ╰── type names are not runtime values
+ 6 │   let _ = n
+   ╰────
+  help: `Rows` refers to a type, not a value · code: [infer.type_used_as_value]

--- a/tests/ui/errors/snapshots/infer_type_alias_of_collection_as_value.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_of_collection_as_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot use a type as a value
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let c = Rows
+   ·           ──┬─
+   ·             ╰── type names are not runtime values
+ 6 │   let _ = c
+   ╰────
+  help: `Rows` refers to a type, not a value · code: [infer.type_used_as_value]


### PR DESCRIPTION
A type name used where a value is expected now fails `lis check` with an error, instead of emitting invalid Go. Struct names already reported this. We now also cover bare enums, type aliases, interfaces, and native or instance methods called on a type-name receiver.

```
  ✕ Cannot use a type as a value
   ╭─[test.lis:5:11]
 4 │ fn main() {
 5 │   let c = Rows
   ·           ──┬─
   ·             ╰── type names are not runtime values
 6 │   let _ = c
   ╰────
  help: `Rows` refers to a type, not a value · code: [infer.type_used_as_value]
```
