### PR TITLE
fix: emit pointer indirection for indirect enum recursion

### DIFF
--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -1,15 +1,16 @@
 use std::rc::Rc;
 
 use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashSet;
 
 use crate::Planner;
 use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
 use crate::definitions::structs::is_raw_function_type;
 use crate::names::go_name;
-use syntax::ast::{Pattern, RestPattern, StructKind};
+use syntax::ast::{Generic, Pattern, RestPattern, StructKind};
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{Type, substitute};
+use syntax::types::{SubstitutionMap, Type, substitute};
 
 impl Planner<'_> {
     pub(crate) fn go_name_for_binding(&self, pattern: &Pattern) -> Option<String> {
@@ -249,7 +250,8 @@ impl Planner<'_> {
         for (vi, variant) in variants.iter().enumerate() {
             for (fi, field) in variant.fields.iter().enumerate() {
                 let mut go_type = self.go_type(&field.ty).code;
-                let recursive = is_recursive_type(&field.ty, enum_id);
+                let recursive =
+                    self.is_recursive_type(&field.ty, enum_id, &mut FxHashSet::default());
 
                 if recursive {
                     go_type = format!("*{}", go_type);
@@ -268,6 +270,65 @@ impl Planner<'_> {
         }
 
         Some(EnumLayout::new(enum_id, generics, variants, &field_types))
+    }
+
+    fn is_recursive_type(&self, ty: &Type, enum_id: &str, visited: &mut FxHashSet<String>) -> bool {
+        let peeled = self.facts.peel_alias(ty);
+        match &peeled {
+            Type::Nominal { id, params, .. } => {
+                if id == enum_id {
+                    return true;
+                }
+                if !visited.insert(format!("{:?}", peeled)) {
+                    return false;
+                }
+                match self.facts.definition(id.as_str()) {
+                    Some(Definition {
+                        body:
+                            DefinitionBody::Struct {
+                                generics, fields, ..
+                            },
+                        ..
+                    }) => {
+                        let substitutions = generic_substitutions(generics, params);
+                        fields.iter().any(|field| {
+                            self.is_recursive_type(
+                                &substitute(&field.ty, &substitutions),
+                                enum_id,
+                                visited,
+                            )
+                        })
+                    }
+                    Some(Definition {
+                        body:
+                            DefinitionBody::Enum {
+                                generics, variants, ..
+                            },
+                        ..
+                    }) => {
+                        let substitutions = generic_substitutions(generics, params);
+                        variants
+                            .iter()
+                            .flat_map(|variant| variant.fields.iter())
+                            .any(|field| {
+                                self.is_recursive_type(
+                                    &substitute(&field.ty, &substitutions),
+                                    enum_id,
+                                    visited,
+                                )
+                            })
+                    }
+                    Some(_) => false,
+                    None => params
+                        .iter()
+                        .any(|param| self.is_recursive_type(param, enum_id, visited)),
+                }
+            }
+            Type::Tuple(elements) => elements
+                .iter()
+                .any(|element| self.is_recursive_type(element, enum_id, visited)),
+            _ => false,
+        }
     }
 
     pub(crate) fn enum_struct_field_name(
@@ -416,9 +477,10 @@ impl Planner<'_> {
     }
 }
 
-fn is_recursive_type(ty: &Type, enum_id: &str) -> bool {
-    match ty.unwrap_forall() {
-        Type::Nominal { id, .. } => id == enum_id,
-        _ => false,
-    }
+fn generic_substitutions(generics: &[Generic], params: &[Type]) -> SubstitutionMap {
+    generics
+        .iter()
+        .map(|generic| generic.name.clone())
+        .zip(params.iter().cloned())
+        .collect()
 }

--- a/tests/e2e_smoke_project/src/fixtures.lis
+++ b/tests/e2e_smoke_project/src/fixtures.lis
@@ -46,3 +46,36 @@ fn maybe_int_for_test(b: bool) -> Option<int> {
 fn unreachable_from_error(_e: string) -> int {
   panic("mapper or fallback should not be called")
 }
+
+enum Tree {
+  Tip(int),
+  Fork(Branch),
+}
+
+struct Branch {
+  left: Tree,
+  right: Tree,
+}
+
+fn tree_sum(t: Tree) -> int {
+  match t {
+    Tree.Tip(n) => n,
+    Tree.Fork(b) => tree_sum(b.left) + tree_sum(b.right),
+  }
+}
+
+enum Ping {
+  Stop,
+  Next(Pong),
+}
+
+enum Pong {
+  Reply(Ping),
+}
+
+fn ping_depth(p: Ping) -> int {
+  match p {
+    Ping.Stop => 0,
+    Ping.Next(Pong.Reply(inner)) => 2 + ping_depth(inner),
+  }
+}

--- a/tests/e2e_smoke_project/src/patterns.test.lis
+++ b/tests/e2e_smoke_project/src/patterns.test.lis
@@ -880,6 +880,21 @@ fn enum_variant_named_string() {
   assert s_ok && n_ok && null_ok
 }
 
+#[test]
+fn indirect_recursive_enum_through_struct() {
+  let t = Tree.Fork(Branch {
+    left: Tree.Tip(1),
+    right: Tree.Fork(Branch { left: Tree.Tip(2), right: Tree.Tip(3) }),
+  })
+  assert tree_sum(t) == 6
+}
+
+#[test]
+fn mutually_recursive_enums() {
+  let p = Ping.Next(Pong.Reply(Ping.Next(Pong.Reply(Ping.Stop))))
+  assert ping_depth(p) == 4
+}
+
 pub enum Color {
   Red,
   Green,

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_alias.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_alias.snap
@@ -1,0 +1,56 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Tree {
+    Leaf(int),
+    Node(P),
+  }
+  
+  type P = Pair
+  
+  struct Pair {
+    l: Tree,
+    r: Tree,
+  }
+  
+  fn test() -> Tree {
+    Tree.Node(Pair { l: Tree.Leaf(1), r: Tree.Leaf(2) })
+  }
+---
+package main
+
+func MakeTreeLeaf(arg0 int) Tree {
+	return Tree{Tag: TreeLeaf, Leaf: arg0}
+}
+
+func MakeTreeNode(arg0 P) Tree {
+	return Tree{Tag: TreeNode, Node: &arg0}
+}
+
+type TreeTag int
+
+const (
+	TreeLeaf TreeTag = iota
+	TreeNode
+)
+
+type Tree struct {
+	Tag  TreeTag
+	Leaf int
+	Node *P
+}
+
+type P = Pair
+
+type Pair struct {
+	l Tree
+	r Tree
+}
+
+func test() Tree {
+	return MakeTreeNode(Pair{
+		l: MakeTreeLeaf(1),
+		r: MakeTreeLeaf(2),
+	})
+}

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_mixed_generic_instantiations.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_mixed_generic_instantiations.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Tree {
+    Leaf,
+    Node(Outer),
+  }
+  
+  struct Outer {
+    a: Box<int>,
+    b: Box<Tree>,
+  }
+  
+  struct Box<T> {
+    value: T,
+  }
+  
+  fn test() -> Tree {
+    Tree.Node(Outer { a: Box { value: 1 }, b: Box { value: Tree.Leaf } })
+  }
+---
+package main
+
+func MakeTreeLeaf() Tree {
+	return Tree{Tag: TreeLeaf}
+}
+
+func MakeTreeNode(arg0 Outer) Tree {
+	return Tree{Tag: TreeNode, Node: &arg0}
+}
+
+type TreeTag int
+
+const (
+	TreeLeaf TreeTag = iota
+	TreeNode
+)
+
+type Tree struct {
+	Tag  TreeTag
+	Node *Outer
+}
+
+type Outer struct {
+	a Box[int]
+	b Box[Tree]
+}
+
+type Box[T any] struct {
+	value T
+}
+
+func test() Tree {
+	return MakeTreeNode(Outer{
+		a: Box[int]{value: 1},
+		b: Box[Tree]{value: MakeTreeLeaf()},
+	})
+}

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_struct.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_struct.snap
@@ -1,0 +1,67 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Tree {
+    Leaf(int),
+    Node(Pair),
+  }
+  
+  struct Pair {
+    l: Tree,
+    r: Tree,
+  }
+  
+  fn sum(t: Tree) -> int {
+    match t {
+      Tree.Leaf(n) => n,
+      Tree.Node(p) => sum(p.l) + sum(p.r),
+    }
+  }
+  
+  fn test() -> Tree {
+    Tree.Node(Pair { l: Tree.Leaf(1), r: Tree.Leaf(2) })
+  }
+---
+package main
+
+func MakeTreeLeaf(arg0 int) Tree {
+	return Tree{Tag: TreeLeaf, Leaf: arg0}
+}
+
+func MakeTreeNode(arg0 Pair) Tree {
+	return Tree{Tag: TreeNode, Node: &arg0}
+}
+
+type TreeTag int
+
+const (
+	TreeLeaf TreeTag = iota
+	TreeNode
+)
+
+type Tree struct {
+	Tag  TreeTag
+	Leaf int
+	Node *Pair
+}
+
+type Pair struct {
+	l Tree
+	r Tree
+}
+
+func sum(t Tree) int {
+	if t.Tag == TreeLeaf {
+		return t.Leaf
+	}
+	p := *t.Node
+	return sum(p.l) + sum(p.r)
+}
+
+func test() Tree {
+	return MakeTreeNode(Pair{
+		l: MakeTreeLeaf(1),
+		r: MakeTreeLeaf(2),
+	})
+}

--- a/tests/spec/emit/snapshots/recursive_enums_mutual.snap
+++ b/tests/spec/emit/snapshots/recursive_enums_mutual.snap
@@ -1,0 +1,57 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum A {
+    End,
+    X(B),
+  }
+  
+  enum B {
+    Y(A),
+  }
+  
+  fn test() -> A {
+    A.X(B.Y(A.End))
+  }
+---
+package main
+
+func MakeAEnd() A {
+	return A{Tag: AEnd}
+}
+
+func MakeAX(arg0 B) A {
+	return A{Tag: AX, X: &arg0}
+}
+
+func MakeBY(arg0 A) B {
+	return B{Tag: BY, Y: &arg0}
+}
+
+type ATag int
+
+const (
+	AEnd ATag = iota
+	AX
+)
+
+type A struct {
+	Tag ATag
+	X   *B
+}
+
+type BTag int
+
+const (
+	BY BTag = iota
+)
+
+type B struct {
+	Tag BTag
+	Y   *A
+}
+
+func test() A {
+	return MakeAX(MakeBY(MakeAEnd()))
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2043,6 +2043,98 @@ fn list_sum(l: List) -> int {
 }
 
 #[test]
+fn recursive_enum_indirect_through_struct() {
+    let input = r#"
+enum Tree {
+  Leaf(int),
+  Node(Pair),
+}
+
+struct Pair {
+  l: Tree,
+  r: Tree,
+}
+
+fn sum(t: Tree) -> int {
+  match t {
+    Tree.Leaf(n) => n,
+    Tree.Node(p) => sum(p.l) + sum(p.r),
+  }
+}
+
+fn test() -> Tree {
+  Tree.Node(Pair { l: Tree.Leaf(1), r: Tree.Leaf(2) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn recursive_enums_mutual() {
+    let input = r#"
+enum A {
+  End,
+  X(B),
+}
+
+enum B {
+  Y(A),
+}
+
+fn test() -> A {
+  A.X(B.Y(A.End))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn recursive_enum_indirect_through_mixed_generic_instantiations() {
+    let input = r#"
+enum Tree {
+  Leaf,
+  Node(Outer),
+}
+
+struct Outer {
+  a: Box<int>,
+  b: Box<Tree>,
+}
+
+struct Box<T> {
+  value: T,
+}
+
+fn test() -> Tree {
+  Tree.Node(Outer { a: Box { value: 1 }, b: Box { value: Tree.Leaf } })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn recursive_enum_indirect_through_alias() {
+    let input = r#"
+enum Tree {
+  Leaf(int),
+  Node(P),
+}
+
+type P = Pair
+
+struct Pair {
+  l: Tree,
+  r: Tree,
+}
+
+fn test() -> Tree {
+  Tree.Node(Pair { l: Tree.Leaf(1), r: Tree.Leaf(2) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn pub_field_assignment_capitalizes() {
     let input = r#"
 pub struct Counter {


### PR DESCRIPTION
Enums whose recursion cycle passes through another type now compile. The emitter now breaks any such cycle with a pointer field, covering cycles through structs, mutually recursive enums, type aliases, and generic instantiations.

```rs
enum Tree {
  Leaf(int),
  Node(Pair),
}

struct Pair {
  l: Tree,
  r: Tree,
}
```


