### PR TITLE
fix: shut down language server gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-lsp",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,7 +29,7 @@ emit = { package = "lisette-emit", version = "=0.7.0", path = "../emit" }
 stdlib = { package = "lisette-stdlib", version = "=0.7.0", path = "../stdlib" }
 deps = { package = "lisette-deps", version = "=0.7.0", path = "../deps" }
 lsp = { package = "lisette-lsp", version = "=0.7.0", path = "../lsp" }
-tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-std", "macros"] }
 tower-lsp = "0.20"
 fs2 = "0.4"
 terminal_size = "0.4"

--- a/crates/cli/src/handlers/lsp.rs
+++ b/crates/cli/src/handlers/lsp.rs
@@ -1,20 +1,25 @@
 use std::sync::Arc;
 
 use deps::BindgenSetup;
-use tower_lsp::{LspService, Server};
+use tower_lsp::Server;
 
 use crate::workspace::WorkspaceBindgenSetup;
 
 pub fn lsp() -> i32 {
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-    rt.block_on(async {
+    let code = rt.block_on(async {
         let stdin = tokio::io::stdin();
         let stdout = tokio::io::stdout();
 
         let setup: Arc<dyn BindgenSetup> = Arc::new(WorkspaceBindgenSetup);
-        let (service, socket) =
-            LspService::new(move |client| lsp::Backend::new(client, Some(setup.clone())));
-        Server::new(stdin, stdout, socket).serve(service).await;
+        let (service, socket, exited) = lsp::build_service(Some(setup));
+        tokio::select! {
+            _ = Server::new(stdin, stdout, socket).serve(service) => 0,
+            code = exited => code.unwrap_or(0),
+        }
     });
-    0
+    // Dropping the runtime would block on the stdin reader thread, which
+    // stays stuck in a read while the client keeps the pipe open.
+    rt.shutdown_background();
+    code
 }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -18,6 +18,7 @@ passes = { package = "lisette-passes", version = "=0.7.0", path = "../passes" }
 diagnostics = { package = "lisette-diagnostics", version = "=0.7.0", path = "../diagnostics" }
 deps = { package = "lisette-deps", version = "=0.7.0", path = "../deps" }
 format = { package = "lisette-format", version = "=0.7.0", path = "../format" }
+tower = { version = "0.4", default-features = false }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 dashmap = "6"

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -9,6 +9,7 @@ mod paths;
 mod patterns;
 mod position;
 mod project;
+mod service;
 mod signature_help;
 mod snapshot;
 mod state;
@@ -36,6 +37,7 @@ use crate::project::find_project_root;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
 
+pub use crate::service::{ProtocolAdapter, build_service};
 pub use crate::state::{Backend, SharedState};
 
 #[tower_lsp::async_trait]

--- a/crates/lsp/src/service.rs
+++ b/crates/lsp/src/service.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use deps::BindgenSetup;
+use tokio::sync::oneshot;
+use tower::Service;
+use tower_lsp::jsonrpc::Request;
+use tower_lsp::{ClientSocket, LspService};
+
+use crate::state::Backend;
+
+pub fn build_service(
+    bindgen_setup: Option<Arc<dyn BindgenSetup>>,
+) -> (
+    ProtocolAdapter<LspService<Backend>>,
+    ClientSocket,
+    oneshot::Receiver<i32>,
+) {
+    let (service, socket) =
+        LspService::new(move |client| Backend::new(client, bindgen_setup.clone()));
+    let (exit_sender, exit_receiver) = oneshot::channel();
+    let adapter = ProtocolAdapter {
+        inner: service,
+        saw_shutdown: false,
+        exit_sender: Some(exit_sender),
+    };
+    (adapter, socket, exit_receiver)
+}
+
+pub struct ProtocolAdapter<S> {
+    inner: S,
+    saw_shutdown: bool,
+    exit_sender: Option<oneshot::Sender<i32>>,
+}
+
+impl<S: Service<Request>> Service<Request> for ProtocolAdapter<S> {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(context)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        match request.method() {
+            "shutdown" => self.saw_shutdown = true,
+            "exit" => {
+                // The LSP spec requires the process to exit with 0 when
+                // shutdown preceded exit, with 1 otherwise.
+                if let Some(sender) = self.exit_sender.take() {
+                    let _ = sender.send(if self.saw_shutdown { 0 } else { 1 });
+                }
+            }
+            _ => {}
+        }
+        let request = if request.params().is_some_and(|params| params.is_null()) {
+            let (method, id, _) = request.into_parts();
+            let builder = Request::build(method);
+            match id {
+                Some(id) => builder.id(id).finish(),
+                None => builder.finish(),
+            }
+        } else {
+            request
+        };
+        self.inner.call(request)
+    }
+}

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -639,11 +639,13 @@ async fn rename_rejects_keywords() {
         .open(TEST_URI, "fn main() {\n  let foo = 1\n  foo + 1\n}")
         .await;
 
-    let edit = client.rename(TEST_URI, 1, 6, "fn").await;
-    assert!(edit.is_none());
-
-    let edit = client.rename(TEST_URI, 1, 6, "assert").await;
-    assert!(edit.is_none());
+    for keyword in ["fn", "assert"] {
+        let error = client
+            .try_rename(TEST_URI, 1, 6, keyword)
+            .await
+            .unwrap_err();
+        assert_eq!(error, format!("'{keyword}' is a reserved keyword"));
+    }
 
     client.shutdown().await;
 }
@@ -4318,7 +4320,7 @@ async fn stress_test_all_positions(source: &str) -> bool {
             let _comp = client.completion(TEST_URI, line, col).await;
             let _sig = client.signature_help(TEST_URI, line, col).await;
             let _refs = client.references(TEST_URI, line, col, true).await;
-            let _rename = client.prepare_rename(TEST_URI, line, col).await;
+            let _rename = client.try_prepare_rename(TEST_URI, line, col).await;
             let _inlay = client
                 .inlay_hint(TEST_URI, (line, col), doc_end(source))
                 .await;
@@ -7125,12 +7127,9 @@ async fn stress_rename_empty_name() {
     client.initialize().await;
     client.open(TEST_URI, "fn main() { let x = 1; x }").await;
 
-    // Rename to empty string — should be rejected by validation
-    let edit = client.rename(TEST_URI, 0, 16, "").await;
-    // rename() returns None or error when validation fails
-    let _ = edit;
+    let error = client.try_rename(TEST_URI, 0, 16, "").await.unwrap_err();
+    assert_eq!(error, "Identifier cannot be empty");
 
-    // Server should still be alive
     let hover = client.hover(TEST_URI, 0, 4).await;
     assert!(hover.is_some());
 
@@ -7143,17 +7142,14 @@ async fn stress_rename_to_keyword() {
     client.initialize().await;
     client.open(TEST_URI, "fn main() { let x = 1; x }").await;
 
-    // Rename to keyword — should be rejected
-    let edit = client.rename(TEST_URI, 0, 16, "fn").await;
-    let _ = edit;
+    for keyword in ["fn", "let", "match"] {
+        let error = client
+            .try_rename(TEST_URI, 0, 16, keyword)
+            .await
+            .unwrap_err();
+        assert_eq!(error, format!("'{keyword}' is a reserved keyword"));
+    }
 
-    let edit = client.rename(TEST_URI, 0, 16, "let").await;
-    let _ = edit;
-
-    let edit = client.rename(TEST_URI, 0, 16, "match").await;
-    let _ = edit;
-
-    // Server still alive
     let hover = client.hover(TEST_URI, 0, 4).await;
     assert!(hover.is_some());
 
@@ -7166,12 +7162,32 @@ async fn stress_rename_to_special_characters() {
     client.initialize().await;
     client.open(TEST_URI, "fn main() { let x = 1; x }").await;
 
-    for name in ["123abc", "a-b", "a b", "a.b", "@foo", ""] {
-        let edit = client.rename(TEST_URI, 0, 16, name).await;
-        let _ = edit;
+    for (name, expected) in [
+        (
+            "123abc",
+            "Identifier must start with a letter or underscore, not '1'",
+        ),
+        (
+            "a-b",
+            "Identifier cannot contain '-' - only letters, digits, and underscores allowed",
+        ),
+        (
+            "a b",
+            "Identifier cannot contain ' ' - only letters, digits, and underscores allowed",
+        ),
+        (
+            "a.b",
+            "Identifier cannot contain '.' - only letters, digits, and underscores allowed",
+        ),
+        (
+            "@foo",
+            "Identifier must start with a letter or underscore, not '@'",
+        ),
+    ] {
+        let error = client.try_rename(TEST_URI, 0, 16, name).await.unwrap_err();
+        assert_eq!(error, expected);
     }
 
-    // Server still alive
     let hover = client.hover(TEST_URI, 0, 4).await;
     assert!(hover.is_some());
 
@@ -12856,4 +12872,21 @@ async fn opening_prelude_source_reports_no_foreign_type_errors() {
         "opening the prelude source must not flag its own impls as foreign: {offenders:?}"
     );
     client.shutdown().await;
+}
+
+#[tokio::test]
+async fn exit_after_shutdown_signals_clean_exit() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.shutdown().await;
+    client.exit().await;
+    assert_eq!(client.await_exit_code().await, 0);
+}
+
+#[tokio::test]
+async fn exit_without_shutdown_signals_error_exit() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+    client.exit().await;
+    assert_eq!(client.await_exit_code().await, 1);
 }

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -7,10 +7,10 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::io::{DuplexStream, ReadHalf, WriteHalf};
 use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite};
+use tower_lsp::Server;
 use tower_lsp::lsp_types::*;
-use tower_lsp::{LspService, Server};
 
-use lisette_lsp::Backend;
+use lisette_lsp::build_service;
 
 /// LSP message codec implementing Content-Length framing.
 struct LspCodec;
@@ -60,6 +60,7 @@ pub struct TestClient {
     writer: FramedWrite<WriteHalf<DuplexStream>, LspCodec>,
     next_id: i64,
     buffered: Vec<Value>,
+    exit_code: tokio::sync::oneshot::Receiver<i32>,
 }
 
 fn init_test_typedef_home() {
@@ -82,7 +83,7 @@ impl TestClient {
         let (server_read, server_write) = tokio::io::split(server);
         let (client_read, client_write) = tokio::io::split(client);
 
-        let (service, socket) = LspService::new(|client| Backend::new(client, None));
+        let (service, socket, exit_code) = build_service(None);
         tokio::spawn(Server::new(server_read, server_write, socket).serve(service));
 
         Self {
@@ -90,10 +91,15 @@ impl TestClient {
             writer: FramedWrite::new(client_write, LspCodec),
             next_id: 1,
             buffered: Vec::new(),
+            exit_code,
         }
     }
 
-    async fn request<T: for<'de> Deserialize<'de>>(&mut self, method: &str, params: Value) -> T {
+    async fn try_request<T: for<'de> Deserialize<'de>>(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> Result<T, String> {
         let id = self.next_id;
         self.next_id += 1;
 
@@ -105,10 +111,22 @@ impl TestClient {
         loop {
             let msg = self.reader.next().await.unwrap().unwrap();
             if msg.get("id") == Some(&json!(id)) {
-                return serde_json::from_value(msg.get("result").cloned().unwrap_or(Value::Null))
-                    .unwrap();
+                if let Some(error) = msg.get("error") {
+                    return Err(error["message"].as_str().unwrap_or_default().to_owned());
+                }
+                return Ok(serde_json::from_value(
+                    msg.get("result").cloned().unwrap_or(Value::Null),
+                )
+                .unwrap());
             }
             self.buffered.push(msg);
+        }
+    }
+
+    async fn request<T: for<'de> Deserialize<'de>>(&mut self, method: &str, params: Value) -> T {
+        match self.try_request(method, params).await {
+            Ok(result) => result,
+            Err(error) => panic!("{method} request failed: {error}"),
         }
     }
 
@@ -294,17 +312,46 @@ impl TestClient {
         .await
     }
 
+    pub async fn try_prepare_rename(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<PrepareRenameResponse>, String> {
+        self.try_request(
+            "textDocument/prepareRename",
+            json!({
+                "textDocument": {"uri": uri},
+                "position": {"line": line, "character": character}
+            }),
+        )
+        .await
+    }
+
     pub async fn prepare_rename(
         &mut self,
         uri: &str,
         line: u32,
         character: u32,
     ) -> Option<PrepareRenameResponse> {
-        self.request(
-            "textDocument/prepareRename",
+        self.try_prepare_rename(uri, line, character)
+            .await
+            .expect("prepareRename request failed")
+    }
+
+    pub async fn try_rename(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+        new_name: &str,
+    ) -> Result<Option<WorkspaceEdit>, String> {
+        self.try_request(
+            "textDocument/rename",
             json!({
                 "textDocument": {"uri": uri},
-                "position": {"line": line, "character": character}
+                "position": {"line": line, "character": character},
+                "newName": new_name
             }),
         )
         .await
@@ -317,15 +364,9 @@ impl TestClient {
         character: u32,
         new_name: &str,
     ) -> Option<WorkspaceEdit> {
-        self.request(
-            "textDocument/rename",
-            json!({
-                "textDocument": {"uri": uri},
-                "position": {"line": line, "character": character},
-                "newName": new_name
-            }),
-        )
-        .await
+        self.try_rename(uri, line, character, new_name)
+            .await
+            .expect("rename request failed")
     }
 
     pub async fn code_action(
@@ -369,6 +410,14 @@ impl TestClient {
 
     pub async fn shutdown(&mut self) {
         let _: Value = self.request("shutdown", json!(null)).await;
+    }
+
+    pub async fn exit(&mut self) {
+        self.notify("exit", json!(null)).await;
+    }
+
+    pub async fn await_exit_code(self) -> i32 {
+        self.exit_code.await.unwrap()
     }
 }
 


### PR DESCRIPTION
The language server now accepts a `shutdown` request when the client sends `params: null`. Also, the server process now exits on the `exit` notification, as the LSP spec requires: code 0 when `shutdown` was received first, code 1 otherwise.
