### PR TITLE
refactor: unify how calls resolve their Go signature

### DIFF
--- a/crates/emit/src/abi/callable.rs
+++ b/crates/emit/src/abi/callable.rs
@@ -1,0 +1,124 @@
+use syntax::types::Type;
+
+/// How a logical tuple payload occupies a callable's physical Go result slots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PayloadLayout {
+    /// One Go result containing Lisette's generated tuple value.
+    Packed,
+    /// One Go result per tuple element.
+    Flattened,
+}
+
+impl PayloadLayout {
+    pub(crate) fn is_flattened(self) -> bool {
+        matches!(self, Self::Flattened)
+    }
+}
+
+/// Physical encoding of an `Option<T>` result at a callable boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OptionReturnAbi {
+    CommaOk,
+    Nullable,
+    Sentinel(i64),
+}
+
+/// Physical Go result contract for a callable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CallableReturnAbi {
+    /// One generated Lisette tagged value (`Result`, `Option`, or tuple).
+    Tagged,
+    /// No generated tagged/lowered boundary encoding is required.
+    Direct,
+    Result {
+        bare_error: bool,
+        payload: PayloadLayout,
+    },
+    Partial {
+        payload: PayloadLayout,
+    },
+    Option {
+        encoding: OptionReturnAbi,
+        payload: PayloadLayout,
+    },
+    Tuple {
+        arity: usize,
+    },
+}
+
+impl CallableReturnAbi {
+    pub(crate) fn transition_to(&self, target: &Self) -> AbiTransition {
+        if self == target {
+            return AbiTransition::Identity;
+        }
+        match (self, target) {
+            (Self::Tagged, target) if target.is_lowered() => AbiTransition::LowerFromTagged,
+            (source, Self::Tagged) if source.is_lowered() => AbiTransition::WrapToTagged,
+            (source, target) if source.is_lowered() && target.is_lowered() => {
+                AbiTransition::Reencode
+            }
+            _ => AbiTransition::Incompatible,
+        }
+    }
+
+    pub(crate) fn is_passthrough(&self) -> bool {
+        matches!(self, Self::Tagged | Self::Direct)
+    }
+
+    pub(crate) fn is_lowered(&self) -> bool {
+        !self.is_passthrough()
+    }
+
+    pub(crate) fn is_multi_return(&self) -> bool {
+        matches!(
+            self,
+            Self::Result {
+                bare_error: false,
+                ..
+            } | Self::Partial { .. }
+                | Self::Option {
+                    encoding: OptionReturnAbi::CommaOk,
+                    ..
+                }
+                | Self::Tuple { .. }
+        )
+    }
+}
+
+/// Required conversion between two callable result contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbiTransition {
+    Identity,
+    /// Convert a tagged Lisette result into a lowered Go result.
+    LowerFromTagged,
+    /// Reconstruct the tagged Lisette result from lowered Go results.
+    WrapToTagged,
+    /// Convert between two non-tagged physical layouts through the logical value.
+    Reencode,
+    /// The contracts describe different logical result types.
+    Incompatible,
+}
+
+/// The instantiated and declaration-level views of one callable parameter.
+#[derive(Debug, Clone)]
+pub(crate) struct CallableParamAbi {
+    pub(crate) instantiated: Type,
+    pub(crate) declared: Option<Type>,
+}
+
+/// Complete physical contract consumed by call lowering.
+#[derive(Debug, Clone)]
+pub(crate) struct CallableAbi {
+    pub(crate) params: Vec<CallableParamAbi>,
+    pub(crate) result: CallableReturnAbi,
+}
+
+impl CallableAbi {
+    pub(crate) fn param(&self, index: usize) -> Option<&CallableParamAbi> {
+        self.params.get(index).or_else(|| {
+            self.params
+                .last()
+                .filter(|param| param.instantiated.get_name() == Some("VarArgs"))
+        })
+    }
+}

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -1,70 +1,63 @@
+pub(crate) mod callable;
 pub(crate) mod coercion;
 pub(crate) mod transition;
 
-use crate::GoCallStrategy;
 use crate::Planner;
 use crate::names::go_name::PRELUDE_ERROR_ID;
 use crate::types::go_type::GoType;
+use callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use syntax::ast::Expression;
 use syntax::types::Type;
 
-/// Go ABI shape that a Lisette type lowers to at function-boundary
-/// positions.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum AbiShape {
-    /// `Result<T, error>` → `(T, error)`.
-    ResultTuple,
-    /// `Result<(), error>` → `error`.
-    BareError,
-    /// `Partial<T, error>` → `(T, error)`. Same Go shape as `ResultTuple`
-    /// but with three-way Ok/Err/Both source variants.
-    PartialTuple,
-    /// `Option<T>` → `(T, bool)` for non-nilable T (Go's comma-ok idiom).
-    CommaOk,
-    /// `Option<Ref<T>>` / `Option<fn>` / `Option<Iface>` → bare nilable T.
-    NullableReturn,
-    /// `Tuple<T1, T2, ...>` → `(T1, T2, ...)`. Arity ≥ 2.
-    Tuple { arity: usize },
-}
-
-impl AbiShape {
-    pub(crate) fn matches_go_strategy(&self, strategy: &GoCallStrategy) -> bool {
-        match (strategy, self) {
-            (GoCallStrategy::Result, AbiShape::ResultTuple | AbiShape::BareError)
-            | (GoCallStrategy::Partial, AbiShape::PartialTuple)
-            | (GoCallStrategy::CommaOk, AbiShape::CommaOk)
-            | (GoCallStrategy::NullableReturn, AbiShape::NullableReturn) => true,
-            (GoCallStrategy::Tuple { arity: a }, AbiShape::Tuple { arity: b }) => a == b,
-            _ => false,
+impl Planner<'_> {
+    /// ABI of a value after it has crossed into Lisette expression space.
+    pub(crate) fn value_return_abi(&self, return_ty: &Type) -> CallableReturnAbi {
+        let peeled = self.facts.peel_alias(return_ty);
+        if peeled.is_result()
+            || peeled.is_partial()
+            || peeled.is_option()
+            || peeled.tuple_arity().is_some_and(|arity| arity >= 2)
+        {
+            CallableReturnAbi::Tagged
+        } else {
+            CallableReturnAbi::Direct
         }
     }
-}
 
-impl Planner<'_> {
+    /// Natural physical ABI of a Lisette-authored callable return.
+    pub(crate) fn callable_return_abi(&self, return_ty: &Type) -> CallableReturnAbi {
+        self.classify_direct_emission(return_ty)
+            .unwrap_or_else(|| self.value_return_abi(return_ty))
+    }
+
     /// Lowered shape for a Lisette return type, or `None` to keep it tagged.
-    pub(crate) fn classify_direct_emission(&self, return_ty: &Type) -> Option<AbiShape> {
+    pub(crate) fn classify_direct_emission(&self, return_ty: &Type) -> Option<CallableReturnAbi> {
         let peeled = self.facts.peel_alias(return_ty);
         if peeled.is_result() && self.err_slot_is_nilable(&peeled) {
-            return Some(if peeled.ok_type().is_unit() {
-                AbiShape::BareError
-            } else {
-                AbiShape::ResultTuple
+            return Some(CallableReturnAbi::Result {
+                bare_error: peeled.ok_type().is_unit(),
+                payload: PayloadLayout::Packed,
             });
         }
         if peeled.is_partial() && self.err_slot_is_nilable(&peeled) {
-            return Some(AbiShape::PartialTuple);
+            return Some(CallableReturnAbi::Partial {
+                payload: PayloadLayout::Packed,
+            });
         }
         if peeled.is_option() {
-            return Some(if self.facts.is_nullable_option(&peeled) {
-                AbiShape::NullableReturn
-            } else {
-                AbiShape::CommaOk
+            return Some(CallableReturnAbi::Option {
+                encoding: if self.facts.is_nullable_option(&peeled) {
+                    OptionReturnAbi::Nullable
+                } else {
+                    OptionReturnAbi::CommaOk
+                },
+                payload: PayloadLayout::Packed,
             });
         }
         if let Some(arity) = peeled.tuple_arity()
             && arity >= 2
         {
-            return Some(AbiShape::Tuple { arity });
+            return Some(CallableReturnAbi::Tuple { arity });
         }
         None
     }
@@ -80,23 +73,35 @@ impl Planner<'_> {
     /// Render the lowered Go return type.
     pub(crate) fn render_lowered_return_ty(
         &mut self,
-        shape: &AbiShape,
+        shape: &CallableReturnAbi,
         return_ty: &Type,
     ) -> String {
         let peeled = self.facts.peel_alias(return_ty);
         match shape {
-            AbiShape::BareError => self.go_type_string(&peeled.err_type()),
-            AbiShape::ResultTuple | AbiShape::PartialTuple => {
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type_string(&peeled),
+            CallableReturnAbi::Result {
+                bare_error: true, ..
+            } => self.go_type_string(&peeled.err_type()),
+            CallableReturnAbi::Result {
+                bare_error: false, ..
+            }
+            | CallableReturnAbi::Partial { .. } => {
                 let ok_str = self.go_type_string(&peeled.ok_type());
                 let err_str = self.go_type_string(&peeled.err_type());
                 format!("({}, {})", ok_str, err_str)
             }
-            AbiShape::CommaOk => {
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                ..
+            } => {
                 let inner_str = self.go_type_string(&peeled.ok_type());
                 format!("({}, bool)", inner_str)
             }
-            AbiShape::NullableReturn => self.go_type_string(&peeled.ok_type()),
-            AbiShape::Tuple { .. } => {
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_),
+                ..
+            } => self.go_type_string(&peeled.ok_type()),
+            CallableReturnAbi::Tuple { .. } => {
                 let parts: Vec<String> = tuple_element_types(&peeled)
                     .iter()
                     .map(|t| self.tuple_slot_lowered_ty_string(t))
@@ -118,11 +123,21 @@ impl Planner<'_> {
 
     /// `&self` variant of `render_lowered_return_ty`, callable from the
     /// `go_type` recursion which doesn't have `&mut self`.
-    pub(crate) fn lowered_return_go_type(&self, shape: &AbiShape, return_ty: &Type) -> GoType {
+    pub(crate) fn lowered_return_go_type(
+        &self,
+        shape: &CallableReturnAbi,
+        return_ty: &Type,
+    ) -> GoType {
         let peeled = self.facts.peel_alias(return_ty);
         match shape {
-            AbiShape::BareError => self.go_type(&peeled.err_type()),
-            AbiShape::ResultTuple | AbiShape::PartialTuple => {
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type(&peeled),
+            CallableReturnAbi::Result {
+                bare_error: true, ..
+            } => self.go_type(&peeled.err_type()),
+            CallableReturnAbi::Result {
+                bare_error: false, ..
+            }
+            | CallableReturnAbi::Partial { .. } => {
                 let ok_go = self.go_type(&peeled.ok_type());
                 let err_go = self.go_type(&peeled.err_type());
                 let mut result = GoType::new(format!("({}, {})", ok_go.code, err_go.code));
@@ -130,14 +145,20 @@ impl Planner<'_> {
                 result.merge(&err_go);
                 result
             }
-            AbiShape::CommaOk => {
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                ..
+            } => {
                 let inner_go = self.go_type(&peeled.ok_type());
                 let mut result = GoType::new(format!("({}, bool)", inner_go.code));
                 result.merge(&inner_go);
                 result
             }
-            AbiShape::NullableReturn => self.go_type(&peeled.ok_type()),
-            AbiShape::Tuple { .. } => {
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_),
+                ..
+            } => self.go_type(&peeled.ok_type()),
+            CallableReturnAbi::Tuple { .. } => {
                 let elements = tuple_element_types(&peeled);
                 let element_gos: Vec<GoType> = elements
                     .iter()

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -2,8 +2,9 @@ use syntax::types::Type;
 
 use crate::Planner;
 use crate::Renderer;
-use crate::abi::{AbiShape, tuple_element_types};
-use crate::calls::go_interop::{TupleReturnLayout, WrapperTarget};
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use crate::abi::tuple_element_types;
+use crate::calls::go_interop::WrapperTarget;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
@@ -42,7 +43,7 @@ pub(crate) fn render_lowered_result_return(
     output: &mut String,
     result_value: &str,
     return_ty: &Type,
-    shape: &AbiShape,
+    shape: &CallableReturnAbi,
 ) {
     let statements = emit_lowered_result_return(planner, result_value, return_ty, shape);
     let block = LoweredBlock { statements };
@@ -60,20 +61,26 @@ fn lowered_zero(planner: &mut Planner, ok_ty: &Type) -> String {
 /// enclosing function's lowered shape (e.g. `[zero, err]`).
 pub(crate) fn lowered_err_values(
     planner: &mut Planner,
-    shape: &AbiShape,
+    shape: &CallableReturnAbi,
     return_ty: &Type,
     err_expr: &str,
 ) -> Vec<String> {
     match shape {
-        AbiShape::BareError => vec![err_expr.to_string()],
-        AbiShape::ResultTuple => {
+        CallableReturnAbi::Result {
+            bare_error: true, ..
+        } => vec![err_expr.to_string()],
+        CallableReturnAbi::Result {
+            bare_error: false, ..
+        } => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
             vec![lowered_zero(planner, &ok_ty), err_expr.to_string()]
         }
-        AbiShape::PartialTuple | AbiShape::Tuple { .. } => {
+        CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
         }
-        AbiShape::CommaOk | AbiShape::NullableReturn => {
+        CallableReturnAbi::Tagged
+        | CallableReturnAbi::Direct
+        | CallableReturnAbi::Option { .. } => {
             unreachable!("Option's failure constructor `None` carries no payload")
         }
     }
@@ -81,15 +88,31 @@ pub(crate) fn lowered_err_values(
 
 /// The lowered Go-return values for a success-constructor payload, in the
 /// enclosing function's lowered shape (e.g. `[ok, "nil"]`).
-pub(crate) fn lowered_ok_values(shape: &AbiShape, ok_expr: &str) -> Vec<String> {
+pub(crate) fn lowered_ok_values(shape: &CallableReturnAbi, ok_expr: &str) -> Vec<String> {
     match shape {
-        AbiShape::BareError => vec!["nil".to_string()],
-        AbiShape::ResultTuple => vec![ok_expr.to_string(), "nil".to_string()],
-        AbiShape::PartialTuple | AbiShape::Tuple { .. } => {
+        CallableReturnAbi::Result {
+            bare_error: true, ..
+        } => vec!["nil".to_string()],
+        CallableReturnAbi::Result {
+            bare_error: false, ..
+        } => vec![ok_expr.to_string(), "nil".to_string()],
+        CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
         }
-        AbiShape::CommaOk => vec![ok_expr.to_string(), "true".to_string()],
-        AbiShape::NullableReturn => vec![ok_expr.to_string()],
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::CommaOk,
+            ..
+        } => vec![ok_expr.to_string(), "true".to_string()],
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Nullable,
+            ..
+        } => vec![ok_expr.to_string()],
+        CallableReturnAbi::Tagged
+        | CallableReturnAbi::Direct
+        | CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Sentinel(_),
+            ..
+        } => unreachable!("not a lowered Lisette return ABI"),
     }
 }
 
@@ -97,15 +120,21 @@ pub(crate) fn lowered_ok_values(shape: &AbiShape, ok_expr: &str) -> Vec<String> 
 /// lowered shape (e.g. `[zero, "false"]`).
 pub(crate) fn lowered_none_values(
     planner: &mut Planner,
-    shape: &AbiShape,
+    shape: &CallableReturnAbi,
     return_ty: &Type,
 ) -> Vec<String> {
     match shape {
-        AbiShape::CommaOk => {
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::CommaOk,
+            ..
+        } => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
             vec![lowered_zero(planner, &inner), "false".to_string()]
         }
-        AbiShape::NullableReturn => vec!["nil".to_string()],
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Nullable,
+            ..
+        } => vec!["nil".to_string()],
         _ => unreachable!("only Option's `None` lacks a payload"),
     }
 }
@@ -116,7 +145,7 @@ pub(crate) fn emit_lowered_result_return(
     planner: &mut Planner,
     result_value: &str,
     return_ty: &Type,
-    shape: &AbiShape,
+    shape: &CallableReturnAbi,
 ) -> Vec<LoweredStatement> {
     planner.require_stdlib();
     let p = result_value;
@@ -125,14 +154,18 @@ pub(crate) fn emit_lowered_result_return(
         lowered_zero(planner, &ok_ty)
     };
     match shape {
-        AbiShape::BareError => vec![
+        CallableReturnAbi::Result {
+            bare_error: true, ..
+        } => vec![
             tag_check(
                 format!("{p}.Tag == {RESULT_OK_TAG}"),
                 vec!["nil".to_string()],
             ),
             multi_value_return(vec![format!("{p}.ErrVal")]),
         ],
-        AbiShape::ResultTuple => {
+        CallableReturnAbi::Result {
+            bare_error: false, ..
+        } => {
             let zero = ok_zero(planner);
             vec![
                 tag_check(
@@ -142,7 +175,7 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(vec![zero, format!("{p}.ErrVal")]),
             ]
         }
-        AbiShape::PartialTuple => {
+        CallableReturnAbi::Partial { .. } => {
             let zero = ok_zero(planner);
             vec![
                 tag_check(
@@ -156,7 +189,10 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(vec![format!("{p}.OkVal"), format!("{p}.ErrVal")]),
             ]
         }
-        AbiShape::CommaOk => {
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::CommaOk,
+            ..
+        } => {
             let zero = ok_zero(planner);
             vec![
                 tag_check(
@@ -166,16 +202,25 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(vec![zero, "false".to_string()]),
             ]
         }
-        AbiShape::NullableReturn => vec![
+        CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Nullable,
+            ..
+        } => vec![
             tag_check(
                 format!("{p}.Tag == {OPTION_SOME_TAG}"),
                 vec![format!("{p}.SomeVal")],
             ),
             multi_value_return(vec!["nil".to_string()]),
         ],
-        AbiShape::Tuple { arity } => {
+        CallableReturnAbi::Tuple { arity, .. } => {
             emit_lowered_tuple_return(planner, result_value, return_ty, *arity)
         }
+        CallableReturnAbi::Tagged
+        | CallableReturnAbi::Direct
+        | CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Sentinel(_),
+            ..
+        } => unreachable!("not a lowered Lisette return ABI"),
     }
 }
 
@@ -214,75 +259,46 @@ fn emit_lowered_tuple_return(
     statements
 }
 
-/// Wrap a lowered-callee `call_str` (Go-shaped return) into the Lisette
-/// tagged shape declared by `result_ty`.
-pub(crate) fn lower_callee_abi_wrapping(
-    planner: &mut Planner,
-    shape: &AbiShape,
-    call_str: &str,
-    result_ty: &Type,
-) -> (Vec<LoweredStatement>, String) {
-    match shape {
-        AbiShape::PartialTuple => {
-            let (statements, outcome) = planner.lower_partial_wrapping(
-                call_str,
-                result_ty,
-                TupleReturnLayout::Packed,
-                WrapperTarget::FreshSlot,
-            );
-            (statements, outcome.expect("wrapper produced no slot"))
+impl Planner<'_> {
+    /// Wrap a callable's physical Go result into the Lisette-visible value.
+    pub(crate) fn lower_abi_to_tagged(
+        &mut self,
+        raw_value: &str,
+        abi: &CallableReturnAbi,
+        result_ty: &Type,
+    ) -> (Vec<LoweredStatement>, String) {
+        if abi.is_passthrough() {
+            return (Vec::new(), raw_value.to_string());
         }
-        AbiShape::CommaOk => {
-            let (statements, outcome) = planner.lower_comma_ok_wrapping(
-                call_str,
-                result_ty,
-                TupleReturnLayout::Packed,
-                WrapperTarget::FreshSlot,
-            );
-            (statements, outcome.expect("wrapper produced no slot"))
-        }
-        AbiShape::NullableReturn => {
+        if let CallableReturnAbi::Tuple { arity } = abi {
             let mut statements = Vec::new();
-            let raw_var = planner.hoist_tmp_value_statement(&mut statements, "raw", call_str);
-            let (wrap, outcome) =
-                planner.lower_nil_check_option_wrap(&raw_var, result_ty, WrapperTarget::FreshSlot);
-            statements.extend(wrap);
-            (statements, outcome.expect("wrapper produced no slot"))
-        }
-        AbiShape::ResultTuple | AbiShape::BareError => {
-            let (statements, outcome) = planner.lower_result_wrapping(
-                call_str,
-                result_ty,
-                TupleReturnLayout::Packed,
-                WrapperTarget::FreshSlot,
-            );
-            (statements, outcome.expect("wrapper produced no slot"))
-        }
-        AbiShape::Tuple { arity } => {
-            let mut statements = Vec::new();
-            let temps = planner.create_temp_vars("ret", *arity);
+            let temps = self.create_temp_vars("ret", *arity);
             statements.push(LoweredStatement::RawGo(format!(
                 "{} := {}\n",
                 temps.join(", "),
-                call_str
+                raw_value
             )));
-            let slot_tys = tuple_element_types(&planner.facts.peel_alias(result_ty));
-            let wrapped: Vec<String> = temps
+            let slot_tys = tuple_element_types(&self.facts.peel_alias(result_ty));
+            let values: Vec<String> = temps
                 .iter()
                 .enumerate()
-                .map(|(i, v)| {
+                .map(|(index, value)| {
                     slot_tys
-                        .get(i)
-                        .filter(|slot_ty| planner.facts.is_nullable_option(slot_ty))
+                        .get(index)
+                        .filter(|slot_ty| self.facts.is_nullable_option(slot_ty))
                         .map(|slot_ty| {
-                            planner.plan_nil_check_option_wrap(&mut statements, v, slot_ty)
+                            self.plan_nil_check_option_wrap(&mut statements, value, slot_ty)
                         })
-                        .unwrap_or_else(|| v.clone())
+                        .unwrap_or_else(|| value.clone())
                 })
                 .collect();
-            let tuple = planner.plan_tuple_from_vars(&mut statements, &wrapped, result_ty);
-            (statements, tuple)
+            let tuple = self.plan_tuple_from_vars(&mut statements, &values, result_ty);
+            return (statements, tuple);
         }
+
+        let (wrap, outcome) =
+            self.lower_abi_wrapping(raw_value, abi, result_ty, WrapperTarget::FreshSlot);
+        (wrap, outcome.expect("wrapper produced no slot"))
     }
 }
 
@@ -506,8 +522,8 @@ pub(crate) fn emit_fn_arg_shape_adapter(
     output: &mut String,
     fn_value: &str,
     arg_fn_type: &Type,
-    arg_shape: &AbiShape,
-    target_shape: Option<&AbiShape>,
+    arg_abi: &CallableReturnAbi,
+    target_abi: &CallableReturnAbi,
 ) -> Option<String> {
     let params = arg_fn_type.get_function_params()?;
     let arg_ret = arg_fn_type.get_function_ret()?;
@@ -516,17 +532,14 @@ pub(crate) fn emit_fn_arg_shape_adapter(
     let (param_strs, arg_names) = planner.build_wrapper_params(params);
     let inner_call = format!("{}({})", cb_var, arg_names.join(", "));
 
-    let outer_ret = match target_shape {
-        Some(shape) => planner.render_lowered_return_ty(shape, arg_ret),
-        None => planner.go_type_string(arg_ret),
-    };
+    let outer_ret = planner.render_lowered_return_ty(target_abi, arg_ret);
 
-    let (wrap_statements, tagged) =
-        lower_callee_abi_wrapping(planner, arg_shape, &inner_call, arg_ret);
+    let (wrap_statements, tagged) = planner.lower_abi_to_tagged(&inner_call, arg_abi, arg_ret);
     let mut body = Renderer.render_setup(&wrap_statements);
-    match target_shape {
-        Some(shape) => render_lowered_result_return(planner, &mut body, &tagged, arg_ret, shape),
-        None => write_line!(body, "return {}", tagged),
+    if target_abi.is_passthrough() {
+        write_line!(body, "return {}", tagged);
+    } else {
+        render_lowered_result_return(planner, &mut body, &tagged, arg_ret, target_abi);
     }
 
     Some(format!(
@@ -555,13 +568,13 @@ pub(crate) fn lower_arg_to_tagged(
     let Some(shape) = planner.classify_direct_emission(inner_ret) else {
         return arg_name.to_string();
     };
+    let abi = shape;
 
     let (inner_param_strs, inner_arg_names) = planner.build_wrapper_params(inner_params);
     let inner_call = format!("{}({})", arg_name, inner_arg_names.join(", "));
     let tagged_ret = planner.go_type_string(inner_ret);
 
-    let (wrap_statements, result_var) =
-        lower_callee_abi_wrapping(planner, &shape, &inner_call, inner_ret);
+    let (wrap_statements, result_var) = planner.lower_abi_to_tagged(&inner_call, &abi, inner_ret);
     let mut body = Renderer.render_setup(&wrap_statements);
     write_line!(body, "return {}", result_var);
 
@@ -586,8 +599,10 @@ pub(crate) fn try_emit_lowered_tail_return(
 ) -> Option<Vec<LoweredStatement>> {
     let shape = planner.return_ctx().lowered_shape()?;
     match shape {
-        AbiShape::PartialTuple => Some(emit_lowered_partial_tail(planner, expression)),
-        AbiShape::Tuple { arity } => Some(emit_lowered_tuple_tail(planner, expression, arity)),
+        CallableReturnAbi::Partial { .. } => Some(emit_lowered_partial_tail(planner, expression)),
+        CallableReturnAbi::Tuple { arity, .. } => {
+            Some(emit_lowered_tuple_tail(planner, expression, arity))
+        }
         _ => None,
     }
 }
@@ -596,7 +611,7 @@ fn lowered_tail_fallback(
     planner: &mut Planner,
     expression: &syntax::ast::Expression,
     return_ty: &Type,
-    shape: &AbiShape,
+    shape: &CallableReturnAbi,
     hoist_hint: Option<&str>,
 ) -> Vec<LoweredStatement> {
     let (mut statements, value) = planner
@@ -645,7 +660,7 @@ fn emit_lowered_tuple_tail(
         planner,
         expression,
         &return_ty,
-        &AbiShape::Tuple { arity },
+        &CallableReturnAbi::Tuple { arity },
         Some("tup"),
     )
 }
@@ -702,7 +717,9 @@ fn emit_lowered_partial_tail(
         planner,
         expression,
         &return_ty,
-        &AbiShape::PartialTuple,
+        &CallableReturnAbi::Partial {
+            payload: PayloadLayout::Packed,
+        },
         None,
     )
 }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -10,11 +10,12 @@ use syntax::program::{
 };
 use syntax::types::{Symbol, Type};
 
+use crate::abi::callable::CallableReturnAbi;
 use crate::classify_go_return_type;
 use crate::context::lowering::LineIndex;
 use crate::names::constraints::GenericConstraintTable;
 use crate::names::go_name;
-use crate::{EmitOptions, GlobalEmitData, GoCallStrategy};
+use crate::{EmitOptions, GlobalEmitData};
 
 pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) definitions: &'a HashMap<Symbol, Definition>,
@@ -106,7 +107,7 @@ impl<'a> EmitFacts<'a> {
         &self,
         return_ty: &Type,
         go_hints: &[String],
-    ) -> Option<GoCallStrategy> {
+    ) -> Option<CallableReturnAbi> {
         classify_go_return_type(self.definitions, return_ty, go_hints)
     }
 
@@ -257,8 +258,8 @@ impl<'a> EmitFacts<'a> {
             .map(String::as_str)
     }
 
-    pub(crate) fn go_call_strategy(&self, qualified_name: &str) -> Option<&GoCallStrategy> {
-        self.globals.go_call_strategies.get(qualified_name)
+    pub(crate) fn go_callable_return(&self, qualified_name: &str) -> Option<&CallableReturnAbi> {
+        self.globals.go_callable_returns.get(qualified_name)
     }
 
     pub(crate) fn resolved_bound_type(&self, span: Span) -> Option<&'a Type> {

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -9,7 +9,7 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::calls::CalleePlan;
+use crate::plan::calls::CallableOrigin;
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
 use syntax::ast::{Expression, StructKind};
@@ -278,22 +278,22 @@ impl Planner<'_> {
             .plan_call(call_expression)
             .expect("plan_call yields Some for a Call expression");
 
-        match &plan.callee {
-            CalleePlan::TupleStructConstructor => {
+        match &plan.resolved.origin {
+            CallableOrigin::TupleStructConstructor => {
                 if let Some(result) = self.try_lower_tuple_struct_call(function, args, call_ty, ctx)
                 {
                     return result;
                 }
             }
-            CalleePlan::AssertType => {
+            CallableOrigin::AssertType => {
                 return self.lower_assert_type(function, args, resolved_type_args);
             }
-            CalleePlan::UfcsMethod => {
-                return self.lower_ufcs_call(function, args, resolved_type_args, spread);
+            CallableOrigin::UfcsMethod => {
+                return self.lower_ufcs_call(function, args, resolved_type_args, spread, &plan);
             }
-            CalleePlan::NativeConstructor(kind)
-            | CalleePlan::NativeMethod(kind)
-            | CalleePlan::NativeMethodIdentifier(kind) => {
+            CallableOrigin::NativeConstructor(kind)
+            | CallableOrigin::NativeMethod(kind)
+            | CallableOrigin::NativeMethodIdentifier(kind) => {
                 let native_type = NativeGoType::from_kind(*kind);
                 let method = extract_native_method_name(function);
                 let native_ctx = NativeCallContext {
@@ -307,7 +307,7 @@ impl Planner<'_> {
                 };
                 return self.lower_native_call(&native_ctx);
             }
-            CalleePlan::ReceiverMethodUfcs { is_public } => {
+            CallableOrigin::ReceiverMethodUfcs { is_public } => {
                 let method = extract_receiver_ufcs_method(function);
                 return self.lower_receiver_method_ufcs(
                     function,
@@ -318,7 +318,7 @@ impl Planner<'_> {
                     spread,
                 );
             }
-            CalleePlan::GoInterop(_) | CalleePlan::Regular => {}
+            CallableOrigin::GoInterop | CallableOrigin::Regular => {}
         }
 
         self.lower_regular_call(call_expression, &plan, call_ty, ctx)
@@ -338,21 +338,21 @@ impl Planner<'_> {
     pub(super) fn infer_return_only_type_args(
         &mut self,
         function: &Expression,
+        declared: Option<&Type>,
         arg_shape: CallArgShape,
     ) -> Option<String> {
-        let definition_ty = self.get_callee_definition_type(function)?;
-        let Type::Forall { vars, body } = definition_ty else {
+        let Type::Forall { vars, body } = declared? else {
             return None;
         };
         let Type::Function(f) = body.as_ref() else {
             return None;
         };
         let generic_params = &f.params;
-        let all_inferrable = all_type_params_inferrable(&vars, generic_params, 0, arg_shape);
+        let all_inferrable = all_type_params_inferrable(vars, generic_params, 0, arg_shape);
 
         let instantiated_ty = function.get_type();
         let mut mapping: HashMap<String, Type> = HashMap::default();
-        extract_type_mapping(&body, &instantiated_ty, &mut mapping);
+        extract_type_mapping(body, &instantiated_ty, &mut mapping);
 
         if all_inferrable {
             let any_needs_explicit = vars.iter().any(|v| {
@@ -375,51 +375,6 @@ impl Planner<'_> {
         }
 
         Some(self.format_type_args(&resolved))
-    }
-
-    fn lookup_definition_type(&self, primary: &str, fallback: Option<&str>) -> Option<Type> {
-        self.facts
-            .definition(primary)
-            .or_else(|| fallback.and_then(|f| self.facts.definition(f)))
-            .map(|d| d.ty().clone())
-    }
-
-    fn get_callee_definition_type(&self, function: &Expression) -> Option<Type> {
-        let function = function.unwrap_parens();
-        match function {
-            Expression::Identifier { value, .. } => {
-                let qualified = self.facts.qualified_current(value);
-                self.lookup_definition_type(&qualified, Some(value.as_str()))
-            }
-            Expression::DotAccess {
-                expression, member, ..
-            } => {
-                if let Expression::Identifier { value, .. } = expression.as_ref() {
-                    let module_name = self.module.module_for_alias(value).unwrap_or(value);
-                    let qualified = format!("{}.{}", module_name, member);
-                    let local = self.facts.qualified_current_member(value, member);
-                    return self.lookup_definition_type(&qualified, Some(&local));
-                }
-                if let Expression::DotAccess {
-                    expression: inner_expression,
-                    member: type_name,
-                    ..
-                } = expression.as_ref()
-                    && let Expression::Identifier {
-                        value: module_name, ..
-                    } = inner_expression.as_ref()
-                {
-                    let module_name = self
-                        .module
-                        .module_for_alias(module_name)
-                        .unwrap_or(module_name);
-                    let qualified = format!("{}.{}.{}", module_name, type_name, member);
-                    return self.lookup_definition_type(&qualified, None);
-                }
-                None
-            }
-            _ => None,
-        }
     }
 
     /// Plan a tuple-struct constructor as a struct literal. `None` when this

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -1,125 +1,90 @@
 mod nullable;
 mod wrappers;
 
-pub(crate) use wrappers::{NilGuard, TupleReturnLayout, WrapperTarget};
+pub(crate) use wrappers::{NilGuard, WrapperTarget};
 
 use crate::Planner;
-use crate::calls::CallBoundary;
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use syntax::ast::Expression;
 use syntax::types::Type;
 
-#[derive(Debug, Clone)]
-pub(crate) enum GoCallStrategy {
-    /// `(T1, T2, ...)` → tuple struct (arity ≥ 2, no error/bool suffix).
-    Tuple { arity: usize },
-    /// `(T, error)` → `Result<T, Error>`.
-    Result,
-    /// `(T, bool)` → `Option<T>` (non-nullable or `#[go(comma_ok)]`).
-    CommaOk,
-    /// Single pointer/interface return → `Option<Ref<T>>` via nil check.
-    NullableReturn,
-    /// `(T, error)` → `Partial<T, error>` (value and error not exclusive,
-    /// e.g. `io.Reader.Read`).
-    Partial,
-    /// Single `T` return → `Option<T>` via `val != sentinel`.
-    Sentinel { value: i64 },
-}
-
-impl GoCallStrategy {
-    pub(crate) fn is_multi_return(&self) -> bool {
-        !matches!(
-            self,
-            GoCallStrategy::NullableReturn | GoCallStrategy::Sentinel { .. }
-        )
-    }
-}
-
 impl Planner<'_> {
-    /// Lower a Go-imported callee through its ABI bridge.
-    pub(crate) fn lower_go_wrapped_call(
+    /// Lower a raw callable result through its canonical physical ABI.
+    pub(crate) fn lower_abi_wrapped_call(
         &mut self,
         call_expression: &Expression,
-        strategy: &GoCallStrategy,
+        abi: &CallableReturnAbi,
         result_ty: &Type,
     ) -> ValuePlan {
-        match strategy {
-            GoCallStrategy::Tuple { arity } => {
-                self.lower_go_tuple_call_wrapped(call_expression, *arity)
+        let (mut setup, call_str) =
+            self.lower_call(call_expression, None, ExpressionContext::value());
+        let (wrap, value) = self.lower_abi_to_tagged(&call_str, abi, result_ty);
+        setup.extend(wrap);
+        value_plan_from_statements(setup, value)
+    }
+
+    pub(crate) fn lower_abi_wrapping(
+        &mut self,
+        call_str: &str,
+        abi: &CallableReturnAbi,
+        result_ty: &Type,
+        target: WrapperTarget<'_>,
+    ) -> (Vec<LoweredStatement>, Option<String>) {
+        match abi {
+            CallableReturnAbi::Tagged
+            | CallableReturnAbi::Direct
+            | CallableReturnAbi::Tuple { .. } => {
+                unreachable!("direct and tuple results do not use a scalar wrapper")
             }
-            GoCallStrategy::Result => self.lower_go_result_call_wrapped(call_expression, result_ty),
-            GoCallStrategy::Partial => {
-                self.lower_go_partial_call_wrapped(call_expression, result_ty)
+            CallableReturnAbi::Result { payload, .. } => {
+                self.require_stdlib();
+                self.lower_result_wrapping(call_str, result_ty, *payload, target)
             }
-            GoCallStrategy::CommaOk => {
-                self.lower_go_option_call_wrapped(call_expression, result_ty)
+            CallableReturnAbi::Partial { payload } => {
+                self.require_stdlib();
+                self.lower_partial_wrapping(call_str, result_ty, *payload, target)
             }
-            GoCallStrategy::NullableReturn => {
-                self.lower_go_single_return_option_wrapped(call_expression, result_ty)
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload,
+            } => self.lower_comma_ok_wrapping(call_str, result_ty, *payload, target),
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                ..
+            } => {
+                let mut statements = Vec::new();
+                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", call_str);
+                let (wrap, outcome) = self.lower_nil_check_option_wrap(&raw_var, result_ty, target);
+                statements.extend(wrap);
+                (statements, outcome)
             }
-            GoCallStrategy::Sentinel { value } => {
-                self.lower_go_sentinel_call_wrapped(call_expression, result_ty, *value)
-            }
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Sentinel(value),
+                ..
+            } => self.lower_sentinel_wrapping(call_str, result_ty, *value, target),
         }
     }
 
-    /// `lower_go_wrapped_call` writing into `target`. `None` for `Tuple`.
-    pub(crate) fn lower_go_wrapped_call_to(
+    pub(crate) fn lower_abi_wrapped_call_to(
         &mut self,
         expression: &Expression,
-        strategy: &GoCallStrategy,
+        abi: &CallableReturnAbi,
         result_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> Option<Vec<LoweredStatement>> {
-        if matches!(strategy, GoCallStrategy::Tuple { .. }) {
+        if matches!(
+            abi,
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct | CallableReturnAbi::Tuple { .. }
+        ) {
             return None;
         }
         let (mut statements, call_str) =
             self.lower_call(expression, None, ExpressionContext::value());
-        let wrap = match strategy {
-            GoCallStrategy::Tuple { .. } => unreachable!("handled above"),
-            GoCallStrategy::Result => {
-                self.require_stdlib();
-                self.lower_result_wrapping(
-                    &call_str,
-                    result_ty,
-                    TupleReturnLayout::Flattened,
-                    target,
-                )
-                .0
-            }
-            GoCallStrategy::CommaOk => {
-                self.lower_comma_ok_wrapping(
-                    &call_str,
-                    result_ty,
-                    TupleReturnLayout::Flattened,
-                    target,
-                )
-                .0
-            }
-            GoCallStrategy::NullableReturn => {
-                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
-                self.lower_nil_check_option_wrap(&raw_var, result_ty, target)
-                    .0
-            }
-            GoCallStrategy::Partial => {
-                self.require_stdlib();
-                self.lower_partial_wrapping(
-                    &call_str,
-                    result_ty,
-                    TupleReturnLayout::Flattened,
-                    target,
-                )
-                .0
-            }
-            GoCallStrategy::Sentinel { value } => {
-                self.lower_sentinel_wrapping(&call_str, result_ty, *value, target)
-                    .0
-            }
-        };
+        let (wrap, _) = self.lower_abi_wrapping(&call_str, abi, result_ty, target);
         statements.extend(wrap);
         Some(statements)
     }
@@ -155,7 +120,7 @@ impl Planner<'_> {
             return None;
         };
 
-        let boundary = self.classify_call(call_expression);
+        let plan = self.plan_call(call_expression)?;
 
         let has_array_return = if let Expression::DotAccess {
             expression: receiver_expression,
@@ -169,7 +134,7 @@ impl Planner<'_> {
             false
         };
 
-        if matches!(boundary, CallBoundary::Plain) && !has_array_return {
+        if plan.resolved.abi.result.is_passthrough() && !has_array_return {
             return None;
         }
 

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,48 +1,13 @@
 use crate::Planner;
+use crate::abi::callable::PayloadLayout;
 use crate::calls::go_interop::build_tuple_literal;
-use crate::calls::go_interop::wrappers::{
-    TupleReturnLayout, WrapperOutcome, WrapperTarget, leaf_block,
-};
-use crate::context::expression::ExpressionContext;
+use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
-use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::types::shape::{CollectionKind, NullableCollectionElement, NullableCollectionShape};
-use syntax::ast::Expression;
 use syntax::types::Type;
 
 impl Planner<'_> {
-    pub(super) fn lower_go_option_call_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        option_ty: &Type,
-    ) -> ValuePlan {
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-        let (wrap_setup, outcome) = self.lower_comma_ok_wrapping(
-            &call_str,
-            option_ty,
-            TupleReturnLayout::Flattened,
-            WrapperTarget::FreshSlot,
-        );
-        setup.extend(wrap_setup);
-        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
-    }
-
-    pub(super) fn lower_go_sentinel_call_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        option_ty: &Type,
-        sentinel: i64,
-    ) -> ValuePlan {
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-        let (wrap_setup, outcome) =
-            self.lower_sentinel_wrapping(&call_str, option_ty, sentinel, WrapperTarget::FreshSlot);
-        setup.extend(wrap_setup);
-        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
-    }
-
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.
     pub(crate) fn lower_sentinel_wrapping(
         &mut self,
@@ -71,7 +36,7 @@ impl Planner<'_> {
         &mut self,
         call_str: &str,
         option_ty: &Type,
-        layout: TupleReturnLayout,
+        layout: PayloadLayout,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         self.require_stdlib();
@@ -181,20 +146,6 @@ impl Planner<'_> {
         let outcome =
             self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
         (statements, outcome)
-    }
-
-    pub(super) fn lower_go_single_return_option_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        option_ty: &Type,
-    ) -> ValuePlan {
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-        let raw_var = self.hoist_tmp_value_statement(&mut setup, "raw", &call_str);
-        let (wrap_setup, outcome) =
-            self.lower_nil_check_option_wrap(&raw_var, option_ty, WrapperTarget::FreshSlot);
-        setup.extend(wrap_setup);
-        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
     }
 
     pub(crate) fn plan_option_projection(

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -1,9 +1,7 @@
 use crate::Planner;
 use crate::Renderer;
-use crate::calls::go_interop::build_tuple_literal;
-use crate::calls::go_interop::go_qualified_name;
+use crate::abi::callable::{CallableReturnAbi, PayloadLayout};
 use crate::calls::go_interop::is_go_receiver;
-use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{
     Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR,
 };
@@ -11,12 +9,9 @@ use crate::control_flow::propagation::plain_return;
 use crate::is_order_sensitive;
 use crate::names::go_name;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement};
-use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::write_line;
 use syntax::ast::Expression;
 use syntax::types::Type;
-
-use super::GoCallStrategy;
 
 #[derive(Clone, Copy)]
 pub(crate) enum NilGuard {
@@ -54,22 +49,6 @@ pub(crate) enum WrapperTarget<'a> {
     Slot(&'a str),
     /// Emit `return X` per branch; caller skips its trailing return.
     Return,
-}
-
-/// How a fallible callee presents a tuple `Ok`/`Some` payload at the Go
-/// boundary: as separate return values (`Flattened`, e.g. a Go-imported
-/// `(A, B, error)`) or already bundled into one tuple value (`Packed`, the
-/// Lisette `(Tuple_n[...], error)` ABI).
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TupleReturnLayout {
-    Packed,
-    Flattened,
-}
-
-impl TupleReturnLayout {
-    pub(crate) fn is_flattened(self) -> bool {
-        matches!(self, TupleReturnLayout::Flattened)
-    }
 }
 
 /// `Some(slot_name)` when the wrapper wrote into a fresh or named slot; `None`
@@ -136,7 +115,7 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         call_str: &str,
         ok_ty: &Type,
-        layout: TupleReturnLayout,
+        layout: PayloadLayout,
     ) -> (String, String) {
         let mut buffer = String::new();
         let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, layout);
@@ -175,54 +154,12 @@ impl Planner<'_> {
 }
 
 impl Planner<'_> {
-    pub(super) fn lower_go_tuple_call_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        arity: usize,
-    ) -> ValuePlan {
-        let Expression::Call { ty, .. } = call_expression else {
-            unreachable!("lower_go_tuple_call_wrapped called with non-call expression");
-        };
-
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-
-        let temp_vars = self.create_temp_vars("ret", arity);
-        setup.push(LoweredStatement::RawGo(format!(
-            "{} := {}\n",
-            temp_vars.join(", "),
-            call_str
-        )));
-
-        let constructor = build_tuple_literal(self, &temp_vars, ty);
-        let tuple = self.hoist_tmp_value_statement(&mut setup, "tup", &constructor);
-        value_plan_from_statements(setup, tuple)
-    }
-
-    pub(super) fn lower_go_partial_call_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        partial_ty: &Type,
-    ) -> ValuePlan {
-        self.require_stdlib();
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-        let (wrap_setup, outcome) = self.lower_partial_wrapping(
-            &call_str,
-            partial_ty,
-            TupleReturnLayout::Flattened,
-            WrapperTarget::FreshSlot,
-        );
-        setup.extend(wrap_setup);
-        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
-    }
-
     /// Lower a `(T, error)` Go return into a tagged `Partial`.
     pub(crate) fn lower_partial_wrapping(
         &mut self,
         call_str: &str,
         partial_ty: &Type,
-        layout: TupleReturnLayout,
+        layout: PayloadLayout,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let ok_ty = partial_ty.ok_type();
@@ -304,24 +241,6 @@ impl Planner<'_> {
         }
     }
 
-    pub(super) fn lower_go_result_call_wrapped(
-        &mut self,
-        call_expression: &Expression,
-        result_ty: &Type,
-    ) -> ValuePlan {
-        self.require_stdlib();
-        let (mut setup, call_str) =
-            self.lower_call(call_expression, None, ExpressionContext::value());
-        let (wrap_setup, outcome) = self.lower_result_wrapping(
-            &call_str,
-            result_ty,
-            TupleReturnLayout::Flattened,
-            WrapperTarget::FreshSlot,
-        );
-        setup.extend(wrap_setup);
-        value_plan_from_statements(setup, outcome.expect("wrapper produced no slot"))
-    }
-
     pub(crate) fn go_result_needs_nil_guard(&self, ok_ty: &Type) -> bool {
         ok_ty.is_ref()
             || self
@@ -347,7 +266,7 @@ impl Planner<'_> {
         &mut self,
         call_str: &str,
         result_ty: &Type,
-        layout: TupleReturnLayout,
+        layout: PayloadLayout,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
@@ -475,7 +394,7 @@ impl Planner<'_> {
         output: &mut String,
         call_str: &str,
         ok_ty: &Type,
-        layout: TupleReturnLayout,
+        layout: PayloadLayout,
     ) -> (String, String) {
         if layout.is_flattened()
             && let Type::Tuple(elements) = ok_ty
@@ -493,39 +412,6 @@ impl Planner<'_> {
             write_line!(output, "{}, {} := {}", val_var, err_var, call_str);
             (err_var, val_var)
         }
-    }
-
-    pub(crate) fn classify_go_fn_value(&self, expression: &Expression) -> Option<GoCallStrategy> {
-        let inner = expression.unwrap_parens();
-
-        if let Expression::DotAccess {
-            expression: receiver,
-            ..
-        } = inner
-            && is_go_receiver(receiver)
-        {
-            let fn_type = expression.get_type();
-            let f = fn_type.as_function_type()?;
-            let return_type = f.return_type.clone();
-
-            let go_hints = if let Expression::DotAccess {
-                expression: receiver_expression,
-                member,
-                ..
-            } = inner
-            {
-                go_qualified_name(receiver_expression, member)
-                    .and_then(|name| self.facts.definition(name.as_str()))
-                    .map(|d| d.go_hints().to_vec())
-                    .unwrap_or_default()
-            } else {
-                vec![]
-            };
-
-            return self.facts.classify_go_return_type(&return_type, &go_hints);
-        }
-
-        None
     }
 
     pub(crate) fn is_go_array_return_value(&self, expression: &Expression) -> bool {
@@ -627,7 +513,7 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        strategy: &GoCallStrategy,
+        abi: &CallableReturnAbi,
     ) -> String {
         self.require_stdlib();
 
@@ -638,35 +524,11 @@ impl Planner<'_> {
         let ret_ty_str = self.go_type_string(&return_type);
 
         let mut statements = Vec::new();
-        let outcome = match strategy {
-            GoCallStrategy::Result => {
-                let (wrap, outcome) = self.lower_result_wrapping(
-                    &call_str,
-                    &return_type,
-                    TupleReturnLayout::Flattened,
-                    WrapperTarget::Return,
-                );
-                statements.extend(wrap);
-                outcome
+        let outcome = match abi {
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct => {
+                unreachable!("passthrough Go function needs no wrapper")
             }
-            GoCallStrategy::CommaOk => {
-                let (wrap, outcome) = self.lower_comma_ok_wrapping(
-                    &call_str,
-                    &return_type,
-                    TupleReturnLayout::Flattened,
-                    WrapperTarget::Return,
-                );
-                statements.extend(wrap);
-                outcome
-            }
-            GoCallStrategy::NullableReturn => {
-                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", &call_str);
-                let (wrap, outcome) =
-                    self.lower_nil_check_option_wrap(&raw_var, &return_type, WrapperTarget::Return);
-                statements.extend(wrap);
-                outcome
-            }
-            GoCallStrategy::Tuple { arity } => {
+            CallableReturnAbi::Tuple { arity } => {
                 let temp_vars = self.create_temp_vars("ret", *arity);
                 statements.push(LoweredStatement::RawGo(format!(
                     "{} := {}\n",
@@ -675,23 +537,9 @@ impl Planner<'_> {
                 )));
                 Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type))
             }
-            GoCallStrategy::Partial => {
-                let (wrap, outcome) = self.lower_partial_wrapping(
-                    &call_str,
-                    &return_type,
-                    TupleReturnLayout::Flattened,
-                    WrapperTarget::Return,
-                );
-                statements.extend(wrap);
-                outcome
-            }
-            GoCallStrategy::Sentinel { value } => {
-                let (wrap, outcome) = self.lower_sentinel_wrapping(
-                    &call_str,
-                    &return_type,
-                    *value,
-                    WrapperTarget::Return,
-                );
+            _ => {
+                let (wrap, outcome) =
+                    self.lower_abi_wrapping(&call_str, abi, &return_type, WrapperTarget::Return);
                 statements.extend(wrap);
                 outcome
             }

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -5,43 +5,9 @@ mod native;
 mod regular;
 mod ufcs;
 
-pub(crate) use regular::effective_param_type;
-
-use crate::GoCallStrategy;
-use crate::Planner;
-use crate::abi::AbiShape;
-use crate::plan::calls::{CallReturnShape, CalleePlan};
 use crate::types::native::NativeGoType;
 use syntax::ast::Expression;
 use syntax::types::Type;
-
-/// How a call's result must be adapted at the call site. The cases are mutually
-/// exclusive: a Go-interop call has a Go receiver, which `CalleePlan::Regular`
-/// excludes, so a call is at most one of these. Derived from `CallPlan` —
-/// renderers should consume the plan directly where possible.
-pub(crate) enum CallBoundary {
-    /// Go-interop call wrapped per its strategy (multi-return, nullable, ...).
-    GoWrapped(GoCallStrategy),
-    /// Lisette call whose callee returns a lowered ABI shape.
-    LoweredCallee(AbiShape),
-    /// Plain call rendered as-is.
-    Plain,
-}
-
-impl Planner<'_> {
-    pub(crate) fn classify_call(&self, call_expression: &Expression) -> CallBoundary {
-        let Some(plan) = self.plan_call(call_expression) else {
-            return CallBoundary::Plain;
-        };
-        match plan.callee {
-            CalleePlan::GoInterop(strategy) => CallBoundary::GoWrapped(strategy),
-            _ => match plan.return_shape {
-                CallReturnShape::Lowered(shape) => CallBoundary::LoweredCallee(shape),
-                CallReturnShape::Direct => CallBoundary::Plain,
-            },
-        }
-    }
-}
 
 pub(super) struct NativeCallContext<'a> {
     pub function: &'a Expression,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -2,10 +2,9 @@ use crate::abi::is_tagged_shape_fn_value;
 use crate::calls::dispatch::{
     CallArgShape, all_type_params_inferrable, is_prelude_variant_constructor,
 };
-use crate::calls::go_interop::is_go_receiver;
 
 use crate::Planner;
-use crate::abi::AbiShape;
+use crate::abi::callable::{AbiTransition, CallableParamAbi, CallableReturnAbi};
 use crate::abi::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
@@ -14,30 +13,17 @@ use crate::expressions::staging::VariadicCombine;
 use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::calls::{ArgumentPlan, CallPlan, CallbackWrapperKind};
-use crate::types::native::NativeGoType;
+use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
 use crate::utils::{contains_call, reads_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Expression, Literal};
-use syntax::program::Definition;
 use syntax::types::Type;
 
-struct CalleeAnalysis<'a> {
-    fn_param_types: Vec<Type>,
-    generic_fn_param_types: Option<&'a [Type]>,
-    is_go_call: bool,
-    is_prelude_dispatch: bool,
-}
-
-struct CallArgsContext<'a> {
-    fn_param_types: &'a [Type],
-    generic_fn_param_types: Option<&'a [Type]>,
-    is_go_call: bool,
+struct CallArgsContext<'plan, 'facts> {
+    plan: &'plan CallPlan<'facts>,
     /// Suppresses the Go-fn identity short-circuit on fn-typed params
     /// dispatching into prelude generic helpers (e.g. `OptionAndThen`).
-    is_prelude_dispatch: bool,
-    declared_param_types: Option<&'a [Type]>,
-    spread: Option<&'a Expression>,
+    spread: Option<&'plan Expression>,
     wrap_spread_to_any: bool,
     combine_variadic: Option<VariadicCombine>,
 }
@@ -136,7 +122,7 @@ impl<'a> Planner<'a> {
     pub(super) fn lower_regular_call(
         &mut self,
         call_expression: &Expression,
-        call_plan: &CallPlan,
+        call_plan: &CallPlan<'a>,
         call_ty: Option<&Type>,
         expression_ctx: ExpressionContext<'_>,
     ) -> (Vec<LoweredStatement>, String) {
@@ -174,6 +160,7 @@ impl<'a> Planner<'a> {
 
         let type_args_string = self.resolve_call_type_args(
             function,
+            &call_plan.resolved,
             resolved_type_args,
             call_ty,
             CallArgShape {
@@ -184,14 +171,8 @@ impl<'a> Planner<'a> {
             expression_ctx,
         );
 
-        let analysis = self.analyze_callee(function);
-        let declared_param_types = self.callee_declared_params(function, args.len());
         let args_ctx = CallArgsContext {
-            fn_param_types: &analysis.fn_param_types,
-            generic_fn_param_types: analysis.generic_fn_param_types,
-            is_go_call: analysis.is_go_call,
-            is_prelude_dispatch: analysis.is_prelude_dispatch,
-            declared_param_types,
+            plan: call_plan,
             spread,
             wrap_spread_to_any: spread_needs_any_wrap(function, spread),
             combine_variadic: call_plan.variadic_combine(0),
@@ -233,39 +214,10 @@ impl<'a> Planner<'a> {
         (setup, value)
     }
 
-    fn analyze_callee(&mut self, function: &Expression) -> CalleeAnalysis<'a> {
-        let fn_param_types: Vec<Type> = function
-            .get_type()
-            .unwrap_forall()
-            .get_function_params()
-            .map(<[Type]>::to_vec)
-            .unwrap_or_default();
-        let generic_fn_param_types = self
-            .callee_definition(function)
-            .and_then(|definition| definition.ty().unwrap_forall().get_function_params());
-        let (is_go_call, is_prelude_dispatch) = match function.unwrap_parens() {
-            Expression::DotAccess { expression, .. } => {
-                let is_prelude = matches!(
-                    expression.get_type().strip_refs().unwrap_forall(),
-                    Type::Nominal { id, .. } if id.starts_with("prelude.")
-                );
-                (is_go_receiver(expression), is_prelude)
-            }
-            Expression::Identifier {
-                qualified: Some(q), ..
-            } if q.starts_with("prelude.") => (false, true),
-            _ => (false, false),
-        };
-        CalleeAnalysis {
-            fn_param_types,
-            generic_fn_param_types,
-            is_go_call,
-            is_prelude_dispatch,
-        }
-    }
-
-    fn callee_collapsed_recipe(&self, function: &Expression) -> Option<String> {
-        self.callee_definition(function)?
+    fn callee_collapsed_recipe(&self, callee: &ResolvedCallee<'_>) -> Option<String> {
+        callee.id.as_deref()?;
+        callee
+            .definition?
             .go_type_param_recipe()
             .map(str::to_string)
     }
@@ -276,11 +228,10 @@ impl<'a> Planner<'a> {
     /// recipe must be rebuilt.
     fn collapsed_callee_fully_inferable(
         &self,
-        function: &Expression,
+        callee: &ResolvedCallee<'_>,
         arg_shape: CallArgShape,
     ) -> bool {
-        let Some(Type::Forall { vars, body }) = self.callee_definition(function).map(|d| d.ty())
-        else {
+        let Some(Type::Forall { vars, body }) = callee.declared.as_ref() else {
             return false;
         };
         let Type::Function(f) = body.as_ref() else {
@@ -291,77 +242,16 @@ impl<'a> Planner<'a> {
 
     fn reconstruct_collapsed_call_type_args(
         &mut self,
-        function: &Expression,
+        callee: &ResolvedCallee<'_>,
         recipe: &str,
     ) -> Option<String> {
-        let definition_ty = self.callee_definition(function)?.ty().clone();
+        let definition_ty = callee.declared.clone()?;
         let Type::Forall { body, .. } = definition_ty else {
             return None;
         };
-        let instantiated = function.get_type();
         let mut mapping = rustc_hash::FxHashMap::default();
-        extract_type_mapping(&body, &instantiated, &mut mapping);
+        extract_type_mapping(&body, &callee.instantiated, &mut mapping);
         self.reconstruct_collapsed_type_args(recipe, &mapping)
-    }
-
-    pub(crate) fn callee_definition(&self, function: &Expression) -> Option<&'a Definition> {
-        match function.unwrap_parens() {
-            Expression::Identifier {
-                qualified: Some(q), ..
-            } => self.facts.definition(q.as_str()),
-            Expression::DotAccess {
-                expression: receiver,
-                member,
-                ..
-            } => {
-                let receiver_ty = receiver.get_type();
-                if let Some(module) = receiver_ty.as_import_namespace() {
-                    return self.facts.definition(&format!("{}.{}", module, member));
-                }
-                match receiver_ty.strip_refs() {
-                    Type::Nominal { id, .. } => {
-                        self.facts.definition(&format!("{}.{}", id, member))
-                    }
-                    _ => None,
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn declared_callee_definition(&self, function: &Expression) -> Option<&'a Definition> {
-        if let Some(definition) = self.callee_definition(function) {
-            return Some(definition);
-        }
-        let Expression::DotAccess {
-            expression: receiver,
-            member,
-            ..
-        } = function.unwrap_parens()
-        else {
-            return None;
-        };
-        let peeled = self.facts.strip_and_peel(&receiver.get_type());
-        if let Some(native) = NativeGoType::from_type(&peeled) {
-            return self
-                .facts
-                .definition(&format!("prelude.{}.{}", native.lisette_name(), member));
-        }
-        match peeled {
-            Type::Nominal { id, .. } => self.facts.definition(&format!("{}.{}", id, member)),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn callee_declared_params(
-        &self,
-        function: &Expression,
-        num_args: usize,
-    ) -> Option<&'a [Type]> {
-        let definition = self.declared_callee_definition(function)?;
-        let params = definition.ty().unwrap_forall().get_function_params()?;
-        let self_offset = params.len().saturating_sub(num_args);
-        params.get(self_offset..)
     }
 
     /// Hoist a Go array-return call into a temp and reslice as `[]T`. Skipped
@@ -384,6 +274,7 @@ impl<'a> Planner<'a> {
     fn resolve_call_type_args(
         &mut self,
         function: &Expression,
+        callee: &ResolvedCallee<'_>,
         type_args: &[Type],
         call_ty: Option<&Type>,
         arg_shape: CallArgShape,
@@ -391,12 +282,12 @@ impl<'a> Planner<'a> {
         ctx: ExpressionContext<'_>,
     ) -> String {
         let has_value_args = arg_shape.value_count > 0 || arg_shape.has_spread;
-        if let Some(recipe) = self.callee_collapsed_recipe(function) {
-            if has_value_args && self.collapsed_callee_fully_inferable(function, arg_shape) {
+        if let Some(recipe) = self.callee_collapsed_recipe(callee) {
+            if has_value_args && self.collapsed_callee_fully_inferable(callee, arg_shape) {
                 return String::new();
             }
             return self
-                .reconstruct_collapsed_call_type_args(function, &recipe)
+                .reconstruct_collapsed_call_type_args(callee, &recipe)
                 .unwrap_or_default();
         }
 
@@ -405,7 +296,8 @@ impl<'a> Planner<'a> {
         let slot_ty = ctx.expected_slot_type();
 
         if type_args_string.is_empty()
-            && let Some(inferred) = self.infer_return_only_type_args(function, arg_shape)
+            && let Some(inferred) =
+                self.infer_return_only_type_args(function, callee.declared.as_ref(), arg_shape)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t).unwrap_or(inferred),
@@ -436,7 +328,7 @@ impl<'a> Planner<'a> {
     fn emit_call_args(
         &mut self,
         args: &[Expression],
-        ctx: &CallArgsContext<'_>,
+        ctx: &CallArgsContext<'_, '_>,
     ) -> (Vec<LoweredStatement>, Vec<String>) {
         let stages: Vec<StagedExpression> = args
             .iter()
@@ -450,7 +342,11 @@ impl<'a> Planner<'a> {
         self.sequence_args_with_spread_adapter(
             stages,
             ctx.spread,
-            ctx.generic_fn_param_types,
+            ctx.plan
+                .resolved
+                .declared
+                .as_ref()
+                .and_then(|ty| ty.unwrap_forall().get_function_params()),
             ctx.wrap_spread_to_any,
             ctx.combine_variadic.clone(),
         )
@@ -466,29 +362,30 @@ impl<'a> Planner<'a> {
         &mut self,
         arg: &Expression,
         index: usize,
-        ctx: &CallArgsContext<'_>,
+        ctx: &CallArgsContext<'_, '_>,
     ) -> (Vec<LoweredStatement>, String) {
-        let effective_param_ty = effective_param_type(index, ctx.fn_param_types);
-        let generic_param_ty = ctx
-            .generic_fn_param_types
-            .and_then(|params| effective_param_type(index, params));
-        let declared_param_ty = ctx
-            .declared_param_types
-            .and_then(|params| effective_param_type(index, params));
+        let param = ctx.plan.resolved.abi.param(index);
+        let effective_param_ty = param.map(|param| &param.instantiated);
+        let generic_param_ty = param.and_then(|param| param.declared.as_ref());
+        let declared_param_ty = generic_param_ty;
 
-        let plan = self.plan_argument(
-            arg,
-            ctx,
-            effective_param_ty,
-            generic_param_ty,
-            declared_param_ty,
-        );
+        let plan = ctx
+            .plan
+            .arguments
+            .get(index)
+            .expect("CallPlan has one argument plan per argument");
 
         match plan {
-            ArgumentPlan::GoCallbackAdapter(kind) => self.lower_callback_wrapper(
+            ArgumentPlan::GoCallbackAdapter {
+                source,
+                target,
+                transition,
+            } => self.lower_callback_wrapper(
                 arg,
                 effective_param_ty.expect("GoCallbackAdapter requires effective_param_ty"),
-                kind,
+                source,
+                target,
+                *transition,
             ),
             ArgumentPlan::LoweredFnShapeAdapter => self
                 .lower_adapt_lowered_fn_arg_shape(
@@ -507,7 +404,7 @@ impl<'a> Planner<'a> {
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
-                let arg_ctx = direct_arg_emit_ctx(ctx, Some(target), true);
+                let arg_ctx = direct_arg_emit_ctx(Some(target), true);
                 let (mut setup, value) = self.lower_composite_value(arg, arg_ctx).into_parts();
                 let lowered = self.emit_lower_arg_to_tagged(&mut setup, &value, target);
                 (setup, lowered)
@@ -521,21 +418,26 @@ impl<'a> Planner<'a> {
     /// Pre-plan adaptations for a single argument. Mirrors the prior
     /// `try_emit_*` chain in order; the first hit wins. Returns `Direct` for
     /// the fallback path (which still handles tagged-Go suppression inline).
-    fn plan_argument(
+    pub(crate) fn plan_argument(
         &self,
         arg: &Expression,
-        ctx: &CallArgsContext<'_>,
-        effective_param_ty: Option<&Type>,
-        generic_param_ty: Option<&Type>,
-        declared_param_ty: Option<&Type>,
+        callee: &ResolvedCallee<'_>,
+        param: Option<&CallableParamAbi>,
     ) -> ArgumentPlan {
-        if ctx.is_go_call
-            && let Some(kind) = self.detect_callback_wrapper(arg, effective_param_ty)
+        let effective_param_ty = param.map(|param| &param.instantiated);
+        let declared_param_ty = param.and_then(|param| param.declared.as_ref());
+        if matches!(callee.origin, CallableOrigin::GoInterop)
+            && let Some((source, target, transition)) =
+                self.detect_callback_wrapper(arg, effective_param_ty)
         {
-            return ArgumentPlan::GoCallbackAdapter(kind);
+            return ArgumentPlan::GoCallbackAdapter {
+                source,
+                target,
+                transition,
+            };
         }
         if self
-            .detect_lowered_fn_arg_shape(arg, generic_param_ty)
+            .detect_lowered_fn_arg_shape(arg, declared_param_ty)
             .is_some()
         {
             return ArgumentPlan::LoweredFnShapeAdapter;
@@ -546,14 +448,14 @@ impl<'a> Planner<'a> {
         {
             return ArgumentPlan::NullableCoercion;
         }
-        if ctx.is_go_call
+        if matches!(callee.origin, CallableOrigin::GoInterop)
             && self
                 .detect_go_pointer_param_unwrap(arg, effective_param_ty)
                 .is_some()
         {
             return ArgumentPlan::GoPointerUnwrap;
         }
-        let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
+        let suppress = would_suppress_tagged_go(callee, declared_param_ty);
         if suppress
             && self
                 .detect_lower_arg_to_tagged(arg, effective_param_ty)
@@ -567,12 +469,12 @@ impl<'a> Planner<'a> {
     fn lower_direct_arg(
         &mut self,
         arg: &Expression,
-        ctx: &CallArgsContext<'_>,
+        ctx: &CallArgsContext<'_, '_>,
         effective_param_ty: Option<&Type>,
         declared_param_ty: Option<&Type>,
     ) -> (Vec<LoweredStatement>, String) {
-        let suppress = would_suppress_tagged_go(ctx, declared_param_ty);
-        let arg_ctx = direct_arg_emit_ctx(ctx, effective_param_ty, suppress);
+        let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
+        let arg_ctx = direct_arg_emit_ctx(effective_param_ty, suppress);
         let (mut setup, value) = self.lower_composite_value(arg, arg_ctx).into_parts();
         let final_value = match effective_param_ty {
             Some(target) => {
@@ -608,7 +510,7 @@ impl<'a> Planner<'a> {
         &self,
         arg: &Expression,
         raw_param_ty: &Type,
-    ) -> Option<(Option<AbiShape>, Type, AbiShape)> {
+    ) -> Option<(CallableReturnAbi, Type, CallableReturnAbi)> {
         let variadic_inner = (raw_param_ty.get_name() == Some("VarArgs"))
             .then(|| raw_param_ty.inner())
             .flatten();
@@ -617,16 +519,18 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(param_ty.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_shape = self.classify_direct_emission(param_ret);
+        let param_abi = self
+            .classify_direct_emission(param_ret)
+            .unwrap_or_else(|| self.value_return_abi(param_ret));
 
         let arg_ty = arg.get_type();
         let arg_fn = self
             .facts
             .resolve_to_function_type(arg_ty.unwrap_forall())?;
         let arg_ret = arg_fn.get_function_ret()?;
-        let arg_shape = self.classify_direct_emission(arg_ret)?;
+        let arg_abi = self.classify_direct_emission(arg_ret)?;
 
-        Some((param_shape, arg_fn, arg_shape))
+        Some((param_abi, arg_fn, arg_abi))
     }
 
     pub(crate) fn detect_lowered_fn_arg_shape(
@@ -638,8 +542,8 @@ impl<'a> Planner<'a> {
             return None;
         }
         let raw_param_ty = generic_param_ty?;
-        let (param_shape, _arg_fn, arg_shape) = self.fn_arg_shapes(arg, raw_param_ty)?;
-        if param_shape.as_ref() == Some(&arg_shape) {
+        let (param_abi, _arg_fn, arg_abi) = self.fn_arg_shapes(arg, raw_param_ty)?;
+        if param_abi == arg_abi {
             return None;
         }
         Some(())
@@ -650,19 +554,13 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         generic_param_ty: &Type,
     ) -> Option<(Vec<LoweredStatement>, String)> {
-        let (param_shape, arg_fn, arg_shape) = self.fn_arg_shapes(arg, generic_param_ty)?;
+        let (param_abi, arg_fn, arg_abi) = self.fn_arg_shapes(arg, generic_param_ty)?;
         let (mut setup, value) = self
             .lower_value(arg, ExpressionContext::value())
             .into_parts();
         let mut buffer = String::new();
-        let adapted = emit_fn_arg_shape_adapter(
-            self,
-            &mut buffer,
-            &value,
-            &arg_fn,
-            &arg_shape,
-            param_shape.as_ref(),
-        )?;
+        let adapted =
+            emit_fn_arg_shape_adapter(self, &mut buffer, &value, &arg_fn, &arg_abi, &param_abi)?;
         if !buffer.is_empty() {
             setup.push(LoweredStatement::RawGo(buffer));
         }
@@ -686,7 +584,9 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(variadic_inner.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_shape = self.classify_direct_emission(param_ret);
+        let param_abi = self
+            .classify_direct_emission(param_ret)
+            .unwrap_or_else(|| self.value_return_abi(param_ret));
 
         let spread_ty = spread.get_type();
         let element_ty = spread_ty.unwrap_forall().inner()?;
@@ -694,9 +594,9 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(element_ty.unwrap_forall())?;
         let arg_ret = arg_fn.get_function_ret()?;
-        let arg_shape = self.classify_direct_emission(arg_ret)?;
+        let arg_abi = self.classify_direct_emission(arg_ret)?;
 
-        if param_shape.as_ref() == Some(&arg_shape) {
+        if param_abi == arg_abi {
             return None;
         }
 
@@ -705,10 +605,7 @@ impl<'a> Planner<'a> {
             .into_parts();
         let src_var = self.hoist_tmp_value_statement(&mut setup, "src", &src_value);
 
-        let target_element_ret = match param_shape.as_ref() {
-            Some(shape) => self.render_lowered_return_ty(shape, arg_ret),
-            None => self.go_type_string(arg_ret),
-        };
+        let target_element_ret = self.render_lowered_return_ty(&param_abi, arg_ret);
         let arg_fn_params = arg_fn.get_function_params().unwrap_or(&[]);
         let param_type_strs: Vec<String> = arg_fn_params
             .iter()
@@ -725,14 +622,8 @@ impl<'a> Planner<'a> {
         let loop_cb = self.fresh_var(Some("cb"));
 
         let mut body = String::new();
-        let closure = emit_fn_arg_shape_adapter(
-            self,
-            &mut body,
-            &loop_cb,
-            &arg_fn,
-            &arg_shape,
-            param_shape.as_ref(),
-        )?;
+        let closure =
+            emit_fn_arg_shape_adapter(self, &mut body, &loop_cb, &arg_fn, &arg_abi, &param_abi)?;
         write_line!(body, "{}[i] = {}", adapted, closure);
 
         setup.push(LoweredStatement::RawGo(format!(
@@ -747,14 +638,12 @@ impl<'a> Planner<'a> {
         Some(self.staged_from_typed_setup(setup, adapted, spread))
     }
 
-    /// Detect whether a Go-call argument needs a callback wrapper. Returns
-    /// `Identity` when the shapes already agree (no wrapping, just emit) and
-    /// `Wrap` when the Lisette callback ABI must be wrapped for the Go param.
+    /// Resolve the source and target callback contracts at a Go call boundary.
     pub(crate) fn detect_callback_wrapper(
         &self,
         arg: &Expression,
         effective_param_ty: Option<&Type>,
-    ) -> Option<CallbackWrapperKind> {
+    ) -> Option<(CallableReturnAbi, CallableReturnAbi, AbiTransition)> {
         let param_fn_ty = effective_param_ty
             .and_then(|param_ty| {
                 self.facts
@@ -769,37 +658,71 @@ impl<'a> Planner<'a> {
                     || f.return_type.tuple_arity().is_some_and(|a| a >= 2)
             })?;
 
-        let arg_ty = arg.get_type();
-        let arg_fn_ty = self.facts.resolve_to_function_type(arg_ty.unwrap_forall());
-        if let Some(Type::Function(arg_f)) = arg_fn_ty.as_ref()
-            && let Type::Function(param_f) = &param_fn_ty
-            && self.classify_direct_emission(&arg_f.return_type).is_some()
-            && self
-                .classify_direct_emission(&param_f.return_type)
-                .is_some()
-        {
-            return Some(CallbackWrapperKind::Identity);
-        }
-        Some(CallbackWrapperKind::Wrap)
+        let Type::Function(param_f) = &param_fn_ty else {
+            return None;
+        };
+        let target = self.classify_direct_emission(&param_f.return_type)?;
+        let source = if is_tagged_shape_fn_value(arg) {
+            CallableReturnAbi::Tagged
+        } else {
+            self.resolve_callable_value(arg)
+                .map(|callee| callee.abi.result)
+                .unwrap_or(CallableReturnAbi::Direct)
+        };
+        let transition = source.transition_to(&target);
+        Some((source, target, transition))
     }
 
     fn lower_callback_wrapper(
         &mut self,
         arg: &Expression,
         effective_param_ty: &Type,
-        kind: CallbackWrapperKind,
+        source: &CallableReturnAbi,
+        target: &CallableReturnAbi,
+        transition: AbiTransition,
     ) -> (Vec<LoweredStatement>, String) {
-        let (mut setup, value) = self
-            .lower_value(arg, ExpressionContext::value())
-            .into_parts();
-        let result = match kind {
-            CallbackWrapperKind::Identity => value,
-            CallbackWrapperKind::Wrap => {
+        let (mut setup, value) = match transition {
+            AbiTransition::Identity => self
+                .lower_value(arg, ExpressionContext::value())
+                .into_parts(),
+            _ => self
+                .plan_operand(
+                    arg,
+                    ExpressionContext::value().with_forced_tagged_go_function(true),
+                )
+                .into_parts(),
+        };
+        let result = match transition {
+            AbiTransition::Identity => value,
+            AbiTransition::LowerFromTagged => {
                 let param_fn_ty = self
                     .facts
                     .resolve_to_function_type(effective_param_ty.unwrap_forall())
-                    .expect("Wrap kind only reached when param resolves to a fn type");
+                    .expect("callback target resolves to a fn type");
                 emit_lisette_callback_wrapper(self, &mut setup, &value, &param_fn_ty)
+            }
+            AbiTransition::WrapToTagged | AbiTransition::Reencode => {
+                let arg_fn_ty = self
+                    .facts
+                    .resolve_to_function_type(arg.get_type().unwrap_forall())
+                    .expect("callback source resolves to a fn type");
+                let mut buffer = String::new();
+                let adapted = emit_fn_arg_shape_adapter(
+                    self,
+                    &mut buffer,
+                    &value,
+                    &arg_fn_ty,
+                    source,
+                    target,
+                )
+                .expect("callback ABI transition has a function signature");
+                if !buffer.is_empty() {
+                    setup.push(LoweredStatement::RawGo(buffer));
+                }
+                adapted
+            }
+            AbiTransition::Incompatible => {
+                unreachable!("type-checked callback ABIs must describe the same result")
             }
         };
         (setup, result)
@@ -909,15 +832,14 @@ fn spread_needs_any_wrap(function: &Expression, spread: Option<&Expression>) -> 
         .is_some_and(|t| !t.is_unknown())
 }
 
-fn would_suppress_tagged_go(ctx: &CallArgsContext<'_>, declared_param_ty: Option<&Type>) -> bool {
+fn would_suppress_tagged_go(callee: &ResolvedCallee<'_>, declared_param_ty: Option<&Type>) -> bool {
     let unwrapped = declared_param_ty.map(|p| p.unwrap_forall());
-    ctx.is_prelude_dispatch && unwrapped.is_some_and(|p| matches!(p, Type::Function(_)))
+    callee.is_prelude_dispatch && unwrapped.is_some_and(|p| matches!(p, Type::Function(_)))
 }
 
 /// Compute the `ExpressionContext` for emitting a Direct or TaggedGoLowering
 /// argument's underlying value via `emit_composite_value`.
 fn direct_arg_emit_ctx<'b>(
-    _ctx: &CallArgsContext<'b>,
     effective_param_ty: Option<&'b Type>,
     suppress: bool,
 ) -> ExpressionContext<'b> {
@@ -926,12 +848,4 @@ fn direct_arg_emit_ctx<'b>(
     ExpressionContext::value()
         .with_forced_tagged_go_function(suppress)
         .with_unknown_argument_target(flows_to_unknown)
-}
-
-pub(crate) fn effective_param_type(index: usize, fn_param_types: &[Type]) -> Option<&Type> {
-    fn_param_types.get(index).or_else(|| {
-        fn_param_types
-            .last()
-            .filter(|t| t.get_name() == Some("VarArgs"))
-    })
 }

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -1,6 +1,5 @@
 use crate::calls::dispatch::{CallArgShape, all_type_params_inferrable};
 use crate::calls::native::apply_inline_import;
-use crate::calls::regular::effective_param_type;
 use crate::plan::calls::plan_variadic_spread;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -10,6 +9,7 @@ use crate::expressions::emission::StagedExpression;
 use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::calls::{CallPlan, ResolvedCallee};
 use crate::types::native::NativeGoType;
 use syntax::ast::{Expression, Literal};
 use syntax::program::ReceiverCoercion;
@@ -20,14 +20,12 @@ impl Planner<'_> {
     fn ufcs_type_args(
         &mut self,
         function: &Expression,
-        qualified_name: &str,
-        member: &str,
+        callee: &ResolvedCallee<'_>,
         receiver_ty: &Type,
         type_args: &[Type],
         arg_shape: CallArgShape,
     ) -> Option<String> {
-        let method_key = format!("{}.{}", qualified_name, member);
-        let definition_ty = self.facts.definition(method_key.as_str())?.ty().clone();
+        let definition_ty = callee.declared.as_ref()?;
 
         // A method with no type parameters lowers to a non-generic free function.
         let Type::Forall { vars, body } = &definition_ty else {
@@ -56,10 +54,7 @@ impl Planner<'_> {
             return (!go_type_strs.is_empty()).then(|| format!("[{}]", go_type_strs.join(", ")));
         }
 
-        let receiver_count = match function.get_type() {
-            Type::Function(inst) if inst.params.len() + 1 == f.params.len() => 1,
-            _ => 0,
-        };
+        let receiver_count = callee.receiver_offset.min(1);
         if all_type_params_inferrable(vars, &f.params, receiver_count, arg_shape) {
             return None;
         }
@@ -94,6 +89,7 @@ impl Planner<'_> {
         args: &[Expression],
         type_args: &[Type],
         spread: Option<&Expression>,
+        call_plan: &CallPlan<'_>,
     ) -> (Vec<LoweredStatement>, String) {
         let Expression::DotAccess {
             expression: receiver,
@@ -114,7 +110,7 @@ impl Planner<'_> {
         };
 
         let (mut setup, receiver_arg, emitted_args) =
-            self.lower_ufcs_call_args(function, receiver, args, spread);
+            self.lower_ufcs_call_args(function, receiver, args, spread, &call_plan.resolved);
         let receiver_arg =
             self.apply_receiver_coercion(&mut setup, receiver, receiver_arg, *coercion);
 
@@ -129,6 +125,7 @@ impl Planner<'_> {
 
         let fn_name = self.build_ufcs_qualified_call(
             function,
+            &call_plan.resolved,
             &receiver_ty,
             qualified_name,
             member,
@@ -147,32 +144,29 @@ impl Planner<'_> {
         receiver: &Expression,
         args: &[Expression],
         spread: Option<&Expression>,
+        callee: &ResolvedCallee<'_>,
     ) -> (Vec<LoweredStatement>, String, Vec<String>) {
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
         // suppresses the Go-fn-value identity short-circuit before dispatch
         // into prelude helpers like `lisette.OptionAndThen`.
-        let formal_params: Vec<Type> = function
-            .get_type()
-            .as_function_type()
-            .map_or_else(Vec::new, |f| f.params.clone());
-        let declared_params =
-            self.ufcs_declared_user_params(receiver, function, formal_params.len());
-        let suppress_declared = declared_params
-            .is_none()
-            .then(|| self.callee_declared_params(function, args.len()))
-            .flatten();
         let mut all_stages: Vec<StagedExpression> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
         all_stages.push(self.stage_operand(receiver, ExpressionContext::value()));
         for (i, arg) in args.iter().enumerate() {
-            let declared = declared_params.and_then(|p| effective_param_type(i, p));
-            let suppress_decl = suppress_declared.and_then(|p| effective_param_type(i, p));
+            let param = callee.abi.param(i);
+            let declared = (!callee.is_prelude_dispatch)
+                .then(|| param.and_then(|param| param.declared.as_ref()))
+                .flatten();
+            let suppress_decl = callee
+                .is_prelude_dispatch
+                .then(|| param.and_then(|param| param.declared.as_ref()))
+                .flatten();
             all_stages.push(self.stage_ufcs_arg(
                 arg,
                 declared,
                 suppress_decl,
-                formal_params.get(i),
+                param.map(|param| &param.instantiated),
             ));
         }
         let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
@@ -180,7 +174,14 @@ impl Planner<'_> {
         let (setup, all_values) = self.sequence_args_with_spread_adapter(
             all_stages,
             spread,
-            declared_params,
+            (!callee.is_prelude_dispatch)
+                .then(|| {
+                    callee
+                        .declared
+                        .as_ref()
+                        .and_then(|ty| ty.unwrap_forall().get_function_params())
+                })
+                .flatten(),
             false,
             combine,
         );
@@ -210,6 +211,7 @@ impl Planner<'_> {
     fn build_ufcs_qualified_call(
         &mut self,
         function: &Expression,
+        callee: &ResolvedCallee<'_>,
         receiver_ty: &Type,
         qualified_name: &str,
         member: &str,
@@ -217,20 +219,11 @@ impl Planner<'_> {
         arg_shape: CallArgShape,
     ) -> String {
         let type_args_string = self
-            .ufcs_type_args(
-                function,
-                qualified_name,
-                member,
-                receiver_ty,
-                type_args,
-                arg_shape,
-            )
+            .ufcs_type_args(function, callee, receiver_ty, type_args, arg_shape)
             .unwrap_or_default();
 
-        let method_key = format!("{}.{}", qualified_name, member);
-        let is_public = self
-            .facts
-            .definition(method_key.as_str())
+        let is_public = callee
+            .definition
             .map(|d| d.visibility().is_public())
             .unwrap_or(false)
             || self.method_needs_export(member);
@@ -312,30 +305,6 @@ impl Planner<'_> {
                 emitted_rest.join(", ")
             ),
         )
-    }
-}
-
-impl<'a> Planner<'a> {
-    fn ufcs_declared_user_params(
-        &self,
-        receiver: &Expression,
-        function: &Expression,
-        arg_count: usize,
-    ) -> Option<&'a [Type]> {
-        let receiver_ty = receiver.get_type().strip_refs();
-        let Type::Nominal { id, .. } = &receiver_ty else {
-            return None;
-        };
-        if id.starts_with("prelude.") || go_name::is_go_import(id.as_str()) {
-            return None;
-        }
-        let declared = self
-            .callee_definition(function)?
-            .ty()
-            .unwrap_forall()
-            .get_function_params()?;
-        let self_offset = declared.len().saturating_sub(arg_count);
-        declared.get(self_offset..)
     }
 }
 

--- a/crates/emit/src/context/expression.rs
+++ b/crates/emit/src/context/expression.rs
@@ -26,10 +26,10 @@ pub(crate) enum GoArrayReturnPolicy {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) enum GoFunctionValuePolicy {
+pub(crate) enum FunctionValueAbiTarget {
     #[default]
-    AllowLoweredIdentity,
-    ForceTaggedWrapper,
+    Natural,
+    Tagged,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -45,7 +45,7 @@ pub(crate) struct ExpressionContext<'a> {
     syntax_context: SyntaxContext,
     expected_slot_type: Option<&'a Type>,
     go_array_return_policy: GoArrayReturnPolicy,
-    go_function_value_policy: GoFunctionValuePolicy,
+    function_value_abi_target: FunctionValueAbiTarget,
     argument_target: ArgumentTarget,
 }
 
@@ -77,7 +77,7 @@ impl<'a> ExpressionContext<'a> {
     pub(crate) fn with_forced_tagged_go_function(self, force: bool) -> Self {
         if force {
             Self {
-                go_function_value_policy: GoFunctionValuePolicy::ForceTaggedWrapper,
+                function_value_abi_target: FunctionValueAbiTarget::Tagged,
                 ..self
             }
         } else {
@@ -110,8 +110,8 @@ impl<'a> ExpressionContext<'a> {
 
     pub(crate) fn forces_tagged_go_function(self) -> bool {
         matches!(
-            self.go_function_value_policy,
-            GoFunctionValuePolicy::ForceTaggedWrapper
+            self.function_value_abi_target,
+            FunctionValueAbiTarget::Tagged
         )
     }
 

--- a/crates/emit/src/context/lowering.rs
+++ b/crates/emit/src/context/lowering.rs
@@ -1,4 +1,4 @@
-use crate::abi::AbiShape;
+use crate::abi::callable::CallableReturnAbi;
 use syntax::types::Type;
 
 #[derive(Clone)]
@@ -40,7 +40,7 @@ pub(crate) enum ReturnContext {
     Tagged(Type),
     Lowered {
         return_ty: Type,
-        shape: AbiShape,
+        shape: CallableReturnAbi,
     },
     TaggedBlock(Type),
 }
@@ -55,7 +55,7 @@ impl ReturnContext {
         }
     }
 
-    pub(crate) fn lowered_shape(&self) -> Option<AbiShape> {
+    pub(crate) fn lowered_shape(&self) -> Option<CallableReturnAbi> {
         match self {
             ReturnContext::Lowered { shape, .. } => Some(shape.clone()),
             _ => None,

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,7 +1,6 @@
-use crate::GoCallStrategy;
 use crate::Planner;
 use crate::Renderer;
-use crate::abi::AbiShape;
+use crate::abi::callable::{CallableReturnAbi, PayloadLayout};
 use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
@@ -10,7 +9,7 @@ use crate::plan::bodies::{
     AssignForm, AssignPlan, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm,
     ReturnStatementPlan,
 };
-use crate::plan::calls::{CallReturnShape, CalleePlan};
+use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -19,7 +18,7 @@ use syntax::types::Type;
 struct WrappedReturnInfo<'a> {
     fallible: &'a Fallible,
     return_ty: &'a Type,
-    lowered: Option<&'a AbiShape>,
+    lowered: Option<&'a CallableReturnAbi>,
 }
 
 pub(crate) fn plain_return(value: String) -> LoweredStatement {
@@ -183,7 +182,15 @@ impl Planner<'_> {
         result_var_name: Option<&str>,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let plan = self.plan_call(expression)?;
-        if !matches!(plan.callee, CalleePlan::GoInterop(GoCallStrategy::Result)) {
+        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+            || !matches!(
+                plan.resolved.abi.result,
+                CallableReturnAbi::Result {
+                    payload: PayloadLayout::Packed,
+                    ..
+                }
+            )
+        {
             return None;
         }
         let ok_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
@@ -417,7 +424,7 @@ impl Planner<'_> {
         &mut self,
         value: String,
         return_ty: &Type,
-        lowered: Option<&AbiShape>,
+        lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
         let Some(shape) = lowered else {
             return vec![plain_return(value)];
@@ -468,11 +475,17 @@ impl Planner<'_> {
         &mut self,
         args: &[Expression],
         fallible: &Fallible,
-        lowered: Option<&AbiShape>,
+        lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
-            let ok_arg = if matches!(shape, AbiShape::BareError) {
+            let ok_arg = if matches!(
+                shape,
+                CallableReturnAbi::Result {
+                    bare_error: true,
+                    ..
+                }
+            ) {
                 if !args.is_empty() {
                     let (setup, _) = self
                         .lower_composite_value(&args[0], ExpressionContext::value())
@@ -511,7 +524,7 @@ impl Planner<'_> {
         args: &[Expression],
         fallible: &Fallible,
         return_ty: &Type,
-        lowered: Option<&AbiShape>,
+        lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
@@ -549,7 +562,7 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         return_ty: &Type,
-        lowered: Option<&AbiShape>,
+        lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered
@@ -561,10 +574,10 @@ impl Planner<'_> {
             return statements;
         }
         if let Some(plan) = self.plan_call(expression)
-            && let CalleePlan::GoInterop(strategy) = plan.callee
+            && !plan.resolved.abi.result.is_passthrough()
         {
             let (setup, result_var) = self
-                .lower_go_wrapped_call(expression, &strategy, return_ty)
+                .lower_abi_wrapped_call(expression, &plan.resolved.abi.result, return_ty)
                 .into_parts();
             statements.extend(setup);
             if let Some(shape) = lowered {
@@ -601,16 +614,11 @@ impl Planner<'_> {
     fn callee_matches_lowered_shape(
         &self,
         call_expression: &Expression,
-        enclosing_shape: &AbiShape,
+        enclosing_shape: &CallableReturnAbi,
     ) -> bool {
         let Some(plan) = self.plan_call(call_expression) else {
             return false;
         };
-        match &plan.callee {
-            CalleePlan::GoInterop(strategy) => enclosing_shape.matches_go_strategy(strategy),
-            _ => {
-                matches!(&plan.return_shape, CallReturnShape::Lowered(shape) if shape == enclosing_shape)
-            }
-        }
+        plan.resolved.abi.result == *enclosing_shape
     }
 }

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet as HashSet;
 use crate::Planner;
 use crate::Renderer;
 use crate::ReturnContext;
-use crate::abi::AbiShape;
+use crate::abi::callable::CallableReturnAbi;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::PatternSubject;
@@ -403,7 +403,7 @@ impl Planner<'_> {
         &mut self,
         function_definition: FunctionDefinitionView<'_>,
         params_to_process: &[Binding],
-        return_shape: Option<&AbiShape>,
+        return_shape: Option<&CallableReturnAbi>,
     ) -> (String, String, Vec<DeferredParamDestructure>) {
         let (params_string, deferred_patterns) = self.emit_function_params(params_to_process);
 

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,5 +1,5 @@
 use crate::Planner;
-use crate::abi::AbiShape;
+use crate::abi::callable::{AbiTransition, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::transition::emit_return_adapter;
 use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
@@ -18,8 +18,8 @@ pub(crate) struct AdapterMethod {
     pub(crate) name: EcoString,
     pub(crate) param_types: Vec<Type>,
     pub(crate) return_type: Type,
-    pub(crate) user_shape: Option<AbiShape>,
-    pub(crate) interface_shape: Option<AbiShape>,
+    pub(crate) user_abi: CallableReturnAbi,
+    pub(crate) interface_abi: CallableReturnAbi,
 }
 
 impl Planner<'_> {
@@ -186,23 +186,27 @@ impl Planner<'_> {
         // Compute the natural shape once and shift it for the interface side
         // if a `#[go(...)]` hint applies, instead of re-walking `peel_alias`
         // twice via two `classify_direct_emission` calls.
-        let user_shape = self.classify_direct_emission(&return_type);
+        let user_abi = self.callable_return_abi(&return_type);
         let interface_hints = self.go_interface_method_hints(declaring_id, method_name);
-        let interface_shape = match user_shape.as_ref() {
-            Some(AbiShape::NullableReturn) if interface_hints.iter().any(|h| h == "comma_ok") => {
-                Some(AbiShape::CommaOk)
-            }
-            other => other.cloned(),
+        let interface_abi = match &user_abi {
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                payload,
+            } if interface_hints.iter().any(|h| h == "comma_ok") => CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload: *payload,
+            },
+            other => other.clone(),
         };
-        let adapted = user_shape != interface_shape;
+        let adapted = user_abi != interface_abi;
 
         Some((
             AdapterMethod {
                 name: method_name.clone(),
                 param_types,
                 return_type,
-                user_shape,
-                interface_shape,
+                user_abi,
+                interface_abi,
             },
             adapted,
         ))
@@ -213,10 +217,20 @@ impl Planner<'_> {
         &mut self,
         inner_call: &str,
         return_ty: &Type,
-        user_shape: &AbiShape,
-        interface_shape: &AbiShape,
+        user_abi: &CallableReturnAbi,
+        interface_abi: &CallableReturnAbi,
     ) -> Option<(String, String)> {
-        let (AbiShape::NullableReturn, AbiShape::CommaOk) = (user_shape, interface_shape) else {
+        let (
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                ..
+            },
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                ..
+            },
+        ) = (user_abi, interface_abi)
+        else {
             return None;
         };
         let inner = self.facts.peel_alias(return_ty).ok_type();
@@ -229,7 +243,13 @@ impl Planner<'_> {
         } else {
             format!("{} != nil", val)
         };
-        let go_ret = self.render_lowered_return_ty(&AbiShape::CommaOk, return_ty);
+        let go_ret = self.render_lowered_return_ty(
+            &CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload: PayloadLayout::Packed,
+            },
+            return_ty,
+        );
         let body = format!("{val} := {inner_call}\nreturn {val}, {nil_check}\n");
         Some((go_ret, body))
     }
@@ -250,16 +270,24 @@ impl Planner<'_> {
 
     /// Classify with `#[go(...)]` hints — `comma_ok` shifts the default
     /// `NullableReturn` to `CommaOk` for nilable `Option`s.
-    pub(crate) fn classify_with_go_hints(
+    pub(crate) fn callable_return_abi_with_go_hints(
         &self,
         return_ty: &Type,
         hints: &[String],
-    ) -> Option<AbiShape> {
-        let base = self.classify_direct_emission(return_ty)?;
-        if matches!(base, AbiShape::NullableReturn) && hints.iter().any(|h| h == "comma_ok") {
-            return Some(AbiShape::CommaOk);
+    ) -> CallableReturnAbi {
+        let base = self.callable_return_abi(return_ty);
+        if let CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Nullable,
+            payload,
+        } = base
+            && hints.iter().any(|h| h == "comma_ok")
+        {
+            return CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload,
+            };
         }
-        Some(base)
+        base
     }
 
     pub(crate) fn ensure_adapter_type(&mut self, plan: AdapterPlan) -> String {
@@ -333,26 +361,32 @@ impl Planner<'_> {
     }
 
     fn build_adapter_body(&mut self, method: &AdapterMethod, inner_call: &str) -> (String, String) {
-        let user_shape = &method.user_shape;
-        let interface_shape = &method.interface_shape;
+        let user_abi = &method.user_abi;
+        let interface_abi = &method.interface_abi;
 
-        if user_shape == interface_shape
-            && let Some(shape) = user_shape
-        {
-            let go_ret = self.render_lowered_return_ty(shape, &method.return_type);
+        if user_abi == interface_abi {
+            if user_abi.is_lowered() {
+                let go_ret = self.render_lowered_return_ty(user_abi, &method.return_type);
+                return (go_ret, format!("return {}\n", inner_call));
+            }
+            if method.return_type.is_unit() {
+                return (String::new(), format!("{}\n", inner_call));
+            }
+            let go_ret = self.go_type_string(&method.return_type);
             return (go_ret, format!("return {}\n", inner_call));
         }
 
-        if let (Some(user), Some(interface)) = (user_shape, interface_shape)
-            && user != interface
-            && let Some(bridge) =
-                self.emit_hint_shift_bridge(inner_call, &method.return_type, user, interface)
+        if let Some(bridge) =
+            self.emit_hint_shift_bridge(inner_call, &method.return_type, user_abi, interface_abi)
         {
             return bridge;
         }
 
-        let adapter = emit_return_adapter(self, inner_call, &method.return_type);
-        if let Some(adapter) = adapter {
+        if matches!(
+            user_abi.transition_to(interface_abi),
+            AbiTransition::LowerFromTagged
+        ) && let Some(adapter) = emit_return_adapter(self, inner_call, &method.return_type)
+        {
             return adapter;
         }
 

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -68,9 +68,11 @@ impl Planner<'_> {
             .clone();
         let qualified_id = self.facts.qualified_current(interface_name);
         let hints = self.go_interface_method_hints(&qualified_id, func.name);
-        let return_type = match self.classify_with_go_hints(&raw_return_ty, &hints) {
-            Some(shape) => self.render_lowered_return_ty(&shape, &raw_return_ty),
-            None => self.go_type_string(&raw_return_ty),
+        let return_abi = self.callable_return_abi_with_go_hints(&raw_return_ty, &hints);
+        let return_type = if return_abi.is_lowered() {
+            self.render_lowered_return_ty(&return_abi, &raw_return_ty)
+        } else {
+            self.go_type_string(&raw_return_ty)
         };
 
         let method_name = if is_public || self.method_needs_export(func.name) {

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -1,12 +1,12 @@
 use crate::Planner;
 use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
-use crate::calls::effective_param_type;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::{CapturePolicy, StagedExpression};
 use crate::expressions::values::is_plain_go_call;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::calls::CallableOrigin;
 use crate::utils::observable_after_mutation;
 use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::types::Type;
@@ -145,7 +145,8 @@ impl Planner<'_> {
         if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
             return false;
         }
-        self.callee_definition(callee)
+        self.resolve_callee_definition(callee)
+            .1
             .is_some_and(|definition| definition.is_type_definition())
     }
 
@@ -228,7 +229,8 @@ impl Planner<'_> {
         if matches!(name, Some("Some" | "Ok" | "Err" | "None")) {
             return true;
         }
-        self.callee_definition(callee)
+        self.resolve_callee_definition(callee)
+            .1
             .is_some_and(|definition| definition.is_type_definition())
     }
 
@@ -312,7 +314,10 @@ impl Planner<'_> {
         if is_tagged_shape_fn_value(arg) {
             return None;
         }
-        if self.classify_go_fn_value(arg).is_some() {
+        if self
+            .resolve_callable_value(arg)
+            .is_some_and(|callee| matches!(callee.origin, CallableOrigin::GoInterop))
+        {
             return None;
         }
         let param_ty = param_ty?;
@@ -341,15 +346,20 @@ impl Planner<'_> {
         function: &Expression,
         args: &[Expression],
     ) -> Vec<StagedExpression> {
-        let fn_ty = function.get_type();
-        let formal_params: &[syntax::types::Type] =
-            fn_ty.as_function_type().map_or(&[], |f| &f.params);
-        let declared_params = self.callee_declared_params(function, args.len());
+        let params = self.resolve_callable_params(function, args.len());
         args.iter()
             .enumerate()
             .map(|(i, arg)| {
-                let declared = declared_params.and_then(|p| effective_param_type(i, p));
-                self.stage_prelude_arg(arg, declared, formal_params.get(i))
+                let param = params.get(i).or_else(|| {
+                    params
+                        .last()
+                        .filter(|param| param.instantiated.get_name() == Some("VarArgs"))
+                });
+                self.stage_prelude_arg(
+                    arg,
+                    param.and_then(|param| param.declared.as_ref()),
+                    param.map(|param| &param.instantiated),
+                )
             })
             .collect()
     }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -2,18 +2,17 @@ use crate::abi::is_tagged_shape_fn_value;
 use crate::expressions::access::struct_call::emit_struct_literal;
 use syntax::program::DefinitionBody;
 
-use crate::GoCallStrategy;
 use crate::Planner;
-use crate::abi::AbiShape;
+use crate::abi::callable::{AbiTransition, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::coercion::{Coercion, CoercionDirection};
-use crate::abi::transition::{emit_lisette_callback_wrapper, lower_callee_abi_wrapping};
-use crate::calls::CallBoundary;
+use crate::abi::transition::emit_lisette_callback_wrapper;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::emission::StagedExpression;
 use crate::is_order_sensitive;
 use crate::plan::bodies::{
     ExpressionStatementForm, ExpressionStatementPlan, LoweredBlock, LoweredStatement,
 };
+use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{ValuePlan, value_plan_from_statements};
 use crate::state::bindings::BindingValue;
 use syntax::ast::Expression;
@@ -26,21 +25,28 @@ impl Planner<'_> {
         expression: &Expression,
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
-        if let Some(strategy) = self.classify_go_fn_value(expression) {
-            if !self.go_fn_matches_lowered_slot(expression, &strategy, ctx) {
+        if let Some(callee) = self.resolve_callable_value(expression)
+            && matches!(callee.origin, CallableOrigin::GoInterop)
+        {
+            let abi = &callee.abi.result;
+            if !self.go_fn_matches_lowered_slot(expression, abi, ctx) {
                 let mut setup = Vec::new();
-                let value = if self.go_fn_needs_lowered_tuple_adapter(expression, ctx) {
+                let value = if self.go_fn_needs_lowered_tuple_adapter(expression, abi, ctx) {
                     self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression)
-                } else if let GoCallStrategy::Sentinel { value } = &strategy
+                } else if let CallableReturnAbi::Option {
+                    encoding: OptionReturnAbi::Sentinel(value),
+                    ..
+                } = abi
                     && !ctx.forces_tagged_go_function()
                 {
                     self.emit_go_fn_sentinel_adapter(&mut setup, expression, *value)
                 } else {
-                    self.emit_go_fn_wrapper(&mut setup, expression, &strategy)
+                    self.emit_go_fn_wrapper(&mut setup, expression, abi)
                 };
                 return value_plan_from_statements(setup, value);
             }
-        } else if self.is_go_array_return_value(expression) {
+        }
+        if self.is_go_array_return_value(expression) {
             let mut setup = Vec::new();
             let value = self.emit_array_return_wrapper(&mut setup, expression);
             return value_plan_from_statements(setup, value);
@@ -100,7 +106,7 @@ impl Planner<'_> {
     fn go_fn_matches_lowered_slot(
         &self,
         expression: &Expression,
-        strategy: &GoCallStrategy,
+        source: &CallableReturnAbi,
         ctx: ExpressionContext<'_>,
     ) -> bool {
         if ctx.forces_tagged_go_function() {
@@ -110,32 +116,17 @@ impl Planner<'_> {
         let Some(f) = fn_ty.as_function_type() else {
             return false;
         };
-        let Some(shape) = self.classify_direct_emission(&f.return_type) else {
-            return false;
-        };
-        if self.fallible_tuple_return(&f.return_type) {
-            return false;
-        }
-        shape.matches_go_strategy(strategy)
-    }
-
-    /// True for a `Result`/`Partial` whose ok-type is a multi-element tuple, which lowers to one bundled value.
-    fn fallible_tuple_return(&self, return_type: &Type) -> bool {
-        matches!(
-            self.classify_direct_emission(return_type),
-            Some(AbiShape::ResultTuple | AbiShape::PartialTuple)
-        ) && self
-            .facts
-            .peel_alias(return_type)
-            .ok_type()
-            .tuple_arity()
-            .is_some_and(|arity| arity >= 2)
+        let target = self
+            .classify_direct_emission(&f.return_type)
+            .unwrap_or_else(|| self.value_return_abi(&f.return_type));
+        source == &target
     }
 
     /// True when a tuple-ok fallible Go function value must be wrapped to match a lowered slot.
     fn go_fn_needs_lowered_tuple_adapter(
         &self,
         expression: &Expression,
+        source: &CallableReturnAbi,
         ctx: ExpressionContext<'_>,
     ) -> bool {
         if ctx.forces_tagged_go_function() {
@@ -145,7 +136,26 @@ impl Planner<'_> {
         let Some(f) = fn_ty.as_function_type() else {
             return false;
         };
-        self.fallible_tuple_return(&f.return_type)
+        let target = self
+            .classify_direct_emission(&f.return_type)
+            .unwrap_or_else(|| self.value_return_abi(&f.return_type));
+        matches!(
+            (source, target),
+            (
+                CallableReturnAbi::Result {
+                    payload: PayloadLayout::Flattened,
+                    ..
+                } | CallableReturnAbi::Partial {
+                    payload: PayloadLayout::Flattened,
+                },
+                CallableReturnAbi::Result {
+                    payload: PayloadLayout::Packed,
+                    ..
+                } | CallableReturnAbi::Partial {
+                    payload: PayloadLayout::Packed,
+                }
+            )
+        )
     }
 
     /// Plan a value-position leaf expression (one `plan_operand` does not lower
@@ -168,22 +178,25 @@ impl Planner<'_> {
                 let value = self.maybe_lower_tagged_fn_ref(&mut setup, expression, ty, raw, ctx);
                 value_plan_from_statements(setup, value)
             }
-            Expression::Call { ty, .. } => match self.classify_call(expression) {
-                CallBoundary::GoWrapped(strategy) => {
-                    self.lower_go_wrapped_call(expression, &strategy, ty)
+            Expression::Call { ty, .. } => {
+                let plan = self
+                    .plan_call(expression)
+                    .expect("plan_call yields Some for a Call expression");
+                match plan.result_transition {
+                    AbiTransition::Identity => {
+                        let (setup, value) = self.lower_call(expression, Some(ty), ctx);
+                        value_plan_from_statements(setup, value)
+                    }
+                    AbiTransition::WrapToTagged => {
+                        self.lower_abi_wrapped_call(expression, &plan.resolved.abi.result, ty)
+                    }
+                    AbiTransition::LowerFromTagged
+                    | AbiTransition::Reencode
+                    | AbiTransition::Incompatible => {
+                        unreachable!("call results target their Lisette value representation")
+                    }
                 }
-                CallBoundary::LoweredCallee(shape) => {
-                    self.require_stdlib();
-                    let (mut setup, call_str) = self.lower_call(expression, Some(ty), ctx);
-                    let (wrap, value) = lower_callee_abi_wrapping(self, &shape, &call_str, ty);
-                    setup.extend(wrap);
-                    value_plan_from_statements(setup, value)
-                }
-                CallBoundary::Plain => {
-                    let (setup, value) = self.lower_call(expression, Some(ty), ctx);
-                    value_plan_from_statements(setup, value)
-                }
-            },
+            }
             Expression::RawGo { text } => ValuePlan::Operand(text.clone()),
             Expression::Unit { .. } => ValuePlan::Operand("struct{}{}".to_string()),
             Expression::NoOp => ValuePlan::Operand(String::new()),

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -16,7 +16,6 @@ pub(crate) mod types;
 mod utils;
 
 pub(crate) use analyze::facts::EmitFacts;
-pub(crate) use calls::go_interop::GoCallStrategy;
 pub(crate) use context::lowering::{LineIndex, LoopContext, ReturnContext};
 pub(crate) use definitions::enum_layout::EnumLayout;
 pub(crate) use names::go_name;
@@ -40,6 +39,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
 use names::constraints::GenericConstraintTable;
 use output::imports::ImportBuilder;
@@ -63,7 +63,7 @@ pub struct EmitOptions {
 
 #[derive(Default)]
 pub(crate) struct GlobalEmitData {
-    pub(crate) go_call_strategies: HashMap<String, GoCallStrategy>,
+    pub(crate) go_callable_returns: HashMap<String, CallableReturnAbi>,
     pub(crate) exported_method_names: HashSet<String>,
     pub(crate) make_function_names: HashMap<String, String>,
 }
@@ -80,7 +80,7 @@ impl GlobalEmitData {
 
         for (key, definition) in definitions.iter() {
             let is_go = go_name::is_go_import(key);
-            globals.register_go_call_strategy(definitions, key, definition, is_go);
+            globals.register_go_callable_return(definitions, key, definition, is_go);
             globals.register_exported_methods(key, definition, is_go);
             globals.register_enum_make_functions(definition);
         }
@@ -88,7 +88,7 @@ impl GlobalEmitData {
         globals
     }
 
-    fn register_go_call_strategy(
+    fn register_go_callable_return(
         &mut self,
         definitions: &HashMap<Symbol, Definition>,
         key: &Symbol,
@@ -100,10 +100,10 @@ impl GlobalEmitData {
                 Type::Forall { body, .. } => body.as_ref(),
                 other => other,
             }
-            && let Some(strategy) =
+            && let Some(result) =
                 classify_go_return_type(definitions, &f.return_type, definition.go_hints())
         {
-            self.go_call_strategies.insert(key.to_string(), strategy);
+            self.go_callable_returns.insert(key.to_string(), result);
         }
     }
 
@@ -165,29 +165,55 @@ pub(crate) fn classify_go_return_type(
     definitions: &HashMap<Symbol, Definition>,
     return_ty: &Type,
     go_hints: &[String],
-) -> Option<GoCallStrategy> {
+) -> Option<CallableReturnAbi> {
+    let payload = || {
+        if return_ty
+            .ok_type()
+            .tuple_arity()
+            .is_some_and(|arity| arity >= 2)
+        {
+            PayloadLayout::Flattened
+        } else {
+            PayloadLayout::Packed
+        }
+    };
     if return_ty.is_partial() {
-        return Some(GoCallStrategy::Partial);
+        return Some(CallableReturnAbi::Partial { payload: payload() });
     }
     if return_ty.is_result() {
-        return Some(GoCallStrategy::Result);
+        return Some(CallableReturnAbi::Result {
+            bare_error: return_ty.ok_type().is_unit(),
+            payload: payload(),
+        });
     }
     if return_ty.is_option() {
         if let Some(value) = sentinel_hint(go_hints) {
-            return Some(GoCallStrategy::Sentinel { value });
+            return Some(CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Sentinel(value),
+                payload: PayloadLayout::Packed,
+            });
         }
         if !is_nullable_option(definitions, return_ty) {
-            return Some(GoCallStrategy::CommaOk);
+            return Some(CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload: payload(),
+            });
         }
         if go_hints.iter().any(|s| s == "comma_ok") {
-            return Some(GoCallStrategy::CommaOk);
+            return Some(CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                payload: payload(),
+            });
         }
-        return Some(GoCallStrategy::NullableReturn);
+        return Some(CallableReturnAbi::Option {
+            encoding: OptionReturnAbi::Nullable,
+            payload: PayloadLayout::Packed,
+        });
     }
     if let Some(arity) = return_ty.tuple_arity()
         && arity >= 2
     {
-        return Some(GoCallStrategy::Tuple { arity });
+        return Some(CallableReturnAbi::Tuple { arity });
     }
     None
 }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,18 +1,17 @@
-use crate::GoCallStrategy;
 use crate::Planner;
-use crate::abi::AbiShape;
+use crate::abi::callable::CallableReturnAbi;
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::tree_emitter::TreePlanner;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
-use crate::plan::calls::{CallPlan, CallReturnShape, CalleePlan};
+use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::state::bindings::BindingValue;
 use syntax::ast::{Expression, MatchArm, Pattern};
 use syntax::types::Type;
 
 struct FusedShape {
-    shape: AbiShape,
+    shape: CallableReturnAbi,
     nil_guard: Option<NilGuard>,
 }
 
@@ -100,25 +99,26 @@ impl Planner<'_> {
     /// The shape a match subject fuses against: lowered Lisette `Result` callees
     /// and single-value Go `(T, error)` calls. `None` keeps the lift-then-match
     /// path (Partial, Option, comma-ok, flattened multi-returns).
-    fn fusable_result_shape(&self, subject: &Expression, plan: &CallPlan) -> Option<FusedShape> {
-        let (shape, nil_guard) = match (&plan.callee, &plan.return_shape) {
-            (_, CallReturnShape::Lowered(shape)) => (shape.clone(), None),
-            (CalleePlan::GoInterop(GoCallStrategy::Result), _) => {
+    fn fusable_result_shape(
+        &self,
+        subject: &Expression,
+        plan: &CallPlan<'_>,
+    ) -> Option<FusedShape> {
+        let shape = plan.resolved.abi.result.clone();
+        let nil_guard = match &plan.resolved.origin {
+            CallableOrigin::GoInterop
+                if matches!(plan.resolved.abi.result, CallableReturnAbi::Result { .. }) =>
+            {
                 let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
                 if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
                     return None;
                 }
-                let shape = if ok_ty.is_unit() {
-                    AbiShape::BareError
-                } else {
-                    AbiShape::ResultTuple
-                };
-                (shape, self.result_nil_guard(&ok_ty))
+                self.result_nil_guard(&ok_ty)
             }
-            _ => return None,
+            CallableOrigin::GoInterop => return None,
+            _ => None,
         };
-        matches!(shape, AbiShape::ResultTuple | AbiShape::BareError)
-            .then_some(FusedShape { shape, nil_guard })
+        matches!(shape, CallableReturnAbi::Result { .. }).then_some(FusedShape { shape, nil_guard })
     }
 
     /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
@@ -143,8 +143,13 @@ impl Planner<'_> {
         let ok_name = ok_binding.filter(|n| *n != "_");
         let err_name = err_binding.filter(|n| *n != "_");
 
-        let need_val =
-            matches!(shape, AbiShape::ResultTuple) && (ok_name.is_some() || nil_guard.is_some());
+        let need_val = matches!(
+            shape,
+            CallableReturnAbi::Result {
+                bare_error: false,
+                ..
+            }
+        ) && (ok_name.is_some() || nil_guard.is_some());
         let val_var = need_val.then(|| {
             let v = self.fresh_var(Some("ret"));
             self.declare(&v);
@@ -157,12 +162,17 @@ impl Planner<'_> {
         let bind_line = match &val_var {
             Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
             None => match shape {
-                AbiShape::ResultTuple => format!("_, {} := {}\n", err_var, call_str),
-                AbiShape::BareError => format!("{} := {}\n", err_var, call_str),
-                AbiShape::PartialTuple
-                | AbiShape::CommaOk
-                | AbiShape::NullableReturn
-                | AbiShape::Tuple { .. } => unreachable!("rejected above"),
+                CallableReturnAbi::Result {
+                    bare_error: false, ..
+                } => format!("_, {} := {}\n", err_var, call_str),
+                CallableReturnAbi::Result {
+                    bare_error: true, ..
+                } => format!("{} := {}\n", err_var, call_str),
+                CallableReturnAbi::Tagged
+                | CallableReturnAbi::Direct
+                | CallableReturnAbi::Partial { .. }
+                | CallableReturnAbi::Option { .. }
+                | CallableReturnAbi::Tuple { .. } => unreachable!("rejected above"),
             },
         };
         statements.push(LoweredStatement::RawGo(bind_line));
@@ -212,12 +222,8 @@ impl Planner<'_> {
         Some(statements)
     }
 
-    fn fusable_partial(&self, subject: &Expression, plan: &CallPlan) -> bool {
-        let is_partial = matches!(
-            (&plan.callee, &plan.return_shape),
-            (_, CallReturnShape::Lowered(AbiShape::PartialTuple))
-                | (CalleePlan::GoInterop(GoCallStrategy::Partial), _)
-        );
+    fn fusable_partial(&self, subject: &Expression, plan: &CallPlan<'_>) -> bool {
+        let is_partial = matches!(plan.resolved.abi.result, CallableReturnAbi::Partial { .. });
         if !is_partial {
             return false;
         }
@@ -504,18 +510,21 @@ fn partial_both_bindings(arm: &MatchArm) -> Option<(&str, &str)> {
 
 /// True when an Ok arm has no value to bind: empty `Ok` or `Ok(())`,
 /// only meaningful under `BareError`.
-fn ok_arm_payload_is_omitted(arm: &MatchArm, shape: &AbiShape) -> bool {
+fn ok_arm_payload_is_omitted(arm: &MatchArm, shape: &CallableReturnAbi) -> bool {
     let Pattern::EnumVariant { fields, .. } = &arm.pattern else {
         return false;
     };
     match shape {
-        AbiShape::BareError => {
-            fields.is_empty() || matches!(fields.as_slice(), [Pattern::Unit { .. }])
+        CallableReturnAbi::Result {
+            bare_error: true, ..
+        } => fields.is_empty() || matches!(fields.as_slice(), [Pattern::Unit { .. }]),
+        CallableReturnAbi::Tagged
+        | CallableReturnAbi::Direct
+        | CallableReturnAbi::Result {
+            bare_error: false, ..
         }
-        AbiShape::ResultTuple
-        | AbiShape::PartialTuple
-        | AbiShape::CommaOk
-        | AbiShape::NullableReturn
-        | AbiShape::Tuple { .. } => false,
+        | CallableReturnAbi::Partial { .. }
+        | CallableReturnAbi::Option { .. }
+        | CallableReturnAbi::Tuple { .. } => false,
     }
 }

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -1,29 +1,42 @@
-use crate::GoCallStrategy;
 use crate::Planner;
-use crate::abi::AbiShape;
+use crate::abi::callable::{AbiTransition, CallableAbi, CallableParamAbi, CallableReturnAbi};
 use crate::calls::go_interop::go_qualified_name;
 use crate::calls::go_interop::is_go_receiver;
 use crate::expressions::staging::VariadicCombine;
 use crate::types::native::NativeGoType;
 use syntax::ast::Expression;
-use syntax::program::{CallKind, NativeTypeKind};
+use syntax::program::{CallKind, Definition, DotAccessKind, NativeTypeKind};
 use syntax::types::Type;
 
 #[derive(Debug)]
-pub(crate) struct CallPlan {
-    pub(crate) callee: CalleePlan,
-    pub(crate) return_shape: CallReturnShape,
+pub(crate) struct CallPlan<'a> {
+    pub(crate) resolved: ResolvedCallee<'a>,
+    pub(crate) arguments: Vec<ArgumentPlan>,
+    pub(crate) result_transition: AbiTransition,
     /// Call-level wrapping (variadic spread, array-return wrapper).
     pub(crate) wrapper: WrapperPlan,
 }
 
-/// AST-level `CallKind` plus emit-side classification.
+/// Canonical identity, signatures, and physical ABI for one callable.
 #[derive(Debug)]
-pub(crate) enum CalleePlan {
+pub(crate) struct ResolvedCallee<'a> {
+    pub(crate) id: Option<String>,
+    pub(crate) origin: CallableOrigin,
+    pub(crate) definition: Option<&'a Definition>,
+    pub(crate) instantiated: Type,
+    pub(crate) declared: Option<Type>,
+    pub(crate) receiver_offset: usize,
+    pub(crate) abi: CallableAbi,
+    pub(crate) is_prelude_dispatch: bool,
+}
+
+/// AST-level `CallKind` plus emit-side classification.
+#[derive(Debug, Clone)]
+pub(crate) enum CallableOrigin {
     /// Regular Lisette function or method call.
     Regular,
-    /// Go interop call. `strategy` describes argument/return handling.
-    GoInterop(GoCallStrategy),
+    /// Go interop call; `ResolvedCallee::abi` describes its physical boundary.
+    GoInterop,
     /// UFCS method call: `receiver.method()` where `method` is a free function.
     UfcsMethod,
     /// Native type constructor: `Channel.new(...)`, `Map.new(...)`.
@@ -40,23 +53,17 @@ pub(crate) enum CalleePlan {
     AssertType,
 }
 
-/// Return-shape adaptation at the call boundary (Go interop is encoded in
-/// `CalleePlan`).
-#[derive(Debug, Clone)]
-pub(crate) enum CallReturnShape {
-    /// No adaptation: rendered call result is used as-is.
-    Direct,
-    /// Lisette callee returns a lowered ABI shape.
-    Lowered(AbiShape),
-}
-
 /// Per-argument adaptation; first applicable wins.
 #[derive(Debug, Clone)]
 pub(crate) enum ArgumentPlan {
     /// No special adaptation beyond the final type coercion.
     Direct,
     /// Wrap a function value in a Go callback adapter (Go calls only).
-    GoCallbackAdapter(CallbackWrapperKind),
+    GoCallbackAdapter {
+        source: CallableReturnAbi,
+        target: CallableReturnAbi,
+        transition: AbiTransition,
+    },
     /// Adapt a lowered-return fn-value arg to the callee's expected shape.
     LoweredFnShapeAdapter,
     /// Nullable `Option` argument flowing into a Go-imported interface:
@@ -66,17 +73,6 @@ pub(crate) enum ArgumentPlan {
     GoPointerUnwrap,
     /// Lower a tagged Go-function value (prelude-dispatch arg).
     TaggedGoLowering,
-}
-
-/// Sub-variants of `ArgumentPlan::GoCallbackAdapter`. `Identity` is the
-/// no-op case where source and target callback ABIs already agree.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum CallbackWrapperKind {
-    /// Both arg and param callback returns are already lowered; pass through.
-    Identity,
-    /// Wrap the Lisette callback so its tagged returns marshal into the
-    /// callee's expected lowered ABI.
-    Wrap,
 }
 
 /// Call-level wrapping (variadic spread, Go-array return).
@@ -114,7 +110,7 @@ impl VariadicSpreadPlan {
     }
 }
 
-impl CallPlan {
+impl CallPlan<'_> {
     /// Derive a `VariadicCombine` from this plan, given the caller's
     /// `extra_leading` argument count (UFCS adds 1 for the implicit receiver).
     pub(crate) fn variadic_combine(&self, extra_leading: usize) -> Option<VariadicCombine> {
@@ -131,14 +127,16 @@ impl CallPlan {
     }
 }
 
-impl Planner<'_> {
+impl<'a> Planner<'a> {
     /// Build a `CallPlan` for the given expression. Returns `None` for
     /// non-Call expressions.
-    pub(crate) fn plan_call(&self, expression: &Expression) -> Option<CallPlan> {
+    pub(crate) fn plan_call(&self, expression: &Expression) -> Option<CallPlan<'a>> {
         let Expression::Call {
             expression: callee,
+            args,
             call_kind,
             spread,
+            ty,
             ..
         } = expression
         else {
@@ -148,41 +146,267 @@ impl Planner<'_> {
         let function = callee.unwrap_parens();
         let wrapper = self.plan_call_wrapper(function, (**spread).as_ref());
 
-        if let Some(strategy) = self.resolve_go_call_strategy(expression) {
-            return Some(CallPlan {
-                callee: CalleePlan::GoInterop(strategy),
-                return_shape: CallReturnShape::Direct,
-                wrapper,
-            });
-        }
+        let go_return = self.resolve_go_call_abi(expression);
 
         let kind = call_kind.filter(|_| !self.is_local_binding(function));
 
-        let callee_plan = match kind {
-            Some(CallKind::TupleStructConstructor) => CalleePlan::TupleStructConstructor,
-            Some(CallKind::AssertType) => CalleePlan::AssertType,
-            Some(CallKind::UfcsMethod) => CalleePlan::UfcsMethod,
-            Some(CallKind::NativeConstructor(kind)) => CalleePlan::NativeConstructor(kind),
-            Some(CallKind::NativeMethod(kind)) => CalleePlan::NativeMethod(kind),
-            Some(CallKind::NativeMethodIdentifier(kind)) => {
-                CalleePlan::NativeMethodIdentifier(kind)
+        let callee_plan = if is_go_callable(function) {
+            CallableOrigin::GoInterop
+        } else {
+            match kind {
+                Some(CallKind::TupleStructConstructor) => CallableOrigin::TupleStructConstructor,
+                Some(CallKind::AssertType) => CallableOrigin::AssertType,
+                Some(CallKind::UfcsMethod) => CallableOrigin::UfcsMethod,
+                Some(CallKind::NativeConstructor(kind)) => CallableOrigin::NativeConstructor(kind),
+                Some(CallKind::NativeMethod(kind)) => CallableOrigin::NativeMethod(kind),
+                Some(CallKind::NativeMethodIdentifier(kind)) => {
+                    CallableOrigin::NativeMethodIdentifier(kind)
+                }
+                Some(CallKind::ReceiverMethodUfcs { is_public }) => {
+                    CallableOrigin::ReceiverMethodUfcs { is_public }
+                }
+                None | Some(CallKind::Regular) => CallableOrigin::Regular,
             }
-            Some(CallKind::ReceiverMethodUfcs { is_public }) => {
-                CalleePlan::ReceiverMethodUfcs { is_public }
-            }
-            None | Some(CallKind::Regular) => CalleePlan::Regular,
         };
 
-        let return_shape = match self.classify_callee_abi(callee) {
-            Some(shape) => CallReturnShape::Lowered(shape),
-            None => CallReturnShape::Direct,
+        let resolved = self.resolve_callee(
+            function,
+            callee_plan.clone(),
+            go_return.as_ref(),
+            args.len(),
+        );
+        let callee_diverges = resolved
+            .instantiated
+            .get_function_ret()
+            .is_some_and(Type::is_never);
+        let result_transition = if callee_diverges {
+            AbiTransition::Identity
+        } else {
+            resolved
+                .abi
+                .result
+                .transition_to(&self.value_return_abi(ty))
         };
+        debug_assert_ne!(
+            result_transition,
+            AbiTransition::Incompatible,
+            "a typed call must preserve its logical result type"
+        );
+        let arguments = args
+            .iter()
+            .enumerate()
+            .map(|(index, argument)| {
+                let param = resolved.abi.param(index);
+                self.plan_argument(argument, &resolved, param)
+            })
+            .collect();
 
         Some(CallPlan {
-            callee: callee_plan,
-            return_shape,
+            resolved,
+            arguments,
+            result_transition,
             wrapper,
         })
+    }
+
+    fn resolve_callee(
+        &self,
+        function: &Expression,
+        origin: CallableOrigin,
+        go_return: Option<&CallableReturnAbi>,
+        arg_count: usize,
+    ) -> ResolvedCallee<'a> {
+        let (id, definition) = self.resolve_callee_definition(function);
+        let declared = definition.map(|definition| definition.ty().clone());
+        let instantiated = self
+            .facts
+            .resolve_to_function_type(function.get_type().unwrap_forall())
+            .unwrap_or_else(|| function.get_type().unwrap_forall().clone());
+        let declared_params = declared
+            .as_ref()
+            .and_then(|ty| ty.unwrap_forall().get_function_params());
+        let receiver_offset =
+            declared_params.map_or(0, |params| params.len().saturating_sub(arg_count));
+        let params = build_param_abi(&instantiated, declared_params, receiver_offset);
+        let result = match go_return {
+            Some(result) => result.clone(),
+            None => self
+                .classify_callee_abi(function, definition)
+                .unwrap_or_else(|| {
+                    instantiated
+                        .get_function_ret()
+                        .map(|return_ty| self.value_return_abi(return_ty))
+                        .unwrap_or(CallableReturnAbi::Direct)
+                }),
+        };
+        let is_prelude_dispatch = match function.unwrap_parens() {
+            Expression::DotAccess { expression, .. } => {
+                let receiver_ty = self.facts.strip_and_peel(&expression.get_type());
+                matches!(
+                    &receiver_ty,
+                    Type::Nominal { id, .. } if id.starts_with("prelude.")
+                ) || NativeGoType::from_type(&receiver_ty).is_some()
+            }
+            Expression::Identifier {
+                qualified: Some(qualified),
+                ..
+            } => qualified.starts_with("prelude."),
+            _ => false,
+        };
+
+        ResolvedCallee {
+            id,
+            origin,
+            definition,
+            instantiated,
+            declared,
+            receiver_offset,
+            abi: CallableAbi { params, result },
+            is_prelude_dispatch,
+        }
+    }
+
+    pub(crate) fn resolve_callable_value(
+        &self,
+        expression: &Expression,
+    ) -> Option<ResolvedCallee<'a>> {
+        let instantiated = self
+            .facts
+            .resolve_to_function_type(expression.get_type().unwrap_forall())?;
+        let params = instantiated.get_function_params()?;
+        let return_ty = instantiated.get_function_ret()?;
+        let go_return = self.resolve_go_callee_abi(expression, return_ty);
+        let origin = if is_go_callable(expression) {
+            CallableOrigin::GoInterop
+        } else {
+            CallableOrigin::Regular
+        };
+        Some(self.resolve_callee(expression, origin, go_return.as_ref(), params.len()))
+    }
+
+    pub(crate) fn resolve_callee_definition(
+        &self,
+        function: &Expression,
+    ) -> (Option<String>, Option<&'a Definition>) {
+        let primary = self.resolve_callee_id(function);
+        if let Some(id) = primary.as_deref()
+            && let Some(definition) = self.facts.definition(id)
+        {
+            return (primary, Some(definition));
+        }
+
+        match function.unwrap_parens() {
+            Expression::Identifier {
+                value, binding_id, ..
+            } if binding_id.is_none() => {
+                let qualified = self.facts.qualified_current(value);
+                if let Some(definition) = self.facts.definition(&qualified) {
+                    return (Some(qualified), Some(definition));
+                }
+                if let Some(definition) = self.facts.definition(value) {
+                    return (Some(value.to_string()), Some(definition));
+                }
+            }
+            Expression::DotAccess {
+                dot_access_kind:
+                    Some(
+                        DotAccessKind::StructField { .. }
+                        | DotAccessKind::TupleStructField { .. }
+                        | DotAccessKind::TupleElement,
+                    ),
+                ..
+            } => {}
+            Expression::DotAccess {
+                expression, member, ..
+            } => {
+                if let Expression::Identifier { value, .. } = expression.as_ref() {
+                    let module = self.module.module_for_alias(value).unwrap_or(value);
+                    let qualified = format!("{module}.{member}");
+                    if let Some(definition) = self.facts.definition(&qualified) {
+                        return (Some(qualified), Some(definition));
+                    }
+                    let local = self.facts.qualified_current_member(value, member);
+                    if let Some(definition) = self.facts.definition(&local) {
+                        return (Some(local), Some(definition));
+                    }
+                }
+                if let Expression::DotAccess {
+                    expression: inner,
+                    member: type_name,
+                    ..
+                } = expression.as_ref()
+                    && let Expression::Identifier { value: module, .. } = inner.as_ref()
+                {
+                    let module = self.module.module_for_alias(module).unwrap_or(module);
+                    let qualified = format!("{module}.{type_name}.{member}");
+                    if let Some(definition) = self.facts.definition(&qualified) {
+                        return (Some(qualified), Some(definition));
+                    }
+                }
+
+                let receiver = self.facts.strip_and_peel(&expression.get_type());
+                if let Some(native) = NativeGoType::from_type(&receiver) {
+                    let qualified = format!("prelude.{}.{}", native.lisette_name(), member);
+                    if let Some(definition) = self.facts.definition(&qualified) {
+                        return (Some(qualified), Some(definition));
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        (primary, None)
+    }
+
+    pub(crate) fn resolve_callable_params(
+        &self,
+        function: &Expression,
+        arg_count: usize,
+    ) -> Vec<CallableParamAbi> {
+        let (_, definition) = self.resolve_callee_definition(function);
+        let declared = definition.map(Definition::ty);
+        let declared_params = declared.and_then(|ty| ty.unwrap_forall().get_function_params());
+        let receiver_offset =
+            declared_params.map_or(0, |params| params.len().saturating_sub(arg_count));
+        let instantiated = self
+            .facts
+            .resolve_to_function_type(function.get_type().unwrap_forall())
+            .unwrap_or_else(|| function.get_type().unwrap_forall().clone());
+        build_param_abi(&instantiated, declared_params, receiver_offset)
+    }
+
+    fn resolve_callee_id(&self, function: &Expression) -> Option<String> {
+        match function.unwrap_parens() {
+            Expression::Identifier {
+                value,
+                qualified,
+                binding_id,
+                ..
+            } => qualified.as_deref().map(str::to_string).or_else(|| {
+                binding_id
+                    .is_none()
+                    .then(|| self.facts.qualified_current(value))
+            }),
+            Expression::DotAccess {
+                dot_access_kind:
+                    Some(
+                        DotAccessKind::StructField { .. }
+                        | DotAccessKind::TupleStructField { .. }
+                        | DotAccessKind::TupleElement,
+                    ),
+                ..
+            } => None,
+            Expression::DotAccess {
+                expression, member, ..
+            } => go_qualified_name(expression, member).or_else(|| {
+                let receiver = self.facts.strip_and_peel(&expression.get_type());
+                match receiver {
+                    Type::Nominal { id, .. } => Some(format!("{id}.{member}")),
+                    _ => None,
+                }
+            }),
+            _ => None,
+        }
     }
 
     /// Plan call-level wrapping. Detects variadic spread (if a trailing
@@ -209,7 +433,11 @@ impl Planner<'_> {
 
     /// Lowered shape of a callee. Type-driven, so it fires regardless of
     /// whether the callee is a direct ref, local, parameter, or field.
-    pub(crate) fn classify_callee_abi(&self, callee: &Expression) -> Option<AbiShape> {
+    fn classify_callee_abi(
+        &self,
+        callee: &Expression,
+        definition: Option<&Definition>,
+    ) -> Option<CallableReturnAbi> {
         let callee_ty = callee.get_type();
         let unwrapped = callee_ty.unwrap_forall();
         let resolved = self
@@ -264,19 +492,15 @@ impl Planner<'_> {
         {
             return None;
         }
-        let declared_return = self
-            .callee_definition(callee)
-            .and_then(|definition| definition.ty().unwrap_forall().get_function_ret());
+        let declared_return =
+            definition.and_then(|definition| definition.ty().unwrap_forall().get_function_ret());
         let classify_ty = declared_return.unwrap_or(f.return_type.as_ref());
 
         self.classify_direct_emission(classify_ty)
     }
 
     /// Resolve a Go-interop call's strategy.
-    pub(crate) fn resolve_go_call_strategy(
-        &self,
-        expression: &Expression,
-    ) -> Option<GoCallStrategy> {
+    pub(crate) fn resolve_go_call_abi(&self, expression: &Expression) -> Option<CallableReturnAbi> {
         let Expression::Call {
             expression: callee,
             ty,
@@ -286,8 +510,15 @@ impl Planner<'_> {
             return None;
         };
 
-        let inner = callee.unwrap_parens();
+        self.resolve_go_callee_abi(callee, ty)
+    }
 
+    fn resolve_go_callee_abi(
+        &self,
+        callee: &Expression,
+        return_ty: &Type,
+    ) -> Option<CallableReturnAbi> {
+        let inner = callee.unwrap_parens();
         if let Expression::DotAccess {
             expression: receiver_expression,
             member,
@@ -296,25 +527,51 @@ impl Planner<'_> {
             && is_go_receiver(receiver_expression)
         {
             if let Some(qualified_name) = go_qualified_name(receiver_expression, member)
-                && let Some(strategy) = self.facts.go_call_strategy(&qualified_name)
+                && let Some(result) = self.facts.go_callable_return(&qualified_name)
             {
-                return Some(strategy.clone());
+                return Some(result.clone());
             }
             let go_hints = go_qualified_name(receiver_expression, member)
                 .and_then(|name| self.facts.definition(name.as_str()))
                 .map(|d| d.go_hints())
                 .unwrap_or_default();
-            return self.facts.classify_go_return_type(ty, go_hints);
+            return self.facts.classify_go_return_type(return_ty, go_hints);
         }
 
         None
     }
 }
 
+fn build_param_abi(
+    instantiated: &Type,
+    declared: Option<&[Type]>,
+    receiver_offset: usize,
+) -> Vec<CallableParamAbi> {
+    instantiated
+        .get_function_params()
+        .unwrap_or(&[])
+        .iter()
+        .enumerate()
+        .map(|(index, instantiated)| CallableParamAbi {
+            instantiated: instantiated.clone(),
+            declared: declared
+                .and_then(|params| params.get(receiver_offset + index))
+                .cloned(),
+        })
+        .collect()
+}
+
 fn receiver_is_prelude_type(ty: &Type) -> bool {
     matches!(
         ty.strip_refs().unwrap_forall(),
         Type::Nominal { id, .. } if id.starts_with("prelude.")
+    )
+}
+
+fn is_go_callable(expression: &Expression) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::DotAccess { expression, .. } if is_go_receiver(expression)
     )
 }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,5 +1,5 @@
 use crate::Planner;
-use crate::calls::CallBoundary;
+use crate::abi::callable::AbiTransition;
 use crate::context::expression::ExpressionContext;
 use crate::plan::bodies::LoweredStatement;
 use syntax::ast::Expression;
@@ -157,16 +157,25 @@ impl Planner<'_> {
             {
                 self.plan_branching_as_operand_temp(expression, ty)
             }
-            Expression::Call { ty, .. } => match self.classify_call(expression) {
-                CallBoundary::Plain => {
-                    let (setup, value) = self.lower_call(expression, Some(ty), ctx);
-                    value_plan_from_statements(setup, value)
+            Expression::Call { ty, .. } => {
+                let plan = self
+                    .plan_call(expression)
+                    .expect("plan_call yields Some for a Call expression");
+                match plan.result_transition {
+                    AbiTransition::Identity => {
+                        let (setup, value) = self.lower_call(expression, Some(ty), ctx);
+                        value_plan_from_statements(setup, value)
+                    }
+                    AbiTransition::WrapToTagged => {
+                        self.lower_abi_wrapped_call(expression, &plan.resolved.abi.result, ty)
+                    }
+                    AbiTransition::LowerFromTagged
+                    | AbiTransition::Reencode
+                    | AbiTransition::Incompatible => {
+                        unreachable!("call results target their Lisette value representation")
+                    }
                 }
-                CallBoundary::GoWrapped(strategy) => {
-                    self.lower_go_wrapped_call(expression, &strategy, ty)
-                }
-                CallBoundary::LoweredCallee(_) => self.plan_operand_leaf(expression, ctx),
-            },
+            }
             _ => self.plan_operand_leaf(expression, ctx),
         }
     }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,12 +1,13 @@
 use crate::Planner;
+use crate::abi::callable::CallableReturnAbi;
 use crate::abi::coercion::{Coercion, CoercionDirection};
-use crate::calls::go_interop::{GoCallStrategy, WrapperTarget};
+use crate::calls::go_interop::WrapperTarget;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::Fallible;
 use crate::escape_reserved;
 use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
 use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
-use crate::plan::calls::CalleePlan;
+use crate::plan::calls::CallableOrigin;
 use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
 use syntax::types::Type;
@@ -308,14 +309,15 @@ impl Planner<'_> {
             return None;
         }
         let plan = self.plan_call(value)?;
-        let CalleePlan::GoInterop(strategy) = plan.callee else {
+        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop) {
             return None;
-        };
-        if matches!(strategy, GoCallStrategy::Tuple { .. }) {
+        }
+        if matches!(plan.resolved.abi.result, CallableReturnAbi::Tuple { .. }) {
             return None;
         }
         let target = WrapperTarget::Slot(&go_identifier);
-        let statements = self.lower_go_wrapped_call_to(value, &strategy, binding_ty, target)?;
+        let statements =
+            self.lower_abi_wrapped_call_to(value, &plan.resolved.abi.result, binding_ty, target)?;
         // `push_wrapper_slot` / `push_simple_wrapper_value` already declared
         // `go_identifier`; only the binding from the user-name still needs setup.
         self.scope.bind(identifier, go_identifier.as_ref());
@@ -530,13 +532,10 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             return false;
         };
 
-        let has_multi_return_go_strategy = matches!(
-            self.planner.plan_call(self.value),
-            Some(plan) if matches!(
-                &plan.callee,
-                CalleePlan::GoInterop(strategy) if strategy.is_multi_return()
-            )
-        );
+        let has_multi_return_go_strategy = self.planner.plan_call(self.value).is_some_and(|plan| {
+            matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+                && plan.resolved.abi.result.is_multi_return()
+        });
         has_multi_return_go_strategy
             && !self.value.get_type().is_result()
             && extract_simple_tuple_vars(&self.binding.pattern).is_some()

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1477,6 +1477,20 @@ fn main() {
 }
 
 #[test]
+fn local_callable_shadow_does_not_inherit_global_abi() {
+    let input = r#"
+fn apply(x: int) -> Result<int, error> { Ok(x) }
+
+fn main() {
+  let apply = |x: int| -> int { x + 1 }
+  let value = apply(1)
+  let _ = value
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn go_fn_value_if_binding_wrapping() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -855,6 +855,21 @@ fn main() {
 }
 
 #[test]
+fn interop_flattened_result_tuple_tail_repackages_payload() {
+    let input = r#"
+import "go:example.com/multi"
+
+fn load() -> Result<(string, int), error> {
+  multi.Load()
+}
+"#;
+    let typedef = r#"
+pub fn Load() -> Result<(string, int), error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/multi", typedef)]);
+}
+
+#[test]
 fn interop_array_return_defer() {
     let input = r#"
 import "go:crypto/sha256"

--- a/tests/spec/emit/snapshots/interop_flattened_result_tuple_tail_repackages_payload.snap
+++ b/tests/spec/emit/snapshots/interop_flattened_result_tuple_tail_repackages_payload.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/multi"
+  
+  fn load() -> Result<(string, int), error> {
+    multi.Load()
+  }
+---
+package main
+
+import (
+	"example.com/multi"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func load() (lisette.Tuple2[string, int], error) {
+	ret_1, ret_2, ret_3 := multi.Load()
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[string, int], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[string, int], error](ret_3)
+	} else {
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[string, int], error](tup_4)
+	}
+	if result_5.Tag == lisette.ResultOk {
+		return result_5.OkVal, nil
+	}
+	return *new(lisette.Tuple2[string, int]), result_5.ErrVal
+}

--- a/tests/spec/emit/snapshots/local_callable_shadow_does_not_inherit_global_abi.snap
+++ b/tests/spec/emit/snapshots/local_callable_shadow_does_not_inherit_global_abi.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn apply(x: int) -> Result<int, error> { Ok(x) }
+  
+  fn main() {
+    let apply = |x: int| -> int { x + 1 }
+    let value = apply(1)
+    let _ = value
+  }
+---
+package main
+
+func apply(x int) (int, error) {
+	return x, nil
+}
+
+func main() {
+	apply := func(x int) int {
+		return x + 1
+	}
+	value := apply(1)
+	_ = value
+}


### PR DESCRIPTION
Codegen until now described a callable's Go boundary through overlapping enums, that could disagree about the same call. Every callsite now consumes one `ResolvedCallee` carrying the callable's identity, signatures, and Go result contract, with a single `AbiTransition` describing how to adapt it.