### PR TITLE
fix: reject non-constructor names in match patterns

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -371,59 +371,44 @@ impl InferCtx<'_, '_> {
         let is_bare_name =
             fields.is_empty() && !identifier.contains('.') && !kind.is_pattern_position();
 
-        let bare_variant_ty = if kind.is_match_arm() {
-            self.resolve_bare_variant_type(&identifier, &expected_ty)
-        } else {
-            None
-        };
-
-        let ty = if let Some(ty) = bare_variant_ty {
+        let constructor_ty = if kind.is_match_arm()
+            && let Some(ty) = self.resolve_bare_variant_type(&identifier, &expected_ty)
+        {
             ty
-        } else if let Some(ty) = self.lookup_type(store, &identifier) {
+        } else if let Some(value_ty) = self.lookup_type(store, &identifier) {
+            if matches!(self.instantiate(&value_ty).0, Type::Error) {
+                return (Pattern::WildCard { span }, TypedPattern::Wildcard);
+            }
+            let Some(ty) =
+                self.resolve_pattern_constructor(&identifier, &expected_ty, is_bare_name)
+            else {
+                return self.reject_non_constructor_pattern(
+                    &identifier,
+                    &expected_ty,
+                    span,
+                    kind,
+                    is_bare_name,
+                );
+            };
             ty
         } else if let Some((alias_ty, _)) = self.try_resolve_type_alias_variant(&identifier) {
             alias_ty
         } else {
-            if is_bare_name {
-                self.sink
-                    .push(diagnostics::infer::uppercase_binding(span, &identifier));
-                return (Pattern::WildCard { span }, TypedPattern::Wildcard);
-            }
-            let enum_info = self.get_enum_variant_info(&expected_ty);
-            let bare_name = unqualified_name(&identifier);
-            self.sink
-                .push(diagnostics::infer::enum_variant_constructor_not_found(
-                    span,
-                    enum_info.as_ref().map(|(n, v)| (n.as_str(), v.as_slice())),
-                    bare_name,
-                    kind.is_match_arm(),
-                ));
-            return (Pattern::WildCard { span }, TypedPattern::Wildcard);
+            return self.reject_non_constructor_pattern(
+                &identifier,
+                &expected_ty,
+                span,
+                kind,
+                is_bare_name,
+            );
         };
 
-        let (value_constructor_type, _) = self.instantiate(&ty);
-
-        if is_bare_name
-            && matches!(
-                &value_constructor_type,
-                Type::Nominal { .. } | Type::Compound { .. } | Type::Simple(_)
-            )
-            && !self.is_enum_type(store, &value_constructor_type)
-        {
-            self.sink
-                .push(diagnostics::infer::uppercase_binding(span, &identifier));
-            return (Pattern::WildCard { span }, TypedPattern::Wildcard);
-        }
-
-        let (pattern_ty, params) = match value_constructor_type {
+        let (pattern_ty, params) = match self.instantiate(&constructor_ty).0 {
             Type::Function(f) => {
                 let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                 (*f.return_type, f.params)
             }
-            Type::Nominal { .. } | Type::Compound { .. } | Type::Simple(_) => {
-                (value_constructor_type, vec![])
-            }
-            _ => unreachable!(),
+            other => (other, vec![]),
         };
 
         let unify_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
@@ -500,6 +485,99 @@ impl InferCtx<'_, '_> {
             span,
         };
         (pattern, typed)
+    }
+
+    fn resolve_pattern_constructor(
+        &self,
+        identifier: &str,
+        expected_ty: &Type,
+        is_bare_name: bool,
+    ) -> Option<Type> {
+        if let Some(ty) = self.resolve_variant_type(identifier, expected_ty) {
+            return Some(ty);
+        }
+        let definition = self.resolve_struct_definition(identifier)?;
+        match &definition.body {
+            DefinitionBody::Struct {
+                constructor: Some(constructor_ty),
+                ..
+            } => Some(constructor_ty.clone()),
+            _ if !is_bare_name && self.scrutinee_is_interface(expected_ty) => {
+                Some(definition.ty().clone())
+            }
+            _ => None,
+        }
+    }
+
+    fn scrutinee_is_interface(&self, expected_ty: &Type) -> bool {
+        let store = self.store;
+        let resolved = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
+        store.is_interface(&resolved)
+    }
+
+    fn resolve_variant_type(&self, identifier: &str, expected_ty: &Type) -> Option<Type> {
+        let store = self.store;
+        // A bare name is a variant of the scrutinee's enum, if any.
+        if !identifier.contains('.') {
+            return self.resolve_bare_variant_type(identifier, expected_ty);
+        }
+        // A qualified name is a variant when it is an enum's own nested member.
+        let qualified = self.lookup_qualified_name(store, identifier)?;
+        let (parent, variant_name) = qualified.rsplit_once('.')?;
+        let variant = store
+            .variants_of(parent)?
+            .iter()
+            .find(|v| v.name == variant_name)?;
+        if let Some(ty) = store.get_type(&qualified) {
+            return Some(ty.clone());
+        }
+        variant
+            .fields
+            .is_empty()
+            .then(|| store.get_type(parent).cloned())
+            .flatten()
+    }
+
+    fn resolve_struct_definition(&self, identifier: &str) -> Option<&Definition> {
+        let store = self.store;
+        let qualified_name = self.lookup_qualified_name(store, identifier)?;
+        let definition = store.get_definition(&qualified_name)?;
+        match &definition.body {
+            DefinitionBody::Struct { .. } => Some(definition),
+            DefinitionBody::TypeAlias { .. } => {
+                let underlying = store.deep_resolve_alias(definition.ty().unwrap_forall());
+                let Type::Nominal { id, .. } = underlying else {
+                    return None;
+                };
+                let target = store.get_definition(&id)?;
+                matches!(target.body, DefinitionBody::Struct { .. }).then_some(target)
+            }
+            _ => None,
+        }
+    }
+
+    fn reject_non_constructor_pattern(
+        &mut self,
+        identifier: &str,
+        expected_ty: &Type,
+        span: Span,
+        kind: BindingKind,
+        is_bare_name: bool,
+    ) -> (Pattern, TypedPattern) {
+        if is_bare_name {
+            self.sink
+                .push(diagnostics::infer::uppercase_binding(span, identifier));
+        } else {
+            let enum_info = self.get_enum_variant_info(expected_ty);
+            self.sink
+                .push(diagnostics::infer::enum_variant_constructor_not_found(
+                    span,
+                    enum_info.as_ref().map(|(n, v)| (n.as_str(), v.as_slice())),
+                    unqualified_name(identifier),
+                    kind.is_match_arm(),
+                ));
+        }
+        (Pattern::WildCard { span }, TypedPattern::Wildcard)
     }
 
     fn try_infer_const_pattern(

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -1900,6 +1900,86 @@ fn recursive_enum_pattern_matching() {
 }
 
 #[test]
+fn match_on_variant_named_never() {
+    infer(
+        r#"
+    enum Signal {
+      Never,
+      Sometimes,
+    }
+
+    fn test(s: Signal) -> int {
+      match s {
+        Never => 0,
+        Sometimes => 1,
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_tuple_struct_through_alias() {
+    infer(
+        r#"
+    struct Wrap(int)
+    type Alias = Wrap
+
+    fn test(w: Wrap) -> int {
+      match w {
+        Alias(x) => x,
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn match_variant_name_sharing_struct_name() {
+    infer(
+        r#"
+    struct Foo { a: int }
+
+    enum E {
+      Foo,
+      Bar,
+    }
+
+    fn test(e: E) -> int {
+      match e {
+        Foo => 1,
+        Bar => 2,
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn variant_pattern_field_type_ignores_shadowing_function() {
+    infer(
+        r#"
+    enum E { V(string), W }
+
+    fn V(x: int) -> E {
+      E.V("")
+    }
+
+    fn test(e: E) {
+      if let V(x) = e {
+        let y: string = x
+        let _ = y
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn for_loop_over_channel() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1366,6 +1366,255 @@ fn test() {
 }
 
 #[test]
+fn infer_never_type_as_match_pattern() {
+    let input = r#"
+enum Status { Active, Inactive }
+
+fn test(s: Status) {
+  match s {
+    Never => {}
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_never_type_as_if_let_pattern() {
+    let input = r#"
+enum Status { Active, Inactive }
+
+fn test(s: Status) {
+  if let Never = s {}
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_never_type_as_let_pattern() {
+    let input = r#"
+enum Status { Active, Inactive }
+
+fn test(s: Status) {
+  let Never = s
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_never_type_alias_as_match_pattern() {
+    let input = r#"
+type Impossible = Never
+
+enum Status { Active, Inactive }
+
+fn test(s: Status) {
+  match s {
+    Impossible => {}
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_never_type_as_pattern_on_never_scrutinee() {
+    let input = r#"
+fn diverge() -> Never {
+  panic("boom")
+}
+
+fn test() {
+  match diverge() {
+    Never => {}
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_never_type_as_pattern_on_interface_scrutinee() {
+    let input = r#"
+interface Event {}
+
+fn test(e: Event) {
+  match e {
+    Never => {}
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_name_as_match_pattern() {
+    let input = r#"
+struct Point { x: int }
+
+fn test(p: Point) -> int {
+  match p {
+    Point => 0,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_enum_name_as_match_pattern() {
+    let input = r#"
+enum Color { Red, Blue }
+
+fn test(c: Color) -> int {
+  match c {
+    Color => 0,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_alias_as_match_pattern() {
+    let input = r#"
+type Ints = Slice<int>
+
+fn test(xs: Ints) -> int {
+  match xs {
+    Ints => 0,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_type_alias_as_match_pattern() {
+    let input = r#"
+type Callback = fn() -> int
+
+fn test(f: Callback) -> int {
+  match f {
+    Callback => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_as_match_pattern() {
+    let input = r#"
+enum Status { Active, Inactive }
+
+pub fn Pretend() -> Status {
+  Status.Active
+}
+
+fn test(s: Status) -> int {
+  match s {
+    Pretend => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_returning_enum_as_pattern() {
+    let input = r#"
+enum Status { Active, Inactive }
+
+pub fn Make(x: int) -> Status {
+  Status.Active
+}
+
+fn test(s: Status) -> int {
+  match s {
+    Make(x) => x,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_const_of_struct_type_as_interface_pattern() {
+    let input = r#"
+interface Shape {}
+
+struct Token(int)
+
+const ZERO: Token = 0
+
+fn test(s: Shape) -> int {
+  match s {
+    ZERO => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_enum_name_as_pattern_on_interface_scrutinee() {
+    let input = r#"
+interface Event {}
+
+enum Color { Red, Blue }
+
+fn test(e: Event) -> int {
+  match e {
+    Color => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_alias_as_pattern_on_interface_scrutinee() {
+    let input = r#"
+interface Event {}
+
+type Ints = Slice<int>
+
+fn test(e: Event) -> int {
+  match e {
+    Ints => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_type_alias_as_pattern_on_interface_scrutinee() {
+    let input = r#"
+interface Event {}
+
+type Callback = fn() -> int
+
+fn test(e: Event) -> int {
+  match e {
+    Callback => 0,
+    _ => 1,
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_enum_variant_misqualified_in_pattern() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/ui/errors/snapshots/infer_const_of_struct_type_as_interface_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_const_of_struct_type_as_interface_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+    ╭─[test.lis:10:5]
+  9 │   match s {
+ 10 │     ZERO => 0,
+    ·     ──┬─
+    ·       ╰── not found
+ 11 │     _ => 1,
+    ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_name_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_enum_name_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match c {
+ 6 │     Color => 0,
+   ·     ──┬──
+   ·       ╰── not found
+ 7 │   }
+   ╰────
+  help: Available variants for `Color` are `Red` and `Blue` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_name_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_enum_name_as_pattern_on_interface_scrutinee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:8:5]
+ 7 │   match e {
+ 8 │     Color => 0,
+   ·     ──┬──
+   ·       ╰── not found
+ 9 │     _ => 1,
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+    ╭─[test.lis:10:5]
+  9 │   match s {
+ 10 │     Pretend => 0,
+    ·     ───┬───
+    ·        ╰── not found
+ 11 │     _ => 1,
+    ╰────
+  help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_returning_enum_as_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_returning_enum_as_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+    ╭─[test.lis:10:5]
+  9 │   match s {
+ 10 │     Make(x) => x,
+    ·     ───┬───
+    ·        ╰── not found
+ 11 │     _ => 1,
+    ╰────
+  help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_type_alias_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match f {
+ 6 │     Callback => 0,
+   ·     ────┬───
+   ·         ╰── not found
+ 7 │     _ => 1,
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_type_alias_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_function_type_alias_as_pattern_on_interface_scrutinee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:8:5]
+ 7 │   match e {
+ 8 │     Callback => 0,
+   ·     ────┬───
+   ·         ╰── not found
+ 9 │     _ => 1,
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_alias_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:8:5]
+ 7 │   match s {
+ 8 │     Impossible => {}
+   ·     ─────┬────
+   ·          ╰── not found
+ 9 │   }
+   ╰────
+  help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_if_let_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_if_let_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:5:10]
+ 4 │ fn test(s: Status) {
+ 5 │   if let Never = s {}
+   ·          ──┬──
+   ·            ╰── not found
+ 6 │ }
+   ╰────
+  help: Available variants for `Status` are `Status.Active` and `Status.Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_let_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_let_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid binding name
+   ╭─[test.lis:5:7]
+ 4 │ fn test(s: Status) {
+ 5 │   let Never = s
+   ·       ──┬──
+   ·         ╰── binding names must start with a lowercase letter
+ 6 │ }
+   ╰────
+  help: Use a lowercase name instead of `Never` · code: [infer.uppercase_binding]

--- a/tests/ui/errors/snapshots/infer_never_type_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match s {
+ 6 │     Never => {}
+   ·     ──┬──
+   ·       ╰── not found
+ 7 │   }
+   ╰────
+  help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_interface_scrutinee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match e {
+ 6 │     Never => {}
+   ·     ──┬──
+   ·       ╰── not found
+ 7 │   }
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_never_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_never_scrutinee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:8:5]
+ 7 │   match diverge() {
+ 8 │     Never => {}
+   ·     ──┬──
+   ·       ╰── not found
+ 9 │   }
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_struct_name_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_struct_name_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match p {
+ 6 │     Point => 0,
+   ·     ──┬──
+   ·       ╰── not found
+ 7 │   }
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_as_match_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:6:5]
+ 5 │   match xs {
+ 6 │     Ints => 0,
+   ·     ──┬─
+   ·       ╰── not found
+ 7 │   }
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_type_alias_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_as_pattern_on_interface_scrutinee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Variant not found
+   ╭─[test.lis:8:5]
+ 7 │   match e {
+ 8 │     Ints => 0,
+   ·     ──┬─
+   ·       ╰── not found
+ 9 │     _ => 1,
+   ╰────
+  help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]


### PR DESCRIPTION
Fix #1019