### PR TITLE
fix: distinguish between same-named structs in unused field lint

### DIFF
--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -113,8 +113,8 @@ pub(super) fn walk_expression(
         } => {
             walk_expression(module, expression, graph, alias_map, ctx);
             let receiver_ty = expression.get_type();
-            if let Some(ty_name) = type_name(&receiver_ty, alias_map) {
-                graph.mark_struct_field_used(StructFieldId::new(&ty_name, member));
+            if let Some(ty_name) = qualified_type_name(&receiver_ty, alias_map) {
+                graph.mark_struct_field_used(StructFieldId::new(ty_name.as_str(), member));
             }
             mark_promoted_field_read(&receiver_ty, member, graph, alias_map);
             if let Some(from) = ctx
@@ -495,32 +495,36 @@ fn walk_struct_call(
         StructSpread::None => {}
         StructSpread::From(spread_expression) => {
             walk_expression(module, spread_expression, graph, alias_map, ctx);
-            if let Some(ty_name) = type_name(&spread_expression.get_type(), alias_map) {
+            if let Some(ty_name) = qualified_type_name(&spread_expression.get_type(), alias_map) {
                 let explicit: HashSet<&str> =
                     field_assignments.iter().map(|f| f.name.as_str()).collect();
-                let qname = Symbol::from_parts(&module.id, &ty_name);
-                if let Some(def) = module.definitions.get(qname.as_str())
+                if let Some(def) = module.definitions.get(ty_name.as_str())
                     && let DefinitionBody::Struct { fields, .. } = &def.body
                 {
                     for field in fields {
                         if !explicit.contains(field.name.as_str()) {
-                            graph.mark_struct_field_used(StructFieldId::new(&ty_name, &field.name));
+                            graph.mark_struct_field_used(StructFieldId::new(
+                                ty_name.as_str(),
+                                &field.name,
+                            ));
                         }
                     }
                 }
             }
         }
         StructSpread::Autofill { .. } => {
-            if let Some(ty_name) = type_name(ty, alias_map) {
+            if let Some(ty_name) = qualified_type_name(ty, alias_map) {
                 let explicit: HashSet<&str> =
                     field_assignments.iter().map(|f| f.name.as_str()).collect();
-                let qname = Symbol::from_parts(&module.id, &ty_name);
-                if let Some(def) = module.definitions.get(qname.as_str())
+                if let Some(def) = module.definitions.get(ty_name.as_str())
                     && let DefinitionBody::Struct { fields, .. } = &def.body
                 {
                     for field in fields {
                         if !explicit.contains(field.name.as_str()) {
-                            graph.mark_struct_field_used(StructFieldId::new(&ty_name, &field.name));
+                            graph.mark_struct_field_used(StructFieldId::new(
+                                ty_name.as_str(),
+                                &field.name,
+                            ));
                         }
                     }
                 }
@@ -598,9 +602,14 @@ fn walk_pattern(
             ..
         } => {
             mark_constructor_pattern(module, identifier, ty, graph, alias_map, ctx);
+            let key = qualified_type_name(ty, alias_map).or_else(|| {
+                (!identifier.contains('.')).then(|| Symbol::from_parts(&module.id, identifier))
+            });
             for f in fields {
                 walk_pattern(module, &f.value, graph, alias_map, ctx);
-                graph.mark_struct_field_used(StructFieldId::new(identifier, &f.name));
+                if let Some(key) = &key {
+                    graph.mark_struct_field_used(StructFieldId::new(key.as_str(), &f.name));
+                }
             }
         }
         Pattern::Tuple { elements, .. } => {
@@ -896,14 +905,20 @@ fn mark_promoted_field_read(
         promotion::resolve_selector(aliases.store, &receiver, member)
         && matches!(resolved.kind, MemberKind::Field { .. })
     {
-        let declaring = unqualified_name(resolved.declaring_type.as_str());
-        graph.mark_struct_field_used(StructFieldId::new(declaring, member));
+        graph.mark_struct_field_used(StructFieldId::new(resolved.declaring_type.as_str(), member));
     }
 }
 
 fn type_name(ty: &Type, aliases: &AliasMap) -> Option<String> {
     match deref_for_keying(ty, aliases) {
         Type::Nominal { id, .. } => Some(unqualified_name(&id).to_string()),
+        _ => None,
+    }
+}
+
+fn qualified_type_name(ty: &Type, aliases: &AliasMap) -> Option<Symbol> {
+    match deref_for_keying(ty, aliases) {
+        Type::Nominal { id, .. } => Some(id),
         _ => None,
     }
 }

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -337,11 +337,11 @@ fn collect_items(
                     });
 
                     let has_display_attr = attributes.iter().any(|a| a.name == "display");
-                    let synthesizes_equals =
-                        equality_index.is_synthesized(&format!("{module_id}.{name}"));
+                    let qualified_name = format!("{module_id}.{name}");
+                    let synthesizes_equals = equality_index.is_synthesized(&qualified_name);
 
                     for struct_field in fields {
-                        let field_id = StructFieldId::new(name, &struct_field.name);
+                        let field_id = StructFieldId::new(&qualified_name, &struct_field.name);
                         let has_tag_attribute =
                             struct_field.attributes.iter().any(|a| a.name == "tag");
                         graph.add_struct_field(

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -7179,6 +7179,121 @@ fn main() {
 }
 
 #[test]
+fn shadowed_embedded_field_still_warns() {
+    assert_lint_snapshot!(
+        r#"
+struct Shadow {
+  depth: int,
+}
+
+struct Panel {
+  depth: int,
+  embed Shadow,
+}
+
+fn main() {
+  let p = Panel { depth: 3, Shadow: Shadow { depth: 4 } };
+  let _ = p.depth
+}
+"#
+    );
+}
+
+#[test]
+fn same_named_type_in_other_module_does_not_mask_unused_field() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Size {
+  pub width: int,
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "geo"
+
+struct Size {
+  width: int,
+}
+
+fn main() {
+  let _ = Size { width: 9 }
+  let g = geo.Size { width: 1 }
+  let _ = g.width
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(
+        result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Unused field"),
+        "local Size.width is never read and must warn despite the geo.Size.width read: {:?}",
+        result.lints
+    );
+}
+
+#[test]
+fn same_named_type_in_other_module_does_not_mask_unused_field_via_embed() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "geo",
+        "lib.lis",
+        r#"
+pub struct Size {
+  pub width: int,
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "geo"
+
+struct Size {
+  width: int,
+}
+
+struct Widget {
+  embed geo.Size,
+}
+
+fn main() {
+  let _ = Size { width: 9 }
+  let w = Widget { Size: geo.Size { width: 1 } }
+  let _ = w.width
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(
+        result
+            .lints
+            .iter()
+            .any(|d| d.plain_message() == "Unused field"),
+        "local Size.width is never read and must warn despite the promoted geo.Size.width read: {:?}",
+        result.lints
+    );
+}
+
+#[test]
 fn struct_field_used_in_pattern() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/shadowed_embedded_field_still_warns.snap
+++ b/tests/ui/lint/snapshots/shadowed_embedded_field_still_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused field
+   ╭─[test.lis:3:3]
+ 2 │ struct Shadow {
+ 3 │   depth: int,
+   ·   ──┬──
+   ·     ╰── never read
+ 4 │ }
+   ╰────
+  help: Use or remove this field · code: [lint.unused_struct_field]


### PR DESCRIPTION
Reading a field on a struct was silencing the unused field warning on any same-named struct's field in another module.

```rs
import "geo"

struct Size {
  width: int,
}

fn main() {
  let _ = Size { width: 9 }
  let g = geo.Size { width: 1 }
  let _ = g.width
}
```
