### PR TITLE
fix: follow embed promotion in unused struct field lint

### DIFF
--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use semantics::checker::promotion::{self, MemberKind, Resolution};
+use semantics::store::Store;
 use syntax::ast::{
     Annotation, Attribute, Binding, Expression, Generic, ImportAlias, Pattern, SelectArm,
     SelectArmPattern, StructSpread,
@@ -12,17 +12,13 @@ use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 use super::reference_graph::{EnumVariantId, ModuleItemId, ReferenceGraph, StructFieldId};
 
-pub struct AliasMap {
+pub struct AliasMap<'a> {
     aliases: HashMap<String, ModuleItemId>,
-    type_aliases: Arc<HashSet<Symbol>>,
+    store: &'a Store,
 }
 
-impl AliasMap {
-    pub fn build(
-        files: &HashMap<u32, File>,
-        go_package_names: &HashMap<String, String>,
-        type_aliases: Arc<HashSet<Symbol>>,
-    ) -> Self {
+impl<'a> AliasMap<'a> {
+    pub fn build(files: &HashMap<u32, File>, store: &'a Store) -> Self {
         let mut aliases = HashMap::default();
 
         for file in files.values() {
@@ -30,16 +26,13 @@ impl AliasMap {
                 if matches!(import.alias, Some(ImportAlias::Blank(_))) {
                     continue;
                 }
-                if let Some(effective) = import.effective_alias(go_package_names) {
+                if let Some(effective) = import.effective_alias(&store.go_package_names) {
                     aliases.insert(effective.clone(), ModuleItemId::new(&effective));
                 }
             }
         }
 
-        Self {
-            aliases,
-            type_aliases,
-        }
+        Self { aliases, store }
     }
 
     fn resolve(&self, module: &Module, name: &str) -> Option<ModuleItemId> {
@@ -55,7 +48,9 @@ impl AliasMap {
     }
 
     fn is_type_alias(&self, id: &Symbol) -> bool {
-        self.type_aliases.contains(id)
+        self.store
+            .get_definition(id.as_str())
+            .is_some_and(|def| def.is_type_alias())
     }
 }
 
@@ -117,9 +112,11 @@ pub(super) fn walk_expression(
             ..
         } => {
             walk_expression(module, expression, graph, alias_map, ctx);
-            if let Some(ty_name) = type_name(&expression.get_type(), alias_map) {
+            let receiver_ty = expression.get_type();
+            if let Some(ty_name) = type_name(&receiver_ty, alias_map) {
                 graph.mark_struct_field_used(StructFieldId::new(&ty_name, member));
             }
+            mark_promoted_field_read(&receiver_ty, member, graph, alias_map);
             if let Some(from) = ctx
                 && is_method_access(dot_access_kind)
                 && credits_local_method(&expression.get_type(), module, alias_map)
@@ -881,6 +878,27 @@ pub(super) fn equals_targets(
 fn is_container_receiver(receiver_ty: &Type, aliases: &AliasMap) -> bool {
     let current = deref_for_keying(receiver_ty, aliases);
     current.is_slice() || current.is_map()
+}
+
+/// Follow promotion so a read through an embed credits the declaring struct's
+/// field, not a non-existent field on the embedder.
+fn mark_promoted_field_read(
+    receiver_ty: &Type,
+    member: &str,
+    graph: &mut ReferenceGraph,
+    aliases: &AliasMap,
+) {
+    let receiver = receiver_ty.strip_refs();
+    if !promotion::has_direct_embed(aliases.store, &receiver) {
+        return;
+    }
+    if let Resolution::Found(resolved) =
+        promotion::resolve_selector(aliases.store, &receiver, member)
+        && matches!(resolved.kind, MemberKind::Field { .. })
+    {
+        let declaring = unqualified_name(resolved.declaring_type.as_str());
+        graph.mark_struct_field_used(StructFieldId::new(declaring, member));
+    }
 }
 
 fn type_name(ty: &Type, aliases: &AliasMap) -> Option<String> {

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -13,12 +13,12 @@ use diagnostics::LocalSink;
 use diagnostics::{Edit, Fix};
 use semantics::context::AnalysisContext;
 use semantics::facts::Facts;
+use semantics::store::Store;
 use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
 use syntax::program::EqualityIndex;
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
 use syntax::program::{File, FileImport};
-use syntax::types::Symbol;
 
 use super::Lint as LintEnum;
 use super::from_facts::LintConfig;
@@ -41,19 +41,7 @@ pub(crate) fn run(
     facts: &Facts,
 ) -> (Vec<LisetteDiagnostic>, UnusedInfo) {
     let store = analysis.store;
-    let go_package_names = &store.go_package_names;
-    let equality_index = &store.equality_index;
     let config = LintConfig::default();
-
-    let type_aliases: Arc<HashSet<Symbol>> = Arc::new(
-        store
-            .modules
-            .values()
-            .flat_map(|m| m.definitions.iter())
-            .filter(|(_, def)| def.is_type_alias())
-            .map(|(id, _)| id.clone())
-            .collect(),
-    );
 
     let mut modules: Vec<&Module> = store
         .modules
@@ -68,16 +56,7 @@ pub(crate) fn run(
     if modules.len() < PARALLEL_THRESHOLD {
         let sink = LocalSink::new();
         for module in &modules {
-            apply_ref_lints(
-                module,
-                go_package_names,
-                equality_index,
-                &config,
-                facts,
-                &type_aliases,
-                &mut unused,
-                &sink,
-            );
+            apply_ref_lints(module, &config, facts, store, &mut unused, &sink);
         }
         return (sink.take(), unused);
     }
@@ -90,11 +69,9 @@ pub(crate) fn run(
             let mut local_unused = UnusedInfo::default();
             apply_ref_lints(
                 module,
-                go_package_names,
-                equality_index,
                 &config,
                 facts,
-                &type_aliases,
+                store,
                 &mut local_unused,
                 &local_sink,
             );
@@ -110,26 +87,15 @@ pub(crate) fn run(
     (LocalSink::merge(worker_sinks), unused)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn apply_ref_lints(
     module: &Module,
-    go_package_names: &HashMap<String, String>,
-    equality_index: &EqualityIndex,
     config: &LintConfig,
     facts: &Facts,
-    type_aliases: &Arc<HashSet<Symbol>>,
+    store: &Store,
     unused: &mut UnusedInfo,
     sink: &LocalSink,
 ) {
-    let result = run_ref_lints(
-        module,
-        &module.files,
-        go_package_names,
-        equality_index,
-        config,
-        facts,
-        type_aliases,
-    );
+    let result = run_ref_lints(module, config, facts, store);
     if !result.unused_import_aliases.is_empty() {
         unused.imports_by_module.insert(
             module.id.clone().into(),
@@ -150,13 +116,12 @@ fn apply_ref_lints(
 
 fn run_ref_lints(
     module: &Module,
-    files: &HashMap<u32, File>,
-    go_package_names: &HashMap<String, String>,
-    equality_index: &EqualityIndex,
     config: &LintConfig,
     facts: &Facts,
-    type_aliases: &Arc<HashSet<Symbol>>,
+    store: &Store,
 ) -> RefLintResult {
+    let files = &module.files;
+    let equality_index = &store.equality_index;
     let mut diagnostics = Vec::new();
     let mut unused_import_aliases = HashSet::default();
     let mut unused_definition_spans = Vec::new();
@@ -165,12 +130,12 @@ fn run_ref_lints(
     collect_items(
         files,
         &module.id,
-        go_package_names,
+        &store.go_package_names,
         equality_index,
         &mut graph,
     );
 
-    let alias_map = AliasMap::build(files, go_package_names, type_aliases.clone());
+    let alias_map = AliasMap::build(files, store);
     for file in files.values() {
         for item in &file.items {
             walk_expression(module, item, &mut graph, &alias_map, None);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -7091,6 +7091,94 @@ fn main() {
 }
 
 #[test]
+fn promoted_field_read_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+struct Size {
+  width: int,
+  height: int,
+}
+
+struct Widget {
+  embed Size,
+}
+
+fn main() {
+  let w = Widget { Size: Size { width: 1, height: 2 } };
+  let _ = w.width + w.height
+}
+"#
+    );
+}
+
+#[test]
+fn promoted_field_read_through_ref_embed_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+struct Size {
+  width: int,
+  height: int,
+}
+
+struct Widget {
+  embed Ref<Size>,
+}
+
+fn main() {
+  let s = Size { width: 1, height: 2 };
+  let w = Widget { Size: &s };
+  let _ = w.width + w.height
+}
+"#
+    );
+}
+
+#[test]
+fn promoted_field_read_through_multi_level_embed_not_unused() {
+    assert_no_lint_warnings!(
+        r#"
+struct Inner {
+  value: int,
+}
+
+struct Middle {
+  embed Inner,
+}
+
+struct Outer {
+  embed Middle,
+}
+
+fn main() {
+  let o = Outer { Middle: Middle { Inner: Inner { value: 1 } } };
+  let _ = o.value
+}
+"#
+    );
+}
+
+#[test]
+fn genuinely_unread_embedded_field_still_warns() {
+    assert_lint_snapshot!(
+        r#"
+struct Size {
+  width: int,
+  height: int,
+}
+
+struct Widget {
+  embed Size,
+}
+
+fn main() {
+  let w = Widget { Size: Size { width: 1, height: 2 } };
+  let _ = w.width
+}
+"#
+    );
+}
+
+#[test]
 fn struct_field_used_in_pattern() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/genuinely_unread_embedded_field_still_warns.snap
+++ b/tests/ui/lint/snapshots/genuinely_unread_embedded_field_still_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused field
+   ╭─[test.lis:4:3]
+ 3 │   width: int,
+ 4 │   height: int,
+   ·   ───┬──
+   ·      ╰── never read
+ 5 │ }
+   ╰────
+  help: Use or remove this field · code: [lint.unused_struct_field]


### PR DESCRIPTION
When embedding a struct, the linter warns about unused fields even when they are used. This fixes that so a field accessed through an embed counts as read.

As an example, the following code previously marked `width` and `height` as unused.

```rust
struct Size { width: int, height: int }
struct Box { embed Size }

fn main() {
  let b = Box { Size: Size { width: 1, height: 2 } }
  let w = b.width   // reads Size.width through promotion
  let h = b.height  // reads Size.height through promotion
}
```

```
  ▲ Unused field
   ╭─[src/main.lis:3:15]
 2 │
 3 │ struct Size { width: int, height: int }
   ·               ──┬──
   ·                 ╰── never read
 4 │
   ╰────
  help: Use or remove this field · code: [lint.unused_struct_field]

  ▲ Unused field
   ╭─[src/main.lis:3:27]
 2 │
 3 │ struct Size { width: int, height: int }
   ·                           ───┬──
   ·                              ╰── never read
 4 │
   ╰────
  help: Use or remove this field · code: [lint.unused_struct_field]
```

Also a small refactor: `Store` is now borrowed by `AliasMap` directly, letting us drop a few params that were passed previously.
