### PR TITLE
fix: preserve interface type in optional field

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -11,6 +11,7 @@ use syntax::types::{
 use super::super::carry_mut::can_carry_mutation_across_fn_boundary;
 use super::super::unify::Dispatched;
 use super::primitives::contains_deref;
+use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
 use crate::checker::registration::test_functions::normalize_test_params;
 use crate::store::ENTRY_MODULE_ID;
@@ -509,10 +510,9 @@ impl InferCtx<'_, '_> {
                 .push(diagnostics::infer::cannot_infer_type_argument(span));
         }
 
-        // Use expected_ty for generic containers (Option, Result) when it has
-        // interface type parameters. This ensures coercion like `Option<Printable>`
-        // from `Some(Text{...})` gets the correct type for codegen.
+        // Widen to the expected interface container for codegen, only when the return is the same container.
         let call_ty = if !expected_ty.is_variable()
+            && same_nominal(&resolved_expected, &resolved_return)
             && self.is_generic_container_with_interface(store, expected_ty)
         {
             expected_ty.clone()

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -597,7 +597,7 @@ impl InferCtx<'_, '_> {
     }
 }
 
-fn same_nominal(a: &Type, b: &Type) -> bool {
+pub(super) fn same_nominal(a: &Type, b: &Type) -> bool {
     matches!(
         (a, b),
         (Type::Nominal { id: ai, .. }, Type::Nominal { id: bi, .. }) if ai == bi

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -782,3 +782,31 @@ fn main() {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[]);
 }
+
+#[test]
+fn call_returning_go_interface_widens_into_option_field() {
+    let input = r#"
+import "go:example.com/srv"
+
+fn setup_handler() -> srv.Handler {
+  srv.NewHandler()
+}
+
+fn main() {
+  let _ = &srv.Server { Addr: ":8000", Handler: setup_handler(), .. }
+}
+"#;
+    let typedef = r#"
+pub interface Handler {
+  fn Serve()
+}
+
+pub struct Server {
+  pub Addr: string,
+  pub Handler: Option<Handler>,
+}
+
+pub fn NewHandler() -> Handler
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/srv", typedef)]);
+}

--- a/tests/spec/emit/snapshots/call_returning_go_interface_widens_into_option_field.snap
+++ b/tests/spec/emit/snapshots/call_returning_go_interface_widens_into_option_field.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  import "go:example.com/srv"
+  
+  fn setup_handler() -> srv.Handler {
+    srv.NewHandler()
+  }
+  
+  fn main() {
+    let _ = &srv.Server { Addr: ":8000", Handler: setup_handler(), .. }
+  }
+---
+package main
+
+import "example.com/srv"
+
+func setup_handler() srv.Handler {
+	return srv.NewHandler()
+}
+
+func main() {
+	_ = &srv.Server{
+		Addr:    ":8000",
+		Handler: setup_handler(),
+	}
+}


### PR DESCRIPTION
Fix #1036