### PR TITLE
fix: sentinel-returning Go functions as values

### DIFF
--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -744,4 +744,30 @@ impl Planner<'_> {
             body
         )
     }
+
+    pub(crate) fn emit_go_fn_sentinel_adapter(
+        &mut self,
+        setup: &mut Vec<LoweredStatement>,
+        expression: &Expression,
+        sentinel: i64,
+    ) -> String {
+        let (return_type, param_strs, call_str) = self
+            .wrapper_call_parts(setup, expression)
+            .expect("expected function type");
+
+        let inner_ty_str = self.go_type_string(&return_type.ok_type());
+        let ret_var = self.fresh_var(Some("ret"));
+        self.declare(&ret_var);
+
+        let mut body = String::new();
+        write_line!(body, "{} := {}", ret_var, call_str);
+        write_line!(body, "return {}, {} != {}", ret_var, ret_var, sentinel);
+
+        format!(
+            "func({}) ({}, bool) {{\n{}}}",
+            param_strs.join(", "),
+            inner_ty_str,
+            body
+        )
+    }
 }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -31,6 +31,10 @@ impl Planner<'_> {
                 let mut setup = Vec::new();
                 let value = if self.go_fn_needs_lowered_tuple_adapter(expression, ctx) {
                     self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression)
+                } else if let GoCallStrategy::Sentinel { value } = &strategy
+                    && !ctx.forces_tagged_go_function()
+                {
+                    self.emit_go_fn_sentinel_adapter(&mut setup, expression, *value)
                 } else {
                     self.emit_go_fn_wrapper(&mut setup, expression, &strategy)
                 };

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -223,6 +223,76 @@ fn main() {
 }
 
 #[test]
+fn interop_sentinel_let_call() {
+    let input = r#"
+import "go:example.com/idx"
+
+fn main() {
+  let f = idx.Find
+  let r = f("hello", "ll")
+  match r {
+    Some(v) => { let _ = v },
+    None => { let _ = -2 },
+  }
+}
+"#;
+    let typedef = r#"
+#[go(sentinel_minus_one)]
+pub fn Find(s: string, substr: string) -> Option<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
+}
+
+#[test]
+fn interop_sentinel_call_arg() {
+    let input = r#"
+import "go:example.com/idx"
+
+fn apply(f: fn(string, string) -> Option<int>, s: string) -> int {
+  match f(s, "ll") {
+    Some(v) => v,
+    None => -2,
+  }
+}
+
+fn main() {
+  let r = apply(idx.Find, "hello")
+  let _ = r
+}
+"#;
+    let typedef = r#"
+#[go(sentinel_minus_one)]
+pub fn Find(s: string, substr: string) -> Option<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
+}
+
+#[test]
+fn interop_sentinel_return_pos() {
+    let input = r#"
+import "go:example.com/idx"
+
+fn make_finder() -> fn(string, string) -> Option<int> {
+  idx.Find
+}
+
+fn main() {
+  let f = make_finder()
+  let r = f("hello", "ll")
+  match r {
+    Some(v) => { let _ = v },
+    None => { let _ = -2 },
+  }
+}
+"#;
+    let typedef = r#"
+#[go(sentinel_minus_one)]
+pub fn Find(s: string, substr: string) -> Option<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
+}
+
+#[test]
 fn interop_nullable_direct_call() {
     let input = r#"
 import "go:flag"

--- a/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/idx"
+  
+  fn apply(f: fn(string, string) -> Option<int>, s: string) -> int {
+    match f(s, "ll") {
+      Some(v) => v,
+      None => -2,
+    }
+  }
+  
+  fn main() {
+    let r = apply(idx.Find, "hello")
+    let _ = r
+  }
+---
+package main
+
+import (
+	"example.com/idx"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func apply(f func(string, string) (int, bool), s string) int {
+	option_2 := lisette.OptionFromCommaOk[int](f(s, "ll"))
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal
+	}
+	return -2
+}
+
+func main() {
+	r := apply(func(arg0 string, arg1 string) (int, bool) {
+		ret_1 := idx.Find(arg0, arg1)
+		return ret_1, ret_1 != -1
+	}, "hello")
+	_ = r
+}

--- a/tests/spec/emit/snapshots/interop_sentinel_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_let_call.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/idx"
+  
+  fn main() {
+    let f = idx.Find
+    let r = f("hello", "ll")
+    match r {
+      Some(v) => { let _ = v },
+      None => { let _ = -2 },
+    }
+  }
+---
+package main
+
+import (
+	"example.com/idx"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	f := func(arg0 string, arg1 string) (int, bool) {
+		ret_1 := idx.Find(arg0, arg1)
+		return ret_1, ret_1 != -1
+	}
+	option_2 := lisette.OptionFromCommaOk[int](f("hello", "ll"))
+	r := option_2
+	if r.Tag == lisette.OptionSome {
+		_ = r.SomeVal
+	} else {
+		_ = -2
+	}
+}

--- a/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/idx"
+  
+  fn make_finder() -> fn(string, string) -> Option<int> {
+    idx.Find
+  }
+  
+  fn main() {
+    let f = make_finder()
+    let r = f("hello", "ll")
+    match r {
+      Some(v) => { let _ = v },
+      None => { let _ = -2 },
+    }
+  }
+---
+package main
+
+import (
+	"example.com/idx"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func make_finder() func(string, string) (int, bool) {
+	return func(arg0 string, arg1 string) (int, bool) {
+		ret_1 := idx.Find(arg0, arg1)
+		return ret_1, ret_1 != -1
+	}
+}
+
+func main() {
+	f := make_finder()
+	option_1 := lisette.OptionFromCommaOk[int](f("hello", "ll"))
+	r := option_1
+	if r.Tag == lisette.OptionSome {
+		_ = r.SomeVal
+	} else {
+		_ = -2
+	}
+}


### PR DESCRIPTION
Using a sentinel-returning Go function as a value emitted invalid Go. Affected storing the function ni a variable, passing it as an argument, or returning it from a function.

```rs
import "go:fmt"
import "go:strings"

fn main() {
  let f = strings.Index
  fmt.Println(f("hello", "ll")) // Some(2)
}
```
