### PR TITLE
fix: prevent unintended mutation from `append` aliasing

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -287,6 +287,7 @@ impl Planner<'_> {
             native_type: &native_type,
             method,
             capture_boundary: CaptureBoundary::SiblingSequence,
+            retired_receiver: None,
         };
         match call_kind {
             CallKind::NativeMethod(_) => {
@@ -355,6 +356,7 @@ impl Planner<'_> {
                     native_type: &native_type,
                     method,
                     capture_boundary: ctx.capture_boundary(),
+                    retired_receiver: ctx.retired_receiver(),
                 };
                 return self.lower_native_call(&native_ctx, &plan.resolved.origin);
             }
@@ -476,9 +478,13 @@ impl Planner<'_> {
     ) -> Option<ValuePlan> {
         let target = self.resolve_tuple_struct_target(function, call_ty)?;
 
+        let arg_ctx = match (ctx.retired_receiver(), args.len()) {
+            (Some(retired), 1) => ExpressionContext::value().with_retired_receiver(retired),
+            _ => ExpressionContext::value(),
+        };
         let stages: Vec<ValuePlan> = args
             .iter()
-            .map(|a| self.stage_composite(a, ExpressionContext::value()))
+            .map(|a| self.stage_composite(a, arg_ctx))
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_arg");
         let effect = EvaluationEffect::PureCall.combine(sequenced.effect);
@@ -635,7 +641,7 @@ impl Planner<'_> {
     }
 }
 
-fn extract_native_method_name(function: &Expression) -> &str {
+pub(super) fn extract_native_method_name(function: &Expression) -> &str {
     match function {
         Expression::DotAccess { member, .. } => member,
         Expression::Identifier { value, .. } => {

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -1,7 +1,7 @@
 mod clone;
 pub(crate) mod dispatch;
 pub(crate) mod go_interop;
-mod native;
+pub(crate) mod native;
 mod regular;
 mod ufcs;
 
@@ -19,4 +19,5 @@ pub(super) struct NativeCallContext<'a> {
     pub native_type: &'a NativeGoType,
     pub method: &'a str,
     pub capture_boundary: CaptureBoundary,
+    pub retired_receiver: Option<&'a Expression>,
 }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -1,15 +1,17 @@
 use super::NativeCallContext;
 use crate::Planner;
+use crate::calls::dispatch::extract_native_method_name;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::access::index_access::range_var_bounds;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, ValuePlan};
+use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
 use crate::utils::reads_mutable_operand;
-use syntax::ast::{Expression, UnaryOperator};
-use syntax::program::DotAccessKind;
+use syntax::ast::{Expression, Literal, UnaryOperator};
+use syntax::program::{CallKind, DotAccessKind, NativeTypeKind};
 use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
 pub(super) struct NativeCallResult {
@@ -222,6 +224,79 @@ static INLINE_METHODS: &[InlineRule] = &[
     },
 ];
 
+pub(crate) fn clip_shared_capacity(receiver: &str) -> String {
+    format!("{r}[:len({r}):len({r})]", r = receiver)
+}
+
+fn grows_into_capacity(method: &str, appends_anything: bool) -> bool {
+    method == "append" && appends_anything
+}
+
+pub(crate) fn is_clip_safe_path(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+}
+
+fn growth_clip_applies(ctx: &NativeCallContext, receiver: &Expression) -> bool {
+    let appends_anything = if matches!(ctx.function, Expression::DotAccess { .. }) {
+        !ctx.args.is_empty() || ctx.spread.is_some()
+    } else {
+        ctx.args.len() > 1 || ctx.spread.is_some()
+    };
+    grows_into_capacity(ctx.method, appends_anything)
+        && !is_fresh_slice_value(receiver)
+        && !ctx
+            .retired_receiver
+            .is_some_and(|target| retired_covers_receiver(target, receiver))
+}
+
+fn is_fresh_slice_value(receiver: &Expression) -> bool {
+    match receiver.unwrap_parens() {
+        Expression::Literal {
+            literal: Literal::Slice(_),
+            ..
+        } => true,
+        Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            call_kind,
+            ..
+        } => match call_kind {
+            Some(CallKind::NativeConstructor(NativeTypeKind::Slice)) => true,
+            Some(
+                CallKind::NativeMethod(NativeTypeKind::Slice)
+                | CallKind::NativeMethodIdentifier(NativeTypeKind::Slice),
+            ) => match extract_native_method_name(callee.unwrap_parens()) {
+                "append" => {
+                    let receiver_argument_count =
+                        matches!(call_kind, Some(CallKind::NativeMethodIdentifier(_))) as usize;
+                    args.len() > receiver_argument_count || spread.is_some()
+                }
+                "clone" | "filter" | "map" => true,
+                _ => false,
+            },
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn retired_covers_receiver(target: &Expression, receiver: &Expression) -> bool {
+    let mut current = receiver.unwrap_parens();
+    loop {
+        if lvalues_match(target, current) {
+            return true;
+        }
+        match current {
+            Expression::DotAccess { expression, .. } => current = expression.unwrap_parens(),
+            _ => return false,
+        }
+    }
+}
+
 fn render_inline(template: &str, receiver: &str, args: &[String]) -> String {
     let mut result = template.replace("{r}", receiver);
     for (i, arg) in args.iter().enumerate() {
@@ -386,6 +461,12 @@ impl Planner<'_> {
 
         let (setup, receiver, emitted_args, effect, contains_deferred_evaluation) =
             self.stage_native_dot_access_call(ctx);
+
+        let receiver = if growth_clip_applies(ctx, expression) {
+            clip_shared_capacity(&receiver)
+        } else {
+            receiver
+        };
 
         if let Some(inlined) = apply_inline_lookup(
             self,
@@ -600,6 +681,11 @@ impl Planner<'_> {
         if expression.get_type().is_ref() {
             receiver_stage = receiver_stage.unary("*");
         }
+        if growth_clip_applies(ctx, expression)
+            && !is_clip_safe_path(&receiver_stage.expression.rendered())
+        {
+            self.pin_staged(&mut receiver_stage, "recv");
+        }
         all_stages.push(receiver_stage);
         all_stages.extend(argument_stages);
         let spread_index = spread_stage.map(|stage| {
@@ -699,8 +785,15 @@ impl Planner<'_> {
             return NativeCallResult::new(setup, body, effect, contains_deferred_evaluation);
         }
 
-        let (setup, emitted_args, effect, contains_deferred_evaluation) =
+        let (setup, mut emitted_args, effect, contains_deferred_evaluation) =
             self.stage_native_identifier_args(ctx);
+
+        if let Some(receiver_expr) = ctx.args.first()
+            && growth_clip_applies(ctx, receiver_expr)
+            && let Some(first) = emitted_args.first_mut()
+        {
+            *first = clip_shared_capacity(first);
+        }
 
         if let Some(inlined) = apply_inline_identifier_lookup(self, ctx, &emitted_args, false) {
             return NativeCallResult::new(setup, inlined, effect, contains_deferred_evaluation);
@@ -756,6 +849,11 @@ impl Planner<'_> {
                 .chain(spread_stage.iter())
                 .any(|stage| stage.evaluation.effect.has_call());
             self.pin_receiver_if_mutated(&mut stages[0], receiver, rest_has_call);
+            if growth_clip_applies(ctx, receiver)
+                && !is_clip_safe_path(&stages[0].expression.rendered())
+            {
+                self.pin_staged(&mut stages[0], "recv");
+            }
         }
         let spread_index = spread_stage.map(|stage| {
             stages.push(stage);

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -29,6 +29,7 @@ struct CallArgsContext<'plan, 'facts> {
     wrap_spread_to_any: bool,
     combine_variadic: Option<VariadicCombine>,
     capture_boundary: CaptureBoundary,
+    retired_receiver: Option<&'plan Expression>,
 }
 
 /// Escape-aware close-quote search; plain `find` would collide with `\"` inside the literal.
@@ -143,9 +144,15 @@ impl<'a> Planner<'a> {
         let spread = (**spread).as_ref();
 
         if let Some(go_name) = self.get_callee_go_name(function).map(str::to_string) {
+            let arg_ctx = match (expression_ctx.retired_receiver(), args.len()) {
+                (Some(retired), 1) if self.callee_lowers_to_type_construction(function) => {
+                    ExpressionContext::value().with_retired_receiver(retired)
+                }
+                _ => ExpressionContext::value(),
+            };
             let stages: Vec<ValuePlan> = args
                 .iter()
-                .map(|a| self.stage_operand(a, ExpressionContext::value()))
+                .map(|a| self.stage_operand(a, arg_ctx))
                 .collect();
             let wrap_to_any = spread_needs_any_wrap(function, spread);
             let combine = call_plan.variadic_combine(0);
@@ -197,6 +204,10 @@ impl<'a> Planner<'a> {
             wrap_spread_to_any: spread_needs_any_wrap(function, spread),
             combine_variadic: call_plan.variadic_combine(0),
             capture_boundary: expression_ctx.capture_boundary(),
+            retired_receiver: (args.len() == 1
+                && self.callee_lowers_to_type_construction(function))
+            .then(|| expression_ctx.retired_receiver())
+            .flatten(),
         };
         let sequenced_args = self.emit_call_args(args, &args_ctx);
         let args_effect = sequenced_args.effect;
@@ -498,7 +509,10 @@ impl<'a> Planner<'a> {
         declared_param_ty: Option<&Type>,
     ) -> ValuePlan {
         let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
-        let arg_ctx = direct_arg_emit_ctx(effective_param_ty, suppress);
+        let mut arg_ctx = direct_arg_emit_ctx(effective_param_ty, suppress);
+        if let Some(retired) = ctx.retired_receiver {
+            arg_ctx = arg_ctx.with_retired_receiver(retired);
+        }
         let argument = self.lower_composite_value(arg, arg_ctx);
         argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
             let final_value = match effective_param_ty {

--- a/crates/emit/src/context/expression.rs
+++ b/crates/emit/src/context/expression.rs
@@ -1,3 +1,4 @@
+use syntax::ast::Expression;
 use syntax::types::Type;
 
 use crate::plan::values::CaptureBoundary;
@@ -42,6 +43,7 @@ pub(crate) struct ExpressionContext<'a> {
     function_value_abi_target: FunctionValueAbiTarget,
     argument_target: ArgumentTarget,
     capture_boundary: CaptureBoundary,
+    retired_receiver: Option<&'a Expression>,
 }
 
 impl<'a> ExpressionContext<'a> {
@@ -116,5 +118,14 @@ impl<'a> ExpressionContext<'a> {
 
     pub(crate) fn capture_boundary(self) -> CaptureBoundary {
         self.capture_boundary
+    }
+
+    pub(crate) fn with_retired_receiver(mut self, target: &'a Expression) -> Self {
+        self.retired_receiver = Some(target);
+        self
+    }
+
+    pub(crate) fn retired_receiver(self) -> Option<&'a Expression> {
+        self.retired_receiver
     }
 }

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
 use crate::analyze::inline_uses::region_blocks_inline;
+use crate::calls::native::{clip_shared_capacity, is_clip_safe_path};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
@@ -541,6 +542,17 @@ impl Planner<'_> {
             let receiver_lv =
                 self.emit_left_value_capturing(&mut capture, unwrapped, Some(&arguments));
             let (args_setup, args_str) = arguments.into_parts();
+            let grows = !args_str.is_empty();
+            let receiver_lv = if grows && receiver_lv != var {
+                let clippable = if is_clip_safe_path(&receiver_lv) && args_setup.is_empty() {
+                    receiver_lv
+                } else {
+                    self.hoist_tmp_value_statement(&mut capture, "recv", &receiver_lv)
+                };
+                clip_shared_capacity(&clippable)
+            } else {
+                receiver_lv
+            };
             capture.extend(args_setup);
             let value = if args_str.is_empty() {
                 receiver_lv

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -57,7 +57,10 @@ impl Planner<'_> {
         // `target = value`. Stage RHS first (so the target capture knows
         // whether RHS produced setup), capture the target, then fold RHS
         // setup + coercion setup into the value plan in emission order.
-        let right_hand_side = self.stage_composite(value, ExpressionContext::value());
+        let right_hand_side = self.stage_composite(
+            value,
+            ExpressionContext::value().with_retired_receiver(target),
+        );
         let (target_capture, target_str) =
             self.capture_assignment_target(target, Some(&right_hand_side));
         let coercion = if let Some((_target_ty, target_layout)) = go_field_slot {
@@ -461,7 +464,7 @@ fn is_literal_one(expression: &Expression) -> bool {
 /// Used to detect `x = x + y` → `x += y` patterns.
 /// Compares by binding_id for identifiers, recursively for DotAccess/Deref.
 /// Deliberately skips IndexedAccess (side-effect hazard from index evaluation).
-fn lvalues_match(a: &Expression, b: &Expression) -> bool {
+pub(crate) fn lvalues_match(a: &Expression, b: &Expression) -> bool {
     let a = a.unwrap_parens();
     let b = b.unwrap_parens();
     match (a, b) {

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -148,6 +148,104 @@ fn test() -> Slice<fn(int)> {
 }
 
 #[test]
+fn append_from_call_result_does_not_alias() {
+    let input = r#"
+fn identity(s: Slice<int>) -> Slice<int> {
+  s
+}
+
+fn main() {
+  let mut base = [1, 2]
+  base = base.append(3)
+  let u = identity(base).append(7)
+  base[0] = 99
+  if u.get(0).unwrap_or(-1) != 1 {
+    panic("a call-produced receiver must not alias the argument")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn append_results_do_not_alias() {
+    let input = r#"
+fn main() {
+  let base = [1, 2]
+  let t = base.append(3)
+  let u1 = t.append(7)
+  let u2 = t.append(8)
+  if u1.get(3).unwrap_or(-1) != 7 {
+    panic("append results must not share a backing array")
+  }
+  if u2.get(3).unwrap_or(-1) != 8 {
+    panic("append results must not share a backing array")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn append_from_zero_growth_append_does_not_alias() {
+    let input = r#"
+fn main() {
+  let mut s = [1, 2]
+  s = s.append(3)
+  let u1 = s.append().append(7)
+  let u2 = s.append().append(8)
+  if u1.get(3).unwrap_or(-1) != 7 {
+    panic("a zero-growth append receiver must not be treated as fresh")
+  }
+  if u2.get(3).unwrap_or(-1) != 8 {
+    panic("a zero-growth append receiver must not be treated as fresh")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn block_tail_append_reads_receiver_before_argument_effects() {
+    let input = r#"
+struct Holder {
+  slc: Slice<()>,
+}
+
+fn main() {
+  let mut h = Holder { slc: [] }
+  let bump = || { h.slc = [(), (), ()] }
+  let ys = {
+    h.slc.append(bump())
+  }
+  if ys.length() != 1 {
+    panic("the receiver must be read before argument effects run")
+  }
+  if h.slc.length() != 3 {
+    panic("the argument mutation must still apply")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn append_base_mutation_does_not_leak_into_result() {
+    let input = r#"
+fn main() {
+  let mut t = [1, 2]
+  t = t.append(3)
+  let u = t.append(7)
+  t[0] = 99
+  if u.get(0).unwrap_or(-1) != 1 {
+    panic("mutating the base must not write through to an append result")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_length() {
     let input = r#"
 fn test(s: Slice<int>) -> int {

--- a/tests/spec/emit/snapshots/append_base_mutation_does_not_leak_into_result.snap
+++ b/tests/spec/emit/snapshots/append_base_mutation_does_not_leak_into_result.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let mut t = [1, 2]
+    t = t.append(3)
+    let u = t.append(7)
+    t[0] = 99
+    if u.get(0).unwrap_or(-1) != 1 {
+      panic("mutating the base must not write through to an append result")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	t := []int{1, 2}
+	t = append(t, 3)
+	u := append(t[:len(t):len(t)], 7)
+	t[0] = 99
+	if lisette.SliceGet(u, 0).UnwrapOr(-1) != 1 {
+		panic("mutating the base must not write through to an append result")
+	}
+}

--- a/tests/spec/emit/snapshots/append_from_call_result_does_not_alias.snap
+++ b/tests/spec/emit/snapshots/append_from_call_result_does_not_alias.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn identity(s: Slice<int>) -> Slice<int> {
+    s
+  }
+  
+  fn main() {
+    let mut base = [1, 2]
+    base = base.append(3)
+    let u = identity(base).append(7)
+    base[0] = 99
+    if u.get(0).unwrap_or(-1) != 1 {
+      panic("a call-produced receiver must not alias the argument")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func identity(s []int) []int {
+	return s
+}
+
+func main() {
+	base := []int{1, 2}
+	base = append(base, 3)
+	recv_1 := identity(base)
+	u := append(recv_1[:len(recv_1):len(recv_1)], 7)
+	base[0] = 99
+	if lisette.SliceGet(u, 0).UnwrapOr(-1) != 1 {
+		panic("a call-produced receiver must not alias the argument")
+	}
+}

--- a/tests/spec/emit/snapshots/append_from_zero_growth_append_does_not_alias.snap
+++ b/tests/spec/emit/snapshots/append_from_zero_growth_append_does_not_alias.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let mut s = [1, 2]
+    s = s.append(3)
+    let u1 = s.append().append(7)
+    let u2 = s.append().append(8)
+    if u1.get(3).unwrap_or(-1) != 7 {
+      panic("a zero-growth append receiver must not be treated as fresh")
+    }
+    if u2.get(3).unwrap_or(-1) != 8 {
+      panic("a zero-growth append receiver must not be treated as fresh")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	s := []int{1, 2}
+	s = append(s, 3)
+	u1 := append(s[:len(s):len(s)], 7)
+	u2 := append(s[:len(s):len(s)], 8)
+	if lisette.SliceGet(u1, 3).UnwrapOr(-1) != 7 {
+		panic("a zero-growth append receiver must not be treated as fresh")
+	}
+	if lisette.SliceGet(u2, 3).UnwrapOr(-1) != 8 {
+		panic("a zero-growth append receiver must not be treated as fresh")
+	}
+}

--- a/tests/spec/emit/snapshots/append_non_lvalue_preserves_args.snap
+++ b/tests/spec/emit/snapshots/append_non_lvalue_preserves_args.snap
@@ -25,5 +25,6 @@ func arg() int {
 }
 
 func main() {
-	_ = append(get(), arg())
+	recv_1 := get()
+	_ = append(recv_1[:len(recv_1):len(recv_1)], arg())
 }

--- a/tests/spec/emit/snapshots/append_non_lvalue_receiver_discards.snap
+++ b/tests/spec/emit/snapshots/append_non_lvalue_receiver_discards.snap
@@ -21,5 +21,6 @@ func get() Items {
 }
 
 func main() {
-	_ = append(get().items, 2)
+	recv_1 := get().items
+	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/append_results_do_not_alias.snap
+++ b/tests/spec/emit/snapshots/append_results_do_not_alias.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let base = [1, 2]
+    let t = base.append(3)
+    let u1 = t.append(7)
+    let u2 = t.append(8)
+    if u1.get(3).unwrap_or(-1) != 7 {
+      panic("append results must not share a backing array")
+    }
+    if u2.get(3).unwrap_or(-1) != 8 {
+      panic("append results must not share a backing array")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	base := []int{1, 2}
+	t := append(base[:len(base):len(base)], 3)
+	u1 := append(t[:len(t):len(t)], 7)
+	u2 := append(t[:len(t):len(t)], 8)
+	if lisette.SliceGet(u1, 3).UnwrapOr(-1) != 7 {
+		panic("append results must not share a backing array")
+	}
+	if lisette.SliceGet(u2, 3).UnwrapOr(-1) != 8 {
+		panic("append results must not share a backing array")
+	}
+}

--- a/tests/spec/emit/snapshots/bare_append_discards_without_writeback.snap
+++ b/tests/spec/emit/snapshots/bare_append_discards_without_writeback.snap
@@ -12,6 +12,6 @@ package main
 
 func main() {
 	items := []int{}
-	_ = append(items, 1)
+	_ = append(items[:len(items):len(items)], 1)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/block_expr_append_non_lvalue_captures_result.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_non_lvalue_captures_result.snap
@@ -22,6 +22,7 @@ func arg() int {
 
 func main() {
 	var x []int
-	x = append(get(), arg())
+	recv_1 := get()
+	x = append(recv_1[:len(recv_1):len(recv_1)], arg())
 	_ = x[1]
 }

--- a/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
@@ -25,6 +25,7 @@ func get() *Wrap {
 
 func main() {
 	var x []int
-	x = append([]int(*get()), 2)
+	recv_1 := []int(*get())
+	x = append(recv_1[:len(recv_1):len(recv_1)], 2)
 	_ = x[0]
 }

--- a/tests/spec/emit/snapshots/block_expr_append_ref_slice_non_lvalue.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_ref_slice_non_lvalue.snap
@@ -27,6 +27,7 @@ func arg() int {
 func main() {
 	var x []int
 	ref_1 := get()
-	x = append(*ref_1, arg())
+	recv_2 := *ref_1
+	x = append(recv_2[:len(recv_2):len(recv_2)], arg())
 	_ = x[1]
 }

--- a/tests/spec/emit/snapshots/block_tail_append_no_writeback.snap
+++ b/tests/spec/emit/snapshots/block_tail_append_no_writeback.snap
@@ -11,6 +11,6 @@ package main
 
 func test(s []int) []int {
 	var x []int
-	x = append(s, 2)
+	x = append(s[:len(s):len(s)], 2)
 	return x
 }

--- a/tests/spec/emit/snapshots/block_tail_append_reads_receiver_before_argument_effects.snap
+++ b/tests/spec/emit/snapshots/block_tail_append_reads_receiver_before_argument_effects.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  struct Holder {
+    slc: Slice<()>,
+  }
+  
+  fn main() {
+    let mut h = Holder { slc: [] }
+    let bump = || { h.slc = [(), (), ()] }
+    let ys = {
+      h.slc.append(bump())
+    }
+    if ys.length() != 1 {
+      panic("the receiver must be read before argument effects run")
+    }
+    if h.slc.length() != 3 {
+      panic("the argument mutation must still apply")
+    }
+  }
+---
+package main
+
+type Holder struct {
+	slc []struct{}
+}
+
+func main() {
+	h := Holder{slc: []struct{}{}}
+	bump := func() {
+		h.slc = []struct{}{struct{}{}, struct{}{}, struct{}{}}
+	}
+	var ys []struct{}
+	recv_1 := h.slc
+	bump()
+	ys = append(recv_1[:len(recv_1):len(recv_1)], struct{}{})
+	if len(ys) != 1 {
+		panic("the receiver must be read before argument effects run")
+	}
+	if len(h.slc) != 3 {
+		panic("the argument mutation must still apply")
+	}
+}

--- a/tests/spec/emit/snapshots/block_tail_append_unused_binding.snap
+++ b/tests/spec/emit/snapshots/block_tail_append_unused_binding.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(s []int) {
-	_ = append(s, 2)
+	_ = append(s[:len(s):len(s)], 2)
 }

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
@@ -22,6 +22,6 @@ func test() {
 	_arg_1 := xs
 	_arg_2 := mark()
 	defer func() {
-		_ = append(_arg_1, _arg_2)
+		_ = append(_arg_1[:len(_arg_1):len(_arg_1)], _arg_2)
 	}()
 }

--- a/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
+++ b/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
@@ -24,6 +24,6 @@ func run() int {
 		return 7
 	}
 	recv_1 := h.slc
-	ys := append(recv_1, bump())
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bump())
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
@@ -22,6 +22,6 @@ func run() int {
 	xss := [][]int{[]int{10}, []int{20}}
 	i := 0
 	recv_1 := xss[i]
-	ys := append(recv_1, bump(&i))
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/immutable_subslice_through_alias_capacity_capped.snap
+++ b/tests/spec/emit/snapshots/immutable_subslice_through_alias_capacity_capped.snap
@@ -19,7 +19,7 @@ type Numbers = []int
 func test() {
 	xs := []int{1, 2, 3}
 	view := xs[0:2:2]
-	grown := append(view, 9)
+	grown := append(view[:len(view):len(view)], 9)
 	_ = grown
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
@@ -25,6 +25,6 @@ func test() int {
 	xss := [][]int{[]int{10}, []int{20}}
 	i := 0
 	recv_1 := xss[i]
-	ys := append(recv_1, bump(&i))
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
@@ -25,6 +25,6 @@ func test() int {
 	xss := [][]int{[]int{10}, []int{20}}
 	i := 0
 	recv_1 := xss[i]
-	ys := append(recv_1, bump_and_make(&i)...)
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bump_and_make(&i)...)
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
@@ -17,5 +17,7 @@ type Wrap []int
 func main() {
 	m := make(map[string]Wrap)
 	m["a"] = Wrap([]int{})
-	m["a"] = Wrap(append([]int(m["a"]), 1))
+	base_2 := m
+	recv_1 := []int(m["a"])
+	base_2["a"] = Wrap(append(recv_1[:len(recv_1):len(recv_1)], 1))
 }

--- a/tests/spec/emit/snapshots/map_field_append_value_position.snap
+++ b/tests/spec/emit/snapshots/map_field_append_value_position.snap
@@ -22,6 +22,7 @@ type Box struct {
 func main() {
 	m := make(map[string]Box)
 	m["a"] = Box{items: []int{1}}
-	xs := append(m["a"].items, 2)
+	recv_1 := m["a"].items
+	xs := append(recv_1[:len(recv_1):len(recv_1)], 2)
 	_ = xs
 }

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
@@ -31,7 +31,8 @@ func main() {
 	}
 	o := subject_1.SomeVal
 	var tmp_2 []int
-	tmp_2 = append(*o.items, 2)
+	recv_3 := *o.items
+	tmp_2 = append(recv_3[:len(recv_3):len(recv_3)], 2)
 	_ = tmp_2
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -28,7 +28,8 @@ func main() {
 		return
 	}
 	r := subject_1.SomeVal
-	ref_2 := r
-	*ref_2 = Wrap(append([]int(*r), 2))
+	ref_3 := r
+	recv_2 := []int(*r)
+	*ref_3 = Wrap(append(recv_2[:len(recv_2):len(recv_2)], 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_append_no_double_eval.snap
@@ -33,5 +33,5 @@ func arg() int {
 
 func main() {
 	recv_1 := *get()
-	_ = append(recv_1, arg())
+	_ = append(recv_1[:len(recv_1):len(recv_1)], arg())
 }

--- a/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
@@ -29,5 +29,6 @@ func get() *Wrap {
 }
 
 func main() {
-	_ = append([]int(*get()), 2)
+	recv_1 := []int(*get())
+	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
@@ -17,5 +17,6 @@ type Wrap []int
 func main() {
 	w := Wrap([]int{1})
 	r := &w
-	_ = append([]int(*r), 2)
+	recv_1 := []int(*r)
+	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
@@ -18,7 +18,8 @@ type Wrap []int
 func main() {
 	w := Wrap([]int{1})
 	r := &w
-	ref_1 := r
-	*ref_1 = Wrap(append([]int(*r), 2))
+	ref_2 := r
+	recv_1 := []int(*r)
+	*ref_2 = Wrap(append(recv_1[:len(recv_1):len(recv_1)], 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_slice_append_expr_position.snap
@@ -13,5 +13,6 @@ package main
 func main() {
 	s := []int{1}
 	r := &s
-	_ = append(*r, 2)
+	recv_1 := *r
+	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
@@ -27,6 +27,6 @@ func run() int {
 	hs := []Holder{Holder{slc: []int{10}}, Holder{slc: []int{20}}}
 	i := 0
 	recv_1 := hs[i].slc
-	ys := append(recv_1, bump(&i))
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/slice_append.snap
+++ b/tests/spec/emit/snapshots/slice_append.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(s []int) []int {
-	return append(s, 1, 2, 3)
+	return append(s[:len(s):len(s)], 1, 2, 3)
 }

--- a/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
+++ b/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
@@ -17,6 +17,8 @@ func make_i() int {
 
 func main() {
 	outer := [][]int{[]int{1}, []int{2}, []int{3}}
-	idx_1 := make_i()
-	outer[idx_1] = append(outer[make_i()], 4)
+	base_2 := outer
+	idx_3 := make_i()
+	recv_1 := outer[make_i()]
+	base_2[idx_3] = append(recv_1[:len(recv_1):len(recv_1)], 4)
 }

--- a/tests/spec/emit/snapshots/spread_arg_into_native_slice_append.snap
+++ b/tests/spec/emit/snapshots/spread_arg_into_native_slice_append.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(s, more []int) []int {
-	return append(s, more...)
+	return append(s[:len(s):len(s)], more...)
 }

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -18,6 +18,6 @@ func main() {
 	xs := []struct{}{}
 	_arg_1 := xs
 	noop()
-	y := append(_arg_1, struct{}{})
+	y := append(_arg_1[:len(_arg_1):len(_arg_1)], struct{}{})
 	_ = y
 }

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -17,5 +17,5 @@ func test() {
 	xs := []struct{}{}
 	_arg_1 := xs
 	noop()
-	_ = append(_arg_1, struct{}{})
+	_ = append(_arg_1[:len(_arg_1):len(_arg_1)], struct{}{})
 }


### PR DESCRIPTION
`append` in value position could return a slice sharing the receiver's backing array whenever spare capacity absorbed the growth. Two `appends` off the same base then silently overwrote each other, violating the contract that `append` retrns a new slice and does not modify the original.

```rs
let t = [1, 2].append(3) // len 3, cap 4: spare capacity
let u1 = t.append(7)
let u2 = t.append(8) // silently sets u1.get(3) to 8 as well
```

The emitted Go now caps these receivers at their length (`s[:len(s):len(s)]`), so every value-position `append` result lands on its own allocation. Accumulator self-reassignment (`acc = acc.append(x)`) is unaffected and keeps growing in place as usual.
