### PR TITLE
feat: polish array API, diagnostics, tooling

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -482,6 +482,10 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
 
 fn build_prelude_index() -> PreludeIndex {
     let mut index = build_index_from_source(stdlib::LIS_PRELUDE_SOURCE);
+    if let Some(array) = index.types.iter_mut().find(|t| t.name == "Array") {
+        array.generics.push("N".to_string());
+        array.definition = "type Array<T, N>".to_string();
+    }
     index.types.push(TypeInfo {
         name: "Unit".to_string(),
         generics: Vec::new(),
@@ -1091,7 +1095,7 @@ fn prelude_categories(index: &PreludeIndex) -> Vec<(&'static str, Vec<String>)> 
             .map(|t| format_type_with_generics_plain(&t.name, &t.generics))
             .collect()
     };
-    composite_leaves.extend(pick_generic(&["Slice", "Map"]));
+    composite_leaves.extend(pick_generic(&["Array", "Slice", "Map"]));
     composite_leaves.extend(pick_generic(&["Ref"]));
     composite_leaves.extend(pick_generic(&["Channel", "Sender", "Receiver"]));
     composite_leaves.extend(
@@ -2044,6 +2048,30 @@ pub fn doc(query: Option<String>) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prelude_displays_array_size_parameter() {
+        let index = build_prelude_index();
+        let array = index
+            .types
+            .iter()
+            .find(|t| t.name == "Array")
+            .expect("`Array` is parsed from the prelude");
+
+        assert_eq!(array.definition, "type Array<T, N>");
+    }
+
+    #[test]
+    fn prelude_lists_array_as_a_composite() {
+        let index = build_prelude_index();
+        let composites = prelude_categories(&index)
+            .into_iter()
+            .find(|(name, _)| *name == "composites")
+            .expect("the prelude has composite types")
+            .1;
+
+        assert!(composites.contains(&"Array<T, N>".to_string()));
+    }
 
     #[test]
     fn test_prelude_exposes_the_handle_methods() {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -562,11 +562,11 @@ pub fn mut_binding_clone_does_not_sever(
     let target = mutation_target(binding_name, source);
     let help = if addressable {
         format!(
-            "`{source}.clone()` leaves collections inside struct or enum values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Either use `&{source}` to take a reference or construct a new value to mutate independently."
+            "`{source}.clone()` leaves collections inside composite values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Either use `&{source}` to take a reference or construct a new value to mutate independently."
         )
     } else {
         format!(
-            "`{source}.clone()` leaves collections inside struct or enum values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Construct a new value to mutate independently."
+            "`{source}.clone()` leaves collections inside composite values shared, so mutating one through `{binding_name}` could still implicitly mutate {target}. Construct a new value to mutate independently."
         )
     };
     LisetteDiagnostic::error(format!("Cannot make a mutable binding to `{source}`"))
@@ -1873,11 +1873,14 @@ pub fn slice_index_type_mismatch(index_ty: &Type, span: Span) -> LisetteDiagnost
         )
 }
 
-pub fn only_slices_and_maps_indexable(ty: &Type, span: Span) -> LisetteDiagnostic {
+pub fn not_indexable(ty: &Type, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Not indexable")
         .with_infer_code("not_indexable")
-        .with_span_label(&span, format!("expected `Slice` or `Map`, found `{}`", ty))
-        .with_help("Only `Slice` and `Map` can be indexed into")
+        .with_span_label(
+            &span,
+            format!("expected `Array`, `Slice`, or `Map`, found `{}`", ty),
+        )
+        .with_help("Only `Array`, `Slice`, and `Map` can be indexed into")
 }
 
 pub fn string_not_indexable(span: Span, receiver: &str) -> LisetteDiagnostic {
@@ -2307,13 +2310,17 @@ pub fn non_int_range_not_iterable(element_ty: &Type, span: Span) -> LisetteDiagn
 }
 
 pub fn only_slices_indexable_by_range(ty: &Type, span: Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Type mismatch")
+    let diagnostic = LisetteDiagnostic::error("Type mismatch")
         .with_infer_code("range_index_not_slice")
-        .with_span_label(
-            &span,
-            format!("expected `Slice` or `string`, found `{}`", ty),
+        .with_span_label(&span, format!("expected `Slice`, found `{}`", ty));
+
+    if matches!(ty, Type::Array { .. }) {
+        diagnostic.with_help(
+            "Call `.to_slice()` to copy the elements into a new slice before range indexing",
         )
-        .with_help("Range indexing only works on `Slice` and `string`")
+    } else {
+        diagnostic.with_help("Range indexing only works on `Slice`")
+    }
 }
 
 pub fn empty_body_return_mismatch(expected_ty: &Type, span: Span) -> LisetteDiagnostic {
@@ -3338,7 +3345,7 @@ pub fn mut_arg_clone_does_not_sever(
     span: Span,
 ) -> LisetteDiagnostic {
     let help = format!(
-        "`{source}.clone()` leaves collections inside struct or enum values shared, so {callee_label} could still mutate one shared with `{source}`. Construct a new value to pass instead."
+        "`{source}.clone()` leaves collections inside composite values shared, so {callee_label} could still mutate one shared with `{source}`. Construct a new value to pass instead."
     );
     LisetteDiagnostic::error("Aliasing argument passed to `mut` parameter")
         .with_infer_code("mut_arg_clone_does_not_sever")

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -276,7 +276,7 @@ pub(super) fn try_inline_native_method(
 }
 
 fn is_native_array_method(method: &str) -> bool {
-    matches!(method, "as_slice" | "get")
+    matches!(method, "to_slice" | "get")
 }
 
 pub(super) fn native_method_lowers_to_plain_call(
@@ -456,7 +456,7 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
     ) -> String {
         match method {
-            "as_slice" => {
+            "to_slice" => {
                 self.require_slices();
                 let view = self.sliceable_receiver(receiver_expr, receiver, setup);
                 format!("slices.Clone({view})")

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -59,9 +59,14 @@ pub(crate) fn definition_to_completion_kind(
     }
 }
 
-/// Extract the element type from a collection type (Slice<T>, EnumeratedSlice<T>, Map<K, V>).
-fn element_type_name(ty: &syntax::types::Type) -> Option<String> {
+/// Extract the element type from an array, slice, or map.
+fn element_type_name(ty: &Type) -> Option<String> {
     use syntax::types::CompoundKind;
+
+    if let Type::Array { element, .. } = ty {
+        return type_name(element);
+    }
+
     match ty.as_compound()? {
         (CompoundKind::Slice | CompoundKind::EnumeratedSlice, args) => {
             args.first().and_then(type_name)

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1790,6 +1790,35 @@ fn main() {
 }
 
 #[tokio::test]
+async fn completion_dot_after_array_indexed_access() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let source = "\
+struct Item { name: string }
+impl Item {
+  pub fn label(self) -> string { self.name }
+}
+fn main() {
+  let items: Array<Item, 1> = [Item { name: \"a\" }]
+  items[0].
+}";
+    client.open(TEST_URI, source).await;
+
+    let response = client.completion(TEST_URI, 6, 11).await;
+    let labels = completion_labels(&response.expect("completion response"));
+
+    assert!(
+        ["label", "name"]
+            .iter()
+            .all(|expected| labels.iter().any(|label| label == expected)),
+        "should include element members, got: {labels:?}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn completion_dot_on_slice_variable() {
     let mut client = TestClient::new().await;
     client.initialize().await;

--- a/crates/semantics/src/checker/infer/carry_mut.rs
+++ b/crates/semantics/src/checker/infer/carry_mut.rs
@@ -9,9 +9,9 @@ use syntax::types::{CompoundKind, Symbol, Type, build_substitution_map, substitu
 
 /// Whether a value of `ty` can carry mutation across a function call boundary.
 ///
-/// True for `Slice<T>`, `Map<K,V>`, `EnumeratedSlice<T>`, and any struct,
-/// tuple, or enum that recursively contains one. `Ref<T>`, `Channel<T>`,
-/// `Sender<T>`, and `Receiver<T>` are excluded by design.
+/// True for `Slice<T>`, `Map<K,V>`, `EnumeratedSlice<T>`, and any array,
+/// struct, tuple, or enum that recursively contains one. `Ref<T>`,
+/// `Channel<T>`, `Sender<T>`, and `Receiver<T>` are excluded by design.
 pub(super) fn can_carry_mutation_across_fn_boundary(
     ty: &Type,
     env: &TypeEnv,

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -161,11 +161,10 @@ impl InferCtx<'_, '_> {
                 };
             }
             _ => {
-                self.sink
-                    .push(diagnostics::infer::only_slices_and_maps_indexable(
-                        &resolved_collection_ty,
-                        collection_expression.get_span(),
-                    ));
+                self.sink.push(diagnostics::infer::not_indexable(
+                    &resolved_collection_ty,
+                    collection_expression.get_span(),
+                ));
                 return Expression::IndexedAccess {
                     expression: collection_expression.into(),
                     index: index_expression.into(),

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -833,6 +833,12 @@ impl InferCtx<'_, '_> {
             return "Unwrap the inner value with `?` or using `match`".to_string();
         }
 
+        if array_to_slice_help_applies(expected, actual) {
+            return format!(
+                "Call `.to_slice()` to copy the elements into a new slice, or change the receiving type to `{actual}`"
+            );
+        }
+
         if actual.wraps("Slice", expected) {
             return "Index into the slice, e.g. `items[0]`".to_string();
         }
@@ -893,6 +899,20 @@ impl InferCtx<'_, '_> {
         }
         absorbed
     }
+}
+
+fn array_to_slice_help_applies(expected: &Type, actual: &Type) -> bool {
+    if !expected.is_slice() {
+        return false;
+    }
+    let Type::Array { element, .. } = actual else {
+        return false;
+    };
+    let Some(expected_element) = expected.get_type_params().and_then(|params| params.first())
+    else {
+        return false;
+    };
+    expected_element == element.as_ref()
 }
 
 fn function_return_under_nominal(ty: &Type) -> Option<&Type> {

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -268,12 +268,12 @@ impl<T, E> Partial<T, E> {
   fn map_err<F>(self, f: fn(E) -> F) -> Partial<T, F>
 }
 
-/// A fixed-sized array, indexable sequence of elements. Equivalent to Go's `[N]T`.
+/// A fixed-size, indexable sequence of elements. Equivalent to Go's `[N]T`.
 ///
 /// Example:
 ///   let xs: Array<int, 3> = [1, 2, 3]
 ///   let n = xs.length()
-///   let s = xs.as_slice()
+///   let s = xs.to_slice()
 type Array<T>
 
 impl<T> Array<T> {
@@ -284,7 +284,7 @@ impl<T> Array<T> {
   fn get(self, index: int) -> Option<T>
 
   /// Copies the elements into a new slice.
-  fn as_slice(self) -> Slice<T>
+  fn to_slice(self) -> Slice<T>
 }
 
 /// A growable, indexable sequence of elements. Equivalent to Go's `[]T`.

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -126,12 +126,12 @@ fn array_equality_and_inequality() {
 }
 
 #[test]
-fn array_for_loop_and_as_slice() {
+fn array_for_loop_and_to_slice() {
   let a: Array<int, 3> = [1, 2, 3]
   let mut sum = 0
   for x in a { sum += x }
   assert sum == 6
-  assert a.as_slice().length() == 3
+  assert a.to_slice().length() == 3
 }
 
 #[test]

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -259,14 +259,14 @@ fn f<T>(b: Box<Array<T, 2>>) -> int {
 }
 
 #[test]
-fn array_get_as_slice_identifier_form() {
+fn array_get_to_slice_identifier_form() {
     let input = r#"
 fn at(xs: Array<int, 3>, i: int) -> Option<int> {
   Array.get(xs, i)
 }
 
 fn all(xs: Array<int, 3>) -> Slice<int> {
-  Array.as_slice(xs)
+  Array.to_slice(xs)
 }
 "#;
     assert_emit_snapshot!(input);
@@ -360,10 +360,10 @@ fn make() -> S {
 }
 
 #[test]
-fn array_as_slice_copies_into_new_slice() {
+fn array_to_slice_copies_into_new_slice() {
     let input = r#"
 fn to_slice(a: Array<int, 3>) -> Slice<int> {
-  a.as_slice()
+  a.to_slice()
 }
 "#;
     assert_emit_snapshot!(input);
@@ -417,7 +417,7 @@ fn at(a: Addr, i: int) -> Option<byte> {
 }
 
 fn to_slice(a: Addr) -> Slice<byte> {
-  a.as_slice()
+  a.to_slice()
 }
 
 fn size(a: Addr) -> int {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1909,13 +1909,13 @@ fn main() {
 }
 
 #[test]
-fn interop_array_return_as_slice() {
+fn interop_array_return_to_slice() {
     let input = r#"
 import "go:crypto/sha256"
 
 fn main() {
   let data = "hi" as Slice<byte>
-  let bytes = sha256.Sum256(data).as_slice()
+  let bytes = sha256.Sum256(data).to_slice()
   let _ = bytes
 }
 "#;

--- a/tests/spec/emit/snapshots/array_get_to_slice_identifier_form.snap
+++ b/tests/spec/emit/snapshots/array_get_to_slice_identifier_form.snap
@@ -7,7 +7,7 @@ description: |
   }
   
   fn all(xs: Array<int, 3>) -> Slice<int> {
-    Array.as_slice(xs)
+    Array.to_slice(xs)
   }
 ---
 package main

--- a/tests/spec/emit/snapshots/array_methods_through_type_alias.snap
+++ b/tests/spec/emit/snapshots/array_methods_through_type_alias.snap
@@ -13,7 +13,7 @@ description: |
   }
   
   fn to_slice(a: Addr) -> Slice<byte> {
-    a.as_slice()
+    a.to_slice()
   }
   
   fn size(a: Addr) -> int {

--- a/tests/spec/emit/snapshots/array_to_slice_copies_into_new_slice.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_copies_into_new_slice.snap
@@ -3,7 +3,7 @@ source: tests/spec/emit/arrays.rs
 description: |
   
   fn to_slice(a: Array<int, 3>) -> Slice<int> {
-    a.as_slice()
+    a.to_slice()
   }
 ---
 package main

--- a/tests/spec/emit/snapshots/interop_array_return_to_slice.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_to_slice.snap
@@ -6,7 +6,7 @@ description: |
   
   fn main() {
     let data = "hi" as Slice<byte>
-    let bytes = sha256.Sum256(data).as_slice()
+    let bytes = sha256.Sum256(data).to_slice()
     let _ = bytes
   }
 ---

--- a/tests/spec/infer/arrays.rs
+++ b/tests/spec/infer/arrays.rs
@@ -305,8 +305,8 @@ fn non_comparable_array_alias_rejected_as_map_key() {
 }
 
 #[test]
-fn array_as_slice_returns_slice_of_element() {
-    infer("let xs: Array<int, 3> = [1, 2, 3]; xs.as_slice()")
+fn array_to_slice_returns_slice_of_element() {
+    infer("let xs: Array<int, 3> = [1, 2, 3]; xs.to_slice()")
         .assert_last_type(slice_type(int_type()));
 }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3225,6 +3225,17 @@ fn test(m: Map<string, int>) {
 }
 
 #[test]
+fn infer_array_range_index_suggests_to_slice() {
+    let input = r#"
+fn test() {
+  let items: Array<int, 3> = [1, 2, 3]
+  let _ = items[1..]
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_interface_bound_not_satisfied() {
     let input = r#"
 interface Writer {
@@ -5321,6 +5332,19 @@ fn test() {
 fn infer_array_size_too_large() {
     let input = r#"
 fn f(x: Array<int, 18000000000000000000>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_to_slice_type_mismatch_hint() {
+    let input = r#"
+fn consume(items: Slice<int>) {}
+
+fn main() {
+  let items: Array<int, 3> = [1, 2, 3]
+  consume(items)
+}
 "#;
     assert_infer_error_snapshot!(input);
 }

--- a/tests/ui/errors/snapshots/infer_array_range_index_suggests_to_slice.snap
+++ b/tests/ui/errors/snapshots/infer_array_range_index_suggests_to_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:4:11]
+ 3 │   let items: Array<int, 3> = [1, 2, 3]
+ 4 │   let _ = items[1..]
+   ·           ──┬──
+   ·             ╰── expected `Slice`, found `Array<int, 3>`
+ 5 │ }
+   ╰────
+  help: Call `.to_slice()` to copy the elements into a new slice before range indexing · code: [infer.range_index_not_slice]

--- a/tests/ui/errors/snapshots/infer_array_to_slice_type_mismatch_hint.snap
+++ b/tests/ui/errors/snapshots/infer_array_to_slice_type_mismatch_hint.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:6:11]
+ 5 │   let items: Array<int, 3> = [1, 2, 3]
+ 6 │   consume(items)
+   ·           ──┬──
+   ·             ╰── expected `Slice<int>`, found `Array<int, 3>`
+ 7 │ }
+   ╰────
+  help: Call `.to_slice()` to copy the elements into a new slice, or change the receiving type to `Array<int, 3>` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_mut_binding_clone_does_not_sever.snap
+++ b/tests/ui/errors/snapshots/infer_mut_binding_clone_does_not_sever.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                        ╰── does not make an independent copy
  6 │   copy[0].tags[0] = "y"
    ╰────
-  help: `docs.clone()` leaves collections inside struct or enum values shared, so mutating one through `copy` could still implicitly mutate `docs`. Either use `&docs` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]
+  help: `docs.clone()` leaves collections inside composite values shared, so mutating one through `copy` could still implicitly mutate `docs`. Either use `&docs` to take a reference or construct a new value to mutate independently · code: [infer.mut_binding_aliases]

--- a/tests/ui/errors/snapshots/infer_range_index_on_non_slice.snap
+++ b/tests/ui/errors/snapshots/infer_range_index_on_non_slice.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(m: Map<string, int>) {
  3 │   m[0..3]
    ·   ┬
-   ·   ╰── expected `Slice` or `string`, found `Map<string, int>`
+   ·   ╰── expected `Slice`, found `Map<string, int>`
  4 │ }
    ╰────
-  help: Range indexing only works on `Slice` and `string` · code: [infer.range_index_not_slice]
+  help: Range indexing only works on `Slice` · code: [infer.range_index_not_slice]

--- a/tests/ui/errors/snapshots/infer_unindexable_type.snap
+++ b/tests/ui/errors/snapshots/infer_unindexable_type.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │   let x = 42;
  4 │   x[0]
    ·   ┬
-   ·   ╰── expected `Slice` or `Map`, found `int`
+   ·   ╰── expected `Array`, `Slice`, or `Map`, found `int`
  5 │ }
    ╰────
-  help: Only `Slice` and `Map` can be indexed into · code: [infer.not_indexable]
+  help: Only `Array`, `Slice`, and `Map` can be indexed into · code: [infer.not_indexable]


### PR DESCRIPTION
- Rename `Array.as_slice()` to `Array.to_slice()`, to highlight the copy (not casting) implication.
- Passing an `Array<T, N>` where a `Slice<T>` is expected now produces a hint pointing to `to_slice`. Same for range-indexing an array.
- The `Not indexable` error now names `Array` as well.
- `lis doc` now shows `Array<T, N>` and lists it among the composite types.
- Editor completions after indexing into an array now offer the element type's fields and methods.

Follow-up to #977
