### PR TITLE
feat: `Slice.make` and `Slice.reserve`

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3538,11 +3538,20 @@ pub fn array_new_no_zero(element: &dyn std::fmt::Display, span: Span) -> Lisette
         )
 }
 
+pub fn negative_size_literal(what: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Negative {what}"))
+        .with_infer_code("negative_size_literal")
+        .with_span_label(&span, format!("a {what} cannot be negative"))
+        .with_help("This would always fail at runtime, so it is rejected here")
+}
+
 pub fn map_no_make_constructor(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`Map` has no `make` constructor")
         .with_infer_code("no_make_constructor")
         .with_span_label(&span, "`Map` has no capacity-taking constructor")
-        .with_help("Use `Map.new<K, V>()`. Go's map capacity hint has no observable effect")
+        .with_help(
+            "Use `Map.new<K, V>()`. Go's map size hint only pre-sizes the initial allocation",
+        )
 }
 
 pub fn channel_no_make_constructor(span: Span) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2451,11 +2451,11 @@ pub fn complex_select_expression(span: Span) -> LisetteDiagnostic {
         .with_help("Hoist to a `let` binding before the `select`")
 }
 
-pub fn ref_slice_append(span: Span) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Cannot call `append` on `Ref<Slice>`")
-        .with_infer_code("ref_slice_append")
+pub fn ref_slice_growth(method: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Cannot call `{method}` on `Ref<Slice>`"))
+        .with_infer_code("ref_slice_growth")
         .with_span_label(&span, "dereference the ref first")
-        .with_help("Use `r.*.append(x)` to deref, then append")
+        .with_help(format!("Use `r.*.{method}(...)` to deref first"))
 }
 
 pub fn map_field_chain_assignment(span: Span) -> LisetteDiagnostic {
@@ -3536,6 +3536,30 @@ pub fn array_new_no_zero(element: &dyn std::fmt::Display, span: Span) -> Lisette
         .with_help(
             "Build the array from a list literal instead, e.g. `let xs: Array<int, 3> = [1, 2, 3]`",
         )
+}
+
+pub fn map_no_make_constructor(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`Map` has no `make` constructor")
+        .with_infer_code("no_make_constructor")
+        .with_span_label(&span, "`Map` has no capacity-taking constructor")
+        .with_help("Use `Map.new<K, V>()`. Go's map capacity hint has no observable effect")
+}
+
+pub fn channel_no_make_constructor(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`Channel` has no `make` constructor")
+        .with_infer_code("no_make_constructor")
+        .with_span_label(&span, "a channel's only size is its buffer")
+        .with_help("Use `Channel.new<T>()` for an unbuffered channel, or `Channel.buffered<T>(n)` for a buffered one")
+}
+
+pub fn slice_make_no_zero(element: &dyn std::fmt::Display, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{element}` has no zero value"))
+        .with_infer_code("slice_make_no_zero")
+        .with_span_label(
+            &span,
+            format!("`Slice.make` zero-fills every element, but `{element}` has none"),
+        )
+        .with_help("Build the slice from a list literal instead, e.g. `let xs = [a, b, c]`")
 }
 
 pub fn array_new_takes_no_arguments(actual: usize, span: Span) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -240,14 +240,29 @@ pub fn ineffective_try_block(span: &Span) -> LisetteDiagnostic {
         .with_help("A `try` block is effective only if the expression may succeed or fail")
 }
 
-pub fn append_to_zero_filled(span: &Span) -> LisetteDiagnostic {
+pub fn append_to_zero_filled(
+    make_span: &Span,
+    append_span: &Span,
+    length: Option<u64>,
+    element: &str,
+) -> LisetteDiagnostic {
+    let append_label = match length {
+        Some(n) => format!("`append` adds element {} here", n + 1),
+        None => "`append` adds elements after the zeros here".to_string(),
+    };
+    let help = match length {
+        Some(n) => format!(
+            "For an empty slice with room for {n}, use `Slice.new<{element}>().reserve({n})`"
+        ),
+        None => format!(
+            "For an empty slice with reserved room, use `Slice.new<{element}>().reserve(n)`"
+        ),
+    };
     LisetteDiagnostic::warn("Appending to a zero-filled slice")
         .with_lint_code("append_to_zero_filled")
-        .with_span_label(span, "every element is already a zero value")
-        .with_help(
-            "`Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. \
-             For an empty slice with room for n, use `Slice.new<T>().reserve(n)`",
-        )
+        .with_span_label(make_span, "every element is already a zero value")
+        .with_span_label(append_span, append_label)
+        .with_help(help)
 }
 
 pub fn replaceable_with_autofill(span: &Span, kept: &str, struct_name: &str) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -18,6 +18,7 @@ pub enum UnusedExpressionKind {
     Partial,
     Value,
     SliceGrow,
+    SliceReserve,
 }
 
 impl UnusedExpressionKind {
@@ -27,7 +28,7 @@ impl UnusedExpressionKind {
             Self::Result => "unused_result",
             Self::Option => "unused_option",
             Self::Partial => "unused_partial",
-            Self::Value | Self::SliceGrow => "unused_value",
+            Self::Value | Self::SliceGrow | Self::SliceReserve => "unused_value",
         }
     }
 }
@@ -185,6 +186,12 @@ pub fn unused_expression(span: &Span, kind: UnusedExpressionKind) -> LisetteDiag
             "output is discarded",
             "`append()` outputs a new slice, leaving the original slice intact. Assign the output back to grow it `let s = s.append(...)` or discard the output with `let _ = s.append(...)`",
         ),
+        UnusedExpressionKind::SliceReserve => (
+            "unused_value",
+            "Unused `reserve()` output",
+            "output is discarded",
+            "`reserve()` outputs a new slice, leaving the original slice intact. Assign the output back `let s = s.reserve(...)` or discard the output with `let _ = s.reserve(...)`",
+        ),
     };
     LisetteDiagnostic::warn(msg)
         .with_lint_code(code)
@@ -231,6 +238,16 @@ pub fn ineffective_try_block(span: &Span) -> LisetteDiagnostic {
         .with_lint_code("try_block_no_success_path")
         .with_span_label(span, "always propagates")
         .with_help("A `try` block is effective only if the expression may succeed or fail")
+}
+
+pub fn append_to_zero_filled(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Appending to a zero-filled slice")
+        .with_lint_code("append_to_zero_filled")
+        .with_span_label(span, "every element is already a zero value")
+        .with_help(
+            "`Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. \
+             For an empty slice with room for n, use `Slice.new<T>().reserve(n)`",
+        )
 }
 
 pub fn replaceable_with_autofill(span: &Span, kept: &str, struct_name: &str) -> LisetteDiagnostic {

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -1,6 +1,7 @@
 use crate::expressions::access::struct_call::emit_struct_literal;
 use crate::names::generics::extract_type_mapping;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::borrow::Cow;
 
 use super::NativeCallContext;
 use crate::Planner;
@@ -111,19 +112,28 @@ impl Planner<'_> {
         type_args: &[Type],
         call_ty: Option<&Type>,
     ) -> String {
-        if !type_args.is_empty() {
-            return self.go_type_string(&type_args[0]);
+        let element = self.resolve_element_lisette_type(function, type_args, call_ty);
+        self.go_type_string(&element)
+    }
+
+    fn resolve_element_lisette_type<'t>(
+        &self,
+        function: &Expression,
+        type_args: &'t [Type],
+        call_ty: Option<&'t Type>,
+    ) -> Cow<'t, Type> {
+        if let Some(first) = type_args.first() {
+            return Cow::Borrowed(first);
         }
         if let Some(call_result_ty) = call_ty
-            && let Some(first) = call_result_ty
-                .get_type_params()
-                .and_then(|ps| ps.first().cloned())
+            && let Some(first) = call_result_ty.get_type_params().and_then(|ps| ps.first())
         {
-            return self.go_type_string(&first);
+            return Cow::Borrowed(first);
         }
-        let param = extract_return_type_param(function)
-            .expect("constructor must have constructor return type");
-        self.go_type_string(&param)
+        Cow::Owned(
+            extract_return_type_param(function)
+                .expect("constructor must have constructor return type"),
+        )
     }
 
     fn resolve_map_types(
@@ -161,6 +171,21 @@ impl Planner<'_> {
         )
     }
 
+    fn stage_size_argument(
+        &mut self,
+        ctx: &NativeCallContext,
+    ) -> (Vec<LoweredStatement>, String, EvaluationEffect) {
+        match ctx.args.first() {
+            Some(a) => {
+                let staged = self.stage_operand(a, ExpressionContext::value());
+                let effect = staged.evaluation.effect;
+                let (setup, value) = staged.into_parts();
+                (setup, value, effect)
+            }
+            None => (Vec::new(), "0".to_string(), EvaluationEffect::Pure),
+        }
+    }
+
     fn try_lower_native_constructor(&mut self, ctx: &NativeCallContext) -> Option<ValuePlan> {
         match (ctx.native_type, ctx.method) {
             (NativeGoType::Channel, "new") => {
@@ -178,15 +203,7 @@ impl Planner<'_> {
             (NativeGoType::Channel, "buffered") => {
                 let element =
                     self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
-                let (setup, capacity, argument_effect) = match ctx.args.first() {
-                    Some(a) => {
-                        let staged = self.stage_operand(a, ExpressionContext::value());
-                        let effect = staged.evaluation.effect;
-                        let (setup, value) = staged.into_parts();
-                        (setup, value, effect)
-                    }
-                    None => (Vec::new(), "0".to_string(), EvaluationEffect::Pure),
-                };
+                let (setup, capacity, argument_effect) = self.stage_size_argument(ctx);
                 Some(ValuePlan::observable_call(
                     setup,
                     GoExpression::call(
@@ -218,6 +235,34 @@ impl Planner<'_> {
                     Vec::new(),
                     GoExpression::composite_literal(format!("[]{}{{}}", element), false),
                     self.native_constructor_effect(ctx, EvaluationEffect::Pure),
+                ))
+            }
+            (NativeGoType::Slice, "make") => {
+                let element_ty = self.resolve_element_lisette_type(
+                    ctx.function,
+                    ctx.resolved_type_args,
+                    ctx.call_ty,
+                );
+                let element = self.go_type_string(&element_ty);
+                let (setup, length, argument_effect) = self.stage_size_argument(ctx);
+                let value = if self.element_go_zero_ok(&element_ty) {
+                    GoExpression::call(
+                        GoExpression::name("make".to_string()),
+                        vec![
+                            GoExpression::opaque(format!("[]{}", element)),
+                            GoExpression::opaque(length),
+                        ],
+                    )
+                } else {
+                    let zero = self.lisette_zero(&element_ty);
+                    GoExpression::opaque(format!(
+                        "func() []{element} {{ s := make([]{element}, {length}); for i := range s {{ s[i] = {zero} }}; return s }}()"
+                    ))
+                };
+                Some(ValuePlan::observable_call(
+                    setup,
+                    value,
+                    self.native_constructor_effect(ctx, argument_effect),
                 ))
             }
             (NativeGoType::Array, "new") => {

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -213,6 +213,14 @@ static INLINE_METHODS: &[InlineRule] = &[
         negated_template: None,
         import: InlineImport::Slices,
     },
+    InlineRule {
+        types: &[N::Slice],
+        method: "reserve",
+        arity: 1,
+        template: "slices.Grow({r}, {0})",
+        negated_template: None,
+        import: InlineImport::Slices,
+    },
     // Variadic methods
     InlineRule {
         types: &[N::Slice],
@@ -229,7 +237,7 @@ pub(crate) fn clip_shared_capacity(receiver: &str) -> String {
 }
 
 fn grows_into_capacity(method: &str, appends_anything: bool) -> bool {
-    method == "append" && appends_anything
+    method == "reserve" || (method == "append" && appends_anything)
 }
 
 pub(crate) fn is_clip_safe_path(value: &str) -> bool {
@@ -275,7 +283,7 @@ fn is_fresh_slice_value(receiver: &Expression) -> bool {
                         matches!(call_kind, Some(CallKind::NativeMethodIdentifier(_))) as usize;
                     args.len() > receiver_argument_count || spread.is_some()
                 }
-                "clone" | "filter" | "map" => true,
+                "reserve" | "clone" | "filter" | "map" => true,
                 _ => false,
             },
             _ => false,

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -381,7 +381,7 @@ impl Planner<'_> {
     /// `[N]E{}` zero differs from Lisette's (e.g. `Option<T>`).
     pub(crate) fn array_zero(&mut self, len: u64, elem: &Type) -> String {
         let elem_go = self.go_type_string(elem);
-        if len == 0 || self.array_element_go_zero_ok(elem) {
+        if len == 0 || self.element_go_zero_ok(elem) {
             return format!("[{}]{}{{}}", len, elem_go);
         }
         let zero = self.lisette_zero(elem);
@@ -391,16 +391,16 @@ impl Planner<'_> {
         )
     }
 
-    /// True when Go's `[N]ty{}` already matches Lisette's zero.
-    fn array_element_go_zero_ok(&self, ty: &Type) -> bool {
+    /// True when Go's zero for the element already matches Lisette's.
+    pub(crate) fn element_go_zero_ok(&self, ty: &Type) -> bool {
         match ty {
             Type::Simple(_) => true,
             Type::Compound {
                 kind: CompoundKind::Slice,
                 ..
             } => true,
-            Type::Array { element, .. } => self.array_element_go_zero_ok(element),
-            Type::Tuple(elements) => elements.iter().all(|e| self.array_element_go_zero_ok(e)),
+            Type::Array { element, .. } => self.element_go_zero_ok(element),
+            Type::Tuple(elements) => elements.iter().all(|e| self.element_go_zero_ok(e)),
             _ => false,
         }
     }

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -467,7 +467,7 @@ impl Planner<'_> {
         if is_unit_call(last) {
             return self.lower_unit_call_into_var(last, var);
         }
-        if let Some(statements) = self.lower_append_to_var(var, last) {
+        if let Some(statements) = self.lower_slice_growth_to_var(var, last) {
             return statements;
         }
         if matches!(
@@ -505,8 +505,8 @@ impl Planner<'_> {
         vec![simple_assign(var, value)]
     }
 
-    /// `None` when `last` is not a slice `append` call.
-    fn lower_append_to_var(
+    /// `None` when `last` is not a slice `append` or `reserve` call.
+    fn lower_slice_growth_to_var(
         &mut self,
         var: &str,
         last: &Expression,
@@ -520,24 +520,14 @@ impl Planner<'_> {
         else {
             return None;
         };
-        if !self.is_slice_append(func) {
-            return None;
-        }
-
-        let Expression::DotAccess {
-            expression: receiver,
-            ..
-        } = func.as_ref()
-        else {
-            return Some(Vec::new());
-        };
+        let (method, receiver) = self.slice_growth_method(func)?;
 
         let unwrapped = receiver.unwrap_parens();
         let receiver_is_lvalue =
             is_lvalue_chain(unwrapped) && !self.contains_newtype_access(unwrapped);
 
         let (value, mut statements) = if receiver_is_lvalue {
-            let arguments = self.lower_append_args(func, args, (**spread).as_ref());
+            let arguments = self.lower_growth_args(func, args, (**spread).as_ref());
             let mut capture: Vec<LoweredStatement> = Vec::new();
             let receiver_lv =
                 self.emit_left_value_capturing(&mut capture, unwrapped, Some(&arguments));
@@ -554,7 +544,10 @@ impl Planner<'_> {
                 receiver_lv
             };
             capture.extend(args_setup);
-            let value = if args_str.is_empty() {
+            let value = if method == "reserve" {
+                self.require_slices();
+                format!("slices.Grow({}, {})", receiver_lv, args_str)
+            } else if args_str.is_empty() {
                 receiver_lv
             } else {
                 format!("append({}, {})", receiver_lv, args_str)
@@ -571,18 +564,19 @@ impl Planner<'_> {
         Some(statements)
     }
 
-    fn is_slice_append(&self, func: &Expression) -> bool {
+    fn slice_growth_method<'e>(&self, func: &'e Expression) -> Option<(&'e str, &'e Expression)> {
         if let Expression::DotAccess {
             expression, member, ..
         } = func
-            && member == "append"
+            && matches!(member.as_str(), "append" | "reserve")
+            && self.is_native_shape(&expression.get_type(), NativeGoType::Slice)
         {
-            return self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
+            return Some((member.as_str(), expression));
         }
-        false
+        None
     }
 
-    fn lower_append_args(
+    fn lower_growth_args(
         &mut self,
         function: &Expression,
         args: &[Expression],

--- a/crates/passes/src/passes/checks/native_value_usage.rs
+++ b/crates/passes/src/passes/checks/native_value_usage.rs
@@ -1,6 +1,6 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Span, StructKind};
-use syntax::program::{Definition, DefinitionBody};
+use syntax::program::{Definition, DefinitionBody, NativeTypeKind};
 use syntax::types::{Symbol, Type, unqualified_name};
 
 use semantics::store::Store;
@@ -116,7 +116,7 @@ fn check_one(
     );
 
     if is_native {
-        if matches!(method_part, "new" | "buffered") {
+        if NativeTypeKind::is_constructor_method(method_part) {
             sink.push(diagnostics::infer::native_constructor_value(value, span));
         } else {
             sink.push(diagnostics::infer::native_method_value(
@@ -128,7 +128,9 @@ fn check_one(
         return;
     }
 
-    if matches!(method_part, "new" | "buffered") {
+    if NativeTypeKind::is_constructor_method(method_part)
+        && !is_user_type(type_part, module_id, store)
+    {
         let ret_ty = match ty {
             Type::Function(f) => Some(f.return_type.as_ref()),
             Type::Forall { body, .. } => match body.as_ref() {
@@ -177,6 +179,18 @@ fn check_one(
     if !is_public {
         sink.push(diagnostics::infer::private_method_expression(span));
     }
+}
+
+fn is_user_type(type_part: &str, module_id: &str, store: &Store) -> bool {
+    let qualified = if type_part.contains('.') {
+        type_part.to_string()
+    } else {
+        Symbol::from_parts(module_id, type_part).to_string()
+    };
+    matches!(
+        store.get_definition(&qualified).map(|d| &d.body),
+        Some(DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. })
+    )
 }
 
 fn resolves_to_struct_kind(qualified: &str, kind: StructKind, store: &Store) -> bool {

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -2,9 +2,10 @@ use diagnostics::LocalSink;
 use rustc_hash::FxHashSet as HashSet;
 
 use semantics::facts::Facts;
-use syntax::types::TypeVarId;
+use semantics::store::Store;
+use syntax::types::{CompoundKind, TypeVarId};
 
-pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
+pub(crate) fn run(store: &Store, facts: &mut Facts, sink: &LocalSink) {
     let mut reported_vars: HashSet<(String, TypeVarId)> = HashSet::default();
     let mut collected = Vec::new();
     let mut report_vars = |ty: &syntax::types::Type, module_id: &str| {
@@ -42,6 +43,24 @@ pub(crate) fn run(facts: &mut Facts, sink: &LocalSink) {
         }
         if reported_literal_spans.insert(check.span) {
             sink.push(diagnostics::infer::empty_slice_no_element_type(check.span));
+        }
+    }
+    for check in std::mem::take(&mut facts.slice_make_checks) {
+        let slice_ty = store.peel_alias(&check.ty);
+        let Some((CompoundKind::Slice, args)) = slice_ty.as_compound() else {
+            continue;
+        };
+        let Some(element_ty) = args.first() else {
+            continue;
+        };
+        if element_ty.is_error() || element_ty.is_variable() {
+            continue;
+        }
+        if let Err(no_zero) = semantics::zero::has_zero(store, element_ty, &check.module_id) {
+            sink.push(diagnostics::infer::slice_make_no_zero(
+                &no_zero.leaf_ty.stringify(),
+                check.span,
+            ));
         }
     }
     for check in std::mem::take(&mut facts.statement_tail_checks) {
@@ -89,7 +108,7 @@ mod tests {
             module_id: literal_module.to_string(),
         });
         let sink = LocalSink::new();
-        run(&mut facts, &sink);
+        run(&Store::new(), &mut facts, &sink);
         sink.take()
             .iter()
             .filter_map(|d| d.code_str().map(str::to_string))

--- a/crates/passes/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/fact_producers/unused_expressions.rs
@@ -1,5 +1,6 @@
 use diagnostics::UnusedExpressionKind;
 use syntax::ast::{Annotation, Expression, SelectArmPattern, Span, UnaryOperator};
+use syntax::program::{CallKind, NativeTypeKind};
 use syntax::types::{Symbol, Type};
 
 use diagnostics::infer::MismatchedTailKind;
@@ -293,21 +294,23 @@ fn emit_unused_at_leaf(leaf: &Expression, module_id: &str, store: &Store, facts:
     if is_channel_send(leaf) {
         allowed_lints.push("unused_value".to_string());
     }
-    if is_lvalue_slice_grow(leaf) {
+    if let Some(kind) = lvalue_slice_growth_kind(leaf) {
         if !allowed_lints.iter().any(|s| s == "unused_value") {
-            facts.add_unused_expression(span, UnusedExpressionKind::SliceGrow);
+            facts.add_unused_expression(span, kind);
         }
         return;
     }
     emit_unused_expression(span, &ty, is_literal, &allowed_lints, facts);
 }
 
-fn is_lvalue_slice_grow(expression: &Expression) -> bool {
+fn lvalue_slice_growth_kind(expression: &Expression) -> Option<UnusedExpressionKind> {
     let Expression::Call {
-        expression: callee, ..
+        expression: callee,
+        call_kind: Some(CallKind::NativeMethod(NativeTypeKind::Slice)),
+        ..
     } = expression
     else {
-        return false;
+        return None;
     };
     let Expression::DotAccess {
         expression: receiver,
@@ -315,15 +318,14 @@ fn is_lvalue_slice_grow(expression: &Expression) -> bool {
         ..
     } = callee.as_ref()
     else {
-        return false;
+        return None;
     };
-    if member != "append" {
-        return false;
-    }
-    if receiver.get_var_name().is_none() {
-        return false;
-    }
-    matches!(receiver.get_type().strip_refs().get_name(), Some("Slice"))
+    let kind = match member.as_str() {
+        "append" => UnusedExpressionKind::SliceGrow,
+        "reserve" => UnusedExpressionKind::SliceReserve,
+        _ => return None,
+    };
+    receiver.get_var_name().map(|_| kind)
 }
 
 fn check_discarded_tail(

--- a/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
@@ -1,71 +1,105 @@
 use super::helpers::{is_bare_identifier, is_zero_literal};
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BindingId, Expression, Pattern, Span};
+use syntax::ast::{BindingId, Expression, Literal, Pattern, Span};
 use syntax::program::{CallKind, NativeTypeKind};
 
 pub fn check_append_to_zero_filled(expression: &Expression, ctx: &NodeCtx) {
     if let Some(receiver) = growing_append_receiver(expression)
-        && let Some(make_span) = zero_filled_make_call(receiver.unwrap_parens())
+        && let Some(make) = zero_filled_make_call(receiver.unwrap_parens())
     {
-        ctx.sink
-            .push(diagnostics::lint::append_to_zero_filled(&make_span));
+        ctx.sink.push(diagnostics::lint::append_to_zero_filled(
+            &make.span,
+            &expression.get_span(),
+            make.length,
+            &make.element,
+        ));
     }
 
     let Expression::Block { items, .. } = expression else {
         return;
     };
     for (index, item) in items.iter().enumerate() {
-        let Some((binding_id, make_span)) = zero_filled_make_binding(item, ctx) else {
+        let Some((binding_id, make)) = zero_filled_make_binding(item, ctx) else {
             continue;
         };
-        if let Some(FirstUse::AppendReceiver) = items[index + 1..]
+        if let Some(FirstUse::AppendReceiver(append_span)) = items[index + 1..]
             .iter()
             .find_map(|later| first_use(later, binding_id))
         {
-            ctx.sink
-                .push(diagnostics::lint::append_to_zero_filled(&make_span));
+            ctx.sink.push(diagnostics::lint::append_to_zero_filled(
+                &make.span,
+                &append_span,
+                make.length,
+                &make.element,
+            ));
         }
     }
 }
 
+struct MakeCall {
+    span: Span,
+    length: Option<u64>,
+    element: String,
+}
+
 /// `Slice.make(n)` with `n` not a literal zero, which has no zeros to append after.
-fn zero_filled_make_call(expression: &Expression) -> Option<Span> {
+fn zero_filled_make_call(expression: &Expression) -> Option<MakeCall> {
     let Expression::Call {
         expression: callee,
         call_kind: Some(CallKind::NativeConstructor(NativeTypeKind::Slice)),
         args,
         span,
+        ty,
         ..
     } = expression
     else {
         return None;
     };
-    let length = args.first()?;
-    if is_zero_literal(length.unwrap_parens()) {
+    let length_arg = args.first()?;
+    if is_zero_literal(length_arg.unwrap_parens()) {
         return None;
     }
-    is_bare_identifier(callee, "Slice.make").then_some(*span)
+    if !is_bare_identifier(callee, "Slice.make") {
+        return None;
+    }
+    let length = match length_arg.unwrap_parens() {
+        Expression::Literal {
+            literal: Literal::Integer { value, .. },
+            ..
+        } if *value > 0 => Some(*value),
+        _ => None,
+    };
+    let element = ty
+        .get_type_params()
+        .and_then(|params| params.first())
+        .map(|element| element.to_string())
+        .unwrap_or_else(|| "T".to_string());
+    Some(MakeCall {
+        span: *span,
+        length,
+        element,
+    })
 }
 
 /// The binding id comes from the pattern-span-keyed facts, so shadows never match.
-fn zero_filled_make_binding(item: &Expression, ctx: &NodeCtx) -> Option<(BindingId, Span)> {
+fn zero_filled_make_binding(item: &Expression, ctx: &NodeCtx) -> Option<(BindingId, MakeCall)> {
     let Expression::Let { binding, value, .. } = item else {
         return None;
     };
     let Pattern::Identifier { identifier, span } = &binding.pattern else {
         return None;
     };
-    let make_span = zero_filled_make_call(value.unwrap_parens())?;
+    let make = zero_filled_make_call(value.unwrap_parens())?;
     let (id, _) = ctx
         .facts
         .bindings
         .iter()
         .find(|(_, fact)| fact.span == *span && fact.name == identifier.as_str())?;
-    Some((*id, make_span))
+    Some((*id, make))
 }
 
 enum FirstUse {
-    AppendReceiver,
+    AppendReceiver(Span),
     Other,
 }
 
@@ -80,7 +114,7 @@ fn first_use(expression: &Expression, binding_id: BindingId) -> Option<FirstUse>
     if let Some(receiver) = growing_append_receiver(expression)
         && is_binding(receiver, binding_id)
     {
-        return Some(FirstUse::AppendReceiver);
+        return Some(FirstUse::AppendReceiver(expression.get_span()));
     }
     if is_binding(expression, binding_id) {
         return Some(FirstUse::Other);

--- a/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
@@ -1,0 +1,139 @@
+use super::helpers::{is_bare_identifier, is_zero_literal};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BindingId, Expression, Pattern, Span};
+use syntax::program::{CallKind, NativeTypeKind};
+
+pub fn check_append_to_zero_filled(expression: &Expression, ctx: &NodeCtx) {
+    if let Some(receiver) = growing_append_receiver(expression)
+        && let Some(make_span) = zero_filled_make_call(receiver.unwrap_parens())
+    {
+        ctx.sink
+            .push(diagnostics::lint::append_to_zero_filled(&make_span));
+    }
+
+    let Expression::Block { items, .. } = expression else {
+        return;
+    };
+    for (index, item) in items.iter().enumerate() {
+        let Some((binding_id, make_span)) = zero_filled_make_binding(item, ctx) else {
+            continue;
+        };
+        if let Some(FirstUse::AppendReceiver) = items[index + 1..]
+            .iter()
+            .find_map(|later| first_use(later, binding_id))
+        {
+            ctx.sink
+                .push(diagnostics::lint::append_to_zero_filled(&make_span));
+        }
+    }
+}
+
+/// `Slice.make(n)` with `n` not a literal zero, which has no zeros to append after.
+fn zero_filled_make_call(expression: &Expression) -> Option<Span> {
+    let Expression::Call {
+        expression: callee,
+        call_kind: Some(CallKind::NativeConstructor(NativeTypeKind::Slice)),
+        args,
+        span,
+        ..
+    } = expression
+    else {
+        return None;
+    };
+    let length = args.first()?;
+    if is_zero_literal(length.unwrap_parens()) {
+        return None;
+    }
+    is_bare_identifier(callee, "Slice.make").then_some(*span)
+}
+
+/// The binding id comes from the pattern-span-keyed facts, so shadows never match.
+fn zero_filled_make_binding(item: &Expression, ctx: &NodeCtx) -> Option<(BindingId, Span)> {
+    let Expression::Let { binding, value, .. } = item else {
+        return None;
+    };
+    let Pattern::Identifier { identifier, span } = &binding.pattern else {
+        return None;
+    };
+    let make_span = zero_filled_make_call(value.unwrap_parens())?;
+    let (id, _) = ctx
+        .facts
+        .bindings
+        .iter()
+        .find(|(_, fact)| fact.span == *span && fact.name == identifier.as_str())?;
+    Some((*id, make_span))
+}
+
+enum FirstUse {
+    AppendReceiver,
+    Other,
+}
+
+/// A reassignment target is not a use, so `x = x.append(1)` classifies by its
+/// right side, and a right side not involving `x` replaces the tracked value.
+fn first_use(expression: &Expression, binding_id: BindingId) -> Option<FirstUse> {
+    if let Expression::Assignment { target, value, .. } = expression
+        && is_binding(target, binding_id)
+    {
+        return first_use(value, binding_id).or(Some(FirstUse::Other));
+    }
+    if let Some(receiver) = growing_append_receiver(expression)
+        && is_binding(receiver, binding_id)
+    {
+        return Some(FirstUse::AppendReceiver);
+    }
+    if is_binding(expression, binding_id) {
+        return Some(FirstUse::Other);
+    }
+    for child in expression.children() {
+        if let Some(found) = first_use(child, binding_id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// The receiver of a `receiver.append(...)` or `Slice.append(receiver, ...)`
+/// call that appends at least one element.
+fn growing_append_receiver(expression: &Expression) -> Option<&Expression> {
+    let Expression::Call {
+        expression: callee,
+        args,
+        spread,
+        call_kind,
+        ..
+    } = expression
+    else {
+        return None;
+    };
+    match call_kind {
+        Some(CallKind::NativeMethod(NativeTypeKind::Slice)) => {
+            let Expression::DotAccess {
+                expression: receiver,
+                member,
+                ..
+            } = callee.unwrap_parens()
+            else {
+                return None;
+            };
+            (member == "append" && (!args.is_empty() || spread.is_some()))
+                .then(|| receiver.as_ref())
+        }
+        Some(CallKind::NativeMethodIdentifier(NativeTypeKind::Slice)) => {
+            if !is_bare_identifier(callee, "Slice.append") {
+                return None;
+            }
+            (args.len() > 1 || spread.is_some())
+                .then(|| args.first())
+                .flatten()
+        }
+        _ => None,
+    }
+}
+
+fn is_binding(expression: &Expression, binding_id: BindingId) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::Identifier { binding_id: Some(id), .. } if *id == binding_id
+    )
+}

--- a/crates/passes/src/passes/lints/ast_walk/checks/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/mod.rs
@@ -1,4 +1,5 @@
 mod almost_swapped;
+mod append_to_zero_filled;
 mod bad_bit_mask;
 mod bind_instead_of_map;
 mod bool_literal_comparison;
@@ -106,6 +107,7 @@ mod while_let_loop;
 mod wildcard_in_or_patterns;
 
 pub use almost_swapped::check_almost_swapped;
+pub use append_to_zero_filled::check_append_to_zero_filled;
 pub use bad_bit_mask::check_bad_bit_mask;
 pub use bind_instead_of_map::check_bind_instead_of_map;
 pub use bool_literal_comparison::check_bool_literal_comparison;

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -19,10 +19,10 @@ use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
-    check_almost_swapped, check_bad_bit_mask, check_bind_instead_of_map,
-    check_bool_literal_comparison, check_collapsible_else_if, check_collapsible_if,
-    check_collapsible_match, check_double_comparison, check_double_negation, check_dup_arg,
-    check_duplicate_cutset, check_duplicate_logical_operand, check_empty_match_arm,
+    check_almost_swapped, check_append_to_zero_filled, check_bad_bit_mask,
+    check_bind_instead_of_map, check_bool_literal_comparison, check_collapsible_else_if,
+    check_collapsible_if, check_collapsible_match, check_double_comparison, check_double_negation,
+    check_dup_arg, check_duplicate_cutset, check_duplicate_logical_operand, check_empty_match_arm,
     check_enum_variant_names, check_equal_operands, check_equatable_if_let,
     check_excess_parens_on_condition, check_exit_after_defer, check_expression_naming,
     check_float_cmp, check_float_equality_without_abs, check_goos_goarch_comparison,
@@ -116,6 +116,7 @@ static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
             (check_negated_equality, &[Unary]),
             (check_let_and_return, &[Block]),
             (check_almost_swapped, &[Block, TryBlock, RecoverBlock]),
+            (check_append_to_zero_filled, &[Block, Call]),
             (check_unnecessary_bool, &[If]),
             (check_unnecessary_range_loop, &[For]),
             (check_unnecessary_return, &[Function]),

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -56,7 +56,7 @@ pub fn run(
     facts.absorb_local_facts(producer_facts);
 
     sink.extend(checks_diagnostics);
-    deferred::run(facts, sink);
+    deferred::run(analysis.store, facts, sink);
     if run_lints {
         lints::from_facts::run(analysis, facts, unused, sink);
     }

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -363,6 +363,9 @@ impl<'a> FreezeFolder<'a> {
         for check in &mut facts.empty_literal_checks {
             self.env.resolve_in_place(&mut check.ty);
         }
+        for check in &mut facts.slice_make_checks {
+            self.env.resolve_in_place(&mut check.ty);
+        }
         for check in &mut facts.statement_tail_checks {
             self.env.resolve_in_place(&mut check.expected_ty);
         }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -259,11 +259,12 @@ impl InferCtx<'_, '_> {
             .or_else(|| self.as_static_method(&args));
 
         if let Some((expression, _kind)) = resolved {
-            if member.as_str() == "append"
+            if matches!(member.as_str(), "append" | "reserve")
                 && resolved_expression_ty.is_ref()
                 && args.deref_ty.has_name("Slice")
             {
-                self.sink.push(diagnostics::infer::ref_slice_append(span));
+                self.sink
+                    .push(diagnostics::infer::ref_slice_growth(&member, span));
             }
             if member.as_str() == "equals" && self.scopes.is_callee_context() {
                 self.gate_container_equals(&args.deref_ty, args.expression.get_span());

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -306,9 +306,35 @@ impl InferCtx<'_, '_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
+        let callee_path = expression.unwrap_parens().as_dotted_path();
+
         // `Array.new` has no prelude signature (no const generics), so resolve inline.
-        if expression.as_dotted_path().as_deref() == Some("Array.new") {
+        if callee_path.as_deref() == Some("Array.new") {
             return self.infer_array_new_call(&expression, args, type_args, span, expected_ty);
+        }
+
+        if let Some(diagnostic) = match callee_path.as_deref() {
+            Some("Map.make") => Some(diagnostics::infer::map_no_make_constructor(span)),
+            Some("Channel.make") => Some(diagnostics::infer::channel_no_make_constructor(span)),
+            _ => None,
+        } {
+            self.sink.push(diagnostic);
+            let new_args: Vec<Expression> = args
+                .into_iter()
+                .map(|arg| self.with_value_context(|s| s.infer_expression(arg, &Type::Error)))
+                .collect();
+            let new_spread = spread
+                .map(|s| self.with_value_context(|state| state.infer_expression(s, &Type::Error)));
+            return Expression::Call {
+                expression,
+                args: new_args,
+                spread: Box::new(new_spread),
+                raw_type_args: type_args,
+                resolved_type_args: Vec::new(),
+                ty: Type::Error,
+                span,
+                call_kind: None,
+            };
         }
 
         let store = self.store;
@@ -522,6 +548,17 @@ impl InferCtx<'_, '_> {
 
         if call_kind == CallKind::AssertType {
             self.check_redundant_assert_type(&return_ty, &new_args, span);
+        }
+
+        if callee_path.as_deref() == Some("Slice.make") {
+            let module_id = self.cursor.module_id.clone();
+            self.facts
+                .slice_make_checks
+                .push(crate::facts::SliceMakeCheck {
+                    ty: call_ty.clone(),
+                    span,
+                    module_id,
+                });
         }
 
         Expression::Call {
@@ -1353,14 +1390,7 @@ impl InferCtx<'_, '_> {
                     return CallKind::TupleStructConstructor;
                 }
 
-                // Native constructor: Channel.new, Map.new, Slice.new
-                let constructor_kind = match value.as_str() {
-                    "Channel.new" | "Channel.buffered" => Some(NativeTypeKind::Channel),
-                    "Map.new" => Some(NativeTypeKind::Map),
-                    "Slice.new" => Some(NativeTypeKind::Slice),
-                    _ => None,
-                };
-                if let Some(kind) = constructor_kind {
+                if let Some(kind) = NativeTypeKind::from_constructor_path(value) {
                     return CallKind::NativeConstructor(kind);
                 }
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1,7 +1,9 @@
 use crate::checker::EnvResolve;
 use ecow::EcoString;
 use syntax::ast::BindingKind;
-use syntax::ast::{Annotation, Binding, Expression, Pattern, Span, StructKind};
+use syntax::ast::{
+    Annotation, Binding, Expression, Literal, Pattern, Span, StructKind, UnaryOperator,
+};
 use syntax::program::{CallKind, Definition, DefinitionBody, NativeTypeKind};
 use syntax::types::{
     Bound, CompoundKind, SubstitutionMap, Symbol, Type, peel_to_range_type, substitute,
@@ -561,6 +563,13 @@ impl InferCtx<'_, '_> {
                 });
         }
 
+        self.check_negative_size_literal(
+            call_kind,
+            &callee_expression,
+            callee_path.as_deref(),
+            &new_args,
+        );
+
         Expression::Call {
             expression: callee_expression.into(),
             args: new_args,
@@ -570,6 +579,49 @@ impl InferCtx<'_, '_> {
             ty: call_ty,
             span,
             call_kind: Some(call_kind),
+        }
+    }
+
+    fn check_negative_size_literal(
+        &mut self,
+        call_kind: CallKind,
+        callee_expression: &Expression,
+        callee_path: Option<&str>,
+        args: &[Expression],
+    ) {
+        let sized = match call_kind {
+            CallKind::NativeConstructor(NativeTypeKind::Slice)
+                if callee_path == Some("Slice.make") =>
+            {
+                args.first().map(|arg| ("length", arg))
+            }
+            CallKind::NativeConstructor(NativeTypeKind::Channel)
+                if callee_path == Some("Channel.buffered") =>
+            {
+                args.first().map(|arg| ("capacity", arg))
+            }
+            CallKind::NativeMethod(NativeTypeKind::Slice) => {
+                match callee_expression.unwrap_parens() {
+                    Expression::DotAccess { member, .. } if member == "reserve" => {
+                        args.first().map(|arg| ("capacity", arg))
+                    }
+                    _ => None,
+                }
+            }
+            CallKind::NativeMethodIdentifier(NativeTypeKind::Slice)
+                if callee_path == Some("Slice.reserve") =>
+            {
+                args.get(1).map(|arg| ("capacity", arg))
+            }
+            _ => None,
+        };
+        if let Some((what, arg)) = sized
+            && is_negative_integer_literal(arg)
+        {
+            self.sink.push(diagnostics::infer::negative_size_literal(
+                what,
+                arg.get_span(),
+            ));
         }
     }
 
@@ -1714,4 +1766,18 @@ fn callee_label(expr: &Expression) -> String {
         },
         _ => "the function".to_string(),
     }
+}
+
+fn is_negative_integer_literal(expression: &Expression) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::Unary {
+            operator: UnaryOperator::Negative,
+            expression: inner,
+            ..
+        } if matches!(
+            inner.unwrap_parens(),
+            Expression::Literal { literal: Literal::Integer { value, .. }, .. } if *value > 0
+        )
+    )
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -54,6 +54,7 @@ pub struct Facts {
     pub generic_call_checks: Vec<GenericCallCheck>,
     pub empty_collection_checks: Vec<EmptyCollectionCheck>,
     pub empty_literal_checks: Vec<EmptyLiteralCheck>,
+    pub slice_make_checks: Vec<SliceMakeCheck>,
     pub statement_tail_checks: Vec<StatementTailCheck>,
 
     /// Value-position `match`/`select` arms that did not reconcile, drained and
@@ -111,6 +112,13 @@ pub struct EmptyLiteralCheck {
 }
 
 #[derive(Debug, Clone)]
+pub struct SliceMakeCheck {
+    pub ty: Type,
+    pub span: Span,
+    pub module_id: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct StatementTailCheck {
     pub expected_ty: Type,
     pub span: Span,
@@ -145,6 +153,7 @@ impl Facts {
             generic_call_checks: Vec::new(),
             empty_collection_checks: Vec::new(),
             empty_literal_checks: Vec::new(),
+            slice_make_checks: Vec::new(),
             statement_tail_checks: Vec::new(),
             branch_subsumptions: Vec::new(),
             select_exhaustiveness_checks: Vec::new(),
@@ -309,6 +318,7 @@ impl Facts {
             generic_call_checks,
             empty_collection_checks,
             empty_literal_checks,
+            slice_make_checks,
             statement_tail_checks,
             branch_subsumptions,
             select_exhaustiveness_checks,
@@ -345,6 +355,7 @@ impl Facts {
         self.generic_call_checks.extend(generic_call_checks);
         self.empty_collection_checks.extend(empty_collection_checks);
         self.empty_literal_checks.extend(empty_literal_checks);
+        self.slice_make_checks.extend(slice_make_checks);
         self.statement_tail_checks.extend(statement_tail_checks);
         self.branch_subsumptions.extend(branch_subsumptions);
         self.select_exhaustiveness_checks

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -307,6 +307,10 @@ impl<T> Slice<T> {
   /// Creates a new empty slice.
   fn new() -> Slice<T>
 
+  /// Creates a slice of `length` elements, each set to its zero value.
+  /// The capacity equals the length.
+  fn make(length: int) -> Slice<T>
+
   /// Returns the number of elements in the slice.
   fn length(self) -> int
 
@@ -315,6 +319,9 @@ impl<T> Slice<T> {
 
   /// Returns the number of elements the slice can hold before reallocating.
   fn capacity(self) -> int
+
+  /// Returns a slice with capacity for at least `additional` more elements.
+  fn reserve(self, additional: int) -> Slice<T>
 
   /// Returns the element at `index`, or `None` if out of bounds.
   fn get(self, index: int) -> Option<T>

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -436,11 +436,9 @@ impl<'source> Parser<'source> {
         let kind = self.classify_go_make()?;
         let help = match (kind, self.scan_go_make_args()) {
             (GoMakeKind::Slice, 0) => "Use `Slice.new<T>()` for an empty slice.",
-            (GoMakeKind::Slice, 1) => {
-                "Use `slices.Repeat([value], n)` after importing `go:slices`."
-            }
+            (GoMakeKind::Slice, 1) => "Use `Slice.make<T>(n)` for a zero-filled slice.",
             (GoMakeKind::Slice, _) => {
-                "Use `slices.Grow(Slice.new<T>(), capacity)` after importing `go:slices`."
+                "For `make([]T, 0, c)` use `Slice.new<T>().reserve(c)`. For a nonzero length, use `Slice.make<T>(n)` and `reserve` the extra capacity."
             }
             (GoMakeKind::Channel, 0) => "Use `Channel.new<T>()`.",
             (GoMakeKind::Channel, _) => "Use `Channel.buffered<T>(n)`.",

--- a/crates/syntax/src/program/resolution.rs
+++ b/crates/syntax/src/program/resolution.rs
@@ -88,6 +88,19 @@ impl NativeTypeKind {
         Self::from_name(name)
     }
 
+    pub fn from_constructor_path(path: &str) -> Option<Self> {
+        match path {
+            "Channel.new" | "Channel.buffered" => Some(Self::Channel),
+            "Map.new" => Some(Self::Map),
+            "Slice.new" | "Slice.make" => Some(Self::Slice),
+            _ => None,
+        }
+    }
+
+    pub fn is_constructor_method(name: &str) -> bool {
+        matches!(name, "new" | "buffered" | "make")
+    }
+
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "Slice" => Some(Self::Slice),

--- a/docs/intro/coming-from-go.md
+++ b/docs/intro/coming-from-go.md
@@ -233,6 +233,9 @@ Lisette uses structural typing for interfaces, like Go.
 nums := []int{1, 2, 3}
 nums = append(nums, 4)
 
+buf := make([]byte, 1024)
+acc := make([]int, 0, 4096)
+
 ages := make(map[string]int)
 ages["Alice"] = 20
 age, ok := ages["Bob"]
@@ -243,6 +246,9 @@ var digest [32]byte
 ```rust
 let nums = [1, 2, 3]
 let nums = nums.append(4)
+
+let buf = Slice.make<byte>(1024)
+let acc = Slice.new<int>().reserve(4096)
 
 let mut ages = Map.new<string, int>()
 ages["Alice"] = 20

--- a/docs/reference/02-types.md
+++ b/docs/reference/02-types.md
@@ -153,6 +153,25 @@ let empty: Slice<int> = []
 let also_empty = Slice.new<int>()
 ```
 
+`Slice.make` creates a slice of a given length with every element set to its zero value, like Go's `make([]T, n)`. The length may be a runtime value:
+
+```rust
+let mut buffer = Slice.make<byte>(1024)
+let n = reader.Read(buffer).unwrap_or(0)
+process(buffer[..n])
+```
+
+If the element type has no zero value (e.g. `Ref<T>`), build the slice from a literal instead.
+
+`reserve` returns a slice with capacity for at least `additional` more elements, like Go's `slices.Grow`. Use it to preallocate an append accumulator:
+
+```rust
+let mut ids = Slice.new<int>().reserve(4096)
+for user in users {
+  ids = ids.append(user.id) // no reallocation until 4096 elements
+}
+```
+
 ```rust
 let first = nums[0]
 let safe = nums.get(0)           // Option<int>

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -148,6 +148,157 @@ fn test() -> Slice<fn(int)> {
 }
 
 #[test]
+fn slice_make() {
+    let input = r#"
+fn test() -> Slice<byte> {
+  Slice.make<byte>(1024)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_make_inferred_type() {
+    let input = r#"
+fn test() -> Slice<string> {
+  Slice.make(5)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_make_runtime_length() {
+    let input = r#"
+fn test(n: int) -> Slice<int> {
+  Slice.make<int>(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_make_zero_filled() {
+    let input = r#"
+fn main() {
+  let xs = Slice.make<int>(3)
+  if xs.length() != 3 {
+    panic("expected length 3")
+  }
+  if xs.capacity() != 3 {
+    panic("expected capacity 3")
+  }
+  if xs.get(0).unwrap_or(-1) != 0 {
+    panic("expected zero-filled elements")
+  }
+  let empty = Slice.make<int>(0)
+  if !empty.is_empty() {
+    panic("expected an empty slice for zero length")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_make_read_loop() {
+    let input = r#"
+import "go:strings"
+
+fn main() {
+  let reader = strings.NewReader("hello world")
+  let mut buffer = Slice.make<byte>(8)
+  let n = reader.Read(buffer).unwrap_or(0)
+  if n != 8 {
+    panic("expected to read 8 bytes into the buffer")
+  }
+  let head = buffer[..n] as string
+  if head != "hello wo" {
+    panic("expected the first 8 bytes of the input")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_reserve_after_new() {
+    let input = r#"
+fn test() -> Slice<int> {
+  Slice.new<int>().reserve(4096)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_reserve_self_reassign_not_clipped() {
+    let input = r#"
+fn test() {
+  let mut acc = [1, 2, 3]
+  acc = acc.reserve(50)
+  let _ = acc
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_reserve_value_position_clips_receiver() {
+    let input = r#"
+fn test(source: Slice<int>) -> Slice<int> {
+  let grown = source.reserve(10)
+  grown
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_reserve_accumulator_round_trip() {
+    let input = r#"
+fn main() {
+  let mut acc = Slice.new<int>().reserve(64)
+  if acc.length() != 0 {
+    panic("expected an empty accumulator")
+  }
+  if acc.capacity() < 64 {
+    panic("expected reserved capacity")
+  }
+  let start = acc.capacity()
+  acc = acc.append(1)
+  acc = acc.append(2)
+  if acc.capacity() != start {
+    panic("expected appends within reserved capacity not to reallocate")
+  }
+  if acc.get(1).unwrap_or(-1) != 2 {
+    panic("expected appended elements to be readable")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_make_fills_elements_without_go_zero() {
+    let input = r#"
+fn main() {
+  let maps = Slice.make<Map<string, int>>(2)
+  let mut first = maps.get(0).unwrap_or(Map.new<string, int>())
+  first["k"] = 1
+  let second = maps.get(1).unwrap_or(Map.new<string, int>())
+  if first.length() != 1 {
+    panic("expected a writable empty map element")
+  }
+  if second.length() != 0 {
+    panic("expected each element to get its own map")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn append_from_call_result_does_not_alias() {
     let input = r#"
 fn identity(s: Slice<int>) -> Slice<int> {

--- a/tests/spec/emit/snapshots/slice_make.snap
+++ b/tests/spec/emit/snapshots/slice_make.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> Slice<byte> {
+    Slice.make<byte>(1024)
+  }
+---
+package main
+
+func test() []byte {
+	return make([]byte, 1024)
+}

--- a/tests/spec/emit/snapshots/slice_make_fills_elements_without_go_zero.snap
+++ b/tests/spec/emit/snapshots/slice_make_fills_elements_without_go_zero.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let maps = Slice.make<Map<string, int>>(2)
+    let mut first = maps.get(0).unwrap_or(Map.new<string, int>())
+    first["k"] = 1
+    let second = maps.get(1).unwrap_or(Map.new<string, int>())
+    if first.length() != 1 {
+      panic("expected a writable empty map element")
+    }
+    if second.length() != 0 {
+      panic("expected each element to get its own map")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	maps_ := func() []map[string]int {
+		s := make([]map[string]int, 2)
+		for i := range s {
+			s[i] = map[string]int{}
+		}
+		return s
+	}()
+	callee_1 := lisette.SliceGet(maps_, 0).UnwrapOr
+	first := callee_1(make(map[string]int))
+	first["k"] = 1
+	callee_2 := lisette.SliceGet(maps_, 1).UnwrapOr
+	second := callee_2(make(map[string]int))
+	if len(first) != 1 {
+		panic("expected a writable empty map element")
+	}
+	if len(second) != 0 {
+		panic("expected each element to get its own map")
+	}
+}

--- a/tests/spec/emit/snapshots/slice_make_inferred_type.snap
+++ b/tests/spec/emit/snapshots/slice_make_inferred_type.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> Slice<string> {
+    Slice.make(5)
+  }
+---
+package main
+
+func test() []string {
+	return make([]string, 5)
+}

--- a/tests/spec/emit/snapshots/slice_make_read_loop.snap
+++ b/tests/spec/emit/snapshots/slice_make_read_loop.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  import "go:strings"
+  
+  fn main() {
+    let reader = strings.NewReader("hello world")
+    let mut buffer = Slice.make<byte>(8)
+    let n = reader.Read(buffer).unwrap_or(0)
+    if n != 8 {
+      panic("expected to read 8 bytes into the buffer")
+    }
+    let head = buffer[..n] as string
+    if head != "hello wo" {
+      panic("expected the first 8 bytes of the input")
+    }
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"strings"
+)
+
+func main() {
+	reader := strings.NewReader("hello world")
+	buffer := make([]byte, 8)
+	ret_1, ret_2 := reader.Read(buffer)
+	var result_3 lisette.Partial[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakePartialBoth[int, error](ret_1, ret_2)
+	} else {
+		result_3 = lisette.MakePartialOk[int, error](ret_1)
+	}
+	n := result_3.UnwrapOr(0)
+	if n != 8 {
+		panic("expected to read 8 bytes into the buffer")
+	}
+	head := string(buffer[:n:n])
+	if head != "hello wo" {
+		panic("expected the first 8 bytes of the input")
+	}
+}

--- a/tests/spec/emit/snapshots/slice_make_runtime_length.snap
+++ b/tests/spec/emit/snapshots/slice_make_runtime_length.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(n: int) -> Slice<int> {
+    Slice.make<int>(n)
+  }
+---
+package main
+
+func test(n int) []int {
+	return make([]int, n)
+}

--- a/tests/spec/emit/snapshots/slice_make_zero_filled.snap
+++ b/tests/spec/emit/snapshots/slice_make_zero_filled.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let xs = Slice.make<int>(3)
+    if xs.length() != 3 {
+      panic("expected length 3")
+    }
+    if xs.capacity() != 3 {
+      panic("expected capacity 3")
+    }
+    if xs.get(0).unwrap_or(-1) != 0 {
+      panic("expected zero-filled elements")
+    }
+    let empty = Slice.make<int>(0)
+    if !empty.is_empty() {
+      panic("expected an empty slice for zero length")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	xs := make([]int, 3)
+	if len(xs) != 3 {
+		panic("expected length 3")
+	}
+	if cap(xs) != 3 {
+		panic("expected capacity 3")
+	}
+	if lisette.SliceGet(xs, 0).UnwrapOr(-1) != 0 {
+		panic("expected zero-filled elements")
+	}
+	empty := make([]int, 0)
+	if len(empty) != 0 {
+		panic("expected an empty slice for zero length")
+	}
+}

--- a/tests/spec/emit/snapshots/slice_reserve_accumulator_round_trip.snap
+++ b/tests/spec/emit/snapshots/slice_reserve_accumulator_round_trip.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn main() {
+    let mut acc = Slice.new<int>().reserve(64)
+    if acc.length() != 0 {
+      panic("expected an empty accumulator")
+    }
+    if acc.capacity() < 64 {
+      panic("expected reserved capacity")
+    }
+    let start = acc.capacity()
+    acc = acc.append(1)
+    acc = acc.append(2)
+    if acc.capacity() != start {
+      panic("expected appends within reserved capacity not to reallocate")
+    }
+    if acc.get(1).unwrap_or(-1) != 2 {
+      panic("expected appended elements to be readable")
+    }
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+)
+
+func main() {
+	acc := slices.Grow([]int{}, 64)
+	if len(acc) != 0 {
+		panic("expected an empty accumulator")
+	}
+	if cap(acc) < 64 {
+		panic("expected reserved capacity")
+	}
+	start := cap(acc)
+	acc = append(acc, 1)
+	acc = append(acc, 2)
+	if cap(acc) != start {
+		panic("expected appends within reserved capacity not to reallocate")
+	}
+	if lisette.SliceGet(acc, 1).UnwrapOr(-1) != 2 {
+		panic("expected appended elements to be readable")
+	}
+}

--- a/tests/spec/emit/snapshots/slice_reserve_after_new.snap
+++ b/tests/spec/emit/snapshots/slice_reserve_after_new.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> Slice<int> {
+    Slice.new<int>().reserve(4096)
+  }
+---
+package main
+
+import "slices"
+
+func test() []int {
+	return slices.Grow([]int{}, 4096)
+}

--- a/tests/spec/emit/snapshots/slice_reserve_self_reassign_not_clipped.snap
+++ b/tests/spec/emit/snapshots/slice_reserve_self_reassign_not_clipped.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() {
+    let mut acc = [1, 2, 3]
+    acc = acc.reserve(50)
+    let _ = acc
+  }
+---
+package main
+
+import "slices"
+
+func test() {
+	acc := []int{1, 2, 3}
+	acc = slices.Grow(acc, 50)
+	_ = acc
+}

--- a/tests/spec/emit/snapshots/slice_reserve_value_position_clips_receiver.snap
+++ b/tests/spec/emit/snapshots/slice_reserve_value_position_clips_receiver.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(source: Slice<int>) -> Slice<int> {
+    let grown = source.reserve(10)
+    grown
+  }
+---
+package main
+
+import "slices"
+
+func test(source []int) []int {
+	grown := slices.Grow(source[:len(source):len(source)], 10)
+	return grown
+}

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -25,6 +25,129 @@ fn slice_new_without_type_arg_errors() {
 }
 
 #[test]
+fn slice_make_without_type_arg_errors() {
+    infer(
+        r#"
+    fn test() {
+      let s = Slice.make(4);
+    }
+        "#,
+    )
+    .assert_infer_code("missing_type_argument");
+}
+
+#[test]
+fn slice_make_with_type_arg_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let s = Slice.make<string>(4);
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn slice_make_type_from_annotation_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let s: Slice<bool> = Slice.make(2);
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn slice_make_zero_length_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let s = Slice.make<int>(0);
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn slice_make_option_ref_element_succeeds() {
+    infer(
+        r#"
+    fn test() {
+      let s = Slice.make<Option<Ref<int>>>(3);
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn slice_make_ref_element_errors() {
+    infer(
+        r#"
+    fn test() {
+      let refs = Slice.make<Ref<int>>(4);
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
+fn slice_make_annotation_ref_element_errors() {
+    infer(
+        r#"
+    fn test() {
+      let refs: Slice<Ref<int>> = Slice.make(4);
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
+fn slice_make_element_resolved_later_errors() {
+    infer(
+        r#"
+    fn test() {
+      let mut chans = Slice.make(1);
+      chans = chans.append(Channel.new<int>());
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
+fn slice_make_struct_with_ref_field_errors() {
+    infer(
+        r#"
+    struct Holder { r: Ref<int> }
+
+    fn test() {
+      let holders = Slice.make<Holder>(1);
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
+fn slice_make_type_parameter_element_errors() {
+    infer(
+        r#"
+    fn make<T>(n: int) -> Slice<T> {
+      Slice.make<T>(n)
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
 fn map_new_without_type_args_errors() {
     infer(
         r#"
@@ -166,6 +289,64 @@ fn channel_new_type_from_return_type_succeeds() {
         "#,
     )
     .assert_no_errors();
+}
+
+#[test]
+fn slice_make_guard_sees_through_parens() {
+    infer(
+        r#"
+    fn test() {
+      let refs: Slice<Ref<int>> = (Slice.make)(4);
+      let _ = refs;
+    }
+        "#,
+    )
+    .assert_infer_code("slice_make_no_zero");
+}
+
+#[test]
+fn user_static_named_make_is_a_legal_value() {
+    infer(
+        r#"
+    struct Builder {}
+
+    impl Builder {
+      fn make() -> Slice<int> {
+        [1, 2]
+      }
+    }
+
+    fn test() {
+      let factory = Builder.make;
+      let made = factory();
+      let _ = made;
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn map_make_recovery_infers_spread() {
+    let result = crate::_harness::infer::infer(
+        r#"
+    fn test(xs: Slice<int>) {
+      let m = Map.make<string, int>(xs...);
+      let _ = m;
+    }
+        "#,
+    );
+    let errors: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .filter_map(|e| e.code_str())
+        .collect();
+    assert_eq!(
+        errors,
+        vec!["infer.no_make_constructor"],
+        "the recovery must infer the spread without cascading"
+    );
 }
 
 #[test]

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -292,6 +292,34 @@ fn channel_new_type_from_return_type_succeeds() {
 }
 
 #[test]
+fn negative_literal_buffered_errors() {
+    infer("fn test() { let c = Channel.buffered<int>(-2); let _ = c }")
+        .assert_infer_code("negative_size_literal");
+}
+
+#[test]
+fn negative_literal_reserve_errors() {
+    infer("fn test() { let mut s = [1]; s = s.reserve(-3); let _ = s }")
+        .assert_infer_code("negative_size_literal");
+}
+
+#[test]
+fn negative_literal_reserve_ufcs_errors() {
+    infer("fn test() { let mut s = [1]; s = Slice.reserve(s, -4); let _ = s }")
+        .assert_infer_code("negative_size_literal");
+}
+
+#[test]
+fn negative_zero_size_literal_is_legal() {
+    infer("fn test() { let a = Slice.make<byte>(-0); let _ = a }").assert_no_errors();
+}
+
+#[test]
+fn computed_negative_size_stays_runtime() {
+    infer("fn test() { let a = Slice.make<byte>(0 - 1); let _ = a }").assert_no_errors();
+}
+
+#[test]
 fn slice_make_guard_sees_through_parens() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2107,6 +2107,46 @@ fn test(holders: Map<string, Holder>) {
 }
 
 #[test]
+fn infer_no_make_constructor_map() {
+    let input = r#"
+fn test() {
+  let m = Map.make<string, int>(8)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_no_make_constructor_channel() {
+    let input = r#"
+fn test() {
+  let c = Channel.make<int>(5)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_ref_slice_reserve() {
+    let input = r#"
+fn test(r: Ref<Slice<int>>) {
+  let _ = r.reserve(10)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_slice_make_no_zero() {
+    let input = r#"
+fn test() {
+  let refs = Slice.make<Ref<int>>(4)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_map_read_no_zero_in_deref_write() {
     let input = r#"
 fn test() {
@@ -9093,7 +9133,7 @@ fn main() {
 }
 
 #[test]
-fn infer_ref_slice_append() {
+fn infer_ref_slice_growth() {
     let input = r#"
 fn main() {
   let mut s = [1, 2, 3]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2137,6 +2137,17 @@ fn test(r: Ref<Slice<int>>) {
 }
 
 #[test]
+fn infer_negative_size_literal_make() {
+    let input = r#"
+fn test() {
+  let a = Slice.make<byte>(-1)
+  let _ = a
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_slice_make_no_zero() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_negative_size_literal_make.snap
+++ b/tests/ui/errors/snapshots/infer_negative_size_literal_make.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Negative length
+   ╭─[test.lis:3:28]
+ 2 │ fn test() {
+ 3 │   let a = Slice.make<byte>(-1)
+   ·                            ─┬
+   ·                             ╰── a length cannot be negative
+ 4 │   let _ = a
+   ╰────
+  help: This would always fail at runtime, so it is rejected here · code: [infer.negative_size_literal]

--- a/tests/ui/errors/snapshots/infer_no_make_constructor_channel.snap
+++ b/tests/ui/errors/snapshots/infer_no_make_constructor_channel.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `Channel` has no `make` constructor
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let c = Channel.make<int>(5)
+   ·           ──────────┬─────────
+   ·                     ╰── a channel's only size is its buffer
+ 4 │ }
+   ╰────
+  help: Use `Channel.new<T>()` for an unbuffered channel, or `Channel.buffered<T>(n)` for a buffered one · code: [infer.no_make_constructor]

--- a/tests/ui/errors/snapshots/infer_no_make_constructor_map.snap
+++ b/tests/ui/errors/snapshots/infer_no_make_constructor_map.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                       ╰── `Map` has no capacity-taking constructor
  4 │ }
    ╰────
-  help: Use `Map.new<K, V>()`. Go's map capacity hint has no observable effect · code: [infer.no_make_constructor]
+  help: Use `Map.new<K, V>()`. Go's map size hint only pre-sizes the initial allocation · code: [infer.no_make_constructor]

--- a/tests/ui/errors/snapshots/infer_no_make_constructor_map.snap
+++ b/tests/ui/errors/snapshots/infer_no_make_constructor_map.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `Map` has no `make` constructor
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let m = Map.make<string, int>(8)
+   ·           ────────────┬───────────
+   ·                       ╰── `Map` has no capacity-taking constructor
+ 4 │ }
+   ╰────
+  help: Use `Map.new<K, V>()`. Go's map capacity hint has no observable effect · code: [infer.no_make_constructor]

--- a/tests/ui/errors/snapshots/infer_ref_slice_growth.snap
+++ b/tests/ui/errors/snapshots/infer_ref_slice_growth.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·       ╰── dereference the ref first
  6 │ }
    ╰────
-  help: Use `r.*.append(x)` to deref, then append · code: [infer.ref_slice_append]
+  help: Use `r.*.append(...)` to deref first · code: [infer.ref_slice_growth]

--- a/tests/ui/errors/snapshots/infer_ref_slice_reserve.snap
+++ b/tests/ui/errors/snapshots/infer_ref_slice_reserve.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot call `reserve` on `Ref<Slice>`
+   ╭─[test.lis:3:11]
+ 2 │ fn test(r: Ref<Slice<int>>) {
+ 3 │   let _ = r.reserve(10)
+   ·           ────┬────
+   ·               ╰── dereference the ref first
+ 4 │ }
+   ╰────
+  help: Use `r.*.reserve(...)` to deref first · code: [infer.ref_slice_growth]

--- a/tests/ui/errors/snapshots/infer_slice_make_no_zero.snap
+++ b/tests/ui/errors/snapshots/infer_slice_make_no_zero.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `Ref<int>` has no zero value
+   ╭─[test.lis:3:14]
+ 2 │ fn test() {
+ 3 │   let refs = Slice.make<Ref<int>>(4)
+   ·              ───────────┬───────────
+   ·                         ╰── `Slice.make` zero-fills every element, but `Ref<int>` has none
+ 4 │ }
+   ╰────
+  help: Build the slice from a list literal instead, e.g. `let xs = [a, b, c]` · code: [infer.slice_make_no_zero]

--- a/tests/ui/errors/snapshots/parse_go_make_sized_slice.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_sized_slice.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                  ╰── Lisette has no `make` builtin
  4 │ }
    ╰────
-  help: Use `slices.Repeat([value], n)` after importing `go:slices` · code: [parse.go_make_builtin]
+  help: Use `Slice.make<T>(n)` for a zero-filled slice · code: [parse.go_make_builtin]

--- a/tests/ui/errors/snapshots/parse_go_make_slice_with_capacity.snap
+++ b/tests/ui/errors/snapshots/parse_go_make_slice_with_capacity.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·              ╰── Lisette has no `make` builtin
  4 │ }
    ╰────
-  help: Use `slices.Grow(Slice.new<T>(), capacity)` after importing `go:slices` · code: [parse.go_make_builtin]
+  help: For `make([]T, 0, c)` use `Slice.new<T>().reserve(c)`. For a nonzero length, use `Slice.make<T>(n)` and `reserve` the extra capacity · code: [parse.go_make_builtin]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -33,6 +33,146 @@ fn main() {
 }
 
 #[test]
+fn append_to_zero_filled_make() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let mut ids = Slice.make<int>(100)
+  ids = ids.append(7)
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_for_zero_length() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut a = Slice.make<int>(0)
+  a = a.append(1)
+  let _ = a
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_for_shadowed_binding() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut ids = Slice.make<int>(5)
+  {
+    let mut ids = Slice.new<int>()
+    ids = ids.append(1)
+    let _ = ids
+  }
+  ids[0] = 1
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_for_loop_shadow() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut ids = Slice.make<int>(5)
+  for ids in [[1], [2]] {
+    let grown = ids.append(9)
+    let _ = grown
+  }
+  ids[0] = 1
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_fires_for_chained_call() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let grown = Slice.make<int>(100).append(1)
+  let _ = grown
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_fires_for_ufcs_call() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let mut ids = Slice.make<int>(100)
+  ids = Slice.append(ids, 7)
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_after_reassignment() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut ids = Slice.make<int>(100)
+  ids = Slice.new<int>()
+  ids = ids.append(7)
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_for_zero_argument_append() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let ids = Slice.make<int>(5)
+  let copied = ids.append()
+  let _ = (ids, copied)
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_silent_after_element_use() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let mut buffer = Slice.make<byte>(8)
+  let n = buffer.length()
+  buffer = buffer.append(1)
+  let _ = (buffer, n)
+}
+"#
+    );
+}
+
+#[test]
+fn reserve_discarded_output_warns() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let ids = Slice.new<int>()
+  ids.reserve(100);
+  let _ = ids
+}
+"#
+    );
+}
+
+#[test]
 fn unused_variable_suppressed_by_underscore() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_chained_call.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_chained_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Appending to a zero-filled slice
+   ╭─[test.lis:3:15]
+ 2 │ fn main() {
+ 3 │   let grown = Slice.make<int>(100).append(1)
+   ·               ──────────┬─────────
+   ·                         ╰── every element is already a zero value
+ 4 │   let _ = grown
+   ╰────
+  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_chained_call.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_chained_call.snap
@@ -5,8 +5,9 @@ source: tests/ui/lint/mod.rs
    ╭─[test.lis:3:15]
  2 │ fn main() {
  3 │   let grown = Slice.make<int>(100).append(1)
-   ·               ──────────┬─────────
+   ·               ──────────┬──────────────┬────
+   ·                         │              ╰── `append` adds element 101 here
    ·                         ╰── every element is already a zero value
  4 │   let _ = grown
    ╰────
-  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]
+  help: For an empty slice with room for 100, use `Slice.new<int>().reserve(100)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_ufcs_call.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_ufcs_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Appending to a zero-filled slice
+   ╭─[test.lis:3:17]
+ 2 │ fn main() {
+ 3 │   let mut ids = Slice.make<int>(100)
+   ·                 ──────────┬─────────
+   ·                           ╰── every element is already a zero value
+ 4 │   ids = Slice.append(ids, 7)
+   ╰────
+  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_ufcs_call.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_fires_for_ufcs_call.snap
@@ -8,5 +8,8 @@ source: tests/ui/lint/mod.rs
    ·                 ──────────┬─────────
    ·                           ╰── every element is already a zero value
  4 │   ids = Slice.append(ids, 7)
+   ·         ──────────┬─────────
+   ·                   ╰── `append` adds element 101 here
+ 5 │   let _ = ids
    ╰────
-  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]
+  help: For an empty slice with room for 100, use `Slice.new<int>().reserve(100)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/append_to_zero_filled_make.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_make.snap
@@ -8,5 +8,8 @@ source: tests/ui/lint/mod.rs
    ·                 ──────────┬─────────
    ·                           ╰── every element is already a zero value
  4 │   ids = ids.append(7)
+   ·         ──────┬──────
+   ·               ╰── `append` adds element 101 here
+ 5 │   let _ = ids
    ╰────
-  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]
+  help: For an empty slice with room for 100, use `Slice.new<int>().reserve(100)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/append_to_zero_filled_make.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_make.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Appending to a zero-filled slice
+   ╭─[test.lis:3:17]
+ 2 │ fn main() {
+ 3 │   let mut ids = Slice.make<int>(100)
+   ·                 ──────────┬─────────
+   ·                           ╰── every element is already a zero value
+ 4 │   ids = ids.append(7)
+   ╰────
+  help: `Slice.make(n)` creates n zero-valued elements, so `append` adds element n+1. For an empty slice with room for n, use `Slice.new<T>().reserve(n)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/reserve_discarded_output_warns.snap
+++ b/tests/ui/lint/snapshots/reserve_discarded_output_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused `reserve()` output
+   ╭─[test.lis:4:3]
+ 3 │   let ids = Slice.new<int>()
+ 4 │   ids.reserve(100);
+   ·   ────────┬───────
+   ·           ╰── output is discarded
+ 5 │   let _ = ids
+   ╰────
+  help: `reserve()` outputs a new slice, leaving the original slice intact. Assign the output back `let s = s.reserve(...)` or discard the output with `let _ = s.reserve(...)` · code: [lint.unused_value]


### PR DESCRIPTION
Adds `Slice.make` and `Slice.reserve` for sized zero-filled slices and capacity reservation, respectively.

| Lisette                     | Go                           | Purpose                                                       |
| ----------------------- | ---------------------------- | ------------------------------------------------------------- |
| `Slice.make<T>(length)` | `make([]T, length)`          | Create slice of `length` elements, each set to its zero value |
| `s.reserve(additional)` | `slices.Grow(s, additional)` | Set capacity for at least `additional` more elements          |

Examples:

```rust
let mut buffer = Slice.make<byte>(1024)
let n = reader.Read(buffer).unwrap_or(0)
process(buffer[..n])

let mut ids = Slice.new<int>().reserve(4096)
for user in users {
  ids = ids.append(user.id)
}
```

If the element type has no zero value, `Slice.make` is rejected at compile time, mirroring `Array.new`. Appending to a zero-filled slice before reading any element produces a lint:

```
  ▲ Appending to a zero-filled slice
   ╭─[test.lis:3:17]
 2 │ fn main() {
 3 │   let mut ids = Slice.make<int>(100)
   ·                 ──────────┬─────────
   ·                           ╰── every element is already a zero value
 4 │   ids = ids.append(7)
   ·         ──────┬──────
   ·               ╰── `append` adds element 101 here
 5 │   let _ = ids
   ╰────
  help: For an empty slice with room for 100, use `Slice.new<int>().reserve(100)` · code: [lint.append_to_zero_filled]
```

## Reasoning

Go's `make([]T, len, cap)` bundles two different intents behind two positional integers. Lisette splits this call into two separate methods, for these reasons:

- One spelling for two intents causes a common silent bug, as documented in @teivah's book "100 Go Mistakes". A buffer needs length, while an accumulator needs capacity. `make` spells both, so users often write `make([]T, n)` when they mean capacity and then call `append` and get `n` leading zeros followed by their data. Go linters can only guess at the intent behind a `make` call in Go. Separate methods disclose intent, allowing Lis to lint for this.
- Reserving capacity is an opt-in performance optimization, as documented in [Google's Go style guide](https://google.github.io/styleguide/go/best-practices#size-hints). This is also something a user may want mid-program, before a large append loop on a slice that already has contents. A method serves both moments, a constructor only the first.
- Reserving capacity as a separate method comes at no extra cost as `Slice.new<T>().reserve(c)` does one heap allocation, like Go's `make([]T, 0, c)`. 
- The rare case of wanting a nonzero length plus extra capacity in one value stays writable as `Slice.make(n)` followed by `reserve()`.