### PR TITLE
refactor: skip `Result` for Go-interop `?` in `try` blocks

### DIFF
--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -64,7 +64,9 @@ impl Planner<'_> {
             return (statements, String::new());
         }
 
-        if let Some(fused) = self.try_lower_fused_go_propagate(expression, result_var_name) {
+        if let Some(fused) =
+            self.try_lower_fused_go_propagate(expression, &fallible, result_var_name)
+        {
             return fused;
         }
 
@@ -150,27 +152,26 @@ impl Planner<'_> {
     ) -> LoweredStatement {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
         let success_tag = fallible.success_tag();
-        let return_ctx = self.return_ctx();
+        let err_expr = format!("{}{}", check_var, err_field);
+        let values = self.propagate_failure_values(fallible, &err_expr);
+        transition::tag_check(format!("{}.Tag != {}", check_var, success_tag), values)
+    }
 
-        let values = if let Some(shape) = return_ctx.lowered_shape() {
+    fn propagate_failure_values(&mut self, fallible: &Fallible, err_expr: &str) -> Vec<String> {
+        let return_ctx = self.return_ctx();
+        if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
             // Option propagation: failure carries no payload, so return a
             // shape-specific `None` rather than an err-return.
             if fallible.is_result() {
-                let err_expr = format!("{}{}", check_var, err_field);
-                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
+                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty)
             }
         } else {
-            let err_return = {
-                let mut fe = FalliblePlanner::new(self, fallible);
-                fe.emit_contextual_failure(Some(&format!("{}{}", check_var, err_field)))
-            };
-            vec![err_return]
-        };
-
-        transition::tag_check(format!("{}.Tag != {}", check_var, success_tag), values)
+            let mut fe = FalliblePlanner::new(self, fallible);
+            vec![fe.emit_contextual_failure(Some(err_expr))]
+        }
     }
 
     /// Fuse `go_call()?` into `v, err := call(); if err != nil { return ... }`,
@@ -178,6 +179,7 @@ impl Planner<'_> {
     fn try_lower_fused_go_propagate(
         &mut self,
         expression: &Expression,
+        fallible: &Fallible,
         result_var_name: Option<&str>,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let plan = self.plan_call(expression)?;
@@ -188,10 +190,15 @@ impl Planner<'_> {
         if ok_ty.is_unit() || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
             return None;
         }
-        let nil_guard = self.result_nil_guard(&ok_ty);
         let return_ctx = self.return_ctx();
-        let shape = return_ctx.lowered_shape()?;
-        let return_ty = return_ctx.expect_ty();
+        let has_fallible_return = return_ctx.lowered_shape().is_some()
+            || return_ctx
+                .ty()
+                .is_some_and(|ty| Fallible::from_type(ty).is_some());
+        if !has_fallible_return {
+            return None;
+        }
+        let nil_guard = self.result_nil_guard(&ok_ty);
 
         let want_value = !matches!(result_var_name, Some("_"));
         let val_var = (want_value || nil_guard.is_some()).then(|| {
@@ -210,7 +217,7 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let failure_values = transition::lowered_err_values(self, &shape, &return_ty, &err_var);
+        let failure_values = self.propagate_failure_values(fallible, &err_var);
         statements.push(transition::tag_check(
             format!("{} != nil", err_var),
             failure_values,
@@ -224,12 +231,8 @@ impl Planner<'_> {
                 self.require_stdlib();
             }
             self.require_errors();
-            let nil_failure = transition::lowered_err_values(
-                self,
-                &shape,
-                &return_ty,
-                "errors.New(\"unexpected nil\")",
-            );
+            let nil_failure =
+                self.propagate_failure_values(fallible, "errors.New(\"unexpected nil\")");
             statements.push(transition::tag_check(guard.is_nil(val), nil_failure));
         }
 

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -631,6 +631,75 @@ fn main() {
 }
 
 #[test]
+fn interop_result_propagate_in_try_block() {
+    let input = r#"
+import "go:strconv"
+
+fn sum_parsed(a: string, b: string) -> Result<int, error> {
+  try {
+    let x = strconv.Atoi(a)?
+    let y = strconv.Atoi(b)?
+    x + y
+  }
+}
+
+fn main() {
+  match sum_parsed("3", "4") {
+    Ok(n) => { let _ = n },
+    Err(_) => { let _ = 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_result_propagate_in_try_block_discard_and_nil_guard() {
+    let input = r#"
+import "go:strconv"
+import "go:os"
+
+fn open_and_check(path: string, n: string) -> Result<int, error> {
+  try {
+    let f = os.Open(path)?
+    let _ = f.Stat()?
+    strconv.Atoi(n)?
+  }
+}
+
+fn main() {
+  match open_and_check("/tmp/x", "7") {
+    Ok(v) => { let _ = v },
+    Err(_) => { let _ = 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_comma_ok_propagate_in_try_block_stays_boxed() {
+    let input = r#"
+import "go:os"
+
+fn lookup(k: string) -> Option<string> {
+  try {
+    let v = os.LookupEnv(k)?
+    v
+  }
+}
+
+fn main() {
+  match lookup("HOME") {
+    Some(v) => { let _ = v },
+    None => { let _ = 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_result_break_value() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_stays_boxed.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_stays_boxed.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:os"
+  
+  fn lookup(k: string) -> Option<string> {
+    try {
+      let v = os.LookupEnv(k)?
+      v
+    }
+  }
+  
+  fn main() {
+    match lookup("HOME") {
+      Some(v) => { let _ = v },
+      None => { let _ = 0 },
+    }
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func lookup(k string) (string, bool) {
+	tryResult_1 := func() lisette.Option[string] {
+		option_2 := lisette.OptionFromCommaOk[string](os.LookupEnv(k))
+		check_3 := option_2
+		if check_3.Tag != lisette.OptionSome {
+			return lisette.MakeOptionNone[string]()
+		}
+		v := check_3.SomeVal
+		return lisette.MakeOptionSome[string](v)
+	}()
+	v_4 := tryResult_1
+	if v_4.Tag == lisette.OptionSome {
+		return v_4.SomeVal, true
+	}
+	return "", false
+}
+
+func main() {
+	option_2 := lisette.OptionFromCommaOk[string](lookup("HOME"))
+	if option_2.Tag == lisette.OptionSome {
+		_ = option_2.SomeVal
+	} else {
+	}
+}

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -1,0 +1,57 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn sum_parsed(a: string, b: string) -> Result<int, error> {
+    try {
+      let x = strconv.Atoi(a)?
+      let y = strconv.Atoi(b)?
+      x + y
+    }
+  }
+  
+  fn main() {
+    match sum_parsed("3", "4") {
+      Ok(n) => { let _ = n },
+      Err(_) => { let _ = 0 },
+    }
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func sum_parsed(a, b string) (int, error) {
+	tryResult_1 := func() lisette.Result[int, error] {
+		ret_2, ret_3 := strconv.Atoi(a)
+		if ret_3 != nil {
+			return lisette.MakeResultErr[int, error](ret_3)
+		}
+		x := ret_2
+		ret_4, ret_5 := strconv.Atoi(b)
+		if ret_5 != nil {
+			return lisette.MakeResultErr[int, error](ret_5)
+		}
+		y := ret_4
+		return lisette.MakeResultOk[int, error](x + y)
+	}()
+	v_6 := tryResult_1
+	if v_6.Tag == lisette.ResultOk {
+		return v_6.OkVal, nil
+	}
+	return 0, v_6.ErrVal
+}
+
+func main() {
+	ret_1, ret_2 := sum_parsed("3", "4")
+	if ret_2 == nil {
+		n := ret_1
+		_ = n
+	} else {
+	}
+}

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -1,0 +1,69 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:strconv"
+  import "go:os"
+  
+  fn open_and_check(path: string, n: string) -> Result<int, error> {
+    try {
+      let f = os.Open(path)?
+      let _ = f.Stat()?
+      strconv.Atoi(n)?
+    }
+  }
+  
+  fn main() {
+    match open_and_check("/tmp/x", "7") {
+      Ok(v) => { let _ = v },
+      Err(_) => { let _ = 0 },
+    }
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+	"strconv"
+)
+
+func open_and_check(path, n string) (int, error) {
+	tryResult_1 := func() lisette.Result[int, error] {
+		ret_2, ret_3 := os.Open(path)
+		if ret_3 != nil {
+			return lisette.MakeResultErr[int, error](ret_3)
+		}
+		if ret_2 == nil {
+			return lisette.MakeResultErr[int, error](errors.New("unexpected nil"))
+		}
+		f := ret_2
+		ret_4, ret_5 := f.Stat()
+		if ret_5 != nil {
+			return lisette.MakeResultErr[int, error](ret_5)
+		}
+		if lisette.IsNilInterface(ret_4) {
+			return lisette.MakeResultErr[int, error](errors.New("unexpected nil"))
+		}
+		ret_6, ret_7 := strconv.Atoi(n)
+		if ret_7 != nil {
+			return lisette.MakeResultErr[int, error](ret_7)
+		}
+		return lisette.MakeResultOk[int, error](ret_6)
+	}()
+	v_8 := tryResult_1
+	if v_8.Tag == lisette.ResultOk {
+		return v_8.OkVal, nil
+	}
+	return 0, v_8.ErrVal
+}
+
+func main() {
+	ret_1, ret_2 := open_and_check("/tmp/x", "7")
+	if ret_2 == nil {
+		v := ret_1
+		_ = v
+	} else {
+	}
+}


### PR DESCRIPTION
`?` on a Go-interop `(T, error)` call inside a `try` block now lowers to the same early-return as a direct `?`, instead of boxing the value into a `lisette.Result` and unboxing it one line later.