### PR TITLE
fix: equality on recursive enums

### DIFF
--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -152,8 +152,12 @@ impl Planner<'_> {
                 .iter()
                 .zip(layout_variant.fields.iter())
                 .map(|(sem_field, layout_field)| {
-                    let lhs = format!("{receiver}.{}", layout_field.go_name);
-                    let rhs = format!("other.{}", layout_field.go_name);
+                    let mut lhs = format!("{receiver}.{}", layout_field.go_name);
+                    let mut rhs = format!("other.{}", layout_field.go_name);
+                    if layout_field.is_recursive {
+                        lhs = format!("(*{lhs})");
+                        rhs = format!("(*{rhs})");
+                    }
                     self.render_equality(&lhs, &rhs, &sem_field.ty)
                 })
                 .collect();

--- a/crates/passes/src/passes/checks/map_key.rs
+++ b/crates/passes/src/passes/checks/map_key.rs
@@ -1,0 +1,66 @@
+use diagnostics::LocalSink;
+use rustc_hash::FxHashSet as HashSet;
+use semantics::checker::{TypeEnv, check_never_comparable};
+use semantics::store::Store;
+use syntax::ast::{Expression, Span};
+use syntax::program::{CallKind, NativeTypeKind};
+use syntax::types::{CompoundKind, Type};
+
+use crate::passes::walk::NodeCtx;
+
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    match expression {
+        Expression::Let { binding, value, .. } => {
+            if binding.annotation.is_some()
+                && let Expression::Call {
+                    call_kind: Some(CallKind::NativeConstructor(NativeTypeKind::Map)),
+                    span,
+                    ..
+                } = value.unwrap_parens()
+            {
+                ctx.claimed_spans.borrow_mut().insert(*span);
+            }
+        }
+        Expression::Call {
+            call_kind: Some(CallKind::NativeConstructor(NativeTypeKind::Map)),
+            ty,
+            span,
+            ..
+        } => {
+            if ctx.claimed_spans.borrow().contains(span) {
+                return;
+            }
+            report_bad_map_key(ctx.store, ty, *span, ctx.sink, &mut HashSet::default());
+        }
+        Expression::TypeAlias { ty, span, .. } => {
+            report_bad_map_key(ctx.store, ty, *span, ctx.sink, &mut HashSet::default());
+        }
+        _ => {}
+    }
+}
+
+fn report_bad_map_key(
+    store: &Store,
+    ty: &Type,
+    span: Span,
+    sink: &LocalSink,
+    visited: &mut HashSet<String>,
+) -> bool {
+    let resolved = store.deep_resolve_alias(ty);
+    if !visited.insert(format!("{resolved:?}")) {
+        return false;
+    }
+    if let Some((CompoundKind::Map, args)) = resolved.as_compound()
+        && let Some(key_ty) = args.first()
+        && let Some(reason) = check_never_comparable(&TypeEnv::default(), store, key_ty)
+    {
+        sink.push(diagnostics::infer::non_comparable_map_key(
+            key_ty, reason, span,
+        ));
+        return true;
+    }
+    resolved
+        .children()
+        .iter()
+        .any(|child| report_bad_map_key(store, child, span, sink, visited))
+}

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod interpolation_stringer;
 pub(crate) mod irrefutable_patterns;
 pub(crate) mod json_methods;
 pub(crate) mod json_serializable_fields;
+pub(crate) mod map_key;
 pub(crate) mod min_max;
 pub(crate) mod nan_comparison;
 pub(crate) mod native_value_usage;

--- a/crates/passes/src/passes/checks/node_walk.rs
+++ b/crates/passes/src/passes/checks/node_walk.rs
@@ -8,9 +8,9 @@ use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
 use super::{
     cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop,
     empty_range, enum_variant_value, impossible_comparison, index_out_of_bounds,
-    irrefutable_patterns, min_max, nan_comparison, newtype, oversized_shift, predeclared_shadowing,
-    pub_type_export, receivers, repeated_if_condition, stringer_signature, temp_producing,
-    unchanging_loop_condition,
+    irrefutable_patterns, map_key, min_max, nan_comparison, newtype, oversized_shift,
+    predeclared_shadowing, pub_type_export, receivers, repeated_if_condition, stringer_signature,
+    temp_producing, unchanging_loop_condition,
 };
 
 static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
@@ -60,6 +60,7 @@ static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
                     Literal,
                 ],
             ),
+            (map_key::check, &[Let, TypeAlias, Call]),
             (newtype::check, &[Assignment, Reference]),
             (enum_variant_value::check, &[Identifier, DotAccess]),
             (unchanging_loop_condition::check, &[While]),

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashSet as HashSet;
+
 use crate::checker::EnvResolve;
 use crate::checker::TypeEnv;
 use crate::checker::infer::InferCtx;
@@ -7,12 +9,36 @@ use syntax::ast::{Annotation, Expression, Span};
 use syntax::program::{DefinitionBody, EqualityUnusableReason, Visibility};
 use syntax::types::{CompoundKind, Type, build_substitution_map, substitute};
 
+const RECURSIVE_TYPES: &str = "recursive types";
+
+fn nested_reason(inner: &'static str, wrapper: &'static str) -> &'static str {
+    if inner == RECURSIVE_TYPES {
+        RECURSIVE_TYPES
+    } else {
+        wrapper
+    }
+}
+
 pub fn check_not_comparable(env: &TypeEnv, store: &Store, ty: &Type) -> Option<&'static str> {
+    check_not_comparable_impl(env, store, ty, &mut HashSet::default(), false)
+}
+
+pub fn check_never_comparable(env: &TypeEnv, store: &Store, ty: &Type) -> Option<&'static str> {
+    check_not_comparable_impl(env, store, ty, &mut HashSet::default(), true)
+}
+
+fn check_not_comparable_impl(
+    env: &TypeEnv,
+    store: &Store,
+    ty: &Type,
+    visiting: &mut HashSet<String>,
+    definite_only: bool,
+) -> Option<&'static str> {
     let resolved = store.deep_resolve_alias(ty);
     let ty = &resolved;
 
     if is_opaque_go_handle(store, ty) {
-        return Some("opaque Go handles");
+        return (!definite_only).then_some("opaque Go handles");
     }
 
     if matches!(ty, Type::Function(_)) {
@@ -35,20 +61,29 @@ pub fn check_not_comparable(env: &TypeEnv, store: &Store, ty: &Type) -> Option<&
     }
 
     if ty.is_unknown() {
-        return Some("interface values");
+        return (!definite_only).then_some("interface values");
     }
 
     if let Some(underlying) = ty.get_underlying() {
-        return check_not_comparable(env, store, underlying);
+        return check_not_comparable_impl(env, store, underlying, visiting, definite_only);
     }
 
     if matches!(ty, Type::Parameter(_)) {
-        return Some("type parameters");
+        return (!definite_only).then_some("type parameters");
     }
 
     if let Some(name) = ty.get_qualified_id()
         && let Some(definition) = store.get_definition(name)
     {
+        if definition_reaches_itself(env, store, name) {
+            return Some(RECURSIVE_TYPES);
+        }
+
+        let type_key = format!("{ty:?}");
+        if !visiting.insert(type_key.clone()) {
+            return Some(RECURSIVE_TYPES);
+        }
+
         let type_args = ty.get_type_params().unwrap_or_default();
         let generics = match &definition.body {
             DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
@@ -66,8 +101,13 @@ pub fn check_not_comparable(env: &TypeEnv, store: &Store, ty: &Type) -> Option<&
             DefinitionBody::Struct { fields, .. } => {
                 for f in fields {
                     let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
-                    if check_not_comparable(env, store, &field_ty).is_some() {
-                        return Some("a struct containing non-comparable fields");
+                    if let Some(inner) =
+                        check_not_comparable_impl(env, store, &field_ty, visiting, definite_only)
+                    {
+                        return Some(nested_reason(
+                            inner,
+                            "a struct containing non-comparable fields",
+                        ));
                     }
                 }
             }
@@ -75,26 +115,139 @@ pub fn check_not_comparable(env: &TypeEnv, store: &Store, ty: &Type) -> Option<&
                 for v in variants {
                     for f in v.fields.iter() {
                         let field_ty = substitute(&f.ty.resolve_in(env), &sub_map);
-                        if check_not_comparable(env, store, &field_ty).is_some() {
-                            return Some("an enum containing non-comparable fields");
+                        if let Some(inner) = check_not_comparable_impl(
+                            env,
+                            store,
+                            &field_ty,
+                            visiting,
+                            definite_only,
+                        ) {
+                            return Some(nested_reason(
+                                inner,
+                                "an enum containing non-comparable fields",
+                            ));
                         }
                     }
                 }
             }
-            DefinitionBody::Interface { .. } => return Some("interface values"),
+            DefinitionBody::Interface { .. } if !definite_only => {
+                return Some("interface values");
+            }
             _ => {}
         }
+
+        visiting.remove(&type_key);
     }
 
     if let Type::Tuple(elems) = ty {
         for e in elems {
-            if check_not_comparable(env, store, &e.resolve_in(env)).is_some() {
-                return Some("a tuple containing non-comparable elements");
+            if let Some(inner) =
+                check_not_comparable_impl(env, store, &e.resolve_in(env), visiting, definite_only)
+            {
+                return Some(nested_reason(
+                    inner,
+                    "a tuple containing non-comparable elements",
+                ));
             }
         }
     }
 
     None
+}
+
+/// Bounds the walk under non-uniform generic recursion, where instantiations never repeat.
+const REACHES_DEPTH_LIMIT: usize = 256;
+
+/// Whether a definition's value layout transitively contains itself.
+fn definition_reaches_itself(env: &TypeEnv, store: &Store, target: &str) -> bool {
+    let Some(definition) = store.get_definition(target) else {
+        return false;
+    };
+    let mut visited = HashSet::default();
+    let mut field_reaches = |field_ty: &Type| {
+        reaches_definition(
+            env,
+            store,
+            &field_ty.resolve_in(env),
+            target,
+            &mut visited,
+            0,
+        )
+    };
+    match &definition.body {
+        DefinitionBody::Struct { fields, .. } => fields.iter().any(|f| field_reaches(&f.ty)),
+        DefinitionBody::Enum { variants, .. } => variants
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .any(|f| field_reaches(&f.ty)),
+        _ => false,
+    }
+}
+
+fn reaches_definition(
+    env: &TypeEnv,
+    store: &Store,
+    ty: &Type,
+    target: &str,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) -> bool {
+    if depth > REACHES_DEPTH_LIMIT {
+        return false;
+    }
+    let resolved = store.deep_resolve_alias(ty);
+    match &resolved {
+        Type::Nominal { id, params, .. } => {
+            if id.as_str() == target {
+                return true;
+            }
+            if !visited.insert(format!("{resolved:?}")) {
+                return false;
+            }
+            let field_types: Vec<(Type, &[syntax::ast::Generic])> =
+                match store.get_definition(id.as_str()).map(|d| &d.body) {
+                    Some(DefinitionBody::Struct {
+                        generics, fields, ..
+                    }) => fields
+                        .iter()
+                        .map(|f| (f.ty.clone(), generics.as_slice()))
+                        .collect(),
+                    Some(DefinitionBody::Enum {
+                        generics, variants, ..
+                    }) => variants
+                        .iter()
+                        .flat_map(|v| v.fields.iter())
+                        .map(|f| (f.ty.clone(), generics.as_slice()))
+                        .collect(),
+                    Some(_) => return false,
+                    None => {
+                        return params.iter().any(|param| {
+                            reaches_definition(env, store, param, target, visited, depth + 1)
+                        });
+                    }
+                };
+            field_types.iter().any(|(field_ty, generics)| {
+                let sub_map = generics
+                    .iter()
+                    .map(|g| g.name.clone())
+                    .zip(params.iter().cloned())
+                    .collect();
+                let substituted = substitute(&field_ty.resolve_in(env), &sub_map);
+                reaches_definition(env, store, &substituted, target, visited, depth + 1)
+            })
+        }
+        Type::Tuple(elements) => elements.iter().any(|element| {
+            reaches_definition(
+                env,
+                store,
+                &element.resolve_in(env),
+                target,
+                visited,
+                depth + 1,
+            )
+        }),
+        _ => false,
+    }
 }
 
 pub(crate) fn is_opaque_go_handle(store: &Store, ty: &Type) -> bool {
@@ -403,6 +556,10 @@ impl InferCtx<'_, '_> {
             .collect();
         field_types.iter().all(|field_ty| {
             let substituted = substitute(&field_ty.resolve_in(&self.env), &sub_map);
+            let field_resolved = self.store.deep_resolve_alias(&substituted);
+            if field_resolved.get_qualified_id() == Some(name) {
+                return true;
+            }
             check_not_equatable(
                 &self.env,
                 self.store,

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -23,7 +23,7 @@ use syntax::program::{
 };
 use syntax::types::{SubstitutionMap, Symbol, Type, substitute};
 
-pub use infer::expressions::comparison::check_not_comparable;
+pub use infer::expressions::comparison::{check_never_comparable, check_not_comparable};
 pub use type_env::{EnvResolve, Speculation, TypeEnv, VarState};
 
 #[derive(Debug, Clone)]

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::checker::EnvResolve;
+use crate::checker::infer::expressions::comparison::check_never_comparable;
 use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span};
 use syntax::program::{Definition, DefinitionBody};
@@ -377,9 +378,6 @@ impl TaskState<'_> {
         (substitute(body, &map), args)
     }
 
-    /// Check that a map key type is comparable.
-    /// Only rejects concrete non-comparable types (Slice, Map, Function).
-    /// Type parameters are allowed here — they may be instantiated with comparable types.
     /// Pre-check impl annotation for undeclared type params (e.g. `impl Container<T>`
     /// without `impl<T>`). Adds them to scope to prevent cascading errors from
     /// `convert_to_type`, and emits a diagnostic with the specific fix.
@@ -446,19 +444,11 @@ impl TaskState<'_> {
             return;
         }
 
-        let reason = if matches!(&resolved, Type::Function(_)) {
-            "functions"
-        } else if resolved.has_name("Slice") {
-            "slices"
-        } else if resolved.has_name("Map") {
-            "maps"
-        } else {
-            return;
-        };
-
-        self.sink.push(diagnostics::infer::non_comparable_map_key(
-            &resolved, reason, span,
-        ));
+        if let Some(reason) = check_never_comparable(&self.env, store, &resolved) {
+            self.sink.push(diagnostics::infer::non_comparable_map_key(
+                &resolved, reason, span,
+            ));
+        }
     }
 }
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -460,6 +460,76 @@ fn main() {
 }
 
 #[test]
+fn run_equality_on_recursive_enums_compares_structurally() {
+    if !go_available() {
+        eprintln!("skipping run_equality_on_recursive_enums_compares_structurally: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"eqrecursive\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+#[equality]
+enum List {
+  Nil,
+  Cons(int, List),
+}
+
+#[equality]
+enum Tree {
+  Leaf,
+  Node(Pair),
+}
+
+#[equality]
+struct Pair {
+  l: Tree,
+  r: Tree,
+}
+
+fn main() {
+  let a = List.Cons(1, List.Cons(2, List.Nil))
+  let b = List.Cons(1, List.Cons(2, List.Nil))
+  let c = List.Cons(1, List.Cons(3, List.Nil))
+  let d = List.Cons(1, List.Nil)
+  fmt.Println(a.equals(b), a.equals(c), a.equals(d))
+  let t1 = Tree.Node(Pair { l: Tree.Leaf, r: Tree.Leaf })
+  let t2 = Tree.Node(Pair { l: Tree.Leaf, r: Tree.Leaf })
+  let t3 = Tree.Node(Pair { l: t1, r: Tree.Leaf })
+  fmt.Println(t1.equals(t2), t1.equals(t3))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.lines().any(|line| line == "true false false")
+            && stdout.lines().any(|line| line == "true false"),
+        "expected structural equality results:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
 fn run_equality_matching_parametrized_interface_bound_builds() {
     if !go_available() {
         eprintln!(

--- a/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
+++ b/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
@@ -1,0 +1,58 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[equality]
+  enum Tree {
+    Leaf,
+    Node(Pair),
+  }
+  
+  #[equality]
+  struct Pair {
+    l: Tree,
+    r: Tree,
+  }
+---
+package main
+
+func MakeTreeLeaf() Tree {
+	return Tree{Tag: TreeLeaf}
+}
+
+func MakeTreeNode(arg0 Pair) Tree {
+	return Tree{Tag: TreeNode, Node: &arg0}
+}
+
+type TreeTag int
+
+const (
+	TreeLeaf TreeTag = iota
+	TreeNode
+)
+
+type Tree struct {
+	Tag  TreeTag
+	Node *Pair
+}
+
+func (t Tree) equals(other Tree) bool {
+	if t.Tag != other.Tag {
+		return false
+	}
+	switch t.Tag {
+	case TreeNode:
+		return (*t.Node).equals((*other.Node))
+	default:
+		return true
+	}
+}
+
+type Pair struct {
+	l Tree
+	r Tree
+}
+
+func (p Pair) equals(other Pair) bool {
+	return p.l.equals(other.l) && p.r.equals(other.r)
+}

--- a/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
+++ b/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
@@ -1,0 +1,75 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[equality]
+  enum A {
+    End,
+    X(B),
+  }
+  
+  #[equality]
+  enum B {
+    Y(A),
+  }
+---
+package main
+
+func MakeAEnd() A {
+	return A{Tag: AEnd}
+}
+
+func MakeAX(arg0 B) A {
+	return A{Tag: AX, X: &arg0}
+}
+
+func MakeBY(arg0 A) B {
+	return B{Tag: BY, Y: &arg0}
+}
+
+type ATag int
+
+const (
+	AEnd ATag = iota
+	AX
+)
+
+type A struct {
+	Tag ATag
+	X   *B
+}
+
+func (a A) equals(other A) bool {
+	if a.Tag != other.Tag {
+		return false
+	}
+	switch a.Tag {
+	case AX:
+		return (*a.X).equals((*other.X))
+	default:
+		return true
+	}
+}
+
+type BTag int
+
+const (
+	BY BTag = iota
+)
+
+type B struct {
+	Tag BTag
+	Y   *A
+}
+
+func (b B) equals(other B) bool {
+	if b.Tag != other.Tag {
+		return false
+	}
+	switch b.Tag {
+	case BY:
+		return (*b.Y).equals((*other.Y))
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
+++ b/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[equality]
+  enum List {
+    Nil,
+    Cons(int, List),
+  }
+---
+package main
+
+func MakeListNil() List {
+	return List{Tag: ListNil}
+}
+
+func MakeListCons(arg0 int, arg1 List) List {
+	return List{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
+}
+
+type ListTag int
+
+const (
+	ListNil ListTag = iota
+	ListCons
+)
+
+type List struct {
+	Tag   ListTag
+	Cons0 int
+	Cons1 *List
+}
+
+func (l List) equals(other List) bool {
+	if l.Tag != other.Tag {
+		return false
+	}
+	switch l.Tag {
+	case ListCons:
+		return l.Cons0 == other.Cons0 && (*l.Cons1).equals((*other.Cons1))
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/nested_generic_instantiation_compares_natively.snap
+++ b/tests/spec/emit/snapshots/nested_generic_instantiation_compares_natively.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Box<T: Comparable> {
+    value: T,
+  }
+  
+  fn same(a: Box<Box<int>>, b: Box<Box<int>>) -> bool {
+    a == b
+  }
+---
+package main
+
+type Box[T comparable] struct {
+	value T
+}
+
+func same(a, b Box[Box[int]]) bool {
+	return a == b
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -342,6 +342,67 @@ enum Event {
 }
 
 #[test]
+fn nested_generic_instantiation_compares_natively() {
+    let input = r#"
+struct Box<T: Comparable> {
+  value: T,
+}
+
+fn same(a: Box<Box<int>>, b: Box<Box<int>>) -> bool {
+  a == b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_recursive_enum_derefs_pointer_payload() {
+    let input = r#"
+#[equality]
+enum List {
+  Nil,
+  Cons(int, List),
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_mutually_recursive_enums_deref_pointer_payloads() {
+    let input = r#"
+#[equality]
+enum A {
+  End,
+  X(B),
+}
+
+#[equality]
+enum B {
+  Y(A),
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_indirect_recursive_enum_through_struct() {
+    let input = r#"
+#[equality]
+enum Tree {
+  Leaf,
+  Node(Pair),
+}
+
+#[equality]
+struct Pair {
+  l: Tree,
+  r: Tree,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn equality_user_equals_over_function_field() {
     let input = r#"
 #[equality]

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1991,6 +1991,21 @@ fn assignment_type_mismatch_single_diagnostic() {
 }
 
 #[test]
+fn annotated_map_binding_bad_key_single_diagnostic() {
+    let result = infer(
+        r#"
+    struct Holder { items: Slice<int> }
+
+    fn test() -> int {
+      let m: Map<Holder, int> = Map.new()
+      m.length()
+    }
+        "#,
+    );
+    assert_eq!(result.errors.len(), 1);
+}
+
+#[test]
 fn mut_binding_from_clone_no_error() {
     infer(r#"{ let a = [1, 2]; let mut b = a.clone(); b = b.append(3); let _ = b; let _ = a }"#)
         .assert_no_errors();

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -7832,6 +7832,62 @@ fn test() {
 }
 
 #[test]
+fn infer_not_comparable_recursive_enum_suggests_equality() {
+    let input = r#"
+enum List {
+  Nil,
+  Cons(int, List),
+}
+
+fn test() {
+  let a = List.Cons(1, List.Nil);
+  let b = List.Nil;
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_recursive_enum_with_equality_suggests_equals() {
+    let input = r#"
+#[equality]
+enum List {
+  Nil,
+  Cons(int, List),
+}
+
+fn test() {
+  let a = List.Cons(1, List.Nil);
+  let b = List.Nil;
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_not_comparable_mutually_recursive_enums() {
+    let input = r#"
+enum A {
+  End,
+  X(B),
+}
+
+enum B {
+  Y(A),
+}
+
+fn test() {
+  let a = A.End;
+  let b = A.X(B.Y(A.End));
+  let result = a == b;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_not_comparable_interface() {
     let input = r#"
 interface Shape {
@@ -10298,6 +10354,23 @@ struct Outer {
 }
 
 #[test]
+fn equality_rejects_recursive_cycle_field_without_equality() {
+    let input = r#"
+#[equality]
+enum Tree {
+  Leaf,
+  Node(Pair),
+}
+
+struct Pair {
+  l: Tree,
+  r: Tree,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn equality_enum_rejects_function_payload() {
     let input = r#"
 #[equality]
@@ -11207,6 +11280,81 @@ struct Key { tags: Slice<int> }
 fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
   a.equals(b)
 }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_annotation_rejects_noncomparable_struct() {
+    let input = r#"
+struct Holder { items: Slice<int> }
+
+fn count(m: Map<Holder, int>) -> int {
+  m.length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_constructor_rejects_noncomparable_struct() {
+    let input = r#"
+struct Holder { items: Slice<int> }
+
+fn test() -> int {
+  let mut m = Map.new<Holder, int>()
+  m[Holder { items: [1] }] = 1
+  m.length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_constructor_rejects_recursive_enum() {
+    let input = r#"
+enum List {
+  Nil,
+  Cons(int, List),
+}
+
+fn test() -> int {
+  let mut m = Map.new<List, int>()
+  m[List.Nil] = 1
+  m.length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_expression_position_rejects_slice_key() {
+    let input = r#"
+fn test() -> int {
+  Map.new<Slice<int>, int>().length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_inferred_rejects_slice_key() {
+    let input = r#"
+fn test() -> int {
+  let mut m = Map.new()
+  m[[1, 2]] = 1
+  m.length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn map_key_alias_body_rejects_noncomparable_struct() {
+    let input = r#"
+struct Holder { items: Slice<int> }
+
+type Index = Map<Holder, int>
 "#;
     assert_infer_error_snapshot!(input);
 }

--- a/tests/ui/errors/snapshots/container_equals_map_non_comparable_key_rejected.snap
+++ b/tests/ui/errors/snapshots/container_equals_map_non_comparable_key_rejected.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Invalid comparison
-   ╭─[test.lis:5:3]
+  ✕ Invalid map key type
+   ╭─[test.lis:4:12]
+ 3 │ 
  4 │ fn test(a: Map<Key, int>, b: Map<Key, int>) -> bool {
+   ·            ──────┬──────
+   ·                  ╰── `Key` is not comparable
  5 │   a.equals(b)
-   ·   ┬
-   ·   ╰── cannot be compared
- 6 │ }
    ╰────
-  help: `Map<Key, int>` cannot be compared because a map with a non-comparable key cannot be compared · code: [infer.not_equatable]
+  help: Map keys must be comparable in Go. a struct containing non-comparable fields cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/equality_rejects_recursive_cycle_field_without_equality.snap
+++ b/tests/ui/errors/snapshots/equality_rejects_recursive_cycle_field_without_equality.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot derive equality
+   ╭─[test.lis:5:3]
+ 4 │   Leaf,
+ 5 │   Node(Pair),
+   ·   ──┬─
+   ·     ╰── `Node` cannot be compared
+ 6 │ }
+   ╰────
+  help: `#[equality]` cannot compare recursive types. Give `Tree` a hand-written `equals` method, mark the field's type `#[equality]`, or remove the field · code: [attribute.cannot_derive_equality]

--- a/tests/ui/errors/snapshots/infer_not_comparable_mutually_recursive_enums.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_mutually_recursive_enums.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:14:16]
+ 13 │   let b = A.X(B.Y(A.End));
+ 14 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `A` cannot be compared with `==`
+ 15 │ }
+    ╰────
+  help: The `==` and `!=` operators cannot be used on recursive types because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_recursive_enum_suggests_equality.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_recursive_enum_suggests_equality.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+    ╭─[test.lis:10:16]
+  9 │   let b = List.Nil;
+ 10 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `List` cannot be compared with `==`
+ 11 │ }
+    ╰────
+  help: Mark `List` with `#[equality]` to compare it with `.equals()` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_not_comparable_recursive_enum_with_equality_suggests_equals.snap
+++ b/tests/ui/errors/snapshots/infer_not_comparable_recursive_enum_with_equality_suggests_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+    ╭─[test.lis:11:16]
+ 10 │   let b = List.Nil;
+ 11 │   let result = a == b;
+    ·                ┬
+    ·                ╰── `List` cannot be compared with `==`
+ 12 │ }
+    ╰────
+  help: Use `.equals()` to compare `List` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/map_key_alias_body_rejects_noncomparable_struct.snap
+++ b/tests/ui/errors/snapshots/map_key_alias_body_rejects_noncomparable_struct.snap
@@ -2,10 +2,10 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid map key type
-   ╭─[test.lis:6:24]
- 5 │ #[equality]
- 6 │ struct Index { values: Map<Key, int> }
-   ·                        ──────┬──────
-   ·                              ╰── `Key` is not comparable
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ type Index = Map<Holder, int>
+   · ──────────────┬──────────────
+   ·               ╰── `Holder` is not comparable
    ╰────
   help: Map keys must be comparable in Go. a struct containing non-comparable fields cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/map_key_annotation_rejects_noncomparable_struct.snap
+++ b/tests/ui/errors/snapshots/map_key_annotation_rejects_noncomparable_struct.snap
@@ -2,10 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid map key type
-   ╭─[test.lis:6:24]
- 5 │ #[equality]
- 6 │ struct Index { values: Map<Key, int> }
-   ·                        ──────┬──────
-   ·                              ╰── `Key` is not comparable
+   ╭─[test.lis:4:13]
+ 3 │ 
+ 4 │ fn count(m: Map<Holder, int>) -> int {
+   ·             ────────┬───────
+   ·                     ╰── `Holder` is not comparable
+ 5 │   m.length()
    ╰────
   help: Map keys must be comparable in Go. a struct containing non-comparable fields cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/map_key_constructor_rejects_noncomparable_struct.snap
+++ b/tests/ui/errors/snapshots/map_key_constructor_rejects_noncomparable_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid map key type
+   ╭─[test.lis:5:15]
+ 4 │ fn test() -> int {
+ 5 │   let mut m = Map.new<Holder, int>()
+   ·               ───────────┬──────────
+   ·                          ╰── `Holder` is not comparable
+ 6 │   m[Holder { items: [1] }] = 1
+   ╰────
+  help: Map keys must be comparable in Go. a struct containing non-comparable fields cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/map_key_constructor_rejects_recursive_enum.snap
+++ b/tests/ui/errors/snapshots/map_key_constructor_rejects_recursive_enum.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid map key type
+   ╭─[test.lis:8:15]
+ 7 │ fn test() -> int {
+ 8 │   let mut m = Map.new<List, int>()
+   ·               ──────────┬─────────
+   ·                         ╰── `List` is not comparable
+ 9 │   m[List.Nil] = 1
+   ╰────
+  help: Map keys must be comparable in Go. recursive types cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/map_key_expression_position_rejects_slice_key.snap
+++ b/tests/ui/errors/snapshots/map_key_expression_position_rejects_slice_key.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid map key type
+   ╭─[test.lis:3:3]
+ 2 │ fn test() -> int {
+ 3 │   Map.new<Slice<int>, int>().length()
+   ·   ─────────────┬────────────
+   ·                ╰── `Slice<int>` is not comparable
+ 4 │ }
+   ╰────
+  help: Map keys must be comparable in Go. slices cannot be used as map keys · code: [infer.non_comparable_map_key]

--- a/tests/ui/errors/snapshots/map_key_inferred_rejects_slice_key.snap
+++ b/tests/ui/errors/snapshots/map_key_inferred_rejects_slice_key.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid map key type
+   ╭─[test.lis:3:15]
+ 2 │ fn test() -> int {
+ 3 │   let mut m = Map.new()
+   ·               ────┬────
+   ·                   ╰── `Slice<int>` is not comparable
+ 4 │   m[[1, 2]] = 1
+   ╰────
+  help: Map keys must be comparable in Go. slices cannot be used as map keys · code: [infer.non_comparable_map_key]


### PR DESCRIPTION
- `==` on a recursive enum crashed `lis check` with a stack overflow. This is now rejected.
- `#[equality]` on a recursive enum generated an `equals` method that failed at `go build`. The generated method now compares recursive payloads structurally.
- Map key types that can never be comparable emitted Go that failed to build. They are now rejected.
