### PR TITLE
fix: preserve Go's `uintptr` in typedefs

### DIFF
--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -213,7 +213,7 @@ func basicToLisette(t *types.Basic) string {
 	case types.Uint64:
 		return "uint64"
 	case types.Uintptr:
-		return "uint"
+		return "uintptr"
 	case types.Float32:
 		return "float32"
 	case types.Float64:

--- a/bindgen/tests/testdata/fixtures/types/types.go
+++ b/bindgen/tests/testdata/fixtures/types/types.go
@@ -18,7 +18,7 @@ func GetFloat64() float64 { return 0 }
 func GetString() string   { return "" }
 func GetRune() rune       { return 0 } // → int32
 func GetByte() byte       { return 0 } // → uint8
-func GetUintptr() uintptr { return 0 } // → uint
+func GetUintptr() uintptr { return 0 }
 
 // Pointers
 

--- a/bindgen/tests/testdata/snapshots/types.d.lis
+++ b/bindgen/tests/testdata/snapshots/types.d.lis
@@ -62,7 +62,7 @@ pub fn GetUint64() -> uint64
 
 pub fn GetUint8() -> uint8
 
-pub fn GetUintptr() -> uint
+pub fn GetUintptr() -> uintptr
 
 pub struct T {
   pub X: int,

--- a/crates/stdlib/typedefs/log/slog.d.lis
+++ b/crates/stdlib/typedefs/log/slog.d.lis
@@ -170,7 +170,7 @@ pub fn NewLogLogger(h: Handler, level: Level) -> Ref<log.Logger>
 /// 
 /// NewRecord is intended for logging APIs that want to support a [Handler] as
 /// a backend.
-pub fn NewRecord(t: time.Time, level: Level, msg: string, pc: uint) -> Record
+pub fn NewRecord(t: time.Time, level: Level, msg: string, pc: uintptr) -> Record
 
 /// NewTextHandler creates a [TextHandler] that writes to w,
 /// using the given options.
@@ -320,7 +320,7 @@ pub struct Record {
   pub Time: time.Time,
   pub Message: string,
   pub Level: Level,
-  pub PC: uint,
+  pub PC: uintptr,
 }
 
 /// Source describes the location of a line of source code.

--- a/crates/stdlib/typedefs/os_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/os_darwin_amd64.d.lis
@@ -312,7 +312,7 @@ pub fn MkdirTemp(dir: string, pattern: string) -> Result<string, error>
 /// 
 /// After passing it to NewFile, fd may become invalid under the same conditions described
 /// in the comments of [File.Fd], and the same constraints apply.
-pub fn NewFile(fd: uint, name: string) -> Option<Ref<File>>
+pub fn NewFile(fd: uintptr, name: string) -> Option<Ref<File>>
 
 /// NewSyscallError returns, as an error, a new [SyscallError]
 /// with the given system call name and error details.
@@ -878,7 +878,7 @@ impl File {
   ///     operations on the file.
   /// 
   /// For most uses prefer the f.SyscallConn method.
-  fn Fd(self: Ref<File>) -> uint
+  fn Fd(self: Ref<File>) -> uintptr
 
   /// Name returns the name of the file as presented to Open.
   /// 

--- a/crates/stdlib/typedefs/os_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/os_linux_amd64.d.lis
@@ -312,7 +312,7 @@ pub fn MkdirTemp(dir: string, pattern: string) -> Result<string, error>
 /// 
 /// After passing it to NewFile, fd may become invalid under the same conditions described
 /// in the comments of [File.Fd], and the same constraints apply.
-pub fn NewFile(fd: uint, name: string) -> Option<Ref<File>>
+pub fn NewFile(fd: uintptr, name: string) -> Option<Ref<File>>
 
 /// NewSyscallError returns, as an error, a new [SyscallError]
 /// with the given system call name and error details.
@@ -878,7 +878,7 @@ impl File {
   ///     operations on the file.
   /// 
   /// For most uses prefer the f.SyscallConn method.
-  fn Fd(self: Ref<File>) -> uint
+  fn Fd(self: Ref<File>) -> uintptr
 
   /// Name returns the name of the file as presented to Open.
   /// 

--- a/crates/stdlib/typedefs/os_windows_amd64.d.lis
+++ b/crates/stdlib/typedefs/os_windows_amd64.d.lis
@@ -312,7 +312,7 @@ pub fn MkdirTemp(dir: string, pattern: string) -> Result<string, error>
 /// 
 /// After passing it to NewFile, fd may become invalid under the same conditions described
 /// in the comments of [File.Fd], and the same constraints apply.
-pub fn NewFile(fd: uint, name: string) -> Option<Ref<File>>
+pub fn NewFile(fd: uintptr, name: string) -> Option<Ref<File>>
 
 /// NewSyscallError returns, as an error, a new [SyscallError]
 /// with the given system call name and error details.
@@ -878,7 +878,7 @@ impl File {
   ///     operations on the file.
   /// 
   /// For most uses prefer the f.SyscallConn method.
-  fn Fd(self: Ref<File>) -> uint
+  fn Fd(self: Ref<File>) -> uintptr
 
   /// Name returns the name of the file as presented to Open.
   /// 

--- a/crates/stdlib/typedefs/reflect.d.lis
+++ b/crates/stdlib/typedefs/reflect.d.lis
@@ -361,7 +361,7 @@ pub struct SelectCase {
 /// 
 /// Deprecated: Use unsafe.Slice or unsafe.SliceData instead.
 pub struct SliceHeader {
-  pub Data: uint,
+  pub Data: uintptr,
   pub Len: int,
   pub Cap: int,
 }
@@ -375,7 +375,7 @@ pub struct SliceHeader {
 /// 
 /// Deprecated: Use unsafe.String or unsafe.StringData instead.
 pub struct StringHeader {
-  pub Data: uint,
+  pub Data: uintptr,
   pub Len: int,
 }
 
@@ -385,7 +385,7 @@ pub struct StructField {
   pub PkgPath: string,
   pub Type: Option<Type>,
   pub Tag: StructTag,
-  pub Offset: uint,
+  pub Offset: uintptr,
   pub Index: Slice<int>,
   pub Anonymous: bool,
 }
@@ -445,7 +445,7 @@ pub interface Type {
   fn OverflowInt(x: int64) -> bool
   fn OverflowUint(x: uint64) -> bool
   fn PkgPath() -> string
-  fn Size() -> uint
+  fn Size() -> uintptr
   fn String() -> string
   #[go(unexported, "reflect.common() *internal/abi.Type")]
   fn common()
@@ -719,7 +719,7 @@ impl Value {
   /// Deprecated: The memory representation of interface values is not
   /// compatible with InterfaceData.
   #[go(array_return)]
-  fn InterfaceData(self) -> Slice<uint>
+  fn InterfaceData(self) -> Slice<uintptr>
 
   /// IsNil reports whether its argument v is nil. The argument must be
   /// a chan, func, interface, map, pointer, or slice value; if it is
@@ -841,7 +841,7 @@ impl Value {
   /// element of the underlying bytes of string.
   /// 
   /// It's preferred to use uintptr(Value.UnsafePointer()) to get the equivalent result.
-  fn Pointer(self) -> uint
+  fn Pointer(self) -> uintptr
 
   /// Recv receives and returns a value from the channel v.
   /// It panics if v's Kind is not [Chan].
@@ -995,7 +995,7 @@ impl Value {
   /// It panics if v is not addressable.
   /// 
   /// It's preferred to use uintptr(Value.Addr().UnsafePointer()) to get the equivalent result.
-  fn UnsafeAddr(self) -> uint
+  fn UnsafeAddr(self) -> uintptr
 
   /// UnsafePointer returns v's value as a [unsafe.Pointer].
   /// It panics if v's Kind is not [Chan], [Func], [Map], [Pointer], [Slice], [String] or [UnsafePointer].

--- a/crates/stdlib/typedefs/runtime/debug.d.lis
+++ b/crates/stdlib/typedefs/runtime/debug.d.lis
@@ -190,7 +190,7 @@ pub fn Stack() -> Slice<byte>
 /// process; instead, use a temporary file or network socket.
 /// 
 /// The heap dump format is defined at https://golang.org/s/go15heapdump.
-pub fn WriteHeapDump(fd: uint)
+pub fn WriteHeapDump(fd: uintptr)
 
 /// BuildInfo represents the build information read from a Go binary.
 pub struct BuildInfo {

--- a/crates/stdlib/typedefs/runtime_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/runtime_darwin_amd64.d.lis
@@ -92,7 +92,7 @@ pub fn CPUProfile() -> Slice<byte>
 /// the program counter, the file name (using forward slashes as path separator, even
 /// on Windows), and the line number within the file of the corresponding call.
 /// The boolean ok is false if it was not possible to recover the information.
-pub fn Caller(skip: int) -> Option<(uint, string, int)>
+pub fn Caller(skip: int) -> Option<(uintptr, string, int)>
 
 /// Callers fills the slice pc with the return program counters of function invocations
 /// on the calling goroutine's stack. The argument skip is the number of stack frames
@@ -107,12 +107,12 @@ pub fn Caller(skip: int) -> Option<(uint, string, int)>
 /// directly is discouraged, as is using [FuncForPC] on any of the
 /// returned PCs, since these cannot account for inlining or return
 /// program counter adjustment.
-pub fn Callers(skip: int, mut pc: Slice<uint>) -> int
+pub fn Callers(skip: int, mut pc: Slice<uintptr>) -> int
 
 /// CallersFrames takes a slice of PC values returned by [Callers] and
 /// prepares to return function/file/line information.
 /// Do not change the slice until you are done with the [Frames].
-pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
+pub fn CallersFrames(callers: Slice<uintptr>) -> Ref<Frames>
 
 /// FuncForPC returns a *[Func] describing the function that contains the
 /// given program counter address, or else nil.
@@ -120,7 +120,7 @@ pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
 /// If pc represents multiple functions because of inlining, it returns
 /// the *Func describing the innermost function, but with an entry of
 /// the outermost function.
-pub fn FuncForPC(pc: uint) -> Option<Ref<Func>>
+pub fn FuncForPC(pc: uintptr) -> Option<Ref<Func>>
 
 /// GC runs a garbage collection and blocks the caller until the
 /// garbage collection is complete. It may also block the entire
@@ -693,12 +693,12 @@ pub interface Error {
 
 /// Frame is the information returned by [Frames] for each call frame.
 pub struct Frame {
-  pub PC: uint,
+  pub PC: uintptr,
   pub Func: Option<Ref<Func>>,
   pub Function: string,
   pub File: string,
   pub Line: int,
-  pub Entry: uint,
+  pub Entry: uintptr,
 }
 
 /// Frames may be used to get function/file/line information for a
@@ -833,13 +833,13 @@ impl Frames {
 
 impl Func {
   /// Entry returns the entry address of the function.
-  fn Entry(self: Ref<Func>) -> uint
+  fn Entry(self: Ref<Func>) -> uintptr
 
   /// FileLine returns the file name and line number of the
   /// source code corresponding to the program counter pc.
   /// The result will not be accurate if pc is not a program
   /// counter within f.
-  fn FileLine(self: Ref<Func>, pc: uint) -> (string, int)
+  fn FileLine(self: Ref<Func>, pc: uintptr) -> (string, int)
 
   /// Name returns the name of the function.
   fn Name(self: Ref<Func>) -> string
@@ -854,7 +854,7 @@ impl MemProfileRecord {
 
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uint>
+  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uintptr>
 }
 
 impl PanicNilError {
@@ -883,7 +883,7 @@ impl Pinner {
 impl StackRecord {
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<StackRecord>) -> Slice<uint>
+  fn Stack(self: Ref<StackRecord>) -> Slice<uintptr>
 }
 
 impl TypeAssertionError {

--- a/crates/stdlib/typedefs/runtime_darwin_arm64.d.lis
+++ b/crates/stdlib/typedefs/runtime_darwin_arm64.d.lis
@@ -92,7 +92,7 @@ pub fn CPUProfile() -> Slice<byte>
 /// the program counter, the file name (using forward slashes as path separator, even
 /// on Windows), and the line number within the file of the corresponding call.
 /// The boolean ok is false if it was not possible to recover the information.
-pub fn Caller(skip: int) -> Option<(uint, string, int)>
+pub fn Caller(skip: int) -> Option<(uintptr, string, int)>
 
 /// Callers fills the slice pc with the return program counters of function invocations
 /// on the calling goroutine's stack. The argument skip is the number of stack frames
@@ -107,12 +107,12 @@ pub fn Caller(skip: int) -> Option<(uint, string, int)>
 /// directly is discouraged, as is using [FuncForPC] on any of the
 /// returned PCs, since these cannot account for inlining or return
 /// program counter adjustment.
-pub fn Callers(skip: int, mut pc: Slice<uint>) -> int
+pub fn Callers(skip: int, mut pc: Slice<uintptr>) -> int
 
 /// CallersFrames takes a slice of PC values returned by [Callers] and
 /// prepares to return function/file/line information.
 /// Do not change the slice until you are done with the [Frames].
-pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
+pub fn CallersFrames(callers: Slice<uintptr>) -> Ref<Frames>
 
 /// FuncForPC returns a *[Func] describing the function that contains the
 /// given program counter address, or else nil.
@@ -120,7 +120,7 @@ pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
 /// If pc represents multiple functions because of inlining, it returns
 /// the *Func describing the innermost function, but with an entry of
 /// the outermost function.
-pub fn FuncForPC(pc: uint) -> Option<Ref<Func>>
+pub fn FuncForPC(pc: uintptr) -> Option<Ref<Func>>
 
 /// GC runs a garbage collection and blocks the caller until the
 /// garbage collection is complete. It may also block the entire
@@ -693,12 +693,12 @@ pub interface Error {
 
 /// Frame is the information returned by [Frames] for each call frame.
 pub struct Frame {
-  pub PC: uint,
+  pub PC: uintptr,
   pub Func: Option<Ref<Func>>,
   pub Function: string,
   pub File: string,
   pub Line: int,
-  pub Entry: uint,
+  pub Entry: uintptr,
 }
 
 /// Frames may be used to get function/file/line information for a
@@ -833,13 +833,13 @@ impl Frames {
 
 impl Func {
   /// Entry returns the entry address of the function.
-  fn Entry(self: Ref<Func>) -> uint
+  fn Entry(self: Ref<Func>) -> uintptr
 
   /// FileLine returns the file name and line number of the
   /// source code corresponding to the program counter pc.
   /// The result will not be accurate if pc is not a program
   /// counter within f.
-  fn FileLine(self: Ref<Func>, pc: uint) -> (string, int)
+  fn FileLine(self: Ref<Func>, pc: uintptr) -> (string, int)
 
   /// Name returns the name of the function.
   fn Name(self: Ref<Func>) -> string
@@ -854,7 +854,7 @@ impl MemProfileRecord {
 
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uint>
+  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uintptr>
 }
 
 impl PanicNilError {
@@ -883,7 +883,7 @@ impl Pinner {
 impl StackRecord {
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<StackRecord>) -> Slice<uint>
+  fn Stack(self: Ref<StackRecord>) -> Slice<uintptr>
 }
 
 impl TypeAssertionError {

--- a/crates/stdlib/typedefs/runtime_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/runtime_linux_amd64.d.lis
@@ -92,7 +92,7 @@ pub fn CPUProfile() -> Slice<byte>
 /// the program counter, the file name (using forward slashes as path separator, even
 /// on Windows), and the line number within the file of the corresponding call.
 /// The boolean ok is false if it was not possible to recover the information.
-pub fn Caller(skip: int) -> Option<(uint, string, int)>
+pub fn Caller(skip: int) -> Option<(uintptr, string, int)>
 
 /// Callers fills the slice pc with the return program counters of function invocations
 /// on the calling goroutine's stack. The argument skip is the number of stack frames
@@ -107,12 +107,12 @@ pub fn Caller(skip: int) -> Option<(uint, string, int)>
 /// directly is discouraged, as is using [FuncForPC] on any of the
 /// returned PCs, since these cannot account for inlining or return
 /// program counter adjustment.
-pub fn Callers(skip: int, mut pc: Slice<uint>) -> int
+pub fn Callers(skip: int, mut pc: Slice<uintptr>) -> int
 
 /// CallersFrames takes a slice of PC values returned by [Callers] and
 /// prepares to return function/file/line information.
 /// Do not change the slice until you are done with the [Frames].
-pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
+pub fn CallersFrames(callers: Slice<uintptr>) -> Ref<Frames>
 
 /// FuncForPC returns a *[Func] describing the function that contains the
 /// given program counter address, or else nil.
@@ -120,7 +120,7 @@ pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
 /// If pc represents multiple functions because of inlining, it returns
 /// the *Func describing the innermost function, but with an entry of
 /// the outermost function.
-pub fn FuncForPC(pc: uint) -> Option<Ref<Func>>
+pub fn FuncForPC(pc: uintptr) -> Option<Ref<Func>>
 
 /// GC runs a garbage collection and blocks the caller until the
 /// garbage collection is complete. It may also block the entire
@@ -693,12 +693,12 @@ pub interface Error {
 
 /// Frame is the information returned by [Frames] for each call frame.
 pub struct Frame {
-  pub PC: uint,
+  pub PC: uintptr,
   pub Func: Option<Ref<Func>>,
   pub Function: string,
   pub File: string,
   pub Line: int,
-  pub Entry: uint,
+  pub Entry: uintptr,
 }
 
 /// Frames may be used to get function/file/line information for a
@@ -833,13 +833,13 @@ impl Frames {
 
 impl Func {
   /// Entry returns the entry address of the function.
-  fn Entry(self: Ref<Func>) -> uint
+  fn Entry(self: Ref<Func>) -> uintptr
 
   /// FileLine returns the file name and line number of the
   /// source code corresponding to the program counter pc.
   /// The result will not be accurate if pc is not a program
   /// counter within f.
-  fn FileLine(self: Ref<Func>, pc: uint) -> (string, int)
+  fn FileLine(self: Ref<Func>, pc: uintptr) -> (string, int)
 
   /// Name returns the name of the function.
   fn Name(self: Ref<Func>) -> string
@@ -854,7 +854,7 @@ impl MemProfileRecord {
 
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uint>
+  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uintptr>
 }
 
 impl PanicNilError {
@@ -883,7 +883,7 @@ impl Pinner {
 impl StackRecord {
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<StackRecord>) -> Slice<uint>
+  fn Stack(self: Ref<StackRecord>) -> Slice<uintptr>
 }
 
 impl TypeAssertionError {

--- a/crates/stdlib/typedefs/runtime_linux_arm64.d.lis
+++ b/crates/stdlib/typedefs/runtime_linux_arm64.d.lis
@@ -92,7 +92,7 @@ pub fn CPUProfile() -> Slice<byte>
 /// the program counter, the file name (using forward slashes as path separator, even
 /// on Windows), and the line number within the file of the corresponding call.
 /// The boolean ok is false if it was not possible to recover the information.
-pub fn Caller(skip: int) -> Option<(uint, string, int)>
+pub fn Caller(skip: int) -> Option<(uintptr, string, int)>
 
 /// Callers fills the slice pc with the return program counters of function invocations
 /// on the calling goroutine's stack. The argument skip is the number of stack frames
@@ -107,12 +107,12 @@ pub fn Caller(skip: int) -> Option<(uint, string, int)>
 /// directly is discouraged, as is using [FuncForPC] on any of the
 /// returned PCs, since these cannot account for inlining or return
 /// program counter adjustment.
-pub fn Callers(skip: int, mut pc: Slice<uint>) -> int
+pub fn Callers(skip: int, mut pc: Slice<uintptr>) -> int
 
 /// CallersFrames takes a slice of PC values returned by [Callers] and
 /// prepares to return function/file/line information.
 /// Do not change the slice until you are done with the [Frames].
-pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
+pub fn CallersFrames(callers: Slice<uintptr>) -> Ref<Frames>
 
 /// FuncForPC returns a *[Func] describing the function that contains the
 /// given program counter address, or else nil.
@@ -120,7 +120,7 @@ pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
 /// If pc represents multiple functions because of inlining, it returns
 /// the *Func describing the innermost function, but with an entry of
 /// the outermost function.
-pub fn FuncForPC(pc: uint) -> Option<Ref<Func>>
+pub fn FuncForPC(pc: uintptr) -> Option<Ref<Func>>
 
 /// GC runs a garbage collection and blocks the caller until the
 /// garbage collection is complete. It may also block the entire
@@ -693,12 +693,12 @@ pub interface Error {
 
 /// Frame is the information returned by [Frames] for each call frame.
 pub struct Frame {
-  pub PC: uint,
+  pub PC: uintptr,
   pub Func: Option<Ref<Func>>,
   pub Function: string,
   pub File: string,
   pub Line: int,
-  pub Entry: uint,
+  pub Entry: uintptr,
 }
 
 /// Frames may be used to get function/file/line information for a
@@ -833,13 +833,13 @@ impl Frames {
 
 impl Func {
   /// Entry returns the entry address of the function.
-  fn Entry(self: Ref<Func>) -> uint
+  fn Entry(self: Ref<Func>) -> uintptr
 
   /// FileLine returns the file name and line number of the
   /// source code corresponding to the program counter pc.
   /// The result will not be accurate if pc is not a program
   /// counter within f.
-  fn FileLine(self: Ref<Func>, pc: uint) -> (string, int)
+  fn FileLine(self: Ref<Func>, pc: uintptr) -> (string, int)
 
   /// Name returns the name of the function.
   fn Name(self: Ref<Func>) -> string
@@ -854,7 +854,7 @@ impl MemProfileRecord {
 
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uint>
+  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uintptr>
 }
 
 impl PanicNilError {
@@ -883,7 +883,7 @@ impl Pinner {
 impl StackRecord {
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<StackRecord>) -> Slice<uint>
+  fn Stack(self: Ref<StackRecord>) -> Slice<uintptr>
 }
 
 impl TypeAssertionError {

--- a/crates/stdlib/typedefs/runtime_windows_amd64.d.lis
+++ b/crates/stdlib/typedefs/runtime_windows_amd64.d.lis
@@ -92,7 +92,7 @@ pub fn CPUProfile() -> Slice<byte>
 /// the program counter, the file name (using forward slashes as path separator, even
 /// on Windows), and the line number within the file of the corresponding call.
 /// The boolean ok is false if it was not possible to recover the information.
-pub fn Caller(skip: int) -> Option<(uint, string, int)>
+pub fn Caller(skip: int) -> Option<(uintptr, string, int)>
 
 /// Callers fills the slice pc with the return program counters of function invocations
 /// on the calling goroutine's stack. The argument skip is the number of stack frames
@@ -107,12 +107,12 @@ pub fn Caller(skip: int) -> Option<(uint, string, int)>
 /// directly is discouraged, as is using [FuncForPC] on any of the
 /// returned PCs, since these cannot account for inlining or return
 /// program counter adjustment.
-pub fn Callers(skip: int, mut pc: Slice<uint>) -> int
+pub fn Callers(skip: int, mut pc: Slice<uintptr>) -> int
 
 /// CallersFrames takes a slice of PC values returned by [Callers] and
 /// prepares to return function/file/line information.
 /// Do not change the slice until you are done with the [Frames].
-pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
+pub fn CallersFrames(callers: Slice<uintptr>) -> Ref<Frames>
 
 /// FuncForPC returns a *[Func] describing the function that contains the
 /// given program counter address, or else nil.
@@ -120,7 +120,7 @@ pub fn CallersFrames(callers: Slice<uint>) -> Ref<Frames>
 /// If pc represents multiple functions because of inlining, it returns
 /// the *Func describing the innermost function, but with an entry of
 /// the outermost function.
-pub fn FuncForPC(pc: uint) -> Option<Ref<Func>>
+pub fn FuncForPC(pc: uintptr) -> Option<Ref<Func>>
 
 /// GC runs a garbage collection and blocks the caller until the
 /// garbage collection is complete. It may also block the entire
@@ -693,12 +693,12 @@ pub interface Error {
 
 /// Frame is the information returned by [Frames] for each call frame.
 pub struct Frame {
-  pub PC: uint,
+  pub PC: uintptr,
   pub Func: Option<Ref<Func>>,
   pub Function: string,
   pub File: string,
   pub Line: int,
-  pub Entry: uint,
+  pub Entry: uintptr,
 }
 
 /// Frames may be used to get function/file/line information for a
@@ -833,13 +833,13 @@ impl Frames {
 
 impl Func {
   /// Entry returns the entry address of the function.
-  fn Entry(self: Ref<Func>) -> uint
+  fn Entry(self: Ref<Func>) -> uintptr
 
   /// FileLine returns the file name and line number of the
   /// source code corresponding to the program counter pc.
   /// The result will not be accurate if pc is not a program
   /// counter within f.
-  fn FileLine(self: Ref<Func>, pc: uint) -> (string, int)
+  fn FileLine(self: Ref<Func>, pc: uintptr) -> (string, int)
 
   /// Name returns the name of the function.
   fn Name(self: Ref<Func>) -> string
@@ -854,7 +854,7 @@ impl MemProfileRecord {
 
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uint>
+  fn Stack(self: Ref<MemProfileRecord>) -> Slice<uintptr>
 }
 
 impl PanicNilError {
@@ -883,7 +883,7 @@ impl Pinner {
 impl StackRecord {
   /// Stack returns the stack trace associated with the record,
   /// a prefix of r.Stack0.
-  fn Stack(self: Ref<StackRecord>) -> Slice<uint>
+  fn Stack(self: Ref<StackRecord>) -> Slice<uintptr>
 }
 
 impl TypeAssertionError {

--- a/crates/stdlib/typedefs/sync/atomic.d.lis
+++ b/crates/stdlib/typedefs/sync/atomic.d.lis
@@ -27,7 +27,7 @@ pub fn AddUint64(addr: Ref<uint64>, delta: uint64) -> uint64
 
 /// AddUintptr atomically adds delta to *addr and returns the new value.
 /// Consider using the more ergonomic and less error-prone [Uintptr.Add] instead.
-pub fn AddUintptr(addr: Ref<uint>, delta: uint) -> uint
+pub fn AddUintptr(addr: Ref<uintptr>, delta: uintptr) -> uintptr
 
 /// AndInt32 atomically performs a bitwise AND operation on *addr using the bitmask provided as mask
 /// and returns the old value.
@@ -52,7 +52,7 @@ pub fn AndUint64(addr: Ref<uint64>, mask: uint64) -> uint64
 /// AndUintptr atomically performs a bitwise AND operation on *addr using the bitmask provided as mask
 /// and returns the old value.
 /// Consider using the more ergonomic and less error-prone [Uintptr.And] instead.
-pub fn AndUintptr(addr: Ref<uint>, mask: uint) -> uint
+pub fn AndUintptr(addr: Ref<uintptr>, mask: uintptr) -> uintptr
 
 /// CompareAndSwapInt32 executes the compare-and-swap operation for an int32 value.
 /// Consider using the more ergonomic and less error-prone [Int32.CompareAndSwap] instead.
@@ -78,7 +78,7 @@ pub fn CompareAndSwapUint64(addr: Ref<uint64>, old: uint64, new: uint64) -> bool
 
 /// CompareAndSwapUintptr executes the compare-and-swap operation for a uintptr value.
 /// Consider using the more ergonomic and less error-prone [Uintptr.CompareAndSwap] instead.
-pub fn CompareAndSwapUintptr(addr: Ref<uint>, old: uint, new: uint) -> bool
+pub fn CompareAndSwapUintptr(addr: Ref<uintptr>, old: uintptr, new: uintptr) -> bool
 
 /// LoadInt32 atomically loads *addr.
 /// Consider using the more ergonomic and less error-prone [Int32.Load] instead.
@@ -104,7 +104,7 @@ pub fn LoadUint64(addr: Ref<uint64>) -> uint64
 
 /// LoadUintptr atomically loads *addr.
 /// Consider using the more ergonomic and less error-prone [Uintptr.Load] instead.
-pub fn LoadUintptr(addr: Ref<uint>) -> uint
+pub fn LoadUintptr(addr: Ref<uintptr>) -> uintptr
 
 /// OrInt32 atomically performs a bitwise OR operation on *addr using the bitmask provided as mask
 /// and returns the old value.
@@ -129,7 +129,7 @@ pub fn OrUint64(addr: Ref<uint64>, mask: uint64) -> uint64
 /// OrUintptr atomically performs a bitwise OR operation on *addr using the bitmask provided as mask
 /// and returns the old value.
 /// Consider using the more ergonomic and less error-prone [Uintptr.Or] instead.
-pub fn OrUintptr(addr: Ref<uint>, mask: uint) -> uint
+pub fn OrUintptr(addr: Ref<uintptr>, mask: uintptr) -> uintptr
 
 /// StoreInt32 atomically stores val into *addr.
 /// Consider using the more ergonomic and less error-prone [Int32.Store] instead.
@@ -155,7 +155,7 @@ pub fn StoreUint64(addr: Ref<uint64>, val: uint64)
 
 /// StoreUintptr atomically stores val into *addr.
 /// Consider using the more ergonomic and less error-prone [Uintptr.Store] instead.
-pub fn StoreUintptr(addr: Ref<uint>, val: uint)
+pub fn StoreUintptr(addr: Ref<uintptr>, val: uintptr)
 
 /// SwapInt32 atomically stores new into *addr and returns the previous *addr value.
 /// Consider using the more ergonomic and less error-prone [Int32.Swap] instead.
@@ -181,7 +181,7 @@ pub fn SwapUint64(addr: Ref<uint64>, new: uint64) -> uint64
 
 /// SwapUintptr atomically stores new into *addr and returns the previous *addr value.
 /// Consider using the more ergonomic and less error-prone [Uintptr.Swap] instead.
-pub fn SwapUintptr(addr: Ref<uint>, new: uint) -> uint
+pub fn SwapUintptr(addr: Ref<uintptr>, new: uintptr) -> uintptr
 
 /// A Bool is an atomic boolean value.
 /// The zero value is false.
@@ -356,27 +356,27 @@ impl Uint64 {
 
 impl Uintptr {
   /// Add atomically adds delta to x and returns the new value.
-  fn Add(self: Ref<Uintptr>, delta: uint) -> uint
+  fn Add(self: Ref<Uintptr>, delta: uintptr) -> uintptr
 
   /// And atomically performs a bitwise AND operation on x using the bitmask
   /// provided as mask and returns the old value.
-  fn And(self: Ref<Uintptr>, mask: uint) -> uint
+  fn And(self: Ref<Uintptr>, mask: uintptr) -> uintptr
 
   /// CompareAndSwap executes the compare-and-swap operation for x.
-  fn CompareAndSwap(self: Ref<Uintptr>, old: uint, new: uint) -> bool
+  fn CompareAndSwap(self: Ref<Uintptr>, old: uintptr, new: uintptr) -> bool
 
   /// Load atomically loads and returns the value stored in x.
-  fn Load(self: Ref<Uintptr>) -> uint
+  fn Load(self: Ref<Uintptr>) -> uintptr
 
   /// Or atomically performs a bitwise OR operation on x using the bitmask
   /// provided as mask and returns the old value.
-  fn Or(self: Ref<Uintptr>, mask: uint) -> uint
+  fn Or(self: Ref<Uintptr>, mask: uintptr) -> uintptr
 
   /// Store atomically stores val into x.
-  fn Store(self: Ref<Uintptr>, val: uint)
+  fn Store(self: Ref<Uintptr>, val: uintptr)
 
   /// Swap atomically stores new into x and returns the previous value.
-  fn Swap(self: Ref<Uintptr>, new: uint) -> uint
+  fn Swap(self: Ref<Uintptr>, new: uintptr) -> uintptr
 }
 
 impl Value {

--- a/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
@@ -19,7 +19,7 @@ import "go:sync"
 /// 
 /// 	_, _, err := syscall.Syscall(...)
 /// 	if errors.Is(err, fs.ErrNotExist) ...
-pub struct Errno(uint)
+pub struct Errno(uintptr)
 
 /// Errors
 pub const E2BIG: Errno = 7
@@ -535,7 +535,7 @@ pub fn Fchmod(fd: int, mode: uint32) -> Result<(), error>
 pub fn Fchown(fd: int, uid: int, gid: int) -> Result<(), error>
 
 /// FcntlFlock performs a fcntl syscall for the [F_GETLK], [F_SETLK] or [F_SETLKW] command.
-pub fn FcntlFlock(fd: uint, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
+pub fn FcntlFlock(fd: uintptr, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
 
 pub fn Flock(fd: int, how: int) -> Result<(), error>
 
@@ -557,7 +557,7 @@ pub fn Ftruncate(fd: int, length: int64) -> Result<(), error>
 
 pub fn Futimes(fd: int, tv: Slice<Timeval>) -> Result<(), error>
 
-pub fn Getdirentries(fd: int, mut buf: Slice<byte>, basep: Ref<uint>) -> Result<int, error>
+pub fn Getdirentries(fd: int, mut buf: Slice<byte>, basep: Ref<uintptr>) -> Result<int, error>
 
 pub fn Getdtablesize() -> int
 
@@ -702,17 +702,17 @@ pub fn PtraceDetach(pid: int) -> Result<(), error>
 
 pub fn Pwrite(fd: int, p: Slice<byte>, offset: int64) -> Result<int, error>
 
-pub fn RawSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn RawSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn RawSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Read(fd: int, mut p: Slice<byte>) -> Result<int, error>
 
@@ -861,7 +861,7 @@ pub fn Socket(domain: int, typ: int, proto: int) -> Result<int, error>
 pub fn Socketpair(domain: int, typ: int, proto: int) -> Result<Slice<int>, error>
 
 /// StartProcess wraps [ForkExec] for package os.
-pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uint), error>
+pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uintptr), error>
 
 pub fn Stat(path: string, stat: Ref<Stat_t>) -> Result<(), error>
 
@@ -892,30 +892,30 @@ pub fn Symlink(path: string, link: string) -> Result<(), error>
 
 pub fn Sync() -> Result<(), error>
 
-pub fn Syscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn Syscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall9(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Sysctl(name: string) -> Result<string, error>
 
@@ -1218,7 +1218,7 @@ pub struct Msghdr {
 pub struct ProcAttr {
   pub Dir: string,
   pub Env: Slice<string>,
-  pub Files: Slice<uint>,
+  pub Files: Slice<uintptr>,
   pub Sys: Option<Ref<SysProcAttr>>,
 }
 
@@ -1230,9 +1230,9 @@ pub struct Radvisory_t {
 
 /// A RawConn is a raw network connection.
 pub interface RawConn {
-  fn Control(f: fn(uint) -> ()) -> Result<(), error>
-  fn Read(f: fn(uint) -> bool) -> Result<(), error>
-  fn Write(f: fn(uint) -> bool) -> Result<(), error>
+  fn Control(f: fn(uintptr) -> ()) -> Result<(), error>
+  fn Read(f: fn(uintptr) -> bool) -> Result<(), error>
+  fn Write(f: fn(uintptr) -> bool) -> Result<(), error>
 }
 
 pub struct RawSockaddr {

--- a/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
@@ -19,7 +19,7 @@ import "go:sync"
 /// 
 /// 	_, _, err := syscall.Syscall(...)
 /// 	if errors.Is(err, fs.ErrNotExist) ...
-pub struct Errno(uint)
+pub struct Errno(uintptr)
 
 /// Errors
 pub const E2BIG: Errno = 7
@@ -538,7 +538,7 @@ pub fn Fchmod(fd: int, mode: uint32) -> Result<(), error>
 pub fn Fchown(fd: int, uid: int, gid: int) -> Result<(), error>
 
 /// FcntlFlock performs a fcntl syscall for the [F_GETLK], [F_SETLK] or [F_SETLKW] command.
-pub fn FcntlFlock(fd: uint, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
+pub fn FcntlFlock(fd: uintptr, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
 
 pub fn Flock(fd: int, how: int) -> Result<(), error>
 
@@ -560,7 +560,7 @@ pub fn Ftruncate(fd: int, length: int64) -> Result<(), error>
 
 pub fn Futimes(fd: int, tv: Slice<Timeval>) -> Result<(), error>
 
-pub fn Getdirentries(fd: int, mut buf: Slice<byte>, basep: Ref<uint>) -> Result<int, error>
+pub fn Getdirentries(fd: int, mut buf: Slice<byte>, basep: Ref<uintptr>) -> Result<int, error>
 
 pub fn Getdtablesize() -> int
 
@@ -705,17 +705,17 @@ pub fn PtraceDetach(pid: int) -> Result<(), error>
 
 pub fn Pwrite(fd: int, p: Slice<byte>, offset: int64) -> Result<int, error>
 
-pub fn RawSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn RawSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn RawSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Read(fd: int, mut p: Slice<byte>) -> Result<int, error>
 
@@ -864,7 +864,7 @@ pub fn Socket(domain: int, typ: int, proto: int) -> Result<int, error>
 pub fn Socketpair(domain: int, typ: int, proto: int) -> Result<Slice<int>, error>
 
 /// StartProcess wraps [ForkExec] for package os.
-pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uint), error>
+pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uintptr), error>
 
 pub fn Stat(path: string, stat: Ref<Stat_t>) -> Result<(), error>
 
@@ -895,30 +895,30 @@ pub fn Symlink(path: string, link: string) -> Result<(), error>
 
 pub fn Sync() -> Result<(), error>
 
-pub fn Syscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn Syscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall9(
-  num: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-) -> (uint, uint, Errno)
+  num: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Sysctl(name: string) -> Result<string, error>
 
@@ -1221,7 +1221,7 @@ pub struct Msghdr {
 pub struct ProcAttr {
   pub Dir: string,
   pub Env: Slice<string>,
-  pub Files: Slice<uint>,
+  pub Files: Slice<uintptr>,
   pub Sys: Option<Ref<SysProcAttr>>,
 }
 
@@ -1233,9 +1233,9 @@ pub struct Radvisory_t {
 
 /// A RawConn is a raw network connection.
 pub interface RawConn {
-  fn Control(f: fn(uint) -> ()) -> Result<(), error>
-  fn Read(f: fn(uint) -> bool) -> Result<(), error>
-  fn Write(f: fn(uint) -> bool) -> Result<(), error>
+  fn Control(f: fn(uintptr) -> ()) -> Result<(), error>
+  fn Read(f: fn(uintptr) -> bool) -> Result<(), error>
+  fn Write(f: fn(uintptr) -> bool) -> Result<(), error>
 }
 
 pub struct RawSockaddr {

--- a/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
@@ -19,7 +19,7 @@ import "go:sync"
 /// 
 /// 	_, _, err := syscall.Syscall(...)
 /// 	if errors.Is(err, fs.ErrNotExist) ...
-pub struct Errno(uint)
+pub struct Errno(uintptr)
 
 /// Errors
 pub const E2BIG: Errno = 7
@@ -554,19 +554,19 @@ pub fn Adjtimex(buf: Ref<Timex>) -> Result<int, error>
 /// AllThreadsSyscall is unaware of any threads that are launched
 /// explicitly by cgo linked code, so the function always returns
 /// [ENOTSUP] in binaries that use cgo.
-pub fn AllThreadsSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn AllThreadsSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 /// AllThreadsSyscall6 is like [AllThreadsSyscall], but extended to six
 /// arguments.
 pub fn AllThreadsSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use golang.org/x/net/bpf instead.
 pub fn AttachLsf(fd: int, i: Slice<SockFilter>) -> Result<(), error>
@@ -651,7 +651,7 @@ pub fn Fchown(fd: int, uid: int, gid: int) -> Result<(), error>
 pub fn Fchownat(dirfd: int, path: string, uid: int, gid: int, flags: int) -> Result<(), error>
 
 /// FcntlFlock performs a fcntl syscall for the [F_GETLK], [F_SETLK] or [F_SETLKW] command.
-pub fn FcntlFlock(fd: uint, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
+pub fn FcntlFlock(fd: uintptr, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
 
 pub fn Fdatasync(fd: int) -> Result<(), error>
 
@@ -789,7 +789,7 @@ pub fn Mount(
   source: string,
   target: string,
   fstype: string,
-  flags: uint,
+  flags: uintptr,
   data: string,
 ) -> Result<(), error>
 
@@ -865,13 +865,13 @@ pub fn PtraceGetEventMsg(pid: int) -> Result<uint, error>
 
 pub fn PtraceGetRegs(pid: int, regsout: Ref<PtraceRegs>) -> Result<(), error>
 
-pub fn PtracePeekData(pid: int, addr: uint, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekData(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePeekText(pid: int, addr: uint, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekText(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePokeData(pid: int, addr: uint, data: Slice<byte>) -> Result<int, error>
+pub fn PtracePokeData(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePokeText(pid: int, addr: uint, data: Slice<byte>) -> Result<int, error>
+pub fn PtracePokeText(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 
 pub fn PtraceSetOptions(pid: int, options: int) -> Result<(), error>
 
@@ -883,17 +883,17 @@ pub fn PtraceSyscall(pid: int, signal: int) -> Result<(), error>
 
 pub fn Pwrite(fd: int, p: Slice<byte>, offset: int64) -> Result<int, error>
 
-pub fn RawSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn RawSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn RawSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Read(fd: int, mut p: Slice<byte>) -> Result<int, error>
 
@@ -1037,7 +1037,7 @@ pub fn Splice(
 ) -> Result<int64, error>
 
 /// StartProcess wraps [ForkExec] for package os.
-pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uint), error>
+pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uintptr), error>
 
 pub fn Stat(path: string, stat: Ref<Stat_t>) -> Result<(), error>
 
@@ -1070,17 +1070,17 @@ pub fn Sync()
 
 pub fn SyncFileRange(fd: int, off: int64, n: int64, flags: int) -> Result<(), error>
 
-pub fn Syscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn Syscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Sysinfo(info: Ref<Sysinfo_t>) -> Result<(), error>
 
@@ -1090,7 +1090,7 @@ pub fn Tgkill(tgid: int, tid: int, sig: Signal) -> Result<(), error>
 
 pub fn Time(t: Ref<Time_t>) -> Result<Time_t, error>
 
-pub fn Times(tms: Ref<Tms>) -> Result<uint, error>
+pub fn Times(tms: Ref<Tms>) -> Result<uintptr, error>
 
 /// TimespecToNsec returns the time stored in ts as nanoseconds.
 pub fn TimespecToNsec(ts: Timespec) -> int64
@@ -1315,7 +1315,7 @@ pub struct NlMsghdr {
 pub struct ProcAttr {
   pub Dir: string,
   pub Env: Slice<string>,
-  pub Files: Slice<uint>,
+  pub Files: Slice<uintptr>,
   pub Sys: Option<Ref<SysProcAttr>>,
 }
 
@@ -1351,9 +1351,9 @@ pub struct PtraceRegs {
 
 /// A RawConn is a raw network connection.
 pub interface RawConn {
-  fn Control(f: fn(uint) -> ()) -> Result<(), error>
-  fn Read(f: fn(uint) -> bool) -> Result<(), error>
-  fn Write(f: fn(uint) -> bool) -> Result<(), error>
+  fn Control(f: fn(uintptr) -> ()) -> Result<(), error>
+  fn Read(f: fn(uintptr) -> bool) -> Result<(), error>
+  fn Write(f: fn(uintptr) -> bool) -> Result<(), error>
 }
 
 pub struct RawSockaddr {
@@ -1555,12 +1555,12 @@ pub struct SysProcAttr {
   pub Foreground: bool,
   pub Pgid: int,
   pub Pdeathsig: Signal,
-  pub Cloneflags: uint,
-  pub Unshareflags: uint,
+  pub Cloneflags: uintptr,
+  pub Unshareflags: uintptr,
   pub UidMappings: Slice<SysProcIDMap>,
   pub GidMappings: Slice<SysProcIDMap>,
   pub GidMappingsEnableSetgroups: bool,
-  pub AmbientCaps: Slice<uint>,
+  pub AmbientCaps: Slice<uintptr>,
   pub UseCgroupFD: bool,
   pub CgroupFD: int,
   pub PidFD: Option<int>,

--- a/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
@@ -19,7 +19,7 @@ import "go:sync"
 /// 
 /// 	_, _, err := syscall.Syscall(...)
 /// 	if errors.Is(err, fs.ErrNotExist) ...
-pub struct Errno(uint)
+pub struct Errno(uintptr)
 
 /// Errors
 pub const E2BIG: Errno = 7
@@ -557,19 +557,19 @@ pub fn Adjtimex(buf: Ref<Timex>) -> Result<int, error>
 /// AllThreadsSyscall is unaware of any threads that are launched
 /// explicitly by cgo linked code, so the function always returns
 /// [ENOTSUP] in binaries that use cgo.
-pub fn AllThreadsSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn AllThreadsSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 /// AllThreadsSyscall6 is like [AllThreadsSyscall], but extended to six
 /// arguments.
 pub fn AllThreadsSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use golang.org/x/net/bpf instead.
 pub fn AttachLsf(fd: int, i: Slice<SockFilter>) -> Result<(), error>
@@ -652,7 +652,7 @@ pub fn Fchown(fd: int, uid: int, gid: int) -> Result<(), error>
 pub fn Fchownat(dirfd: int, path: string, uid: int, gid: int, flags: int) -> Result<(), error>
 
 /// FcntlFlock performs a fcntl syscall for the [F_GETLK], [F_SETLK] or [F_SETLKW] command.
-pub fn FcntlFlock(fd: uint, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
+pub fn FcntlFlock(fd: uintptr, cmd: int, lk: Ref<Flock_t>) -> Result<(), error>
 
 pub fn Fdatasync(fd: int) -> Result<(), error>
 
@@ -788,7 +788,7 @@ pub fn Mount(
   source: string,
   target: string,
   fstype: string,
-  flags: uint,
+  flags: uintptr,
   data: string,
 ) -> Result<(), error>
 
@@ -864,13 +864,13 @@ pub fn PtraceGetEventMsg(pid: int) -> Result<uint, error>
 
 pub fn PtraceGetRegs(pid: int, regsout: Ref<PtraceRegs>) -> Result<(), error>
 
-pub fn PtracePeekData(pid: int, addr: uint, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekData(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePeekText(pid: int, addr: uint, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekText(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePokeData(pid: int, addr: uint, data: Slice<byte>) -> Result<int, error>
+pub fn PtracePokeData(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePokeText(pid: int, addr: uint, data: Slice<byte>) -> Result<int, error>
+pub fn PtracePokeText(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 
 pub fn PtraceSetOptions(pid: int, options: int) -> Result<(), error>
 
@@ -882,17 +882,17 @@ pub fn PtraceSyscall(pid: int, signal: int) -> Result<(), error>
 
 pub fn Pwrite(fd: int, p: Slice<byte>, offset: int64) -> Result<int, error>
 
-pub fn RawSyscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn RawSyscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn RawSyscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Read(fd: int, mut p: Slice<byte>) -> Result<int, error>
 
@@ -1036,7 +1036,7 @@ pub fn Splice(
 ) -> Result<int64, error>
 
 /// StartProcess wraps [ForkExec] for package os.
-pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uint), error>
+pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uintptr), error>
 
 pub fn Stat(path: string, stat: Ref<Stat_t>) -> Result<(), error>
 
@@ -1069,17 +1069,17 @@ pub fn Sync()
 
 pub fn SyncFileRange(fd: int, off: int64, n: int64, flags: int) -> Result<(), error>
 
-pub fn Syscall(trap: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn Syscall(trap: uintptr, a1: uintptr, a2: uintptr, a3: uintptr) -> (uintptr, uintptr, Errno)
 
 pub fn Syscall6(
-  trap: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 pub fn Sysinfo(info: Ref<Sysinfo_t>) -> Result<(), error>
 
@@ -1089,7 +1089,7 @@ pub fn Tgkill(tgid: int, tid: int, sig: Signal) -> Result<(), error>
 
 pub fn Time(t: Ref<Time_t>) -> Result<Time_t, error>
 
-pub fn Times(tms: Ref<Tms>) -> Result<uint, error>
+pub fn Times(tms: Ref<Tms>) -> Result<uintptr, error>
 
 /// TimespecToNsec returns the time stored in ts as nanoseconds.
 pub fn TimespecToNsec(ts: Timespec) -> int64
@@ -1312,7 +1312,7 @@ pub struct NlMsghdr {
 pub struct ProcAttr {
   pub Dir: string,
   pub Env: Slice<string>,
-  pub Files: Slice<uint>,
+  pub Files: Slice<uintptr>,
   pub Sys: Option<Ref<SysProcAttr>>,
 }
 
@@ -1325,9 +1325,9 @@ pub struct PtraceRegs {
 
 /// A RawConn is a raw network connection.
 pub interface RawConn {
-  fn Control(f: fn(uint) -> ()) -> Result<(), error>
-  fn Read(f: fn(uint) -> bool) -> Result<(), error>
-  fn Write(f: fn(uint) -> bool) -> Result<(), error>
+  fn Control(f: fn(uintptr) -> ()) -> Result<(), error>
+  fn Read(f: fn(uintptr) -> bool) -> Result<(), error>
+  fn Write(f: fn(uintptr) -> bool) -> Result<(), error>
 }
 
 pub struct RawSockaddr {
@@ -1530,12 +1530,12 @@ pub struct SysProcAttr {
   pub Foreground: bool,
   pub Pgid: int,
   pub Pdeathsig: Signal,
-  pub Cloneflags: uint,
-  pub Unshareflags: uint,
+  pub Cloneflags: uintptr,
+  pub Unshareflags: uintptr,
   pub UidMappings: Slice<SysProcIDMap>,
   pub GidMappings: Slice<SysProcIDMap>,
   pub GidMappingsEnableSetgroups: bool,
-  pub AmbientCaps: Slice<uint>,
+  pub AmbientCaps: Slice<uintptr>,
   pub UseCgroupFD: bool,
   pub CgroupFD: int,
   pub PidFD: Option<int>,

--- a/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
@@ -12,7 +12,7 @@ import "go:sync"
 /// 
 /// 	_, _, err := syscall.Syscall(...)
 /// 	if errors.Is(err, fs.ErrNotExist) ...
-pub struct Errno(uint)
+pub struct Errno(uintptr)
 
 pub const E2BIG: Errno = 536870912
 
@@ -413,22 +413,22 @@ pub fn CertGetCertificateChain(
   additionalStore: Handle,
   para: Ref<CertChainPara>,
   flags: uint32,
-  reserved: uint,
+  reserved: uintptr,
   chainCtx: Ref<Ref<CertChainContext>>,
 ) -> Result<(), error>
 
 pub fn CertOpenStore(
-  storeProvider: uint,
+  storeProvider: uintptr,
   msgAndCertEncodingType: uint32,
-  cryptProv: uint,
+  cryptProv: uintptr,
   flags: uint32,
-  para: uint,
+  para: uintptr,
 ) -> Result<Handle, error>
 
 pub fn CertOpenSystemStore(hprov: Handle, name: Ref<uint16>) -> Result<Handle, error>
 
 pub fn CertVerifyCertificateChainPolicy(
-  policyOID: uint,
+  policyOID: uintptr,
   chain: Ref<CertChainContext>,
   para: Ref<CertChainPolicyPara>,
   status: Ref<CertChainPolicyStatus>,
@@ -497,7 +497,7 @@ pub fn CreateFileMapping(
 pub fn CreateHardLink(
   filename: Ref<uint16>,
   existingfilename: Ref<uint16>,
-  reserved: uint,
+  reserved: uintptr,
 ) -> Result<(), error>
 
 /// Deprecated: CreateIoCompletionPort has the wrong function signature. Use x/sys/windows.CreateIoCompletionPort.
@@ -631,7 +631,7 @@ pub fn FindNextFile(handle: Handle, data: Ref<Win32finddata>) -> Result<(), erro
 
 pub fn FlushFileBuffers(handle: Handle) -> Result<(), error>
 
-pub fn FlushViewOfFile(addr: uint, length: uint) -> Result<(), error>
+pub fn FlushViewOfFile(addr: uintptr, length: uintptr) -> Result<(), error>
 
 /// FormatMessage is deprecated (msgsrc should be uintptr, not uint32, but can
 /// not be changed due to the Go 1 compatibility guarantee).
@@ -727,7 +727,7 @@ pub fn GetLengthSid(sid: Ref<SID>) -> uint32
 
 pub fn GetLongPathName(path: Ref<uint16>, buf: Ref<uint16>, buflen: uint32) -> Result<uint32, error>
 
-pub fn GetProcAddress(module: Handle, procname: string) -> Result<uint, error>
+pub fn GetProcAddress(module: Handle, procname: string) -> Result<uintptr, error>
 
 pub fn GetProcessTimes(
   handle: Handle,
@@ -881,8 +881,8 @@ pub fn MapViewOfFile(
   access: uint32,
   offsetHigh: uint32,
   offsetLow: uint32,
-  length: uint,
-) -> Result<uint, error>
+  length: uintptr,
+) -> Result<uintptr, error>
 
 pub fn Mkdir(path: string, mode: uint32) -> Result<(), error>
 
@@ -912,7 +912,7 @@ pub fn NetUserGetInfo(
 /// Only a limited number of callbacks may be created in a single Go process, and any memory allocated
 /// for these callbacks is never released.
 /// Between NewCallback and NewCallbackCDecl, at least 1024 callbacks can always be created.
-pub fn NewCallback(fn_: Unknown) -> uint
+pub fn NewCallback(fn_: Unknown) -> uintptr
 
 /// NewCallbackCDecl converts a Go function to a function pointer conforming to the cdecl calling convention.
 /// This is useful when interoperating with Windows code requiring callbacks.
@@ -920,7 +920,7 @@ pub fn NewCallback(fn_: Unknown) -> uint
 /// Only a limited number of callbacks may be created in a single Go process, and any memory allocated
 /// for these callbacks is never released.
 /// Between NewCallback and NewCallbackCDecl, at least 1024 callbacks can always be created.
-pub fn NewCallbackCDecl(fn_: Unknown) -> uint
+pub fn NewCallbackCDecl(fn_: Unknown) -> uintptr
 
 /// NewLazyDLL creates new [LazyDLL] associated with [DLL] file.
 pub fn NewLazyDLL(name: string) -> Ref<LazyDLL>
@@ -975,7 +975,7 @@ pub fn ReadDirectoryChanges(
   mask: uint32,
   retlen: Ref<uint32>,
   overlapped: Ref<Overlapped>,
-  completionRoutine: uint,
+  completionRoutine: uintptr,
 ) -> Result<(), error>
 
 pub fn ReadFile(
@@ -1124,7 +1124,7 @@ pub fn Shutdown(fd: Handle, how: int) -> Result<(), error>
 
 pub fn Socket(domain: int, typ: int, proto: int) -> Result<Handle, error>
 
-pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uint), error>
+pub fn StartProcess(argv0: string, argv: Slice<string>, attr: Ref<ProcAttr>) -> Result<(int, uintptr), error>
 
 /// StringBytePtr returns a pointer to a NUL-terminated array of bytes.
 /// If s contains a NUL byte this function panics instead of returning
@@ -1162,99 +1162,105 @@ pub fn StringToUTF16Ptr(s: string) -> Ref<uint16>
 pub fn Symlink(path: string, link: string) -> Result<(), error>
 
 /// Deprecated: Use [SyscallN] instead.
-pub fn Syscall(trap: uint, nargs: uint, a1: uint, a2: uint, a3: uint) -> (uint, uint, Errno)
+pub fn Syscall(
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use [SyscallN] instead.
 pub fn Syscall12(
-  trap: uint,
-  nargs: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-  a10: uint,
-  a11: uint,
-  a12: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+  a10: uintptr,
+  a11: uintptr,
+  a12: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use [SyscallN] instead.
 pub fn Syscall15(
-  trap: uint,
-  nargs: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-  a10: uint,
-  a11: uint,
-  a12: uint,
-  a13: uint,
-  a14: uint,
-  a15: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+  a10: uintptr,
+  a11: uintptr,
+  a12: uintptr,
+  a13: uintptr,
+  a14: uintptr,
+  a15: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use [SyscallN] instead.
 pub fn Syscall18(
-  trap: uint,
-  nargs: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-  a10: uint,
-  a11: uint,
-  a12: uint,
-  a13: uint,
-  a14: uint,
-  a15: uint,
-  a16: uint,
-  a17: uint,
-  a18: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+  a10: uintptr,
+  a11: uintptr,
+  a12: uintptr,
+  a13: uintptr,
+  a14: uintptr,
+  a15: uintptr,
+  a16: uintptr,
+  a17: uintptr,
+  a18: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use [SyscallN] instead.
 pub fn Syscall6(
-  trap: uint,
-  nargs: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+) -> (uintptr, uintptr, Errno)
 
 /// Deprecated: Use [SyscallN] instead.
 pub fn Syscall9(
-  trap: uint,
-  nargs: uint,
-  a1: uint,
-  a2: uint,
-  a3: uint,
-  a4: uint,
-  a5: uint,
-  a6: uint,
-  a7: uint,
-  a8: uint,
-  a9: uint,
-) -> (uint, uint, Errno)
+  trap: uintptr,
+  nargs: uintptr,
+  a1: uintptr,
+  a2: uintptr,
+  a3: uintptr,
+  a4: uintptr,
+  a5: uintptr,
+  a6: uintptr,
+  a7: uintptr,
+  a8: uintptr,
+  a9: uintptr,
+) -> (uintptr, uintptr, Errno)
 
-pub fn SyscallN(trap: uint, args: VarArgs<uint>) -> (uint, uint, Errno)
+pub fn SyscallN(trap: uintptr, args: VarArgs<uintptr>) -> (uintptr, uintptr, Errno)
 
 pub fn TerminateProcess(handle: Handle, exitcode: uint32) -> Result<(), error>
 
@@ -1306,7 +1312,7 @@ pub fn UTF16ToString(s: Slice<uint16>) -> string
 
 pub fn Unlink(path: string) -> Result<(), error>
 
-pub fn UnmapViewOfFile(addr: uint) -> Result<(), error>
+pub fn UnmapViewOfFile(addr: uintptr) -> Result<(), error>
 
 pub fn Unsetenv(key: string) -> Result<(), error>
 
@@ -1314,9 +1320,9 @@ pub fn Utimes(path: string, tv: Slice<Timeval>) -> Result<(), error>
 
 pub fn UtimesNano(path: string, ts: Slice<Timespec>) -> Result<(), error>
 
-pub fn VirtualLock(addr: uint, length: uint) -> Result<(), error>
+pub fn VirtualLock(addr: uintptr, length: uintptr) -> Result<(), error>
 
-pub fn VirtualUnlock(addr: uint, length: uint) -> Result<(), error>
+pub fn VirtualUnlock(addr: uintptr, length: uintptr) -> Result<(), error>
 
 pub fn WSACleanup() -> Result<(), error>
 
@@ -1335,7 +1341,7 @@ pub fn WSAIoctl(
   cbob: uint32,
   cbbr: Ref<uint32>,
   overlapped: Ref<Overlapped>,
-  completionRoutine: uint,
+  completionRoutine: uintptr,
 ) -> Result<(), error>
 
 pub fn WSARecv(
@@ -1419,7 +1425,7 @@ pub struct AddrinfoW {
   pub Family: int32,
   pub Socktype: int32,
   pub Protocol: int32,
-  pub Addrlen: uint,
+  pub Addrlen: uintptr,
   pub Canonname: Option<uint16>,
   pub Addr: Pointer,
   pub Next: Option<Ref<AddrinfoW>>,
@@ -1604,7 +1610,7 @@ pub struct GUID {
   // SKIPPED field "Data4": array-currently-not-representable — fixed-size array cannot currently be represented in Lisette
 }
 
-pub struct Handle(uint)
+pub struct Handle(uintptr)
 
 pub struct Hostent {
   pub Name: Option<Ref<byte>>,
@@ -1717,8 +1723,8 @@ pub struct MibIfRow {
 }
 
 pub struct Overlapped {
-  pub Internal: uint,
-  pub InternalHigh: uint,
+  pub Internal: uintptr,
+  pub InternalHigh: uintptr,
   pub Offset: uint32,
   pub OffsetHigh: uint32,
   pub HEvent: Handle,
@@ -1741,7 +1747,7 @@ pub struct Proc {
 pub struct ProcAttr {
   pub Dir: string,
   pub Env: Slice<string>,
-  pub Files: Slice<uint>,
+  pub Files: Slice<uintptr>,
   pub Sys: Option<Ref<SysProcAttr>>,
 }
 
@@ -1749,7 +1755,7 @@ pub struct ProcessEntry32 {
   pub Size: uint32,
   pub Usage: uint32,
   pub ProcessID: uint32,
-  pub DefaultHeapID: uint,
+  pub DefaultHeapID: uintptr,
   pub ModuleID: uint32,
   pub Threads: uint32,
   pub ParentProcessID: uint32,
@@ -1773,9 +1779,9 @@ pub struct Protoent {
 
 /// A RawConn is a raw network connection.
 pub interface RawConn {
-  fn Control(f: fn(uint) -> ()) -> Result<(), error>
-  fn Read(f: fn(uint) -> bool) -> Result<(), error>
-  fn Write(f: fn(uint) -> bool) -> Result<(), error>
+  fn Control(f: fn(uintptr) -> ()) -> Result<(), error>
+  fn Read(f: fn(uintptr) -> bool) -> Result<(), error>
+  fn Write(f: fn(uintptr) -> bool) -> Result<(), error>
 }
 
 pub struct RawSockaddr {
@@ -1834,7 +1840,7 @@ pub struct SSLExtraCertChainPolicyPara {
 
 pub struct SecurityAttributes {
   pub Length: uint32,
-  pub SecurityDescriptor: uint,
+  pub SecurityDescriptor: uintptr,
   pub InheritHandle: uint32,
 }
 
@@ -1944,7 +1950,7 @@ pub struct Timezoneinformation {
 /// privileges. The system uses the token to control access to securable
 /// objects and to control the ability of the user to perform various
 /// system-related operations on the local computer.
-pub struct Token(uint)
+pub struct Token(uintptr)
 
 pub struct Tokenprimarygroup {
   pub PrimaryGroup: Option<Ref<SID>>,
@@ -1955,9 +1961,9 @@ pub struct Tokenuser {
 }
 
 pub struct TransmitFileBuffers {
-  pub Head: uint,
+  pub Head: uintptr,
   pub HeadLength: uint32,
-  pub Tail: uint,
+  pub Tail: uintptr,
   pub TailLength: uint32,
 }
 
@@ -3110,7 +3116,7 @@ impl Filetime {
 
 impl LazyDLL {
   /// Handle returns d's module handle.
-  fn Handle(self: Ref<LazyDLL>) -> uint
+  fn Handle(self: Ref<LazyDLL>) -> uintptr
 
   /// Load loads DLL file d.Name into memory. It returns an error if fails.
   /// Load will not try to load DLL, if it is already loaded into memory.
@@ -3123,11 +3129,11 @@ impl LazyDLL {
 impl LazyProc {
   /// Addr returns the address of the procedure represented by p.
   /// The return value can be passed to Syscall to run the procedure.
-  fn Addr(self: Ref<LazyProc>) -> uint
+  fn Addr(self: Ref<LazyProc>) -> uintptr
 
   /// Call executes procedure p with arguments a. See the documentation of
   /// Proc.Call for more information.
-  fn Call(self: Ref<LazyProc>, a: VarArgs<uint>) -> Result<(uint, uint), error>
+  fn Call(self: Ref<LazyProc>, a: VarArgs<uintptr>) -> Result<(uintptr, uintptr), error>
 
   /// Find searches [DLL] for procedure named p.Name. It returns
   /// an error if search fails. Find will not search procedure,
@@ -3138,7 +3144,7 @@ impl LazyProc {
 impl Proc {
   /// Addr returns the address of the procedure represented by p.
   /// The return value can be passed to Syscall to run the procedure.
-  fn Addr(self: Ref<Proc>) -> uint
+  fn Addr(self: Ref<Proc>) -> uintptr
 
   /// Call executes procedure p with arguments a.
   /// 
@@ -3154,7 +3160,7 @@ impl Proc {
   /// values are returned in r2. The return value for C type "float" is
   /// [math.Float32frombits](uint32(r2)). For C type "double", it is
   /// [math.Float64frombits](uint64(r2)).
-  fn Call(self: Ref<Proc>, a: VarArgs<uint>) -> Result<(uint, uint), error>
+  fn Call(self: Ref<Proc>, a: VarArgs<uintptr>) -> Result<(uintptr, uintptr), error>
 }
 
 impl RawSockaddrAny {


### PR DESCRIPTION
Go's `uintptr` is now preserved as `uintptr` in typedefs, so they now type-check faithfully.

```rs
fn take_uint(x: uint) -> uint { x + 1 }

fn main() {
  fmt.Println(take_uint(os.Stdout.Fd() as uint))
}
```
