### PR TITLE
perf: parallelize source hashing and test-module discovery

### DIFF
--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -135,6 +135,18 @@ pub fn compute_emit_artifact_hash(production_hash: u64, go_module: &str) -> u64 
     hasher.finish()
 }
 
+/// Hashes a module's sources: the production-only hash drives dependents and
+/// the emit artifact, the all-files hash drives the module's own validity.
+pub fn hash_module_source_pair(files: &[File]) -> (u64, u64) {
+    let production_hash = hash_module_sources(files.iter().filter(|f| !f.is_test()));
+    let full_hash = if files.iter().any(|f| f.is_test()) {
+        hash_module_sources(files)
+    } else {
+        production_hash
+    };
+    (production_hash, full_hash)
+}
+
 pub fn hash_module_sources<'a>(files: impl IntoIterator<Item = &'a File>) -> u64 {
     let mut hasher = FnvHasher::new();
 

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -14,7 +14,7 @@ use crate::cache::{
     CachedModuleBuild, CompiledModule, ModuleInterface, build_cached_module,
     compute_emit_artifact_hash, compute_module_hash, get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
-    hash_module_sources, is_cache_disabled, prelude as prelude_cache, try_load_cache,
+    hash_module_source_pair, is_cache_disabled, prelude as prelude_cache, try_load_cache,
 };
 use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
@@ -214,6 +214,21 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         let mut to_infer: Vec<(usize, String)> = Vec::new();
         let mut candidates: Vec<CacheCandidate> = Vec::new();
 
+        let source_hashes: HashMap<String, (u64, u64)> =
+            if graph_result.files.len() < PARALLEL_THRESHOLD {
+                graph_result
+                    .files
+                    .iter()
+                    .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                    .collect()
+            } else {
+                graph_result
+                    .files
+                    .par_iter()
+                    .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                    .collect()
+            };
+
         for (topo_rank, module_id) in order.into_iter().enumerate() {
             if module_id.starts_with("go:") {
                 if graph_result.link_only_modules.contains(&module_id) {
@@ -237,8 +252,10 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
             let files = graph_result.files.remove(&module_id).unwrap_or_default();
             // Production-only hash drives dependents/emit; all-files hash drives own validity.
-            let production_hash = hash_module_sources(files.iter().filter(|f| !f.is_test()));
-            let full_hash = hash_module_sources(&files);
+            let (production_hash, full_hash) = source_hashes
+                .get(&module_id)
+                .copied()
+                .unwrap_or_else(|| hash_module_source_pair(&files));
 
             let dep_hashes = get_dependency_module_hashes(&module_id, edges, &module_hashes);
             let production_dep_hashes =

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -44,110 +44,115 @@ pub fn build_module_graph(
     let mut edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut production_edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut to_visit = vec![entry_module.to_string()];
-    if include_tests
-        && discover_test_modules
-        && let Some(loader) = loader
-    {
-        to_visit.extend(loader.test_module_ids());
-    }
     let mut visited: HashSet<ModuleId> = HashSet::default();
     let mut files: HashMap<ModuleId, Vec<File>> = HashMap::default();
     let mut import_spans: HashMap<ModuleId, Span> = HashMap::default();
     let mut blank_tracker = BlankTracker::default();
 
-    while !to_visit.is_empty() {
-        let drained: Vec<ModuleId> = std::mem::take(&mut to_visit);
-        let mut batch: Vec<ModuleId> = Vec::with_capacity(drained.len());
-        for module_id in drained {
-            if visited.insert(module_id.clone()) {
-                batch.push(module_id);
-            }
-        }
-        if batch.is_empty() {
-            continue;
-        }
+    let walk_loader = (include_tests && discover_test_modules)
+        .then_some(loader)
+        .flatten();
+    std::thread::scope(|scope| {
+        let mut walk = walk_loader.map(|walk_loader| scope.spawn(|| walk_loader.test_module_ids()));
+        loop {
+            while !to_visit.is_empty() {
+                let drained: Vec<ModuleId> = std::mem::take(&mut to_visit);
+                let mut batch: Vec<ModuleId> = Vec::with_capacity(drained.len());
+                for module_id in drained {
+                    if visited.insert(module_id.clone()) {
+                        batch.push(module_id);
+                    }
+                }
+                if batch.is_empty() {
+                    continue;
+                }
 
-        batch.sort();
+                batch.sort();
 
-        let mut parsed = batch_parse_modules(&batch, store, loader, sink, include_tests);
+                let mut parsed = batch_parse_modules(&batch, store, loader, sink, include_tests);
 
-        for module_id in &batch {
-            let module_files = parsed.remove(module_id).unwrap_or_default();
-            let file_imports: Vec<_> = if !module_files.is_empty() {
-                module_files.iter().flat_map(|f| f.imports()).collect()
-            } else if let Some(module) = store.get_module(module_id) {
-                module.all_imports()
-            } else {
-                Vec::new()
-            };
-            let has_parsed_files = !module_files.is_empty();
-            let production_import_names: HashSet<String> = module_files
-                .iter()
-                .filter(|f| !f.is_test())
-                .flat_map(|f| f.imports())
-                .map(|import| import.name.to_string())
-                .collect();
-            let imports_with_spans = process_file_imports(
-                file_imports,
-                sink,
-                standalone_mode,
-                locator,
-                &mut blank_tracker,
-            );
-
-            let has_production_file = module_files.iter().any(|file| !file.is_test());
-            let module_exists = has_production_file
-                || store.has(module_id)
-                || module_id == entry_module
-                || module_id.starts_with("go:");
-
-            if !module_exists {
-                if let Some(span) = import_spans.get(module_id) {
-                    let is_go_stdlib =
-                        stdlib::get_go_stdlib_typedef(module_id, locator.target()).is_some();
-
-                    let src_prefix_hint = module_id
-                        .strip_prefix("src/")
-                        .filter(|stripped| {
-                            loader.is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
-                        })
-                        .map(String::from);
-
-                    sink.push(diagnostics::module_graph::module_not_found(
-                        module_id,
-                        *span,
-                        is_go_stdlib,
+                for module_id in &batch {
+                    let module_files = parsed.remove(module_id).unwrap_or_default();
+                    let file_imports: Vec<_> = if !module_files.is_empty() {
+                        module_files.iter().flat_map(|f| f.imports()).collect()
+                    } else if let Some(module) = store.get_module(module_id) {
+                        module.all_imports()
+                    } else {
+                        Vec::new()
+                    };
+                    let has_parsed_files = !module_files.is_empty();
+                    let production_import_names: HashSet<String> = module_files
+                        .iter()
+                        .filter(|f| !f.is_test())
+                        .flat_map(|f| f.imports())
+                        .map(|import| import.name.to_string())
+                        .collect();
+                    let imports_with_spans = process_file_imports(
+                        file_imports,
+                        sink,
                         standalone_mode,
-                        src_prefix_hint,
-                    ));
+                        locator,
+                        &mut blank_tracker,
+                    );
+
+                    let has_production_file = module_files.iter().any(|file| !file.is_test());
+                    let module_exists = has_production_file
+                        || store.has(module_id)
+                        || module_id == entry_module
+                        || module_id.starts_with("go:");
+
+                    if !module_exists {
+                        if let Some(span) = import_spans.get(module_id) {
+                            let is_go_stdlib =
+                                stdlib::get_go_stdlib_typedef(module_id, locator.target())
+                                    .is_some();
+
+                            let src_prefix_hint = module_id
+                                .strip_prefix("src/")
+                                .filter(|stripped| {
+                                    loader.is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
+                                })
+                                .map(String::from);
+
+                            sink.push(diagnostics::module_graph::module_not_found(
+                                module_id,
+                                *span,
+                                is_go_stdlib,
+                                standalone_mode,
+                                src_prefix_hint,
+                            ));
+                        }
+                        continue;
+                    }
+
+                    files.insert(module_id.clone(), module_files);
+
+                    let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
+
+                    for (import, span) in imports_with_spans {
+                        if !visited.contains(&import) {
+                            to_visit.push(import.clone());
+                        }
+                        import_spans.entry(import).or_insert(span);
+                    }
+
+                    let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
+                        imports
+                            .iter()
+                            .filter(|import| production_import_names.contains(import.as_str()))
+                            .cloned()
+                            .collect()
+                    } else {
+                        imports.clone()
+                    };
+                    production_edges.insert(module_id.clone(), production_edge_set);
+                    edges.insert(module_id.clone(), imports);
                 }
-                continue;
             }
-
-            files.insert(module_id.clone(), module_files);
-
-            let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
-
-            for (import, span) in imports_with_spans {
-                if !visited.contains(&import) {
-                    to_visit.push(import.clone());
-                }
-                import_spans.entry(import).or_insert(span);
-            }
-
-            let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
-                imports
-                    .iter()
-                    .filter(|import| production_import_names.contains(import.as_str()))
-                    .cloned()
-                    .collect()
-            } else {
-                imports.clone()
-            };
-            production_edges.insert(module_id.clone(), production_edge_set);
-            edges.insert(module_id.clone(), imports);
+            let Some(handle) = walk.take() else { break };
+            to_visit.extend(handle.join().unwrap());
         }
-    }
+    });
 
     let (order, cycles) = kahn::topological_sort(&edges);
 


### PR DESCRIPTION
Speeds up `lis check` and `lis build` by removing the last two serial steps before inference. The orphan-test-module dir walk now runs concurrently with the import scan, and per-module source hashing runs in parallel ahead of the topological loop. Warm `lis check` on a 200-module project drops by ~5%, with smaller gains on cold builds.
