### PR TITLE
refactor: report signed lower bound in overflow helptext

### DIFF
--- a/crates/semantics/src/checker/infer/validation/numeric.rs
+++ b/crates/semantics/src/checker/infer/validation/numeric.rs
@@ -24,7 +24,7 @@ impl InferCtx<'_, '_> {
         if value as i128 > bounds.max {
             self.sink.push(diagnostics::infer::integer_literal_overflow(
                 bounds.name,
-                0,
+                bounds.min,
                 bounds.max,
                 span,
             ));

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7394,6 +7394,26 @@ fn test() {
 }
 
 #[test]
+fn infer_integer_literal_overflow_int32() {
+    let input = r#"
+fn test() {
+  let x: int32 = 3000000000;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_integer_literal_overflow_int64() {
+    let input = r#"
+fn test() {
+  let x: int64 = 10000000000000000000;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_negative_literal_overflow_int8() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_integer_literal_overflow_int16.snap
+++ b/tests/ui/errors/snapshots/infer_integer_literal_overflow_int16.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                    ╰── overflows `int16`
  4 │ }
    ╰────
-  help: `int16` must be in range `0` to `32767` · code: [infer.integer_literal_overflow]
+  help: `int16` must be in range `-32768` to `32767` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/infer_integer_literal_overflow_int32.snap
+++ b/tests/ui/errors/snapshots/infer_integer_literal_overflow_int32.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer literal overflow
+   ╭─[test.lis:3:18]
+ 2 │ fn test() {
+ 3 │   let x: int32 = 3000000000;
+   ·                  ─────┬────
+   ·                       ╰── overflows `int32`
+ 4 │ }
+   ╰────
+  help: `int32` must be in range `-2147483648` to `2147483647` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/infer_integer_literal_overflow_int64.snap
+++ b/tests/ui/errors/snapshots/infer_integer_literal_overflow_int64.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer literal overflow
+   ╭─[test.lis:3:18]
+ 2 │ fn test() {
+ 3 │   let x: int64 = 10000000000000000000;
+   ·                  ──────────┬─────────
+   ·                            ╰── overflows `int64`
+ 4 │ }
+   ╰────
+  help: `int64` must be in range `-9223372036854775808` to `9223372036854775807` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/infer_integer_literal_overflow_int8.snap
+++ b/tests/ui/errors/snapshots/infer_integer_literal_overflow_int8.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                   ╰── overflows `int8`
  4 │ }
    ╰────
-  help: `int8` must be in range `0` to `127` · code: [infer.integer_literal_overflow]
+  help: `int8` must be in range `-128` to `127` · code: [infer.integer_literal_overflow]


### PR DESCRIPTION
The suggestion in the overflow diagnostic for a positive literal on a signed type now reports the type's true lower bound instead of `0`.
