### PR TITLE
fix: `#[display]` for embeddings

### DIFF
--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -240,6 +240,12 @@ impl Planner<'_> {
                 .or_default()
                 .push(*name_span);
         }
+        if self.synthesizes_embedded_stringer_shadow(name) {
+            members
+                .entry(ENUM_STRINGER_METHOD.to_string())
+                .or_default()
+                .push(*name_span);
+        }
         if self.should_synthesize_to_string(name, attributes) {
             members
                 .entry(self.to_string_method_go_name())

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -118,6 +118,17 @@ impl<'a> EmitFacts<'a> {
         self.peel_alias(&ty.strip_refs())
     }
 
+    pub(crate) fn resolve_embed_target(&self, ty: &Type) -> Type {
+        let mut current = ty.clone();
+        loop {
+            let next = self.peel_alias(&current.strip_refs());
+            if next == current {
+                return next;
+            }
+            current = next;
+        }
+    }
+
     pub(crate) fn as_interface(&self, ty: &Type) -> Option<String> {
         as_interface(self.definitions, ty)
     }

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -4,8 +4,11 @@ use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name::{self, prelude_qualifier};
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::borrow::Cow;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructKind};
-use syntax::program::{Definition, DefinitionBody};
+use syntax::attributes::struct_attribute_forces_field_export;
+use syntax::program::{Definition, DefinitionBody, Interface, MethodSignatures};
 use syntax::types::Type;
 
 pub(crate) const DEBUG_STRING_METHOD: &str = "DebugString";
@@ -66,7 +69,107 @@ impl Planner<'_> {
         self.append_struct_debug_method(&mut result, name, &receiver_generics, &stringer_fields);
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
         self.append_equals_method(&mut result, name, &receiver_generics, fields, struct_attrs);
+        self.append_embedded_stringer_shadow(
+            &mut result,
+            name,
+            &receiver_generics,
+            &stringer_fields,
+        );
         result
+    }
+
+    fn append_embedded_stringer_shadow(
+        &self,
+        out: &mut String,
+        name: &str,
+        receiver_generics: &str,
+        stringer_fields: &[StringerField],
+    ) {
+        if !self.synthesizes_embedded_stringer_shadow(name) {
+            return;
+        }
+        self.require_fmt();
+        out.push_str("\n\n");
+        out.push_str(&emit_struct_shadow_stringer_method(
+            name,
+            receiver_generics,
+            stringer_fields,
+        ));
+    }
+
+    pub(crate) fn synthesizes_embedded_stringer_shadow(&self, name: &str) -> bool {
+        let id = self.facts.qualified_current(name);
+        let Some(definition) = self.facts.definition(&id) else {
+            return false;
+        };
+        !definition.is_display()
+            && self.stringer_kind_of(&id, &mut FxHashSet::default())
+                == Some(StringerKind::Synthesized)
+    }
+
+    fn stringer_kind(&self, ty: &Type, visited: &mut FxHashSet<String>) -> Option<StringerKind> {
+        let Type::Nominal { id, .. } = &self.facts.resolve_embed_target(ty) else {
+            return None;
+        };
+        if !visited.insert(id.to_string()) {
+            return None;
+        }
+        let kind = self.stringer_kind_of(id.as_str(), visited);
+        visited.remove(id.as_str());
+        kind
+    }
+
+    fn stringer_kind_of(&self, id: &str, visited: &mut FxHashSet<String>) -> Option<StringerKind> {
+        let definition = self.facts.definition(id)?;
+        if definition_declares_string(definition, |m| self.facts.is_ufcs_method(id, m)) {
+            return Some(StringerKind::Foreign);
+        }
+        if let DefinitionBody::Interface {
+            definition: interface,
+        } = &definition.body
+        {
+            return self
+                .interface_has_string_selector(interface, visited)
+                .then_some(StringerKind::Foreign);
+        }
+        if definition_emits_go_string_field(definition) {
+            return Some(StringerKind::Foreign);
+        }
+        if definition.is_display() {
+            return Some(StringerKind::Synthesized);
+        }
+        let DefinitionBody::Struct { fields, .. } = &definition.body else {
+            return None;
+        };
+        self.promoted_stringer_kind(fields, visited)
+    }
+
+    fn promoted_stringer_kind(
+        &self,
+        fields: &[StructFieldDefinition],
+        visited: &mut FxHashSet<String>,
+    ) -> Option<StringerKind> {
+        let mut kinds = fields
+            .iter()
+            .filter(|f| f.embedded)
+            .filter_map(|f| self.stringer_kind(&f.ty, visited));
+        let first = kinds.next()?;
+        if kinds.next().is_some() {
+            return None;
+        }
+        matches!(first, StringerKind::Synthesized).then_some(StringerKind::Synthesized)
+    }
+
+    fn interface_has_string_selector(
+        &self,
+        interface: &Interface,
+        visited: &mut FxHashSet<String>,
+    ) -> bool {
+        interface_declares_string(&interface.methods)
+            || interface
+                .parents
+                .iter()
+                .any(|parent| self.stringer_kind(parent, visited).is_some())
     }
 
     /// Emit a tuple struct and its optional Stringer.
@@ -197,12 +300,7 @@ impl Planner<'_> {
         let methods = self
             .facts
             .definition(qualified.as_str())
-            .and_then(|definition| match &definition.body {
-                DefinitionBody::Struct { methods, .. }
-                | DefinitionBody::Enum { methods, .. }
-                | DefinitionBody::TypeAlias { methods, .. } => Some(methods),
-                _ => None,
-            });
+            .and_then(type_methods);
 
         let is_user_stringer = |method_name: &str| {
             methods.is_some_and(|m| m.get(method_name).is_some_and(Type::is_stringer_signature))
@@ -220,12 +318,7 @@ impl Planner<'_> {
         let methods = self
             .facts
             .definition(qualified.as_str())
-            .and_then(|definition| match &definition.body {
-                DefinitionBody::Struct { methods, .. }
-                | DefinitionBody::Enum { methods, .. }
-                | DefinitionBody::TypeAlias { methods, .. } => Some(methods),
-                _ => None,
-            });
+            .and_then(type_methods);
         let has_signature = |method_name: &str| {
             methods.is_some_and(|m| m.get(method_name).is_some_and(Type::is_stringer_signature))
                 && !self.facts.is_ufcs_method(&qualified, method_name)
@@ -417,15 +510,23 @@ pub(crate) fn struct_field_go_name(
     field: &StructFieldDefinition,
     struct_attrs: &[Attribute],
 ) -> String {
+    let struct_forces_export = struct_attrs
+        .iter()
+        .any(struct_attribute_forces_field_export);
+    field_go_name(field, struct_forces_export).into_owned()
+}
+
+fn field_go_name(field: &StructFieldDefinition, struct_forces_export: bool) -> Cow<'_, str> {
     if field.embedded {
-        return go_name::escape_keyword(&field.name).into_owned();
+        return go_name::escape_keyword(&field.name);
     }
-    let needs_export =
-        field.visibility.is_public() || !interpret_field_attributes(field, struct_attrs).is_empty();
-    if needs_export {
-        go_name::make_exported(&field.name)
+    let exported = field.visibility.is_public()
+        || struct_forces_export
+        || !interpret_field_attributes(field, &[]).is_empty();
+    if exported {
+        Cow::Owned(go_name::make_exported(&field.name))
     } else {
-        go_name::escape_keyword(&field.name).into_owned()
+        go_name::escape_keyword(&field.name)
     }
 }
 
@@ -494,6 +595,71 @@ fn emit_struct_stringer_method(
     format!(
         "func ({receiver} {receiver_type}) {method_name}() string {{\nreturn fmt.Sprintf(\"{name} {{ {} }}\", {})\n}}",
         format_parts.join(", "),
+        args.join(", ")
+    )
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum StringerKind {
+    Synthesized,
+    Foreign,
+}
+
+fn definition_emits_go_string_field(definition: &Definition) -> bool {
+    let DefinitionBody::Struct { fields, .. } = &definition.body else {
+        return false;
+    };
+    let forces_export = definition.is_serialized();
+    fields
+        .iter()
+        .any(|field| field_go_name(field, forces_export) == ENUM_STRINGER_METHOD)
+}
+
+fn type_methods(definition: &Definition) -> Option<&MethodSignatures> {
+    match &definition.body {
+        DefinitionBody::Struct { methods, .. }
+        | DefinitionBody::Enum { methods, .. }
+        | DefinitionBody::TypeAlias { methods, .. } => Some(methods),
+        _ => None,
+    }
+}
+
+fn definition_declares_string(definition: &Definition, is_ufcs: impl Fn(&str) -> bool) -> bool {
+    let Some(methods) = type_methods(definition) else {
+        return false;
+    };
+    ["string", ENUM_STRINGER_METHOD]
+        .iter()
+        .any(|method| methods.contains_key(*method) && !is_ufcs(method))
+}
+
+fn interface_declares_string(methods: &FxHashMap<ecow::EcoString, Type>) -> bool {
+    ["string", ENUM_STRINGER_METHOD]
+        .iter()
+        .any(|method| methods.contains_key(*method))
+}
+
+fn emit_struct_shadow_stringer_method(
+    name: &str,
+    receiver_generics: &str,
+    fields: &[StringerField],
+) -> String {
+    let receiver = synthesized_receiver_name(name, receiver_generics);
+    let go_type_name = go_name::escape_keyword(name);
+    let receiver_type = format!("{go_type_name}{receiver_generics}");
+    if fields.is_empty() {
+        return format!(
+            "func ({receiver} {receiver_type}) String() string {{\nreturn \"{{}}\"\n}}"
+        );
+    }
+    let placeholders: Vec<&str> = fields.iter().map(|_| "%v").collect();
+    let args: Vec<String> = fields
+        .iter()
+        .map(|f| format!("{receiver}.{}", f.go_name))
+        .collect();
+    format!(
+        "func ({receiver} {receiver_type}) String() string {{\nreturn fmt.Sprintf(\"{{{}}}\", {})\n}}",
+        placeholders.join(" "),
         args.join(", ")
     )
 }

--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -1,5 +1,5 @@
 use syntax::ast::{Attribute, AttributeArg, StructFieldDefinition};
-use syntax::attributes::is_serialization_key;
+use syntax::attributes::{is_serialization_key, struct_attribute_forces_field_export};
 
 #[derive(Default)]
 pub(super) struct TagConfig {
@@ -75,14 +75,13 @@ pub(super) fn interpret_field_attributes(
 }
 
 fn interpret_struct_attribute(attribute: &Attribute) -> Option<TagConfig> {
-    let key = &attribute.name;
-
-    if key == "tag" {
-        return interpret_struct_tag_attribute(attribute);
+    if !struct_attribute_forces_field_export(attribute) {
+        return None;
     }
 
-    if !is_serialization_key(key) {
-        return None;
+    let key = &attribute.name;
+    if key == "tag" {
+        return interpret_struct_tag_attribute(attribute);
     }
 
     let mut config = TagConfig {

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -694,6 +694,42 @@ mod tests {
     }
 
     #[test]
+    fn serialized_attribute_survives_cache_roundtrip() {
+        use syntax::ast::StructKind;
+        use syntax::program::{Attributes, Definition, DefinitionBody, TypeAttribute, Visibility};
+
+        let mut attributes = Attributes::default();
+        attributes.insert(TypeAttribute::Serialized, ());
+
+        let struct_def = Definition {
+            visibility: Visibility::Public,
+            ty: Type::Nominal {
+                id: Symbol::from_raw("dep.Inner"),
+                params: vec![],
+                underlying_ty: None,
+            },
+            name: Some("Inner".into()),
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::Struct {
+                generics: vec![],
+                fields: vec![],
+                kind: StructKind::Record,
+                methods: Default::default(),
+                constructor: None,
+                attributes,
+            },
+        };
+
+        let empty_files = HashMap::default();
+        let cached = CachedDefinition::from_definition(&struct_def, false, &empty_files);
+        let bytes = bincode::serialize(&cached).unwrap();
+        let restored: CachedDefinition = bincode::deserialize(&bytes).unwrap();
+
+        assert!(restored.to_definition(&[]).is_serialized());
+    }
+
+    #[test]
     fn test_cache_validity_checks_dep_hashes() {
         let mut cached_deps = HashMap::default();
         cached_deps.insert("dep".to_string(), 111u64);

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -19,6 +19,7 @@ use syntax::ast::{
     Annotation, Attribute, AttributeArg, Binding, EnumVariant, Expression, Generic, Span,
     StructKind, Visibility as SyntacticVisibility,
 };
+use syntax::attributes::struct_attribute_forces_field_export;
 use syntax::program::{
     Attributes, Definition, DefinitionBody, File, FileImport, TypeAttribute, Visibility,
 };
@@ -107,6 +108,10 @@ pub(super) fn has_unexported_attribute(attributes: &[Attribute]) -> bool {
         .any(|flag| flag == "unexported")
 }
 
+pub(super) fn has_serialization_attribute(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(struct_attribute_forces_field_export)
+}
+
 pub(super) fn collect_enum_attributes(attributes: &[Attribute]) -> Attributes {
     let mut map = Attributes::default();
     if has_display_attribute(attributes) {
@@ -128,6 +133,9 @@ pub(super) fn collect_struct_attributes(attributes: &[Attribute]) -> Attributes 
     }
     if has_hidden_embed_attribute(attributes) {
         map.insert(TypeAttribute::HiddenEmbed, ());
+    }
+    if has_serialization_attribute(attributes) {
+        map.insert(TypeAttribute::Serialized, ());
     }
     map
 }

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -120,6 +120,16 @@ pub fn is_serialization_key(key: &str) -> bool {
     SERIALIZATION_KEYS.contains(&key)
 }
 
+pub fn struct_attribute_forces_field_export(attribute: &crate::ast::Attribute) -> bool {
+    if attribute.name == "tag" {
+        return matches!(
+            attribute.args.first(),
+            Some(crate::ast::AttributeArg::String(_))
+        );
+    }
+    is_serialization_key(&attribute.name)
+}
+
 pub fn known_attribute_names() -> Vec<&'static str> {
     ATTRIBUTES.iter().map(|a| a.name).collect()
 }

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -26,6 +26,7 @@ pub enum TypeAttribute {
     /// Go struct that looks flat but hides an embed bindgen could not emit, so it
     /// cannot be soundly embedded.
     HiddenEmbed,
+    Serialized,
 }
 
 pub type Attributes = HashMap<TypeAttribute, ()>;
@@ -180,6 +181,11 @@ impl Definition {
     pub fn is_closed_domain(&self) -> bool {
         self.attributes()
             .is_some_and(|a| a.contains_key(&TypeAttribute::ClosedDomain))
+    }
+
+    pub fn is_serialized(&self) -> bool {
+        self.attributes()
+            .is_some_and(|a| a.contains_key(&TypeAttribute::Serialized))
     }
 
     pub fn is_anon_struct(&self) -> bool {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -107,6 +107,51 @@ fn main() {
 }
 
 #[test]
+fn embedded_cross_module_json_string_field_blocks_shadow() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "dep",
+        "inner.lis",
+        r#"
+#[display]
+pub struct Logger { pub prefix: string }
+
+#[json]
+pub struct Inner {
+  embed Logger,
+  string: int,
+}
+
+pub fn make(p: string, n: int) -> Inner {
+  Inner { Logger: Logger { prefix: p }, string: n }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "dep"
+
+struct Outer {
+  embed dep.Inner,
+  pub name: string,
+}
+
+fn main() {
+  let o = Outer { Inner: dep.make("srv:", 5), name: "n" }
+  fmt.Println(o)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn display_cross_module_satisfies_local_interface() {
     let mut fs = MockFileSystem::new();
 
@@ -176,6 +221,37 @@ fn main() {
     assert!(
         codes.iter().any(|code| code == "emit.go_name_collision"),
         "a wrong-signature user to_string does not suppress synthesis, so the synthesized to_string collides with it; got: {codes:?}"
+    );
+}
+
+#[test]
+fn embedded_display_beside_string_field_needs_no_shadow() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+#[display]
+struct Logger {
+  pub prefix: string,
+}
+
+struct Server {
+  embed Logger,
+  pub string: int,
+}
+
+fn main() {
+  let s = Server { Logger: Logger { prefix: "srv:" }, string: 5 }
+  let _ = s.string
+}
+"#,
+    );
+
+    let codes = emit_diagnostic_codes(fs);
+    assert!(
+        !codes.iter().any(|code| code == "emit.go_name_collision"),
+        "the `String` field occupies the selector, so no shadow is synthesized and nothing collides; got: {codes:?}"
     );
 }
 

--- a/tests/spec/build/snapshots/embedded_cross_module_json_string_field_blocks_shadow.snap
+++ b/tests/spec/build/snapshots/embedded_cross_module_json_string_field_blocks_shadow.snap
@@ -1,0 +1,53 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === dep/inner.go ===
+package dep
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) ToString() string {
+	return l.String()
+}
+
+type Inner struct {
+	Logger
+	String int `json:"string"`
+}
+
+func Make(p string, n int) Inner {
+	return Inner{
+		Logger: Logger{Prefix: p},
+		String: n,
+	}
+}
+
+
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"github.com/user/myproject/dep"
+)
+
+type Outer struct {
+	dep.Inner
+	Name string
+}
+
+func main() {
+	o := Outer{
+		Inner: dep.Make("srv:", 5),
+		Name:  "n",
+	}
+	fmt.Println(o)
+}

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -1,6 +1,30 @@
 use crate::{assert_emit_snapshot, assert_emit_snapshot_with_go_typedefs};
 
 #[test]
+fn embedded_imported_non_stringer_string_method_blocks_shadow() {
+    let input = r#"
+import "go:example.com/lib"
+
+#[display]
+struct D { pub x: int }
+
+struct C {
+  embed lib.N,
+  embed D,
+  pub n: int,
+}
+"#;
+    let typedef = r#"
+pub struct N {}
+
+impl N {
+  pub fn String(self) -> int
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
+}
+
+#[test]
 fn import_single() {
     let input = r#"
 import "go:io"

--- a/tests/spec/emit/snapshots/bare_tag_does_not_force_export_so_outer_still_shadows.snap
+++ b/tests/spec/emit/snapshots/bare_tag_does_not_force_export_so_outer_still_shadows.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  #[tag]
+  struct Inner {
+    embed Logger,
+    string: int,
+  }
+  
+  struct Outer {
+    embed Inner,
+    pub name: string,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Inner struct {
+	Logger
+	string int
+}
+
+func (i Inner) String() string {
+	return fmt.Sprintf("{%v %v}", i.Logger, i.string)
+}
+
+type Outer struct {
+	Inner
+	Name string
+}
+
+func (o Outer) String() string {
+	return fmt.Sprintf("{%v %v}", o.Inner, o.Name)
+}

--- a/tests/spec/emit/snapshots/deeper_promoted_stringer_does_not_block_shallower_display_shadow.snap
+++ b/tests/spec/emit/snapshots/deeper_promoted_stringer_does_not_block_shallower_display_shadow.snap
@@ -1,0 +1,62 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  struct N { pub n: int }
+  
+  impl N {
+    fn string(self) -> string {
+      "N"
+    }
+  }
+  
+  struct P {
+    embed N,
+  }
+  
+  struct C {
+    embed D,
+    embed P,
+    pub c: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type N struct {
+	N int
+}
+
+func (n N) String() string {
+	return "N"
+}
+
+type P struct {
+	N
+}
+
+type C struct {
+	D
+	P
+	C int
+}
+
+func (c C) String() string {
+	return fmt.Sprintf("{%v %v %v}", c.D, c.P, c.C)
+}

--- a/tests/spec/emit/snapshots/display_outer_over_embedded_display_needs_no_shadow.snap
+++ b/tests/spec/emit/snapshots/display_outer_over_embedded_display_needs_no_shadow.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  #[display]
+  struct Server {
+    embed Logger,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	Logger
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("Server { Logger: %v, port: %v }", s.Logger, s.Port)
+}
+
+func (s Server) to_string() string {
+	return s.String()
+}

--- a/tests/spec/emit/snapshots/embedded_alias_of_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_alias_of_display_gets_shadow.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  type Alias = Logger
+  
+  struct Server {
+    embed Alias,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Alias = Logger
+
+type Server struct {
+	Alias
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.Alias, s.Port)
+}

--- a/tests/spec/emit/snapshots/embedded_alias_to_ref_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_alias_to_ref_display_gets_shadow.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  type P = Ref<Logger>
+  
+  struct Server {
+    embed P,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type P = *Logger
+
+type Server struct {
+	P
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.P, s.Port)
+}

--- a/tests/spec/emit/snapshots/embedded_display_and_user_stringer_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_and_user_stringer_are_ambiguous_no_shadow.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct A { pub a: int }
+  
+  struct N { pub n: int }
+  
+  impl N {
+    fn string(self) -> string {
+      "N!"
+    }
+  }
+  
+  struct C {
+    embed A,
+    embed N,
+  }
+---
+package main
+
+import "fmt"
+
+type A struct {
+	A int
+}
+
+func (a A) String() string {
+	return fmt.Sprintf("A { a: %v }", a.A)
+}
+
+func (a A) to_string() string {
+	return a.String()
+}
+
+type N struct {
+	N int
+}
+
+func (n N) String() string {
+	return "N!"
+}
+
+type C struct {
+	A
+	N
+}

--- a/tests/spec/emit/snapshots/embedded_display_pointer_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_pointer_gets_shadow.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  struct Server {
+    embed Ref<Logger>,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	*Logger
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.Logger, s.Port)
+}

--- a/tests/spec/emit/snapshots/embedded_display_shadow_is_transitive.snap
+++ b/tests/spec/emit/snapshots/embedded_display_shadow_is_transitive.snap
@@ -1,0 +1,50 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  struct Server {
+    embed Logger,
+    pub port: int,
+  }
+  
+  struct Cluster {
+    embed Server,
+    pub name: string,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	Logger
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.Logger, s.Port)
+}
+
+type Cluster struct {
+	Server
+	Name string
+}
+
+func (c Cluster) String() string {
+	return fmt.Sprintf("{%v %v}", c.Server, c.Name)
+}

--- a/tests/spec/emit/snapshots/embedded_display_struct_gets_shadow_stringer.snap
+++ b/tests/spec/emit/snapshots/embedded_display_struct_gets_shadow_stringer.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  struct Server {
+    embed Logger,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	Logger
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.Logger, s.Port)
+}

--- a/tests/spec/emit/snapshots/embedded_display_with_user_stringer_promotes_without_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_with_user_stringer_promotes_without_shadow.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  impl Logger {
+    fn string(self) -> string {
+      "custom"
+    }
+  }
+  
+  struct Server {
+    embed Logger,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) GoString() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+func (l Logger) String() string {
+	return "custom"
+}
+
+type Server struct {
+	Logger
+	Port int
+}

--- a/tests/spec/emit/snapshots/embedded_generic_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_generic_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface Base<T> {
+    fn string(self) -> T
+  }
+  
+  struct C {
+    embed D,
+    embed Base<string>,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type Base[T any] interface {
+	String() T
+}
+
+type C struct {
+	D
+	Base[string]
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_generic_parent_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_generic_parent_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface Base<T> {
+    fn string(self) -> T
+  }
+  
+  interface I {
+    embed Base<string>
+    fn area(self) -> int
+  }
+  
+  struct C {
+    embed D,
+    embed I,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type Base[T any] interface {
+	String() T
+}
+
+type I interface {
+	Base[string]
+	area() int
+}
+
+type C struct {
+	D
+	I
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_imported_non_stringer_string_method_blocks_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_imported_non_stringer_string_method_blocks_shadow.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:example.com/lib"
+  
+  #[display]
+  struct D { pub x: int }
+  
+  struct C {
+    embed lib.N,
+    embed D,
+    pub n: int,
+  }
+---
+package main
+
+import (
+	"example.com/lib"
+	"fmt"
+)
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type C struct {
+	lib.N
+	D
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_interface_non_stringer_string_method_is_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_non_stringer_string_method_is_ambiguous_no_shadow.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface I {
+    fn string(self) -> int
+  }
+  
+  struct C {
+    embed D,
+    embed I,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type I interface {
+	String() int
+}
+
+type C struct {
+	D
+	I
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_interface_parent_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_parent_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface Base {
+    fn string(self) -> string
+  }
+  
+  interface I {
+    embed Base
+    fn area(self) -> int
+  }
+  
+  struct C {
+    embed D,
+    embed I,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type Base interface {
+	String() string
+}
+
+type I interface {
+	Base
+	area() int
+}
+
+type C struct {
+	D
+	I
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface I {
+    fn string(self) -> string
+  }
+  
+  struct C {
+    embed D,
+    embed I,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type I interface {
+	String() string
+}
+
+type C struct {
+	D
+	I
+	N int
+}

--- a/tests/spec/emit/snapshots/embedded_interface_without_stringer_leaves_display_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_without_stringer_leaves_display_shadow.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct D { pub x: int }
+  
+  interface I {
+    fn area(self) -> int
+  }
+  
+  struct C {
+    embed D,
+    embed I,
+    pub n: int,
+  }
+---
+package main
+
+import "fmt"
+
+type D struct {
+	X int
+}
+
+func (d D) String() string {
+	return fmt.Sprintf("D { x: %v }", d.X)
+}
+
+func (d D) to_string() string {
+	return d.String()
+}
+
+type I interface {
+	area() int
+}
+
+type C struct {
+	D
+	I
+	N int
+}
+
+func (c C) String() string {
+	return fmt.Sprintf("{%v %v %v}", c.D, c.I, c.N)
+}

--- a/tests/spec/emit/snapshots/embedded_intermediate_user_stringer_stops_shadow_walk.snap
+++ b/tests/spec/emit/snapshots/embedded_intermediate_user_stringer_stops_shadow_walk.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  struct Server {
+    embed Logger,
+    pub port: int,
+  }
+  
+  impl Server {
+    fn string(self) -> string {
+      "srv"
+    }
+  }
+  
+  struct Cluster {
+    embed Server,
+    pub name: string,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	Logger
+	Port int
+}
+
+func (s Server) String() string {
+	return "srv"
+}
+
+type Cluster struct {
+	Server
+	Name string
+}

--- a/tests/spec/emit/snapshots/embedded_plain_struct_gets_no_shadow_stringer.snap
+++ b/tests/spec/emit/snapshots/embedded_plain_struct_gets_no_shadow_stringer.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Plain { pub v: int }
+  
+  struct Wrapper {
+    embed Plain,
+    pub tag: int,
+  }
+---
+package main
+
+type Plain struct {
+	V int
+}
+
+type Wrapper struct {
+	Plain
+	Tag int
+}

--- a/tests/spec/emit/snapshots/embedded_ref_to_alias_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_ref_to_alias_display_gets_shadow.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  type L = Logger
+  
+  struct Server {
+    embed Ref<L>,
+    pub port: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type L = Logger
+
+type Server struct {
+	*L
+	Port int
+}
+
+func (s Server) String() string {
+	return fmt.Sprintf("{%v %v}", s.L, s.Port)
+}

--- a/tests/spec/emit/snapshots/embedded_user_stringer_promotes_without_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_user_stringer_promotes_without_shadow.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Named { pub who: string }
+  
+  impl Named {
+    fn string(self) -> string {
+      "Named!"
+    }
+  }
+  
+  struct Holder {
+    embed Named,
+    pub n: int,
+  }
+---
+package main
+
+type Named struct {
+	Who string
+}
+
+func (n Named) String() string {
+	return "Named!"
+}
+
+type Holder struct {
+	Named
+	N int
+}

--- a/tests/spec/emit/snapshots/keyed_tag_forces_export_so_string_field_blocks_outer_shadow.snap
+++ b/tests/spec/emit/snapshots/keyed_tag_forces_export_so_string_field_blocks_outer_shadow.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  #[tag("validate", "required")]
+  struct Inner {
+    embed Logger,
+    string: int,
+  }
+  
+  struct Outer {
+    embed Inner,
+    pub name: string,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Inner struct {
+	Logger
+	String int `validate:"string"`
+}
+
+type Outer struct {
+	Inner
+	Name string
+}

--- a/tests/spec/emit/snapshots/single_embedded_display_beside_plain_embed_shadows.snap
+++ b/tests/spec/emit/snapshots/single_embedded_display_beside_plain_embed_shadows.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct A { pub a: int }
+  
+  struct P { pub p: int }
+  
+  struct C {
+    embed A,
+    embed P,
+  }
+---
+package main
+
+import "fmt"
+
+type A struct {
+	A int
+}
+
+func (a A) String() string {
+	return fmt.Sprintf("A { a: %v }", a.A)
+}
+
+func (a A) to_string() string {
+	return a.String()
+}
+
+type P struct {
+	P int
+}
+
+type C struct {
+	A
+	P
+}
+
+func (c C) String() string {
+	return fmt.Sprintf("{%v %v}", c.A, c.P)
+}

--- a/tests/spec/emit/snapshots/string_field_beside_embedded_display_blocks_shadow.snap
+++ b/tests/spec/emit/snapshots/string_field_beside_embedded_display_blocks_shadow.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  struct Server {
+    embed Logger,
+    pub string: int,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Server struct {
+	Logger
+	String int
+}

--- a/tests/spec/emit/snapshots/tag_exported_string_field_on_embed_blocks_outer_shadow.snap
+++ b/tests/spec/emit/snapshots/tag_exported_string_field_on_embed_blocks_outer_shadow.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Logger { pub prefix: string }
+  
+  #[json]
+  struct Inner {
+    embed Logger,
+    string: int,
+  }
+  
+  struct Outer {
+    embed Inner,
+    pub name: string,
+  }
+---
+package main
+
+import "fmt"
+
+type Logger struct {
+	Prefix string
+}
+
+func (l Logger) String() string {
+	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
+}
+
+func (l Logger) to_string() string {
+	return l.String()
+}
+
+type Inner struct {
+	Logger
+	String int `json:"string"`
+}
+
+type Outer struct {
+	Inner
+	Name string
+}

--- a/tests/spec/emit/snapshots/two_embedded_display_stringers_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/two_embedded_display_stringers_are_ambiguous_no_shadow.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct A { pub a: int }
+  
+  #[display]
+  struct B { pub b: int }
+  
+  struct C {
+    embed A,
+    embed B,
+  }
+---
+package main
+
+import "fmt"
+
+type A struct {
+	A int
+}
+
+func (a A) String() string {
+	return fmt.Sprintf("A { a: %v }", a.A)
+}
+
+func (a A) to_string() string {
+	return a.String()
+}
+
+type B struct {
+	B int
+}
+
+func (b B) String() string {
+	return fmt.Sprintf("B { b: %v }", b.B)
+}
+
+func (b B) to_string() string {
+	return b.String()
+}
+
+type C struct {
+	A
+	B
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -189,6 +189,473 @@ impl Point {
 }
 
 #[test]
+fn embedded_display_struct_gets_shadow_stringer() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_display_shadow_is_transitive() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+
+struct Cluster {
+  embed Server,
+  pub name: string,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_plain_struct_gets_no_shadow_stringer() {
+    let input = r#"
+struct Plain { pub v: int }
+
+struct Wrapper {
+  embed Plain,
+  pub tag: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn display_outer_over_embedded_display_needs_no_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+#[display]
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_user_stringer_promotes_without_shadow() {
+    let input = r#"
+struct Named { pub who: string }
+
+impl Named {
+  fn string(self) -> string {
+    "Named!"
+  }
+}
+
+struct Holder {
+  embed Named,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_display_with_user_stringer_promotes_without_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+impl Logger {
+  fn string(self) -> string {
+    "custom"
+  }
+}
+
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn deeper_promoted_stringer_does_not_block_shallower_display_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+struct N { pub n: int }
+
+impl N {
+  fn string(self) -> string {
+    "N"
+  }
+}
+
+struct P {
+  embed N,
+}
+
+struct C {
+  embed D,
+  embed P,
+  pub c: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_intermediate_user_stringer_stops_shadow_walk() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+struct Server {
+  embed Logger,
+  pub port: int,
+}
+
+impl Server {
+  fn string(self) -> string {
+    "srv"
+  }
+}
+
+struct Cluster {
+  embed Server,
+  pub name: string,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_alias_of_display_gets_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+type Alias = Logger
+
+struct Server {
+  embed Alias,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_display_pointer_gets_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+struct Server {
+  embed Ref<Logger>,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_alias_to_ref_display_gets_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+type P = Ref<Logger>
+
+struct Server {
+  embed P,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_ref_to_alias_display_gets_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+type L = Logger
+
+struct Server {
+  embed Ref<L>,
+  pub port: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn two_embedded_display_stringers_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct A { pub a: int }
+
+#[display]
+struct B { pub b: int }
+
+struct C {
+  embed A,
+  embed B,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_display_and_user_stringer_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct A { pub a: int }
+
+struct N { pub n: int }
+
+impl N {
+  fn string(self) -> string {
+    "N!"
+  }
+}
+
+struct C {
+  embed A,
+  embed N,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn single_embedded_display_beside_plain_embed_shadows() {
+    let input = r#"
+#[display]
+struct A { pub a: int }
+
+struct P { pub p: int }
+
+struct C {
+  embed A,
+  embed P,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_interface_stringer_and_display_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface I {
+  fn string(self) -> string
+}
+
+struct C {
+  embed D,
+  embed I,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_interface_parent_stringer_and_display_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface Base {
+  fn string(self) -> string
+}
+
+interface I {
+  embed Base
+  fn area(self) -> int
+}
+
+struct C {
+  embed D,
+  embed I,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_interface_without_stringer_leaves_display_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface I {
+  fn area(self) -> int
+}
+
+struct C {
+  embed D,
+  embed I,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_interface_non_stringer_string_method_is_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface I {
+  fn string(self) -> int
+}
+
+struct C {
+  embed D,
+  embed I,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_generic_interface_stringer_and_display_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface Base<T> {
+  fn string(self) -> T
+}
+
+struct C {
+  embed D,
+  embed Base<string>,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn embedded_generic_parent_interface_stringer_and_display_are_ambiguous_no_shadow() {
+    let input = r#"
+#[display]
+struct D { pub x: int }
+
+interface Base<T> {
+  fn string(self) -> T
+}
+
+interface I {
+  embed Base<string>
+  fn area(self) -> int
+}
+
+struct C {
+  embed D,
+  embed I,
+  pub n: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_field_beside_embedded_display_blocks_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+struct Server {
+  embed Logger,
+  pub string: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tag_exported_string_field_on_embed_blocks_outer_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+#[json]
+struct Inner {
+  embed Logger,
+  string: int,
+}
+
+struct Outer {
+  embed Inner,
+  pub name: string,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn bare_tag_does_not_force_export_so_outer_still_shadows() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+#[tag]
+struct Inner {
+  embed Logger,
+  string: int,
+}
+
+struct Outer {
+  embed Inner,
+  pub name: string,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn keyed_tag_forces_export_so_string_field_blocks_outer_shadow() {
+    let input = r#"
+#[display]
+struct Logger { pub prefix: string }
+
+#[tag("validate", "required")]
+struct Inner {
+  embed Logger,
+  string: int,
+}
+
+struct Outer {
+  embed Inner,
+  pub name: string,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn equality_struct_comparable_fields() {
     let input = r#"
 #[equality]


### PR DESCRIPTION
A struct that embeds a `#[display]` type now prints all of its own fields, not just the embedded part.

```rs
#[display]
struct Logger {
  pub prefix: string,
}

struct Server {
  embed Logger,
  pub port: int,
}

fmt.Println(Server { Logger: Logger { prefix: "srv:" }, port: 8080 })
```
