### PR TITLE
refactor: preserve lexical control targets when lowering

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -497,6 +497,7 @@ impl Planner<'_> {
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
+            target: None,
             label: None,
             header: format!("for {index}, {element} := range {source} {{\n"),
             body,

--- a/crates/emit/src/context/lowering.rs
+++ b/crates/emit/src/context/lowering.rs
@@ -1,4 +1,5 @@
 use crate::abi::callable::CallableReturnAbi;
+use crate::plan::bodies::LoopId;
 use syntax::types::Type;
 
 #[derive(Clone)]
@@ -70,6 +71,6 @@ impl ReturnContext {
 }
 
 pub(crate) struct LoopContext {
+    pub(crate) id: LoopId,
     pub(crate) result_var: String,
-    pub(crate) label: Option<String>,
 }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -3,7 +3,7 @@ use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
-use crate::plan::bodies::{LoopPlan, LoweredBlock, LoweredStatement, directed};
+use crate::plan::bodies::{LoweredBlock, LoweredStatement, directed};
 use crate::plan::values::CaptureBoundary;
 use crate::types::native::NativeGoType;
 use crate::types::shape::RangeShape;
@@ -17,7 +17,6 @@ impl Planner<'_> {
             binding,
             iterable,
             body,
-            needs_label,
             ..
         } = full_expression
         else {
@@ -25,7 +24,6 @@ impl Planner<'_> {
         };
         let iterable = iterable.as_ref();
         let body = body.as_ref();
-        let needs_label = *needs_label;
         let iterable_ty = iterable.get_type();
         let is_range = matches!(iterable, Expression::Range { .. });
         let stored_range = (!is_range)
@@ -43,8 +41,6 @@ impl Planner<'_> {
 
         let directive = self.maybe_line_directive(&full_expression.get_span());
         self.push_loop("_");
-        self.set_current_loop_label_if_needed(needs_label);
-        let label = self.current_loop_label().map(str::to_string);
 
         let (prologue, header, lowered_body) = if is_range {
             self.lower_range_for(binding, iterable, body)
@@ -63,17 +59,9 @@ impl Planner<'_> {
             self.lower_pattern_site_for(binding, iterable, body)
         };
 
+        let plan = self.build_source_loop(prologue, header, lowered_body);
         self.pop_loop();
-
-        directed(
-            directive,
-            LoweredStatement::Loop(LoopPlan {
-                prologue,
-                label,
-                header,
-                body: lowered_body,
-            }),
-        )
+        directed(directive, LoweredStatement::Loop(plan))
     }
 
     /// Plan `expr` as an operand, pushing its setup into `prologue` and

--- a/crates/emit/src/control_flow/mod.rs
+++ b/crates/emit/src/control_flow/mod.rs
@@ -3,3 +3,4 @@ mod fallible_blocks;
 mod loops;
 pub(crate) mod propagation;
 mod select;
+pub(crate) mod targets;

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -284,7 +284,10 @@ impl Planner<'_> {
             return Some(LoweredBlock {
                 statements: vec![
                     LoweredStatement::RawGo(format!("{} = nil\n", retry_var)),
-                    LoweredStatement::Continue { label: None },
+                    LoweredStatement::Continue {
+                        target: None,
+                        label: None,
+                    },
                 ],
             });
         }

--- a/crates/emit/src/control_flow/targets.rs
+++ b/crates/emit/src/control_flow/targets.rs
@@ -1,0 +1,211 @@
+use crate::plan::bodies::{
+    AssignForm, BreakValueDisposition, CompoundKind, ElseArm, ExpressionStatementForm, IfPlan,
+    LetForm, LoopId, LoopPlan, LoweredBlock, LoweredStatement, ReturnForm,
+};
+use crate::plan::values::ValuePlan;
+
+#[derive(Clone, Copy, Default)]
+struct Interception {
+    break_transfer: bool,
+    continue_transfer: bool,
+}
+
+impl Interception {
+    fn all() -> Self {
+        Self {
+            break_transfer: true,
+            continue_transfer: true,
+        }
+    }
+
+    fn breakable(self) -> Self {
+        Self {
+            break_transfer: true,
+            ..self
+        }
+    }
+}
+
+pub(crate) fn legalize_source_loop(plan: &mut LoopPlan) {
+    let Some(target) = plan.target else {
+        return;
+    };
+    debug_assert!(plan.label.is_none());
+    let mut legalizer = Legalizer::new(target);
+    legalizer.walk_block(&mut plan.body, Interception::default());
+    plan.label = legalizer.label;
+}
+
+struct Legalizer {
+    target: LoopId,
+    label: Option<String>,
+}
+
+impl Legalizer {
+    fn new(target: LoopId) -> Self {
+        Self {
+            target,
+            label: None,
+        }
+    }
+
+    fn walk_block(&mut self, block: &mut LoweredBlock, interception: Interception) {
+        self.walk_statements(&mut block.statements, interception);
+    }
+
+    fn walk_statements(&mut self, statements: &mut [LoweredStatement], interception: Interception) {
+        for statement in statements {
+            self.walk_statement(statement, interception);
+        }
+    }
+
+    fn walk_value(&mut self, value: &mut ValuePlan, interception: Interception) {
+        self.walk_statements(&mut value.setup, interception);
+    }
+
+    fn resolve_transfer(
+        &mut self,
+        transfer_target: Option<LoopId>,
+        resolved_label: &mut Option<String>,
+        intercepted: bool,
+    ) {
+        if transfer_target != Some(self.target) {
+            return;
+        }
+        if intercepted {
+            let label_number = self.target.0 + 1;
+            let label = self
+                .label
+                .get_or_insert_with(|| format!("loop_{label_number}"));
+            *resolved_label = Some(label.clone());
+        } else {
+            *resolved_label = None;
+        }
+    }
+
+    fn walk_statement(&mut self, statement: &mut LoweredStatement, interception: Interception) {
+        match statement {
+            LoweredStatement::If(plan) => self.walk_if(plan, interception),
+            LoweredStatement::Loop(plan) => {
+                self.walk_statements(&mut plan.prologue, interception);
+                if plan.target.is_none() {
+                    self.walk_block(&mut plan.body, Interception::all());
+                }
+            }
+            LoweredStatement::Block(body) => self.walk_block(body, interception),
+            LoweredStatement::Break { target, label } => {
+                self.resolve_transfer(*target, label, interception.break_transfer)
+            }
+            LoweredStatement::Continue { target, label } => {
+                self.resolve_transfer(*target, label, interception.continue_transfer)
+            }
+            LoweredStatement::Const(plan) => self.walk_value(&mut plan.value, interception),
+            LoweredStatement::Return(plan) => match &mut plan.form {
+                ReturnForm::Plain { value } => self.walk_value(value, interception),
+                ReturnForm::Unit { side_effect } => {
+                    if let Some(body) = side_effect {
+                        self.walk_block(body, interception);
+                    }
+                }
+                ReturnForm::LoweredAbi { body } | ReturnForm::Wrapped { body } => {
+                    self.walk_block(body, interception)
+                }
+                ReturnForm::Multi { .. } => {}
+            },
+            LoweredStatement::BreakValue(plan) => {
+                self.walk_value(&mut plan.value, interception);
+                if !matches!(&plan.disposition, BreakValueDisposition::Diverged) {
+                    self.resolve_transfer(
+                        plan.target,
+                        &mut plan.label,
+                        interception.break_transfer,
+                    );
+                }
+            }
+            LoweredStatement::Let(plan) => {
+                if let LetForm::Never {
+                    declaration: Some(declaration),
+                    ..
+                } = &mut plan.form
+                {
+                    self.walk_statement(declaration, interception);
+                }
+                self.walk_block(plan.form.body_mut(), interception);
+            }
+            LoweredStatement::Assign(plan) => match &mut plan.form {
+                AssignForm::Compound {
+                    target_capture,
+                    kind,
+                    ..
+                } => {
+                    self.walk_statements(target_capture, interception);
+                    if let CompoundKind::OpAssign { rhs, .. } = kind {
+                        self.walk_value(rhs, interception);
+                    }
+                }
+                AssignForm::Simple {
+                    target_capture,
+                    value,
+                    ..
+                } => {
+                    self.walk_statements(target_capture, interception);
+                    self.walk_value(value, interception);
+                }
+                AssignForm::Discard { body } | AssignForm::NeverTyped { body } => {
+                    self.walk_block(body, interception)
+                }
+            },
+            LoweredStatement::Expression(plan) => match &mut plan.form {
+                ExpressionStatementForm::Async { value } => self.walk_value(value, interception),
+                ExpressionStatementForm::AsyncBlock { .. } => {}
+                ExpressionStatementForm::Propagate { body }
+                | ExpressionStatementForm::Discard { body } => self.walk_block(body, interception),
+            },
+            LoweredStatement::Match(plan) => self.walk_block(&mut plan.body, interception),
+            LoweredStatement::Select(plan) => {
+                self.walk_statements(&mut plan.setup, interception);
+                let arm_interception = if plan.retry_loop {
+                    Interception::all()
+                } else {
+                    interception.breakable()
+                };
+                for arm in &mut plan.arms {
+                    self.walk_block(arm.body_mut(), arm_interception);
+                }
+                self.walk_statements(&mut plan.postlude, interception);
+            }
+            LoweredStatement::Switch(plan) => {
+                let case_interception = interception.breakable();
+                for case in &mut plan.cases {
+                    self.walk_block(&mut case.body, case_interception);
+                }
+                if let Some(body) = &mut plan.default {
+                    self.walk_block(body, case_interception);
+                }
+                self.walk_statements(&mut plan.postlude, interception);
+            }
+            LoweredStatement::WhileLet(plan) => self.walk_block(&mut plan.body, interception),
+            LoweredStatement::Directed { inner, .. } => self.walk_statement(inner, interception),
+            LoweredStatement::TempBind { .. }
+            | LoweredStatement::VarDecl { .. }
+            | LoweredStatement::ClosureBind { .. }
+            | LoweredStatement::RawGo(_)
+            | LoweredStatement::DivergingRawGo(_)
+            | LoweredStatement::UnreachablePanic => {}
+        }
+    }
+
+    fn walk_else(&mut self, arm: &mut ElseArm, interception: Interception) {
+        match arm {
+            ElseArm::None => {}
+            ElseArm::ElseIf(plan) => self.walk_if(plan, interception),
+            ElseArm::Else { body, .. } => self.walk_block(body, interception),
+        }
+    }
+
+    fn walk_if(&mut self, plan: &mut IfPlan, interception: Interception) {
+        self.walk_statements(&mut plan.condition_setup, interception);
+        self.walk_block(&mut plan.then_body, interception);
+        self.walk_else(&mut plan.else_arm, interception);
+    }
+}

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) mod types;
 mod utils;
 
 pub(crate) use analyze::facts::EmitFacts;
-pub(crate) use context::lowering::{LineIndex, LoopContext, ReturnContext};
+pub(crate) use context::lowering::{LineIndex, ReturnContext};
 pub(crate) use definitions::enum_layout::EnumLayout;
 pub(crate) use names::go_name;
 pub(crate) use names::go_name::escape_reserved;
@@ -45,7 +45,7 @@ use names::constraints::GenericConstraintTable;
 use names::go_name::GeneratedPackage;
 use names::packages::{PackageRequirements, PackageUse};
 use plan::ModulePlan;
-use plan::bodies::{LoweredBlock, LoweredStatement};
+use plan::bodies::{LoopId, LoweredBlock, LoweredStatement};
 use state::adapter_registry::AdapterRegistry;
 use state::file_namespace::FileNamespace;
 use state::module_state::{FunctionEmissionState, ModuleState};
@@ -419,10 +419,7 @@ impl<'a> Planner<'a> {
     }
 
     pub(crate) fn push_loop(&mut self, result_var: impl Into<String>) {
-        self.scope.push_loop(LoopContext {
-            result_var: result_var.into(),
-            label: None,
-        });
+        self.scope.push_loop(result_var.into());
     }
 
     pub(crate) fn pop_loop(&mut self) {
@@ -433,8 +430,8 @@ impl<'a> Planner<'a> {
         self.scope.current_loop_result_var()
     }
 
-    pub(crate) fn current_loop_label(&self) -> Option<&str> {
-        self.scope.current_loop_label()
+    pub(crate) fn current_loop_id(&self) -> Option<LoopId> {
+        self.scope.current_loop_id()
     }
 
     /// Push the enclosing function/lambda/try/recover return context. This
@@ -540,13 +537,6 @@ impl<'a> Planner<'a> {
 
     pub(crate) fn fresh_var(&mut self, hint: Option<&str>) -> String {
         self.scope.fresh_go_name(hint)
-    }
-
-    pub(crate) fn set_current_loop_label_if_needed(&mut self, needs_label: bool) {
-        if needs_label {
-            let label = self.fresh_var(Some("loop"));
-            self.scope.set_current_loop_label(label);
-        }
     }
 
     pub(crate) fn push_const_frame(&mut self) {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -13,7 +13,7 @@ use crate::patterns::binding_emit::{
     drop_inline_overlays, tree_assignment_statements, tree_binding_statements,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
-use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::state::bindings::BindingValue;
 use crate::utils::wrap_if_struct_literal;
 use crate::write_line;
@@ -263,10 +263,7 @@ impl Planner<'_> {
         typed: Option<&TypedPattern>,
         scrutinee: &Expression,
         body: &Expression,
-        needs_label: bool,
     ) -> LoweredBlock {
-        self.set_current_loop_label_if_needed(needs_label);
-        let label = self.current_loop_label().map(str::to_string);
         let scrutinee_ty = scrutinee.get_type();
         let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee);
 
@@ -285,17 +282,16 @@ impl Planner<'_> {
                     ty: &scrutinee_ty,
                 },
                 body,
-                label.as_deref(),
+            );
+            let plan = self.build_source_loop(
+                Vec::new(),
+                "for {\n".to_string(),
+                LoweredBlock {
+                    statements: loop_body,
+                },
             );
             return LoweredBlock {
-                statements: vec![LoweredStatement::Loop(LoopPlan {
-                    prologue: Vec::new(),
-                    label,
-                    header: "for {\n".to_string(),
-                    body: LoweredBlock {
-                        statements: loop_body,
-                    },
-                })],
+                statements: vec![LoweredStatement::Loop(plan)],
             };
         }
 
@@ -323,22 +319,23 @@ impl Planner<'_> {
             else_arm: ElseArm::Else {
                 body: LoweredBlock {
                     statements: vec![LoweredStatement::Break {
-                        label: label.clone(),
+                        target: self.current_loop_id(),
+                        label: None,
                     }],
                 },
                 inline: false,
             },
         }));
 
+        let plan = self.build_source_loop(
+            Vec::new(),
+            "for {\n".to_string(),
+            LoweredBlock {
+                statements: loop_body,
+            },
+        );
         LoweredBlock {
-            statements: vec![LoweredStatement::Loop(LoopPlan {
-                prologue: Vec::new(),
-                label,
-                header: "for {\n".to_string(),
-                body: LoweredBlock {
-                    statements: loop_body,
-                },
-            })],
+            statements: vec![LoweredStatement::Loop(plan)],
         }
     }
 
@@ -556,7 +553,6 @@ impl Planner<'_> {
         patterns: &[Pattern],
         subject: TypedSubject,
         body: &Expression,
-        label: Option<&str>,
     ) {
         let TypedSubject {
             var: subject_var,
@@ -607,7 +603,8 @@ impl Planner<'_> {
 
         let terminal = LoweredBlock {
             statements: vec![LoweredStatement::Break {
-                label: label.map(str::to_string),
+                target: self.current_loop_id(),
+                label: None,
             }],
         };
         statements.push(assemble_if_else_chain(pieces, terminal));

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -312,11 +312,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         self.walk(&mut body, tree, &ctx);
         if !unguarded_exit {
             body.push(LoweredStatement::Break {
+                target: None,
                 label: Some(label.clone()),
             });
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
+            target: None,
             label: Some(label),
             header: "for {\n".to_string(),
             body: LoweredBlock { statements: body },
@@ -1158,6 +1160,7 @@ fn apply_leaf_terminator(
         && !body_diverges
     {
         statements.push(LoweredStatement::Break {
+            target: None,
             label: Some(label.to_string()),
         });
     }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -26,6 +26,9 @@ pub(crate) struct LoweredBlock {
     pub(crate) statements: Vec<LoweredStatement>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct LoopId(pub(crate) u32);
+
 pub(crate) fn directed(directive: String, stmt: LoweredStatement) -> LoweredStatement {
     if directive.is_empty() {
         stmt
@@ -42,9 +45,11 @@ pub(crate) enum LoweredStatement {
     Loop(LoopPlan),
     Block(LoweredBlock),
     Break {
+        target: Option<LoopId>,
         label: Option<String>,
     },
     Continue {
+        target: Option<LoopId>,
         label: Option<String>,
     },
     Const(ConstPlan),
@@ -134,6 +139,7 @@ pub(crate) enum ReturnForm {
 pub(crate) struct BreakValuePlan {
     pub(crate) value: ValuePlan,
     pub(crate) disposition: BreakValueDisposition,
+    pub(crate) target: Option<LoopId>,
     pub(crate) label: Option<String>,
 }
 
@@ -190,6 +196,17 @@ pub(crate) enum LetForm {
 
 impl LetForm {
     pub(crate) fn body(&self) -> &LoweredBlock {
+        match self {
+            LetForm::Never { body, .. }
+            | LetForm::SimpleIdentifier { body }
+            | LetForm::Discard { body }
+            | LetForm::ComplexPattern { body }
+            | LetForm::MultiValueCall { body }
+            | LetForm::Refutable { body } => body,
+        }
+    }
+
+    pub(crate) fn body_mut(&mut self) -> &mut LoweredBlock {
         match self {
             LetForm::Never { body, .. }
             | LetForm::SimpleIdentifier { body }
@@ -354,6 +371,14 @@ impl SelectArmPlan {
             | SelectArmPlan::Default { body } => body,
         }
     }
+
+    pub(crate) fn body_mut(&mut self) -> &mut LoweredBlock {
+        match self {
+            SelectArmPlan::Receive { body, .. }
+            | SelectArmPlan::Send { body, .. }
+            | SelectArmPlan::Default { body } => body,
+        }
+    }
 }
 
 pub(crate) struct WhileLetPlan {
@@ -365,6 +390,7 @@ pub(crate) struct WhileLetPlan {
 /// opening brace; `label` is the optional break/continue label.
 pub(crate) struct LoopPlan {
     pub(crate) prologue: Vec<LoweredStatement>,
+    pub(crate) target: Option<LoopId>,
     pub(crate) label: Option<String>,
     pub(crate) header: String,
     pub(crate) body: LoweredBlock,

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -3,6 +3,7 @@ use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
+use crate::control_flow::targets::legalize_source_loop;
 use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
 use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
 use crate::plan::bodies::{
@@ -117,15 +118,12 @@ impl Planner<'_> {
         expression: &Expression,
         ty: &Type,
     ) -> ValuePlan {
-        let Expression::Loop {
-            body, needs_label, ..
-        } = expression
-        else {
+        let Expression::Loop { body, .. } = expression else {
             unreachable!("plan_loop_as_operand_temp called on non-Loop expression");
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty);
         self.push_loop(result_var.clone());
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label);
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body);
         self.pop_loop();
         ValuePlan::name(
             vec![declaration, LoweredStatement::Loop(plan)],
@@ -219,19 +217,14 @@ impl Planner<'_> {
                     self.lower_if(condition, consequence, alternative, &PlacePlan::Statement);
                 self.directed_at(expression, LoweredStatement::If(plan))
             }
-            Expression::Loop {
-                body, needs_label, ..
-            } => {
-                let plan = self.lower_infinite_loop(body, *needs_label);
+            Expression::Loop { body, .. } => {
+                let plan = self.lower_infinite_loop(body);
                 self.directed_at(expression, LoweredStatement::Loop(plan))
             }
             Expression::While {
-                condition,
-                body,
-                needs_label,
-                ..
+                condition, body, ..
             } => {
-                let plan = self.lower_while(condition, body, *needs_label);
+                let plan = self.lower_while(condition, body);
                 self.directed_at(expression, LoweredStatement::Loop(plan))
             }
             Expression::Block { .. } => {
@@ -242,12 +235,24 @@ impl Planner<'_> {
             }
             Expression::For { .. } => self.lower_for_statement(expression),
             Expression::Continue { .. } => {
-                let label = self.current_loop_label().map(str::to_string);
-                self.directed_at(expression, LoweredStatement::Continue { label })
+                let target = self.current_loop_id();
+                self.directed_at(
+                    expression,
+                    LoweredStatement::Continue {
+                        target,
+                        label: None,
+                    },
+                )
             }
             Expression::Break { value: None, .. } => {
-                let label = self.current_loop_label().map(str::to_string);
-                self.directed_at(expression, LoweredStatement::Break { label })
+                let target = self.current_loop_id();
+                self.directed_at(
+                    expression,
+                    LoweredStatement::Break {
+                        target,
+                        label: None,
+                    },
+                )
             }
             Expression::Break {
                 value: Some(value), ..
@@ -630,7 +635,6 @@ impl Planner<'_> {
             typed_pattern,
             scrutinee,
             body,
-            needs_label,
             ..
         } = expression
         else {
@@ -638,20 +642,14 @@ impl Planner<'_> {
         };
         let directive = self.maybe_line_directive(&expression.get_span());
         self.push_loop("_");
-        let body = self.lower_while_let(
-            pattern,
-            typed_pattern.as_ref(),
-            scrutinee,
-            body,
-            *needs_label,
-        );
+        let body = self.lower_while_let(pattern, typed_pattern.as_ref(), scrutinee, body);
         self.pop_loop();
         directed(directive, LoweredStatement::WhileLet(WhileLetPlan { body }))
     }
 
-    fn lower_infinite_loop(&mut self, body: &Expression, needs_label: bool) -> LoopPlan {
+    fn lower_infinite_loop(&mut self, body: &Expression) -> LoopPlan {
         self.push_loop("_");
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body, needs_label);
+        let plan = self.lower_loop_with_header("for {\n".to_string(), body);
         self.pop_loop();
         plan
     }
@@ -661,12 +659,7 @@ impl Planner<'_> {
         plan.into_parts()
     }
 
-    fn lower_while(
-        &mut self,
-        condition: &Expression,
-        body: &Expression,
-        needs_label: bool,
-    ) -> LoopPlan {
+    fn lower_while(&mut self, condition: &Expression, body: &Expression) -> LoopPlan {
         self.push_loop("_");
         let (setup, rendered) = self.lower_condition(condition);
         let header = if !setup.is_empty() {
@@ -685,30 +678,38 @@ impl Planner<'_> {
         } else {
             format!("for {} {{\n", wrap_if_struct_literal(rendered))
         };
-        let plan = self.lower_loop_with_header(header, body, needs_label);
+        let plan = self.lower_loop_with_header(header, body);
         self.pop_loop();
         plan
     }
 
-    /// Shared loop lowering once the header is known: set the label, lower
-    /// the body in a fresh scope. Caller owns `push_loop`/`pop_loop`.
-    pub(crate) fn lower_loop_with_header(
-        &mut self,
-        header: String,
-        body: &Expression,
-        needs_label: bool,
-    ) -> LoopPlan {
-        self.set_current_loop_label_if_needed(needs_label);
-        let label = self.current_loop_label().map(str::to_string);
+    /// Shared loop lowering once the header is known. Caller owns
+    /// `push_loop`/`pop_loop`.
+    pub(crate) fn lower_loop_with_header(&mut self, header: String, body: &Expression) -> LoopPlan {
         self.enter_scope();
         let lowered_body = self.lower_block_as_body(body);
         self.exit_scope();
-        LoopPlan {
-            prologue: Vec::new(),
-            label,
+        self.build_source_loop(Vec::new(), header, lowered_body)
+    }
+
+    pub(crate) fn build_source_loop(
+        &mut self,
+        prologue: Vec<LoweredStatement>,
+        header: String,
+        body: LoweredBlock,
+    ) -> LoopPlan {
+        let mut plan = LoopPlan {
+            prologue,
+            target: Some(
+                self.current_loop_id()
+                    .expect("source loop plan requires an active loop context"),
+            ),
+            label: None,
             header,
-            body: lowered_body,
-        }
+            body,
+        };
+        legalize_source_loop(&mut plan);
+        plan
     }
 
     /// Lower a branch arm body in statement position (`PlacePlan::Statement`).

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -262,12 +262,9 @@ impl Planner<'_> {
             return self.lower_option_result_assignment(var, target_ty, expression);
         }
 
-        if let Expression::Loop {
-            body, needs_label, ..
-        } = expression
-        {
+        if let Expression::Loop { body, .. } = expression {
             self.push_loop(var);
-            let plan = self.lower_loop_with_header("for {\n".to_string(), body, *needs_label);
+            let plan = self.lower_loop_with_header("for {\n".to_string(), body);
             self.pop_loop();
             return vec![LoweredStatement::Loop(plan)];
         }
@@ -670,11 +667,11 @@ impl Planner<'_> {
         } else {
             BreakValueDisposition::Discard
         };
-        let label = self.current_loop_label().map(str::to_string);
         BreakValuePlan {
             value,
             disposition,
-            label,
+            target: self.current_loop_id(),
+            label: None,
         }
     }
 }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -132,11 +132,11 @@ impl Renderer {
                 self.render_lowered_block(output, body);
                 output.push_str("}\n");
             }
-            LoweredStatement::Break { label } => match label {
+            LoweredStatement::Break { label, .. } => match label {
                 Some(label) => write_line!(output, "break {}", label),
                 None => output.push_str("break\n"),
             },
-            LoweredStatement::Continue { label } => match label {
+            LoweredStatement::Continue { label, .. } => match label {
                 Some(label) => write_line!(output, "continue {}", label),
                 None => output.push_str("continue\n"),
             },

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -6,10 +6,12 @@ use crate::Bindings;
 use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::escape_reserved;
+use crate::plan::bodies::LoopId;
 use crate::state::bindings::{BindingValue, InlineExpr};
 
 pub(crate) struct ScopeState {
     next_var: usize,
+    next_loop_id: u32,
     bindings: Bindings,
     declared: Vec<HashSet<String>>,
     type_param_go_names: HashSet<String>,
@@ -36,6 +38,7 @@ impl ScopeState {
     pub(crate) fn new() -> Self {
         Self {
             next_var: 0,
+            next_loop_id: 0,
             bindings: Bindings::new(),
             declared: vec![HashSet::default()],
             type_param_go_names: HashSet::default(),
@@ -70,6 +73,7 @@ impl ScopeState {
 
     pub(crate) fn reset_for_top_level(&mut self) {
         self.next_var = 0;
+        self.next_loop_id = 0;
         self.bindings.reset();
         self.declared.clear();
         self.declared.push(HashSet::default());
@@ -215,8 +219,10 @@ impl ScopeState {
         self.next_var = checkpoint;
     }
 
-    pub(crate) fn push_loop(&mut self, ctx: LoopContext) {
-        self.loop_stack.push(ctx);
+    pub(crate) fn push_loop(&mut self, result_var: String) {
+        let id = LoopId(self.next_loop_id);
+        self.next_loop_id += 1;
+        self.loop_stack.push(LoopContext { id, result_var });
     }
 
     pub(crate) fn pop_loop(&mut self) {
@@ -251,14 +257,8 @@ impl ScopeState {
         self.loop_stack.last().map(|c| c.result_var.as_str())
     }
 
-    pub(crate) fn current_loop_label(&self) -> Option<&str> {
-        self.loop_stack.last().and_then(|c| c.label.as_deref())
-    }
-
-    pub(crate) fn set_current_loop_label(&mut self, label: String) {
-        if let Some(ctx) = self.loop_stack.last_mut() {
-            ctx.label = Some(label);
-        }
+    pub(crate) fn current_loop_id(&self) -> Option<LoopId> {
+        self.loop_stack.last().map(|context| context.id)
     }
 
     pub(crate) fn try_acquire_assign_target(&mut self, var: &str) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -406,7 +406,6 @@ impl InferCtx<'_, '_> {
         let needs_reconciliation =
             !arms_independent && result_ty.resolve_in(&self.env).is_variable();
 
-        let match_has_guard = arms.iter().any(|a| a.guard.is_some());
         let new_arms = arms
             .into_iter()
             .map(|a| {
@@ -427,15 +426,9 @@ impl InferCtx<'_, '_> {
                 } else {
                     &result_ty
                 };
-                let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-                let saved_in_retry_loop_arm = self
-                    .scopes
-                    .set_in_retry_loop_arm(self.scopes.is_in_retry_loop_arm() || match_has_guard);
                 // Arm body is a tail-like context where Never calls are valid.
                 self.scopes.set_in_subexpression(false);
                 let new_expression = self.infer_expression(*a.expression, arm_expected);
-                self.scopes.set_in_retry_loop_arm(saved_in_retry_loop_arm);
-                self.scopes.set_in_match_arm(saved_in_match_arm);
 
                 self.scopes.pop();
 
@@ -474,13 +467,7 @@ impl InferCtx<'_, '_> {
         let prev_break_type = self.scopes.loop_break_type().cloned();
         self.scopes.set_loop_break_type(break_ty.clone());
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(false);
-        self.scopes.push_loop_needs_label();
-
         let new_body = self.infer_in_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        let needs_label = self.scopes.pop_loop_needs_label();
-        self.scopes.set_in_match_arm(saved_in_match_arm);
 
         if let Some(prev) = prev_break_type {
             self.scopes.set_loop_break_type(prev);
@@ -502,7 +489,6 @@ impl InferCtx<'_, '_> {
             body: new_body.into(),
             ty: loop_type,
             span,
-            needs_label,
         }
     }
 
@@ -521,20 +507,13 @@ impl InferCtx<'_, '_> {
                 .push(diagnostics::infer::propagate_in_condition(span));
         }
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(false);
-        self.scopes.push_loop_needs_label();
-
         let new_body =
             self.infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        let needs_label = self.scopes.pop_loop_needs_label();
-        self.scopes.set_in_match_arm(saved_in_match_arm);
 
         Expression::While {
             condition: new_condition.into(),
             body: new_body.into(),
             span,
-            needs_label,
         }
     }
 
@@ -563,14 +542,8 @@ impl InferCtx<'_, '_> {
             BindingKind::WhileLet,
         );
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(false);
-        self.scopes.push_loop_needs_label();
-
         let new_body =
             self.infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        let needs_label = self.scopes.pop_loop_needs_label();
-        self.scopes.set_in_match_arm(saved_in_match_arm);
 
         self.scopes.pop();
 
@@ -580,7 +553,6 @@ impl InferCtx<'_, '_> {
             body: new_body.into(),
             typed_pattern: Some(typed_pattern),
             span,
-            needs_label,
         }
     }
 
@@ -754,14 +726,8 @@ impl InferCtx<'_, '_> {
             }
         }
 
-        let saved_in_match_arm = self.scopes.set_in_match_arm(false);
-        self.scopes.push_loop_needs_label();
-
         let new_body =
             self.infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        let needs_label = self.scopes.pop_loop_needs_label();
-        self.scopes.set_in_match_arm(saved_in_match_arm);
 
         self.scopes.pop();
 
@@ -770,7 +736,6 @@ impl InferCtx<'_, '_> {
             iterable: new_iterable.into(),
             body: new_body.into(),
             span,
-            needs_label,
             binding_id,
         }
     }
@@ -922,8 +887,6 @@ impl InferCtx<'_, '_> {
         self.check_break_in_recover_block(span);
         self.check_break_in_defer_block(span);
 
-        self.mark_loop_needs_label_in_match_arm();
-
         let new_value = if let Some(val) = value {
             if self.scopes.loop_break_type().is_none() && self.scopes.is_inside_loop() {
                 self.sink
@@ -966,17 +929,7 @@ impl InferCtx<'_, '_> {
         self.check_continue_in_recover_block(span);
         self.check_continue_in_defer_block(span);
 
-        if self.scopes.is_in_retry_loop_arm() {
-            self.scopes.mark_current_loop_needs_label();
-        }
-
         Expression::Continue { span }
-    }
-
-    fn mark_loop_needs_label_in_match_arm(&mut self) {
-        if self.scopes.is_in_match_arm() {
-            self.scopes.mark_current_loop_needs_label();
-        }
     }
 
     pub(crate) fn find_propagate(expression: &Expression) -> Option<Span> {

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -48,10 +48,6 @@ impl InferCtx<'_, '_> {
         self.check_multiple_select_receives(&arms);
         self.check_duplicate_select_defaults(&arms);
 
-        let has_retry_loop = arms.iter().any(|arm| {
-            matches!(&arm.pattern, SelectArmPattern::Receive { binding, .. } if binding.is_some_pattern())
-        });
-
         let result_ty = self.new_type_var();
         self.unify(expected_ty, &result_ty, &span);
 
@@ -88,18 +84,12 @@ impl InferCtx<'_, '_> {
                         receive_expression,
                         body,
                         ..
-                    } => self.infer_select_receive(
-                        binding,
-                        receive_expression,
-                        body,
-                        arm_target,
-                        has_retry_loop,
-                    ),
+                    } => self.infer_select_receive(binding, receive_expression, body, arm_target),
 
                     SelectArmPattern::Send {
                         send_expression,
                         body,
-                    } => self.infer_select_send(send_expression, body, arm_target, has_retry_loop),
+                    } => self.infer_select_send(send_expression, body, arm_target),
 
                     SelectArmPattern::MatchReceive {
                         receive_expression,
@@ -109,11 +99,10 @@ impl InferCtx<'_, '_> {
                         match_arms,
                         arm_target,
                         value_position,
-                        has_retry_loop,
                     ),
 
                     SelectArmPattern::WildCard { body } => {
-                        self.infer_select_wildcard(body, arm_target, has_retry_loop)
+                        self.infer_select_wildcard(body, arm_target)
                     }
                 };
 
@@ -161,30 +150,12 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    fn infer_select_arm_body(
-        &mut self,
-        body: Expression,
-        expected_ty: &Type,
-        has_retry_loop: bool,
-    ) -> Expression {
-        let saved_in_match_arm = self.scopes.set_in_match_arm(true);
-        let saved_in_retry_loop_arm = self
-            .scopes
-            .set_in_retry_loop_arm(self.scopes.is_in_retry_loop_arm() || has_retry_loop);
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(body, expected_ty);
-        self.scopes.set_in_retry_loop_arm(saved_in_retry_loop_arm);
-        self.scopes.set_in_match_arm(saved_in_match_arm);
-        new_body
-    }
-
     fn infer_select_receive(
         &mut self,
         binding: Box<Pattern>,
         receive_expression: Box<Expression>,
         body: Box<Expression>,
         result_ty: &Type,
-        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let receive_ty = self.new_type_var();
         let new_receive_expression = self.infer_expression(*receive_expression, &receive_ty);
@@ -255,7 +226,8 @@ impl InferCtx<'_, '_> {
             syntax::ast::BindingKind::Let { mutable: false },
         );
 
-        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
+        self.scopes.set_in_subexpression(false);
+        let new_body = self.infer_expression(*body, result_ty);
 
         SelectArmPattern::Receive {
             binding: Box::new(new_binding),
@@ -270,7 +242,6 @@ impl InferCtx<'_, '_> {
         send_expression: Box<Expression>,
         body: Box<Expression>,
         result_ty: &Type,
-        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let send_ty = self.new_type_var();
         let new_send_expression = self.infer_expression(*send_expression, &send_ty);
@@ -285,7 +256,8 @@ impl InferCtx<'_, '_> {
             ));
         }
 
-        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
+        self.scopes.set_in_subexpression(false);
+        let new_body = self.infer_expression(*body, result_ty);
 
         SelectArmPattern::Send {
             send_expression: Box::new(new_send_expression),
@@ -299,7 +271,6 @@ impl InferCtx<'_, '_> {
         match_arms: Vec<MatchArm>,
         result_ty: &Type,
         value_position: bool,
-        has_retry_loop: bool,
     ) -> SelectArmPattern {
         let receive_ty = self.new_type_var();
         let new_receive_expression = self.infer_expression(*receive_expression, &receive_ty);
@@ -356,8 +327,8 @@ impl InferCtx<'_, '_> {
                     result_ty
                 };
 
-                let new_expression =
-                    self.infer_select_arm_body(*match_arm.expression, arm_expected, has_retry_loop);
+                self.scopes.set_in_subexpression(false);
+                let new_expression = self.infer_expression(*match_arm.expression, arm_expected);
 
                 if needs_reconciliation {
                     arm_expression_types.push(arm_expected.clone());
@@ -399,9 +370,9 @@ impl InferCtx<'_, '_> {
         &mut self,
         body: Box<Expression>,
         result_ty: &Type,
-        has_retry_loop: bool,
     ) -> SelectArmPattern {
-        let new_body = self.infer_select_arm_body(*body, result_ty, has_retry_loop);
+        self.scopes.set_in_subexpression(false);
+        let new_body = self.infer_expression(*body, result_ty);
         SelectArmPattern::WildCard {
             body: Box::new(new_body),
         }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -124,18 +124,6 @@ impl Scope {
 
 pub struct Scopes {
     stack: Vec<Scope>,
-    /// True when inferring a match/select arm body. Consumed by `infer_break`:
-    /// a Go `break` inside a switch case escapes only the switch.
-    in_match_arm: Cell<bool>,
-    /// True inside an arm whose body lowers into a synthetic retry `for` loop:
-    /// a guarded match arm, or any arm of a `select` with a shorthand receive.
-    /// Consumed by `infer_continue`: a `continue` there needs a label to
-    /// target the user loop rather than the retry loop.
-    in_retry_loop_arm: Cell<bool>,
-    /// One entry per enclosing loop. Set to `true` by a `break` in a match arm
-    /// or a `continue` in a retry-loop arm. The top is popped by the loop's
-    /// inference function and recorded on the Loop/While/For/WhileLet AST node.
-    loop_needs_label_stack: std::cell::RefCell<Vec<bool>>,
     /// True when inferring inside a compound expression (call arg, binary
     /// operand, etc.). Used to reject `Err(x)?`/`None?` and similar control-flow
     /// in positions where they can never produce a value.
@@ -164,9 +152,6 @@ impl Scopes {
     pub fn new() -> Self {
         Scopes {
             stack: vec![Scope::new()],
-            in_match_arm: Cell::new(false),
-            in_retry_loop_arm: Cell::new(false),
-            loop_needs_label_stack: std::cell::RefCell::new(Vec::new()),
             in_subexpression: Cell::new(false),
             dot_access_base: Cell::new(false),
             let_binding_rhs: Cell::new(false),
@@ -207,9 +192,6 @@ impl Scopes {
     pub fn reset(&mut self) {
         self.stack.clear();
         self.stack.push(Scope::new());
-        self.in_match_arm.set(false);
-        self.in_retry_loop_arm.set(false);
-        self.loop_needs_label_stack.borrow_mut().clear();
         self.in_subexpression.set(false);
         self.dot_access_base.set(false);
         self.impl_receiver_type = None;
@@ -468,39 +450,6 @@ impl Scopes {
 
     pub fn is_assignment_target_context(&self) -> bool {
         self.current().use_context.get() == UseContext::AssignmentTarget
-    }
-
-    pub fn is_in_match_arm(&self) -> bool {
-        self.in_match_arm.get()
-    }
-
-    pub fn set_in_match_arm(&self, value: bool) -> bool {
-        self.in_match_arm.replace(value)
-    }
-
-    pub fn is_in_retry_loop_arm(&self) -> bool {
-        self.in_retry_loop_arm.get()
-    }
-
-    pub fn set_in_retry_loop_arm(&self, value: bool) -> bool {
-        self.in_retry_loop_arm.replace(value)
-    }
-
-    pub fn push_loop_needs_label(&self) {
-        self.loop_needs_label_stack.borrow_mut().push(false);
-    }
-
-    pub fn pop_loop_needs_label(&self) -> bool {
-        self.loop_needs_label_stack
-            .borrow_mut()
-            .pop()
-            .expect("loop_needs_label_stack must not be empty when popping")
-    }
-
-    pub fn mark_current_loop_needs_label(&self) {
-        if let Some(flag) = self.loop_needs_label_stack.borrow_mut().last_mut() {
-            *flag = true;
-        }
     }
 
     pub fn is_in_subexpression(&self) -> bool {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -946,13 +946,11 @@ pub enum Expression {
         body: Box<Expression>,
         ty: Type,
         span: Span,
-        needs_label: bool,
     },
     While {
         condition: Box<Expression>,
         body: Box<Expression>,
         span: Span,
-        needs_label: bool,
     },
     WhileLet {
         pattern: Pattern,
@@ -960,14 +958,12 @@ pub enum Expression {
         body: Box<Expression>,
         typed_pattern: Option<TypedPattern>,
         span: Span,
-        needs_label: bool,
     },
     For {
         binding: Box<Binding>,
         iterable: Box<Expression>,
         body: Box<Expression>,
         span: Span,
-        needs_label: bool,
         binding_id: Option<BindingId>,
     },
     Break {

--- a/crates/syntax/src/ast_folder.rs
+++ b/crates/syntax/src/ast_folder.rs
@@ -338,14 +338,12 @@ pub trait AstFolder {
                 iterable,
                 body,
                 span,
-                needs_label,
                 binding_id,
             } => For {
                 binding,
                 iterable: Box::new(self.fold_expression(*iterable)?),
                 body: Box::new(self.fold_expression(*body)?),
                 span,
-                needs_label,
                 binding_id,
             },
 
@@ -353,12 +351,10 @@ pub trait AstFolder {
                 condition,
                 body,
                 span,
-                needs_label,
             } => While {
                 condition: Box::new(self.fold_expression(*condition)?),
                 body: Box::new(self.fold_expression(*body)?),
                 span,
-                needs_label,
             },
 
             WhileLet {
@@ -367,26 +363,18 @@ pub trait AstFolder {
                 body,
                 typed_pattern,
                 span,
-                needs_label,
             } => WhileLet {
                 pattern,
                 scrutinee: Box::new(self.fold_expression(*scrutinee)?),
                 body: Box::new(self.fold_expression(*body)?),
                 typed_pattern,
                 span,
-                needs_label,
             },
 
-            Loop {
-                body,
-                ty,
-                span,
-                needs_label,
-            } => Loop {
+            Loop { body, ty, span } => Loop {
                 body: Box::new(self.fold_expression(*body)?),
                 ty,
                 span,
-                needs_label,
             },
 
             Task {

--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -271,7 +271,6 @@ impl<'source> Parser<'source> {
             iterable: iterable.into(),
             body: body.into(),
             span: self.span_from_tokens(start),
-            needs_label: false,
             binding_id: None,
         }
     }
@@ -292,7 +291,6 @@ impl<'source> Parser<'source> {
             condition: condition.into(),
             body: body.into(),
             span: self.span_from_tokens(start),
-            needs_label: false,
         }
     }
 
@@ -310,7 +308,6 @@ impl<'source> Parser<'source> {
             body: body.into(),
             typed_pattern: None,
             span: self.span_from_tokens(start),
-            needs_label: false,
         }
     }
 
@@ -324,7 +321,6 @@ impl<'source> Parser<'source> {
             body: body.into(),
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
-            needs_label: false,
         }
     }
 

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -724,6 +724,35 @@ fn main() {
 }
 
 #[test]
+fn select_retry_region_preserves_nested_loop_target() {
+    let input = r#"
+fn main() {
+  let ch = Channel.buffered<int>(1)
+  ch.send(1)
+  let mut total = 0
+  loop {
+    select {
+      let Some(_) = ch.receive() => {
+        for i in 0..2 {
+          if i == 0 {
+            continue
+          }
+          total += 1
+        }
+        break
+      },
+      _ => break,
+    }
+  }
+  if total != 1 {
+    panic(f"expected 1, got {total}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn select_arm_binding_does_not_leak() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
@@ -19,18 +19,18 @@ func find_first_negative(items []int) int {
 	result := 0
 loop_1:
 	for _, item := range items {
-		subject_2 := item
-	match_3:
+		subject_1 := item
+	match_2:
 		for {
 			{
-				n := subject_2
+				n := subject_1
 				if n < 0 {
 					result = n
 					break loop_1
 				}
 			}
 			{
-				break match_3
+				break match_2
 			}
 		}
 	}

--- a/tests/spec/emit/snapshots/break_in_match_as_expression_no_value.snap
+++ b/tests/spec/emit/snapshots/break_in_match_as_expression_no_value.snap
@@ -18,12 +18,11 @@ package main
 
 func test() {
 	i := 0
-loop_1:
 	for i < 100 {
 		var v int
-		subject_2 := i >= 5
-		if subject_2 {
-			break loop_1
+		subject_1 := i >= 5
+		if subject_1 {
+			break
 		}
 		v = i
 		_ = v

--- a/tests/spec/emit/snapshots/break_in_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_match_in_loop.snap
@@ -17,10 +17,9 @@ package main
 
 func test(items []int) int {
 	sum := 0
-loop_1:
 	for _, item := range items {
 		if item == 0 {
-			break loop_1
+			break
 		}
 		sum += item
 	}

--- a/tests/spec/emit/snapshots/break_value_in_match_as_expression_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_value_in_match_as_expression_in_loop.snap
@@ -17,15 +17,14 @@ package main
 func test() int {
 	n := 0
 	var tmp_1 int
-loop_2:
 	for {
-		var tmp_3 int
+		var tmp_2 int
 		if n == 5 {
 			tmp_1 = n
-			break loop_2
+			break
 		}
-		tmp_3 = n + 1
-		n = tmp_3
+		tmp_2 = n + 1
+		n = tmp_2
 	}
 	return tmp_1
 }

--- a/tests/spec/emit/snapshots/break_value_in_match_branch_assignment_rhs.snap
+++ b/tests/spec/emit/snapshots/break_value_in_match_branch_assignment_rhs.snap
@@ -15,16 +15,15 @@ package main
 
 func test() {
 	var tmp_1 int
-loop_2:
 	for {
 		x := 0
-		var tmp_3 int
+		var tmp_2 int
 		if 1 == 1 {
 			tmp_1 = 1
-			break loop_2
+			break
 		}
-		tmp_3 = 1
-		x = tmp_3
+		tmp_2 = 1
+		x = tmp_2
 		_ = x
 	}
 	_ = tmp_1

--- a/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
@@ -19,14 +19,14 @@ func sum_positives(items []int) int {
 	sum := 0
 loop_1:
 	for _, item := range items {
-		subject_2 := item
-	match_3:
+		subject_1 := item
+	match_2:
 		for {
 			{
-				n := subject_2
+				n := subject_1
 				if n > 0 {
 					sum += n
-					break match_3
+					break match_2
 				}
 			}
 			{

--- a/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
+++ b/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
@@ -31,25 +31,24 @@ import (
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
-loop_1:
 	for {
-		var r_2 rune
-		ret_4, ret_5, ret_6 := reader.ReadRune()
-		tup_7 := lisette.MakeTuple2(ret_4, ret_5)
-		var result_8 lisette.Result[lisette.Tuple2[rune, int], error]
-		if ret_6 != nil {
-			result_8 = lisette.MakeResultErr[lisette.Tuple2[rune, int], error](ret_6)
+		var r_1 rune
+		ret_3, ret_4, ret_5 := reader.ReadRune()
+		tup_6 := lisette.MakeTuple2(ret_3, ret_4)
+		var result_7 lisette.Result[lisette.Tuple2[rune, int], error]
+		if ret_5 != nil {
+			result_7 = lisette.MakeResultErr[lisette.Tuple2[rune, int], error](ret_5)
 		} else {
-			result_8 = lisette.MakeResultOk[lisette.Tuple2[rune, int], error](tup_7)
+			result_7 = lisette.MakeResultOk[lisette.Tuple2[rune, int], error](tup_6)
 		}
-		if result_8.Tag == lisette.ResultOk {
-			r_2 = result_8.OkVal.First
+		if result_7.Tag == lisette.ResultOk {
+			r_1 = result_7.OkVal.First
 		} else {
-			if result_8.ErrVal == io.EOF {
-				break loop_1
+			if result_7.ErrVal == io.EOF {
+				break
 			}
 			panic("error")
 		}
-		fmt.Printf("%c", r_2)
+		fmt.Printf("%c", r_1)
 	}
 }

--- a/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
+++ b/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
@@ -35,19 +35,18 @@ func maybe(flag bool) (int, bool) {
 
 func test() int {
 	count := 0
-loop_1:
 	for {
 		count++
 		if count > 5 {
-			break loop_1
+			break
 		}
 		if count == 1 {
-			option_3 := lisette.OptionFromCommaOk[int](maybe(true))
-			subject_2 := option_3
-			if subject_2.Tag != lisette.OptionSome {
-				break loop_1
+			option_2 := lisette.OptionFromCommaOk[int](maybe(true))
+			subject_1 := option_2
+			if subject_1.Tag != lisette.OptionSome {
+				break
 			}
-			v := subject_2.SomeVal
+			v := subject_1.SomeVal
 			_ = v
 		}
 	}

--- a/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_break_in_loop_needs_label.snap
@@ -31,15 +31,15 @@ func main() {
 	_ = lisette.ChannelSend(ch, "hello")
 loop_1:
 	for {
-		ch_2 := ch
+		ch_1 := ch
 		for {
 			select {
-			case msg, ok := <-ch_2:
+			case msg, ok := <-ch_1:
 				if ok {
 					fmt.Println(msg)
 					break loop_1
 				} else {
-					ch_2 = nil
+					ch_1 = nil
 					continue
 				}
 			default:

--- a/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
@@ -37,12 +37,12 @@ loop_1:
 		if i == 1 {
 			_ = lisette.ChannelSend(ch, 7)
 		}
-		ch_2 := ch
+		ch_1 := ch
 		for {
 			select {
-			case _, ok := <-ch_2:
+			case _, ok := <-ch_1:
 				if !ok {
-					ch_2 = nil
+					ch_1 = nil
 					continue
 				}
 			default:

--- a/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
@@ -42,18 +42,18 @@ func main() {
 	lisette.ChannelClose(ch)
 	processed := ""
 loop_1:
-	for _i_2 := 0; _i_2 < 2; _i_2++ {
-		ch_3 := ch
+	for _i_1 := 0; _i_1 < 2; _i_1++ {
+		ch_2 := ch
 		for {
 			select {
-			case x, ok := <-ch_3:
+			case x, ok := <-ch_2:
 				if ok {
 					if x < 0 {
 						continue loop_1
 					}
 					processed += fmt.Sprintf("%d,", x)
 				} else {
-					ch_3 = nil
+					ch_2 = nil
 					continue
 				}
 			default:

--- a/tests/spec/emit/snapshots/select_retry_region_preserves_nested_loop_target.snap
+++ b/tests/spec/emit/snapshots/select_retry_region_preserves_nested_loop_target.snap
@@ -1,0 +1,65 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: |
+  
+  fn main() {
+    let ch = Channel.buffered<int>(1)
+    ch.send(1)
+    let mut total = 0
+    loop {
+      select {
+        let Some(_) = ch.receive() => {
+          for i in 0..2 {
+            if i == 0 {
+              continue
+            }
+            total += 1
+          }
+          break
+        },
+        _ => break,
+      }
+    }
+    if total != 1 {
+      panic(f"expected 1, got {total}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ch := make(chan int, 1)
+	_ = lisette.ChannelSend(ch, 1)
+	total := 0
+loop_1:
+	for {
+		ch_1 := ch
+		for {
+			select {
+			case _, ok := <-ch_1:
+				if ok {
+					for i := 0; i < 2; i++ {
+						if i == 0 {
+							continue
+						}
+						total++
+					}
+					break loop_1
+				} else {
+					ch_1 = nil
+					continue
+				}
+			default:
+				break loop_1
+			}
+		}
+	}
+	if total != 1 {
+		panic(fmt.Sprintf("expected 1, got %d", total))
+	}
+}

--- a/tests/spec/parse/snapshots/for_loop.snap
+++ b/tests/spec/parse/snapshots/for_loop.snap
@@ -151,7 +151,6 @@ description: |
                         byte_offset: 35,
                         byte_length: 40,
                     },
-                    needs_label: false,
                     binding_id: None,
                 },
             ],

--- a/tests/spec/parse/snapshots/for_loop_tuple_binding.snap
+++ b/tests/spec/parse/snapshots/for_loop_tuple_binding.snap
@@ -190,7 +190,6 @@ description: |
                         byte_offset: 41,
                         byte_length: 57,
                     },
-                    needs_label: false,
                     binding_id: None,
                 },
             ],

--- a/tests/spec/parse/snapshots/let_else_with_break.snap
+++ b/tests/spec/parse/snapshots/let_else_with_break.snap
@@ -204,7 +204,6 @@ description: |
                         byte_offset: 15,
                         byte_length: 79,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/let_else_with_continue.snap
+++ b/tests/spec/parse/snapshots/let_else_with_continue.snap
@@ -229,7 +229,6 @@ description: |
                         byte_offset: 15,
                         byte_length: 99,
                     },
-                    needs_label: false,
                     binding_id: None,
                 },
             ],

--- a/tests/spec/parse/snapshots/loop_infinite.snap
+++ b/tests/spec/parse/snapshots/loop_infinite.snap
@@ -91,7 +91,6 @@ description: |
                         byte_offset: 15,
                         byte_length: 32,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/loop_with_break.snap
+++ b/tests/spec/parse/snapshots/loop_with_break.snap
@@ -118,7 +118,6 @@ description: |
                         byte_offset: 15,
                         byte_length: 52,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/loop_with_break_value.snap
+++ b/tests/spec/parse/snapshots/loop_with_break_value.snap
@@ -149,7 +149,6 @@ description: |
                             byte_offset: 23,
                             byte_length: 48,
                         },
-                        needs_label: false,
                     },
                     mutable: false,
                     mut_span: None,

--- a/tests/spec/parse/snapshots/loop_with_continue.snap
+++ b/tests/spec/parse/snapshots/loop_with_continue.snap
@@ -146,7 +146,6 @@ description: |
                         byte_offset: 15,
                         byte_length: 68,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/range_from.snap
+++ b/tests/spec/parse/snapshots/range_from.snap
@@ -92,7 +92,6 @@ description: |
                         byte_offset: 13,
                         byte_length: 23,
                     },
-                    needs_label: false,
                     binding_id: None,
                 },
             ],

--- a/tests/spec/parse/snapshots/range_in_for_loop.snap
+++ b/tests/spec/parse/snapshots/range_in_for_loop.snap
@@ -141,7 +141,6 @@ description: |
                         byte_offset: 13,
                         byte_length: 27,
                     },
-                    needs_label: false,
                     binding_id: None,
                 },
             ],

--- a/tests/spec/parse/snapshots/try_block_with_control_flow.snap
+++ b/tests/spec/parse/snapshots/try_block_with_control_flow.snap
@@ -174,7 +174,6 @@ description: |
                                     byte_offset: 38,
                                     byte_length: 63,
                                 },
-                                needs_label: false,
                                 binding_id: None,
                             },
                             Propagate {

--- a/tests/spec/parse/snapshots/while_let_simple.snap
+++ b/tests/spec/parse/snapshots/while_let_simple.snap
@@ -305,7 +305,6 @@ description: |
                         byte_offset: 57,
                         byte_length: 63,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/while_let_tuple_pattern.snap
+++ b/tests/spec/parse/snapshots/while_let_tuple_pattern.snap
@@ -364,7 +364,6 @@ description: |
                         byte_offset: 64,
                         byte_length: 72,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {

--- a/tests/spec/parse/snapshots/while_loop.snap
+++ b/tests/spec/parse/snapshots/while_loop.snap
@@ -237,7 +237,6 @@ description: |
                         byte_offset: 36,
                         byte_length: 63,
                     },
-                    needs_label: false,
                 },
             ],
             ty: Var {


### PR DESCRIPTION
This PR keeps each `break` and `continue` tied to its original source loop until Go lowering is complete. Emit adds a label only when generated control flow would otherwise intercept it, so we can remove removing Go-specific label tracking from syntax and semantics.