### PR TITLE
refactor: simplify `mut` aliasing protection

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/aliasing.rs
+++ b/crates/semantics/src/checker/infer/expressions/aliasing.rs
@@ -1,86 +1,161 @@
-use syntax::ast::{Expression, Literal, UnaryOperator};
-use syntax::program::CallKind;
+use syntax::ast::{Expression, Literal, Span, UnaryOperator};
+use syntax::program::{CallKind, DefinitionBody};
+use syntax::types::Type;
 
+use crate::checker::EnvResolve;
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::addressability::check_is_non_addressable;
 use crate::checker::infer::carry_mut::{
     can_carry_mutation_across_fn_boundary, clone_recipe_is_known, clone_severs_alias,
 };
 
+struct AliasFinding {
+    source: String,
+    span: Span,
+    via_non_severing_clone: bool,
+    clone_severs: bool,
+    addressable: bool,
+}
+
 impl InferCtx<'_, '_> {
-    /// Reject a mutable binding that would alias a carry-mut place. A
-    /// `clone()` of the place is exempt only when the clone actually severs.
+    /// Reject a mutable binding that would share the backing store of a live one.
     pub(super) fn check_mut_binding_alias(&mut self, binding_name: &str, value: &Expression) {
-        let expr = value.unwrap_parens();
-        let (place, via_clone) = match clone_call_receiver(expr) {
-            Some(receiver) => (receiver.unwrap_parens(), true),
-            None => (expr, false),
+        let Some(finding) = self.find_alias(value, true) else {
+            return;
         };
-        if !is_aliasing_place(place) {
+        self.push_binding_alias(binding_name, finding);
+    }
+
+    pub(super) fn check_mut_reassignment_alias(&mut self, binding_name: &str, value: &Expression) {
+        let Some(finding) = self.find_alias(value, false) else {
             return;
-        }
-        let rooted_in_binding = place_root_name(place)
-            .is_some_and(|root| self.scopes.lookup_binding_id(&root).is_some());
-        if !rooted_in_binding {
-            return;
-        }
-        let ty = if via_clone {
-            place.get_type()
-        } else {
-            value.get_type()
         };
-        if !can_carry_mutation_across_fn_boundary(&ty, &self.env, self.store) {
-            return;
-        }
-        if via_clone && !clone_recipe_is_known(&ty, &self.env, self.store) {
-            return;
-        }
-        let clone_severs = clone_severs_alias(&ty, &self.env, self.store);
-        if via_clone && clone_severs {
-            return;
-        }
-        let source = render_place(place);
-        let addressable = check_is_non_addressable(place, &self.env).is_none();
-        let diagnostic = if via_clone {
+        self.push_binding_alias(binding_name, finding);
+    }
+
+    fn push_binding_alias(&mut self, binding_name: &str, finding: AliasFinding) {
+        let diagnostic = if finding.via_non_severing_clone {
             diagnostics::infer::mut_binding_clone_does_not_sever(
                 binding_name,
-                &source,
-                addressable,
-                value.get_span(),
+                &finding.source,
+                finding.addressable,
+                finding.span,
             )
         } else {
             diagnostics::infer::mut_binding_aliases(
                 binding_name,
-                &source,
-                addressable,
-                clone_severs,
-                value.get_span(),
+                &finding.source,
+                finding.addressable,
+                finding.clone_severs,
+                finding.span,
             )
         };
         self.sink.push(diagnostic);
     }
 
-    /// Source of a `.clone()` of a local carry-mut place that the clone does
-    /// not fully sever, or `None` when the clone is fresh, opaque, or severing.
-    pub(super) fn non_severing_clone_source(&self, value: &Expression) -> Option<String> {
-        let receiver = clone_call_receiver(value.unwrap_parens())?;
-        let place = receiver.unwrap_parens();
-        if !is_aliasing_place(place) {
+    fn find_alias(&self, value: &Expression, through_constructions: bool) -> Option<AliasFinding> {
+        let expr = value.unwrap_parens();
+
+        if let Some(receiver) = clone_call_receiver(expr) {
+            return self.alias_leaf(receiver.unwrap_parens(), true, expr.get_span());
+        }
+
+        match expr {
+            Expression::Identifier { .. }
+            | Expression::DotAccess { .. }
+            | Expression::IndexedAccess { .. }
+            | Expression::Unary {
+                operator: UnaryOperator::Deref,
+                ..
+            } => return self.alias_leaf(expr, false, expr.get_span()),
+            _ => {}
+        }
+
+        if !through_constructions
+            || !can_carry_mutation_across_fn_boundary(&expr.get_type(), &self.env, self.store)
+        {
             return None;
         }
-        let root = place_root_name(place)?;
-        self.scopes.lookup_binding_id(&root)?;
+
+        match expr {
+            Expression::Block { items, .. } => self.find_alias(items.last()?, true),
+            Expression::If {
+                consequence,
+                alternative,
+                ..
+            } => self
+                .find_alias(consequence, true)
+                .or_else(|| self.find_alias(alternative, true)),
+            Expression::Tuple { elements, .. } => {
+                elements.iter().find_map(|e| self.find_alias(e, true))
+            }
+            Expression::StructCall {
+                field_assignments,
+                ty,
+                ..
+            } if self.is_struct_backed(ty) => field_assignments
+                .iter()
+                .find_map(|f| self.find_alias(&f.value, true)),
+            Expression::Literal {
+                literal: Literal::Slice(elements),
+                ..
+            } => elements.iter().find_map(|e| self.find_alias(e, true)),
+            Expression::Call {
+                args,
+                call_kind: Some(CallKind::TupleStructConstructor),
+                ..
+            } => args.iter().find_map(|a| self.find_alias(a, true)),
+            _ => None,
+        }
+    }
+
+    fn is_struct_backed(&self, ty: &Type) -> bool {
+        let Type::Nominal { id, .. } = self.store.peel_alias(&ty.resolve_in(&self.env)) else {
+            return false;
+        };
+        matches!(
+            self.store.get_definition(id.as_str()).map(|d| &d.body),
+            Some(DefinitionBody::Struct { .. })
+        )
+    }
+
+    fn alias_leaf(&self, place: &Expression, via_clone: bool, span: Span) -> Option<AliasFinding> {
+        let Expression::Identifier {
+            value,
+            binding_id: Some(root_id),
+            ..
+        } = place_root(place)?
+        else {
+            return None;
+        };
+        if self.scopes.lookup_binding_id(value) != Some(*root_id) {
+            return None;
+        }
         let ty = place.get_type();
         if !can_carry_mutation_across_fn_boundary(&ty, &self.env, self.store) {
             return None;
         }
-        if !clone_recipe_is_known(&ty, &self.env, self.store) {
+        if via_clone && !clone_recipe_is_known(&ty, &self.env, self.store) {
             return None;
         }
-        if clone_severs_alias(&ty, &self.env, self.store) {
+        let clone_severs = clone_severs_alias(&ty, &self.env, self.store);
+        if via_clone && clone_severs {
             return None;
         }
-        Some(render_place(place))
+        Some(AliasFinding {
+            source: render_place(place),
+            span,
+            via_non_severing_clone: via_clone,
+            clone_severs,
+            addressable: check_is_non_addressable(place, &self.env).is_none(),
+        })
+    }
+
+    pub(super) fn non_severing_clone_source(&self, value: &Expression) -> Option<String> {
+        let expr = value.unwrap_parens();
+        let receiver = clone_call_receiver(expr)?;
+        let finding = self.alias_leaf(receiver.unwrap_parens(), true, expr.get_span())?;
+        Some(finding.source)
     }
 }
 
@@ -121,10 +196,9 @@ pub(super) fn clone_call_receiver(expression: &Expression) -> Option<&Expression
     }
 }
 
-/// Name of the identifier a place expression is rooted at.
-pub(super) fn place_root_name(expression: &Expression) -> Option<String> {
+fn place_root(expression: &Expression) -> Option<&Expression> {
     match expression {
-        Expression::Identifier { .. } => expression.get_var_name(),
+        Expression::Identifier { .. } => Some(expression),
         Expression::DotAccess {
             expression: inner, ..
         }
@@ -135,29 +209,14 @@ pub(super) fn place_root_name(expression: &Expression) -> Option<String> {
             operator: UnaryOperator::Deref,
             expression: inner,
             ..
-        } => place_root_name(inner.unwrap_parens()),
+        } => place_root(inner.unwrap_parens()),
         _ => None,
     }
 }
 
-/// Identifiers, field accesses, indexed accesses, and derefs rooted at one of
-/// these.
-fn is_aliasing_place(expression: &Expression) -> bool {
-    match expression {
-        Expression::Identifier { .. } => true,
-        Expression::DotAccess {
-            expression: inner, ..
-        } => is_aliasing_place(inner.unwrap_parens()),
-        Expression::IndexedAccess {
-            expression: inner, ..
-        } => is_aliasing_place(inner.unwrap_parens()),
-        Expression::Unary {
-            operator: UnaryOperator::Deref,
-            expression: inner,
-            ..
-        } => is_aliasing_place(inner.unwrap_parens()),
-        _ => false,
-    }
+/// Name of the identifier a place expression is rooted at.
+pub(super) fn place_root_name(expression: &Expression) -> Option<String> {
+    place_root(expression)?.get_var_name()
 }
 
 /// Reconstructed source text for a place expression. Indexes that are not

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -420,7 +420,7 @@ impl InferCtx<'_, '_> {
             let self_sourced =
                 super::aliasing::place_root_name(value_place).is_some_and(|root| root == var_name);
             if compound_operator.is_none() && is_simple_target && is_mutable && !self_sourced {
-                self.check_mut_binding_alias(&var_name, &new_value);
+                self.check_mut_reassignment_alias(&var_name, &new_value);
             }
         }
 

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -2260,6 +2260,151 @@ fn mut_binding_container_of_user_clone_single_diagnostic() {
 }
 
 #[test]
+fn mut_binding_from_block_tail_single_diagnostic() {
+    let result = infer(r#"{ let a = [1, 2, 3]; let mut b = { a }; b[0] = 9; let _ = a }"#);
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_constructor_field_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Box { items: Slice<int> }
+
+    fn main() {
+      let a = [1, 2, 3]
+      let mut boxed = Box { items: a }
+      boxed.items[0] = 9
+      let _ = a
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_tuple_literal_single_diagnostic() {
+    let result = infer(r#"{ let a = [1, 2, 3]; let mut p = (a, 0); p.0[0] = 9; let _ = a }"#);
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_if_branch_single_diagnostic() {
+    let result = infer(
+        r#"{ let a = [1, 2, 3]; let c = true; let mut b = if c { a } else { [0] }; b[0] = 9; let _ = a }"#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_slice_literal_element_single_diagnostic() {
+    let result = infer(r#"{ let a = [1, 2, 3]; let mut o = [a]; o[0][0] = 9; let _ = a }"#);
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_constructor_field_clone_no_error() {
+    infer(
+        r#"
+    struct Box { items: Slice<int> }
+
+    fn main() {
+      let a = [1, 2, 3]
+      let mut boxed = Box { items: a.clone() }
+      boxed.items[0] = 9
+      let _ = a
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_if_branch_clone_no_error() {
+    infer(
+        r#"{ let a = [1, 2, 3]; let c = true; let mut b = if c { a.clone() } else { [0] }; b[0] = 9; let _ = a }"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_scalar_tuple_literal_no_error() {
+    infer(r#"{ let mut p = (1, 2); p.0 = 9; let _ = p }"#).assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_tuple_struct_constructor_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Pair(Slice<int>, int)
+
+    fn main() {
+      let a = [1, 2, 3]
+      let mut p = Pair(a, 0)
+      p.0[0] = 9
+      let _ = a
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
+fn mut_binding_from_block_local_shadow_no_error() {
+    infer(
+        r#"
+    fn main() {
+      let x = [1, 2, 3]
+      let mut b = { let x = [9, 9]; x }
+      b[0] = 0
+      let _ = x
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_reassignment_moves_binding_into_constructor_no_error() {
+    infer(
+        r#"
+    struct Wrap(Slice<int>)
+
+    fn main() {
+      let mut w = Wrap([1])
+      let p = [2, 3]
+      w = Wrap(p)
+      let _ = w
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_unit_if_no_error() {
+    infer(r#"{ let a = [1, 2, 3]; let c = true; let mut b = if c { a }; let _ = b; let _ = a }"#)
+        .assert_no_errors();
+}
+
+#[test]
+fn mut_binding_from_enum_struct_variant_no_error() {
+    infer(
+        r#"
+    enum Holder { Tags { items: Slice<int> }, Empty }
+
+    fn main() {
+      let a = [1, 2, 3]
+      let mut h = Holder.Tags { items: a }
+      let _ = h
+      let _ = a
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn float_remainder_by_zero_single_diagnostic() {
     let result = infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2483,6 +2483,32 @@ fn test(h1: Holder) {
 }
 
 #[test]
+fn infer_mut_binding_aliases_block_tail() {
+    let input = r#"
+fn test() {
+  let a = [1, 2, 3]
+  let mut b = { a }
+  b[0] = 9
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_binding_aliases_constructor_field() {
+    let input = r#"
+struct Box { items: Slice<int> }
+
+fn test() {
+  let a = [1, 2, 3]
+  let mut boxed = Box { items: a }
+  boxed.items[0] = 9
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_mut_binding_aliases_generic_param_fed() {
     let input = r#"
 struct Box<T> { items: Slice<T> }

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_block_tail.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_block_tail.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `a`
+   ╭─[test.lis:4:17]
+ 3 │   let a = [1, 2, 3]
+ 4 │   let mut b = { a }
+   ·                 ┬
+   ·                 ╰── would be mutated implicitly
+ 5 │   b[0] = 9
+   ╰────
+  help: Mutating `b` would implicitly mutate `a`. Either use `a.clone()` to make a copy or `&a` to take a reference · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_mut_binding_aliases_constructor_field.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_aliases_constructor_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot make a mutable binding to `a`
+   ╭─[test.lis:6:32]
+ 5 │   let a = [1, 2, 3]
+ 6 │   let mut boxed = Box { items: a }
+   ·                                ┬
+   ·                                ╰── would be mutated implicitly
+ 7 │   boxed.items[0] = 9
+   ╰────
+  help: Mutating `boxed` would implicitly mutate `a`. Either use `a.clone()` to make a copy or `&a` to take a reference · code: [infer.mut_binding_aliases]


### PR DESCRIPTION
Replaces the flat `mut` binding alias check with a single `find_alias` reachability walk, folding the duplicated place-root resolution into one traversal. This allows the rule "a mutable binding must own its value" to reach through constructed values via one path instead of matching individually.
