### PR TITLE
fix: stop rejecting generic returns constrained by builtins

### DIFF
--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{Annotation, Expression, Generic, Span};
 use syntax::types::{Bound, Symbol, Type};
 
+use semantics::prelude::PRELUDE_MODULE_ID;
 use semantics::store::Store;
 
 pub(crate) fn run(typed_ast: &[Expression], module_id: &str, store: &Store, sink: &LocalSink) {
@@ -198,12 +199,14 @@ fn lookup_qualified_name(id: &str, module_id: &str, store: &Store) -> Option<Str
         return Some(id.to_string());
     }
 
-    let candidate = Symbol::from_parts(module_id, id);
-    if store
-        .get_module(module_id)
-        .is_some_and(|m| m.definitions.contains_key(candidate.as_str()))
-    {
-        return Some(candidate.to_string());
+    for module in [module_id, PRELUDE_MODULE_ID] {
+        let candidate = Symbol::from_parts(module, id);
+        if store
+            .get_module(module)
+            .is_some_and(|m| m.definitions.contains_key(candidate.as_str()))
+        {
+            return Some(candidate.to_string());
+        }
     }
     None
 }

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -358,3 +358,82 @@ fn empty_literal_in_tuple_destructuring_errors() {
     )
     .assert_infer_code("empty_slice_no_element_type");
 }
+
+#[test]
+fn impl_generic_constraint_satisfies_generic_return_type() {
+    infer(
+        r#"
+struct Foo<E: error> {}
+
+impl<E: error> Foo<E> {
+  fn new() -> Foo<E> {
+    Foo {}
+  }
+
+  fn bar(self) -> int {
+    42
+  }
+}
+
+fn main() {
+  let foo = Foo.new<error>()
+  let _ = foo.bar()
+}
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn function_generic_constraint_satisfies_generic_return_type() {
+    infer(
+        r#"
+struct Foo<E: error> {}
+
+struct Factory {}
+
+impl Factory {
+  fn new<E: error>() -> Foo<E> {
+    Foo {}
+  }
+}
+
+impl<E: error> Foo<E> {
+  fn bar(self) -> int {
+    42
+  }
+}
+
+fn main() {
+  let foo = Factory.new<error>()
+  let _ = foo.bar()
+}
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn unconstrained_generic_return_type_with_prelude_bound_errors() {
+    infer(
+        r#"
+struct Foo<E: error> {}
+
+impl<E: error> Foo<E> {
+  fn bar(self) -> int {
+    42
+  }
+}
+
+fn make<E>() -> Foo<E> {
+  Foo {}
+}
+
+fn main() {
+  let foo = make<error>()
+  let _ = foo.bar()
+}
+        "#,
+    )
+    .assert_infer_code("missing_constraint_on_return_type");
+}


### PR DESCRIPTION
Fix #1021