### PR TITLE
fix: preserve mutations through `Ref` method receivers

### DIFF
--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -109,10 +109,19 @@ impl Planner<'_> {
             unreachable!("UFCS receiver must be a constructor type");
         };
 
-        let (mut setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) =
-            self.lower_ufcs_call_args(function, receiver, args, spread, &call_plan.resolved);
-        let receiver_arg =
-            self.apply_receiver_coercion(&mut setup, receiver, receiver_arg, *coercion);
+        let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) = self
+            .lower_ufcs_call_args(
+                function,
+                receiver,
+                args,
+                spread,
+                &call_plan.resolved,
+                *coercion,
+            );
+        let receiver_arg = match coercion {
+            Some(ReceiverCoercion::AutoDeref) => format!("*{receiver_arg}"),
+            Some(ReceiverCoercion::AutoAddress) | None => receiver_arg,
+        };
 
         if let Some(inlined) =
             try_inline_native_ufcs(self, receiver, member, &receiver_arg, &emitted_args)
@@ -176,6 +185,7 @@ impl Planner<'_> {
         args: &[Expression],
         spread: Option<&Expression>,
         callee: &ResolvedCallee<'_>,
+        coercion: Option<ReceiverCoercion>,
     ) -> (Vec<LoweredStatement>, String, Vec<String>, bool) {
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
@@ -183,7 +193,11 @@ impl Planner<'_> {
         // into prelude helpers like `lisette.OptionAndThen`.
         let mut all_stages: Vec<ValuePlan> =
             Vec::with_capacity(1 + args.len() + spread.is_some() as usize);
-        all_stages.push(self.stage_operand(receiver, ExpressionContext::value()));
+        let mut receiver_stage = self.stage_operand(receiver, ExpressionContext::value());
+        if coercion == Some(ReceiverCoercion::AutoAddress) {
+            receiver_stage = self.coerce_receiver_address_stage(receiver, receiver_stage);
+        }
+        all_stages.push(receiver_stage);
         for (i, arg) in args.iter().enumerate() {
             let param = callee.abi.param(i);
             let declared = (!callee.is_prelude_dispatch)
@@ -270,24 +284,28 @@ impl Planner<'_> {
         format!("{}{}", qualified_method_name, type_args_string)
     }
 
-    fn apply_receiver_coercion(
+    fn coerce_receiver_address_stage(
         &mut self,
-        setup: &mut Vec<LoweredStatement>,
         receiver: &Expression,
-        receiver_arg: String,
-        coercion: Option<ReceiverCoercion>,
-    ) -> String {
-        match coercion {
-            Some(ReceiverCoercion::AutoAddress) => {
-                if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
-                    let tmp = self.hoist_tmp_value_statement(setup, "ref", &receiver_arg);
-                    format!("&{}", tmp)
-                } else {
-                    format!("&{}", receiver_arg)
-                }
-            }
-            Some(ReceiverCoercion::AutoDeref) => format!("*{}", receiver_arg),
-            None => receiver_arg,
+        mut stage: ValuePlan,
+    ) -> ValuePlan {
+        let value = stage.expression.rendered();
+        if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", &value);
+            stage.expression = GoExpression::opaque(format!("&{tmp}"));
+            return stage.into_addressed_location();
+        }
+        let addressed = format!("&{value}");
+        if matches!(receiver.unwrap_parens(), Expression::Identifier { .. }) {
+            stage.expression = GoExpression::opaque(addressed);
+            stage.into_addressed_location()
+        } else if stage.setup.is_empty() {
+            stage.expression = GoExpression::opaque(addressed);
+            stage.make_observable_computed();
+            stage
+        } else {
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", &addressed);
+            ValuePlan::captured(stage.setup, tmp)
         }
     }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -559,6 +559,12 @@ impl ValuePlan {
         self.make_observable();
     }
 
+    pub(crate) fn into_addressed_location(mut self) -> Self {
+        self.evaluation.form = OperandForm::Other;
+        self.evaluation.stability = Stability::StableAcrossCalls;
+        self
+    }
+
     pub(crate) fn replace_with_pinned_name(&mut self, name: String) {
         self.expression = GoExpression::name(name);
         self.evaluation.form = OperandForm::Name;

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1942,6 +1942,111 @@ fn run() -> Result<int, error> {
 }
 
 #[test]
+fn auto_addressed_receiver_is_not_copied_before_effectful_arg() {
+    let input = r#"
+struct Foo { count: int }
+
+impl Foo {
+  fn add<T>(self: Ref<Foo>, _val: Bar) {
+    self.count += 1
+  }
+}
+
+struct Bar {}
+
+impl Bar {
+  fn new() -> Bar {
+    Bar {}
+  }
+}
+
+fn run() {
+  let mut foo = Foo { count: 0 }
+  foo.add<int>(Bar.new())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn auto_addressed_index_receiver_pinned_before_effectful_arg() {
+    let input = r#"
+struct Cell { v: int }
+
+impl Cell {
+  fn add<T>(self: Ref<Cell>, delta: int) {
+    self.v += delta
+  }
+}
+
+fn bump(i: Ref<int>) -> int {
+  i.* = 1
+  7
+}
+
+fn run() {
+  let mut items = [Cell { v: 0 }, Cell { v: 0 }]
+  let mut i = 0
+  items[i].add<int>(bump(&i))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn auto_addressed_struct_literal_receiver_pinned_before_effectful_arg() {
+    let input = r#"
+struct Cell { v: int }
+
+impl Cell {
+  fn add<T>(self: Ref<Cell>, delta: int) {
+    self.v += delta
+  }
+}
+
+fn bump(i: Ref<int>) -> int {
+  i.* = 1
+  7
+}
+
+fn run() {
+  let mut i = 0
+  Cell { v: i }.add<int>(bump(&i))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg() {
+    let input = r#"
+struct Cell { a: int, b: int }
+
+impl Cell {
+  fn add<T>(self: Ref<Cell>, delta: int) {
+    self.b += delta
+  }
+}
+
+fn seed() -> Result<int, error> {
+  Ok(1)
+}
+
+fn bump(i: Ref<int>) -> Result<int, error> {
+  i.* = 99
+  Ok(7)
+}
+
+fn run() -> Result<(), error> {
+  let mut i = 0
+  Cell { a: seed()?, b: i }.add<int>(bump(&i)?)
+  Ok(())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn discarded_tail_call_to_go_builtin_uses_underscore() {
     let input = r#"
 fn test() {

--- a/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Cell { v: int }
+  
+  impl Cell {
+    fn add<T>(self: Ref<Cell>, delta: int) {
+      self.v += delta
+    }
+  }
+  
+  fn bump(i: Ref<int>) -> int {
+    i.* = 1
+    7
+  }
+  
+  fn run() {
+    let mut items = [Cell { v: 0 }, Cell { v: 0 }]
+    let mut i = 0
+    items[i].add<int>(bump(&i))
+  }
+---
+package main
+
+type Cell struct {
+	v int
+}
+
+func Cell_add[T any](self *Cell, delta int) {
+	self.v += delta
+}
+
+func bump(i *int) int {
+	*i = 1
+	return 7
+}
+
+func run() {
+	items := []Cell{Cell{v: 0}, Cell{v: 0}}
+	i := 0
+	_arg_1 := &items[i]
+	Cell_add[int](_arg_1, bump(&i))
+}

--- a/tests/spec/emit/snapshots/auto_addressed_receiver_is_not_copied_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_receiver_is_not_copied_before_effectful_arg.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Foo { count: int }
+  
+  impl Foo {
+    fn add<T>(self: Ref<Foo>, _val: Bar) {
+      self.count += 1
+    }
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn new() -> Bar {
+      Bar {}
+    }
+  }
+  
+  fn run() {
+    let mut foo = Foo { count: 0 }
+    foo.add<int>(Bar.new())
+  }
+---
+package main
+
+type Foo struct {
+	count int
+}
+
+func Foo_add[T any](self *Foo, _ Bar) {
+	self.count++
+}
+
+type Bar struct{}
+
+func Bar_new() Bar {
+	return Bar{}
+}
+
+func run() {
+	foo := Foo{count: 0}
+	Foo_add[int](&foo, Bar_new())
+}

--- a/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
@@ -1,0 +1,80 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Cell { a: int, b: int }
+  
+  impl Cell {
+    fn add<T>(self: Ref<Cell>, delta: int) {
+      self.b += delta
+    }
+  }
+  
+  fn seed() -> Result<int, error> {
+    Ok(1)
+  }
+  
+  fn bump(i: Ref<int>) -> Result<int, error> {
+    i.* = 99
+    Ok(7)
+  }
+  
+  fn run() -> Result<(), error> {
+    let mut i = 0
+    Cell { a: seed()?, b: i }.add<int>(bump(&i)?)
+    Ok(())
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Cell struct {
+	a int
+	b int
+}
+
+func Cell_add[T any](self *Cell, delta int) {
+	self.b += delta
+}
+
+func seed() (int, error) {
+	return 1, nil
+}
+
+func bump(i *int) (int, error) {
+	*i = 99
+	return 7, nil
+}
+
+func run() error {
+	i := 0
+	ret_1, ret_2 := seed()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	check_4 := result_3
+	if check_4.Tag != lisette.ResultOk {
+		return check_4.ErrVal
+	}
+	ref_5 := &Cell{
+		a: check_4.OkVal,
+		b: i,
+	}
+	ret_6, ret_7 := bump(&i)
+	var result_8 lisette.Result[int, error]
+	if ret_7 != nil {
+		result_8 = lisette.MakeResultErr[int, error](ret_7)
+	} else {
+		result_8 = lisette.MakeResultOk[int, error](ret_6)
+	}
+	check_9 := result_8
+	if check_9.Tag != lisette.ResultOk {
+		return check_9.ErrVal
+	}
+	Cell_add[int](ref_5, check_9.OkVal)
+	return nil
+}

--- a/tests/spec/emit/snapshots/auto_addressed_struct_literal_receiver_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_struct_literal_receiver_pinned_before_effectful_arg.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Cell { v: int }
+  
+  impl Cell {
+    fn add<T>(self: Ref<Cell>, delta: int) {
+      self.v += delta
+    }
+  }
+  
+  fn bump(i: Ref<int>) -> int {
+    i.* = 1
+    7
+  }
+  
+  fn run() {
+    let mut i = 0
+    Cell { v: i }.add<int>(bump(&i))
+  }
+---
+package main
+
+type Cell struct {
+	v int
+}
+
+func Cell_add[T any](self *Cell, delta int) {
+	self.v += delta
+}
+
+func bump(i *int) int {
+	*i = 1
+	return 7
+}
+
+func run() {
+	i := 0
+	_arg_1 := &Cell{v: i}
+	Cell_add[int](_arg_1, bump(&i))
+}


### PR DESCRIPTION
Fix #1022