### PR TITLE
fix: `fmt.Println` for concatenated f-strings

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -18,7 +18,7 @@ use crate::plan::calls::{ArgumentPlan, CallPlan, CallbackWrapperKind};
 use crate::types::native::NativeGoType;
 use crate::utils::{contains_call, reads_mutable_operand};
 use crate::write_line;
-use syntax::ast::Expression;
+use syntax::ast::{Expression, Literal};
 use syntax::program::Definition;
 use syntax::types::Type;
 
@@ -59,6 +59,19 @@ fn find_go_string_literal_close(s: &str) -> Option<usize> {
     None
 }
 
+fn lowers_to_bare_sprintf(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Literal {
+            literal: Literal::FormatString(_),
+            ..
+        } => true,
+        Expression::Call {
+            expression: callee, ..
+        } => callee.unwrap_parens().as_dotted_path().as_deref() == Some("fmt.Sprintf"),
+        _ => false,
+    }
+}
+
 /// Collapse redundant fmt wrappers:
 /// - `fmt.Print{ln}(fmt.Sprintf(...))` → `fmt.Printf(..., "\n")`
 /// - `fmt.Print{ln}(fmt.Sprint(x))` → `fmt.Print{ln}(x)`
@@ -76,9 +89,11 @@ fn collapse_fmt_print(
     }
     let arg = &args_strings[0];
 
-    if let Some(inner) = arg
-        .strip_prefix("fmt.Sprintf(")
-        .and_then(|s| s.strip_suffix(')'))
+    if let Some(arg_expression) = args.first()
+        && lowers_to_bare_sprintf(arg_expression)
+        && let Some(inner) = arg
+            .strip_prefix("fmt.Sprintf(")
+            .and_then(|s| s.strip_suffix(')'))
     {
         let suffix = if function_string == "fmt.Println" {
             "\\n"

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4354,6 +4354,46 @@ fn test(x: int) {
 }
 
 #[test]
+fn fmt_println_still_collapses_explicit_sprintf() {
+    let input = r#"
+import "go:fmt"
+
+fn test(x: int) {
+  fmt.Println(fmt.Sprintf("%d", x))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_does_not_collapse_concatenated_format_strings() {
+    let input = r#"
+import "go:fmt"
+
+fn test(a: int, b: int) {
+  fmt.Println(f"a={a}" + f" b={b}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_does_not_collapse_sprintf_plus_call() {
+    let input = r#"
+import "go:fmt"
+
+fn suffix() -> string {
+  "tail"
+}
+
+fn test() {
+  fmt.Println(fmt.Sprintf("%d", 1) + suffix())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn newtype_return_from_underlying_variable_casts() {
     let input = r#"
 struct UserId(int)

--- a/tests/spec/emit/snapshots/fmt_println_does_not_collapse_concatenated_format_strings.snap
+++ b/tests/spec/emit/snapshots/fmt_println_does_not_collapse_concatenated_format_strings.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(a: int, b: int) {
+    fmt.Println(f"a={a}" + f" b={b}")
+  }
+---
+package main
+
+import "fmt"
+
+func test(a, b int) {
+	fmt.Println(fmt.Sprintf("a=%d", a) + fmt.Sprintf(" b=%d", b))
+}

--- a/tests/spec/emit/snapshots/fmt_println_does_not_collapse_sprintf_plus_call.snap
+++ b/tests/spec/emit/snapshots/fmt_println_does_not_collapse_sprintf_plus_call.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn suffix() -> string {
+    "tail"
+  }
+  
+  fn test() {
+    fmt.Println(fmt.Sprintf("%d", 1) + suffix())
+  }
+---
+package main
+
+import "fmt"
+
+func suffix() string {
+	return "tail"
+}
+
+func test() {
+	fmt.Println(fmt.Sprintf("%d", 1) + suffix())
+}

--- a/tests/spec/emit/snapshots/fmt_println_still_collapses_explicit_sprintf.snap
+++ b/tests/spec/emit/snapshots/fmt_println_still_collapses_explicit_sprintf.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(x: int) {
+    fmt.Println(fmt.Sprintf("%d", x))
+  }
+---
+package main
+
+import "fmt"
+
+func test(x int) {
+	fmt.Printf("%d\n", x)
+}


### PR DESCRIPTION
Printing a concatenation of f-strings emitted invalid Go. The emitter rewrote the first f-string into `fmt.Printf` and dropped the enclosing `fmt.Println`, leaving the rest of the concatenation dangling.

```rs
fmt.Println(f"a={a}" + f" b={b}")
```


