### PR TITLE
refactor: model recursive Go slot layouts with provenance

### DIFF
--- a/crates/emit/src/abi/callable.rs
+++ b/crates/emit/src/abi/callable.rs
@@ -1,5 +1,7 @@
 use syntax::types::Type;
 
+use crate::abi::layout::{SlotOrigin, ValueLayout};
+
 /// How a logical tuple payload occupies a callable's physical Go result slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PayloadLayout {
@@ -104,6 +106,8 @@ pub(crate) enum AbiTransition {
 pub(crate) struct CallableParamAbi {
     pub(crate) instantiated: Type,
     pub(crate) declared: Option<Type>,
+    pub(crate) origin: SlotOrigin,
+    pub(crate) layout: ValueLayout,
 }
 
 /// Complete physical contract consumed by call lowering.
@@ -111,6 +115,7 @@ pub(crate) struct CallableParamAbi {
 pub(crate) struct CallableAbi {
     pub(crate) params: Vec<CallableParamAbi>,
     pub(crate) result: CallableReturnAbi,
+    pub(crate) return_layout: ValueLayout,
 }
 
 impl CallableAbi {

--- a/crates/emit/src/abi/catalog.rs
+++ b/crates/emit/src/abi/catalog.rs
@@ -1,0 +1,118 @@
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use syntax::program::{Definition, DefinitionBody};
+use syntax::types::{Symbol, Type};
+
+use crate::abi::callable::CallableReturnAbi;
+use crate::abi::layout::SlotOrigin;
+use crate::classify_go_return_type;
+use crate::names::go_name;
+
+#[derive(Debug, Default)]
+pub(crate) struct GoAbiCatalog {
+    callables: HashMap<String, GoCallableSlots>,
+    fields: HashMap<String, HashMap<String, GoSlotDescriptor>>,
+    imported_types: HashSet<String>,
+}
+
+#[derive(Debug)]
+struct GoCallableSlots {
+    parameters: Vec<GoSlotDescriptor>,
+    return_slot: GoSlotDescriptor,
+    return_abi: Option<CallableReturnAbi>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GoSlotDescriptor {
+    pub(crate) origin: SlotOrigin,
+    pub(crate) declared_type: Type,
+}
+
+impl GoAbiCatalog {
+    pub(crate) fn from_definitions(definitions: &HashMap<Symbol, Definition>) -> Self {
+        let mut catalog = Self::default();
+        for (qualified_name, definition) in definitions {
+            if !go_name::is_go_import(qualified_name) {
+                continue;
+            }
+            catalog.register_callable(definitions, qualified_name, definition);
+            catalog.register_fields(qualified_name, definition);
+        }
+        catalog
+    }
+
+    pub(crate) fn callable_parameter(
+        &self,
+        qualified_name: &str,
+        index: usize,
+    ) -> Option<&GoSlotDescriptor> {
+        self.callables.get(qualified_name)?.parameters.get(index)
+    }
+
+    pub(crate) fn callable_return_slot(&self, qualified_name: &str) -> Option<&GoSlotDescriptor> {
+        self.callables
+            .get(qualified_name)
+            .map(|callable| &callable.return_slot)
+    }
+
+    pub(crate) fn callable_return_abi(&self, qualified_name: &str) -> Option<&CallableReturnAbi> {
+        self.callables.get(qualified_name)?.return_abi.as_ref()
+    }
+
+    pub(crate) fn field(&self, owner: &str, field: &str) -> Option<&GoSlotDescriptor> {
+        self.fields.get(owner)?.get(field)
+    }
+
+    pub(crate) fn is_imported_type(&self, qualified_name: &str) -> bool {
+        self.imported_types.contains(qualified_name)
+    }
+
+    fn register_callable(
+        &mut self,
+        definitions: &HashMap<Symbol, Definition>,
+        qualified_name: &str,
+        definition: &Definition,
+    ) {
+        let Type::Function(function) = definition.ty().unwrap_forall() else {
+            return;
+        };
+        let parameters = function
+            .params
+            .iter()
+            .map(|parameter| GoSlotDescriptor {
+                origin: SlotOrigin::go_parameter(parameter),
+                declared_type: parameter.clone(),
+            })
+            .collect();
+        let return_slot = GoSlotDescriptor {
+            origin: SlotOrigin::go_return(&function.return_type),
+            declared_type: (*function.return_type).clone(),
+        };
+        let return_abi =
+            classify_go_return_type(definitions, &function.return_type, definition.go_hints());
+        self.callables.insert(
+            qualified_name.to_string(),
+            GoCallableSlots {
+                parameters,
+                return_slot,
+                return_abi,
+            },
+        );
+    }
+
+    fn register_fields(&mut self, qualified_name: &str, definition: &Definition) {
+        let DefinitionBody::Struct { fields, .. } = &definition.body else {
+            return;
+        };
+        self.imported_types.insert(qualified_name.to_string());
+        let slots = self.fields.entry(qualified_name.to_string()).or_default();
+        for field in fields {
+            slots.insert(
+                field.name.to_string(),
+                GoSlotDescriptor {
+                    origin: SlotOrigin::go_field(&field.ty),
+                    declared_type: field.ty.clone(),
+                },
+            );
+        }
+    }
+}

--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -4,66 +4,114 @@ use syntax::types::Type;
 use crate::Planner;
 use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
+use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::types::shape::NullableCollectionShape;
 
-pub(crate) struct Coercion {
+use super::layout::ValueLayout;
+
+pub(crate) struct CoercionPlan {
     kind: CoercionKind,
 }
 
-pub(crate) enum CoercionKind {
+enum CoercionKind {
     Identity,
     WrapAsInterface(AdapterPlan),
-    WrapNewtype {
-        ty: Type,
-    },
+    WrapNewtype { ty: Type },
+    Layout(LayoutBridge),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BridgeDirection {
+    ToGo,
+    FromGo,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LayoutBridge {
+    Identity,
     UnwrapNullableOption {
-        ty: Type,
+        option_type: Type,
+        target_payload: Box<ValueLayout>,
+        payload: Box<LayoutBridge>,
     },
     UnwrapPointerOption {
-        ty: Type,
-    },
-    UnwrapNullableCollection {
-        ty: Type,
-        shape: NullableCollectionShape,
+        option_type: Type,
+        target_payload: Box<ValueLayout>,
+        payload: Box<LayoutBridge>,
     },
     WrapNullableOption {
-        ty: Type,
+        option_type: Type,
+        source_payload: Box<ValueLayout>,
+        payload: Box<LayoutBridge>,
     },
     WrapPointerOption {
-        ty: Type,
+        option_type: Type,
+        source_payload: Box<ValueLayout>,
+        payload: Box<LayoutBridge>,
     },
-    WrapNullableCollection {
-        ty: Type,
-        shape: NullableCollectionShape,
+    Aggregate {
+        source: Box<ValueLayout>,
+        target: Box<ValueLayout>,
+        key: Option<Box<LayoutBridge>>,
+        element: Box<LayoutBridge>,
     },
 }
 
-#[derive(Clone, Copy)]
-pub(crate) enum CoercionDirection {
-    Internal,
-    ToGoBoundary,
-    FromGoBoundary,
+impl LayoutBridge {
+    pub(crate) fn is_identity(&self) -> bool {
+        matches!(self, Self::Identity)
+    }
+
+    pub(crate) fn direction(&self) -> Option<BridgeDirection> {
+        match self {
+            Self::Identity => None,
+            Self::UnwrapNullableOption { .. } | Self::UnwrapPointerOption { .. } => {
+                Some(BridgeDirection::ToGo)
+            }
+            Self::WrapNullableOption { .. } | Self::WrapPointerOption { .. } => {
+                Some(BridgeDirection::FromGo)
+            }
+            Self::Aggregate { key, element, .. } => key
+                .as_deref()
+                .and_then(LayoutBridge::direction)
+                .or_else(|| element.direction()),
+        }
+    }
 }
 
-impl Coercion {
-    pub(crate) fn resolve(
-        planner: &Planner,
-        from: &Type,
-        to: &Type,
-        direction: CoercionDirection,
-    ) -> Self {
-        let kind = match direction {
-            CoercionDirection::Internal => resolve_internal(planner, from, to),
-            CoercionDirection::ToGoBoundary => resolve_to_go(planner, from, to),
-            CoercionDirection::FromGoBoundary => resolve_from_go(planner, from),
+impl CoercionPlan {
+    pub(crate) fn internal(planner: &Planner<'_>, from: &Type, to: &Type) -> Self {
+        let kind = if let Some(plan) = planner.needs_adapter(from, to) {
+            CoercionKind::WrapAsInterface(plan)
+        } else if needs_newtype_wrap(planner, from, to) {
+            CoercionKind::WrapNewtype { ty: to.clone() }
+        } else {
+            CoercionKind::Identity
         };
         Self { kind }
     }
 
+    pub(crate) fn bridge(
+        planner: &Planner<'_>,
+        source: &ValueLayout,
+        target: &ValueLayout,
+    ) -> Self {
+        let bridge = resolve_layout_bridge(planner, source, target);
+        let kind = if bridge.is_identity() {
+            CoercionKind::Identity
+        } else {
+            CoercionKind::Layout(bridge)
+        };
+        Self { kind }
+    }
+
+    pub(crate) fn is_identity(&self) -> bool {
+        matches!(self.kind, CoercionKind::Identity)
+    }
+
     pub(crate) fn lower(
         self,
-        planner: &mut Planner,
+        planner: &mut Planner<'_>,
         value: String,
     ) -> (Vec<LoweredStatement>, String) {
         let mut statements = Vec::new();
@@ -77,25 +125,8 @@ impl Coercion {
                 let type_name = planner.go_type_string(&ty);
                 format!("{}({})", type_name, value)
             }
-            CoercionKind::UnwrapNullableOption { ty } => {
-                let inner = planner.go_type_string(&ty.ok_type());
-                planner.plan_option_projection(&mut statements, &value, "unwrap", &inner, false)
-            }
-            CoercionKind::UnwrapPointerOption { ty } => {
-                let ptr = format!("*{}", planner.go_type_string(&ty.ok_type()));
-                planner.plan_option_projection(&mut statements, &value, "ptr", &ptr, true)
-            }
-            CoercionKind::UnwrapNullableCollection { ty, shape } => {
-                planner.plan_collection_nullable_unwrap(&mut statements, &value, &ty, &shape)
-            }
-            CoercionKind::WrapNullableOption { ty } => {
-                planner.plan_nil_check_option_wrap(&mut statements, &value, &ty)
-            }
-            CoercionKind::WrapPointerOption { ty } => {
-                planner.plan_pointer_to_option_wrap(&mut statements, &value, &ty)
-            }
-            CoercionKind::WrapNullableCollection { ty, shape } => {
-                planner.plan_collection_nullable_wrap(&mut statements, &value, &ty, &shape)
+            CoercionKind::Layout(bridge) => {
+                planner.plan_layout_bridge(&mut statements, &value, &bridge)
             }
         };
         (statements, value)
@@ -113,90 +144,205 @@ impl Planner<'_> {
         let Some(target) = target_ty else {
             return emitted;
         };
-        let coercion = Coercion::resolve(
-            self,
-            &expression.get_type(),
-            target,
-            CoercionDirection::Internal,
-        );
+        let coercion = CoercionPlan::internal(self, &expression.get_type(), target);
         let (setup, value) = coercion.lower(self, emitted);
         output.push_str(&Renderer.render_setup(&setup));
         value
     }
 }
 
-fn resolve_internal(planner: &Planner, from: &Type, to: &Type) -> CoercionKind {
-    if let Some(plan) = planner.needs_adapter(from, to) {
-        CoercionKind::WrapAsInterface(plan)
-    } else if needs_newtype_wrap(planner, from, to) {
-        CoercionKind::WrapNewtype { ty: to.clone() }
-    } else {
-        CoercionKind::Identity
+fn resolve_layout_bridge(
+    planner: &Planner<'_>,
+    source: &ValueLayout,
+    target: &ValueLayout,
+) -> LayoutBridge {
+    if source.same_representation(target) {
+        return LayoutBridge::Identity;
     }
-}
 
-/// Option-related shape of a type at a Go boundary. Adding a new variant is
-/// a compile-time call to revisit every `match` against it.
-pub(crate) enum OptionShape {
-    Plain,
-    /// Lisette `Option<T>` where `T` is Go-nilable (interface, slice, pointer);
-    /// the Go side uses nil itself as the absence marker.
-    Nullable,
-    /// Lisette `Option<T>` where `T` is a Go non-nilable scalar; the Go side
-    /// uses `*T` and bridges nil ↔ `None`.
-    PointerBridged,
-    NullableCollection {
-        shape: NullableCollectionShape,
-    },
-}
+    use ValueLayout::{Array, Map, Named, NullableOption, PointerOption, Slice, TaggedOption};
 
-pub(crate) fn classify_option_shape(planner: &Planner, ty: &Type) -> OptionShape {
-    if planner.facts.is_nullable_option(ty) {
-        OptionShape::Nullable
-    } else if planner.is_non_nilable_option(ty) {
-        OptionShape::PointerBridged
-    } else if let Some(shape) = planner.nullable_collection_shape(ty) {
-        OptionShape::NullableCollection { shape }
-    } else {
-        OptionShape::Plain
-    }
-}
-
-fn resolve_to_go(planner: &Planner, from: &Type, to: &Type) -> CoercionKind {
-    use OptionShape::*;
-    if to.resolves_to_unknown() && from.is_option() {
-        return CoercionKind::Identity;
-    }
-    match classify_option_shape(planner, from) {
-        Plain => CoercionKind::Identity,
-        Nullable => CoercionKind::UnwrapNullableOption { ty: from.clone() },
-        // Only unwrap to `*T` when the Go side also expects `*T`. A
-        // pointer-bridged source against any other target stays tagged.
-        PointerBridged if matches!(classify_option_shape(planner, to), PointerBridged) => {
-            CoercionKind::UnwrapPointerOption { ty: from.clone() }
+    match (source, target) {
+        (
+            TaggedOption {
+                option_type,
+                payload: source_payload,
+            },
+            NullableOption {
+                payload: target_payload,
+                ..
+            },
+        ) => LayoutBridge::UnwrapNullableOption {
+            option_type: option_type.clone(),
+            target_payload: target_payload.clone(),
+            payload: Box::new(resolve_layout_bridge(
+                planner,
+                source_payload,
+                target_payload,
+            )),
+        },
+        (
+            TaggedOption {
+                option_type,
+                payload: source_payload,
+            },
+            PointerOption {
+                payload: target_payload,
+                ..
+            },
+        ) => LayoutBridge::UnwrapPointerOption {
+            option_type: option_type.clone(),
+            target_payload: target_payload.clone(),
+            payload: Box::new(resolve_layout_bridge(
+                planner,
+                source_payload,
+                target_payload,
+            )),
+        },
+        (
+            NullableOption {
+                payload: source_payload,
+                ..
+            },
+            TaggedOption {
+                option_type,
+                payload: target_payload,
+            },
+        ) => LayoutBridge::WrapNullableOption {
+            option_type: option_type.clone(),
+            source_payload: source_payload.clone(),
+            payload: Box::new(resolve_layout_bridge(
+                planner,
+                source_payload,
+                target_payload,
+            )),
+        },
+        (
+            PointerOption {
+                payload: source_payload,
+                ..
+            },
+            TaggedOption {
+                option_type,
+                payload: target_payload,
+            },
+        ) => LayoutBridge::WrapPointerOption {
+            option_type: option_type.clone(),
+            source_payload: source_payload.clone(),
+            payload: Box::new(resolve_layout_bridge(
+                planner,
+                source_payload,
+                target_payload,
+            )),
+        },
+        (
+            TaggedOption {
+                option_type,
+                payload: source_payload,
+            },
+            target,
+        ) if is_go_interface_slot(planner, target.logical_type()) => {
+            LayoutBridge::UnwrapNullableOption {
+                option_type: option_type.clone(),
+                target_payload: Box::new(target.clone()),
+                payload: Box::new(resolve_layout_bridge(planner, source_payload, target)),
+            }
         }
-        PointerBridged => CoercionKind::Identity,
-        NullableCollection { shape } => CoercionKind::UnwrapNullableCollection {
-            ty: from.clone(),
-            shape,
-        },
+        (
+            Slice {
+                element: source_element,
+                ..
+            },
+            Slice {
+                element: target_element,
+                ..
+            },
+        )
+        | (
+            Array {
+                element: source_element,
+                ..
+            },
+            Array {
+                element: target_element,
+                ..
+            },
+        ) => aggregate_bridge(
+            planner,
+            source,
+            target,
+            None,
+            source_element,
+            target_element,
+        ),
+        (
+            Map {
+                key: source_key,
+                value: source_value,
+                ..
+            },
+            Map {
+                key: target_key,
+                value: target_value,
+                ..
+            },
+        ) => aggregate_bridge(
+            planner,
+            source,
+            target,
+            Some((source_key, target_key)),
+            source_value,
+            target_value,
+        ),
+        (
+            Named {
+                underlying: source_underlying,
+                ..
+            },
+            target,
+        ) => resolve_layout_bridge(planner, source_underlying, target),
+        (
+            source,
+            Named {
+                underlying: target_underlying,
+                ..
+            },
+        ) => resolve_layout_bridge(planner, source, target_underlying),
+        _ => LayoutBridge::Identity,
     }
 }
 
-fn resolve_from_go(planner: &Planner, from: &Type) -> CoercionKind {
-    use OptionShape::*;
-    match classify_option_shape(planner, from) {
-        Plain => CoercionKind::Identity,
-        Nullable => CoercionKind::WrapNullableOption { ty: from.clone() },
-        PointerBridged => CoercionKind::WrapPointerOption { ty: from.clone() },
-        NullableCollection { shape } => CoercionKind::WrapNullableCollection {
-            ty: from.clone(),
-            shape,
-        },
+fn aggregate_bridge(
+    planner: &Planner<'_>,
+    source: &ValueLayout,
+    target: &ValueLayout,
+    key_layouts: Option<(&ValueLayout, &ValueLayout)>,
+    source_element: &ValueLayout,
+    target_element: &ValueLayout,
+) -> LayoutBridge {
+    let key = key_layouts
+        .map(|(source, target)| Box::new(resolve_layout_bridge(planner, source, target)));
+    let element = resolve_layout_bridge(planner, source_element, target_element);
+    if element.is_identity() && key.as_deref().is_none_or(LayoutBridge::is_identity) {
+        LayoutBridge::Identity
+    } else {
+        LayoutBridge::Aggregate {
+            source: Box::new(source.clone()),
+            target: Box::new(target.clone()),
+            key,
+            element: Box::new(element),
+        }
     }
 }
 
-fn needs_newtype_wrap(planner: &Planner, from: &Type, to: &Type) -> bool {
+fn is_go_interface_slot(planner: &Planner<'_>, ty: &Type) -> bool {
+    planner
+        .facts
+        .as_interface(ty)
+        .is_some_and(|id| go_name::is_go_import(&id))
+}
+
+fn needs_newtype_wrap(planner: &Planner<'_>, from: &Type, to: &Type) -> bool {
     if from == to {
         return false;
     }

--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -1,0 +1,495 @@
+use syntax::types::{CompoundKind, Type};
+
+use crate::Planner;
+use crate::abi::callable::CallableReturnAbi;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlotOrigin {
+    Lisette,
+    GoParameter,
+    GoReturn,
+    GoField,
+    GoAny,
+}
+
+impl SlotOrigin {
+    pub(crate) fn go_parameter(ty: &Type) -> Self {
+        Self::go_slot(Self::GoParameter, ty)
+    }
+
+    pub(crate) fn go_return(ty: &Type) -> Self {
+        Self::go_slot(Self::GoReturn, ty)
+    }
+
+    pub(crate) fn go_field(ty: &Type) -> Self {
+        Self::go_slot(Self::GoField, ty)
+    }
+
+    fn go_slot(origin: Self, ty: &Type) -> Self {
+        if ty.resolves_to_unknown() {
+            Self::GoAny
+        } else {
+            origin
+        }
+    }
+
+    fn nested(self) -> Self {
+        if matches!(self, Self::GoAny) {
+            Self::Lisette
+        } else {
+            self
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FunctionLayout {
+    pub(crate) parameters: Vec<ValueLayout>,
+    pub(crate) result: Box<ValueLayout>,
+    pub(crate) return_abi: CallableReturnAbi,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ValueLayout {
+    Plain(Type),
+    TaggedOption {
+        option_type: Type,
+        payload: Box<ValueLayout>,
+    },
+    NullableOption {
+        option_type: Type,
+        payload: Box<ValueLayout>,
+    },
+    PointerOption {
+        option_type: Type,
+        payload: Box<ValueLayout>,
+    },
+    Slice {
+        collection_type: Type,
+        element: Box<ValueLayout>,
+    },
+    Map {
+        collection_type: Type,
+        key: Box<ValueLayout>,
+        value: Box<ValueLayout>,
+    },
+    Array {
+        array_type: Type,
+        length: u64,
+        element: Box<ValueLayout>,
+    },
+    Function {
+        function_type: Type,
+        layout: FunctionLayout,
+    },
+    Tuple {
+        tuple_type: Type,
+        elements: Vec<ValueLayout>,
+    },
+    Named {
+        named_type: Type,
+        underlying: Box<ValueLayout>,
+    },
+}
+
+impl ValueLayout {
+    pub(crate) fn option_payload(&self) -> Option<&Self> {
+        match self {
+            Self::TaggedOption { payload, .. }
+            | Self::NullableOption { payload, .. }
+            | Self::PointerOption { payload, .. } => Some(payload),
+            Self::Named { underlying, .. } => underlying.option_payload(),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn same_representation(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Plain(_), Self::Plain(_)) => true,
+            (
+                Self::TaggedOption { payload: left, .. },
+                Self::TaggedOption { payload: right, .. },
+            )
+            | (
+                Self::NullableOption { payload: left, .. },
+                Self::NullableOption { payload: right, .. },
+            )
+            | (
+                Self::PointerOption { payload: left, .. },
+                Self::PointerOption { payload: right, .. },
+            )
+            | (Self::Slice { element: left, .. }, Self::Slice { element: right, .. })
+            | (
+                Self::Named {
+                    underlying: left, ..
+                },
+                Self::Named {
+                    underlying: right, ..
+                },
+            ) => left.same_representation(right),
+            (
+                Self::Array {
+                    length: left_length,
+                    element: left,
+                    ..
+                },
+                Self::Array {
+                    length: right_length,
+                    element: right,
+                    ..
+                },
+            ) => left_length == right_length && left.same_representation(right),
+            (
+                Self::Map {
+                    key: left_key,
+                    value: left_value,
+                    ..
+                },
+                Self::Map {
+                    key: right_key,
+                    value: right_value,
+                    ..
+                },
+            ) => {
+                left_key.same_representation(right_key)
+                    && left_value.same_representation(right_value)
+            }
+            (Self::Function { layout: left, .. }, Self::Function { layout: right, .. }) => {
+                left.return_abi == right.return_abi
+                    && left.parameters.len() == right.parameters.len()
+                    && left
+                        .parameters
+                        .iter()
+                        .zip(&right.parameters)
+                        .all(|(left, right)| left.same_representation(right))
+                    && left.result.same_representation(&right.result)
+            }
+            (
+                Self::Tuple { elements: left, .. },
+                Self::Tuple {
+                    elements: right, ..
+                },
+            ) => {
+                left.len() == right.len()
+                    && left
+                        .iter()
+                        .zip(right)
+                        .all(|(left, right)| left.same_representation(right))
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn logical_type(&self) -> &Type {
+        match self {
+            Self::Plain(ty)
+            | Self::TaggedOption {
+                option_type: ty, ..
+            }
+            | Self::NullableOption {
+                option_type: ty, ..
+            }
+            | Self::PointerOption {
+                option_type: ty, ..
+            }
+            | Self::Slice {
+                collection_type: ty,
+                ..
+            }
+            | Self::Map {
+                collection_type: ty,
+                ..
+            }
+            | Self::Array { array_type: ty, .. }
+            | Self::Function {
+                function_type: ty, ..
+            }
+            | Self::Tuple { tuple_type: ty, .. }
+            | Self::Named { named_type: ty, .. } => ty,
+        }
+    }
+
+    pub(crate) fn go_type(&self, planner: &Planner<'_>) -> String {
+        match self {
+            Self::NullableOption { payload, .. } => payload.go_type(planner),
+            Self::PointerOption { payload, .. } => format!("*{}", payload.go_type(planner)),
+            Self::Slice { element, .. } => format!("[]{}", element.go_type(planner)),
+            Self::Map { key, value, .. } => {
+                format!("map[{}]{}", key.go_type(planner), value.go_type(planner))
+            }
+            Self::Array {
+                length, element, ..
+            } => format!("[{length}]{}", element.go_type(planner)),
+            Self::Plain(ty)
+            | Self::TaggedOption {
+                option_type: ty, ..
+            }
+            | Self::Function {
+                function_type: ty, ..
+            }
+            | Self::Tuple { tuple_type: ty, .. }
+            | Self::Named { named_type: ty, .. } => planner.go_type_string(ty),
+        }
+    }
+}
+
+impl Planner<'_> {
+    pub(crate) fn field_slot_layout(
+        &self,
+        owner_type: &Type,
+        field: &str,
+        value_type: &Type,
+    ) -> Option<ValueLayout> {
+        let owner = self.resolve_nominal(owner_type)?;
+        let slot = self.facts.go_field(owner.id.as_str(), field)?;
+        Some(self.value_layout_with_declaration(value_type, slot.origin, &slot.declared_type))
+    }
+
+    pub(crate) fn is_go_abi_type(&self, ty: &Type) -> bool {
+        self.resolve_nominal(ty)
+            .is_some_and(|resolved| self.facts.is_go_imported_type(resolved.id.as_str()))
+    }
+
+    pub(crate) fn value_layout(&self, ty: &Type, origin: SlotOrigin) -> ValueLayout {
+        self.value_layout_with_hint(ty, origin, None)
+    }
+
+    pub(crate) fn value_layout_with_declaration(
+        &self,
+        ty: &Type,
+        origin: SlotOrigin,
+        declaration: &Type,
+    ) -> ValueLayout {
+        self.value_layout_with_hint(ty, origin, Some(declaration))
+    }
+
+    fn value_layout_with_hint(
+        &self,
+        ty: &Type,
+        origin: SlotOrigin,
+        declaration: Option<&Type>,
+    ) -> ValueLayout {
+        let resolved_declaration = declaration.map(|ty| self.facts.peel_alias(ty));
+        if resolved_declaration
+            .as_ref()
+            .is_some_and(is_opaque_layout_hint)
+        {
+            return self.value_layout_with_hint(ty, SlotOrigin::Lisette, None);
+        }
+
+        let resolved = self.facts.peel_alias(ty);
+        if resolved != *ty {
+            return ValueLayout::Named {
+                named_type: ty.clone(),
+                underlying: Box::new(self.value_layout_resolved(
+                    resolved,
+                    origin,
+                    resolved_declaration.as_ref(),
+                )),
+            };
+        }
+        self.value_layout_resolved(resolved, origin, resolved_declaration.as_ref())
+    }
+
+    fn value_layout_resolved(
+        &self,
+        ty: Type,
+        origin: SlotOrigin,
+        declaration: Option<&Type>,
+    ) -> ValueLayout {
+        if ty.is_option() {
+            let declared_payload = declaration.filter(|ty| ty.is_option()).map(Type::ok_type);
+            let payload = Box::new(self.value_layout_with_hint(
+                &ty.ok_type(),
+                origin.nested(),
+                declared_payload.as_ref(),
+            ));
+            return match origin {
+                SlotOrigin::Lisette | SlotOrigin::GoAny => ValueLayout::TaggedOption {
+                    option_type: ty,
+                    payload,
+                },
+                SlotOrigin::GoParameter | SlotOrigin::GoField
+                    if self.facts.is_nullable_option(&ty) =>
+                {
+                    ValueLayout::NullableOption {
+                        option_type: ty,
+                        payload,
+                    }
+                }
+                SlotOrigin::GoParameter | SlotOrigin::GoReturn | SlotOrigin::GoField
+                    if self.is_non_nilable_option(&ty) =>
+                {
+                    ValueLayout::PointerOption {
+                        option_type: ty,
+                        payload,
+                    }
+                }
+                SlotOrigin::GoReturn if self.facts.is_nullable_option(&ty) => {
+                    ValueLayout::NullableOption {
+                        option_type: ty,
+                        payload,
+                    }
+                }
+                SlotOrigin::GoParameter | SlotOrigin::GoReturn | SlotOrigin::GoField => {
+                    ValueLayout::TaggedOption {
+                        option_type: ty,
+                        payload,
+                    }
+                }
+            };
+        }
+
+        match &ty {
+            Type::Compound {
+                kind: kind @ (CompoundKind::Slice | CompoundKind::EnumeratedSlice),
+                args,
+            } => {
+                let Some(element) = args.first() else {
+                    return ValueLayout::Plain(ty);
+                };
+                ValueLayout::Slice {
+                    collection_type: ty.clone(),
+                    element: Box::new(self.value_layout_with_hint(
+                        element,
+                        origin.nested(),
+                        compound_hint(declaration, *kind, 0),
+                    )),
+                }
+            }
+            Type::Compound {
+                kind: CompoundKind::Map,
+                args,
+            } => {
+                let [key, value] = args.as_slice() else {
+                    return ValueLayout::Plain(ty);
+                };
+                ValueLayout::Map {
+                    collection_type: ty.clone(),
+                    key: Box::new(self.value_layout_with_hint(
+                        key,
+                        origin.nested(),
+                        compound_hint(declaration, CompoundKind::Map, 0),
+                    )),
+                    value: Box::new(self.value_layout_with_hint(
+                        value,
+                        origin.nested(),
+                        compound_hint(declaration, CompoundKind::Map, 1),
+                    )),
+                }
+            }
+            Type::Array { length, element } => ValueLayout::Array {
+                array_type: ty.clone(),
+                length: *length,
+                element: Box::new(self.value_layout_with_hint(
+                    element,
+                    origin.nested(),
+                    array_hint(declaration),
+                )),
+            },
+            Type::Tuple(elements) => ValueLayout::Tuple {
+                tuple_type: ty.clone(),
+                elements: elements
+                    .iter()
+                    .enumerate()
+                    .map(|(index, element)| {
+                        self.value_layout_with_hint(
+                            element,
+                            origin.nested(),
+                            tuple_hint(declaration, index),
+                        )
+                    })
+                    .collect(),
+            },
+            _ => {
+                if let Some(function_type) = self.facts.resolve_to_function_type(&ty) {
+                    let declared_function =
+                        declaration.and_then(|ty| self.facts.resolve_to_function_type(ty));
+                    let declared_parameters = declared_function
+                        .as_ref()
+                        .and_then(Type::get_function_params)
+                        .unwrap_or_default();
+                    let parameters = function_type
+                        .get_function_params()
+                        .unwrap_or_default()
+                        .iter()
+                        .enumerate()
+                        .map(|(index, parameter)| {
+                            self.value_layout_with_hint(
+                                parameter,
+                                origin.nested(),
+                                declared_parameters.get(index),
+                            )
+                        })
+                        .collect();
+                    let result_type = function_type
+                        .get_function_ret()
+                        .cloned()
+                        .unwrap_or(Type::Never);
+                    let declared_result =
+                        declared_function.as_ref().and_then(Type::get_function_ret);
+                    let result = Box::new(self.value_layout_with_hint(
+                        &result_type,
+                        origin.nested(),
+                        declared_result,
+                    ));
+                    let return_abi = self.callable_return_abi(&result_type);
+                    return ValueLayout::Function {
+                        function_type: ty,
+                        layout: FunctionLayout {
+                            parameters,
+                            result,
+                            return_abi,
+                        },
+                    };
+                }
+                if let Some(underlying) = self.get_newtype_underlying(&ty) {
+                    let declared_underlying =
+                        declaration.and_then(|ty| self.get_newtype_underlying(ty));
+                    return ValueLayout::Named {
+                        named_type: ty,
+                        underlying: Box::new(self.value_layout_with_hint(
+                            &underlying,
+                            origin.nested(),
+                            declared_underlying.as_ref(),
+                        )),
+                    };
+                }
+                ValueLayout::Plain(ty)
+            }
+        }
+    }
+}
+
+fn is_opaque_layout_hint(ty: &Type) -> bool {
+    ty.resolves_to_unknown()
+        || matches!(
+            ty.unwrap_forall(),
+            Type::Parameter(_) | Type::Var { .. } | Type::ReceiverPlaceholder
+        )
+}
+
+fn compound_hint(
+    declaration: Option<&Type>,
+    expected_kind: CompoundKind,
+    index: usize,
+) -> Option<&Type> {
+    let Type::Compound { kind, args } = declaration? else {
+        return None;
+    };
+    (*kind == expected_kind).then(|| args.get(index)).flatten()
+}
+
+fn array_hint(declaration: Option<&Type>) -> Option<&Type> {
+    let Type::Array { element, .. } = declaration? else {
+        return None;
+    };
+    Some(element)
+}
+
+fn tuple_hint(declaration: Option<&Type>, index: usize) -> Option<&Type> {
+    let Type::Tuple(elements) = declaration? else {
+        return None;
+    };
+    elements.get(index)
+}

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod callable;
+pub(crate) mod catalog;
 pub(crate) mod coercion;
+pub(crate) mod layout;
 pub(crate) mod transition;
 
 use crate::Planner;

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -11,6 +11,7 @@ use syntax::program::{
 use syntax::types::{Symbol, Type};
 
 use crate::abi::callable::CallableReturnAbi;
+use crate::abi::catalog::GoSlotDescriptor;
 use crate::classify_go_return_type;
 use crate::context::lowering::LineIndex;
 use crate::names::constraints::GenericConstraintTable;
@@ -259,7 +260,36 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn go_callable_return(&self, qualified_name: &str) -> Option<&CallableReturnAbi> {
-        self.globals.go_callable_returns.get(qualified_name)
+        self.globals
+            .go_abi_catalog
+            .callable_return_abi(qualified_name)
+    }
+
+    pub(crate) fn go_callable_parameter(
+        &self,
+        qualified_name: &str,
+        index: usize,
+    ) -> Option<&GoSlotDescriptor> {
+        self.globals
+            .go_abi_catalog
+            .callable_parameter(qualified_name, index)
+    }
+
+    pub(crate) fn go_callable_return_slot(
+        &self,
+        qualified_name: &str,
+    ) -> Option<&GoSlotDescriptor> {
+        self.globals
+            .go_abi_catalog
+            .callable_return_slot(qualified_name)
+    }
+
+    pub(crate) fn go_field(&self, owner: &str, field: &str) -> Option<&GoSlotDescriptor> {
+        self.globals.go_abi_catalog.field(owner, field)
+    }
+
+    pub(crate) fn is_go_imported_type(&self, qualified_name: &str) -> bool {
+        self.globals.go_abi_catalog.is_imported_type(qualified_name)
     }
 
     pub(crate) fn resolved_bound_type(&self, span: Span) -> Option<&'a Type> {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -207,12 +207,6 @@ impl Planner<'_> {
         let inner = ty.ok_type();
         self.facts.is_interface(&inner)
     }
-
-    pub(crate) fn is_go_nullable(&self, ty: &Type) -> bool {
-        self.facts.is_nullable_option(ty)
-            || self.is_non_nilable_option(ty)
-            || self.nullable_collection_shape(ty).is_some()
-    }
 }
 
 impl Planner<'_> {

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::NativeCallContext;
 use crate::Planner;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
 use crate::calls::native::native_method_lowers_to_plain_call;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
@@ -500,8 +500,7 @@ impl Planner<'_> {
             .enumerate()
         {
             let value_ty = arg.get_type();
-            let coercion =
-                Coercion::resolve(self, &value_ty, field_ty, CoercionDirection::Internal);
+            let coercion = CoercionPlan::internal(self, &value_ty, field_ty);
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             field_pairs.push((format!("F{}", i), coerced));

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -4,7 +4,9 @@ mod wrappers;
 pub(crate) use wrappers::{NilGuard, WrapperTarget};
 
 use crate::Planner;
-use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
+use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::SlotOrigin;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -14,20 +16,67 @@ use syntax::types::Type;
 
 impl Planner<'_> {
     /// Lower a raw callable result through its canonical physical ABI.
-    pub(crate) fn lower_abi_wrapped_call(
+    pub(crate) fn lower_go_abi_wrapped_call(
         &mut self,
         call_expression: &Expression,
-        abi: &CallableReturnAbi,
+        abi: &CallableAbi,
         result_ty: &Type,
     ) -> ValuePlan {
+        if let Some(bridge) = self.go_result_layout_bridge(abi, result_ty) {
+            let call = self.lower_call(call_expression, None, ExpressionContext::value());
+            return call.map_rendered_as_observable_computed(
+                |setup, call_string, _contains_deferred_evaluation| {
+                    let (bridge_setup, value) = bridge.lower(self, call_string);
+                    setup.extend(bridge_setup);
+                    GoExpression::opaque(value)
+                },
+            );
+        }
+
+        let payload_bridge = self.option_result_payload_bridge(abi, result_ty);
         let call_plan = self.lower_call(call_expression, None, ExpressionContext::value());
         call_plan.map_rendered_as_observable_computed(
             |setup, call_string, _contains_deferred_evaluation| {
-                let (wrap, value) = self.lower_abi_to_tagged(&call_string, abi, result_ty);
+                let (wrap, value) = if payload_bridge.is_some() {
+                    let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
+                        &call_string,
+                        &abi.result,
+                        result_ty,
+                        payload_bridge,
+                        WrapperTarget::FreshSlot,
+                    );
+                    (wrap, outcome.expect("wrapper produced no slot"))
+                } else {
+                    self.lower_abi_to_tagged(&call_string, &abi.result, result_ty)
+                };
                 setup.extend(wrap);
                 GoExpression::opaque(value)
             },
         )
+    }
+
+    pub(crate) fn go_result_layout_bridge(
+        &self,
+        abi: &CallableAbi,
+        result_ty: &Type,
+    ) -> Option<CoercionPlan> {
+        let target = self.value_layout(result_ty, SlotOrigin::Lisette);
+        match abi.result {
+            CallableReturnAbi::Direct => {}
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                ..
+            } => {
+                let source_payload = abi.return_layout.option_payload()?;
+                let target_payload = target.option_payload()?;
+                if source_payload.same_representation(target_payload) {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+        let bridge = CoercionPlan::bridge(self, &abi.return_layout, &target);
+        (!bridge.is_identity()).then_some(bridge)
     }
 
     pub(crate) fn lower_abi_wrapping(
@@ -35,6 +84,17 @@ impl Planner<'_> {
         call_str: &str,
         abi: &CallableReturnAbi,
         result_ty: &Type,
+        target: WrapperTarget<'_>,
+    ) -> (Vec<LoweredStatement>, Option<String>) {
+        self.lower_abi_wrapping_with_payload_bridge(call_str, abi, result_ty, None, target)
+    }
+
+    fn lower_abi_wrapping_with_payload_bridge(
+        &mut self,
+        call_str: &str,
+        abi: &CallableReturnAbi,
+        result_ty: &Type,
+        payload_bridge: Option<CoercionPlan>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, Option<String>) {
         match abi {
@@ -54,7 +114,9 @@ impl Planner<'_> {
             CallableReturnAbi::Option {
                 encoding: OptionReturnAbi::CommaOk,
                 payload,
-            } => self.lower_comma_ok_wrapping(call_str, result_ty, *payload, target),
+            } => {
+                self.lower_comma_ok_wrapping(call_str, result_ty, *payload, payload_bridge, target)
+            }
             CallableReturnAbi::Option {
                 encoding: OptionReturnAbi::Nullable,
                 ..
@@ -75,22 +137,44 @@ impl Planner<'_> {
     pub(crate) fn lower_abi_wrapped_call_to(
         &mut self,
         expression: &Expression,
-        abi: &CallableReturnAbi,
+        abi: &CallableAbi,
         result_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> Option<Vec<LoweredStatement>> {
         if matches!(
-            abi,
+            abi.result,
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct | CallableReturnAbi::Tuple { .. }
         ) {
             return None;
         }
+        let payload_bridge = self.option_result_payload_bridge(abi, result_ty);
         let (mut statements, call_str) = self
             .lower_call(expression, None, ExpressionContext::value())
             .into_parts();
-        let (wrap, _) = self.lower_abi_wrapping(&call_str, abi, result_ty, target);
+        let (wrap, _) = self.lower_abi_wrapping_with_payload_bridge(
+            &call_str,
+            &abi.result,
+            result_ty,
+            payload_bridge,
+            target,
+        );
         statements.extend(wrap);
         Some(statements)
+    }
+
+    fn option_result_payload_bridge(
+        &self,
+        abi: &CallableAbi,
+        result_ty: &Type,
+    ) -> Option<CoercionPlan> {
+        if !matches!(abi.result, CallableReturnAbi::Option { .. }) {
+            return None;
+        }
+        let source = abi.return_layout.option_payload()?;
+        let target_layout = self.value_layout(result_ty, SlotOrigin::Lisette);
+        let target = target_layout.option_payload()?;
+        let bridge = CoercionPlan::bridge(self, source, target);
+        (!bridge.is_identity()).then_some(bridge)
     }
 
     pub(crate) fn emit_go_call_discarded(

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,10 +1,11 @@
 use crate::Planner;
 use crate::abi::callable::PayloadLayout;
+use crate::abi::coercion::{BridgeDirection, CoercionPlan, LayoutBridge};
+use crate::abi::layout::ValueLayout;
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
-use crate::types::shape::{CollectionKind, NullableCollectionElement, NullableCollectionShape};
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -37,6 +38,7 @@ impl Planner<'_> {
         call_str: &str,
         option_ty: &Type,
         layout: PayloadLayout,
+        payload_bridge: Option<CoercionPlan>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         self.require_stdlib();
@@ -46,8 +48,9 @@ impl Planner<'_> {
         let inner_tuple_arity = inner_ty.tuple_arity();
         let needs_nilable_validation = self.facts.is_nullable_option(option_ty);
 
-        let needs_complex =
-            needs_nilable_validation || (layout.is_flattened() && inner_tuple_arity.is_some());
+        let needs_complex = payload_bridge.is_some()
+            || needs_nilable_validation
+            || (layout.is_flattened() && inner_tuple_arity.is_some());
 
         if !needs_complex {
             let inner_ty_str = self.go_type_string(&inner_ty);
@@ -85,6 +88,10 @@ impl Planner<'_> {
         } else {
             val_vars[0].clone()
         };
+        let (mut payload_setup, val_expression) = match payload_bridge {
+            Some(bridge) => bridge.lower(self, val_expression),
+            None => (Vec::new(), val_expression),
+        };
 
         let option_ty_str = {
             let mut fe = FalliblePlanner::new(self, &fallible);
@@ -111,10 +118,14 @@ impl Planner<'_> {
             fe.emit_failure(None)
         };
 
+        let mut then_body = leaf_block(&sink, &some_wrapper);
+        payload_setup.append(&mut then_body.statements);
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
             condition,
-            then_body: leaf_block(&sink, &some_wrapper),
+            then_body: LoweredBlock {
+                statements: payload_setup,
+            },
             else_arm: ElseArm::Else {
                 body: leaf_block(&sink, &none_wrapper),
                 inline: false,
@@ -209,151 +220,311 @@ impl Planner<'_> {
         outcome.expect("FreshSlot produces a slot")
     }
 
-    pub(crate) fn plan_collection_nullable_wrap(
+    pub(crate) fn plan_layout_bridge(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: &str,
+        bridge: &LayoutBridge,
+    ) -> String {
+        match bridge {
+            LayoutBridge::Identity => value.to_string(),
+            LayoutBridge::UnwrapNullableOption {
+                option_type,
+                target_payload,
+                payload,
+            } => {
+                if payload.is_identity() {
+                    let slot_type = target_payload.go_type(self);
+                    self.plan_option_projection(statements, value, "unwrap", &slot_type, false)
+                } else {
+                    self.plan_option_projection_with_bridge(
+                        statements,
+                        value,
+                        option_type,
+                        target_payload,
+                        payload,
+                        false,
+                    )
+                }
+            }
+            LayoutBridge::UnwrapPointerOption {
+                option_type,
+                target_payload,
+                payload,
+            } => {
+                if payload.is_identity() {
+                    let slot_type = format!("*{}", target_payload.go_type(self));
+                    self.plan_option_projection(statements, value, "ptr", &slot_type, true)
+                } else {
+                    self.plan_option_projection_with_bridge(
+                        statements,
+                        value,
+                        option_type,
+                        target_payload,
+                        payload,
+                        true,
+                    )
+                }
+            }
+            LayoutBridge::WrapNullableOption {
+                option_type,
+                source_payload,
+                payload,
+            } => {
+                if payload.is_identity() {
+                    self.plan_nil_check_option_wrap(statements, value, option_type)
+                } else {
+                    self.plan_option_wrap_with_bridge(
+                        statements,
+                        value,
+                        option_type,
+                        source_payload,
+                        payload,
+                        false,
+                    )
+                }
+            }
+            LayoutBridge::WrapPointerOption {
+                option_type,
+                source_payload,
+                payload,
+            } => {
+                if payload.is_identity() {
+                    self.plan_pointer_to_option_wrap(statements, value, option_type)
+                } else {
+                    self.plan_option_wrap_with_bridge(
+                        statements,
+                        value,
+                        option_type,
+                        source_payload,
+                        payload,
+                        true,
+                    )
+                }
+            }
+            LayoutBridge::Aggregate {
+                source,
+                target,
+                key,
+                element,
+            } => self.plan_aggregate_layout_bridge(
+                statements,
+                value,
+                source,
+                target,
+                key.as_deref(),
+                element,
+            ),
+        }
+    }
+
+    fn plan_option_projection_with_bridge(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        option_value: &str,
+        _option_type: &Type,
+        target_payload: &ValueLayout,
+        payload_bridge: &LayoutBridge,
+        address: bool,
+    ) -> String {
+        let option = self.hoist_tmp_value_statement(statements, "opt", option_value);
+        let target_type = target_payload.go_type(self);
+        let slot_type = if address {
+            format!("*{target_type}")
+        } else {
+            target_type
+        };
+        let slot_hint = if address { "ptr" } else { "unwrap" };
+        let slot = self.fresh_var(Some(slot_hint));
+        self.declare(&slot);
+        statements.push(LoweredStatement::VarDecl {
+            name: slot.clone(),
+            go_type: slot_type,
+            value: None,
+        });
+
+        let mut then_statements = Vec::new();
+        let payload = self.plan_layout_bridge(
+            &mut then_statements,
+            &format!("{}.SomeVal", option),
+            payload_bridge,
+        );
+        let payload = if address {
+            format!("&{payload}")
+        } else {
+            payload
+        };
+        then_statements.push(LoweredStatement::RawGo(format!("{slot} = {payload}\n")));
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: format!("{}.Tag == {}", option, OPTION_SOME_TAG),
+            then_body: LoweredBlock {
+                statements: then_statements,
+            },
+            else_arm: ElseArm::None,
+        }));
+        slot
+    }
+
+    fn plan_option_wrap_with_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         raw_value: &str,
-        collection_ty: &Type,
-        shape: &NullableCollectionShape,
+        option_type: &Type,
+        _source_payload: &ValueLayout,
+        payload_bridge: &LayoutBridge,
+        pointer: bool,
     ) -> String {
         self.require_stdlib();
-
-        let lisette_collection_ty = self.go_type_string(collection_ty);
-        let src_var = self.hoist_tmp_value_statement(statements, "src", raw_value);
-        let wrapped_var = self.plan_boundary_collection_dest(
-            statements,
-            shape.kind,
-            "wrapped",
-            &lisette_collection_ty,
-            &src_var,
-        );
-        let index_var = self.fresh_var(Some("i"));
-        self.declare(&index_var);
-        let val_var = self.fresh_var(Some("v"));
-        self.declare(&val_var);
-
-        let loop_body = match &shape.element {
-            NullableCollectionElement::Option(opt_ty) => {
-                let fallible = Fallible::from_type(opt_ty).expect("Option type expected");
-                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
-                let is_interface = self.is_interface_option(opt_ty);
-                let some_input = if is_pointer_bridged {
-                    format!("*{}", val_var)
-                } else {
-                    val_var.clone()
-                };
-                let some_wrapper = {
-                    let mut fe = FalliblePlanner::new(self, &fallible);
-                    fe.emit_success(&some_input)
-                };
-                let none_wrapper = {
-                    let mut fe = FalliblePlanner::new(self, &fallible);
-                    fe.emit_failure(None)
-                };
-                let condition = if is_interface {
-                    format!("!lisette.IsNilInterface({})", val_var)
-                } else {
-                    format!("{} != nil", val_var)
-                };
-                let then_body = LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(format!(
-                        "{}[{}] = {}\n",
-                        wrapped_var, index_var, some_wrapper
-                    ))],
-                };
-                let else_body = LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(format!(
-                        "{}[{}] = {}\n",
-                        wrapped_var, index_var, none_wrapper
-                    ))],
-                };
-                let if_plan = IfPlan {
-                    condition_setup: Vec::new(),
-                    condition,
-                    then_body,
-                    else_arm: ElseArm::Else {
-                        body: else_body,
-                        inline: false,
-                    },
-                };
-                LoweredBlock {
-                    statements: vec![LoweredStatement::If(if_plan)],
-                }
-            }
-            NullableCollectionElement::Nested(inner_shape) => {
-                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
-                let mut inner_statements = Vec::new();
-                let inner_var = self.plan_collection_nullable_wrap(
-                    &mut inner_statements,
-                    &val_var,
-                    &inner_lisette_ty,
-                    inner_shape,
-                );
-                inner_statements.push(LoweredStatement::RawGo(format!(
-                    "{}[{}] = {}\n",
-                    wrapped_var, index_var, inner_var
-                )));
-                LoweredBlock {
-                    statements: inner_statements,
-                }
-            }
+        let source = self.hoist_tmp_value_statement(statements, "raw", raw_value);
+        let fallible = Fallible::from_type(option_type).expect("Option type expected");
+        let option_type_string = {
+            let mut planner = FalliblePlanner::new(self, &fallible);
+            planner.full_type_string()
         };
+        let option = self.fresh_var(Some("option"));
+        self.declare(&option);
+        statements.push(LoweredStatement::VarDecl {
+            name: option.clone(),
+            go_type: option_type_string,
+            value: None,
+        });
 
+        let raw_payload = if pointer {
+            format!("*{source}")
+        } else {
+            source.clone()
+        };
+        let mut then_statements = Vec::new();
+        let payload = self.plan_layout_bridge(&mut then_statements, &raw_payload, payload_bridge);
+        let some = {
+            let mut planner = FalliblePlanner::new(self, &fallible);
+            planner.emit_success(&payload)
+        };
+        then_statements.push(LoweredStatement::RawGo(format!("{option} = {some}\n")));
+        let none = {
+            let mut planner = FalliblePlanner::new(self, &fallible);
+            planner.emit_failure(None)
+        };
+        let condition = if !pointer && self.is_interface_option(option_type) {
+            format!("!lisette.IsNilInterface({source})")
+        } else {
+            format!("{source} != nil")
+        };
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition,
+            then_body: LoweredBlock {
+                statements: then_statements,
+            },
+            else_arm: ElseArm::Else {
+                body: LoweredBlock {
+                    statements: vec![LoweredStatement::RawGo(format!("{option} = {none}\n"))],
+                },
+                inline: false,
+            },
+        }));
+        option
+    }
+
+    fn plan_aggregate_layout_bridge(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: &str,
+        source_layout: &ValueLayout,
+        target_layout: &ValueLayout,
+        key_bridge: Option<&LayoutBridge>,
+        element_bridge: &LayoutBridge,
+    ) -> String {
+        self.require_stdlib();
+        let source = self.hoist_tmp_value_statement(statements, "src", value);
+        let direction = key_bridge
+            .and_then(LayoutBridge::direction)
+            .or_else(|| element_bridge.direction())
+            .expect("aggregate layout bridge must contain an option bridge");
+        let output_hint = match direction {
+            BridgeDirection::ToGo => "unwrapped",
+            BridgeDirection::FromGo => "wrapped",
+        };
+        let target_type = target_layout.go_type(self);
+        let output = if matches!(target_layout, ValueLayout::Array { .. }) {
+            let output = self.fresh_var(Some(output_hint));
+            self.declare(&output);
+            statements.push(LoweredStatement::VarDecl {
+                name: output.clone(),
+                go_type: target_type,
+                value: None,
+            });
+            output
+        } else {
+            self.hoist_tmp_value_statement(
+                statements,
+                output_hint,
+                &format!("make({}, len({}))", target_type, source),
+            )
+        };
+        let index = self.fresh_var(Some("i"));
+        self.declare(&index);
+        let element = self.fresh_var(Some("v"));
+        self.declare(&element);
+        let mut key_statements = Vec::new();
+        let output_index = key_bridge.map_or_else(
+            || index.clone(),
+            |bridge| self.plan_layout_bridge(&mut key_statements, &index, bridge),
+        );
+        let mut body = self.plan_aggregate_element_bridge(
+            &output,
+            &output_index,
+            &element,
+            source_layout,
+            element_bridge,
+        );
+        if !key_statements.is_empty() {
+            key_statements.append(&mut body.statements);
+            body.statements = key_statements;
+        }
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
             label: None,
-            header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),
-            body: loop_body,
+            header: format!("for {index}, {element} := range {source} {{\n"),
+            body,
         }));
-
-        wrapped_var
+        output
     }
 
-    pub(crate) fn plan_collection_nullable_unwrap(
+    fn plan_aggregate_element_bridge(
         &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        lisette_value: &str,
-        collection_ty: &Type,
-        shape: &NullableCollectionShape,
-    ) -> String {
-        self.require_stdlib();
-        let raw_collection_ty = self.shape_raw_collection_ty(shape);
-
-        let src_var = self.hoist_tmp_value_statement(statements, "src", lisette_value);
-        let unwrapped_var = self.plan_boundary_collection_dest(
-            statements,
-            shape.kind,
-            "unwrapped",
-            &raw_collection_ty,
-            &src_var,
-        );
-        let index_var = self.fresh_var(Some("i"));
-        self.declare(&index_var);
-        let val_var = self.fresh_var(Some("v"));
-        self.declare(&val_var);
-
-        let loop_body = match &shape.element {
-            NullableCollectionElement::Option(opt_ty) => {
-                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
-                let is_map = matches!(shape.kind, CollectionKind::Map);
-                let emit_nil_else = is_map || is_pointer_bridged;
-                let some_assignment = if is_pointer_bridged {
-                    format!("&{}.SomeVal", val_var)
+        output: &str,
+        index: &str,
+        element: &str,
+        source_layout: &ValueLayout,
+        bridge: &LayoutBridge,
+    ) -> LoweredBlock {
+        match bridge {
+            LayoutBridge::UnwrapNullableOption { payload, .. }
+            | LayoutBridge::UnwrapPointerOption { payload, .. } => {
+                let pointer = matches!(bridge, LayoutBridge::UnwrapPointerOption { .. });
+                let mut then_statements = Vec::new();
+                let projected = format!("{element}.SomeVal");
+                let projected = if payload.is_identity() {
+                    projected
                 } else {
-                    format!("{}.SomeVal", val_var)
+                    self.plan_layout_bridge(&mut then_statements, &projected, payload)
                 };
-                let then_body = LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(format!(
-                        "{}[{}] = {}\n",
-                        unwrapped_var, index_var, some_assignment
-                    ))],
+                let projected = if pointer {
+                    format!("&{projected}")
+                } else {
+                    projected
                 };
-                let else_arm = if emit_nil_else {
+                then_statements.push(LoweredStatement::RawGo(format!(
+                    "{output}[{index}] = {projected}\n"
+                )));
+                let needs_nil_else = matches!(source_layout, ValueLayout::Map { .. }) || pointer;
+                let else_arm = if needs_nil_else {
                     ElseArm::Else {
                         body: LoweredBlock {
                             statements: vec![LoweredStatement::RawGo(format!(
-                                "{}[{}] = nil\n",
-                                unwrapped_var, index_var
+                                "{output}[{index}] = nil\n"
                             ))],
                         },
                         inline: false,
@@ -361,118 +532,89 @@ impl Planner<'_> {
                 } else {
                     ElseArm::None
                 };
-                let if_plan = IfPlan {
-                    condition_setup: Vec::new(),
-                    condition: format!("{}.Tag == {}", val_var, OPTION_SOME_TAG),
-                    then_body,
-                    else_arm,
-                };
                 LoweredBlock {
-                    statements: vec![LoweredStatement::If(if_plan)],
+                    statements: vec![LoweredStatement::If(IfPlan {
+                        condition_setup: Vec::new(),
+                        condition: format!("{element}.Tag == {OPTION_SOME_TAG}"),
+                        then_body: LoweredBlock {
+                            statements: then_statements,
+                        },
+                        else_arm,
+                    })],
                 }
             }
-            NullableCollectionElement::Nested(inner_shape) => {
-                let inner_lisette_ty = self.collection_element_ty(collection_ty, shape);
+            LayoutBridge::WrapNullableOption {
+                option_type,
+                payload,
+                ..
+            }
+            | LayoutBridge::WrapPointerOption {
+                option_type,
+                payload,
+                ..
+            } => {
+                let pointer = matches!(bridge, LayoutBridge::WrapPointerOption { .. });
+                let raw_payload = if pointer {
+                    format!("*{element}")
+                } else {
+                    element.to_string()
+                };
+                let mut then_statements = Vec::new();
+                let payload = if payload.is_identity() {
+                    raw_payload
+                } else {
+                    self.plan_layout_bridge(&mut then_statements, &raw_payload, payload)
+                };
+                let fallible = Fallible::from_type(option_type).expect("Option type expected");
+                let some = {
+                    let mut planner = FalliblePlanner::new(self, &fallible);
+                    planner.emit_success(&payload)
+                };
+                let none = {
+                    let mut planner = FalliblePlanner::new(self, &fallible);
+                    planner.emit_failure(None)
+                };
+                then_statements.push(LoweredStatement::RawGo(format!(
+                    "{output}[{index}] = {some}\n"
+                )));
+                let condition = if !pointer && self.is_interface_option(option_type) {
+                    format!("!lisette.IsNilInterface({element})")
+                } else {
+                    format!("{element} != nil")
+                };
+                LoweredBlock {
+                    statements: vec![LoweredStatement::If(IfPlan {
+                        condition_setup: Vec::new(),
+                        condition,
+                        then_body: LoweredBlock {
+                            statements: then_statements,
+                        },
+                        else_arm: ElseArm::Else {
+                            body: LoweredBlock {
+                                statements: vec![LoweredStatement::RawGo(format!(
+                                    "{output}[{index}] = {none}\n"
+                                ))],
+                            },
+                            inline: false,
+                        },
+                    })],
+                }
+            }
+            LayoutBridge::Aggregate { .. } => {
                 let mut inner_statements = Vec::new();
-                let inner_var = self.plan_collection_nullable_unwrap(
-                    &mut inner_statements,
-                    &val_var,
-                    &inner_lisette_ty,
-                    inner_shape,
-                );
+                let inner = self.plan_layout_bridge(&mut inner_statements, element, bridge);
                 inner_statements.push(LoweredStatement::RawGo(format!(
-                    "{}[{}] = {}\n",
-                    unwrapped_var, index_var, inner_var
+                    "{output}[{index}] = {inner}\n"
                 )));
                 LoweredBlock {
                     statements: inner_statements,
                 }
             }
-        };
-
-        statements.push(LoweredStatement::Loop(LoopPlan {
-            prologue: Vec::new(),
-            label: None,
-            header: format!("for {}, {} := range {} {{\n", index_var, val_var, src_var),
-            body: loop_body,
-        }));
-
-        unwrapped_var
-    }
-
-    /// Destination for a boundary-conversion loop: `make(...)` for slices and
-    /// maps, a zero-valued `var` for fixed arrays, which Go cannot `make`.
-    fn plan_boundary_collection_dest(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        kind: CollectionKind,
-        prefix: &str,
-        go_ty: &str,
-        src_var: &str,
-    ) -> String {
-        if matches!(kind, CollectionKind::Array { .. }) {
-            let var = self.fresh_var(Some(prefix));
-            self.declare(&var);
-            statements.push(LoweredStatement::VarDecl {
-                name: var.clone(),
-                go_type: go_ty.to_string(),
-                value: None,
-            });
-            var
-        } else {
-            self.hoist_tmp_value_statement(
-                statements,
-                prefix,
-                &format!("make({}, len({}))", go_ty, src_var),
-            )
-        }
-    }
-
-    /// Lisette element type of a collection: `Slice<X>` to `X`, `Map<K, V>` to
-    /// `V`, `Array<X, N>` to `X`.
-    fn collection_element_ty(&self, collection_ty: &Type, shape: &NullableCollectionShape) -> Type {
-        match self.emit_shape_ty(collection_ty) {
-            Type::Array { element, .. } => *element,
-            resolved => {
-                let params = resolved
-                    .get_type_params()
-                    .expect("native collection has type params");
-                let index = if matches!(shape.kind, CollectionKind::Map) {
-                    1
-                } else {
-                    0
-                };
-                params[index].clone()
-            }
-        }
-    }
-
-    /// Raw Go type for an unwrapped collection; walks the shape recursively so
-    /// nested options lower past the outer `[]` (e.g. to `[][]*T`).
-    fn shape_raw_collection_ty(&mut self, shape: &NullableCollectionShape) -> String {
-        let raw_element_ty = match &shape.element {
-            NullableCollectionElement::Option(opt_ty) => {
-                let is_pointer_bridged = self.is_non_nilable_option(opt_ty);
-                let inner_ty = opt_ty.ok_type();
-                let inner_ty_str = self.go_type_string(&inner_ty);
-                if is_pointer_bridged {
-                    format!("*{}", inner_ty_str)
-                } else {
-                    inner_ty_str
-                }
-            }
-            NullableCollectionElement::Nested(inner_shape) => {
-                self.shape_raw_collection_ty(inner_shape)
-            }
-        };
-        match shape.kind {
-            CollectionKind::Map => {
-                let key_ty_str = self
-                    .go_type_string(shape.key_ty.as_ref().expect("map shape carries a key type"));
-                format!("map[{}]{}", key_ty_str, raw_element_ty)
-            }
-            CollectionKind::Array { length } => format!("[{}]{}", length, raw_element_ty),
-            CollectionKind::Slice => format!("[]{}", raw_element_ty),
+            LayoutBridge::Identity => LoweredBlock {
+                statements: vec![LoweredStatement::RawGo(format!(
+                    "{output}[{index}] = {element}\n"
+                ))],
+            },
         }
     }
 }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -5,12 +5,12 @@ use crate::calls::dispatch::{
 
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableParamAbi, CallableReturnAbi};
-use crate::abi::coercion::{Coercion, CoercionDirection, OptionShape, classify_option_shape};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
 use crate::expressions::staging::VariadicCombine;
 use crate::names::generics::extract_type_mapping;
-use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
 use crate::plan::values::{
@@ -374,10 +374,8 @@ impl<'a> Planner<'a> {
 
     /// Classify and lower a single call argument: dispatch is plan-driven and
     /// returns typed setup. The plain `Direct` / `TaggedGoLowering` paths produce
-    /// typed `TempBind` setup; the remaining adapter paths (`GoCallbackAdapter`,
-    /// `LoweredFnShapeAdapter`, `NullableCoercion`, `GoPointerUnwrap`) capture
-    /// their string emission as a single `RawGo` until each is individually
-    /// converted.
+    /// typed `TempBind` setup; adapter and slot-bridge paths retain their own
+    /// structured setup until sequencing.
     fn lower_call_arg(
         &mut self,
         arg: &Expression,
@@ -413,14 +411,8 @@ impl<'a> Planner<'a> {
                     generic_param_ty.expect("LoweredFnShapeAdapter requires generic_param_ty"),
                 )
                 .expect("detect_lowered_fn_arg_shape ensures Some"),
-            ArgumentPlan::NullableCoercion => {
-                let arg_ty = arg.get_type();
-                self.lower_unwrap_go_nullable_arg(arg, &arg_ty)
-            }
-            ArgumentPlan::GoPointerUnwrap => self.lower_go_pointer_param_unwrap(
-                arg,
-                effective_param_ty.expect("GoPointerUnwrap requires effective_param_ty"),
-            ),
+            ArgumentPlan::GoSlotBridge => self
+                .lower_go_slot_bridge(arg, param.expect("GoSlotBridge requires a parameter ABI")),
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
@@ -464,18 +456,8 @@ impl<'a> Planner<'a> {
         {
             return ArgumentPlan::LoweredFnShapeAdapter;
         }
-        if self
-            .detect_nullable_coercion(arg, effective_param_ty)
-            .is_some()
-        {
-            return ArgumentPlan::NullableCoercion;
-        }
-        if matches!(callee.origin, CallableOrigin::GoInterop)
-            && self
-                .detect_go_pointer_param_unwrap(arg, effective_param_ty)
-                .is_some()
-        {
-            return ArgumentPlan::GoPointerUnwrap;
+        if param.is_some_and(|param| self.argument_needs_slot_bridge(arg, param)) {
+            return ArgumentPlan::GoSlotBridge;
         }
         let suppress = would_suppress_tagged_go(callee, declared_param_ty);
         if suppress
@@ -501,12 +483,7 @@ impl<'a> Planner<'a> {
         argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
             let final_value = match effective_param_ty {
                 Some(target) => {
-                    let coercion = Coercion::resolve(
-                        self,
-                        &arg.get_type(),
-                        target,
-                        CoercionDirection::Internal,
-                    );
+                    let coercion = CoercionPlan::internal(self, &arg.get_type(), target);
                     let (coercion_setup, coerced) = coercion.lower(self, value);
                     setup.extend(coercion_setup);
                     coerced
@@ -759,78 +736,48 @@ impl<'a> Planner<'a> {
         })
     }
 
-    /// Detect whether `arg`/`param_ty` form a Go pointer-param unwrap pair.
-    /// Bridges a Lisette `Option<T>` argument to Go's nil-accepting form when
-    /// the param and arg agree on an Option shape Go expresses as `*T`:
-    /// either both `Nullable` (`Option<Ref<T>>`) or both `PointerBridged`
-    /// (`Option<scalar>` produced by bindgen's `nilable_param` config).
-    /// Pure: no emission, callable from the planning layer.
-    pub(crate) fn detect_go_pointer_param_unwrap(
-        &self,
-        arg: &Expression,
-        effective_param_ty: Option<&Type>,
-    ) -> Option<()> {
-        let param_ty = effective_param_ty?;
-        let arg_ty = arg.get_type();
-        match (
-            classify_option_shape(self, param_ty),
-            classify_option_shape(self, &arg_ty),
-        ) {
-            (OptionShape::Nullable, OptionShape::Nullable)
-            | (OptionShape::PointerBridged, OptionShape::PointerBridged) => Some(()),
-            _ => None,
+    fn argument_slot_layout(&self, parameter: &CallableParamAbi) -> ValueLayout {
+        if parameter.instantiated.get_name() == Some("VarArgs") {
+            let slot_type = varargs_inner_or_self(&parameter.instantiated);
+            let declared_slot = parameter.declared.as_ref().map(varargs_inner_or_self);
+            declared_slot.as_ref().map_or_else(
+                || self.value_layout(&slot_type, parameter.origin),
+                |declared| {
+                    self.value_layout_with_declaration(&slot_type, parameter.origin, declared)
+                },
+            )
+        } else {
+            parameter.layout.clone()
         }
     }
 
-    fn lower_go_pointer_param_unwrap(&mut self, arg: &Expression, param_ty: &Type) -> ValuePlan {
-        if arg.is_none_literal() {
+    fn argument_needs_slot_bridge(
+        &self,
+        argument: &Expression,
+        parameter: &CallableParamAbi,
+    ) -> bool {
+        let source = self.value_layout(&argument.get_type(), SlotOrigin::Lisette);
+        let target = self.argument_slot_layout(parameter);
+        !CoercionPlan::bridge(self, &source, &target).is_identity()
+    }
+
+    fn lower_go_slot_bridge(
+        &mut self,
+        argument: &Expression,
+        parameter: &CallableParamAbi,
+    ) -> ValuePlan {
+        if argument.is_none_literal() {
             return ValuePlan::evaluated_literal(
                 Vec::new(),
                 "nil".to_string(),
                 EvaluationEffect::PureCall,
             );
         }
-        let arg_ty = arg.get_type();
-        let argument = self.lower_value(arg, ExpressionContext::value());
-        let coercion = Coercion::resolve(self, &arg_ty, param_ty, CoercionDirection::ToGoBoundary);
-        argument.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
-            let (coercion_setup, coerced) = coercion.lower(self, value);
-            setup.extend(coercion_setup);
-            GoExpression::opaque_with_deferred_evaluation(coerced, true)
-        })
-    }
-
-    /// Detect a nullable `Option` argument flowing into a Go-imported
-    /// interface param. Pure: no emission, callable from the planning layer.
-    pub(crate) fn detect_nullable_coercion(
-        &self,
-        arg: &Expression,
-        effective_param_ty: Option<&Type>,
-    ) -> Option<()> {
-        let param_ty = effective_param_ty?;
-        let arg_ty = arg.get_type();
-        let check_ty = varargs_inner_or_self(param_ty);
-
-        if !matches!(classify_option_shape(self, &arg_ty), OptionShape::Nullable) {
-            return None;
-        }
-        self.facts
-            .as_interface(&check_ty)
-            .is_some_and(|id| go_name::is_go_import(&id))
-            .then_some(())
-    }
-
-    fn lower_unwrap_go_nullable_arg(&mut self, arg: &Expression, arg_ty: &Type) -> ValuePlan {
-        if arg.is_none_literal() {
-            return ValuePlan::evaluated_literal(
-                Vec::new(),
-                "nil".to_string(),
-                EvaluationEffect::PureCall,
-            );
-        }
-        let argument = self.lower_value(arg, ExpressionContext::value());
-        let coercion = Coercion::resolve(self, arg_ty, arg_ty, CoercionDirection::ToGoBoundary);
-        argument.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
+        let source = self.value_layout(&argument.get_type(), SlotOrigin::Lisette);
+        let target = self.argument_slot_layout(parameter);
+        let coercion = CoercionPlan::bridge(self, &source, &target);
+        let value = self.lower_value(argument, ExpressionContext::value());
+        value.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             GoExpression::opaque_with_deferred_evaluation(coerced, true)

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -579,7 +579,7 @@ impl Planner<'_> {
             && !plan.resolved.abi.result.is_passthrough()
         {
             let (setup, result_var) = self
-                .lower_abi_wrapped_call(expression, &plan.resolved.abi.result, return_ty)
+                .lower_go_abi_wrapped_call(expression, &plan.resolved.abi, return_ty)
                 .into_parts();
             statements.extend(setup);
             if let Some(shape) = lowered {

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -5,7 +5,8 @@ use syntax::program::{
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::SlotOrigin;
 use crate::context::expression::ExpressionContext;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -81,6 +82,7 @@ impl Planner<'_> {
         if let Some(s) = self.plan_nullable_field_access(
             &mut setup,
             &expression_string,
+            member,
             &field,
             &expression_ty,
             result_ty,
@@ -211,21 +213,19 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression_string: &str,
+        member: &str,
         field: &str,
         expression_ty: &Type,
         result_ty: &Type,
     ) -> Option<String> {
-        if self.go_imported_shape(expression_ty).is_none() || !self.is_go_nullable(result_ty) {
+        let source_layout = self.field_slot_layout(expression_ty, member, result_ty)?;
+        let target_layout = self.value_layout(result_ty, SlotOrigin::Lisette);
+        let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
+        if coercion.is_identity() {
             return None;
         }
         let raw_access = format!("{}.{}", expression_string, field);
         let raw_var = self.hoist_tmp_value_statement(setup, "raw", &raw_access);
-        let coercion = Coercion::resolve(
-            self,
-            result_ty,
-            result_ty,
-            CoercionDirection::FromGoBoundary,
-        );
         let (coercion_setup, coerced) = coercion.lower(self, raw_var);
         setup.extend(coercion_setup);
         Some(coerced)

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -6,7 +6,8 @@ use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{CompoundKind, SimpleKind, Type, unqualified_name};
 
 use crate::Planner;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
 use crate::definitions::enum_layout;
 use crate::go_name;
@@ -47,7 +48,7 @@ impl Planner<'_> {
             )
         });
 
-        let is_go_struct = self.go_imported_shape(ty).is_some();
+        let is_go_struct = self.is_go_abi_type(ty);
         let kept = self.kept_struct_call_fields(field_assignments, spread, ty, is_go_struct);
 
         let stages: Vec<ValuePlan> = kept
@@ -74,12 +75,14 @@ impl Planner<'_> {
             value = self.wrap_recursive_enum_field(&mut setup, value, f, &ctx);
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
+            let field_layout =
+                self.field_slot_layout(ty, &f.name, field_ty.as_ref().unwrap_or(&value_ty));
             value = self.coerce_struct_field(
                 &mut setup,
                 value,
                 &value_ty,
                 field_ty.as_ref(),
-                is_go_struct,
+                field_layout.as_ref(),
             );
             field_names.push(field_name);
             field_values.push(value);
@@ -161,18 +164,17 @@ impl Planner<'_> {
         mut value: String,
         value_ty: &Type,
         field_ty: Option<&Type>,
-        is_go_struct: bool,
+        field_layout: Option<&ValueLayout>,
     ) -> String {
-        if is_go_struct {
-            let target_ty = field_ty.unwrap_or(value_ty);
-            let coercion =
-                Coercion::resolve(self, value_ty, target_ty, CoercionDirection::ToGoBoundary);
+        if let Some(field_layout) = field_layout {
+            let source_layout = self.value_layout(value_ty, SlotOrigin::Lisette);
+            let coercion = CoercionPlan::bridge(self, &source_layout, field_layout);
             let (coercion_setup, coerced) = coercion.lower(self, value);
             statements.extend(coercion_setup);
             value = coerced;
         }
         if let Some(field_ty) = field_ty {
-            let coercion = Coercion::resolve(self, value_ty, field_ty, CoercionDirection::Internal);
+            let coercion = CoercionPlan::internal(self, value_ty, field_ty);
             let (coercion_setup, coerced) = coercion.lower(self, value);
             statements.extend(coercion_setup);
             value = coerced;
@@ -315,37 +317,37 @@ impl Planner<'_> {
     }
 
     pub(crate) fn lisette_zero(&mut self, ty: &Type) -> String {
-        match ty {
-            Type::Simple(kind) => match kind {
+        let layout = self.value_layout(ty, SlotOrigin::Lisette);
+        match (ty, &layout) {
+            (Type::Simple(kind), _) => match kind {
                 SimpleKind::Bool => "false".to_string(),
                 SimpleKind::String => "\"\"".to_string(),
                 SimpleKind::Unit => "struct{}{}".to_string(),
                 _ => "0".to_string(),
             },
-            Type::Compound { kind, args } => match kind {
-                CompoundKind::Slice => {
-                    let inner = args
-                        .first()
-                        .map(|a| self.go_type_string(a))
-                        .unwrap_or_else(|| "any".to_string());
-                    format!("([]{})(nil)", inner)
-                }
-                CompoundKind::Map => {
-                    let key = args
-                        .first()
-                        .map(|a| self.go_type_string(a))
-                        .unwrap_or_else(|| "any".to_string());
-                    let val = args
-                        .get(1)
-                        .map(|a| self.go_type_string(a))
-                        .unwrap_or_else(|| "any".to_string());
-                    format!("map[{}]{}{{}}", key, val)
-                }
-                _ => format!("{}{{}}", self.go_type_string(ty)),
-            },
-            Type::Nominal { id, params, .. } => self.lisette_zero_nominal(ty, id.as_str(), params),
-            Type::Tuple(elements) => {
-                let parts: Vec<String> = elements.iter().map(|e| self.lisette_zero(e)).collect();
+            (
+                Type::Compound {
+                    kind: CompoundKind::Slice,
+                    ..
+                },
+                ValueLayout::Slice { element, .. },
+            ) => format!("([]{})(nil)", element.go_type(self)),
+            (
+                Type::Compound {
+                    kind: CompoundKind::Map,
+                    ..
+                },
+                ValueLayout::Map { key, value, .. },
+            ) => format!("map[{}]{}{{}}", key.go_type(self), value.go_type(self)),
+            (Type::Compound { .. }, _) => format!("{}{{}}", self.go_type_string(ty)),
+            (Type::Nominal { id, params, .. }, _) => {
+                self.lisette_zero_nominal(ty, id.as_str(), params)
+            }
+            (Type::Tuple(_), ValueLayout::Tuple { elements, .. }) => {
+                let parts: Vec<String> = elements
+                    .iter()
+                    .map(|element| self.lisette_zero(element.logical_type()))
+                    .collect();
                 self.require_stdlib();
                 format!(
                     "{}.MakeTuple{}({})",
@@ -354,7 +356,12 @@ impl Planner<'_> {
                     parts.join(", ")
                 )
             }
-            Type::Array { length, element } => self.array_zero(*length, element),
+            (
+                Type::Array { .. },
+                ValueLayout::Array {
+                    length, element, ..
+                },
+            ) => self.array_zero(*length, element.logical_type()),
             _ => format!("{}{{}}", self.go_type_string(ty)),
         }
     }

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::Planner;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
 use crate::context::expression::ExpressionContext;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use syntax::ast::{Expression, FormatStringPart, Literal};
@@ -91,12 +91,7 @@ impl Planner<'_> {
 
         let mut wrapped: Vec<String> = Vec::with_capacity(rendered.len());
         for (expr, emitted) in elements.iter().zip(rendered) {
-            let coercion = Coercion::resolve(
-                self,
-                &expr.get_type(),
-                &element_lisette_ty,
-                CoercionDirection::Internal,
-            );
+            let coercion = CoercionPlan::internal(self, &expr.get_type(), &element_lisette_ty);
             let (coercion_setup, coerced) = coercion.lower(self, emitted);
             setup.extend(coercion_setup);
             wrapped.push(coerced);

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -4,14 +4,15 @@ use syntax::program::DefinitionBody;
 
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::SlotOrigin;
 use crate::abi::transition::emit_lisette_callback_wrapper;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::plan::bodies::{
     ExpressionStatementForm, ExpressionStatementPlan, LoweredBlock, LoweredStatement,
 };
-use crate::plan::calls::CallableOrigin;
+use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, OperandForm, ValuePlan,
 };
@@ -79,6 +80,54 @@ impl Planner<'_> {
                 });
         }
         self.lower_value(expression, ctx)
+    }
+
+    pub(crate) fn lower_call_value(
+        &mut self,
+        expression: &Expression,
+        result_type: &Type,
+        context: ExpressionContext<'_>,
+    ) -> ValuePlan {
+        let plan = self
+            .plan_call(expression)
+            .expect("plan_call yields Some for a Call expression");
+        let layout_bridge = self.call_result_layout_bridge(&plan, result_type);
+
+        if let Some(bridge) = layout_bridge {
+            let call_type =
+                matches!(plan.result_transition, AbiTransition::Identity).then_some(result_type);
+            let call = self.lower_call(expression, call_type, context);
+            return call.map_rendered_as_observable_computed(
+                |setup, call_string, _contains_deferred_evaluation| {
+                    let (bridge_setup, value) = bridge.lower(self, call_string);
+                    setup.extend(bridge_setup);
+                    GoExpression::opaque(value)
+                },
+            );
+        }
+
+        match plan.result_transition {
+            AbiTransition::Identity => self.lower_call(expression, Some(result_type), context),
+            AbiTransition::WrapToTagged => {
+                self.lower_go_abi_wrapped_call(expression, &plan.resolved.abi, result_type)
+            }
+            AbiTransition::LowerFromTagged
+            | AbiTransition::Reencode
+            | AbiTransition::Incompatible => {
+                unreachable!("call results target their Lisette value representation")
+            }
+        }
+    }
+
+    pub(crate) fn call_result_layout_bridge(
+        &self,
+        plan: &CallPlan<'_>,
+        result_type: &Type,
+    ) -> Option<CoercionPlan> {
+        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop) {
+            return None;
+        }
+        self.go_result_layout_bridge(&plan.resolved.abi, result_type)
     }
 
     /// Wrap a captured tagged-shape prelude fn ref into a lowered-ABI closure
@@ -203,22 +252,7 @@ impl Planner<'_> {
                     })
                 }
             }
-            Expression::Call { ty, .. } => {
-                let plan = self
-                    .plan_call(expression)
-                    .expect("plan_call yields Some for a Call expression");
-                match plan.result_transition {
-                    AbiTransition::Identity => self.lower_call(expression, Some(ty), ctx),
-                    AbiTransition::WrapToTagged => {
-                        self.lower_abi_wrapped_call(expression, &plan.resolved.abi.result, ty)
-                    }
-                    AbiTransition::LowerFromTagged
-                    | AbiTransition::Reencode
-                    | AbiTransition::Incompatible => {
-                        unreachable!("call results target their Lisette value representation")
-                    }
-                }
-            }
+            Expression::Call { ty, .. } => self.lower_call_value(expression, ty, ctx),
             Expression::RawGo { text } => ValuePlan::opaque(text.clone()),
             Expression::Unit { .. } => ValuePlan::opaque("struct{}{}".to_string()),
             Expression::NoOp => ValuePlan::opaque(String::new()),
@@ -295,12 +329,7 @@ impl Planner<'_> {
         for (i, (expr, emitted)) in elements.iter().zip(element_expressions).enumerate() {
             let value = match slot_types.get(i) {
                 Some(slot) => {
-                    let coercion = Coercion::resolve(
-                        self,
-                        &expr.get_type(),
-                        slot,
-                        CoercionDirection::Internal,
-                    );
+                    let coercion = CoercionPlan::internal(self, &expr.get_type(), slot);
                     let (coercion_setup, coerced) = coercion.lower(self, emitted);
                     setup.extend(coercion_setup);
                     coerced
@@ -352,7 +381,7 @@ impl Planner<'_> {
 
         if self.facts.is_interface(ty) {
             let source_ty = expression.get_type();
-            let coercion = Coercion::resolve(self, &source_ty, ty, CoercionDirection::Internal);
+            let coercion = CoercionPlan::internal(self, &source_ty, ty);
             let mut converted =
                 inner.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
                     let (coercion_setup, coerced) = coercion.lower(self, value);
@@ -462,26 +491,28 @@ impl Planner<'_> {
 
         if let Expression::DotAccess {
             expression: receiver,
+            member,
             ty,
             ..
         } = target
-            && self.go_imported_shape(&receiver.get_type()).is_some()
-            && self.is_go_nullable(ty)
+            && let Some(target_layout) = self.field_slot_layout(&receiver.get_type(), member, ty)
         {
-            let coercion =
-                Coercion::resolve(self, &value.get_type(), ty, CoercionDirection::ToGoBoundary);
-            let (coercion_setup, unwrapped) = coercion.lower(self, rhs_value);
-            setup.extend(coercion_setup);
-            setup.push(LoweredStatement::RawGo(format!(
-                "{} = {}\n",
-                target_str, unwrapped
-            )));
-        } else {
-            setup.push(LoweredStatement::RawGo(format!(
-                "{} = {}\n",
-                target_str, rhs_value
-            )));
+            let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
+            let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
+            if !coercion.is_identity() {
+                let (coercion_setup, unwrapped) = coercion.lower(self, rhs_value);
+                setup.extend(coercion_setup);
+                setup.push(LoweredStatement::RawGo(format!(
+                    "{} = {}\n",
+                    target_str, unwrapped
+                )));
+                return setup;
+            }
         }
+        setup.push(LoweredStatement::RawGo(format!(
+            "{} = {}\n",
+            target_str, rhs_value
+        )));
         setup
     }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 
 use abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use abi::catalog::GoAbiCatalog;
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
 use names::constraints::GenericConstraintTable;
 use output::imports::ImportBuilder;
@@ -64,14 +65,17 @@ pub struct EmitOptions {
 
 #[derive(Default)]
 pub(crate) struct GlobalEmitData {
-    pub(crate) go_callable_returns: HashMap<String, CallableReturnAbi>,
+    pub(crate) go_abi_catalog: GoAbiCatalog,
     pub(crate) exported_method_names: HashSet<String>,
     pub(crate) make_function_names: HashMap<String, String>,
 }
 
 impl GlobalEmitData {
     fn compute(definitions: &HashMap<Symbol, Definition>) -> Self {
-        let mut globals = GlobalEmitData::default();
+        let mut globals = GlobalEmitData {
+            go_abi_catalog: GoAbiCatalog::from_definitions(definitions),
+            ..GlobalEmitData::default()
+        };
 
         for prelude_type in PreludeType::enum_types() {
             for (constructor, make_fn) in prelude_type.make_function_entries() {
@@ -81,31 +85,11 @@ impl GlobalEmitData {
 
         for (key, definition) in definitions.iter() {
             let is_go = go_name::is_go_import(key);
-            globals.register_go_callable_return(definitions, key, definition, is_go);
             globals.register_exported_methods(key, definition, is_go);
             globals.register_enum_make_functions(definition);
         }
 
         globals
-    }
-
-    fn register_go_callable_return(
-        &mut self,
-        definitions: &HashMap<Symbol, Definition>,
-        key: &Symbol,
-        definition: &Definition,
-        is_go: bool,
-    ) {
-        if is_go
-            && let Type::Function(f) = match definition.ty() {
-                Type::Forall { body, .. } => body.as_ref(),
-                other => other,
-            }
-            && let Some(result) =
-                classify_go_return_type(definitions, &f.return_type, definition.go_hints())
-        {
-            self.go_callable_returns.insert(key.to_string(), result);
-        }
     }
 
     fn register_exported_methods(&mut self, key: &Symbol, definition: &Definition, is_go: bool) {

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableAbi, CallableParamAbi, CallableReturnAbi};
+use crate::abi::layout::SlotOrigin;
 use crate::calls::go_interop::go_qualified_name;
 use crate::calls::go_interop::is_go_receiver;
 use crate::expressions::staging::VariadicCombine;
@@ -67,11 +68,8 @@ pub(crate) enum ArgumentPlan {
     },
     /// Adapt a lowered-return fn-value arg to the callee's expected shape.
     LoweredFnShapeAdapter,
-    /// Nullable `Option` argument flowing into a Go-imported interface:
-    /// unwrap the option and apply the Go-boundary coercion.
-    NullableCoercion,
-    /// Unwrap a Go pointer parameter at the call site (`&x` or `*x`).
-    GoPointerUnwrap,
+    /// Bridge the Lisette value layout to the parameter slot's physical layout.
+    GoSlotBridge,
     /// Lower a tagged Go-function value (prelude-dispatch arg).
     TaggedGoLowering,
 }
@@ -209,7 +207,14 @@ impl<'a> Planner<'a> {
             .and_then(|ty| ty.unwrap_forall().get_function_params());
         let receiver_offset =
             declared_params.map_or(0, |params| params.len().saturating_sub(arg_count));
-        let params = build_param_abi(&instantiated, declared_params, receiver_offset);
+        let params = build_param_abi(
+            self,
+            &instantiated,
+            declared_params,
+            receiver_offset,
+            id.as_deref(),
+            &origin,
+        );
         let result = match go_return {
             Some(result) => result.clone(),
             None => self
@@ -220,6 +225,23 @@ impl<'a> Planner<'a> {
                         .map(|return_ty| self.value_return_abi(return_ty))
                         .unwrap_or(CallableReturnAbi::Direct)
                 }),
+        };
+        let return_type = instantiated.get_function_ret().unwrap_or(&Type::Never);
+        let return_layout = if matches!(origin, CallableOrigin::GoInterop) {
+            id.as_deref()
+                .and_then(|id| self.facts.go_callable_return_slot(id))
+                .map(|slot| {
+                    self.value_layout_with_declaration(
+                        return_type,
+                        slot.origin,
+                        &slot.declared_type,
+                    )
+                })
+                .unwrap_or_else(|| {
+                    self.value_layout(return_type, SlotOrigin::go_return(return_type))
+                })
+        } else {
+            self.value_layout(return_type, SlotOrigin::Lisette)
         };
         let is_prelude_dispatch = match function.unwrap_parens() {
             Expression::DotAccess { expression, .. } => {
@@ -243,7 +265,11 @@ impl<'a> Planner<'a> {
             instantiated,
             declared,
             receiver_offset,
-            abi: CallableAbi { params, result },
+            abi: CallableAbi {
+                params,
+                result,
+                return_layout,
+            },
             is_prelude_dispatch,
         }
     }
@@ -345,7 +371,7 @@ impl<'a> Planner<'a> {
         function: &Expression,
         arg_count: usize,
     ) -> Vec<CallableParamAbi> {
-        let (_, definition) = self.resolve_callee_definition(function);
+        let (id, definition) = self.resolve_callee_definition(function);
         let declared = definition.map(Definition::ty);
         let declared_params = declared.and_then(|ty| ty.unwrap_forall().get_function_params());
         let receiver_offset =
@@ -354,7 +380,19 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(function.get_type().unwrap_forall())
             .unwrap_or_else(|| function.get_type().unwrap_forall().clone());
-        build_param_abi(&instantiated, declared_params, receiver_offset)
+        let origin = if is_go_callable(function) {
+            CallableOrigin::GoInterop
+        } else {
+            CallableOrigin::Regular
+        };
+        build_param_abi(
+            self,
+            &instantiated,
+            declared_params,
+            receiver_offset,
+            id.as_deref(),
+            &origin,
+        )
     }
 
     fn resolve_callee_id(&self, function: &Expression) -> Option<String> {
@@ -487,9 +525,12 @@ impl<'a> Planner<'a> {
             && is_go_receiver(receiver_expression)
         {
             if let Some(qualified_name) = go_qualified_name(receiver_expression, member)
-                && let Some(result) = self.facts.go_callable_return(&qualified_name)
+                && self
+                    .facts
+                    .go_callable_return_slot(&qualified_name)
+                    .is_some()
             {
-                return Some(result.clone());
+                return self.facts.go_callable_return(&qualified_name).cloned();
             }
             let go_hints = go_qualified_name(receiver_expression, member)
                 .and_then(|name| self.facts.definition(name.as_str()))
@@ -503,20 +544,57 @@ impl<'a> Planner<'a> {
 }
 
 fn build_param_abi(
+    planner: &Planner<'_>,
     instantiated: &Type,
     declared: Option<&[Type]>,
     receiver_offset: usize,
+    callee_id: Option<&str>,
+    callable_origin: &CallableOrigin,
 ) -> Vec<CallableParamAbi> {
     instantiated
         .get_function_params()
         .unwrap_or(&[])
         .iter()
         .enumerate()
-        .map(|(index, instantiated)| CallableParamAbi {
-            instantiated: instantiated.clone(),
-            declared: declared
+        .map(|(index, instantiated)| {
+            let declared = declared
                 .and_then(|params| params.get(receiver_offset + index))
-                .cloned(),
+                .cloned();
+            let catalog_slot = if matches!(callable_origin, CallableOrigin::GoInterop) {
+                callee_id.and_then(|id| {
+                    planner
+                        .facts
+                        .go_callable_parameter(id, receiver_offset + index)
+                })
+            } else {
+                None
+            };
+            let origin = catalog_slot.map_or_else(
+                || {
+                    if matches!(callable_origin, CallableOrigin::GoInterop) {
+                        SlotOrigin::go_parameter(declared.as_ref().unwrap_or(instantiated))
+                    } else {
+                        SlotOrigin::Lisette
+                    }
+                },
+                |slot| slot.origin,
+            );
+            let layout = catalog_slot
+                .map(|slot| {
+                    planner.value_layout_with_declaration(instantiated, origin, &slot.declared_type)
+                })
+                .or_else(|| {
+                    declared.as_ref().map(|declared| {
+                        planner.value_layout_with_declaration(instantiated, origin, declared)
+                    })
+                })
+                .unwrap_or_else(|| planner.value_layout(instantiated, origin));
+            CallableParamAbi {
+                instantiated: instantiated.clone(),
+                declared,
+                origin,
+                layout,
+            }
         })
         .collect()
 }

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,5 +1,4 @@
 use crate::Planner;
-use crate::abi::callable::AbiTransition;
 use crate::context::expression::ExpressionContext;
 use crate::plan::bodies::LoweredStatement;
 use std::fmt::{self, Display, Formatter};
@@ -711,22 +710,7 @@ impl Planner<'_> {
             {
                 self.plan_branching_as_operand_temp(expression, ty)
             }
-            Expression::Call { ty, .. } => {
-                let plan = self
-                    .plan_call(expression)
-                    .expect("plan_call yields Some for a Call expression");
-                match plan.result_transition {
-                    AbiTransition::Identity => self.lower_call(expression, Some(ty), ctx),
-                    AbiTransition::WrapToTagged => {
-                        self.lower_abi_wrapped_call(expression, &plan.resolved.abi.result, ty)
-                    }
-                    AbiTransition::LowerFromTagged
-                    | AbiTransition::Reencode
-                    | AbiTransition::Incompatible => {
-                        unreachable!("call results target their Lisette value representation")
-                    }
-                }
-            }
+            Expression::Call { ty, .. } => self.lower_call_value(expression, ty, ctx),
             _ => self.plan_operand_leaf(expression, ctx),
         }
     }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
 use crate::names::go_name;
@@ -41,13 +42,15 @@ impl Planner<'_> {
             };
         }
 
-        let go_field_ty: Option<Type> = match target {
-            Expression::DotAccess { expression, ty, .. }
-                if self.go_imported_shape(&expression.get_type()).is_some()
-                    && (self.is_go_nullable(ty) || ty.resolves_to_unknown()) =>
-            {
-                Some(ty.clone())
-            }
+        let go_field_slot: Option<(Type, ValueLayout)> = match target {
+            Expression::DotAccess {
+                expression,
+                member,
+                ty,
+                ..
+            } => self
+                .field_slot_layout(&expression.get_type(), member, ty)
+                .map(|layout| (ty.clone(), layout)),
             _ => None,
         };
 
@@ -57,20 +60,11 @@ impl Planner<'_> {
         let right_hand_side = self.stage_composite(value, ExpressionContext::value());
         let (target_capture, target_str) =
             self.capture_assignment_target(target, Some(&right_hand_side));
-        let coercion = if let Some(target_ty) = go_field_ty {
-            Coercion::resolve(
-                self,
-                &value.get_type(),
-                &target_ty,
-                CoercionDirection::ToGoBoundary,
-            )
+        let coercion = if let Some((_target_ty, target_layout)) = go_field_slot {
+            let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
+            CoercionPlan::bridge(self, &source_layout, &target_layout)
         } else {
-            Coercion::resolve(
-                self,
-                &value.get_type(),
-                &target.get_type(),
-                CoercionDirection::Internal,
-            )
+            CoercionPlan::internal(self, &value.get_type(), &target.get_type())
         };
         let value = right_hand_side.map_rendered_as_computed(
             |value_setup, rhs_value, contains_deferred_evaluation| {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
 use crate::abi::callable::CallableReturnAbi;
-use crate::abi::coercion::{Coercion, CoercionDirection};
+use crate::abi::coercion::CoercionPlan;
 use crate::calls::go_interop::WrapperTarget;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::Fallible;
@@ -253,12 +253,7 @@ impl Planner<'_> {
         let (mut statements, value_expression) = self
             .lower_value(value, ExpressionContext::value())
             .into_parts();
-        let coercion = Coercion::resolve(
-            self,
-            &value.get_type(),
-            binding_ty,
-            CoercionDirection::Internal,
-        );
+        let coercion = CoercionPlan::internal(self, &value.get_type(), binding_ty);
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
         statements.extend(coercion_setup);
 
@@ -315,9 +310,12 @@ impl Planner<'_> {
         if matches!(plan.resolved.abi.result, CallableReturnAbi::Tuple { .. }) {
             return None;
         }
+        if self.call_result_layout_bridge(&plan, binding_ty).is_some() {
+            return None;
+        }
         let target = WrapperTarget::Slot(&go_identifier);
         let statements =
-            self.lower_abi_wrapped_call_to(value, &plan.resolved.abi.result, binding_ty, target)?;
+            self.lower_abi_wrapped_call_to(value, &plan.resolved.abi, binding_ty, target)?;
         // `push_wrapper_slot` / `push_simple_wrapper_value` already declared
         // `go_identifier`; only the binding from the user-name still needs setup.
         self.scope.bind(identifier, go_identifier.as_ref());

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -1,11 +1,12 @@
 use crate::EmitEffects;
 use crate::Planner;
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::definitions::structs::struct_field_go_name;
 use crate::names::go_name;
 use crate::types::native::NativeGoType;
 use crate::types::prelude::PreludeType;
 use syntax::program::DefinitionBody;
-use syntax::types::Type;
+use syntax::types::{CompoundKind, SimpleKind, Type};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct GoType {
@@ -410,27 +411,44 @@ impl Planner<'_> {
         let go_ty = self.go_type(ty);
         effects.merge_from_go_type(&go_ty);
 
-        let value = match go_ty.code.as_str() {
-            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
-            | "uint32" | "uint64" | "uintptr" | "byte" | "rune" => "0".to_string(),
-            "float32" | "float64" => "0.0".to_string(),
-            "bool" => "false".to_string(),
-            "string" => "\"\"".to_string(),
-            "struct{}" => "struct{}{}".to_string(),
-            // `[N]E` (digit after `[`) zeroes to `[N]E{}`.
-            s if s.starts_with('[') && s.as_bytes().get(1).is_some_and(u8::is_ascii_digit) => {
-                format!("{}{{}}", s)
-            }
-            s if s.starts_with("[]")
-                || s.starts_with("map[")
-                || s.starts_with("chan ")
-                || s.starts_with("chan<-")
-                || s.starts_with("<-chan")
-                || s.starts_with("*")
-                || s.starts_with("func") =>
-            {
-                "nil".to_string()
-            }
+        let layout = self.value_layout(ty, SlotOrigin::Lisette);
+        let value = match layout {
+            ValueLayout::Plain(Type::Simple(kind)) => match kind {
+                SimpleKind::Int
+                | SimpleKind::Int8
+                | SimpleKind::Int16
+                | SimpleKind::Int32
+                | SimpleKind::Int64
+                | SimpleKind::Uint
+                | SimpleKind::Uint8
+                | SimpleKind::Uint16
+                | SimpleKind::Uint32
+                | SimpleKind::Uint64
+                | SimpleKind::Uintptr
+                | SimpleKind::Byte
+                | SimpleKind::Rune => "0".to_string(),
+                SimpleKind::Float32 | SimpleKind::Float64 => "0.0".to_string(),
+                SimpleKind::Bool => "false".to_string(),
+                SimpleKind::String => "\"\"".to_string(),
+                SimpleKind::Unit => "struct{}{}".to_string(),
+                SimpleKind::Complex64 | SimpleKind::Complex128 => {
+                    format!("*new({})", go_ty.code)
+                }
+            },
+            ValueLayout::Array { .. } => format!("{}{{}}", go_ty.code),
+            ValueLayout::Slice { .. }
+            | ValueLayout::Map { .. }
+            | ValueLayout::Function { .. }
+            | ValueLayout::NullableOption { .. }
+            | ValueLayout::PointerOption { .. }
+            | ValueLayout::Plain(Type::Compound {
+                kind:
+                    CompoundKind::Ref
+                    | CompoundKind::Channel
+                    | CompoundKind::Sender
+                    | CompoundKind::Receiver,
+                ..
+            }) => "nil".to_string(),
             _ => format!("*new({})", go_ty.code),
         };
         (value, effects)

--- a/crates/emit/src/types/shape.rs
+++ b/crates/emit/src/types/shape.rs
@@ -1,13 +1,11 @@
-use syntax::types::{CompoundKind, Symbol, Type};
+use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
-use crate::names::go_name;
 use crate::types::native::NativeGoType;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NativeShape {
     pub(crate) kind: NativeGoType,
-    pub(crate) params: Vec<Type>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,32 +15,6 @@ pub(crate) enum RangeShape {
     RangeFrom,
     RangeTo,
     RangeToInclusive,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct GoImportedShape {
-    #[allow(dead_code)]
-    pub(crate) id: Symbol,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CollectionKind {
-    Slice,
-    Map,
-    Array { length: u64 },
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct NullableCollectionShape {
-    pub(crate) kind: CollectionKind,
-    pub(crate) key_ty: Option<Type>,
-    pub(crate) element: NullableCollectionElement,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum NullableCollectionElement {
-    Option(Type),
-    Nested(Box<NullableCollectionShape>),
 }
 
 impl Planner<'_> {
@@ -65,13 +37,9 @@ impl Planner<'_> {
     /// only accepts `Type::Compound` shapes (not nominals whose leaf name
     /// happens to be `Slice`/`Map`/etc.) plus `SimpleKind::String`.
     pub(crate) fn native_shape(&self, ty: &Type) -> Option<NativeShape> {
-        self.native_shape_from_resolved(self.emit_shape_ty(ty))
-    }
-
-    /// `native_shape` on a type already resolved by `emit_shape_ty`.
-    fn native_shape_from_resolved(&self, resolved: Type) -> Option<NativeShape> {
+        let resolved = self.emit_shape_ty(ty);
         match resolved {
-            Type::Compound { kind, args } => {
+            Type::Compound { kind, .. } => {
                 let native = match kind {
                     CompoundKind::Slice => NativeGoType::Slice,
                     CompoundKind::EnumeratedSlice => NativeGoType::EnumeratedSlice,
@@ -81,14 +49,10 @@ impl Planner<'_> {
                     CompoundKind::Receiver => NativeGoType::Receiver,
                     CompoundKind::Ref | CompoundKind::VarArgs => return None,
                 };
-                Some(NativeShape {
-                    kind: native,
-                    params: args,
-                })
+                Some(NativeShape { kind: native })
             }
             Type::Simple(syntax::types::SimpleKind::String) => Some(NativeShape {
                 kind: NativeGoType::String,
-                params: Vec::new(),
             }),
             _ => None,
         }
@@ -115,86 +79,5 @@ impl Planner<'_> {
             "prelude.RangeToInclusive" => Some(RangeShape::RangeToInclusive),
             _ => None,
         }
-    }
-
-    /// Classify a type as a Go-imported nominal after alias peeling.
-    /// `type MyFlag = flag.Flag` and `Ref<MyFlag>` both match.
-    pub(crate) fn go_imported_shape(&self, ty: &Type) -> Option<GoImportedShape> {
-        let resolved = self.emit_shape_ty(ty);
-        let Type::Nominal { id, .. } = resolved else {
-            return None;
-        };
-        if go_name::is_go_import(id.as_str()) {
-            Some(GoImportedShape { id })
-        } else {
-            None
-        }
-    }
-
-    /// Classify a type as a nullable collection (`Slice<Option<...>>`,
-    /// `Map<K, Option<...>>`, or `Array<Option<...>, N>`) after alias peeling.
-    /// Element option types are also alias-aware via the inner option
-    /// classifier. Nested collections (e.g. `Slice<Slice<Option<T>>>`) are
-    /// detected recursively.
-    pub(crate) fn nullable_collection_shape(&self, ty: &Type) -> Option<NullableCollectionShape> {
-        match self.emit_shape_ty(ty) {
-            Type::Array { length, element } => {
-                let element = self.classify_nullable_element(&element)?;
-                Some(NullableCollectionShape {
-                    kind: CollectionKind::Array { length },
-                    key_ty: None,
-                    element,
-                })
-            }
-            resolved => {
-                let shape = self.native_shape_from_resolved(resolved)?;
-                match shape.kind {
-                    NativeGoType::Slice => {
-                        let element_ty = shape.params.into_iter().next()?;
-                        let element = self.classify_nullable_element(&element_ty)?;
-                        Some(NullableCollectionShape {
-                            kind: CollectionKind::Slice,
-                            key_ty: None,
-                            element,
-                        })
-                    }
-                    NativeGoType::Map => {
-                        let mut iter = shape.params.into_iter();
-                        let key_ty = iter.next()?;
-                        let val_ty = iter.next()?;
-                        let element = self.classify_nullable_element(&val_ty)?;
-                        Some(NullableCollectionShape {
-                            kind: CollectionKind::Map,
-                            key_ty: Some(key_ty),
-                            element,
-                        })
-                    }
-                    _ => None,
-                }
-            }
-        }
-    }
-
-    fn classify_nullable_element(&self, element_ty: &Type) -> Option<NullableCollectionElement> {
-        if let Some(opt) = self.pointer_bridged_option_ty(element_ty) {
-            return Some(NullableCollectionElement::Option(opt));
-        }
-        let nested = self.nullable_collection_shape(element_ty)?;
-        Some(NullableCollectionElement::Nested(Box::new(nested)))
-    }
-
-    fn pointer_bridged_option_ty(&self, ty: &Type) -> Option<Type> {
-        let resolved = self.emit_shape_ty(ty);
-        if !resolved.is_option() {
-            return None;
-        }
-        let inner = resolved.ok_type();
-        if self.facts.is_nilable_go_type(&inner) {
-            return Some(resolved);
-        }
-        if inner.contains_unknown() || inner.has_name("any") {
-            return None;
-        }
-        Some(resolved)
     }
 }

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1686,6 +1686,87 @@ pub struct Group {
 }
 
 #[test]
+fn interop_array_of_pointer_options_bridges_go_field_round_trip() {
+    let input = r#"
+import "go:example.com/arrays"
+
+fn main() {
+  let values: Array<Option<int>, 2> = [Some(1), None]
+  let container = arrays.Container { Values: values }
+  let roundtrip = container.Values
+  let _ = roundtrip
+}
+"#;
+    let typedef = r#"
+pub struct Container {
+  pub Values: Array<Option<int>, 2>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/arrays", typedef)]);
+}
+
+#[test]
+fn interop_map_with_pointer_option_keys_bridges_go_field_round_trip() {
+    let input = r#"
+import "go:example.com/maps"
+
+fn main() {
+  let mut values = Map.new<Option<int>, string>()
+  values[Some(1)] = "one"
+  values[None] = "none"
+  let container = maps.Container { Values: values }
+  let roundtrip = container.Values
+  let _ = roundtrip
+}
+"#;
+    let typedef = r#"
+pub struct Container {
+  pub Values: Map<Option<int>, string>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/maps", typedef)]);
+}
+
+#[test]
+fn interop_nested_option_collection_bridges_go_field_round_trip() {
+    let input = r#"
+import "go:example.com/nested"
+
+fn main() {
+  let values: Option<Slice<Option<int>>> = Some([Some(1), None])
+  let container = nested.Container { Values: values }
+  let roundtrip = container.Values
+  let _ = roundtrip
+}
+"#;
+    let typedef = r#"
+pub struct Container {
+  pub Values: Option<Slice<Option<int>>>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/nested", typedef)]);
+}
+
+#[test]
+fn interop_nested_option_collections_bridge_go_returns() {
+    let input = r#"
+import "go:example.com/nested"
+
+fn main() {
+  let values = nested.Values()
+  let maybe_values = nested.MaybeValues()
+  let _ = values
+  let _ = maybe_values
+}
+"#;
+    let typedef = r#"
+pub fn Values() -> Slice<Option<int>>
+pub fn MaybeValues() -> Option<Slice<Option<int>>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/nested", typedef)]);
+}
+
+#[test]
 fn interop_some_stores_result_fn_in_lowered_abi() {
     let input = r#"
 import ext "go:example.com/ext"

--- a/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/arrays\"\n\nfn main() {\n  let values: Array<Option<int>, 2> = [Some(1), None]\n  let container = arrays.Container { Values: values }\n  let roundtrip = container.Values\n  let _ = roundtrip\n}\n"
+---
+package main
+
+import (
+	"example.com/arrays"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	values := [2]lisette.Option[int]{lisette.MakeOptionSome(1), lisette.MakeOptionNone[int]()}
+	src_1 := values
+	var unwrapped_2 [2]*int
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = &v_4.SomeVal
+		} else {
+			unwrapped_2[i_3] = nil
+		}
+	}
+	container := arrays.Container{Values: unwrapped_2}
+	raw_5 := container.Values
+	src_6 := raw_5
+	var wrapped_7 [2]lisette.Option[int]
+	for i_8, v_9 := range src_6 {
+		if v_9 != nil {
+			wrapped_7[i_8] = lisette.MakeOptionSome[int](*v_9)
+		} else {
+			wrapped_7[i_8] = lisette.MakeOptionNone[int]()
+		}
+	}
+	roundtrip := wrapped_7
+	_ = roundtrip
+}

--- a/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/maps\"\n\nfn main() {\n  let mut values = Map.new<Option<int>, string>()\n  values[Some(1)] = \"one\"\n  values[None] = \"none\"\n  let container = maps.Container { Values: values }\n  let roundtrip = container.Values\n  let _ = roundtrip\n}\n"
+---
+package main
+
+import (
+	"example.com/maps"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	values := make(map[lisette.Option[int]]string)
+	values[lisette.MakeOptionSome(1)] = "one"
+	values[lisette.MakeOptionNone[int]()] = "none"
+	src_1 := values
+	unwrapped_2 := make(map[*int]string, len(src_1))
+	for i_3, v_4 := range src_1 {
+		opt_5 := i_3
+		var ptr_6 *int
+		if opt_5.Tag == lisette.OptionSome {
+			ptr_6 = &opt_5.SomeVal
+		}
+		unwrapped_2[ptr_6] = v_4
+	}
+	container := maps.Container{Values: unwrapped_2}
+	raw_7 := container.Values
+	src_8 := raw_7
+	wrapped_9 := make(map[lisette.Option[int]]string, len(src_8))
+	for i_10, v_11 := range src_8 {
+		option_12 := lisette.OptionFromPointer[int](i_10)
+		wrapped_9[option_12] = v_11
+	}
+	roundtrip := wrapped_9
+	_ = roundtrip
+}

--- a/tests/spec/emit/snapshots/interop_nested_option_collection_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_nested_option_collection_bridges_go_field_round_trip.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/nested\"\n\nfn main() {\n  let values: Option<Slice<Option<int>>> = Some([Some(1), None])\n  let container = nested.Container { Values: values }\n  let roundtrip = container.Values\n  let _ = roundtrip\n}\n"
+---
+package main
+
+import (
+	"example.com/nested"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	values := lisette.MakeOptionSome([]lisette.Option[int]{lisette.MakeOptionSome(1), lisette.MakeOptionNone[int]()})
+	opt_1 := values
+	var ptr_2 *[]*int
+	if opt_1.Tag == lisette.OptionSome {
+		src_3 := opt_1.SomeVal
+		unwrapped_4 := make([]*int, len(src_3))
+		for i_5, v_6 := range src_3 {
+			if v_6.Tag == lisette.OptionSome {
+				unwrapped_4[i_5] = &v_6.SomeVal
+			} else {
+				unwrapped_4[i_5] = nil
+			}
+		}
+		ptr_2 = &unwrapped_4
+	}
+	container := nested.Container{Values: ptr_2}
+	raw_7 := container.Values
+	raw_8 := raw_7
+	var option_9 lisette.Option[[]lisette.Option[int]]
+	if raw_8 != nil {
+		src_10 := *raw_8
+		wrapped_11 := make([]lisette.Option[int], len(src_10))
+		for i_12, v_13 := range src_10 {
+			if v_13 != nil {
+				wrapped_11[i_12] = lisette.MakeOptionSome[int](*v_13)
+			} else {
+				wrapped_11[i_12] = lisette.MakeOptionNone[int]()
+			}
+		}
+		option_9 = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_11)
+	} else {
+		option_9 = lisette.MakeOptionNone[[]lisette.Option[int]]()
+	}
+	roundtrip := option_9
+	_ = roundtrip
+}

--- a/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
+++ b/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/nested\"\n\nfn main() {\n  let values = nested.Values()\n  let maybe_values = nested.MaybeValues()\n  let _ = values\n  let _ = maybe_values\n}\n"
+---
+package main
+
+import (
+	"example.com/nested"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	src_1 := nested.Values()
+	wrapped_2 := make([]lisette.Option[int], len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[int](*v_4)
+		} else {
+			wrapped_2[i_3] = lisette.MakeOptionNone[int]()
+		}
+	}
+	values := wrapped_2
+	ret_5, ret_6 := nested.MaybeValues()
+	var maybe_values lisette.Option[[]lisette.Option[int]]
+	if ret_6 {
+		src_7 := ret_5
+		wrapped_8 := make([]lisette.Option[int], len(src_7))
+		for i_9, v_10 := range src_7 {
+			if v_10 != nil {
+				wrapped_8[i_9] = lisette.MakeOptionSome[int](*v_10)
+			} else {
+				wrapped_8[i_9] = lisette.MakeOptionNone[int]()
+			}
+		}
+		maybe_values = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_8)
+	} else {
+		maybe_values = lisette.MakeOptionNone[[]lisette.Option[int]]()
+	}
+	_ = values
+	_ = maybe_values
+}

--- a/tests/spec/emit/snapshots/option_in_go_generic_slots_stays_tagged.snap
+++ b/tests/spec/emit/snapshots/option_in_go_generic_slots_stays_tagged.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nimport \"go:example.com/generic\"\n\nfn main() {\n  let option = Some(1)\n  let options: Slice<Option<int>> = [option]\n  generic.Store(option)\n  generic.StoreAll(options)\n  generic.StoreMany(option, option)\n  let loaded = generic.Load(option)\n  let loaded_all = generic.LoadAll(options)\n  let bag = generic.Bag { Value: option, Values: options }\n  generic.Store(bag.Value)\n  generic.Store(loaded)\n  generic.StoreAll(loaded_all)\n}\n"
+---
+package main
+
+import (
+	"example.com/generic"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	option := lisette.MakeOptionSome(1)
+	options := []lisette.Option[int]{option}
+	generic.Store(option)
+	generic.StoreAll(options)
+	generic.StoreMany(option, option)
+	loaded := generic.Load(option)
+	loaded_all := generic.LoadAll(options)
+	bag := generic.Bag[lisette.Option[int]]{
+		Value:  option,
+		Values: options,
+	}
+	generic.Store(bag.Value)
+	generic.Store(loaded)
+	generic.StoreAll(loaded_all)
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -4552,6 +4552,40 @@ pub fn Store(key: string, value: Unknown) -> int
 }
 
 #[test]
+fn option_in_go_generic_slots_stays_tagged() {
+    let input = r#"
+import "go:example.com/generic"
+
+fn main() {
+  let option = Some(1)
+  let options: Slice<Option<int>> = [option]
+  generic.Store(option)
+  generic.StoreAll(options)
+  generic.StoreMany(option, option)
+  let loaded = generic.Load(option)
+  let loaded_all = generic.LoadAll(options)
+  let bag = generic.Bag { Value: option, Values: options }
+  generic.Store(bag.Value)
+  generic.Store(loaded)
+  generic.StoreAll(loaded_all)
+}
+"#;
+    let typedef = r#"
+pub fn Store<T>(value: T)
+pub fn StoreAll<T>(values: Slice<T>)
+pub fn StoreMany<T>(values: VarArgs<T>)
+pub fn Load<T>(value: T) -> T
+pub fn LoadAll<T>(values: Slice<T>) -> Slice<T>
+
+pub struct Bag<T> {
+  pub Value: T,
+  pub Values: Slice<T>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/generic", typedef)]);
+}
+
+#[test]
 fn omitted_return_in_callback_param_stays_void() {
     let input = r#"
 fn run(callback: fn(int)) {}


### PR DESCRIPTION
This stops re-deriving the Go shape of a value (tagged option, pointer, comma-ok pair) at every boundary crossing independently. A value's layout is now computed once, recursively, from its type plus where the slot lives (Lisette code, Go parameter, Go field, Go `any`), and boundary conversions are the result of comparing two layouts.