### PR TITLE
fix: reject built-in types as interface values

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2123,6 +2123,23 @@ pub fn wrapper_does_not_implement_interface(
         .with_help(help)
 }
 
+pub fn builtin_type_cannot_implement_interface(
+    interface_name: &str,
+    type_name: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Interface not implemented")
+        .with_infer_code("interface_not_implemented")
+        .with_span_label(
+            &span,
+            format!("`{type_name}` cannot implement `{interface_name}`"),
+        )
+        .with_help(format!(
+            "Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the \
+             value in a struct that implements `{interface_name}`."
+        ))
+}
+
 pub fn pointer_receiver_interface_mismatch(
     interface_name: &str,
     type_name: &str,

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -612,12 +612,6 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    /// A container's `equals` lowers to a free function, not a Go method, so it cannot satisfy an interface or bound.
-    pub(in crate::checker::infer) fn is_native_container(&self, ty: &Type) -> bool {
-        let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
-        resolved.is_slice() || resolved.is_map()
-    }
-
     fn container_equals_element(&self, ty: &Type) -> Option<Type> {
         let resolved = self.store.deep_resolve_alias(&ty.resolve_in(&self.env));
         match resolved.as_compound() {

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -73,52 +73,83 @@ impl InferCtx<'_, '_> {
 
         self.satisfying_stack.remove(&pair);
 
-        if violations.is_empty() {
-            Ok(())
+        let builtin_receiver = self.is_builtin_receiver(ty);
+
+        if violations.is_empty()
+            && !(builtin_receiver
+                && interface_declares_methods(
+                    self.store,
+                    interface,
+                    &mut rustc_hash::FxHashSet::default(),
+                ))
+        {
+            return Ok(());
+        }
+
+        if let Some(sealed) = violations.iter().find(|v| {
+            v.missing
+                .iter()
+                .any(|(name, _)| crate::checker::sealing::is_unexported_key(name))
+        }) {
+            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            self.sink
+                .push(diagnostics::infer::sealed_interface_not_satisfiable(
+                    &sealed.interface_name,
+                    &type_name,
+                    *span,
+                ));
+            return Err(violations);
+        }
+        let resolved = ty.resolve_in(&self.env);
+        let wrapper = if resolved.is_result() {
+            Some(diagnostics::infer::WrapperKind::Result)
+        } else if resolved.is_option() {
+            Some(diagnostics::infer::WrapperKind::Option)
+        } else if resolved.is_partial() {
+            Some(diagnostics::infer::WrapperKind::Partial)
         } else {
-            if let Some(sealed) = violations.iter().find(|v| {
-                v.missing
-                    .iter()
-                    .any(|(name, _)| crate::checker::sealing::is_unexported_key(name))
-            }) {
-                let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
-                self.sink
-                    .push(diagnostics::infer::sealed_interface_not_satisfiable(
-                        &sealed.interface_name,
-                        &type_name,
-                        *span,
-                    ));
-                return Err(violations);
+            None
+        };
+        if let Some(wrapper) = wrapper {
+            self.sink
+                .push(diagnostics::infer::wrapper_does_not_implement_interface(
+                    &interface.name,
+                    wrapper,
+                    &resolved,
+                    *span,
+                ));
+        } else if builtin_receiver {
+            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            self.sink
+                .push(diagnostics::infer::builtin_type_cannot_implement_interface(
+                    &interface.name,
+                    &type_name,
+                    *span,
+                ));
+        } else {
+            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            self.sink
+                .push(diagnostics::infer::interface_not_implemented(
+                    &interface.name,
+                    &type_name,
+                    &violations,
+                    *span,
+                ));
+        }
+        Err(violations)
+    }
+
+    fn is_builtin_receiver(&self, ty: &Type) -> bool {
+        let resolved = self
+            .store
+            .deep_resolve_alias(&ty.strip_refs().resolve_in(&self.env));
+        match resolved.strip_refs() {
+            Type::Simple(_) | Type::Compound { .. } | Type::Array { .. } => true,
+            Type::Nominal { id, .. } => {
+                id.as_str().starts_with("prelude.")
+                    && self.store.get_interface(id.as_str()).is_none()
             }
-            let resolved = ty.resolve_in(&self.env);
-            let wrapper = if resolved.is_result() {
-                Some(diagnostics::infer::WrapperKind::Result)
-            } else if resolved.is_option() {
-                Some(diagnostics::infer::WrapperKind::Option)
-            } else if resolved.is_partial() {
-                Some(diagnostics::infer::WrapperKind::Partial)
-            } else {
-                None
-            };
-            if let Some(wrapper) = wrapper {
-                self.sink
-                    .push(diagnostics::infer::wrapper_does_not_implement_interface(
-                        &interface.name,
-                        wrapper,
-                        &resolved,
-                        *span,
-                    ));
-            } else {
-                let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
-                self.sink
-                    .push(diagnostics::infer::interface_not_implemented(
-                        &interface.name,
-                        &type_name,
-                        &violations,
-                        *span,
-                    ));
-            }
-            Err(violations)
+            _ => false,
         }
     }
 
@@ -252,10 +283,6 @@ impl InferCtx<'_, '_> {
             .unwrap_or_default();
 
         for (method_name, method_ty) in &interface.methods {
-            if method_name.as_str() == "equals" && self.is_native_container(ty) {
-                missing.push((method_name.to_string(), method_ty.clone()));
-                continue;
-            }
             let Some(symbol_method) = symbol_methods.get(method_name.as_str()) else {
                 missing.push((method_name.to_string(), method_ty.clone()));
                 continue;
@@ -435,6 +462,25 @@ impl InferCtx<'_, '_> {
             _ => ty.clone(),
         }
     }
+}
+
+fn interface_declares_methods(
+    store: &Store,
+    interface: &Interface,
+    seen: &mut rustc_hash::FxHashSet<String>,
+) -> bool {
+    if !interface.methods.is_empty() {
+        return true;
+    }
+    interface.parents.iter().any(|parent| {
+        let parent_name = parent.get_qualified_name();
+        seen.insert(parent_name.to_string())
+            && store
+                .get_interface(&parent_name)
+                .is_some_and(|parent_interface| {
+                    interface_declares_methods(store, parent_interface, seen)
+                })
+    })
 }
 
 /// Lift impl return T to Option<T> when the interface is Go-imported, the

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -78,20 +78,18 @@ impl InferCtx<'_, '_> {
             return;
         }
 
+        if store.peel_alias_deep(&source_ty) == store.peel_alias_deep(&target_ty) {
+            return;
+        }
+
         // Concrete type -> interface: allowed if source satisfies the interface.
         // Used for explicit coercion before wrapping in generic containers,
         // e.g. `Some(my_dog as Animal)` to get `Option<Animal>`.
         let peeled_target = store.peel_alias(&target_ty);
         if let Type::Nominal { id, params, .. } = &peeled_target
             && let Some(interface) = store.get_interface(id).cloned()
-            && self
-                .satisfies_interface(&source_ty, &interface, id, params, &span)
-                .is_ok()
         {
-            return;
-        }
-
-        if store.peel_alias_deep(&source_ty) == store.peel_alias_deep(&target_ty) {
+            let _ = self.satisfies_interface(&source_ty, &interface, id, params, &span);
             return;
         }
 

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1669,6 +1669,35 @@ fn main() {
 }
 
 #[test]
+fn builtin_type_satisfies_empty_interface() {
+    infer(
+        r#"
+interface Marker {}
+fn tag(m: Marker) -> Marker { m }
+fn main() {
+  let _ = tag([1, 2, 3])
+  let _ = [1, 2] as Marker
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn failed_cast_to_interface_reports_single_error() {
+    infer(
+        r#"
+interface Sized { fn length(self) -> int }
+fn main() {
+  let _ = [1, 2, 3] as Sized
+}
+"#,
+    )
+    .assert_infer_code_once("interface_not_implemented")
+    .assert_infer_code_count("invalid_cast", 0);
+}
+
+#[test]
 fn generic_impl_mismatched_param_position_rejected() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3398,6 +3398,60 @@ fn test() {
 }
 
 #[test]
+fn infer_array_cast_to_interface() {
+    let input = r#"
+interface Sized { fn length(self) -> int }
+
+fn f(a: Array<int, 3>) -> Sized {
+  a as Sized
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_slice_cast_to_interface() {
+    let input = r#"
+interface Sized { fn length(self) -> int }
+
+fn f(s: Slice<int>) -> Sized {
+  s as Sized
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_slice_passed_as_interface() {
+    let input = r#"
+interface Sized { fn length(self) -> int }
+
+fn takes(s: Sized) -> int {
+  s.length()
+}
+
+fn main() {
+  let _ = takes([1, 2, 3])
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_coerced_to_interface_annotation() {
+    let input = r#"
+interface Sized { fn length(self) -> int }
+
+fn main() {
+  let m = Map.new<string, int>()
+  let s: Sized = m
+  let _ = s
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_comma_ok_abi_mismatch() {
     let typedef = r#"
 pub interface Lookup {
@@ -3438,7 +3492,7 @@ fn main() {}
 }
 
 #[test]
-fn builtin_generic_type_satisfies_interface_bound() {
+fn infer_builtin_type_fails_interface_bound() {
     let input = r#"
 interface HasLength {
   fn length() -> int;
@@ -3452,8 +3506,7 @@ fn main() -> int {
   print_length([1, 2, 3])
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
-    result.assert_no_errors();
+    assert_infer_error_snapshot!(input);
 }
 
 #[test]

--- a/tests/ui/errors/snapshots/infer_array_cast_to_interface.snap
+++ b/tests/ui/errors/snapshots/infer_array_cast_to_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+   ╭─[test.lis:5:3]
+ 4 │ fn f(a: Array<int, 3>) -> Sized {
+ 5 │   a as Sized
+   ·   ─────┬────
+   ·        ╰── `Array` cannot implement `Sized`
+ 6 │ }
+   ╰────
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Sized` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_bounded_function_assigned_to_concrete_function_type.snap
+++ b/tests/ui/errors/snapshots/infer_bounded_function_assigned_to_concrete_function_type.snap
@@ -6,10 +6,7 @@ source: tests/ui/errors/mod.rs
  14 │ fn main() {
  15 │   accept(bounded)
     ·          ───┬───
-    ·             ╰── `int` does not implement `Display`
+    ·             ╰── `int` cannot implement `Display`
  16 │ }
     ╰────
-  help: Missing methods:
-          From `Display`
-            - show: fn () -> string
-        code: [infer.interface_not_implemented]
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Display` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_builtin_type_fails_interface_bound.snap
+++ b/tests/ui/errors/snapshots/infer_builtin_type_fails_interface_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:11:16]
+ 10 │ fn main() -> int {
+ 11 │   print_length([1, 2, 3])
+    ·                ────┬────
+    ·                    ╰── `Slice` cannot implement `HasLength`
+ 12 │ }
+    ╰────
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `HasLength` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_equals_container_fails_interface_bound.snap
+++ b/tests/ui/errors/snapshots/infer_equals_container_fails_interface_bound.snap
@@ -6,10 +6,7 @@ source: tests/ui/errors/mod.rs
  11 │   let x = [1, 2]
  12 │   let _ = same(x, x)
     ·                ┬
-    ·                ╰── `Slice` does not implement `Equatable`
+    ·                ╰── `Slice` cannot implement `Equatable`
  13 │ }
     ╰────
-  help: Missing methods:
-          From `Equatable`
-            - equals: fn (T) -> bool
-        code: [infer.interface_not_implemented]
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Equatable` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_bound_not_satisfied.snap
+++ b/tests/ui/errors/snapshots/infer_interface_bound_not_satisfied.snap
@@ -6,10 +6,7 @@ source: tests/ui/errors/mod.rs
  10 │ fn test() {
  11 │   use_writer(42)
     ·              ─┬
-    ·               ╰── `int` does not implement `Writer`
+    ·               ╰── `int` cannot implement `Writer`
  12 │ }
     ╰────
-  help: Missing methods:
-          From `Writer`
-            - write: fn (string) -> int
-        code: [infer.interface_not_implemented]
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Writer` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_map_coerced_to_interface_annotation.snap
+++ b/tests/ui/errors/snapshots/infer_map_coerced_to_interface_annotation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+   ╭─[test.lis:6:18]
+ 5 │   let m = Map.new<string, int>()
+ 6 │   let s: Sized = m
+   ·                  ┬
+   ·                  ╰── `Map` cannot implement `Sized`
+ 7 │   let _ = s
+   ╰────
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Sized` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_slice_cast_to_interface.snap
+++ b/tests/ui/errors/snapshots/infer_slice_cast_to_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+   ╭─[test.lis:5:3]
+ 4 │ fn f(s: Slice<int>) -> Sized {
+ 5 │   s as Sized
+   ·   ─────┬────
+   ·        ╰── `Slice` cannot implement `Sized`
+ 6 │ }
+   ╰────
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Sized` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_slice_passed_as_interface.snap
+++ b/tests/ui/errors/snapshots/infer_slice_passed_as_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:9:17]
+  8 │ fn main() {
+  9 │   let _ = takes([1, 2, 3])
+    ·                 ────┬────
+    ·                     ╰── `Slice` cannot implement `Sized`
+ 10 │ }
+    ╰────
+  help: Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the value in a struct that implements `Sized` · code: [infer.interface_not_implemented]


### PR DESCRIPTION
Casting a built-in type to an interface passed `lis check` and then failed `go build`. Methods on built-in types have no Go method behind them, so the emitted interface coercion was invalid Go. The checker now rejects this with a diagnostic instead.