### PR TITLE
fix: make empty slice literals consistent with constructors

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2939,6 +2939,15 @@ pub fn cannot_infer_type_argument(span: Span) -> LisetteDiagnostic {
         .with_help("Supply a type argument for the call, e.g. `Channel.new<int>()`")
 }
 
+pub fn empty_slice_no_element_type(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot infer the element type of this empty slice")
+        .with_infer_code("empty_slice_no_element_type")
+        .with_span_label(&span, "`[]` needs an element type from context")
+        .with_help(
+            "Annotate the enclosing binding, e.g. `let xs: Slice<int> = []`, or write `Slice.new<int>()`",
+        )
+}
+
 fn format_list<T, F>(items: &[T], fmt: F) -> String
 where
     F: Fn(&T) -> String,

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -49,9 +49,8 @@ impl Planner<'_> {
         });
 
         let is_go_struct = self.is_go_abi_type(ty);
-        let kept = self.kept_struct_call_fields(field_assignments, spread, ty, is_go_struct);
 
-        let stages: Vec<ValuePlan> = kept
+        let stages: Vec<ValuePlan> = field_assignments
             .iter()
             .map(|f| self.stage_composite(&f.value, ExpressionContext::value()))
             .collect();
@@ -69,7 +68,7 @@ impl Planner<'_> {
 
         let mut field_names: Vec<String> = Vec::new();
         let mut field_values: Vec<String> = Vec::new();
-        for (slot, f) in kept.iter().enumerate() {
+        for (slot, f) in field_assignments.iter().enumerate() {
             let field_name = self.resolve_struct_call_field_name(&f.name, ty, &ctx);
             let mut value = emitted_values[slot].clone();
             value = self.wrap_recursive_enum_field(&mut setup, value, f, &ctx);
@@ -206,37 +205,6 @@ impl Planner<'_> {
             let zero = self.lisette_zero(&field_ty);
             field_pairs.push((go_field_name, zero));
         }
-    }
-
-    /// Drop empty `Slice<T>` field assignments so Go's nil zero-value applies
-    /// instead of an `[]T{}` allocation. Skipped for Go-imported structs (the
-    /// Go API may distinguish nil from empty) and `From` spreads (the override
-    /// must still fire to clear the inherited value).
-    fn kept_struct_call_fields<'a>(
-        &self,
-        field_assignments: &'a [StructFieldAssignment],
-        spread: &StructSpread,
-        ty: &Type,
-        is_go_struct: bool,
-    ) -> Vec<&'a StructFieldAssignment> {
-        let can_omit_slices = !is_go_struct
-            && !matches!(spread, StructSpread::From(_))
-            && field_assignments
-                .iter()
-                .any(|f| f.value.is_empty_collection());
-        if !can_omit_slices {
-            return field_assignments.iter().collect();
-        }
-        field_assignments
-            .iter()
-            .filter(|f| {
-                !(f.value.is_empty_collection()
-                    && self
-                        .lookup_struct_field_ty(ty, &f.name)
-                        .as_ref()
-                        .is_some_and(Type::is_slice))
-            })
-            .collect()
     }
 
     /// Look up unspecified fields of a Lisette-defined struct or enum struct variant,

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -48,10 +48,8 @@ impl Planner<'_> {
 
     fn emit_slice_literal(&mut self, elements: &[Expression], ty: &Type) -> ValuePlan {
         // A list literal builds a slice or a fixed-size array, per its type.
-        let (element_lisette_ty, type_prefix, is_array) = match ty {
-            Type::Array { length, element } => {
-                (element.as_ref().clone(), format!("[{}]", length), true)
-            }
+        let (element_lisette_ty, type_prefix) = match ty {
+            Type::Array { length, element } => (element.as_ref().clone(), format!("[{}]", length)),
             _ => (
                 ty.get_type_params()
                     .expect("Slice type must have type args")
@@ -59,23 +57,17 @@ impl Planner<'_> {
                     .expect("Slice type must have element type")
                     .clone(),
                 "[]".to_string(),
-                false,
             ),
         };
         let element_ty = self.go_type_string(&element_lisette_ty);
 
         if elements.is_empty() {
-            let value = if is_array {
-                format!("{}{}{{}}", type_prefix, element_ty)
-            } else {
-                // Parens around the slice type disambiguate the conversion when
-                // the element type itself ends in `)` (e.g. `func(int)`); Go
-                // otherwise parses `[]func(int)(nil)` as a call expression.
-                format!("({}{})(nil)", type_prefix, element_ty)
-            };
             return ValuePlan::computed(
                 Vec::new(),
-                GoExpression::composite_literal(value, false),
+                GoExpression::composite_literal(
+                    format!("{}{}{{}}", type_prefix, element_ty),
+                    false,
+                ),
                 EvaluationEffect::Pure,
             );
         }

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -1,11 +1,21 @@
 use diagnostics::LocalSink;
+use rustc_hash::FxHashSet as HashSet;
 
 use semantics::facts::Facts;
+use syntax::types::TypeVarId;
 
 pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
+    let mut reported_vars: HashSet<(String, TypeVarId)> = HashSet::default();
+    let mut collected = Vec::new();
+    let mut report_vars = |ty: &syntax::types::Type, module_id: &str| {
+        collected.clear();
+        ty.collect_unbound_variables(&mut collected);
+        reported_vars.extend(collected.iter().map(|v| (module_id.to_string(), *v)));
+    };
     for check in std::mem::take(&mut facts.generic_call_checks) {
         if check.ty.has_unbound_variables() {
             sink.push(diagnostics::infer::cannot_infer_type_argument(check.span));
+            report_vars(&check.ty, &check.module_id);
         }
     }
     for check in std::mem::take(&mut facts.empty_collection_checks) {
@@ -14,6 +24,24 @@ pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
                 &check.name,
                 check.span,
             ));
+            report_vars(&check.ty, &check.module_id);
+        }
+    }
+    let mut reported_literal_spans = HashSet::default();
+    for check in std::mem::take(&mut facts.empty_literal_checks) {
+        if !check.ty.has_unbound_variables() {
+            continue;
+        }
+        let mut literal_vars = Vec::new();
+        check.ty.collect_unbound_variables(&mut literal_vars);
+        if literal_vars
+            .iter()
+            .any(|v| reported_vars.contains(&(check.module_id.clone(), *v)))
+        {
+            continue;
+        }
+        if reported_literal_spans.insert(check.span) {
+            sink.push(diagnostics::infer::empty_slice_no_element_type(check.span));
         }
     }
     for check in std::mem::take(&mut facts.statement_tail_checks) {
@@ -27,5 +55,60 @@ pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
                 &check.expected_ty,
             ));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use semantics::facts::{BindingIdAllocator, EmptyLiteralCheck, GenericCallCheck};
+    use std::sync::Arc;
+    use syntax::ast::Span;
+    use syntax::types::{CompoundKind, Type};
+
+    fn unbound_slice(id: u32) -> Type {
+        Type::Compound {
+            kind: CompoundKind::Slice,
+            args: vec![Type::Var {
+                id: TypeVarId(id),
+                hint: Some("T".into()),
+            }],
+        }
+    }
+
+    fn run_checks(call_module: &str, literal_module: &str) -> Vec<String> {
+        let mut facts = Facts::new(Arc::new(BindingIdAllocator::default()));
+        facts.generic_call_checks.push(GenericCallCheck {
+            ty: unbound_slice(5),
+            span: Span::new(0, 0, 10),
+            module_id: call_module.to_string(),
+        });
+        facts.empty_literal_checks.push(EmptyLiteralCheck {
+            ty: unbound_slice(5),
+            span: Span::new(1, 4, 2),
+            module_id: literal_module.to_string(),
+        });
+        let sink = LocalSink::new();
+        run(&mut facts, &sink);
+        sink.take()
+            .iter()
+            .filter_map(|d| d.code_str().map(str::to_string))
+            .collect()
+    }
+
+    #[test]
+    fn same_module_shared_var_suppresses_literal() {
+        assert_eq!(run_checks("a", "a"), vec!["infer.missing_type_argument"]);
+    }
+
+    #[test]
+    fn same_var_id_across_modules_does_not_suppress() {
+        assert_eq!(
+            run_checks("a", "b"),
+            vec![
+                "infer.missing_type_argument",
+                "infer.empty_slice_no_element_type"
+            ]
+        );
     }
 }

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -360,6 +360,9 @@ impl<'a> FreezeFolder<'a> {
         for check in &mut facts.empty_collection_checks {
             self.env.resolve_in_place(&mut check.ty);
         }
+        for check in &mut facts.empty_literal_checks {
+            self.env.resolve_in_place(&mut check.ty);
+        }
         for check in &mut facts.statement_tail_checks {
             self.env.resolve_in_place(&mut check.expected_ty);
         }

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -175,12 +175,14 @@ impl InferCtx<'_, '_> {
             && new_value.is_empty_collection()
             && let Some(ref name) = binding_name
         {
+            let module_id = self.cursor.module_id.clone();
             self.facts
                 .empty_collection_checks
                 .push(crate::facts::EmptyCollectionCheck {
                     name: name.to_string(),
                     ty: new_binding.ty.clone(),
                     span,
+                    module_id,
                 });
         }
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -472,11 +472,13 @@ impl InferCtx<'_, '_> {
             && type_args.is_empty()
             && !self.is_enum_type(store, &resolved_return);
         if return_check_recorded {
+            let module_id = self.cursor.module_id.clone();
             self.facts
                 .generic_call_checks
                 .push(crate::facts::GenericCallCheck {
                     ty: return_ty.clone(),
                     span,
+                    module_id,
                 });
         }
 
@@ -491,11 +493,13 @@ impl InferCtx<'_, '_> {
             let already_covered = return_check_recorded
                 && resolved_return.contains_type(&elem_ty.resolve_in(&self.env));
             if !already_covered {
+                let module_id = self.cursor.module_id.clone();
                 self.facts
                     .generic_call_checks
                     .push(crate::facts::GenericCallCheck {
                         ty: elem_ty.clone(),
                         span,
+                        module_id,
                     });
             }
         }

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -172,7 +172,18 @@ impl InferCtx<'_, '_> {
                     .collect();
 
                 let slice_ty = self.type_slice(element_expected_ty);
-                self.unify(expected_ty, &slice_ty, &span);
+                let unified = self.unify(expected_ty, &slice_ty, &span);
+
+                if new_elements.is_empty() && unified {
+                    let module_id = self.cursor.module_id.clone();
+                    self.facts
+                        .empty_literal_checks
+                        .push(crate::facts::EmptyLiteralCheck {
+                            ty: slice_ty.clone(),
+                            span,
+                            module_id,
+                        });
+                }
 
                 Expression::Literal {
                     literal: Literal::Slice(new_elements),

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -53,18 +53,20 @@ pub enum Dispatched {
 }
 
 impl InferCtx<'_, '_> {
-    /// Make two types equal.
+    /// Make two types equal. Returns `false` when they do not match.
     ///
     /// - For two concrete types, verifies that they match.
     /// - For two variable types, records that the first equals the second.
     /// - For a concrete and a variable type, records that the variable equals the concrete.
-    pub(super) fn unify(&mut self, t1: &Type, t2: &Type, span: &Span) {
-        if let Err(unify_error) = self.try_unify(t1, t2, span) {
-            if unify_error == UnifyError::AlreadyReported {
-                return;
+    pub(super) fn unify(&mut self, t1: &Type, t2: &Type, span: &Span) -> bool {
+        match self.try_unify(t1, t2, span) {
+            Ok(()) => true,
+            Err(UnifyError::AlreadyReported) => false,
+            Err(unify_error) => {
+                let err = self.unification_diagnostic(t1, t2, span, &unify_error);
+                self.sink.push(err);
+                false
             }
-            let err = self.unification_diagnostic(t1, t2, span, &unify_error);
-            self.sink.push(err);
         }
     }
 

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -53,6 +53,7 @@ pub struct Facts {
     // Drained by passes::deferred via mem::take.
     pub generic_call_checks: Vec<GenericCallCheck>,
     pub empty_collection_checks: Vec<EmptyCollectionCheck>,
+    pub empty_literal_checks: Vec<EmptyLiteralCheck>,
     pub statement_tail_checks: Vec<StatementTailCheck>,
 
     /// Value-position `match`/`select` arms that did not reconcile, drained and
@@ -89,6 +90,8 @@ pub struct GenericCallCheck {
     /// unbound type variables, the call's generic parameter couldn't be inferred.
     pub ty: Type,
     pub span: Span,
+    /// Qualifies `ty`'s variable ids, which are unique only per inference context.
+    pub module_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -96,6 +99,15 @@ pub struct EmptyCollectionCheck {
     pub name: String,
     pub ty: Type,
     pub span: Span,
+    pub module_id: String,
+}
+
+/// An empty slice literal, rejected if its element type stays unbound.
+#[derive(Debug, Clone)]
+pub struct EmptyLiteralCheck {
+    pub ty: Type,
+    pub span: Span,
+    pub module_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -132,6 +144,7 @@ impl Facts {
             expression_only_fstrings: Vec::new(),
             generic_call_checks: Vec::new(),
             empty_collection_checks: Vec::new(),
+            empty_literal_checks: Vec::new(),
             statement_tail_checks: Vec::new(),
             branch_subsumptions: Vec::new(),
             select_exhaustiveness_checks: Vec::new(),
@@ -295,6 +308,7 @@ impl Facts {
             expression_only_fstrings,
             generic_call_checks,
             empty_collection_checks,
+            empty_literal_checks,
             statement_tail_checks,
             branch_subsumptions,
             select_exhaustiveness_checks,
@@ -330,6 +344,7 @@ impl Facts {
             .extend(expression_only_fstrings);
         self.generic_call_checks.extend(generic_call_checks);
         self.empty_collection_checks.extend(empty_collection_checks);
+        self.empty_literal_checks.extend(empty_literal_checks);
         self.statement_tail_checks.extend(statement_tail_checks);
         self.branch_subsumptions.extend(branch_subsumptions);
         self.select_exhaustiveness_checks

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1304,6 +1304,45 @@ impl Type {
         }
     }
 
+    pub fn collect_unbound_variables(&self, out: &mut Vec<TypeVarId>) {
+        match self {
+            Type::Var { id, hint } => {
+                if hint.is_some() {
+                    out.push(*id);
+                }
+            }
+            Type::Nominal { params, .. } => {
+                for p in params {
+                    p.collect_unbound_variables(out);
+                }
+            }
+            Type::Function(f) => {
+                for p in &f.params {
+                    p.collect_unbound_variables(out);
+                }
+                f.return_type.collect_unbound_variables(out);
+            }
+            Type::Forall { body, .. } => body.collect_unbound_variables(out),
+            Type::Tuple(elements) => {
+                for e in elements {
+                    e.collect_unbound_variables(out);
+                }
+            }
+            Type::Array { element, .. } => element.collect_unbound_variables(out),
+            Type::Compound { args, .. } => {
+                for a in args {
+                    a.collect_unbound_variables(out);
+                }
+            }
+            Type::Simple(_)
+            | Type::Parameter(_)
+            | Type::Never
+            | Type::Error
+            | Type::ImportNamespace(_)
+            | Type::ReceiverPlaceholder => {}
+        }
+    }
+
     pub fn remove_found_type_names(&self, names: &mut HashSet<EcoString>) {
         if names.is_empty() {
             return;

--- a/tests/spec/build/snapshots/cross_file_inferred_go_type_emits_matching_import.snap
+++ b/tests/spec/build/snapshots/cross_file_inferred_go_type_emits_matching_import.snap
@@ -20,5 +20,5 @@ import (
 )
 
 func main() {
-	fmt.Println(Count(([]time.Duration)(nil)))
+	fmt.Println(Count([]time.Duration{}))
 }

--- a/tests/spec/build/snapshots/cross_file_inferred_local_type_emits_matching_import.snap
+++ b/tests/spec/build/snapshots/cross_file_inferred_local_type_emits_matching_import.snap
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	fmt.Println(Count(([]util.Box[string])(nil)))
+	fmt.Println(Count([]util.Box[string]{}))
 }
 
 

--- a/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
+++ b/tests/spec/build/snapshots/cross_module_generic_constructor_type_args.snap
@@ -23,5 +23,5 @@ type Box[T any] struct {
 }
 
 func Box_New[T any]() Box[T] {
-	return Box[T]{}
+	return Box[T]{Items: []T{}}
 }

--- a/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
@@ -49,6 +49,6 @@ func (s *Status) UnmarshalJSON(data []byte) error {
 
 func main() {
 	s := MakeStatusReady()
-	_ = js.Valid(([]byte)(nil))
+	_ = js.Valid([]byte{})
 	_ = s
 }

--- a/tests/spec/emit/literals.rs
+++ b/tests/spec/emit/literals.rs
@@ -151,6 +151,31 @@ fn test() {
 }
 
 #[test]
+fn empty_slice_literal_is_not_nil_at_go_boundary() {
+    let input = r#"
+import "go:encoding/json"
+
+struct Payload {
+  pub items: Slice<int>,
+}
+
+fn main() {
+  let xs: Slice<int> = []
+  let encoded = json.Marshal(xs).unwrap_or([]) as string
+  if encoded != "[]" {
+    panic(f"expected an explicit empty literal to encode as [], got {encoded}")
+  }
+  let payload = Payload { items: [] }
+  let wrapped = json.Marshal(payload).unwrap_or([]) as string
+  if wrapped != "{\"Items\":[]}" {
+    panic(f"expected an empty slice field to encode as [], got {wrapped}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn empty_slice_of_function_type() {
     let input = r#"
 fn test() {

--- a/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
@@ -19,7 +19,7 @@ func bump(a int) int {
 }
 
 func run() int {
-	items := ([]int)(nil)
+	items := []int{}
 	i := 0
 	ibump := func() int {
 		i = 1

--- a/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
@@ -23,7 +23,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	items := ([]int)(nil)
+	items := []int{}
 	_arg_1 := i
 	items = append(items, _arg_1, bump(&i))
 	_ = items

--- a/tests/spec/emit/snapshots/bare_append_discards_without_writeback.snap
+++ b/tests/spec/emit/snapshots/bare_append_discards_without_writeback.snap
@@ -11,7 +11,7 @@ description: |
 package main
 
 func main() {
-	items := ([]int)(nil)
+	items := []int{}
 	_ = append(items, 1)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/double_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/double_newtype_slice_append.snap
@@ -17,6 +17,6 @@ type A []int
 type B A
 
 func main() {
-	w := B(A(([]int)(nil)))
+	w := B(A([]int{}))
 	w = B(A(append([]int(A(w)), 1)))
 }

--- a/tests/spec/emit/snapshots/empty_slice.snap
+++ b/tests/spec/emit/snapshots/empty_slice.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test() {
-	_ = ([]int)(nil)
+	_ = []int{}
 }

--- a/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
+++ b/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
@@ -1,0 +1,61 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  import "go:encoding/json"
+  
+  struct Payload {
+    pub items: Slice<int>,
+  }
+  
+  fn main() {
+    let xs: Slice<int> = []
+    let encoded = json.Marshal(xs).unwrap_or([]) as string
+    if encoded != "[]" {
+      panic(f"expected an explicit empty literal to encode as [], got {encoded}")
+    }
+    let payload = Payload { items: [] }
+    let wrapped = json.Marshal(payload).unwrap_or([]) as string
+    if wrapped != "{\"Items\":[]}" {
+      panic(f"expected an empty slice field to encode as [], got {wrapped}")
+    }
+  }
+---
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Payload struct {
+	Items []int
+}
+
+func main() {
+	xs := []int{}
+	ret_1, ret_2 := json.Marshal(xs)
+	var result_3 lisette.Result[[]byte, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]byte, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[[]byte, error](ret_1)
+	}
+	encoded := string(result_3.UnwrapOr([]byte{}))
+	if encoded != "[]" {
+		panic(fmt.Sprintf("expected an explicit empty literal to encode as [], got %s", encoded))
+	}
+	payload := Payload{Items: []int{}}
+	ret_4, ret_5 := json.Marshal(payload)
+	var result_6 lisette.Result[[]byte, error]
+	if ret_5 != nil {
+		result_6 = lisette.MakeResultErr[[]byte, error](ret_5)
+	} else {
+		result_6 = lisette.MakeResultOk[[]byte, error](ret_4)
+	}
+	wrapped := string(result_6.UnwrapOr([]byte{}))
+	if wrapped != "{\"Items\":[]}" {
+		panic(fmt.Sprintf("expected an empty slice field to encode as [], got %s", wrapped))
+	}
+}

--- a/tests/spec/emit/snapshots/empty_slice_of_function_type.snap
+++ b/tests/spec/emit/snapshots/empty_slice_of_function_type.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test() {
-	_ = ([]func(int) int)(nil)
+	_ = []func(int) int{}
 }

--- a/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
+++ b/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
@@ -29,5 +29,5 @@ type Status struct {
 }
 
 func (s Status) MarshalJSON() ([]byte, error) {
-	return ([]byte)(nil), nil
+	return []byte{}, nil
 }

--- a/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_emits_type_params.snap
@@ -21,7 +21,7 @@ type Stack[T any] struct {
 }
 
 func Stack_new[T any]() Stack[T] {
-	return Stack[T]{}
+	return Stack[T]{items: []T{}}
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
+++ b/tests/spec/emit/snapshots/generic_static_method_return_only_type_param.snap
@@ -25,7 +25,10 @@ type Container[T any] struct {
 }
 
 func Container_new[T any](name string) Container[T] {
-	return Container[T]{name: name}
+	return Container[T]{
+		items: []T{},
+		name:  name,
+	}
 }
 
 func test() Container[string] {

--- a/tests/spec/emit/snapshots/interop_result_slice_append.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_append.snap
@@ -19,7 +19,7 @@ import "strconv"
 type F func(string) (int, error)
 
 func main() {
-	xs := ([]F)(nil)
+	xs := []F{}
 	xs = append(xs, strconv.Atoi)
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
+++ b/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
@@ -12,6 +12,6 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
-	xs := ([]lisette.Option[int])(nil)
+	xs := []lisette.Option[int]{}
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/interop_some_stores_result_fn_in_lowered_abi.snap
+++ b/tests/spec/emit/snapshots/interop_some_stores_result_fn_in_lowered_abi.snap
@@ -19,7 +19,7 @@ import (
 )
 
 func configure(conf *ext.Config) {
-	wrapped := ([]lisette.Option[func(ext.Config) (ext.Listener, error)])(nil)
+	wrapped := []lisette.Option[func(ext.Config) (ext.Listener, error)]{}
 	for _, listener := range ext.WrapListeners(conf.Listeners) {
 		wrapped = append(wrapped, lisette.MakeOptionSome(listener))
 	}

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	buckets := ([]aws.Bucket)(nil)
+	buckets := []aws.Bucket{}
 	for _, bucket := range buckets {
 		raw_2 := bucket.Name
 		option_3 := lisette.OptionFromPointer[string](raw_2)

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -38,7 +38,7 @@ func main() {
 	if opt_1.Tag == lisette.OptionSome {
 		unwrap_2 = opt_1.SomeVal
 	}
-	src_3 := ([]lisette.Option[ast.Expr])(nil)
+	src_3 := []lisette.Option[ast.Expr]{}
 	unwrapped_4 := make([]ast.Expr, len(src_3))
 	for i_5, v_6 := range src_3 {
 		if v_6.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/map_entry_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append.snap
@@ -24,7 +24,7 @@ type Box struct {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{}
+	m["a"] = Box{items: []int{}}
 	entry := Box{items: slices.Clone(m["a"].items)}
 	entry.items = append(entry.items, 1)
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_deref_map.snap
@@ -25,7 +25,7 @@ type Box struct {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{}
+	m["a"] = Box{items: []int{}}
 	r := &m
 	entry := Box{items: slices.Clone((*r)["a"].items)}
 	entry.items = append(entry.items, 1)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
@@ -33,7 +33,7 @@ func get_map(m map[string]Box) map[string]Box {
 
 func main() {
 	m := make(map[string]Box)
-	m["a"] = Box{}
+	m["a"] = Box{items: []int{}}
 	map_ := get_map(m)
 	entry := Box{items: slices.Clone(map_["a"].items)}
 	entry.items = append(entry.items, 1)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
@@ -16,6 +16,6 @@ type Wrap []int
 
 func main() {
 	m := make(map[string]Wrap)
-	m["a"] = Wrap(([]int)(nil))
+	m["a"] = Wrap([]int{})
 	m["a"] = Wrap(append([]int(m["a"]), 1))
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype_inner_field.snap
@@ -27,7 +27,7 @@ type Wrap Inner
 
 func main() {
 	m := make(map[string]Wrap)
-	m["a"] = Wrap(Inner{})
+	m["a"] = Wrap(Inner{items: []int{}})
 	inner := Inner{items: slices.Clone(Inner(m["a"]).items)}
 	inner.items = append(inner.items, 1)
 	m["a"] = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_struct_field.snap
@@ -24,7 +24,7 @@ type Wrap struct {
 func main() {
 	m := make(map[string]Wrap)
 	m["a"] = Wrap{
-		F0: ([]int)(nil),
+		F0: []int{},
 		F1: 0,
 	}
 	entry := Wrap{

--- a/tests/spec/emit/snapshots/recover_block_with_panic_never_type.snap
+++ b/tests/spec/emit/snapshots/recover_block_with_panic_never_type.snap
@@ -16,7 +16,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func panicky() int {
-	arr := ([]int)(nil)
+	arr := []int{}
 	return arr[0]
 }
 

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -15,7 +15,7 @@ package main
 func noop() {}
 
 func main() {
-	xs := ([]struct{})(nil)
+	xs := []struct{}{}
 	_arg_1 := xs
 	noop()
 	y := append(_arg_1, struct{}{})

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -14,7 +14,7 @@ package main
 func noop() {}
 
 func test() {
-	xs := ([]struct{})(nil)
+	xs := []struct{}{}
 	_arg_1 := xs
 	noop()
 	_ = append(_arg_1, struct{}{})

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -167,3 +167,194 @@ fn channel_new_type_from_return_type_succeeds() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn empty_literal_in_generic_call_errors() {
+    infer(
+        r#"
+    fn count<T>(items: Slice<T>) -> int {
+      items.length()
+    }
+
+    fn test() -> int {
+      count([])
+    }
+        "#,
+    )
+    .assert_infer_code("empty_slice_no_element_type");
+}
+
+#[test]
+fn empty_literal_unresolved_binding_reports_once() {
+    let result = crate::_harness::infer::infer("fn test() { let xs = []; let _ = xs }");
+    let errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .filter_map(|e| e.code_str())
+        .collect();
+    assert_eq!(
+        errors,
+        vec!["infer.type_not_inferred"],
+        "an unresolved empty-literal binding must report only the binding diagnostic"
+    );
+}
+
+#[test]
+fn empty_literal_concrete_param_succeeds() {
+    infer(
+        r#"
+    fn take(xs: Slice<int>) -> int {
+      xs.length()
+    }
+
+    fn test() -> int {
+      take([])
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_literal_annotation_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let xs: Slice<string> = [];
+      let _ = xs;
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_literal_resolved_by_later_append_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let mut xs = [];
+      xs = xs.append(1);
+      let _ = xs;
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_literal_in_generic_return_position_succeeds() {
+    infer(
+        r#"
+    fn empty_of<T>() -> Slice<T> {
+      []
+    }
+
+    fn test() {
+      let xs: Slice<string> = empty_of();
+      let _ = xs;
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_literal_against_non_slice_param_reports_only_mismatch() {
+    let result = crate::_harness::infer::infer(
+        r#"
+    fn take(x: int) -> int {
+      x
+    }
+
+    fn test() -> int {
+      take([])
+    }
+        "#,
+    );
+    let errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .filter_map(|e| e.code_str())
+        .collect();
+    assert_eq!(
+        errors,
+        vec!["infer.type_mismatch"],
+        "a context mismatch must not cascade into an empty-literal report"
+    );
+}
+
+#[test]
+fn empty_literal_in_uninferred_generic_call_reports_only_call() {
+    let result = crate::_harness::infer::infer(
+        r#"
+    fn keep<T>(items: Slice<T>) -> Slice<T> {
+      items
+    }
+
+    fn test() {
+      let _ = keep([]);
+    }
+        "#,
+    );
+    let errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .filter_map(|e| e.code_str())
+        .collect();
+    assert_eq!(
+        errors,
+        vec!["infer.missing_type_argument"],
+        "an uninferred generic call must not cascade into an empty-literal report"
+    );
+}
+
+#[test]
+fn empty_literal_with_unrelated_var_reports_inside_uninferred_call() {
+    let result = crate::_harness::infer::infer(
+        r#"
+    fn count<U>(items: Slice<U>) -> int {
+      items.length()
+    }
+
+    fn outer<T>(n: int) -> Slice<T> {
+      []
+    }
+
+    fn test() {
+      let _ = outer(count([]));
+    }
+        "#,
+    );
+    let mut errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .filter_map(|e| e.code_str())
+        .collect();
+    errors.sort_unstable();
+    assert_eq!(
+        errors,
+        vec![
+            "infer.empty_slice_no_element_type",
+            "infer.missing_type_argument"
+        ],
+        "the literal's unresolved element is independent of the outer call's type argument, so both must report"
+    );
+}
+
+#[test]
+fn empty_literal_in_tuple_destructuring_errors() {
+    infer(
+        r#"
+    fn test() {
+      let (a, b) = ([], [1]);
+      let _ = (a, b);
+    }
+        "#,
+    )
+    .assert_infer_code("empty_slice_no_element_type");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3100,6 +3100,20 @@ fn test() {
 }
 
 #[test]
+fn infer_empty_slice_no_element_type() {
+    let input = r#"
+fn count<T>(items: Slice<T>) -> int {
+  items.length()
+}
+
+fn test() -> int {
+  count([])
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_cannot_infer_type_arguments() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_empty_slice_no_element_type.snap
+++ b/tests/ui/errors/snapshots/infer_empty_slice_no_element_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot infer the element type of this empty slice
+   ╭─[test.lis:7:9]
+ 6 │ fn test() -> int {
+ 7 │   count([])
+   ·         ─┬
+   ·          ╰── `[]` needs an element type from context
+ 8 │ }
+   ╰────
+  help: Annotate the enclosing binding, e.g. `let xs: Slice<int> = []`, or write `Slice.new<int>()` · code: [infer.empty_slice_no_element_type]


### PR DESCRIPTION
Empty slice literals now behave like the `Slice` constructors.

- `[]` produces the same non-nil empty slice as `Slice.new()`. Explicitly constructed empties now encode as `[]` in JSON instead of `null`, including struct fields assigned `[]`.
- An empty slice literal whose element type cannot be inferred is rejected at compile time, instead of silently becoming a slice of Go `any`.