### PR TITLE
fix: convert `Option` values across Go callable boundaries

### DIFF
--- a/crates/emit/src/abi/callable.rs
+++ b/crates/emit/src/abi/callable.rs
@@ -1,6 +1,6 @@
 use syntax::types::Type;
 
-use crate::abi::layout::{SlotOrigin, ValueLayout};
+use crate::abi::layout::{FunctionLayout, SlotOrigin, ValueLayout};
 
 /// How a logical tuple payload occupies a callable's physical Go result slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,6 +116,7 @@ pub(crate) struct CallableAbi {
     pub(crate) params: Vec<CallableParamAbi>,
     pub(crate) result: CallableReturnAbi,
     pub(crate) return_layout: ValueLayout,
+    pub(crate) return_payload_layout: Option<ValueLayout>,
 }
 
 impl CallableAbi {
@@ -125,5 +126,18 @@ impl CallableAbi {
                 .last()
                 .filter(|param| param.instantiated.get_name() == Some("VarArgs"))
         })
+    }
+
+    pub(crate) fn function_layout(&self) -> FunctionLayout {
+        FunctionLayout {
+            parameters: self
+                .params
+                .iter()
+                .map(|param| param.layout.clone())
+                .collect(),
+            result: Box::new(self.return_layout.clone()),
+            payload: self.return_payload_layout.clone().map(Box::new),
+            return_abi: self.result.clone(),
+        }
     }
 }

--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -7,7 +7,8 @@ use crate::definitions::interface_adapter::AdapterPlan;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 
-use super::layout::ValueLayout;
+use super::callable::AbiTransition;
+use super::layout::{FunctionLayout, ValueLayout};
 
 pub(crate) struct CoercionPlan {
     kind: CoercionKind,
@@ -49,6 +50,14 @@ pub(crate) enum LayoutBridge {
         source_payload: Box<ValueLayout>,
         payload: Box<LayoutBridge>,
     },
+    Reference {
+        pointee: Box<LayoutBridge>,
+    },
+    Function {
+        source: Box<FunctionLayout>,
+        target: Box<FunctionLayout>,
+        direction: BridgeDirection,
+    },
     Aggregate {
         source: Box<ValueLayout>,
         target: Box<ValueLayout>,
@@ -71,6 +80,8 @@ impl LayoutBridge {
             Self::WrapNullableOption { .. } | Self::WrapPointerOption { .. } => {
                 Some(BridgeDirection::FromGo)
             }
+            Self::Reference { pointee } => pointee.direction(),
+            Self::Function { direction, .. } => Some(*direction),
             Self::Aggregate { key, element, .. } => key
                 .as_deref()
                 .and_then(LayoutBridge::direction)
@@ -151,7 +162,7 @@ impl Planner<'_> {
     }
 }
 
-fn resolve_layout_bridge(
+pub(crate) fn resolve_layout_bridge(
     planner: &Planner<'_>,
     source: &ValueLayout,
     target: &ValueLayout,
@@ -160,7 +171,9 @@ fn resolve_layout_bridge(
         return LayoutBridge::Identity;
     }
 
-    use ValueLayout::{Array, Map, Named, NullableOption, PointerOption, Slice, TaggedOption};
+    use ValueLayout::{
+        Array, Function, Map, Named, NullableOption, PointerOption, Reference, Slice, TaggedOption,
+    };
 
     match (source, target) {
         (
@@ -248,6 +261,34 @@ fn resolve_layout_bridge(
                 payload: Box::new(resolve_layout_bridge(planner, source_payload, target)),
             }
         }
+        (Function { layout: source, .. }, Function { layout: target, .. })
+            if source.return_abi == target.return_abi =>
+        {
+            LayoutBridge::Function {
+                direction: function_bridge_direction(planner, source, target),
+                source: Box::new(source.clone()),
+                target: Box::new(target.clone()),
+            }
+        }
+        (
+            Reference {
+                pointee: source_pointee,
+                ..
+            },
+            Reference {
+                pointee: target_pointee,
+                ..
+            },
+        ) => {
+            let pointee = resolve_layout_bridge(planner, source_pointee, target_pointee);
+            if pointee.is_identity() {
+                LayoutBridge::Identity
+            } else {
+                LayoutBridge::Reference {
+                    pointee: Box::new(pointee),
+                }
+            }
+        }
         (
             Slice {
                 element: source_element,
@@ -309,6 +350,45 @@ fn resolve_layout_bridge(
             },
         ) => resolve_layout_bridge(planner, source, target_underlying),
         _ => LayoutBridge::Identity,
+    }
+}
+
+fn function_bridge_direction(
+    planner: &Planner<'_>,
+    source: &FunctionLayout,
+    target: &FunctionLayout,
+) -> BridgeDirection {
+    let result = resolve_layout_bridge(planner, &source.result, &target.result).direction();
+    let payload = source
+        .payload
+        .as_deref()
+        .zip(target.payload.as_deref())
+        .and_then(|(source, target)| resolve_layout_bridge(planner, source, target).direction());
+    let parameter = target
+        .parameters
+        .iter()
+        .zip(&source.parameters)
+        .find_map(|(target, source)| resolve_layout_bridge(planner, target, source).direction())
+        .map(invert_direction);
+    result
+        .or(payload)
+        .or(parameter)
+        .or_else(
+            || match source.return_abi.transition_to(&target.return_abi) {
+                AbiTransition::LowerFromTagged => Some(BridgeDirection::ToGo),
+                AbiTransition::WrapToTagged => Some(BridgeDirection::FromGo),
+                AbiTransition::Identity | AbiTransition::Reencode | AbiTransition::Incompatible => {
+                    None
+                }
+            },
+        )
+        .unwrap_or(BridgeDirection::ToGo)
+}
+
+fn invert_direction(direction: BridgeDirection) -> BridgeDirection {
+    match direction {
+        BridgeDirection::ToGo => BridgeDirection::FromGo,
+        BridgeDirection::FromGo => BridgeDirection::ToGo,
     }
 }
 

--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -1,7 +1,7 @@
 use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
-use crate::abi::callable::CallableReturnAbi;
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SlotOrigin {
@@ -46,7 +46,97 @@ impl SlotOrigin {
 pub(crate) struct FunctionLayout {
     pub(crate) parameters: Vec<ValueLayout>,
     pub(crate) result: Box<ValueLayout>,
+    pub(crate) payload: Option<Box<ValueLayout>>,
     pub(crate) return_abi: CallableReturnAbi,
+}
+
+impl FunctionLayout {
+    fn result_same_representation(&self, other: &Self) -> bool {
+        match self.return_abi {
+            CallableReturnAbi::Result { .. }
+            | CallableReturnAbi::Partial { .. }
+            | CallableReturnAbi::Option { .. } => {
+                optional_layouts_match(self.payload.as_deref(), other.payload.as_deref())
+            }
+            CallableReturnAbi::Tagged
+            | CallableReturnAbi::Direct
+            | CallableReturnAbi::Tuple { .. } => self.result.same_representation(&other.result),
+        }
+    }
+
+    pub(crate) fn go_type(&self, planner: &Planner<'_>) -> String {
+        let parameters = self
+            .parameters
+            .iter()
+            .map(|parameter| parameter.go_type(planner))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let result = self.result_go_type(planner);
+        if result.is_empty() {
+            format!("func({parameters})")
+        } else {
+            format!("func({parameters}) {result}")
+        }
+    }
+
+    pub(crate) fn result_go_type(&self, planner: &Planner<'_>) -> String {
+        if self.result.logical_type().is_unit() {
+            return String::new();
+        }
+        match &self.return_abi {
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.result.go_type(planner),
+            CallableReturnAbi::Result {
+                bare_error: true, ..
+            } => planner.go_type_string(&self.result.logical_type().err_type()),
+            CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
+                let payload = self
+                    .payload
+                    .as_deref()
+                    .expect("fallible callable layout has a payload");
+                let error = planner.go_type_string(&self.result.logical_type().err_type());
+                format!("({}, {error})", payload.go_type(planner))
+            }
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                ..
+            } => {
+                let payload = self
+                    .payload
+                    .as_deref()
+                    .expect("option callable layout has a payload");
+                format!("({}, bool)", payload.go_type(planner))
+            }
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                ..
+            } => self
+                .payload
+                .as_deref()
+                .expect("option callable layout has a payload")
+                .go_type(planner),
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Sentinel(_),
+                ..
+            } => self
+                .payload
+                .as_deref()
+                .expect("option callable layout has a payload")
+                .go_type(planner),
+            CallableReturnAbi::Tuple { .. } => {
+                let ValueLayout::Tuple { elements, .. } = self.result.as_ref() else {
+                    return self.result.go_type(planner);
+                };
+                format!(
+                    "({})",
+                    elements
+                        .iter()
+                        .map(|element| element.go_type(planner))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +153,10 @@ pub(crate) enum ValueLayout {
     PointerOption {
         option_type: Type,
         payload: Box<ValueLayout>,
+    },
+    Reference {
+        reference_type: Type,
+        pointee: Box<ValueLayout>,
     },
     Slice {
         collection_type: Type,
@@ -118,6 +212,7 @@ impl ValueLayout {
                 Self::PointerOption { payload: left, .. },
                 Self::PointerOption { payload: right, .. },
             )
+            | (Self::Reference { pointee: left, .. }, Self::Reference { pointee: right, .. })
             | (Self::Slice { element: left, .. }, Self::Slice { element: right, .. })
             | (
                 Self::Named {
@@ -162,7 +257,7 @@ impl ValueLayout {
                         .iter()
                         .zip(&right.parameters)
                         .all(|(left, right)| left.same_representation(right))
-                    && left.result.same_representation(&right.result)
+                    && left.result_same_representation(right)
             }
             (
                 Self::Tuple { elements: left, .. },
@@ -192,6 +287,9 @@ impl ValueLayout {
             | Self::PointerOption {
                 option_type: ty, ..
             }
+            | Self::Reference {
+                reference_type: ty, ..
+            }
             | Self::Slice {
                 collection_type: ty,
                 ..
@@ -213,6 +311,7 @@ impl ValueLayout {
         match self {
             Self::NullableOption { payload, .. } => payload.go_type(planner),
             Self::PointerOption { payload, .. } => format!("*{}", payload.go_type(planner)),
+            Self::Reference { pointee, .. } => format!("*{}", pointee.go_type(planner)),
             Self::Slice { element, .. } => format!("[]{}", element.go_type(planner)),
             Self::Map { key, value, .. } => {
                 format!("map[{}]{}", key.go_type(planner), value.go_type(planner))
@@ -220,12 +319,10 @@ impl ValueLayout {
             Self::Array {
                 length, element, ..
             } => format!("[{length}]{}", element.go_type(planner)),
+            Self::Function { layout, .. } => layout.go_type(planner),
             Self::Plain(ty)
             | Self::TaggedOption {
                 option_type: ty, ..
-            }
-            | Self::Function {
-                function_type: ty, ..
             }
             | Self::Tuple { tuple_type: ty, .. }
             | Self::Named { named_type: ty, .. } => planner.go_type_string(ty),
@@ -261,6 +358,17 @@ impl Planner<'_> {
         declaration: &Type,
     ) -> ValueLayout {
         self.value_layout_with_hint(ty, origin, Some(declaration))
+    }
+
+    pub(crate) fn callable_payload_layout(
+        &self,
+        result_type: &Type,
+        origin: SlotOrigin,
+        declaration: Option<&Type>,
+    ) -> Option<ValueLayout> {
+        let payload = callable_payload_type(result_type)?;
+        let declared_payload = declaration.and_then(callable_payload_type);
+        Some(self.value_layout_with_hint(&payload, origin.nested(), declared_payload.as_ref()))
     }
 
     fn value_layout_with_hint(
@@ -341,6 +449,22 @@ impl Planner<'_> {
         }
 
         match &ty {
+            Type::Compound {
+                kind: CompoundKind::Ref,
+                args,
+            } => {
+                let Some(pointee) = args.first() else {
+                    return ValueLayout::Plain(ty);
+                };
+                ValueLayout::Reference {
+                    reference_type: ty.clone(),
+                    pointee: Box::new(self.value_layout_with_hint(
+                        pointee,
+                        origin.nested(),
+                        compound_hint(declaration, CompoundKind::Ref, 0),
+                    )),
+                }
+            }
             Type::Compound {
                 kind: kind @ (CompoundKind::Slice | CompoundKind::EnumeratedSlice),
                 args,
@@ -433,12 +557,16 @@ impl Planner<'_> {
                         origin.nested(),
                         declared_result,
                     ));
+                    let payload = self
+                        .callable_payload_layout(&result_type, origin, declared_result)
+                        .map(Box::new);
                     let return_abi = self.callable_return_abi(&result_type);
                     return ValueLayout::Function {
                         function_type: ty,
                         layout: FunctionLayout {
                             parameters,
                             result,
+                            payload,
                             return_abi,
                         },
                     };
@@ -458,6 +586,18 @@ impl Planner<'_> {
                 ValueLayout::Plain(ty)
             }
         }
+    }
+}
+
+fn callable_payload_type(ty: &Type) -> Option<Type> {
+    (ty.is_result() || ty.is_partial() || ty.is_option()).then(|| ty.ok_type())
+}
+
+fn optional_layouts_match(left: Option<&ValueLayout>, right: Option<&ValueLayout>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left.same_representation(right),
+        (None, None) => true,
+        _ => false,
     }
 }
 

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -5,11 +5,12 @@ pub(crate) use wrappers::{NilGuard, WrapperTarget};
 
 use crate::Planner;
 use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi};
-use crate::abi::coercion::CoercionPlan;
-use crate::abi::layout::SlotOrigin;
+use crate::abi::coercion::{CoercionPlan, LayoutBridge, resolve_layout_bridge};
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -22,6 +23,25 @@ impl Planner<'_> {
         abi: &CallableAbi,
         result_ty: &Type,
     ) -> ValuePlan {
+        if let Some(bridges) = self.go_tuple_result_bridges(abi, result_ty) {
+            let call = self.lower_call(call_expression, None, ExpressionContext::value());
+            return call.map_rendered_as_observable_computed(|setup, call_string, _| {
+                let values = self.create_temp_vars("ret", bridges.len());
+                setup.push(LoweredStatement::RawGo(format!(
+                    "{} := {}\n",
+                    values.join(", "),
+                    call_string
+                )));
+                let values = values
+                    .into_iter()
+                    .zip(&bridges)
+                    .map(|(value, bridge)| self.plan_layout_bridge(setup, &value, bridge))
+                    .collect::<Vec<_>>();
+                let tuple = self.plan_tuple_from_vars(setup, &values, result_ty);
+                GoExpression::opaque(tuple)
+            });
+        }
+
         if let Some(bridge) = self.go_result_layout_bridge(abi, result_ty) {
             let call = self.lower_call(call_expression, None, ExpressionContext::value());
             return call.map_rendered_as_observable_computed(
@@ -33,7 +53,7 @@ impl Planner<'_> {
             );
         }
 
-        let payload_bridge = self.option_result_payload_bridge(abi, result_ty);
+        let payload_bridge = self.go_return_payload_bridge(abi, result_ty);
         let call_plan = self.lower_call(call_expression, None, ExpressionContext::value());
         call_plan.map_rendered_as_observable_computed(
             |setup, call_string, _contains_deferred_evaluation| {
@@ -42,7 +62,7 @@ impl Planner<'_> {
                         &call_string,
                         &abi.result,
                         result_ty,
-                        payload_bridge,
+                        payload_bridge.as_ref(),
                         WrapperTarget::FreshSlot,
                     );
                     (wrap, outcome.expect("wrapper produced no slot"))
@@ -79,6 +99,40 @@ impl Planner<'_> {
         (!bridge.is_identity()).then_some(bridge)
     }
 
+    pub(crate) fn go_tuple_result_bridges(
+        &self,
+        abi: &CallableAbi,
+        result_ty: &Type,
+    ) -> Option<Vec<LayoutBridge>> {
+        if !matches!(abi.result, CallableReturnAbi::Tuple { .. }) {
+            return None;
+        }
+        let ValueLayout::Tuple {
+            elements: source, ..
+        } = &abi.return_layout
+        else {
+            return None;
+        };
+        let ValueLayout::Tuple {
+            elements: target, ..
+        } = self.value_layout(result_ty, SlotOrigin::Lisette)
+        else {
+            return None;
+        };
+        if source.len() != target.len() {
+            return None;
+        }
+        let bridges = source
+            .iter()
+            .zip(&target)
+            .map(|(source, target)| resolve_layout_bridge(self, source, target))
+            .collect::<Vec<_>>();
+        bridges
+            .iter()
+            .any(|bridge| !bridge.is_identity())
+            .then_some(bridges)
+    }
+
     pub(crate) fn lower_abi_wrapping(
         &mut self,
         call_str: &str,
@@ -94,7 +148,7 @@ impl Planner<'_> {
         call_str: &str,
         abi: &CallableReturnAbi,
         result_ty: &Type,
-        payload_bridge: Option<CoercionPlan>,
+        payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, Option<String>) {
         match abi {
@@ -105,11 +159,11 @@ impl Planner<'_> {
             }
             CallableReturnAbi::Result { payload, .. } => {
                 self.require_stdlib();
-                self.lower_result_wrapping(call_str, result_ty, *payload, target)
+                self.lower_result_wrapping(call_str, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Partial { payload } => {
                 self.require_stdlib();
-                self.lower_partial_wrapping(call_str, result_ty, *payload, target)
+                self.lower_partial_wrapping(call_str, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Option {
                 encoding: OptionReturnAbi::CommaOk,
@@ -147,7 +201,7 @@ impl Planner<'_> {
         ) {
             return None;
         }
-        let payload_bridge = self.option_result_payload_bridge(abi, result_ty);
+        let payload_bridge = self.go_return_payload_bridge(abi, result_ty);
         let (mut statements, call_str) = self
             .lower_call(expression, None, ExpressionContext::value())
             .into_parts();
@@ -155,25 +209,22 @@ impl Planner<'_> {
             &call_str,
             &abi.result,
             result_ty,
-            payload_bridge,
+            payload_bridge.as_ref(),
             target,
         );
         statements.extend(wrap);
         Some(statements)
     }
 
-    fn option_result_payload_bridge(
+    pub(crate) fn go_return_payload_bridge(
         &self,
         abi: &CallableAbi,
         result_ty: &Type,
-    ) -> Option<CoercionPlan> {
-        if !matches!(abi.result, CallableReturnAbi::Option { .. }) {
-            return None;
-        }
-        let source = abi.return_layout.option_payload()?;
-        let target_layout = self.value_layout(result_ty, SlotOrigin::Lisette);
-        let target = target_layout.option_payload()?;
-        let bridge = CoercionPlan::bridge(self, source, target);
+    ) -> Option<LayoutBridge> {
+        let source = abi.return_payload_layout.as_ref()?;
+        let target_type = result_ty.ok_type();
+        let target = self.value_layout(&target_type, SlotOrigin::Lisette);
+        let bridge = resolve_layout_bridge(self, source, &target);
         (!bridge.is_identity()).then_some(bridge)
     }
 
@@ -183,7 +234,12 @@ impl Planner<'_> {
         call_expression: &Expression,
     ) -> Option<String> {
         let plan = self.plan_call(call_expression)?;
-        if plan.resolved.abi.result.is_passthrough() {
+        if plan.resolved.abi.result.is_passthrough()
+            && (!matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+                || self
+                    .go_result_layout_bridge(&plan.resolved.abi, &call_expression.get_type())
+                    .is_none())
+        {
             return None;
         }
 

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
 use crate::abi::callable::PayloadLayout;
-use crate::abi::coercion::{BridgeDirection, CoercionPlan, LayoutBridge};
+use crate::abi::coercion::{BridgeDirection, LayoutBridge};
 use crate::abi::layout::ValueLayout;
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
@@ -38,7 +38,7 @@ impl Planner<'_> {
         call_str: &str,
         option_ty: &Type,
         layout: PayloadLayout,
-        payload_bridge: Option<CoercionPlan>,
+        payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         self.require_stdlib();
@@ -89,7 +89,11 @@ impl Planner<'_> {
             val_vars[0].clone()
         };
         let (mut payload_setup, val_expression) = match payload_bridge {
-            Some(bridge) => bridge.lower(self, val_expression),
+            Some(bridge) => {
+                let mut setup = Vec::new();
+                let value = self.plan_layout_bridge(&mut setup, &val_expression, bridge);
+                (setup, value)
+            }
             None => (Vec::new(), val_expression),
         };
 
@@ -301,6 +305,14 @@ impl Planner<'_> {
                         true,
                     )
                 }
+            }
+            LayoutBridge::Reference { pointee } => {
+                let source = self.hoist_tmp_value_statement(statements, "src", value);
+                let pointee = self.plan_layout_bridge(statements, &format!("*{source}"), pointee);
+                self.hoist_tmp_value_statement(statements, "ref", &format!("&{pointee}"))
+            }
+            LayoutBridge::Function { source, target, .. } => {
+                self.plan_function_layout_bridge(statements, value, source, target)
             }
             LayoutBridge::Aggregate {
                 source,
@@ -600,7 +612,9 @@ impl Planner<'_> {
                     })],
                 }
             }
-            LayoutBridge::Aggregate { .. } => {
+            LayoutBridge::Aggregate { .. }
+            | LayoutBridge::Reference { .. }
+            | LayoutBridge::Function { .. } => {
                 let mut inner_statements = Vec::new();
                 let inner = self.plan_layout_bridge(&mut inner_statements, element, bridge);
                 inner_statements.push(LoweredStatement::RawGo(format!(

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -1,6 +1,8 @@
 use crate::Planner;
 use crate::Renderer;
-use crate::abi::callable::{CallableReturnAbi, PayloadLayout};
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use crate::abi::coercion::{LayoutBridge, resolve_layout_bridge};
+use crate::abi::layout::{FunctionLayout, ValueLayout};
 use crate::control_flow::fallible::{
     Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR,
 };
@@ -75,6 +77,171 @@ pub(super) fn leaf_block(sink: &ResolvedSink, value: &str) -> LoweredBlock {
 }
 
 impl Planner<'_> {
+    pub(crate) fn plan_function_layout_bridge(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: &str,
+        source: &FunctionLayout,
+        target: &FunctionLayout,
+    ) -> String {
+        debug_assert_eq!(source.return_abi, target.return_abi);
+        let function = self.hoist_tmp_value_statement(statements, "cb", value);
+        let mut body = Vec::new();
+        let mut parameters = Vec::new();
+        let mut arguments = Vec::new();
+
+        for (index, (source, target)) in
+            source.parameters.iter().zip(&target.parameters).enumerate()
+        {
+            let name = format!("arg{index}");
+            parameters.push(format!("{name} {}", target.go_type(self)));
+            let bridge = resolve_layout_bridge(self, target, source);
+            let argument = self.plan_layout_bridge(&mut body, &name, &bridge);
+            if source.logical_type().get_name() == Some("VarArgs") {
+                arguments.push(format!("{argument}..."));
+            } else {
+                arguments.push(argument);
+            }
+        }
+
+        let call = format!("{function}({})", arguments.join(", "));
+        self.plan_function_result_bridge(&mut body, &call, source, target);
+        let body = Renderer.render_setup(&body);
+        let result = target.result_go_type(self);
+        let signature = if result.is_empty() {
+            format!("func({})", parameters.join(", "))
+        } else {
+            format!("func({}) {result}", parameters.join(", "))
+        };
+        format!("{signature} {{\n{body}}}")
+    }
+
+    fn plan_function_result_bridge(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        call: &str,
+        source: &FunctionLayout,
+        target: &FunctionLayout,
+    ) {
+        match &source.return_abi {
+            CallableReturnAbi::Tagged | CallableReturnAbi::Direct => {
+                if source.result.logical_type().is_unit() {
+                    statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+                    return;
+                }
+                let bridge = resolve_layout_bridge(self, &source.result, &target.result);
+                let value = self.plan_layout_bridge(statements, call, &bridge);
+                statements.push(plain_return(value));
+            }
+            CallableReturnAbi::Result {
+                bare_error: true, ..
+            } => statements.push(plain_return(call.to_string())),
+            CallableReturnAbi::Result { .. }
+            | CallableReturnAbi::Partial { .. }
+            | CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::CommaOk,
+                ..
+            } => {
+                let value = self.fresh_var(Some("ret"));
+                self.declare(&value);
+                let auxiliary = self.fresh_var(Some("ret"));
+                self.declare(&auxiliary);
+                statements.push(LoweredStatement::RawGo(format!(
+                    "{value}, {auxiliary} := {call}\n"
+                )));
+
+                if matches!(source.return_abi, CallableReturnAbi::Partial { .. }) {
+                    let ok_type = source.result.logical_type().ok_type();
+                    if let Some(condition) = self.partial_ok_nil_check(&ok_type, &value) {
+                        statements.push(LoweredStatement::If(IfPlan {
+                            condition_setup: Vec::new(),
+                            condition,
+                            then_body: LoweredBlock {
+                                statements: vec![plain_return(format!("nil, {auxiliary}"))],
+                            },
+                            else_arm: ElseArm::None,
+                        }));
+                    }
+                }
+
+                let source_payload = source
+                    .payload
+                    .as_deref()
+                    .expect("lowered callable has a payload layout");
+                let target_payload = target
+                    .payload
+                    .as_deref()
+                    .expect("lowered callable target has a payload layout");
+                let bridge = resolve_layout_bridge(self, source_payload, target_payload);
+                let value = self.plan_layout_bridge(statements, &value, &bridge);
+                statements.push(plain_return(format!("{value}, {auxiliary}")));
+            }
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Nullable,
+                ..
+            } => {
+                let raw = self.hoist_tmp_value_statement(statements, "raw", call);
+                let condition = if self.is_interface_option(source.result.logical_type()) {
+                    self.require_stdlib();
+                    format!("lisette.IsNilInterface({raw})")
+                } else {
+                    format!("{raw} == nil")
+                };
+                statements.push(LoweredStatement::If(IfPlan {
+                    condition_setup: Vec::new(),
+                    condition,
+                    then_body: LoweredBlock {
+                        statements: vec![plain_return("nil".to_string())],
+                    },
+                    else_arm: ElseArm::None,
+                }));
+                let source_payload = source
+                    .payload
+                    .as_deref()
+                    .expect("nullable option callable has a payload layout");
+                let target_payload = target
+                    .payload
+                    .as_deref()
+                    .expect("nullable option target has a payload layout");
+                let bridge = resolve_layout_bridge(self, source_payload, target_payload);
+                let value = self.plan_layout_bridge(statements, &raw, &bridge);
+                statements.push(plain_return(value));
+            }
+            CallableReturnAbi::Option {
+                encoding: OptionReturnAbi::Sentinel(_),
+                ..
+            } => statements.push(plain_return(call.to_string())),
+            CallableReturnAbi::Tuple { arity } => {
+                let values = self.create_temp_vars("ret", *arity);
+                statements.push(LoweredStatement::RawGo(format!(
+                    "{} := {call}\n",
+                    values.join(", ")
+                )));
+                let (
+                    ValueLayout::Tuple {
+                        elements: source, ..
+                    },
+                    ValueLayout::Tuple {
+                        elements: target, ..
+                    },
+                ) = (source.result.as_ref(), target.result.as_ref())
+                else {
+                    statements.push(plain_return(values.join(", ")));
+                    return;
+                };
+                let values = values
+                    .into_iter()
+                    .zip(source.iter().zip(target))
+                    .map(|(value, (source, target))| {
+                        let bridge = resolve_layout_bridge(self, source, target);
+                        self.plan_layout_bridge(statements, &value, &bridge)
+                    })
+                    .collect::<Vec<_>>();
+                statements.push(plain_return(values.join(", ")));
+            }
+        }
+    }
+
     /// Prepare a wrapper sink: declare `var slot T` (slot targets) or route
     /// writes to `return`.
     pub(super) fn push_wrapper_slot(
@@ -159,6 +326,7 @@ impl Planner<'_> {
         call_str: &str,
         partial_ty: &Type,
         layout: PayloadLayout,
+        payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let ok_ty = partial_ty.ok_type();
@@ -176,7 +344,22 @@ impl Planner<'_> {
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
-        let both = format!("{PARTIAL_BOTH_CTOR}[{type_params}]({val_var}, {err_var})");
+        let (mut both_setup, both_value) =
+            self.plan_optional_payload_bridge(&val_var, payload_bridge);
+        let both = format!("{PARTIAL_BOTH_CTOR}[{type_params}]({both_value}, {err_var})");
+        both_setup.push(leaf_statement(&sink, &both));
+        let both_body = LoweredBlock {
+            statements: both_setup,
+        };
+
+        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(&val_var, payload_bridge);
+        ok_setup.push(leaf_statement(
+            &sink,
+            &format!("{PARTIAL_OK_CTOR}[{type_params}]({ok_value})"),
+        ));
+        let ok_body = LoweredBlock {
+            statements: ok_setup,
+        };
 
         let then_body = if let Some(check) = &nil_check {
             let inner = IfPlan {
@@ -187,7 +370,7 @@ impl Planner<'_> {
                     &format!("{PARTIAL_ERR_CTOR}[{type_params}]({err_var})"),
                 ),
                 else_arm: ElseArm::Else {
-                    body: leaf_block(&sink, &both),
+                    body: both_body,
                     inline: false,
                 },
             };
@@ -195,14 +378,11 @@ impl Planner<'_> {
                 statements: vec![LoweredStatement::If(inner)],
             }
         } else {
-            leaf_block(&sink, &both)
+            both_body
         };
 
         let else_arm = ElseArm::Else {
-            body: leaf_block(
-                &sink,
-                &format!("{PARTIAL_OK_CTOR}[{type_params}]({})", val_var),
-            ),
+            body: ok_body,
             inline: false,
         };
 
@@ -266,6 +446,7 @@ impl Planner<'_> {
         call_str: &str,
         result_ty: &Type,
         layout: PayloadLayout,
+        payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
@@ -287,6 +468,16 @@ impl Planner<'_> {
 
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
+
+        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(&ok_val, payload_bridge);
+        let ok_wrapper = {
+            let mut fe = FalliblePlanner::new(self, &fallible);
+            fe.emit_success(&ok_value)
+        };
+        ok_setup.push(leaf_statement(&sink, &ok_wrapper));
+        let ok_body = LoweredBlock {
+            statements: ok_setup,
+        };
 
         let err_wrapper = {
             let mut fe = FalliblePlanner::new(self, &fallible);
@@ -310,26 +501,18 @@ impl Planner<'_> {
                 let mut fe = FalliblePlanner::new(self, &fallible);
                 fe.emit_failure(Some("errors.New(\"unexpected nil\")"))
             };
-            let ok_wrapper = {
-                let mut fe = FalliblePlanner::new(self, &fallible);
-                fe.emit_success(&ok_val)
-            };
             ElseArm::ElseIf(Box::new(IfPlan {
                 condition_setup: Vec::new(),
                 condition: nil_condition,
                 then_body: leaf_block(&sink, &nil_err),
                 else_arm: ElseArm::Else {
-                    body: leaf_block(&sink, &ok_wrapper),
+                    body: ok_body,
                     inline: false,
                 },
             }))
         } else {
-            let ok_wrapper = {
-                let mut fe = FalliblePlanner::new(self, &fallible);
-                fe.emit_success(&ok_val)
-            };
             ElseArm::Else {
-                body: leaf_block(&sink, &ok_wrapper),
+                body: ok_body,
                 inline: false,
             }
         };
@@ -341,6 +524,19 @@ impl Planner<'_> {
             else_arm,
         }));
         (statements, outcome)
+    }
+
+    fn plan_optional_payload_bridge(
+        &mut self,
+        value: &str,
+        bridge: Option<&LayoutBridge>,
+    ) -> (Vec<LoweredStatement>, String) {
+        let mut statements = Vec::new();
+        let value = bridge.map_or_else(
+            || value.to_string(),
+            |bridge| self.plan_layout_bridge(&mut statements, value, bridge),
+        );
+        (statements, value)
     }
 
     fn lower_unit_result_wrapping(

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -352,11 +352,27 @@ impl<'a> Planner<'a> {
         args: &[Expression],
         ctx: &CallArgsContext<'_, '_>,
     ) -> SequencedValues {
-        let stages: Vec<ValuePlan> = args
+        let mut stages: Vec<ValuePlan> = args
             .iter()
             .enumerate()
             .map(|(i, arg)| self.lower_call_arg(arg, i, ctx))
             .collect();
+
+        if let Some(spread) = ctx.spread
+            && let Some(stage) =
+                self.lower_variadic_spread_slot_bridge(spread, ctx.plan.resolved.abi.params.last())
+        {
+            stages.push(stage);
+            let spread_index = stages.len() - 1;
+            let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "_arg");
+            self.finalize_spread_stage(
+                &mut sequenced.values,
+                spread_index,
+                ctx.wrap_spread_to_any,
+                ctx.combine_variadic.clone(),
+            );
+            return sequenced;
+        }
 
         self.sequence_args_with_spread_adapter_values(
             stages,
@@ -677,7 +693,7 @@ impl<'a> Planner<'a> {
                 .unwrap_or(CallableReturnAbi::Direct)
         };
         let transition = source.transition_to(&target);
-        Some((source, target, transition))
+        (!matches!(transition, AbiTransition::Identity)).then_some((source, target, transition))
     }
 
     fn lower_callback_wrapper(
@@ -756,9 +772,20 @@ impl<'a> Planner<'a> {
         argument: &Expression,
         parameter: &CallableParamAbi,
     ) -> bool {
-        let source = self.value_layout(&argument.get_type(), SlotOrigin::Lisette);
+        let physical_source = self.go_physical_expression_layout(argument);
+        let source = physical_source
+            .clone()
+            .unwrap_or_else(|| self.value_layout(&argument.get_type(), SlotOrigin::Lisette));
         let target = self.argument_slot_layout(parameter);
-        !CoercionPlan::bridge(self, &source, &target).is_identity()
+        let can_forward_physical = match (&physical_source, &target) {
+            (
+                Some(ValueLayout::Function { layout: source, .. }),
+                ValueLayout::Function { layout: target, .. },
+            ) => source.return_abi == target.return_abi,
+            (Some(_), _) => true,
+            (None, _) => false,
+        };
+        can_forward_physical || !CoercionPlan::bridge(self, &source, &target).is_identity()
     }
 
     fn lower_go_slot_bridge(
@@ -773,15 +800,79 @@ impl<'a> Planner<'a> {
                 EvaluationEffect::PureCall,
             );
         }
-        let source = self.value_layout(&argument.get_type(), SlotOrigin::Lisette);
+        let raw_source = self.go_physical_expression_layout(argument);
+        let source = raw_source
+            .clone()
+            .unwrap_or_else(|| self.value_layout(&argument.get_type(), SlotOrigin::Lisette));
         let target = self.argument_slot_layout(parameter);
         let coercion = CoercionPlan::bridge(self, &source, &target);
-        let value = self.lower_value(argument, ExpressionContext::value());
+        let value = if raw_source.is_some() {
+            if matches!(argument.unwrap_parens(), Expression::Call { .. }) {
+                self.lower_call(
+                    argument,
+                    Some(&argument.get_type()),
+                    ExpressionContext::value(),
+                )
+            } else {
+                self.plan_operand(argument, ExpressionContext::value())
+            }
+        } else {
+            self.lower_value(argument, ExpressionContext::value())
+        };
         value.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             GoExpression::opaque_with_deferred_evaluation(coerced, true)
         })
+    }
+
+    fn go_physical_expression_layout(&self, expression: &Expression) -> Option<ValueLayout> {
+        if let Some(plan) = self.plan_call(expression)
+            && matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+            && matches!(plan.resolved.abi.result, CallableReturnAbi::Direct)
+        {
+            return Some(plan.resolved.abi.return_layout.clone());
+        }
+        let callable = self.resolve_callable_value(expression)?;
+        matches!(callable.origin, CallableOrigin::GoInterop).then(|| ValueLayout::Function {
+            function_type: expression.get_type(),
+            layout: callable.abi.function_layout(),
+        })
+    }
+
+    fn lower_variadic_spread_slot_bridge(
+        &mut self,
+        spread: &Expression,
+        parameter: Option<&CallableParamAbi>,
+    ) -> Option<ValuePlan> {
+        let parameter = parameter?;
+        if parameter.instantiated.get_name() != Some("VarArgs") {
+            return None;
+        }
+
+        let raw_source = self.go_physical_expression_layout(spread);
+        let source = raw_source
+            .clone()
+            .unwrap_or_else(|| self.value_layout(&spread.get_type(), SlotOrigin::Lisette));
+        let target = ValueLayout::Slice {
+            collection_type: spread.get_type(),
+            element: Box::new(self.argument_slot_layout(parameter)),
+        };
+        let coercion = CoercionPlan::bridge(self, &source, &target);
+        if coercion.is_identity() && raw_source.is_none() {
+            return None;
+        }
+
+        let value = if raw_source.is_some() {
+            self.lower_call(spread, Some(&spread.get_type()), ExpressionContext::value())
+        } else {
+            self.lower_value(spread, ExpressionContext::value())
+        };
+        Some(value.map_rendered_as_computed(|setup, value, _| {
+            let (coercion_setup, coerced) = coercion.lower(self, value);
+            setup.extend(coercion_setup);
+            GoExpression::opaque_with_deferred_evaluation(coerced, true)
+        }))
     }
 }
 

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -185,6 +185,12 @@ impl Planner<'_> {
         if ok_ty.is_unit() || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
             return None;
         }
+        if self
+            .go_return_payload_bridge(&plan.resolved.abi, &expression.get_type())
+            .is_some()
+        {
+            return None;
+        }
         let return_ctx = self.return_ctx();
         let has_fallible_return = return_ctx.lowered_shape().is_some()
             || return_ctx

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -5,7 +5,7 @@ use syntax::program::DefinitionBody;
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::coercion::CoercionPlan;
-use crate::abi::layout::SlotOrigin;
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::emit_lisette_callback_wrapper;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
@@ -31,6 +31,24 @@ impl Planner<'_> {
             && matches!(callee.origin, CallableOrigin::GoInterop)
         {
             let abi = &callee.abi.result;
+            let source_layout = ValueLayout::Function {
+                function_type: expression.get_type(),
+                layout: callee.abi.function_layout(),
+            };
+            let target_layout = self.value_layout(&expression.get_type(), SlotOrigin::Lisette);
+            let same_abi = matches!(
+                &target_layout,
+                ValueLayout::Function { layout, .. } if layout.return_abi == *abi
+            );
+            let layout_coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
+            if !ctx.is_callee() && same_abi && !layout_coercion.is_identity() {
+                let value = self.plan_operand(expression, ctx);
+                return value.map_rendered_as_computed(|setup, value, _| {
+                    let (bridge_setup, value) = layout_coercion.lower(self, value);
+                    setup.extend(bridge_setup);
+                    GoExpression::opaque_with_deferred_evaluation(value, true)
+                });
+            }
             if !self.go_fn_matches_lowered_slot(expression, abi, ctx) {
                 let mut setup = Vec::new();
                 let value = if self.go_fn_needs_lowered_tuple_adapter(expression, abi, ctx) {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -113,6 +113,12 @@ impl Planner<'_> {
                 if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
                     return None;
                 }
+                if self
+                    .go_return_payload_bridge(&plan.resolved.abi, &subject.get_type())
+                    .is_some()
+                {
+                    return None;
+                }
                 self.result_nil_guard(&ok_ty)
             }
             CallableOrigin::GoInterop => return None,
@@ -227,6 +233,12 @@ impl Planner<'_> {
     fn fusable_partial(&self, subject: &Expression, plan: &CallPlan<'_>) -> bool {
         let is_partial = matches!(plan.resolved.abi.result, CallableReturnAbi::Partial { .. });
         if !is_partial {
+            return false;
+        }
+        if self
+            .go_return_payload_bridge(&plan.resolved.abi, &subject.get_type())
+            .is_some()
+        {
             return false;
         }
         let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -227,22 +227,31 @@ impl<'a> Planner<'a> {
                 }),
         };
         let return_type = instantiated.get_function_ret().unwrap_or(&Type::Never);
-        let return_layout = if matches!(origin, CallableOrigin::GoInterop) {
-            id.as_deref()
-                .and_then(|id| self.facts.go_callable_return_slot(id))
-                .map(|slot| {
-                    self.value_layout_with_declaration(
-                        return_type,
-                        slot.origin,
-                        &slot.declared_type,
-                    )
-                })
-                .unwrap_or_else(|| {
-                    self.value_layout(return_type, SlotOrigin::go_return(return_type))
-                })
+        let declared_return = declared
+            .as_ref()
+            .and_then(|ty| ty.unwrap_forall().get_function_ret());
+        let catalog_return = matches!(origin, CallableOrigin::GoInterop)
+            .then(|| {
+                id.as_deref()
+                    .and_then(|id| self.facts.go_callable_return_slot(id))
+            })
+            .flatten();
+        let return_origin = if matches!(origin, CallableOrigin::GoInterop) {
+            catalog_return.map_or_else(|| SlotOrigin::go_return(return_type), |slot| slot.origin)
         } else {
-            self.value_layout(return_type, SlotOrigin::Lisette)
+            SlotOrigin::Lisette
         };
+        let return_declaration = catalog_return
+            .map(|slot| &slot.declared_type)
+            .or(declared_return);
+        let return_layout = return_declaration.map_or_else(
+            || self.value_layout(return_type, return_origin),
+            |declaration| {
+                self.value_layout_with_declaration(return_type, return_origin, declaration)
+            },
+        );
+        let return_payload_layout =
+            self.callable_payload_layout(return_type, return_origin, return_declaration);
         let is_prelude_dispatch = match function.unwrap_parens() {
             Expression::DotAccess { expression, .. } => {
                 let receiver_ty = self.facts.strip_and_peel(&expression.get_type());
@@ -269,6 +278,7 @@ impl<'a> Planner<'a> {
                 params,
                 result,
                 return_layout,
+                return_payload_layout,
             },
             is_prelude_dispatch,
         }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -533,6 +533,10 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
         let has_multi_return_go_strategy = self.planner.plan_call(self.value).is_some_and(|plan| {
             matches!(plan.resolved.origin, CallableOrigin::GoInterop)
                 && plan.resolved.abi.result.is_multi_return()
+                && self
+                    .planner
+                    .go_tuple_result_bridges(&plan.resolved.abi, &self.value.get_type())
+                    .is_none()
         });
         has_multi_return_go_strategy
             && !self.value.get_type().is_result()

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -439,6 +439,7 @@ impl Planner<'_> {
             ValueLayout::Slice { .. }
             | ValueLayout::Map { .. }
             | ValueLayout::Function { .. }
+            | ValueLayout::Reference { .. }
             | ValueLayout::NullableOption { .. }
             | ValueLayout::PointerOption { .. }
             | ValueLayout::Plain(Type::Compound {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -2002,3 +2002,570 @@ fn main() {
 "#;
     assert_emit_snapshot!(input);
 }
+#[test]
+fn interop_fn_arg_slice_option_string() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use([Some("hi"), None])
+}
+"#;
+    let typedef = r#"
+pub fn Use(xs: Slice<Option<string>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_arg_map_option_string() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let mut xs = Map.new<string, Option<string>>()
+  xs["k"] = Some("hi")
+  xs["gone"] = None
+  aws.Use(xs)
+}
+"#;
+    let typedef = r#"
+pub fn Use(xs: Map<string, Option<string>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_arg_variadic_option_pointer() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let n = aws.Node { .. }
+  aws.Use(Some(&n), None)
+}
+"#;
+    let typedef = r#"
+pub struct Node {
+  pub Value: int,
+}
+
+pub fn Use(xs: VarArgs<Option<Ref<Node>>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_arg_spread_variadic_option_pointer() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let n = aws.Node { .. }
+  let xs = [Some(&n), None]
+  aws.Use(xs...)
+}
+"#;
+    let typedef = r#"
+pub struct Node {
+  pub Value: int,
+}
+
+pub fn Use(xs: VarArgs<Option<Ref<Node>>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_return_slice_option_string() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  for x in aws.Make() {
+    match x {
+      Some(v) => { let _ = v },
+      None => {},
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<string>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_value_slice_option_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  let f = aws.Make
+  for x in f() {
+    match x {
+      Some(v) => fmt.Println(v),
+      None => fmt.Println("none"),
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<string>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_value_result_slice_option_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  let f = aws.Make
+  match f() {
+    Ok(xs) => {
+      for x in xs {
+        match x {
+          Some(v) => fmt.Println(v),
+          None => fmt.Println("none"),
+        }
+      }
+    },
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Result<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_result_slice_option_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  match aws.Make() {
+    Ok(xs) => {
+      for x in xs {
+        match x {
+          Some(v) => fmt.Println(v),
+          None => fmt.Println("none"),
+        }
+      }
+    },
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Result<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_propagate_slice_option_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn run() -> Result<(), error> {
+  let xs = aws.Make()?
+  for x in xs {
+    match x {
+      Some(v) => fmt.Println(v),
+      None => fmt.Println("none"),
+    }
+  }
+  Ok(())
+}
+
+fn main() {
+  let _ = run()
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Result<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_comma_ok_slice_option_return() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  match aws.Fetch() {
+    Some(xs) => {
+      for x in xs {
+        match x {
+          Some(v) => fmt.Println(v),
+          None => fmt.Println("none"),
+        }
+      }
+    },
+    None => fmt.Println("missing"),
+  }
+}
+"#;
+    let typedef = r#"
+#[go(comma_ok)]
+pub fn Fetch() -> Option<Slice<Option<string>>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_tuple_slice_option_slot() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  let (xs, n) = aws.Make()
+  fmt.Println(n)
+  for x in xs {
+    match x {
+      Some(v) => fmt.Println(v),
+      None => fmt.Println("none"),
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> (Slice<Option<string>>, int)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_value_result_let_call() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  let f = aws.Make
+  let r = f()
+  match r {
+    Ok(xs) => {
+      for x in xs {
+        match x {
+          Some(v) => fmt.Println(v),
+          None => fmt.Println("none"),
+        }
+      }
+    },
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Result<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_value_partial_slice_option() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  let f = aws.Read
+  match f() {
+    Ok(xs) => fmt.Println("ok", Slice.length(xs)),
+    Both(xs, e) => fmt.Println("both", Slice.length(xs), e),
+    Err(e) => fmt.Println("err", e),
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Read() -> Partial<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_lisette_result_slice_option_let() {
+    let input = r#"
+import "go:fmt"
+
+fn make() -> Result<Slice<Option<string>>, error> {
+  Ok([Some("hi"), None])
+}
+
+fn main() {
+  let r = make()
+  match r {
+    Ok(xs) => {
+      for x in xs {
+        match x {
+          Some(v) => fmt.Println(v),
+          None => fmt.Println("none"),
+        }
+      }
+    },
+    Err(e) => { let _ = e },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_go_fn_into_go_callback_param() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use(aws.Make)
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<string>>
+
+pub fn Use(f: fn() -> Slice<Option<string>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_go_fn_into_go_callback_param_result() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use(aws.Make)
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Result<Slice<Option<string>>, error>
+
+pub fn Use(f: fn() -> Result<Slice<Option<string>>, error>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_lisette_fn_into_go_callback_param() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn make_it() -> Slice<Option<string>> {
+  [Some("hi"), None]
+}
+
+fn main() {
+  aws.Use(make_it)
+}
+"#;
+    let typedef = r#"
+pub fn Use(f: fn() -> Slice<Option<string>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_go_fn_into_lisette_fn_param() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn apply(f: fn() -> Slice<Option<string>>) -> Slice<Option<string>> {
+  f()
+}
+
+fn main() {
+  let xs = apply(aws.Make)
+  for x in xs {
+    match x {
+      Some(v) => { let _ = v },
+      None => {},
+    }
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<string>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_go_return_into_go_param() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use(aws.Make())
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<int>>
+
+pub fn Use(xs: Slice<Option<int>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_go_return_spread_into_go_variadic() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use(aws.Make()...)
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<int>>
+
+pub fn Use(xs: VarArgs<Option<int>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_fn_value_tuple_nested_option_slot() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn apply(f: fn() -> (Option<Slice<Option<string>>>, int)) -> (Option<Slice<Option<string>>>, int) {
+  f()
+}
+
+fn main() {
+  let (xs, n) = apply(aws.Make)
+  let _ = n
+  match xs {
+    Some(inner) => { for x in inner { let _ = x } },
+    None => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> (Option<Slice<Option<string>>>, int)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_discarded_collection_return() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Make()
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Slice<Option<string>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_lisette_tuple_nested_option_slot() {
+    let input = r#"
+fn make() -> (Option<Slice<Option<string>>>, int) {
+  (Some([Some("hi"), None]), 7)
+}
+
+fn main() {
+  let t = make()
+  let (xs, n) = t
+  let _ = n
+  match xs {
+    Some(inner) => { for x in inner { let _ = x } },
+    None => {},
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_lisette_nested_option_return() {
+    let input = r#"
+fn make() -> Option<Slice<Option<string>>> {
+  Some([Some("hi"), None])
+}
+
+fn use_it(o: Option<Slice<Option<string>>>) {
+  match o {
+    Some(inner) => { for x in inner { let _ = x } },
+    None => {},
+  }
+}
+
+fn main() {
+  use_it(make())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_fn_arg_nested_option_slice() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  aws.Use(Some([Some("hi"), None]))
+  aws.Use(None)
+}
+"#;
+    let typedef = r#"
+pub fn Use(x: Option<Slice<Option<string>>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_ref_slice_option_return_and_arg() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let xs = aws.Make()
+  aws.Use(xs)
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Ref<Slice<Option<string>>>
+
+pub fn Use(x: Ref<Slice<Option<string>>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn interop_option_ref_slice_option() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  match aws.Make() {
+    Some(xs) => aws.Use(Some(xs)),
+    None => aws.Use(None),
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Make() -> Option<Ref<Slice<Option<string>>>>
+
+pub fn Use(x: Option<Ref<Slice<Option<string>>>>)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_comma_ok_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_slice_option_return.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  match aws.Fetch() {\n    Some(xs) => {\n      for x in xs {\n        match x {\n          Some(v) => fmt.Println(v),\n          None => fmt.Println(\"none\"),\n        }\n      }\n    },\n    None => fmt.Println(\"missing\"),\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ret_2, ret_3 := aws.Fetch()
+	var option_8 lisette.Option[[]lisette.Option[string]]
+	if ret_3 {
+		src_4 := ret_2
+		wrapped_5 := make([]lisette.Option[string], len(src_4))
+		for i_6, v_7 := range src_4 {
+			if v_7 != nil {
+				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+			} else {
+				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			}
+		}
+		option_8 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_5)
+	} else {
+		option_8 = lisette.MakeOptionNone[[]lisette.Option[string]]()
+	}
+	if option_8.Tag == lisette.OptionSome {
+		for _, x := range option_8.SomeVal {
+			if x.Tag == lisette.OptionSome {
+				fmt.Println(x.SomeVal)
+			} else {
+				fmt.Println("none")
+			}
+		}
+	} else {
+		fmt.Println("missing")
+	}
+}

--- a/tests/spec/emit/snapshots/interop_discarded_collection_return.snap
+++ b/tests/spec/emit/snapshots/interop_discarded_collection_return.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Make()\n}\n"
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Make()
+}

--- a/tests/spec/emit/snapshots/interop_fn_arg_map_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_map_option_string.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  let mut xs = Map.new<string, Option<string>>()\n  xs[\"k\"] = Some(\"hi\")\n  xs[\"gone\"] = None\n  aws.Use(xs)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	xs := make(map[string]lisette.Option[string])
+	xs["k"] = lisette.MakeOptionSome("hi")
+	xs["gone"] = lisette.MakeOptionNone[string]()
+	src_1 := xs
+	unwrapped_2 := make(map[string]*string, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = &v_4.SomeVal
+		} else {
+			unwrapped_2[i_3] = nil
+		}
+	}
+	aws.Use(unwrapped_2)
+}

--- a/tests/spec/emit/snapshots/interop_fn_arg_nested_option_slice.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_nested_option_slice.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use(Some([Some(\"hi\"), None]))\n  aws.Use(None)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	opt_1 := lisette.MakeOptionSome([]lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	})
+	var ptr_2 *[]*string
+	if opt_1.Tag == lisette.OptionSome {
+		src_3 := opt_1.SomeVal
+		unwrapped_4 := make([]*string, len(src_3))
+		for i_5, v_6 := range src_3 {
+			if v_6.Tag == lisette.OptionSome {
+				unwrapped_4[i_5] = &v_6.SomeVal
+			} else {
+				unwrapped_4[i_5] = nil
+			}
+		}
+		ptr_2 = &unwrapped_4
+	}
+	aws.Use(ptr_2)
+	aws.Use(nil)
+}

--- a/tests/spec/emit/snapshots/interop_fn_arg_slice_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_slice_option_string.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use([Some(\"hi\"), None])\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	src_1 := []lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	}
+	unwrapped_2 := make([]*string, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = &v_4.SomeVal
+		} else {
+			unwrapped_2[i_3] = nil
+		}
+	}
+	aws.Use(unwrapped_2)
+}

--- a/tests/spec/emit/snapshots/interop_fn_arg_spread_variadic_option_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_spread_variadic_option_pointer.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  let n = aws.Node { .. }\n  let xs = [Some(&n), None]\n  aws.Use(xs...)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	n := aws.Node{}
+	xs := []lisette.Option[*aws.Node]{
+		lisette.MakeOptionSome(&n),
+		lisette.MakeOptionNone[*aws.Node](),
+	}
+	src_1 := xs
+	unwrapped_2 := make([]*aws.Node, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = v_4.SomeVal
+		}
+	}
+	aws.Use(unwrapped_2...)
+}

--- a/tests/spec/emit/snapshots/interop_fn_arg_variadic_option_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_variadic_option_pointer.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  let n = aws.Node { .. }\n  aws.Use(Some(&n), None)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	n := aws.Node{}
+	opt_1 := lisette.MakeOptionSome(&n)
+	var unwrap_2 *aws.Node
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	aws.Use(unwrap_2, nil)
+}

--- a/tests/spec/emit/snapshots/interop_fn_return_slice_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_fn_return_slice_option_string.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  for x in aws.Make() {\n    match x {\n      Some(v) => { let _ = v },\n      None => {},\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	src_1 := aws.Make()
+	wrapped_2 := make([]lisette.Option[string], len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[string](*v_4)
+		} else {
+			wrapped_2[i_3] = lisette.MakeOptionNone[string]()
+		}
+	}
+	for _, x := range wrapped_2 {
+		if x.Tag == lisette.OptionSome {
+			_ = x.SomeVal
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  let f = aws.Read\n  match f() {\n    Ok(xs) => fmt.Println(\"ok\", Slice.length(xs)),\n    Both(xs, e) => fmt.Println(\"both\", Slice.length(xs), e),\n    Err(e) => fmt.Println(\"err\", e),\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	cb_1 := aws.Read
+	f := func() ([]lisette.Option[string], error) {
+		ret_2, ret_3 := cb_1()
+		if ret_2 == nil {
+			return nil, ret_3
+		}
+		src_4 := ret_2
+		wrapped_5 := make([]lisette.Option[string], len(src_4))
+		for i_6, v_7 := range src_4 {
+			if v_7 != nil {
+				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+			} else {
+				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			}
+		}
+		return wrapped_5, ret_3
+	}
+	ret_8, ret_9 := f()
+	if ret_9 == nil {
+		xs := ret_8
+		fmt.Println("ok", len(xs))
+	} else if ret_8 == nil {
+		e := ret_9
+		fmt.Println("err", e)
+	} else {
+		xs := ret_8
+		e := ret_9
+		fmt.Println("both", len(xs), e)
+	}
+}

--- a/tests/spec/emit/snapshots/interop_fn_value_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_let_call.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  let f = aws.Make\n  let r = f()\n  match r {\n    Ok(xs) => {\n      for x in xs {\n        match x {\n          Some(v) => fmt.Println(v),\n          None => fmt.Println(\"none\"),\n        }\n      }\n    },\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	cb_1 := aws.Make
+	f := func() ([]lisette.Option[string], error) {
+		ret_2, ret_3 := cb_1()
+		src_4 := ret_2
+		wrapped_5 := make([]lisette.Option[string], len(src_4))
+		for i_6, v_7 := range src_4 {
+			if v_7 != nil {
+				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+			} else {
+				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			}
+		}
+		return wrapped_5, ret_3
+	}
+	ret_8, ret_9 := f()
+	var result_10 lisette.Result[[]lisette.Option[string], error]
+	if ret_9 != nil {
+		result_10 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_9)
+	} else {
+		result_10 = lisette.MakeResultOk[[]lisette.Option[string], error](ret_8)
+	}
+	r := result_10
+	if r.Tag == lisette.ResultOk {
+		for _, x := range r.OkVal {
+			if x.Tag == lisette.OptionSome {
+				fmt.Println(x.SomeVal)
+			} else {
+				fmt.Println("none")
+			}
+		}
+	} else {
+		_ = r.ErrVal
+	}
+}

--- a/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  let f = aws.Make\n  match f() {\n    Ok(xs) => {\n      for x in xs {\n        match x {\n          Some(v) => fmt.Println(v),\n          None => fmt.Println(\"none\"),\n        }\n      }\n    },\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	cb_1 := aws.Make
+	f := func() ([]lisette.Option[string], error) {
+		ret_2, ret_3 := cb_1()
+		src_4 := ret_2
+		wrapped_5 := make([]lisette.Option[string], len(src_4))
+		for i_6, v_7 := range src_4 {
+			if v_7 != nil {
+				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+			} else {
+				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			}
+		}
+		return wrapped_5, ret_3
+	}
+	ret_8, ret_9 := f()
+	if ret_9 == nil {
+		xs := ret_8
+		for _, x := range xs {
+			if x.Tag == lisette.OptionSome {
+				fmt.Println(x.SomeVal)
+			} else {
+				fmt.Println("none")
+			}
+		}
+	} else {
+		e := ret_9
+		_ = e
+	}
+}

--- a/tests/spec/emit/snapshots/interop_fn_value_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_slice_option_return.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  let f = aws.Make\n  for x in f() {\n    match x {\n      Some(v) => fmt.Println(v),\n      None => fmt.Println(\"none\"),\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	cb_1 := aws.Make
+	f := func() []lisette.Option[string] {
+		src_2 := cb_1()
+		wrapped_3 := make([]lisette.Option[string], len(src_2))
+		for i_4, v_5 := range src_2 {
+			if v_5 != nil {
+				wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+			} else {
+				wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+			}
+		}
+		return wrapped_3
+	}
+	for _, x := range f() {
+		if x.Tag == lisette.OptionSome {
+			fmt.Println(x.SomeVal)
+		} else {
+			fmt.Println("none")
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn apply(f: fn() -> (Option<Slice<Option<string>>>, int)) -> (Option<Slice<Option<string>>>, int) {\n  f()\n}\n\nfn main() {\n  let (xs, n) = apply(aws.Make)\n  let _ = n\n  match xs {\n    Some(inner) => { for x in inner { let _ = x } },\n    None => {},\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func apply(f func() (lisette.Option[[]lisette.Option[string]], int)) (lisette.Option[[]lisette.Option[string]], int) {
+	ret_1, ret_2 := f()
+	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
+	tup_4 := tup_3
+	return tup_4.First, tup_4.Second
+}
+
+func main() {
+	cb_2 := aws.Make
+	ret_11, ret_12 := apply(func() (lisette.Option[[]lisette.Option[string]], int) {
+		ret_3, ret_4 := cb_2()
+		raw_5 := ret_3
+		var option_6 lisette.Option[[]lisette.Option[string]]
+		if raw_5 != nil {
+			src_7 := *raw_5
+			wrapped_8 := make([]lisette.Option[string], len(src_7))
+			for i_9, v_10 := range src_7 {
+				if v_10 != nil {
+					wrapped_8[i_9] = lisette.MakeOptionSome[string](*v_10)
+				} else {
+					wrapped_8[i_9] = lisette.MakeOptionNone[string]()
+				}
+			}
+			option_6 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_8)
+		} else {
+			option_6 = lisette.MakeOptionNone[[]lisette.Option[string]]()
+		}
+		return option_6, ret_4
+	})
+	tup_13 := lisette.MakeTuple2(ret_11, ret_12)
+	tmp_1 := tup_13
+	xs := tmp_1.First
+	n := tmp_1.Second
+	_ = n
+	if xs.Tag == lisette.OptionSome {
+		for _, x := range xs.SomeVal {
+			_ = x
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_go_fn_into_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_go_fn_into_go_callback_param.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use(aws.Make)\n}\n"
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Use(aws.Make)
+}

--- a/tests/spec/emit/snapshots/interop_go_fn_into_go_callback_param_result.snap
+++ b/tests/spec/emit/snapshots/interop_go_fn_into_go_callback_param_result.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use(aws.Make)\n}\n"
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Use(aws.Make)
+}

--- a/tests/spec/emit/snapshots/interop_go_fn_into_lisette_fn_param.snap
+++ b/tests/spec/emit/snapshots/interop_go_fn_into_lisette_fn_param.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn apply(f: fn() -> Slice<Option<string>>) -> Slice<Option<string>> {\n  f()\n}\n\nfn main() {\n  let xs = apply(aws.Make)\n  for x in xs {\n    match x {\n      Some(v) => { let _ = v },\n      None => {},\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func apply(f func() []lisette.Option[string]) []lisette.Option[string] {
+	return f()
+}
+
+func main() {
+	cb_1 := aws.Make
+	xs := apply(func() []lisette.Option[string] {
+		src_2 := cb_1()
+		wrapped_3 := make([]lisette.Option[string], len(src_2))
+		for i_4, v_5 := range src_2 {
+			if v_5 != nil {
+				wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+			} else {
+				wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+			}
+		}
+		return wrapped_3
+	})
+	for _, x := range xs {
+		if x.Tag == lisette.OptionSome {
+			_ = x.SomeVal
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_go_return_into_go_param.snap
+++ b/tests/spec/emit/snapshots/interop_go_return_into_go_param.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use(aws.Make())\n}\n"
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Use(aws.Make())
+}

--- a/tests/spec/emit/snapshots/interop_go_return_spread_into_go_variadic.snap
+++ b/tests/spec/emit/snapshots/interop_go_return_spread_into_go_variadic.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  aws.Use(aws.Make()...)\n}\n"
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Use(aws.Make()...)
+}

--- a/tests/spec/emit/snapshots/interop_lisette_fn_into_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_into_go_callback_param.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn make_it() -> Slice<Option<string>> {\n  [Some(\"hi\"), None]\n}\n\nfn main() {\n  aws.Use(make_it)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func make_it() []lisette.Option[string] {
+	return []lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	}
+}
+
+func main() {
+	cb_1 := make_it
+	aws.Use(func() []*string {
+		src_2 := cb_1()
+		unwrapped_3 := make([]*string, len(src_2))
+		for i_4, v_5 := range src_2 {
+			if v_5.Tag == lisette.OptionSome {
+				unwrapped_3[i_4] = &v_5.SomeVal
+			} else {
+				unwrapped_3[i_4] = nil
+			}
+		}
+		return unwrapped_3
+	})
+}

--- a/tests/spec/emit/snapshots/interop_lisette_nested_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_nested_option_return.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nfn make() -> Option<Slice<Option<string>>> {\n  Some([Some(\"hi\"), None])\n}\n\nfn use_it(o: Option<Slice<Option<string>>>) {\n  match o {\n    Some(inner) => { for x in inner { let _ = x } },\n    None => {},\n  }\n}\n\nfn main() {\n  use_it(make())\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func make_() ([]lisette.Option[string], bool) {
+	return []lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	}, true
+}
+
+func use_it(o lisette.Option[[]lisette.Option[string]]) {
+	if o.Tag == lisette.OptionSome {
+		for _, x := range o.SomeVal {
+			_ = x
+		}
+	}
+}
+
+func main() {
+	option_1 := lisette.OptionFromCommaOk[[]lisette.Option[string]](make_())
+	use_it(option_1)
+}

--- a/tests/spec/emit/snapshots/interop_lisette_result_slice_option_let.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_result_slice_option_let.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\n\nfn make() -> Result<Slice<Option<string>>, error> {\n  Ok([Some(\"hi\"), None])\n}\n\nfn main() {\n  let r = make()\n  match r {\n    Ok(xs) => {\n      for x in xs {\n        match x {\n          Some(v) => fmt.Println(v),\n          None => fmt.Println(\"none\"),\n        }\n      }\n    },\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func make_() ([]lisette.Option[string], error) {
+	return []lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	}, nil
+}
+
+func main() {
+	ret_1, ret_2 := make_()
+	var result_3 lisette.Result[[]lisette.Option[string], error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[[]lisette.Option[string], error](ret_1)
+	}
+	r := result_3
+	if r.Tag == lisette.ResultOk {
+		for _, x := range r.OkVal {
+			if x.Tag == lisette.OptionSome {
+				fmt.Println(x.SomeVal)
+			} else {
+				fmt.Println("none")
+			}
+		}
+	} else {
+		_ = r.ErrVal
+	}
+}

--- a/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nfn make() -> (Option<Slice<Option<string>>>, int) {\n  (Some([Some(\"hi\"), None]), 7)\n}\n\nfn main() {\n  let t = make()\n  let (xs, n) = t\n  let _ = n\n  match xs {\n    Some(inner) => { for x in inner { let _ = x } },\n    None => {},\n  }\n}\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func make_() (lisette.Option[[]lisette.Option[string]], int) {
+	return lisette.MakeOptionSome([]lisette.Option[string]{
+		lisette.MakeOptionSome("hi"),
+		lisette.MakeOptionNone[string](),
+	}), 7
+}
+
+func main() {
+	ret_1, ret_2 := make_()
+	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
+	t := tup_3
+	xs := t.First
+	n := t.Second
+	_ = n
+	if xs.Tag == lisette.OptionSome {
+		for _, x := range xs.SomeVal {
+			_ = x
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  match aws.Make() {\n    Some(xs) => aws.Use(Some(xs)),\n    None => aws.Use(None),\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	raw_2 := aws.Make()
+	var option_3 lisette.Option[*[]lisette.Option[string]]
+	if raw_2 != nil {
+		src_4 := raw_2
+		src_5 := *src_4
+		wrapped_6 := make([]lisette.Option[string], len(src_5))
+		for i_7, v_8 := range src_5 {
+			if v_8 != nil {
+				wrapped_6[i_7] = lisette.MakeOptionSome[string](*v_8)
+			} else {
+				wrapped_6[i_7] = lisette.MakeOptionNone[string]()
+			}
+		}
+		ref_9 := &wrapped_6
+		option_3 = lisette.MakeOptionSome[*[]lisette.Option[string]](ref_9)
+	} else {
+		option_3 = lisette.MakeOptionNone[*[]lisette.Option[string]]()
+	}
+	if option_3.Tag == lisette.OptionSome {
+		opt_10 := lisette.MakeOptionSome(option_3.SomeVal)
+		var unwrap_11 *[]*string
+		if opt_10.Tag == lisette.OptionSome {
+			src_12 := opt_10.SomeVal
+			src_13 := *src_12
+			unwrapped_14 := make([]*string, len(src_13))
+			for i_15, v_16 := range src_13 {
+				if v_16.Tag == lisette.OptionSome {
+					unwrapped_14[i_15] = &v_16.SomeVal
+				} else {
+					unwrapped_14[i_15] = nil
+				}
+			}
+			ref_17 := &unwrapped_14
+			unwrap_11 = ref_17
+		}
+		aws.Use(unwrap_11)
+	} else {
+		aws.Use(nil)
+	}
+}

--- a/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
+++ b/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
@@ -26,7 +26,13 @@ import (
 )
 
 func main() {
-	src, db := migrate.Close()
+	ret_2, ret_3 := migrate.Close()
+	option_4 := lisette.OptionFromNilable[error](ret_2, lisette.IsNilInterface(ret_2))
+	option_5 := lisette.OptionFromNilable[error](ret_3, lisette.IsNilInterface(ret_3))
+	tup_6 := lisette.MakeTuple2(option_4, option_5)
+	tmp_1 := tup_6
+	src := tmp_1.First
+	db := tmp_1.Second
 	if src.Tag == lisette.OptionSome {
 		fmt.Println("source:", src.SomeVal)
 	}

--- a/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn run() -> Result<(), error> {\n  let xs = aws.Make()?\n  for x in xs {\n    match x {\n      Some(v) => fmt.Println(v),\n      None => fmt.Println(\"none\"),\n    }\n  }\n  Ok(())\n}\n\nfn main() {\n  let _ = run()\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func run() error {
+	ret_1, ret_2 := aws.Make()
+	var result_3 lisette.Result[[]lisette.Option[string], error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
+	} else {
+		src_4 := ret_1
+		wrapped_5 := make([]lisette.Option[string], len(src_4))
+		for i_6, v_7 := range src_4 {
+			if v_7 != nil {
+				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+			} else {
+				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			}
+		}
+		result_3 = lisette.MakeResultOk[[]lisette.Option[string], error](wrapped_5)
+	}
+	check_8 := result_3
+	if check_8.Tag != lisette.ResultOk {
+		return check_8.ErrVal
+	}
+	xs := check_8.OkVal
+	for _, x := range xs {
+		if x.Tag == lisette.OptionSome {
+			fmt.Println(x.SomeVal)
+		} else {
+			fmt.Println("none")
+		}
+	}
+	return nil
+}
+
+func main() {
+	run()
+}

--- a/tests/spec/emit/snapshots/interop_ref_slice_option_return_and_arg.snap
+++ b/tests/spec/emit/snapshots/interop_ref_slice_option_return_and_arg.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:example.com/aws\"\n\nfn main() {\n  let xs = aws.Make()\n  aws.Use(xs)\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	src_1 := aws.Make()
+	src_2 := *src_1
+	wrapped_3 := make([]lisette.Option[string], len(src_2))
+	for i_4, v_5 := range src_2 {
+		if v_5 != nil {
+			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+		} else {
+			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+		}
+	}
+	ref_6 := &wrapped_3
+	xs := ref_6
+	src_7 := xs
+	src_8 := *src_7
+	unwrapped_9 := make([]*string, len(src_8))
+	for i_10, v_11 := range src_8 {
+		if v_11.Tag == lisette.OptionSome {
+			unwrapped_9[i_10] = &v_11.SomeVal
+		} else {
+			unwrapped_9[i_10] = nil
+		}
+	}
+	ref_12 := &unwrapped_9
+	aws.Use(ref_12)
+}

--- a/tests/spec/emit/snapshots/interop_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_option_return.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  match aws.Make() {\n    Ok(xs) => {\n      for x in xs {\n        match x {\n          Some(v) => fmt.Println(v),\n          None => fmt.Println(\"none\"),\n        }\n      }\n    },\n    Err(e) => { let _ = e },\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ret_2, ret_3 := aws.Make()
+	var result_4 lisette.Result[[]lisette.Option[string], error]
+	if ret_3 != nil {
+		result_4 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_3)
+	} else {
+		src_5 := ret_2
+		wrapped_6 := make([]lisette.Option[string], len(src_5))
+		for i_7, v_8 := range src_5 {
+			if v_8 != nil {
+				wrapped_6[i_7] = lisette.MakeOptionSome[string](*v_8)
+			} else {
+				wrapped_6[i_7] = lisette.MakeOptionNone[string]()
+			}
+		}
+		result_4 = lisette.MakeResultOk[[]lisette.Option[string], error](wrapped_6)
+	}
+	if result_4.Tag == lisette.ResultOk {
+		for _, x := range result_4.OkVal {
+			if x.Tag == lisette.OptionSome {
+				fmt.Println(x.SomeVal)
+			} else {
+				fmt.Println("none")
+			}
+		}
+	} else {
+		_ = result_4.ErrVal
+	}
+}

--- a/tests/spec/emit/snapshots/interop_tuple_slice_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_slice_option_slot.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: "\nimport \"go:fmt\"\nimport \"go:example.com/aws\"\n\nfn main() {\n  let (xs, n) = aws.Make()\n  fmt.Println(n)\n  for x in xs {\n    match x {\n      Some(v) => fmt.Println(v),\n      None => fmt.Println(\"none\"),\n    }\n  }\n}\n"
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ret_2, ret_3 := aws.Make()
+	src_4 := ret_2
+	wrapped_5 := make([]lisette.Option[string], len(src_4))
+	for i_6, v_7 := range src_4 {
+		if v_7 != nil {
+			wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+		} else {
+			wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+		}
+	}
+	tup_8 := lisette.MakeTuple2(wrapped_5, ret_3)
+	tmp_1 := tup_8
+	xs := tmp_1.First
+	n := tmp_1.Second
+	fmt.Println(n)
+	for _, x := range xs {
+		if x.Tag == lisette.OptionSome {
+			fmt.Println(x.SomeVal)
+		} else {
+			fmt.Println("none")
+		}
+	}
+}


### PR DESCRIPTION
`Option` values inside nested layouts (including tuples, variadic args, and fn args) now convert correctly between Lisette’s tagged representation and the representation required by Go parameter and return slots.

Surfaced by #990
