### PR TITLE
fix: reject enum variant spread when fields may be absent

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2458,6 +2458,47 @@ pub fn enum_field_type_conflict(
         ))
 }
 
+pub fn enum_spread_missing_fields(
+    enum_name: &str,
+    target_variant: &str,
+    missing: &[String],
+    counterexample: Option<(&str, &str)>,
+    span: Span,
+) -> LisetteDiagnostic {
+    let (noun, pronoun, fields_fmt) = if missing.len() == 1 {
+        ("field", "it", format!("`{}`", missing[0]))
+    } else {
+        let formatted: Vec<String> = missing.iter().map(|f| format!("`{}`", f)).collect();
+        ("fields", "them", formatted.join(", "))
+    };
+
+    let (label, help) = match counterexample {
+        Some((lacking_variant, lacked_field)) => (
+            format!("may be `{enum_name}.{lacking_variant}`, which has no field `{lacked_field}`"),
+            format!(
+                "A spread can only fill fields that exist in every `{enum_name}` variant. Assign {noun} {fields_fmt} explicitly, or bind {pronoun} first when the source is known to be `{enum_name}.{target_variant}`: `let {enum_name}.{target_variant} {{ {pattern}, .. }} = source else {{ ... }}`",
+                pattern = missing.join(", "),
+            ),
+        ),
+        None => (
+            format!("may hold any `{enum_name}` variant"),
+            format!(
+                "Every `{enum_name}` variant has {fields_fmt}, but the {name_noun} with a built-in enum member, so each variant stores {pronoun} separately and a spread cannot fill {pronoun}. Assign {noun} {fields_fmt} explicitly",
+                name_noun = if missing.len() == 1 {
+                    "name collides"
+                } else {
+                    "names collide"
+                },
+            ),
+        ),
+    };
+
+    LisetteDiagnostic::error("Enum spread cannot fill variant-specific fields")
+        .with_infer_code("enum_spread_missing_fields")
+        .with_span_label(&span, label)
+        .with_help(help)
+}
+
 pub fn cannot_auto_address_receiver(
     receiver_kind: &str,
     method_name: &str,

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -13,7 +13,7 @@ use crate::expressions::emission::StagedExpression;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
-use crate::utils::observable_after_mutation;
+use crate::utils::{is_order_sensitive, observable_after_mutation};
 
 struct StructCallContext {
     go_type: String,
@@ -100,7 +100,26 @@ impl Planner<'_> {
                             .iter()
                             .map(|f| observable_after_mutation(&f.value)),
                     );
-                    self.lower_struct_update(&mut setup, base, &field_pairs, &field_side_effects)
+                    if ctx.enum_ctx.is_some() {
+                        self.lower_enum_variant_spread(
+                            &mut setup,
+                            base,
+                            name,
+                            ty,
+                            &ctx,
+                            field_pairs,
+                            &field_side_effects,
+                            field_assignments,
+                            expression_ctx,
+                        )
+                    } else {
+                        self.lower_struct_update(
+                            &mut setup,
+                            base,
+                            &field_pairs,
+                            &field_side_effects,
+                        )
+                    }
                 }
             }
             StructSpread::ZeroFill { .. } if !is_go_struct => {
@@ -589,6 +608,60 @@ impl Planner<'_> {
         }
 
         tmp
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_enum_variant_spread(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        base: &Expression,
+        name: &str,
+        ty: &Type,
+        ctx: &StructCallContext,
+        field_pairs: Vec<(String, String)>,
+        field_side_effects: &[bool],
+        field_assignments: &[StructFieldAssignment],
+        expression_ctx: ExpressionContext<'_>,
+    ) -> String {
+        let mut pairs: Vec<(String, String)> = field_pairs
+            .into_iter()
+            .enumerate()
+            .map(|(i, (field_name, value))| {
+                if field_side_effects.get(i).copied().unwrap_or(false) {
+                    let temp = self.hoist_tmp_value_statement(statements, "field", &value);
+                    (field_name, temp)
+                } else {
+                    (field_name, value)
+                }
+            })
+            .collect();
+
+        let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
+        let carried = self
+            .lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned)
+            .unwrap_or_default();
+
+        let base_staged = self.stage_operand(base, ExpressionContext::value());
+        statements.extend(base_staged.setup);
+
+        if carried.is_empty() {
+            statements.push(LoweredStatement::RawGo(format!(
+                "_ = {}\n",
+                base_staged.value
+            )));
+            return emit_struct_literal(&ctx.go_type, &pairs, expression_ctx);
+        }
+
+        let source = if is_order_sensitive(base) {
+            self.hoist_tmp_value_statement(statements, "spread", &base_staged.value)
+        } else {
+            base_staged.value
+        };
+        for (field_name, _) in carried {
+            let slot = self.resolve_struct_call_field_name(&field_name, ty, ctx);
+            pairs.push((slot.clone(), format!("{}.{}", source, slot)));
+        }
+        emit_struct_literal(&ctx.go_type, &pairs, expression_ctx)
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -386,6 +386,16 @@ impl InferCtx<'_, '_> {
             );
         }
 
+        if let StructSpread::From(spread_expression) = &new_spread {
+            self.check_enum_spread_fields(
+                &resolved_enum,
+                &variant_name,
+                &variant_fields,
+                &matched_fields,
+                spread_expression.get_span(),
+            );
+        }
+
         Expression::StructCall {
             name: variant_name,
             field_assignments: new_field_assignments,
@@ -405,6 +415,80 @@ impl InferCtx<'_, '_> {
             }
             StructSpread::ZeroFill { span } => StructSpread::ZeroFill { span },
         }
+    }
+
+    fn check_enum_spread_fields(
+        &mut self,
+        resolved_enum: &Type,
+        written_name: &str,
+        variant_fields: &[syntax::ast::EnumFieldDefinition],
+        matched_fields: &HashSet<EcoString>,
+        spread_span: Span,
+    ) {
+        let store = self.store;
+        let Type::Nominal { id, .. } = resolved_enum else {
+            return;
+        };
+        let Some(variants) = store.variants_of(id) else {
+            return;
+        };
+        let enum_name = unqualified_name(id);
+        let target_variant = unqualified_name(written_name);
+        let written_enum = written_name
+            .rsplit_once('.')
+            .map_or(enum_name, |(prefix, _)| prefix);
+        let target_single = variant_fields.len() == 1;
+
+        let missing: Vec<String> = variant_fields
+            .iter()
+            .enumerate()
+            .filter(|(_, field)| !matched_fields.contains(&field.name))
+            .filter(|(field_index, field)| {
+                let target_slot = syntax::go_names::enum_field_go_name(
+                    target_variant,
+                    &field.name,
+                    *field_index,
+                    true,
+                    target_single,
+                    enum_name,
+                );
+                !variants.iter().all(|variant| {
+                    variant
+                        .fields
+                        .iter()
+                        .enumerate()
+                        .any(|(other_index, other)| {
+                            other.name == field.name
+                                && syntax::go_names::enum_field_go_name(
+                                    &variant.name,
+                                    &other.name,
+                                    other_index,
+                                    variant.fields.is_struct(),
+                                    variant.fields.len() == 1,
+                                    enum_name,
+                                ) == target_slot
+                        })
+                })
+            })
+            .map(|(_, field)| field.name.to_string())
+            .collect();
+        if missing.is_empty() {
+            return;
+        }
+        let counterexample = missing.iter().find_map(|field_name| {
+            variants
+                .iter()
+                .find(|variant| !variant.fields.iter().any(|f| f.name == field_name.as_str()))
+                .map(|variant| (variant.name.as_str(), field_name.as_str()))
+        });
+        self.sink
+            .push(diagnostics::infer::enum_spread_missing_fields(
+                written_enum,
+                target_variant,
+                &missing,
+                counterexample,
+                spread_span,
+            ));
     }
 
     fn infer_structish_fields<'a, FindDef>(

--- a/tests/e2e_smoke_project/src/structs.test.lis
+++ b/tests/e2e_smoke_project/src/structs.test.lis
@@ -15,14 +15,22 @@ fn struct_spread_override_last() {
 }
 
 #[test]
-fn struct_variant_spread() {
-  let base = Event.Click { x: 10, y: 20 }
-  let e = Event.Click { x: 100, ..base }
-  let result = match e {
-    Event.Click { x, y } => x + y,
+fn struct_variant_spread_carries_shared_field() {
+  let base = Cursor.Point { id: 7, x: 10, y: 20 }
+  let area = Cursor.Area { w: 3, h: 4, ..base }
+  let result = match area {
+    Cursor.Area { id, w, h } => id * 100 + w * 10 + h,
     _ => 0,
   }
-  assert result == 120
+  assert result == 734
+}
+
+#[test]
+fn struct_variant_spread_no_stale_slots() {
+  let base = Cursor.Point { id: 7, x: 10, y: 20 }
+  let from_spread = Cursor.Area { w: 3, h: 4, ..base }
+  let fresh = Cursor.Area { id: 7, w: 3, h: 4 }
+  assert from_spread == fresh
 }
 
 #[test]
@@ -358,6 +366,11 @@ fn returns_slice() -> Slice<int> {
 struct SliceHolder { items: Slice<int> }
 
 struct MutPoint { x: int, y: int }
+
+enum Cursor {
+  Point { id: int, x: int, y: int },
+  Area { id: int, w: int, h: int },
+}
 
 struct UserId(int)
 

--- a/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_consumes_identifier_base.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_consumes_identifier_base.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Cursor {
+    Point { id: int, x: int },
+    Area { id: int, w: int },
+  }
+  
+  fn test() -> Cursor {
+    let base = Cursor.Point { id: 1, x: 2 };
+    Cursor.Area { id: 4, w: 3, ..base }
+  }
+---
+package main
+
+func MakeCursorPoint(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorPoint, Id: arg0, X: arg1}
+}
+
+func MakeCursorArea(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
+}
+
+type CursorTag int
+
+const (
+	CursorPoint CursorTag = iota
+	CursorArea
+)
+
+type Cursor struct {
+	Tag CursorTag
+	Id  int
+	X   int
+	W   int
+}
+
+func test() Cursor {
+	base := Cursor{
+		Tag: CursorPoint,
+		Id:  1,
+		X:   2,
+	}
+	_ = base
+	return Cursor{
+		Tag: CursorArea,
+		Id:  4,
+		W:   3,
+	}
+}

--- a/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
@@ -1,0 +1,60 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:fmt"
+  
+  enum Cursor {
+    Point { id: int, x: int },
+    Area { id: int, w: int },
+  }
+  
+  fn make_base() -> Cursor { fmt.Println("base"); Cursor.Point { id: 1, x: 2 } }
+  
+  fn test() -> Cursor {
+    Cursor.Area { id: 4, w: 3, ..make_base() }
+  }
+---
+package main
+
+import "fmt"
+
+func MakeCursorPoint(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorPoint, Id: arg0, X: arg1}
+}
+
+func MakeCursorArea(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
+}
+
+type CursorTag int
+
+const (
+	CursorPoint CursorTag = iota
+	CursorArea
+)
+
+type Cursor struct {
+	Tag CursorTag
+	Id  int
+	X   int
+	W   int
+}
+
+func make_base() Cursor {
+	fmt.Println("base")
+	return Cursor{
+		Tag: CursorPoint,
+		Id:  1,
+		X:   2,
+	}
+}
+
+func test() Cursor {
+	_ = make_base()
+	return Cursor{
+		Tag: CursorArea,
+		Id:  4,
+		W:   3,
+	}
+}

--- a/tests/spec/emit/snapshots/enum_variant_spread_builds_fresh_literal.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_builds_fresh_literal.snap
@@ -1,0 +1,50 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Cursor {
+    Point { id: int, x: int },
+    Area { id: int, w: int },
+  }
+  
+  fn test() -> Cursor {
+    let base = Cursor.Point { id: 7, x: 10 };
+    Cursor.Area { w: 3, ..base }
+  }
+---
+package main
+
+func MakeCursorPoint(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorPoint, Id: arg0, X: arg1}
+}
+
+func MakeCursorArea(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
+}
+
+type CursorTag int
+
+const (
+	CursorPoint CursorTag = iota
+	CursorArea
+)
+
+type Cursor struct {
+	Tag CursorTag
+	Id  int
+	X   int
+	W   int
+}
+
+func test() Cursor {
+	base := Cursor{
+		Tag: CursorPoint,
+		Id:  7,
+		X:   10,
+	}
+	return Cursor{
+		Tag: CursorArea,
+		W:   3,
+		Id:  base.Id,
+	}
+}

--- a/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
@@ -1,0 +1,60 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:fmt"
+  
+  enum Cursor {
+    Point { id: int, x: int },
+    Area { id: int, w: int },
+  }
+  
+  fn make_base() -> Cursor { fmt.Println("base"); Cursor.Point { id: 1, x: 2 } }
+  
+  fn test() -> Cursor {
+    Cursor.Area { w: 3, ..make_base() }
+  }
+---
+package main
+
+import "fmt"
+
+func MakeCursorPoint(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorPoint, Id: arg0, X: arg1}
+}
+
+func MakeCursorArea(arg0 int, arg1 int) Cursor {
+	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
+}
+
+type CursorTag int
+
+const (
+	CursorPoint CursorTag = iota
+	CursorArea
+)
+
+type Cursor struct {
+	Tag CursorTag
+	Id  int
+	X   int
+	W   int
+}
+
+func make_base() Cursor {
+	fmt.Println("base")
+	return Cursor{
+		Tag: CursorPoint,
+		Id:  1,
+		X:   2,
+	}
+}
+
+func test() Cursor {
+	spread_1 := make_base()
+	return Cursor{
+		Tag: CursorArea,
+		W:   3,
+		Id:  spread_1.Id,
+	}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1698,6 +1698,76 @@ fn main() {
 }
 
 #[test]
+fn enum_variant_spread_builds_fresh_literal() {
+    let input = r#"
+enum Cursor {
+  Point { id: int, x: int },
+  Area { id: int, w: int },
+}
+
+fn test() -> Cursor {
+  let base = Cursor.Point { id: 7, x: 10 };
+  Cursor.Area { w: 3, ..base }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn enum_variant_spread_all_fields_assigned_discards_base_call() {
+    let input = r#"
+import "go:fmt"
+
+enum Cursor {
+  Point { id: int, x: int },
+  Area { id: int, w: int },
+}
+
+fn make_base() -> Cursor { fmt.Println("base"); Cursor.Point { id: 1, x: 2 } }
+
+fn test() -> Cursor {
+  Cursor.Area { id: 4, w: 3, ..make_base() }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn enum_variant_spread_all_fields_assigned_consumes_identifier_base() {
+    let input = r#"
+enum Cursor {
+  Point { id: int, x: int },
+  Area { id: int, w: int },
+}
+
+fn test() -> Cursor {
+  let base = Cursor.Point { id: 1, x: 2 };
+  Cursor.Area { id: 4, w: 3, ..base }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn enum_variant_spread_side_effecting_base_evaluated_once() {
+    let input = r#"
+import "go:fmt"
+
+enum Cursor {
+  Point { id: int, x: int },
+  Area { id: int, w: int },
+}
+
+fn make_base() -> Cursor { fmt.Println("base"); Cursor.Point { id: 1, x: 2 } }
+
+fn test() -> Cursor {
+  Cursor.Area { w: 3, ..make_base() }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn struct_spread_field_before_base_eval_order() {
     let input = r#"
 import "go:fmt"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2140,6 +2140,54 @@ fn test() {
 }
 
 #[test]
+fn infer_enum_spread_missing_field() {
+    let input = r#"
+enum E {
+  A { x: int, z: int },
+  B { x: int, y: int },
+}
+
+fn test() {
+  let e = E.A { x: 1, z: 2 }
+  let _f = E.B { x: 9, ..e }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_enum_spread_missing_fields_plural() {
+    let input = r#"
+enum E {
+  A { x: int },
+  B { x: int, y: int, z: int },
+}
+
+fn test() {
+  let a = E.A { x: 1 }
+  let _b = E.B { ..a }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_enum_spread_shared_field_slot_mismatch() {
+    let input = r#"
+enum E {
+  A { tag: int, x: int },
+  B { tag: int, y: int },
+}
+
+fn test() {
+  let a = E.A { tag: 1, x: 2 }
+  let _b = E.B { y: 3, ..a }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_struct_not_found() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_enum_spread_missing_field.snap
+++ b/tests/ui/errors/snapshots/infer_enum_spread_missing_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Enum spread cannot fill variant-specific fields
+    ╭─[test.lis:9:26]
+  8 │   let e = E.A { x: 1, z: 2 }
+  9 │   let _f = E.B { x: 9, ..e }
+    ·                          ┬
+    ·                          ╰── may be `E.A`, which has no field `y`
+ 10 │ }
+    ╰────
+  help: A spread can only fill fields that exist in every `E` variant. Assign field `y` explicitly, or bind it first when the source is known to be `E.B`: `let E.B { y, .. } = source else { ... }` · code: [infer.enum_spread_missing_fields]

--- a/tests/ui/errors/snapshots/infer_enum_spread_missing_fields_plural.snap
+++ b/tests/ui/errors/snapshots/infer_enum_spread_missing_fields_plural.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Enum spread cannot fill variant-specific fields
+    ╭─[test.lis:9:20]
+  8 │   let a = E.A { x: 1 }
+  9 │   let _b = E.B { ..a }
+    ·                    ┬
+    ·                    ╰── may be `E.A`, which has no field `y`
+ 10 │ }
+    ╰────
+  help: A spread can only fill fields that exist in every `E` variant. Assign fields `y`, `z` explicitly, or bind them first when the source is known to be `E.B`: `let E.B { y, z, .. } = source else { ... }` · code: [infer.enum_spread_missing_fields]

--- a/tests/ui/errors/snapshots/infer_enum_spread_shared_field_slot_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_enum_spread_shared_field_slot_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Enum spread cannot fill variant-specific fields
+    ╭─[test.lis:9:26]
+  8 │   let a = E.A { tag: 1, x: 2 }
+  9 │   let _b = E.B { y: 3, ..a }
+    ·                          ┬
+    ·                          ╰── may hold any `E` variant
+ 10 │ }
+    ╰────
+  help: Every `E` variant has `tag`, but the name collides with a built-in enum member, so each variant stores it separately and a spread cannot fill it. Assign field `tag` explicitly · code: [infer.enum_spread_missing_fields]


### PR DESCRIPTION
Spreading an enum value into a variant literal could zero-fill fields the source variant does not have. A value typed as the enum may hold any variant at runtime, so `..` can only fill fields that acttuallyexist in every variant. Anything else must now be assigned explicitly.

```rs
enum E {
  A { x: int, z: int },
  B { x: int, y: int },
}

let e = E.A { x: 1, z: 2 }
let f = E.B { x: 9, ..e } // ran and printed y as 0, now rejected
```
