### PR TITLE
fix: let Go infer method call type arguments

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -360,14 +360,8 @@ impl Planner<'_> {
             }
             CallableOrigin::ReceiverMethodUfcs { is_public } => {
                 let method = extract_receiver_ufcs_method(function);
-                return self.lower_receiver_method_ufcs(
-                    function,
-                    args,
-                    resolved_type_args,
-                    &method,
-                    *is_public,
-                    spread,
-                );
+                return self
+                    .lower_receiver_method_ufcs(function, args, &method, *is_public, spread);
             }
             CallableOrigin::GoInterop | CallableOrigin::Regular => {}
         }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -303,6 +303,10 @@ impl<'a> Planner<'a> {
         function_string: &mut String,
         ctx: ExpressionContext<'_>,
     ) -> String {
+        if callee_curries_receiver(callee) {
+            return String::new();
+        }
+
         let has_value_args = arg_shape.value_count > 0 || arg_shape.has_spread;
         if let Some(recipe) = self.callee_collapsed_recipe(callee) {
             if has_value_args && self.collapsed_callee_fully_inferable(callee, arg_shape) {
@@ -874,6 +878,19 @@ impl<'a> Planner<'a> {
             GoExpression::opaque_with_deferred_evaluation(coerced, true)
         }))
     }
+}
+
+fn callee_curries_receiver(callee: &ResolvedCallee<'_>) -> bool {
+    let Some(Type::Forall { body, .. }) = callee.declared.as_ref() else {
+        return false;
+    };
+    let Type::Function(declared_fn) = body.as_ref() else {
+        return false;
+    };
+    callee
+        .instantiated
+        .as_function_type()
+        .is_some_and(|instantiated_fn| instantiated_fn.params.len() < declared_fn.params.len())
 }
 
 /// The element type of a `VarArgs<T>`, or the type itself when not variadic.

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -291,12 +291,10 @@ impl Planner<'_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn lower_receiver_method_ufcs(
         &mut self,
         function: &Expression,
         args: &[Expression],
-        type_args: &[Type],
         method: &str,
         is_public: bool,
         spread: Option<&Expression>,
@@ -326,8 +324,6 @@ impl Planner<'_> {
         let receiver = emitted_all[0].clone();
         let emitted_rest: Vec<String> = emitted_all[1..].to_vec();
 
-        let type_args_string = self.format_type_args(type_args);
-
         let receiver = if let Some(stripped) = receiver.strip_prefix('&') {
             if is_address_of_composite_literal(args.first()) {
                 format!("(&{})", stripped)
@@ -343,7 +339,7 @@ impl Planner<'_> {
         ValuePlan::observable_call(
             setup,
             GoExpression::call(
-                GoExpression::opaque(format!("{}.{}{}", receiver, go_method, type_args_string)),
+                GoExpression::opaque(format!("{}.{}", receiver, go_method)),
                 emitted_rest.into_iter().map(GoExpression::opaque).collect(),
             ),
             EvaluationEffect::EffectfulCall,

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -2569,3 +2569,31 @@ pub fn Use(x: Option<Ref<Slice<Option<string>>>>)
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
 }
+
+#[test]
+fn interop_generic_go_method_no_type_args() {
+    let input = r#"
+import "go:example.com/ttl"
+
+fn main() {
+  let cache = ttl.New<string, int>()
+  let _ = cache.Get("key")
+  cache.Set("key", 1, ttl.DefaultTTL)
+}
+"#;
+    let typedef = r#"
+pub type Duration = int64
+
+pub const DefaultTTL: Duration = 0
+
+pub type Cache<K: Comparable, V>
+
+pub fn New<K: Comparable, V>() -> Ref<Cache<K, V>>
+
+impl<K: Comparable, V> Cache<K, V> {
+  fn Get(self: Ref<Cache<K, V>>, key: K) -> V
+  fn Set(self: Ref<Cache<K, V>>, key: K, value: V, ttl: Duration)
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/ttl", typedef)]);
+}

--- a/tests/spec/emit/snapshots/generic_receiver_method_ufcs_explicit_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_receiver_method_ufcs_explicit_type_arg.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Box<T> { value: T }
+  
+  impl<T> Box<T> {
+    fn get(self) -> T {
+      self.value
+    }
+  }
+  
+  fn main() -> int {
+    let b = Box { value: 42 };
+    Box.get<int>(b)
+  }
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func (b Box[T]) get() T {
+	return b.value
+}
+
+func main() int {
+	b := Box[int]{value: 42}
+	return b.get()
+}

--- a/tests/spec/emit/snapshots/interop_generic_go_method_no_type_args.snap
+++ b/tests/spec/emit/snapshots/interop_generic_go_method_no_type_args.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/ttl"
+  
+  fn main() {
+    let cache = ttl.New<string, int>()
+    let _ = cache.Get("key")
+    cache.Set("key", 1, ttl.DefaultTTL)
+  }
+---
+package main
+
+import "example.com/ttl"
+
+func main() {
+	cache := ttl.New[string, int]()
+	_ = cache.Get("key")
+	cache.Set("key", 1, ttl.DefaultTTL)
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1433,6 +1433,25 @@ fn main() -> int {
 }
 
 #[test]
+fn generic_receiver_method_ufcs_explicit_type_arg() {
+    let input = r#"
+struct Box<T> { value: T }
+
+impl<T> Box<T> {
+  fn get(self) -> T {
+    self.value
+  }
+}
+
+fn main() -> int {
+  let b = Box { value: 42 };
+  Box.get<int>(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn generic_fn_explicit_unknown_type_arg() {
     let input = r#"
 fn foo<T>(args: T) -> T {


### PR DESCRIPTION
Calling a method on an instantiated generic type no longer emits explicit type args on the method itself. A Go method binds its type args from the receiver and rejects type args at callsite, so the emitted call now lets Go infer them.

```rs
let cache = ttlcache.New<string, int>()
let _ = cache.Set("key", 1, ttlcache.DefaultTTL)
```

This also covers the case where the type arguments are written explicitly, such as `Box.get<int>(b)`.

Fixes #992
