### PR TITLE
perf: resolve display paths without per-file syscalls

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -8,14 +8,13 @@ use std::{
 
 use semantics::cache::cache_file_name;
 use semantics::loader::{FileContent, Files, Loader};
-use semantics::path::relative_to_cwd_with;
+use semantics::path::DisplayPathBase;
 use semantics::store::ENTRY_MODULE_ID;
 
 pub use semantics::path::relative_to_cwd;
 
 pub struct LocalFileSystem {
-    search_paths: Vec<PathBuf>,
-    display_cwd: Option<PathBuf>,
+    search_paths: Vec<(PathBuf, DisplayPathBase)>,
 }
 
 impl LocalFileSystem {
@@ -26,12 +25,17 @@ impl LocalFileSystem {
             .join("std");
 
         Self {
-            search_paths: vec![current_path, stdlib_path],
-            display_cwd: std::env::current_dir().ok(),
+            search_paths: [current_path, stdlib_path]
+                .into_iter()
+                .map(|path| {
+                    let display_base = DisplayPathBase::new(&path);
+                    (path, display_base)
+                })
+                .collect(),
         }
     }
 
-    fn collect_files(&self, folder_path: &Path) -> Files {
+    fn collect_files(&self, folder_path: &Path, fs_name: &str, base: &DisplayPathBase) -> Files {
         let Ok(entries) = read_dir(folder_path) else {
             return HashMap::default();
         };
@@ -45,7 +49,8 @@ impl LocalFileSystem {
                 && let Ok(source) = read_to_string(&path)
                 && let Some(name) = path.file_name().and_then(|s| s.to_str())
             {
-                let display_path = relative_to_cwd_with(&path, self.display_cwd.as_deref())
+                let display_path = base
+                    .relative(&Path::new(fs_name).join(name))
                     .unwrap_or_else(|| name.to_string());
                 files.insert(name.to_string(), FileContent::new(source, display_path));
             }
@@ -311,13 +316,13 @@ fn entry_is_dir(entry: &std::fs::DirEntry, path: &Path) -> bool {
 impl Loader for LocalFileSystem {
     fn scan_folder(&self, folder_name: &str) -> Files {
         let fs_name = to_fs_path(folder_name);
-        for search_path in &self.search_paths {
+        for (search_path, display_base) in &self.search_paths {
             let folder_path = if fs_name.is_empty() {
                 search_path.clone()
             } else {
                 search_path.join(fs_name)
             };
-            let files = self.collect_files(&folder_path);
+            let files = self.collect_files(&folder_path, fs_name, display_base);
 
             if !files.is_empty() {
                 return files;
@@ -328,7 +333,7 @@ impl Loader for LocalFileSystem {
     }
 
     fn test_module_ids(&self) -> Vec<String> {
-        let Some(root) = self.search_paths.first() else {
+        let Some((root, _)) = self.search_paths.first() else {
             return Vec::new();
         };
         let mut with_test: HashSet<PathBuf> = HashSet::default();

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -2,6 +2,7 @@ pub mod go_stdlib;
 pub mod prelude;
 pub mod types;
 
+use crate::path::DisplayPathBase;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fs;
 use std::hash::{Hash, Hasher};
@@ -390,7 +391,7 @@ pub(crate) fn build_cached_module(
     module_id: String,
     file_id_base: u32,
     cached: ModuleInterface,
-    project_root: &Path,
+    display_base: &DisplayPathBase,
 ) -> CachedModuleBuild {
     let mut module = Module::new(&module_id);
     let mut file_ids: Vec<u32> = Vec::with_capacity(cached.files.len());
@@ -401,7 +402,7 @@ pub(crate) fn build_cached_module(
         file_ids.push(file_id);
         file_map.push((file_id, module_id.clone()));
 
-        let display_path = cached_file_display_path(project_root, &module_id, &cached_file.name);
+        let display_path = cached_file_display_path(display_base, &module_id, &cached_file.name);
         let file = File::new_cached(
             &module_id,
             &cached_file.name,
@@ -428,13 +429,19 @@ pub(crate) fn build_cached_module(
     }
 }
 
-fn cached_file_display_path(project_root: &Path, module_id: &str, bare_name: &str) -> String {
-    let on_disk = if module_id == ENTRY_MODULE_ID {
-        project_root.join("src").join(bare_name)
+fn cached_file_display_path(
+    display_base: &DisplayPathBase,
+    module_id: &str,
+    bare_name: &str,
+) -> String {
+    let rel = if module_id == ENTRY_MODULE_ID {
+        PathBuf::from(bare_name)
     } else {
-        project_root.join("src").join(module_id).join(bare_name)
+        Path::new(module_id).join(bare_name)
     };
-    crate::path::relative_to_cwd(&on_disk).unwrap_or_else(|| bare_name.to_string())
+    display_base
+        .relative(&rel)
+        .unwrap_or_else(|| bare_name.to_string())
 }
 
 /// Set or clear the `emit_stamp` for each module's cache file. Missing files
@@ -699,7 +706,12 @@ mod tests {
             emit_stamp: None,
         };
 
-        let built = build_cached_module("mymod".to_string(), 0, interface, Path::new("/project"));
+        let built = build_cached_module(
+            "mymod".to_string(),
+            0,
+            interface,
+            &DisplayPathBase::new(Path::new("/project/src")),
+        );
 
         assert!(built.module.const_names.contains("mymod.MAX"));
         assert!(!built.module.const_names.contains("mymod.counter"));

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -489,8 +489,14 @@ fn load_cache_candidates(
     let Some(root) = project_root else {
         return result;
     };
+    let display_base = crate::path::DisplayPathBase::new(&root.join("src"));
     let build = |job: CacheBuildJob| {
-        build_cached_module(job.module_id, job.file_id_base, job.interface, root)
+        build_cached_module(
+            job.module_id,
+            job.file_id_base,
+            job.interface,
+            &display_base,
+        )
     };
     let run_build = || -> Vec<CachedModuleBuild> {
         if build_jobs.len() < PARALLEL_THRESHOLD {

--- a/crates/semantics/src/path.rs
+++ b/crates/semantics/src/path.rs
@@ -1,9 +1,52 @@
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 
 /// Returns path relative to the cwd as a forward-slash string.
 /// Returns None if the cwd is unknown or the path lies outside it.
 pub fn relative_to_cwd(path: &Path) -> Option<String> {
     relative_to_cwd_with(path, std::env::current_dir().ok().as_deref())
+}
+
+/// Cwd-relative display paths under a fixed base dir, resolving prefixes once.
+pub struct DisplayPathBase {
+    canonical: Option<(PathBuf, PathBuf)>,
+    plain: Option<(PathBuf, PathBuf)>,
+}
+
+impl DisplayPathBase {
+    pub fn new(base_dir: &Path) -> Self {
+        Self::with_cwd(base_dir, std::env::current_dir().ok())
+    }
+
+    fn with_cwd(base_dir: &Path, cwd: Option<PathBuf>) -> Self {
+        let Some(cwd) = cwd else {
+            return Self {
+                canonical: None,
+                plain: None,
+            };
+        };
+        let absolute_base = if base_dir.is_absolute() {
+            base_dir.to_path_buf()
+        } else {
+            cwd.join(base_dir)
+        };
+        let canonical = match (cwd.canonicalize(), absolute_base.canonicalize()) {
+            (Ok(canonical_cwd), Ok(canonical_base)) => Some((canonical_base, canonical_cwd)),
+            _ => None,
+        };
+        Self {
+            canonical,
+            plain: Some((absolute_base, cwd)),
+        }
+    }
+
+    /// Mirrors `relative_to_cwd` on the base dir joined with `rel`.
+    pub fn relative(&self, rel: &Path) -> Option<String> {
+        if let Some((base, cwd)) = &self.canonical {
+            return relativize(base.join(rel).strip_prefix(cwd).ok()?);
+        }
+        let (base, cwd) = self.plain.as_ref()?;
+        relativize(base.join(rel).strip_prefix(cwd).ok()?)
+    }
 }
 
 pub fn relative_to_cwd_with(path: &Path, cwd: Option<&Path>) -> Option<String> {
@@ -107,6 +150,64 @@ mod tests {
 
         assert_eq!(
             relative_to_cwd_with(&real.join("src/main.lis"), Some(&link)),
+            Some("src/main.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn display_base_inside_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        stdfs::create_dir_all(cwd.join("src")).unwrap();
+        let base = DisplayPathBase::with_cwd(&cwd.join("src"), Some(cwd.to_path_buf()));
+        assert_eq!(
+            base.relative(Path::new("main.lis")),
+            Some("src/main.lis".to_string())
+        );
+        assert_eq!(
+            base.relative(&Path::new("module_x").join("lib.lis")),
+            Some("src/module_x/lib.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn display_base_equal_to_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        let base = DisplayPathBase::with_cwd(cwd, Some(cwd.to_path_buf()));
+        assert_eq!(
+            base.relative(Path::new("lib.lis")),
+            Some("lib.lis".to_string())
+        );
+    }
+
+    #[test]
+    fn display_base_outside_cwd_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let base =
+            DisplayPathBase::with_cwd(&other.path().join("src"), Some(tmp.path().to_path_buf()));
+        assert_eq!(base.relative(Path::new("main.lis")), None);
+    }
+
+    #[test]
+    fn display_base_unknown_cwd_returns_none() {
+        let base = DisplayPathBase::with_cwd(Path::new("/any/src"), None);
+        assert_eq!(base.relative(Path::new("main.lis")), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_base_under_symlinked_cwd_strips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        stdfs::create_dir_all(real.join("src")).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let base = DisplayPathBase::with_cwd(&real.join("src"), Some(link));
+        assert_eq!(
+            base.relative(Path::new("main.lis")),
             Some("src/main.lis".to_string())
         );
     }


### PR DESCRIPTION
Building diagnostic display paths cost a `getcwd` plus two `canonicalize` syscalls per file on every `lis check`, in both the cached-module loader and the source-tree scan. Both sites now resolve their prefixes once per run, which cuts warm no-op check time by ~5% at 2k modules.
