### PR TITLE
fix: require `mut` for `copy_from`

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1499,11 +1499,11 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    /// `Map.delete` modifies the map in place, so its receiver needs `mut`.
-    /// `append` is pure (it returns a new slice and needs no `mut`): growing in
-    /// place is the reassignment `s = s.append(x)`, checked as an ordinary
-    /// assignment, including the rejection of writing back to a non-addressable
-    /// map-value field.
+    /// `Map.delete` and `Slice.copy_from` modify the receiver in place, so it
+    /// needs `mut`. `append` is pure (it returns a new slice and needs no
+    /// `mut`): growing in place is the reassignment `s = s.append(x)`, checked
+    /// as an ordinary assignment, including the rejection of writing back to a
+    /// non-addressable map-value field.
     fn check_native_mutating_call(&mut self, callee: &Expression, span: &Span) {
         let store = self.store;
         let Expression::DotAccess {
@@ -1516,7 +1516,11 @@ impl InferCtx<'_, '_> {
         };
         let receiver_ty = receiver.get_type().resolve_in(&self.env).strip_refs();
 
-        let is_mutating = matches!(receiver_ty.get_name(), Some("Map")) && member == "delete";
+        let is_mutating = match receiver_ty.get_name() {
+            Some("Map") => member == "delete",
+            Some("Slice") => member == "copy_from",
+            _ => false,
+        };
         if !is_mutating {
             return;
         }

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -186,7 +186,7 @@ fn slice_append_spread() {
 
 #[test]
 fn slice_copy_from() {
-  let dst = [0, 0, 0]
+  let mut dst = [0, 0, 0]
   let src = [1, 2, 3]
   let copied = dst.copy_from(src)
   assert copied == 3 && dst[0] == 1 && dst[2] == 3

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -275,7 +275,7 @@ fn test(s: Slice<int>) {
 #[test]
 fn slice_copy_from() {
     let input = r#"
-fn test(dst: Slice<int>, src: Slice<int>) -> int {
+fn test(mut dst: Slice<int>, src: Slice<int>) -> int {
   dst.copy_from(src)
 }
 "#;

--- a/tests/spec/emit/snapshots/slice_copy_from.snap
+++ b/tests/spec/emit/snapshots/slice_copy_from.snap
@@ -2,7 +2,7 @@
 source: tests/spec/emit/prelude.rs
 description: |
   
-  fn test(dst: Slice<int>, src: Slice<int>) -> int {
+  fn test(mut dst: Slice<int>, src: Slice<int>) -> int {
     dst.copy_from(src)
   }
 ---

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1373,6 +1373,28 @@ fn delete_on_mutable_map_is_allowed() {
 }
 
 #[test]
+fn cannot_copy_into_immutable_slice() {
+    infer(
+        r#"{
+    let dst = [0, 0, 0];
+    dst.copy_from([1, 2, 3])
+  }"#,
+    )
+    .assert_infer_code("immutable");
+}
+
+#[test]
+fn copy_from_on_mutable_slice_is_allowed() {
+    infer(
+        r#"{
+    let mut dst = [0, 0, 0];
+    dst.copy_from([1, 2, 3])
+  }"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn auto_address_value_to_ref_receiver() {
     infer(
         r#"


### PR DESCRIPTION
`Slice.copy_from` overwrites its receiver in place, but the checker accepted calls on immutable bindings. It now requires `mut`.

```rs
let dst = [0, 0, 0]
dst.copy_from([1, 2, 3]) // error: cannot mutate an immutable variable

let mut dst = [0, 0, 0]
dst.copy_from([1, 2, 3]) // ok
```
