### PR TITLE
fix: reject missing transitive generic bounds

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1295,6 +1295,21 @@ pub fn missing_bound_on_param(
         ))
 }
 
+pub fn missing_transitive_bound(
+    param_name: &str,
+    required_bound: &str,
+    referenced_type: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Missing bound on type parameter")
+        .with_infer_code("missing_transitive_bound")
+        .with_span_label(&span, format!("must satisfy `{required_bound}`"))
+        .with_help(format!(
+            "`{}` requires its type argument to satisfy `{}`. Add the bound: `{}: {}`",
+            referenced_type, required_bound, param_name, required_bound
+        ))
+}
+
 pub fn division_by_zero(span: Span, ieee: bool) -> LisetteDiagnostic {
     let help = if ieee {
         "This operation evaluates to `+Inf`, `-Inf`, or `NaN` at runtime, which is almost never intended"

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -106,6 +106,13 @@ fn strip_self_referential_bounds(generics: &[Generic], interface_name: &str) -> 
                 .filter(|ann| !bound_references_interface(ann, interface_name))
                 .cloned()
                 .collect(),
+            resolved_bounds: g
+                .bounds
+                .iter()
+                .zip(&g.resolved_bounds)
+                .filter(|(ann, _)| !bound_references_interface(ann, interface_name))
+                .map(|(_, ty)| ty.clone())
+                .collect(),
             span: g.span,
         })
         .collect()

--- a/crates/semantics/src/cache/bounds.rs
+++ b/crates/semantics/src/cache/bounds.rs
@@ -1,0 +1,222 @@
+use diagnostics::LocalSink;
+use rustc_hash::FxHashSet;
+use syntax::ast::{Expression, Generic};
+use syntax::program::{FileImport, Visibility};
+use syntax::types::Symbol;
+
+use crate::checker::{FileContextKind, TaskState};
+use crate::prelude::PRELUDE_MODULE_ID;
+use crate::store::Store;
+
+struct CachedFileBounds {
+    file_id: u32,
+    items: Vec<Expression>,
+    missing_types: Vec<Expression>,
+    imports: Vec<FileImport>,
+}
+
+pub(crate) fn restore_cached_generic_bounds(
+    store: &mut Store,
+    sink: &LocalSink,
+    cached_modules: &FxHashSet<String>,
+) {
+    let mut checker = TaskState::with_fresh_allocator(sink);
+    let module_ids = store.module_ids.clone();
+    for module_id in module_ids {
+        restore_module_bounds(
+            &mut checker,
+            store,
+            &module_id,
+            cached_modules.contains(&module_id),
+        );
+    }
+}
+
+fn restore_module_bounds(
+    checker: &mut TaskState,
+    store: &mut Store,
+    module_id: &str,
+    scan_missing_types: bool,
+) {
+    let Some(module) = store.get_module(module_id) else {
+        return;
+    };
+    let pending: FxHashSet<Symbol> = module
+        .definitions
+        .iter()
+        .filter_map(|(name, definition)| {
+            let generics = definition.body.generics()?;
+            if generics.iter().any(needs_restoration) {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    if pending.is_empty() && !scan_missing_types {
+        return;
+    }
+    let cached_names: FxHashSet<Symbol> = module.definitions.keys().cloned().collect();
+    let sources: Vec<(u32, String)> = module
+        .files
+        .values()
+        .chain(module.typedefs.values())
+        .filter(|file| file.items.is_empty() && !file.is_test())
+        .map(|file| (file.id, file.source.clone()))
+        .collect();
+    let files: Vec<CachedFileBounds> = sources
+        .into_iter()
+        .map(|(file_id, source)| {
+            let items = syntax::build_ast(&source, file_id).ast;
+            let imports = cached_imports(&items);
+            let missing_types = items
+                .iter()
+                .filter(|item| {
+                    type_name(item).is_some_and(|name| {
+                        !cached_names.contains(&Symbol::from_parts(module_id, name))
+                    })
+                })
+                .cloned()
+                .collect();
+            CachedFileBounds {
+                file_id,
+                items,
+                missing_types,
+                imports,
+            }
+        })
+        .collect();
+    if pending.is_empty() && files.iter().all(|file| file.missing_types.is_empty()) {
+        return;
+    }
+
+    for file in &files {
+        if file.missing_types.is_empty() {
+            continue;
+        }
+        checker.with_file_context_mut(
+            store,
+            module_id,
+            file.file_id,
+            &file.imports,
+            file_context_kind(module_id),
+            |checker, store| {
+                checker.register_type_names(store, &file.missing_types, &Visibility::Private);
+            },
+        );
+    }
+
+    for file in &files {
+        if file.missing_types.is_empty() {
+            continue;
+        }
+        checker.with_file_context_mut(
+            store,
+            module_id,
+            file.file_id,
+            &file.imports,
+            file_context_kind(module_id),
+            |checker, store| checker.register_type_definitions(store, &file.missing_types),
+        );
+    }
+
+    for file in files {
+        let definitions: Vec<(Symbol, Vec<Generic>)> = file
+            .items
+            .iter()
+            .filter_map(|item| {
+                let (name, generics) = type_generics(item)?;
+                let name = Symbol::from_parts(module_id, name);
+                pending.contains(&name).then(|| (name, generics.to_vec()))
+            })
+            .collect();
+        if definitions.is_empty() {
+            continue;
+        }
+        checker.with_file_context_mut(
+            store,
+            module_id,
+            file.file_id,
+            &file.imports,
+            file_context_kind(module_id),
+            |checker, store| {
+                for (name, generics) in definitions {
+                    let Some(span) = generics.first().map(|generic| generic.span) else {
+                        continue;
+                    };
+                    checker.scopes.push();
+                    checker.put_in_scope(&generics);
+                    let resolved = checker.resolve_generic_bounds(&*store, &generics, &span);
+                    checker.scopes.pop();
+
+                    let Some(definition) = store
+                        .get_module_mut(module_id)
+                        .and_then(|module| module.definitions.get_mut(&name))
+                    else {
+                        continue;
+                    };
+                    if let Some(target) = definition.body.generics_mut() {
+                        target.clone_from_slice(&resolved);
+                    }
+                }
+            },
+        );
+    }
+}
+
+fn cached_imports(items: &[Expression]) -> Vec<FileImport> {
+    items
+        .iter()
+        .filter_map(|item| {
+            let Expression::ModuleImport {
+                name,
+                name_span,
+                alias,
+                span,
+            } = item
+            else {
+                return None;
+            };
+            Some(FileImport {
+                name: name.clone(),
+                name_span: *name_span,
+                alias: alias.clone(),
+                span: *span,
+            })
+        })
+        .collect()
+}
+
+fn type_name(expression: &Expression) -> Option<&str> {
+    match expression {
+        Expression::Enum { name, .. }
+        | Expression::Struct { name, .. }
+        | Expression::Interface { name, .. }
+        | Expression::TypeAlias { name, .. } => Some(name),
+        _ => None,
+    }
+}
+
+fn type_generics(expression: &Expression) -> Option<(&str, &[Generic])> {
+    match expression {
+        Expression::Enum { name, generics, .. }
+        | Expression::Struct { name, generics, .. }
+        | Expression::Interface { name, generics, .. }
+        | Expression::TypeAlias { name, generics, .. } => Some((name, generics)),
+        _ => None,
+    }
+}
+
+fn file_context_kind(module_id: &str) -> FileContextKind {
+    if module_id == PRELUDE_MODULE_ID {
+        FileContextKind::Prelude
+    } else if module_id.starts_with("go:") {
+        FileContextKind::ImportedTypedef
+    } else {
+        FileContextKind::Standard
+    }
+}
+
+fn needs_restoration(generic: &Generic) -> bool {
+    generic.bounds.len() != generic.resolved_bounds.len()
+}

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -1,6 +1,9 @@
+mod bounds;
 pub mod go_stdlib;
 pub mod prelude;
 pub mod types;
+
+pub(crate) use bounds::restore_cached_generic_bounds;
 
 use crate::path::DisplayPathBase;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -58,6 +58,7 @@ impl CachedGeneric {
         Generic {
             name: EcoString::from(self.name.as_str()),
             bounds: self.bounds.clone(),
+            resolved_bounds: vec![],
             span: self.span.to_span(file_ids),
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -434,19 +434,23 @@ fn interface_closure_any(
     start: &Type,
     mut predicate: impl FnMut(&Type) -> bool,
 ) -> bool {
-    let mut stack = vec![store.deep_resolve_alias(start)];
-    let mut seen: Vec<Type> = Vec::new();
-    while let Some(current) = stack.pop() {
-        if predicate(&current) {
-            return true;
-        }
+    let mut stack = vec![(store.deep_resolve_alias(start), Vec::<String>::new())];
+    let mut seen = Vec::new();
+    while let Some((current, mut path)) = stack.pop() {
         if seen.contains(&current) {
             continue;
         }
         seen.push(current.clone());
+        if predicate(&current) {
+            return true;
+        }
         let Some(id) = current.get_qualified_id() else {
             continue;
         };
+        if path.iter().any(|seen_id| seen_id == id) {
+            continue;
+        }
+        path.push(id.to_string());
         let Some(interface) = store.get_interface(id) else {
             continue;
         };
@@ -455,7 +459,10 @@ fn interface_closure_any(
             current.get_type_params().unwrap_or_default(),
         );
         for parent in &interface.parents {
-            stack.push(store.deep_resolve_alias(&substitute(parent, &map)));
+            stack.push((
+                store.deep_resolve_alias(&substitute(parent, &map)),
+                path.clone(),
+            ));
         }
     }
     false

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1,4 +1,4 @@
-use crate::checker::EnvResolve;
+use crate::checker::{EnvResolve, resolved_generic_bounds};
 use ecow::EcoString;
 use syntax::ast::BindingKind;
 use syntax::ast::{Annotation, Binding, Expression, Pattern, Span, StructKind};
@@ -125,20 +125,8 @@ impl InferCtx<'_, '_> {
         self.scopes.push();
 
         self.put_in_scope(&generics);
-
-        let mut bounds = vec![];
-
-        for generic in &generics {
-            for bound in &generic.bounds {
-                let bound_ty = self.register_generic_bound(store, &generic.name, bound, &span);
-
-                bounds.push(Bound {
-                    param_name: generic.name.clone(),
-                    generic: Type::Parameter(generic.name.clone()),
-                    ty: bound_ty,
-                });
-            }
-        }
+        let generics = self.ensure_generic_bounds(store, generics, &span);
+        let bounds = resolved_generic_bounds(&generics);
 
         let resolved_expected = expected_ty.resolve_in(&self.env);
         let expected_params = resolved_expected.get_function_params().unwrap_or_default();
@@ -1249,7 +1237,7 @@ impl InferCtx<'_, '_> {
                     binding
                         .annotation
                         .as_ref()
-                        .map(|a| self.convert_to_type_inner(store, a, pattern_span, true, true))
+                        .map(|a| self.convert_variadic_to_type(store, a, pattern_span))
                         .unwrap_or_else(|| self.new_type_var())
                 });
 

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -18,15 +18,10 @@ impl InferCtx<'_, '_> {
         self.scopes.push();
 
         self.put_in_scope(&generics);
-
-        for generic in &generics {
-            for bound in &generic.bounds {
-                self.register_generic_bound(store, &generic.name, bound, &span);
-            }
-        }
+        let generics = self.ensure_generic_bounds(store, generics, &span);
 
         self.check_undeclared_impl_type_params(&annotation, &generics);
-        let impl_ty = self.convert_to_type_inner(store, &annotation, &span, false, false);
+        let impl_ty = self.convert_receiver_to_type(store, &annotation, &span);
 
         if self.impl_has_simple_type_params(&impl_ty, &generics) {
             let receiver_qualified = impl_ty.get_qualified_name();
@@ -106,7 +101,7 @@ impl InferCtx<'_, '_> {
 
         self.scopes.push();
         self.put_in_scope(&generics);
-        self.validate_generic_bounds(store, &generics, &span);
+        let generics = self.ensure_generic_bounds(store, generics, &span);
 
         // Interface method parameters are declarations, not implementations — they
         // have no body and are always "unused". Remove their bindings so the unused

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -36,6 +36,22 @@ fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
 }
 
 impl InferCtx<'_, '_> {
+    pub(crate) fn check_concrete_bound(&mut self, ty: &Type, bound: &Type, span: &Span) {
+        let bound = self.store.deep_resolve_alias(bound);
+        let Type::Nominal { id, params, .. } = bound else {
+            return;
+        };
+        let Some(interface) = self.store.get_interface(&id).cloned() else {
+            return;
+        };
+        if self
+            .satisfies_interface(ty, &interface, &id, &params, span)
+            .is_ok()
+        {
+            let _ = self.check_pointer_receivers(ty, &interface, &id, span);
+        }
+    }
+
     pub(super) fn satisfies_interface(
         &mut self,
         ty: &Type,

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -22,7 +22,7 @@ use syntax::program::{
     Definition, DefinitionBody, File, FileImport, MethodSignatures, Module, NativeTypeKind,
     go_import_default_name,
 };
-use syntax::types::{SubstitutionMap, Symbol, Type, substitute};
+use syntax::types::{Bound, SubstitutionMap, Symbol, Type, substitute};
 
 pub use infer::expressions::comparison::{check_never_comparable, check_not_comparable};
 pub use type_env::{EnvResolve, Speculation, TypeEnv, VarState};
@@ -127,10 +127,7 @@ pub struct TaskState<'s> {
     pub ufcs_shared: Option<Arc<HashSet<(String, String)>>>,
     /// Typed files produced by inference.
     pub typed_files: Vec<(String, File)>,
-    /// Reentrancy counter: > 0 while resolving a generic bound annotation.
-    /// Lets `convert_to_type` admit bound-only markers (e.g. `Comparable`)
-    /// without flagging them as misuse in value positions.
-    pub bound_position_depth: u32,
+    pub(crate) pending_generic_bound_checks: Vec<(Type, Type, Span)>,
 }
 
 impl<'s> TaskState<'s> {
@@ -150,7 +147,7 @@ impl<'s> TaskState<'s> {
             ufcs_methods: HashSet::default(),
             ufcs_shared: None,
             typed_files: Vec::new(),
-            bound_position_depth: 0,
+            pending_generic_bound_checks: Vec::new(),
         }
     }
 
@@ -264,30 +261,47 @@ impl<'s> TaskState<'s> {
         }
     }
 
-    /// Validate that all bound annotations on generics refer to types that exist in scope.
-    pub(crate) fn validate_generic_bounds(
+    pub(crate) fn resolve_generic_bounds(
         &mut self,
         store: &Store,
         generics: &[Generic],
         span: &Span,
-    ) {
+    ) -> Vec<Generic> {
+        let mut resolved = generics.to_vec();
+        for generic in &mut resolved {
+            generic.resolved_bounds = generic
+                .bounds
+                .iter()
+                .map(|bound| self.register_bound_annotation(store, bound, span))
+                .collect();
+        }
+        self.record_resolved_generic_bounds(&resolved);
+        resolved
+    }
+
+    pub(crate) fn record_resolved_generic_bounds(&mut self, generics: &[Generic]) {
         for generic in generics {
-            for bound in &generic.bounds {
-                self.register_generic_bound(store, &generic.name, bound, span);
+            for bound in &generic.resolved_bounds {
+                self.record_generic_bound(&generic.name, bound.clone());
             }
         }
     }
 
-    pub(crate) fn register_generic_bound(
+    pub(crate) fn ensure_generic_bounds(
         &mut self,
         store: &Store,
-        parameter: &str,
-        bound: &Annotation,
+        generics: Vec<Generic>,
         span: &Span,
-    ) -> Type {
-        let bound_ty = self.register_bound_annotation(store, bound, span);
-        self.record_generic_bound(parameter, bound_ty.clone());
-        bound_ty
+    ) -> Vec<Generic> {
+        if generics
+            .iter()
+            .all(|generic| generic.bounds.len() == generic.resolved_bounds.len())
+        {
+            self.record_resolved_generic_bounds(&generics);
+            generics
+        } else {
+            self.resolve_generic_bounds(store, &generics, span)
+        }
     }
 
     pub(crate) fn record_generic_bound(&mut self, parameter: &str, bound: Type) {
@@ -957,6 +971,19 @@ impl<'s> TaskState<'s> {
         self.env.end_speculation(spec, result.is_err());
         result
     }
+}
+
+pub(crate) fn resolved_generic_bounds(generics: &[Generic]) -> Vec<Bound> {
+    generics
+        .iter()
+        .flat_map(|generic| {
+            generic.resolved_bounds.iter().cloned().map(|ty| Bound {
+                param_name: generic.name.clone(),
+                generic: Type::Parameter(generic.name.clone()),
+                ty,
+            })
+        })
+        .collect()
 }
 
 /// Returns `true` if the given name is reserved and cannot be used as an import alias.

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -521,6 +521,7 @@ mod tests {
                         .map(|g| Generic {
                             name: g.into(),
                             bounds: vec![],
+                            resolved_bounds: vec![],
                             span: Span::dummy(),
                         })
                         .collect(),

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -10,10 +10,35 @@ use syntax::ast::{Annotation, Generic, Span};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{SubstitutionMap, Symbol, Type, substitute, unqualified_name};
 
-use super::impl_bounds::import_module_for_alias;
 use crate::checker::TaskState;
 use crate::prelude::PRELUDE_MODULE_ID;
 use crate::store::Store;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TypePosition {
+    Value,
+    Bound,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TypeArgumentChecks {
+    All,
+    Descendants,
+    Deferred,
+}
+
+impl TypeArgumentChecks {
+    fn current(self) -> bool {
+        self == Self::All
+    }
+
+    fn nested(self) -> Self {
+        match self {
+            Self::Descendants => Self::All,
+            other => other,
+        }
+    }
+}
 
 impl TaskState<'_> {
     /// Resolves a generic-bound annotation. Bound-only markers like
@@ -25,9 +50,14 @@ impl TaskState<'_> {
         annotation: &Annotation,
         span: &Span,
     ) -> Type {
-        self.bound_position_depth += 1;
-        let result = self.convert_to_type(store, annotation, span);
-        self.bound_position_depth -= 1;
+        let result = self.convert_to_type_mode(
+            store,
+            annotation,
+            span,
+            false,
+            TypeArgumentChecks::Deferred,
+            TypePosition::Bound,
+        );
         if !result.contains_error() {
             self.facts
                 .bound_types
@@ -37,16 +67,56 @@ impl TaskState<'_> {
     }
 
     pub fn convert_to_type(&mut self, store: &Store, annotation: &Annotation, span: &Span) -> Type {
-        self.convert_to_type_inner(store, annotation, span, false, true)
+        self.convert_to_type_mode(
+            store,
+            annotation,
+            span,
+            false,
+            TypeArgumentChecks::All,
+            TypePosition::Value,
+        )
     }
 
-    pub(crate) fn convert_to_type_inner(
+    pub(crate) fn convert_variadic_to_type(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+        span: &Span,
+    ) -> Type {
+        self.convert_to_type_mode(
+            store,
+            annotation,
+            span,
+            true,
+            TypeArgumentChecks::All,
+            TypePosition::Value,
+        )
+    }
+
+    pub(crate) fn convert_receiver_to_type(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+        span: &Span,
+    ) -> Type {
+        self.convert_to_type_mode(
+            store,
+            annotation,
+            span,
+            false,
+            TypeArgumentChecks::Descendants,
+            TypePosition::Value,
+        )
+    }
+
+    fn convert_to_type_mode(
         &mut self,
         store: &Store,
         annotation: &Annotation,
         span: &Span,
         variadic_allowed: bool,
-        check_type_argument_bounds: bool,
+        type_argument_checks: TypeArgumentChecks,
+        position: TypePosition,
     ) -> Type {
         match annotation {
             Annotation::Unknown => self.new_type_var(),
@@ -62,11 +132,14 @@ impl TaskState<'_> {
                     .iter()
                     .enumerate()
                     .map(|(index, param)| {
-                        if index == last_param {
-                            self.convert_to_type_inner(store, param, span, true, true)
-                        } else {
-                            self.convert_to_type(store, param, span)
-                        }
+                        self.convert_to_type_mode(
+                            store,
+                            param,
+                            span,
+                            index == last_param,
+                            type_argument_checks.nested(),
+                            TypePosition::Value,
+                        )
                     })
                     .collect();
                 // For function type annotations, omitted return type means Unit (`()`),
@@ -74,7 +147,14 @@ impl TaskState<'_> {
                 let new_return_type = if matches!(return_type.as_ref(), Annotation::Unknown) {
                     self.type_unit()
                 } else {
-                    self.convert_to_type(store, return_type, span)
+                    self.convert_to_type_mode(
+                        store,
+                        return_type,
+                        span,
+                        false,
+                        type_argument_checks.nested(),
+                        TypePosition::Value,
+                    )
                 };
 
                 Type::function(
@@ -120,7 +200,13 @@ impl TaskState<'_> {
 
                 // `Array` carries a const-integer size, so it needs its own path.
                 if type_name == "Array" {
-                    return self.convert_array_annotation(store, params, *annotation_span, span);
+                    return self.convert_array_annotation(
+                        store,
+                        params,
+                        *annotation_span,
+                        span,
+                        type_argument_checks,
+                    );
                 }
 
                 let Some((qualified_name, ty)) =
@@ -160,7 +246,7 @@ impl TaskState<'_> {
                     type_name.len() as u32,
                 );
 
-                if self.bound_position_depth == 0
+                if position == TypePosition::Value
                     && let Some(builtin) =
                         crate::checker::infer::BuiltinBound::from_qualified_id(&qualified_name)
                 {
@@ -179,7 +265,16 @@ impl TaskState<'_> {
 
                 let concrete_args: Vec<Type> = params
                     .iter()
-                    .map(|arg| self.convert_to_type(store, arg, span))
+                    .map(|arg| {
+                        self.convert_to_type_mode(
+                            store,
+                            arg,
+                            span,
+                            false,
+                            type_argument_checks.nested(),
+                            TypePosition::Value,
+                        )
+                    })
                     .collect();
 
                 if generics.len() != params.len() {
@@ -192,7 +287,7 @@ impl TaskState<'_> {
                         *span,
                     ));
                 }
-                if check_type_argument_bounds && qualified_name != "prelude.Map" {
+                if type_argument_checks.current() && qualified_name != "prelude.Map" {
                     self.check_builtin_type_argument_bounds(
                         store,
                         &qualified_name,
@@ -228,7 +323,8 @@ impl TaskState<'_> {
                     }
                 }
 
-                if qualified_name == "prelude.Map"
+                if type_argument_checks.current()
+                    && qualified_name == "prelude.Map"
                     && let Some(key_ty) = resolved_ty
                         .get_type_params()
                         .and_then(|parameters| parameters.first())
@@ -267,7 +363,16 @@ impl TaskState<'_> {
             Annotation::Tuple { elements, .. } => {
                 let element_types = elements
                     .iter()
-                    .map(|e| self.convert_to_type(store, e, span))
+                    .map(|element| {
+                        self.convert_to_type_mode(
+                            store,
+                            element,
+                            span,
+                            false,
+                            type_argument_checks.nested(),
+                            TypePosition::Value,
+                        )
+                    })
                     .collect();
                 Type::Tuple(element_types)
             }
@@ -292,9 +397,17 @@ impl TaskState<'_> {
         params: &[Annotation],
         annotation_span: Span,
         span: &Span,
+        type_argument_checks: TypeArgumentChecks,
     ) -> Type {
         if params.len() == 1 && self.cursor.module_id == PRELUDE_MODULE_ID {
-            let element = self.convert_to_type(store, &params[0], span);
+            let element = self.convert_to_type_mode(
+                store,
+                &params[0],
+                span,
+                false,
+                type_argument_checks.nested(),
+                TypePosition::Value,
+            );
             return Type::Nominal {
                 id: Symbol::from_parts("prelude", "Array"),
                 params: vec![element],
@@ -308,12 +421,26 @@ impl TaskState<'_> {
                 annotation_span,
             ));
             for param in params {
-                let _ = self.convert_to_type(store, param, span);
+                let _ = self.convert_to_type_mode(
+                    store,
+                    param,
+                    span,
+                    false,
+                    type_argument_checks.nested(),
+                    TypePosition::Value,
+                );
             }
             return Type::Error;
         }
 
-        let element = self.convert_to_type(store, &params[0], span);
+        let element = self.convert_to_type_mode(
+            store,
+            &params[0],
+            span,
+            false,
+            type_argument_checks.nested(),
+            TypePosition::Value,
+        );
         if element.contains_error() {
             return Type::Error;
         }
@@ -517,7 +644,7 @@ impl TaskState<'_> {
         }
     }
 
-    fn check_map_key_comparable(&mut self, store: &Store, key_ty: &Type, span: Span) {
+    pub(super) fn check_map_key_comparable(&mut self, store: &Store, key_ty: &Type, span: Span) {
         let resolved = key_ty.resolve_in(&self.env);
 
         if self.is_lis(store) && resolved.resolves_to_unknown() {
@@ -578,28 +705,15 @@ impl TaskState<'_> {
         let Some(definition) = store.get_definition(definition_name) else {
             return;
         };
-        let generics = match &definition.body {
-            DefinitionBody::Struct { generics, .. }
-            | DefinitionBody::Enum { generics, .. }
-            | DefinitionBody::TypeAlias { generics, .. } => generics,
-            DefinitionBody::Interface { definition } => &definition.generics,
-            DefinitionBody::Value { .. } => return,
-        };
-        let Some(module_name) = store.module_for_qualified_name(definition_name) else {
-            return;
-        };
+        let generics = definition.body.generics().unwrap_or_default();
         for (generic, argument) in generics.iter().zip(arguments) {
-            for bound in &generic.bounds {
-                let required = self
-                    .facts
-                    .bound_types
-                    .get(&bound.get_span())
-                    .and_then(Type::get_qualified_id)
-                    .and_then(BuiltinBound::from_qualified_id)
-                    .or_else(|| builtin_bound_from_annotation(store, module_name, bound));
-                if let Some(required) = required {
-                    self.check_builtin_bound_argument(store, argument, required, span);
-                }
+            for required in generic
+                .resolved_bounds
+                .iter()
+                .filter_map(Type::get_qualified_id)
+                .filter_map(BuiltinBound::from_qualified_id)
+            {
+                self.check_builtin_bound_argument(store, argument, required, span);
             }
         }
     }
@@ -658,25 +772,6 @@ impl TaskState<'_> {
                     .push(diagnostics::infer::not_orderable_bound(span));
             }
             BuiltinBound::Ordered => {}
-        }
-    }
-}
-
-fn builtin_bound_from_annotation(
-    store: &Store,
-    definition_module: &str,
-    annotation: &Annotation,
-) -> Option<BuiltinBound> {
-    let Annotation::Constructor { name, .. } = annotation else {
-        return None;
-    };
-    match name.as_str() {
-        "Comparable" | "prelude.Comparable" => Some(BuiltinBound::Comparable),
-        "Ordered" | "prelude.Ordered" | "go:cmp.Ordered" => Some(BuiltinBound::Ordered),
-        _ => {
-            let (alias, bound_name) = name.split_once('.')?;
-            let module = import_module_for_alias(store, definition_module, alias)?;
-            BuiltinBound::from_qualified_id(&format!("{module}.{bound_name}"))
         }
     }
 }

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -5,7 +5,7 @@ use syntax::ast::{Attribute, Expression, Generic, Span, VariantFields};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
 
-use super::{TaskState, wrap_with_impl_generics};
+use super::{TaskState, resolved_generic_bounds, wrap_with_impl_generics};
 use crate::checker::infer::expressions::comparison::{check_not_equatable, param_is_comparable};
 use crate::store::Store;
 
@@ -219,13 +219,7 @@ impl TaskState<'_> {
 
         self.scopes.push();
         self.put_in_scope(&generics);
-        let before = self.sink.len();
-        for generic in &generics {
-            for bound in &generic.bounds {
-                self.register_generic_bound(store, &generic.name, bound, &generic.span);
-            }
-        }
-        self.sink.truncate(before);
+        self.record_resolved_generic_bounds(&generics);
 
         for (field_name, field_span, field_ty) in &fields {
             let reason = check_not_equatable(&self.env, store, field_ty, module_id, &|name| {
@@ -283,34 +277,6 @@ impl TaskState<'_> {
         }
     }
 
-    fn type_generic_bounds(
-        &mut self,
-        store: &Store,
-        qualified: &Symbol,
-        generics: &[Generic],
-    ) -> Vec<syntax::types::Bound> {
-        self.scopes.push();
-        self.put_in_scope(generics);
-        let before = self.sink.len();
-        let mut bounds = Vec::new();
-        for generic in generics {
-            for bound in &generic.bounds {
-                if let Some(bound_ty) =
-                    self.resolve_type_bound(store, bound, &generic.span, qualified)
-                {
-                    bounds.push(syntax::types::Bound {
-                        param_name: generic.name.clone(),
-                        generic: Type::Parameter(generic.name.clone()),
-                        ty: bound_ty,
-                    });
-                }
-            }
-        }
-        self.sink.truncate(before);
-        self.scopes.pop();
-        bounds
-    }
-
     fn synthesize_equals(&mut self, store: &mut Store, module_id: &str, qualified: &Symbol) {
         let Some(scheme) = store.get_type(qualified.as_str()).cloned() else {
             return;
@@ -334,7 +300,7 @@ impl TaskState<'_> {
             Default::default(),
             Box::new(Type::bool()),
         );
-        let impl_bounds = self.type_generic_bounds(store, qualified, &generics);
+        let impl_bounds = resolved_generic_bounds(&generics);
         let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
 
         let equals_key = qualified.with_segment("equals");

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -1,0 +1,178 @@
+use syntax::ast::{Generic, Span};
+use syntax::types::{CompoundKind, SubstitutionMap, Type, substitute, unqualified_name};
+
+use crate::checker::EnvResolve;
+use crate::checker::TaskState;
+use crate::checker::infer::expressions::comparison::bound_implied;
+use crate::checker::infer::{BuiltinBound, InferCtx};
+use crate::store::Store;
+
+impl TaskState<'_> {
+    pub(crate) fn check_transitive_generic_bounds(
+        &mut self,
+        store: &Store,
+        own_generics: &[Generic],
+        declaration_span: Span,
+    ) {
+        for generic in own_generics {
+            for bound in &generic.resolved_bounds {
+                self.check_bound_type(store, own_generics, declaration_span, bound);
+            }
+        }
+    }
+
+    fn check_bound_type(
+        &mut self,
+        store: &Store,
+        own_generics: &[Generic],
+        declaration_span: Span,
+        ty: &Type,
+    ) {
+        if let Type::Nominal { id, params, .. } = ty
+            && !params.is_empty()
+        {
+            self.check_nominal_arguments(store, own_generics, declaration_span, id, params);
+        }
+        if let Type::Compound {
+            kind: CompoundKind::Map,
+            args,
+        } = ty
+            && let Some(key) = args.first()
+        {
+            self.check_map_key_comparable(store, key, declaration_span);
+        }
+        for child in type_argument_children(ty) {
+            self.check_bound_type(store, own_generics, declaration_span, child);
+        }
+    }
+
+    fn check_nominal_arguments(
+        &mut self,
+        store: &Store,
+        own_generics: &[Generic],
+        declaration_span: Span,
+        referenced_id: &str,
+        argument_types: &[Type],
+    ) {
+        let Some(definition) = store.get_definition(referenced_id) else {
+            return;
+        };
+        let referenced_generics = definition.body.generics().unwrap_or_default();
+        let substitution: SubstitutionMap = referenced_generics
+            .iter()
+            .map(|generic| generic.name.clone())
+            .zip(argument_types.iter().cloned())
+            .collect();
+
+        for (referenced_generic, argument_type) in referenced_generics.iter().zip(argument_types) {
+            for declared in &referenced_generic.resolved_bounds {
+                if declared.get_qualified_id() == Some(referenced_id) {
+                    continue;
+                }
+                let required = substitute(declared, &substitution);
+                if required.contains_error() {
+                    continue;
+                }
+                let argument = store.deep_resolve_alias(&argument_type.resolve_in(&self.env));
+                if let Type::Parameter(parameter_name) = &argument {
+                    let Some(parameter_bounds) =
+                        self.parameter_bounds(parameter_name, own_generics)
+                    else {
+                        continue;
+                    };
+                    if !bound_implied(store, &parameter_bounds, &required) {
+                        let span = own_generics
+                            .iter()
+                            .find(|generic| generic.name == *parameter_name)
+                            .map_or(declaration_span, |generic| generic.span);
+                        self.sink.push(diagnostics::infer::missing_transitive_bound(
+                            parameter_name,
+                            &type_bound_display(&required),
+                            unqualified_name(referenced_id),
+                            span,
+                        ));
+                    }
+                } else if let Some(required) = store
+                    .deep_resolve_alias(&required)
+                    .get_qualified_id()
+                    .and_then(BuiltinBound::from_qualified_id)
+                {
+                    self.check_builtin_bound_argument(store, &argument, required, declaration_span);
+                } else if !argument.contains_error()
+                    && !argument.contains_unknown()
+                    && !argument.is_variable()
+                    && store
+                        .deep_resolve_alias(&required)
+                        .get_qualified_id()
+                        .is_some_and(|id| store.get_interface(id).is_some())
+                {
+                    self.pending_generic_bound_checks
+                        .push((argument, required, declaration_span));
+                }
+            }
+        }
+    }
+
+    pub fn check_pending_generic_bounds(&mut self, store: &Store) {
+        let pending = std::mem::take(&mut self.pending_generic_bound_checks);
+        let mut ctx = InferCtx::new(self, store);
+        for (argument, required, span) in pending {
+            ctx.check_concrete_bound(&argument, &required, &span);
+        }
+    }
+
+    fn parameter_bounds(
+        &self,
+        parameter_name: &str,
+        own_generics: &[Generic],
+    ) -> Option<Vec<Type>> {
+        if self.scopes.lookup_type_param(parameter_name).is_some() {
+            let mut bounds = Vec::new();
+            self.scopes
+                .for_each_bound_on_param(parameter_name, |bound| {
+                    bounds.push(bound.resolve_in(&self.env));
+                });
+            return (!bounds.iter().any(Type::contains_error)).then_some(bounds);
+        }
+        let generic = own_generics
+            .iter()
+            .find(|generic| generic.name == parameter_name)?;
+        (!generic.resolved_bounds.iter().any(Type::contains_error))
+            .then(|| generic.resolved_bounds.clone())
+    }
+}
+
+fn type_argument_children(ty: &Type) -> Vec<&Type> {
+    match ty {
+        Type::Nominal { params, .. } => params.iter().collect(),
+        Type::Compound { args, .. } => args.iter().collect(),
+        Type::Array { element, .. } => vec![element],
+        Type::Tuple(elements) => elements.iter().collect(),
+        Type::Function(function) => function
+            .params
+            .iter()
+            .chain(std::iter::once(function.return_type.as_ref()))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn type_bound_display(ty: &Type) -> String {
+    match ty {
+        Type::Nominal { id, params, .. } => {
+            let name = unqualified_name(id).to_string();
+            if params.is_empty() {
+                name
+            } else {
+                let arguments = params
+                    .iter()
+                    .map(type_bound_display)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{name}<{arguments}>")
+            }
+        }
+        Type::Parameter(name) => name.to_string(),
+        other => other.to_string(),
+    }
+}

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use syntax::EcoString;
-use syntax::ast::{Annotation, Generic, Span};
+use syntax::ast::Generic;
 use syntax::program::DefinitionBody;
 use syntax::types::{Bound, Symbol, Type, substitute, unqualified_name};
 
@@ -38,36 +38,16 @@ impl TaskState<'_> {
             })
             .collect();
 
-        self.scopes.push();
-        self.put_in_scope(&type_generics);
-        let before = self.sink.len();
         let mut bounds_by_position = Vec::with_capacity(type_generics.len());
         for generic in &type_generics {
-            let mut resolved_bounds = Vec::with_capacity(generic.bounds.len());
-            for annotation in &generic.bounds {
-                let bound = self
-                    .facts
-                    .bound_types
-                    .get(&annotation.get_span())
-                    .cloned()
-                    .or_else(|| {
-                        self.resolve_type_bound(
-                            store,
-                            annotation,
-                            &generic.span,
-                            receiver_qualified,
-                        )
-                    });
-                if let Some(bound) = bound
-                    && !bound.contains_error()
-                {
-                    resolved_bounds.push(substitute(&bound, &alpha));
-                }
-            }
+            let resolved_bounds: Vec<Type> = generic
+                .resolved_bounds
+                .iter()
+                .filter(|bound| !bound.contains_error())
+                .map(|bound| substitute(bound, &alpha))
+                .collect();
             bounds_by_position.push(resolved_bounds);
         }
-        self.sink.truncate(before);
-        self.scopes.pop();
 
         for (generic, bounds) in impl_generics.iter().zip(&bounds_by_position) {
             for bound in bounds {
@@ -112,121 +92,4 @@ impl TaskState<'_> {
             }
         }
     }
-
-    /// Resolve a type generic's bound annotation to a type, type arguments preserved so
-    /// `Parent<string>` and `Parent<int>` stay distinct.
-    pub(super) fn resolve_type_bound(
-        &mut self,
-        store: &Store,
-        bound: &Annotation,
-        span: &Span,
-        type_qualified: &Symbol,
-    ) -> Option<Type> {
-        let bound_ty = self.register_bound_annotation(store, bound, span);
-        let id = match store.deep_resolve_alias(&bound_ty).get_qualified_id() {
-            Some(id) => id.to_string(),
-            None => self.resolve_type_bound_id(store, bound, span, type_qualified)?,
-        };
-        let type_module = store.module_for_qualified_name(type_qualified.as_str())?;
-        // Arguments come from the annotation, so they survive even when
-        // `register_bound_annotation` drops them or cannot resolve the bound.
-        let params = match bound {
-            Annotation::Constructor { params, .. } => params
-                .iter()
-                .map(|param| self.resolve_bound_arg(store, param, span, type_module))
-                .collect(),
-            _ => Vec::new(),
-        };
-        Some(Type::Nominal {
-            id: id.into(),
-            params,
-            underlying_ty: None,
-        })
-    }
-
-    /// Resolve a bound's type argument to a type. `convert_to_type` handles primitives,
-    /// builtins, and in-scope parameters; an out-of-scope user type is resolved against the
-    /// store instead so it carries the same `Nominal` the method side does.
-    fn resolve_bound_arg(
-        &mut self,
-        store: &Store,
-        annotation: &Annotation,
-        span: &Span,
-        type_module: &str,
-    ) -> Type {
-        let ty = self.convert_to_type(store, annotation, span);
-        if !matches!(ty, Type::Error) {
-            return ty;
-        }
-        let Annotation::Constructor { name, params, .. } = annotation else {
-            return ty;
-        };
-        let Some(id) = resolve_definition_id(store, type_module, name) else {
-            return ty;
-        };
-        let params = params
-            .iter()
-            .map(|param| self.resolve_bound_arg(store, param, span, type_module))
-            .collect();
-        Type::Nominal {
-            id: id.into(),
-            params,
-            underlying_ty: None,
-        }
-    }
-
-    /// Resolve a user interface bound's qualified id when it is out of scope: a bare name
-    /// against the type's own module, or an `alias.Name` against the aliased module.
-    fn resolve_type_bound_id(
-        &mut self,
-        store: &Store,
-        bound: &Annotation,
-        _span: &Span,
-        type_qualified: &Symbol,
-    ) -> Option<String> {
-        let Annotation::Constructor { name, .. } = bound else {
-            return None;
-        };
-        let type_module = store.module_for_qualified_name(type_qualified.as_str())?;
-        let (bound_module, bound_name) = match name.split_once('.') {
-            Some((alias, type_name)) => (
-                import_module_for_alias(store, type_module, alias)?,
-                type_name,
-            ),
-            None => (type_module.to_string(), name.as_str()),
-        };
-        let candidate = Symbol::from_parts(&bound_module, bound_name);
-        matches!(
-            store.get_definition(candidate.as_str()).map(|d| &d.body),
-            Some(DefinitionBody::Interface { .. })
-        )
-        .then(|| candidate.to_string())
-    }
-}
-
-/// Resolve a type name (any definition kind) to its qualified id out of file context:
-/// a bare name against `type_module`, or an `alias.Name` against the aliased module.
-fn resolve_definition_id(store: &Store, type_module: &str, name: &str) -> Option<String> {
-    let (module, bare) = match name.split_once('.') {
-        Some((alias, type_name)) => (
-            import_module_for_alias(store, type_module, alias)?,
-            type_name,
-        ),
-        None => (type_module.to_string(), name),
-    };
-    let candidate = Symbol::from_parts(&module, bare);
-    store
-        .get_definition(candidate.as_str())
-        .map(|_| candidate.to_string())
-}
-
-/// The module id that `alias` imports within `module`, or `None`.
-pub(super) fn import_module_for_alias(store: &Store, module: &str, alias: &str) -> Option<String> {
-    let module = store.get_module(module)?;
-    module.files.values().find_map(|file| {
-        file.imports().into_iter().find_map(|import| {
-            (import.effective_alias(&store.go_package_names).as_deref() == Some(alias))
-                .then(|| import.name.to_string())
-        })
-    })
 }

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -5,12 +5,11 @@ use syntax::ast::{
 };
 use syntax::program::{Definition, DefinitionBody, Interface, Visibility};
 use syntax::types::{
-    Bound, Symbol, Type, build_substitution_map, substitute, type_args_match_params,
-    unqualified_name,
+    Symbol, Type, build_substitution_map, substitute, type_args_match_params, unqualified_name,
 };
 
 use super::{extract_attribute_flags, has_recursive_instantiation, wrap_with_impl_generics};
-use crate::checker::TaskState;
+use crate::checker::{TaskState, resolved_generic_bounds};
 use crate::store::Store;
 
 impl TaskState<'_> {
@@ -137,21 +136,11 @@ impl TaskState<'_> {
     ) {
         self.scopes.push();
         self.put_in_scope(generics);
+        let generics = self.resolve_generic_bounds(&*store, generics, span);
+        let impl_bounds = resolved_generic_bounds(&generics);
 
-        let mut impl_bounds: Vec<Bound> = Vec::new();
-        for generic in generics {
-            for bound in &generic.bounds {
-                let bound_ty = self.register_generic_bound(&*store, &generic.name, bound, span);
-                impl_bounds.push(Bound {
-                    param_name: generic.name.clone(),
-                    generic: Type::Parameter(generic.name.clone()),
-                    ty: bound_ty,
-                });
-            }
-        }
-
-        self.check_undeclared_impl_type_params(annotation, generics);
-        let receiver_ty = self.convert_to_type_inner(&*store, annotation, span, false, false);
+        self.check_undeclared_impl_type_params(annotation, &generics);
+        let receiver_ty = self.convert_receiver_to_type(&*store, annotation, span);
         let Some(type_name) = receiver_ty.get_name() else {
             self.scopes.pop();
             return;
@@ -216,17 +205,18 @@ impl TaskState<'_> {
             return;
         }
 
-        if self.impl_has_simple_type_params(&receiver_ty, generics) {
+        if self.impl_has_simple_type_params(&receiver_ty, &generics) {
             let receiver_bounds =
-                self.register_receiver_type_bounds(&*store, &receiver_qualified_name, generics);
+                self.register_receiver_type_bounds(&*store, &receiver_qualified_name, &generics);
             self.check_strengthened_impl_bounds(
                 &*store,
                 &receiver_qualified_name,
-                generics,
+                &generics,
                 &impl_bounds,
                 &receiver_bounds,
             );
         }
+        self.check_transitive_generic_bounds(&*store, &generics, *span);
 
         let mut static_methods: Vec<(String, Type)> = Vec::new();
 
@@ -247,12 +237,13 @@ impl TaskState<'_> {
                 Visibility::Private
             };
             let fn_sig = function.to_function_signature();
+            let fn_span = function.get_span();
             let mut fn_ty = self.extract_signature_parts(
                 &*store,
                 &fn_sig.generics,
                 &fn_sig.params,
                 &fn_sig.annotation,
-                span,
+                &fn_span,
             );
             let qualified_name = format!("{}.{}", type_name, fn_sig.name);
             let module_qualified_name = Symbol::from_parts(&module_id, &qualified_name);
@@ -269,7 +260,7 @@ impl TaskState<'_> {
                 fn_ty = fn_ty.with_replaced_first_param(&receiver_ty);
             }
 
-            let method_ty = wrap_with_impl_generics(&fn_ty, generics, &impl_bounds);
+            let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
 
             let go_hints = extract_attribute_flags(fn_attrs, "go");
             let method_key: EcoString =
@@ -280,7 +271,7 @@ impl TaskState<'_> {
                 };
 
             if !generics.is_empty()
-                && self.impl_has_simple_type_params(&receiver_ty, generics)
+                && self.impl_has_simple_type_params(&receiver_ty, &generics)
                 && has_recursive_instantiation(&receiver_qualified_name, &fn_ty)
             {
                 self.sink
@@ -360,7 +351,7 @@ impl TaskState<'_> {
     ) {
         self.scopes.push();
         self.put_in_scope(generics);
-        self.validate_generic_bounds(&*store, generics, span);
+        let generics = self.resolve_generic_bounds(&*store, generics, span);
 
         let new_parents = parents
             .iter()
@@ -390,12 +381,13 @@ impl TaskState<'_> {
                     (&[][..], None)
                 };
                 let method_sig = fe.to_function_signature();
+                let method_span = fe.get_span();
                 let fn_ty = self.extract_signature_parts(
                     &*store,
                     &method_sig.generics,
                     &method_sig.params,
                     &method_sig.annotation,
-                    span,
+                    &method_span,
                 );
                 let fn_ty = match &fn_ty {
                     Type::Forall { body, .. } => body.as_ref().clone(),
@@ -448,7 +440,7 @@ impl TaskState<'_> {
 
         let interface = Interface {
             name: interface_name.into(),
-            generics: generics.to_owned(),
+            generics,
             parents: new_parents,
             methods,
         };

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -2,6 +2,7 @@ mod builtins;
 mod convert;
 mod display;
 mod equality;
+mod generic_bounds;
 mod impl_bounds;
 mod iterate;
 mod methods;
@@ -24,7 +25,7 @@ use syntax::program::{
 };
 use syntax::types::{Symbol, Type};
 
-use super::{FileContextKind, TaskState};
+use super::{FileContextKind, TaskState, resolved_generic_bounds};
 use crate::store::Store;
 
 pub(crate) fn extract_package_directive(source: &str) -> Option<String> {
@@ -266,9 +267,7 @@ impl TaskState<'_> {
     }
 
     pub fn register_module(&mut self, store: &mut Store, id: &str) {
-        let type_name_entries =
-            self.with_module_cursor(id, |this| this.collect_module_type_name_entries(store, id));
-        self.insert_type_name_entries(store, id, type_name_entries);
+        self.predeclare_module_types(store, id);
 
         let file_data = self.module_file_data(store, id);
 
@@ -291,6 +290,28 @@ impl TaskState<'_> {
 
         self.register_module_equality(store, id);
         self.register_module_tests(store, id);
+        self.populate_module_generic_bounds(store, id);
+    }
+
+    pub(crate) fn predeclare_module_types(&mut self, store: &mut Store, id: &str) {
+        let type_name_entries =
+            self.with_module_cursor(id, |this| this.collect_module_type_name_entries(store, id));
+        self.insert_type_name_entries(store, id, type_name_entries);
+    }
+
+    fn populate_module_generic_bounds(&self, store: &mut Store, module_id: &str) {
+        let Some(module) = store.get_module_mut(module_id) else {
+            return;
+        };
+        for file in module
+            .files
+            .values_mut()
+            .chain(module.typedefs.values_mut())
+        {
+            for item in &mut file.items {
+                populate_expression_generic_bounds(item, &self.facts.bound_types);
+            }
+        }
     }
 
     /// Register a Go module (stdlib or third-party). Unlike regular modules,
@@ -514,6 +535,7 @@ impl TaskState<'_> {
                         .items,
                 );
 
+                this.check_type_generic_bounds(store, &items);
                 this.register_impl_blocks(store, &items);
                 this.register_values(store, &items, &Visibility::Private);
 
@@ -533,6 +555,7 @@ impl TaskState<'_> {
     ) {
         self.register_type_names(store, items, visibility);
         self.register_type_definitions(store, items);
+        self.check_type_generic_bounds(store, items);
         self.register_impl_blocks(store, items);
         self.register_values(store, items, visibility);
         self.register_iterate(store, items);
@@ -787,6 +810,34 @@ impl TaskState<'_> {
                 ),
                 _ => (),
             }
+        }
+    }
+
+    fn check_type_generic_bounds(&mut self, store: &Store, items: &[Expression]) {
+        for item in items {
+            let (name, span) = match item {
+                Expression::Enum { name, span, .. }
+                | Expression::Struct { name, span, .. }
+                | Expression::Interface { name, span, .. }
+                | Expression::TypeAlias { name, span, .. } => (name, *span),
+                _ => continue,
+            };
+            let Some(definition) = store.get_definition(&self.qualify_name(name)) else {
+                continue;
+            };
+            let Some(generics) = definition.body.generics().map(|generics| generics.to_vec())
+            else {
+                continue;
+            };
+            if generics.is_empty() {
+                continue;
+            }
+
+            self.scopes.push();
+            self.put_in_scope(&generics);
+            self.record_resolved_generic_bounds(&generics);
+            self.check_transitive_generic_bounds(store, &generics, span);
+            self.scopes.pop();
         }
     }
 
@@ -1107,27 +1158,16 @@ impl TaskState<'_> {
     ) -> Type {
         self.scopes.push();
         self.put_in_scope(generics);
-
-        let mut bounds = vec![];
-
-        for generic in generics {
-            for bound in &generic.bounds {
-                let bound_ty = self.register_generic_bound(store, &generic.name, bound, span);
-
-                bounds.push(syntax::types::Bound {
-                    param_name: generic.name.clone(),
-                    generic: Type::Parameter(generic.name.clone()),
-                    ty: bound_ty,
-                });
-            }
-        }
+        let generics = self.resolve_generic_bounds(store, generics, span);
+        self.check_transitive_generic_bounds(store, &generics, *span);
+        let bounds = resolved_generic_bounds(&generics);
 
         let before = self.sink.len();
 
         let param_types: Vec<Type> = params
             .iter()
             .map(|binding| match &binding.annotation {
-                Some(a) => self.convert_to_type_inner(store, a, span, true, true),
+                Some(a) => self.convert_variadic_to_type(store, a, span),
                 None if !binding.ty.is_uninferred() => binding.ty.clone(),
                 None => self.new_type_var(),
             })
@@ -1160,6 +1200,55 @@ impl TaskState<'_> {
                 body: Box::new(base_fn_ty),
             }
         }
+    }
+}
+
+fn populate_expression_generic_bounds(
+    expression: &mut Expression,
+    bound_types: &rustc_hash::FxHashMap<Span, Type>,
+) {
+    match expression {
+        Expression::Function { generics, .. }
+        | Expression::Struct { generics, .. }
+        | Expression::Enum { generics, .. }
+        | Expression::TypeAlias { generics, .. } => populate_generic_bounds(generics, bound_types),
+        Expression::ImplBlock {
+            generics, methods, ..
+        } => {
+            populate_generic_bounds(generics, bound_types);
+            for method in methods {
+                populate_expression_generic_bounds(method, bound_types);
+            }
+        }
+        Expression::Interface {
+            generics,
+            method_signatures,
+            ..
+        } => {
+            populate_generic_bounds(generics, bound_types);
+            for method in method_signatures {
+                populate_expression_generic_bounds(method, bound_types);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn populate_generic_bounds(
+    generics: &mut [Generic],
+    bound_types: &rustc_hash::FxHashMap<Span, Type>,
+) {
+    for generic in generics {
+        generic.resolved_bounds = generic
+            .bounds
+            .iter()
+            .map(|bound| {
+                bound_types
+                    .get(&bound.get_span())
+                    .cloned()
+                    .unwrap_or(Type::Error)
+            })
+            .collect();
     }
 }
 

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -33,7 +33,7 @@ impl TaskState<'_> {
 
         self.scopes.push();
         self.put_in_scope(generics);
-        self.validate_generic_bounds(&*store, generics, span);
+        let generics = self.resolve_generic_bounds(&*store, generics, span);
 
         let new_variants: Vec<_> = variants
             .iter()
@@ -45,7 +45,7 @@ impl TaskState<'_> {
         self.check_enum_field_type_conflicts(name, &new_variants);
 
         for new_variant in &new_variants {
-            self.add_enum_variant_to_scope(new_variant, name, &enum_ty, generics);
+            self.add_enum_variant_to_scope(new_variant, name, &enum_ty, &generics);
         }
 
         let visibility = self
@@ -60,7 +60,7 @@ impl TaskState<'_> {
         let variant_definitions: Vec<_> = new_variants
             .iter()
             .map(|v| {
-                let variant_ty = enum_variant_constructor_type(v, &enum_ty, generics);
+                let variant_ty = enum_variant_constructor_type(v, &enum_ty, &generics);
                 let qualified_variant_name = qualified_name.with_segment(&v.name);
                 let simple_qualified_name = if is_prelude {
                     Some(self.qualify_name(&v.name))
@@ -123,7 +123,7 @@ impl TaskState<'_> {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Enum {
-                    generics: generics.to_vec(),
+                    generics,
                     variants: new_variants,
                     methods: MethodSignatures::default(),
                     attributes,
@@ -292,7 +292,7 @@ impl TaskState<'_> {
 
         self.scopes.push();
         self.put_in_scope(generics);
-        self.validate_generic_bounds(&*store, generics, span);
+        let generics = self.resolve_generic_bounds(&*store, generics, span);
 
         let new_fields: Vec<StructFieldDefinition> = fields
             .iter()
@@ -352,7 +352,7 @@ impl TaskState<'_> {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Struct {
-                    generics: generics.to_vec(),
+                    generics,
                     fields: new_fields,
                     kind,
                     methods: Default::default(),
@@ -501,6 +501,10 @@ impl TaskState<'_> {
     ) {
         let qualified_name = self.qualify_name(name);
 
+        self.scopes.push();
+        self.put_in_scope(generics);
+        let generics = self.resolve_generic_bounds(&*store, generics, span);
+
         if annotation.is_opaque() {
             if self.is_lis(&*store) {
                 self.sink
@@ -563,6 +567,8 @@ impl TaskState<'_> {
                 ));
             }
 
+            self.scopes.pop();
+
             self.current_module_mut(store).definitions.insert(
                 qualified_name,
                 Definition {
@@ -572,7 +578,7 @@ impl TaskState<'_> {
                     name_span: Some(*name_span),
                     doc: doc.clone(),
                     body: DefinitionBody::TypeAlias {
-                        generics: generics.to_vec(),
+                        generics,
                         annotation: annotation.clone(),
                         methods: Default::default(),
                         attributes: super::collect_struct_attributes(attributes),
@@ -582,11 +588,6 @@ impl TaskState<'_> {
 
             return;
         }
-
-        self.scopes.push();
-
-        self.put_in_scope(generics);
-        self.validate_generic_bounds(&*store, generics, span);
 
         let body_ty = self.convert_to_type(&*store, annotation, span);
         let is_function_body = matches!(body_ty, Type::Function(_));
@@ -645,7 +646,7 @@ impl TaskState<'_> {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::TypeAlias {
-                    generics: generics.to_vec(),
+                    generics,
                     annotation: annotation.clone(),
                     methods: Default::default(),
                     attributes: super::collect_struct_attributes(attributes),

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 
 use diagnostics::LocalSink;
 use ecow::EcoString;
-use syntax::ast::{Expression, StructFieldDefinition};
+use syntax::ast::{Expression, Span, StructFieldDefinition};
 use syntax::program::{File, Module};
+use syntax::types::Type;
 
 use deps::TypedefLocator;
 
@@ -14,7 +15,8 @@ use crate::cache::{
     CachedModuleBuild, CompiledModule, ModuleInterface, build_cached_module,
     compute_emit_artifact_hash, compute_module_hash, get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
-    hash_module_source_pair, is_cache_disabled, prelude as prelude_cache, try_load_cache,
+    hash_module_source_pair, is_cache_disabled, prelude as prelude_cache,
+    restore_cached_generic_bounds, try_load_cache,
 };
 use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
@@ -309,6 +311,11 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         cached_modules.extend(cache_load.cached);
         to_infer.extend(cache_load.to_infer);
 
+        for (_, module_id) in &to_infer {
+            checker.predeclare_module_types(&mut store, module_id);
+        }
+        restore_cached_generic_bounds(&mut store, &sink, &cached_modules);
+
         to_infer.sort_by_key(|(topo_rank, _)| *topo_rank);
         let to_infer: Vec<String> = to_infer.into_iter().map(|(_, id)| id).collect();
 
@@ -576,6 +583,7 @@ fn register_modules(
             HashSet<(String, String)>,
             HashMap<EcoString, Arc<[StructFieldDefinition]>>,
             Facts,
+            Vec<(Type, Type, Span)>,
             LocalSink,
         );
         let outputs: Vec<RegisterOutput> = chunks
@@ -601,19 +609,22 @@ fn register_modules(
                     std::mem::take(&mut worker.ufcs_methods),
                     worker.module_fields_snapshot(),
                     facts,
+                    std::mem::take(&mut worker.pending_generic_bound_checks),
                     local_sink,
                 )
             })
             .collect();
 
         let mut worker_sinks: Vec<LocalSink> = Vec::with_capacity(outputs.len());
-        for (registered, ufcs_methods, module_fields, facts, sink_local) in outputs {
+        for (registered, ufcs_methods, module_fields, facts, pending_bounds, sink_local) in outputs
+        {
             for (module_id, module) in registered {
                 store.modules.insert(module_id, module);
             }
             checker.ufcs_methods.extend(ufcs_methods);
             checker.merge_module_fields(module_fields);
             checker.facts.merge(facts);
+            checker.pending_generic_bound_checks.extend(pending_bounds);
             worker_sinks.push(sink_local);
         }
         sink.extend(LocalSink::merge(worker_sinks));
@@ -628,6 +639,7 @@ fn infer_modules(
     binding_ids: &Arc<BindingIdAllocator>,
 ) {
     checker.finalize_equality(store);
+    checker.check_pending_generic_bounds(store);
     checker.finalize_tests(store);
 
     let module_files: Vec<(String, Vec<File>)> = to_infer

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -58,6 +58,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
                 checker.register_impl_blocks(store, &file.items);
                 checker.register_values(store, &file.items, &Visibility::Public);
             }
+            checker.check_pending_generic_bounds(&*store);
         },
     );
 }
@@ -107,6 +108,7 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
                 checker.register_impl_blocks(store, &file.items);
                 checker.register_values(store, &file.items, &Visibility::Public);
             }
+            checker.check_pending_generic_bounds(&*store);
         },
     );
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -710,6 +710,7 @@ impl Annotation {
 pub struct Generic {
     pub name: EcoString,
     pub bounds: Vec<Annotation>,
+    pub resolved_bounds: Vec<Type>,
     pub span: Span,
 }
 

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -304,6 +304,7 @@ impl<'source> Parser<'source> {
         Generic {
             name: self.read_identifier(),
             bounds: self.parse_generic_bounds(),
+            resolved_bounds: vec![],
             span: self.span_from_tokens(start),
         }
     }

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -72,6 +72,28 @@ pub enum DefinitionBody {
     },
 }
 
+impl DefinitionBody {
+    pub fn generics(&self) -> Option<&[Generic]> {
+        match self {
+            Self::TypeAlias { generics, .. }
+            | Self::Enum { generics, .. }
+            | Self::Struct { generics, .. } => Some(generics),
+            Self::Interface { definition } => Some(&definition.generics),
+            Self::Value { .. } => None,
+        }
+    }
+
+    pub fn generics_mut(&mut self) -> Option<&mut [Generic]> {
+        match self {
+            Self::TypeAlias { generics, .. }
+            | Self::Enum { generics, .. }
+            | Self::Struct { generics, .. } => Some(generics),
+            Self::Interface { definition } => Some(&mut definition.generics),
+            Self::Value { .. } => None,
+        }
+    }
+}
+
 impl Definition {
     pub fn ty(&self) -> &Type {
         &self.ty

--- a/fuzz/fuzz_targets/infer.rs
+++ b/fuzz/fuzz_targets/infer.rs
@@ -35,6 +35,7 @@ fuzz_target!(|data: &[u8]| {
         &desugar_result.ast,
         &lisette_syntax::program::Visibility::Private,
     );
+    checker.check_pending_generic_bounds(&store);
 
     for expression in desugar_result.ast {
         let type_var = checker.new_type_var();

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -123,6 +123,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         }
 
         checker.finalize_equality(&mut store);
+        checker.check_pending_generic_bounds(&store);
         checker.finalize_tests(&mut store);
 
         for module_id in &to_infer {

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -83,6 +83,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     checker.register_types_and_values(&mut store, &ast, &Visibility::Private);
     checker.register_equality(&mut store, &ast);
     checker.finalize_equality(&mut store);
+    checker.check_pending_generic_bounds(&store);
 
     let mut typed_ast = vec![];
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -189,6 +189,7 @@ impl CompiledTest {
 
             checker.register_equality(&mut store, &self.ast);
             checker.finalize_equality(&mut store);
+            checker.check_pending_generic_bounds(&store);
 
             let mut typed_ast = vec![];
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -200,6 +200,310 @@ fn main() {
 }
 
 #[test]
+fn cached_aliased_interface_bound_keeps_its_identity() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/constraints")).unwrap();
+    fs::create_dir_all(project.join("src/box")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/boundcache\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/constraints/constraints.lis"),
+        "pub interface Parent<T> {\n  fn value(self) -> T\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/box/box.lis"),
+        "import c \"constraints\"\n\npub interface Box<T: c.Parent<string>> {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"box\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let first = lis(&project, "check");
+    assert!(
+        first.status.success(),
+        "first check should cache `box`:\nstderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    fs::create_dir_all(project.join("src/wrap")).unwrap();
+    fs::write(
+        project.join("src/wrap/wrap.lis"),
+        r#"import "box"
+import c "constraints"
+
+pub interface Wrap<U: box.Box<T>, T: c.Parent<string>> {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"wrap\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let matching = lis(&project, "check");
+    assert!(
+        matching.status.success(),
+        "matching imported bounds should pass after a cache hit:\nstderr: {}",
+        String::from_utf8_lossy(&matching.stderr)
+    );
+
+    fs::write(
+        project.join("src/wrap/wrap.lis"),
+        r#"import "box"
+import c "constraints"
+
+pub interface Wrap<U: box.Box<T>, T: c.Parent<int>> {}
+"#,
+    )
+    .unwrap();
+    assert_rejected_at_check(&lis(&project, "check"), "Missing bound on type parameter");
+}
+
+#[test]
+fn cached_public_bound_can_reference_private_interface() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/box")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/privatebound\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/box/box.lis"),
+        r#"interface Hidden {
+  fn show(self) -> string
+}
+
+pub interface Box<T: Hidden> {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"box\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let first = lis(&project, "check");
+    assert!(
+        first.status.success(),
+        "first check should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = lis(&project, "check");
+    assert!(
+        second.status.success(),
+        "cached check should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    fs::create_dir_all(project.join("src/wrap")).unwrap();
+    fs::write(
+        project.join("src/wrap/wrap.lis"),
+        r#"import "box"
+
+struct Plain {}
+
+pub interface Wrap<T: box.Box<Plain>> {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"wrap\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+}
+
+#[test]
+fn cached_public_function_bound_can_reference_private_interface() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/api")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/privatefunctionbound\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/api/api.lis"),
+        r#"interface Hidden {
+  fn show(self) -> string
+}
+
+pub fn use<T: Hidden>(_value: T) {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"api\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let first = lis(&project, "check");
+    assert!(
+        first.status.success(),
+        "first check should cache `api`:\nstderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    fs::create_dir_all(project.join("src/use_api")).unwrap();
+    fs::write(
+        project.join("src/use_api/use_api.lis"),
+        r#"import "api"
+
+struct Plain {}
+
+pub fn call() {
+  api.use(Plain {})
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"use_api\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+}
+
+#[test]
+fn cached_public_interface_can_embed_private_parent() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/api")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/privateparent\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/api/api.lis"),
+        r#"interface Hidden {
+  fn show(self) -> string
+}
+
+pub interface Public {
+  embed Hidden
+}
+
+pub fn use(_value: Public) {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"api\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let first = lis(&project, "check");
+    assert!(
+        first.status.success(),
+        "first check should cache `api`:\nstderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    fs::create_dir_all(project.join("src/use_api")).unwrap();
+    fs::write(
+        project.join("src/use_api/use_api.lis"),
+        r#"import "api"
+
+struct Plain {}
+
+pub fn call() {
+  api.use(Plain {})
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"use_api\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+}
+
+#[test]
+fn parallel_registration_validates_bounds_with_dependency_ufcs_methods() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    for module in ["dep", "use_a", "use_b"] {
+        fs::create_dir_all(project.join("src").join(module)).unwrap();
+    }
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/parallelbounds\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/dep/dep.lis"),
+        r#"pub struct Box<T> {
+  pub value: T
+}
+
+impl Box<int> {
+  pub fn show(self) -> string { "box" }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/use_a/use_a.lis"),
+        r#"import "dep"
+
+pub interface Shower {
+  fn show(self) -> string
+}
+
+pub interface Need<T: Shower> {}
+
+pub interface Uses<T: Need<dep.Box<int>>> {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/use_b/use_b.lis"),
+        r#"import "dep"
+
+pub struct Keep {
+  pub value: dep.Box<int>
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"use_a\"\nimport \"use_b\"\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    assert_rejected_at_check(
+        &lis(&project, "check"),
+        "Specialized impl cannot satisfy interface",
+    );
+}
+
+#[test]
 fn imported_weaker_interface_bound_equals_accepted() {
     if !go_available() {
         eprintln!("skipping imported_weaker_interface_bound_equals_accepted: `go` not found");

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -212,7 +212,7 @@ fn cached_aliased_interface_bound_keeps_its_identity() {
     .unwrap();
     fs::write(
         project.join("src/constraints/constraints.lis"),
-        "pub interface Parent<T> {\n  fn value(self) -> T\n}\n",
+        "pub interface Parent<T> {\n  fn value() -> T\n}\n",
     )
     .unwrap();
     fs::write(
@@ -281,7 +281,7 @@ fn cached_public_bound_can_reference_private_interface() {
     fs::write(
         project.join("src/box/box.lis"),
         r#"interface Hidden {
-  fn show(self) -> string
+  fn show() -> string
 }
 
 pub interface Box<T: Hidden> {}
@@ -342,7 +342,7 @@ fn cached_public_function_bound_can_reference_private_interface() {
     fs::write(
         project.join("src/api/api.lis"),
         r#"interface Hidden {
-  fn show(self) -> string
+  fn show() -> string
 }
 
 pub fn use<T: Hidden>(_value: T) {}
@@ -397,7 +397,7 @@ fn cached_public_interface_can_embed_private_parent() {
     fs::write(
         project.join("src/api/api.lis"),
         r#"interface Hidden {
-  fn show(self) -> string
+  fn show() -> string
 }
 
 pub interface Public {
@@ -472,7 +472,7 @@ impl Box<int> {
         r#"import "dep"
 
 pub interface Shower {
-  fn show(self) -> string
+  fn show() -> string
 }
 
 pub interface Need<T: Shower> {}
@@ -852,7 +852,7 @@ fn run_equality_matching_parametrized_interface_bound_builds() {
         r#"import "go:fmt"
 
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 struct Holder { tag: string }
@@ -920,7 +920,7 @@ fn run_equality_user_type_parametrized_bound_builds() {
 struct Key { v: int }
 
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 struct Leaf { k: Key }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -5318,6 +5318,64 @@ fn main() { take(S {}) }
 }
 
 #[test]
+fn transforming_interface_cycle_with_bound_check_terminates() {
+    infer(
+        r#"
+interface Required {
+  fn required(self)
+}
+
+interface A<T> {
+  embed B<Slice<T>>
+}
+
+interface B<T> {
+  embed A<Slice<T>>
+}
+
+interface Holder<T: Required> {}
+
+interface Uses<T: Holder<U>, U: A<int>> {}
+"#,
+    )
+    .assert_infer_code("interface_cycle");
+}
+
+#[test]
+fn concrete_generic_argument_must_satisfy_user_interface_bound() {
+    infer(
+        r#"
+interface Shower {
+  fn show(self) -> string
+}
+
+interface Need<T: Shower> {}
+
+struct Plain {}
+
+interface Uses<T: Need<Plain>> {}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn nested_impl_receiver_argument_keeps_its_bound_check() {
+    infer(
+        r#"
+struct Inner<T: Comparable> {}
+
+struct Pair<A, B> {}
+
+impl<T> Pair<Inner<T>, int> {
+  fn value(self) -> int { 0 }
+}
+"#,
+    )
+    .assert_infer_code("missing_bound_on_param");
+}
+
+#[test]
 fn interface_diamond_conflicting_type_args_rejected() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/parse/snapshots/enum_with_generics.snap
+++ b/tests/spec/parse/snapshots/enum_with_generics.snap
@@ -21,6 +21,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,
@@ -30,6 +31,7 @@ description: |
             Generic {
                 name: "E",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/function_with_generic.snap
+++ b/tests/spec/parse/snapshots/function_with_generic.snap
@@ -22,6 +22,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 9,

--- a/tests/spec/parse/snapshots/generic_enum_multiple.snap
+++ b/tests/spec/parse/snapshots/generic_enum_multiple.snap
@@ -21,6 +21,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,
@@ -30,6 +31,7 @@ description: |
             Generic {
                 name: "E",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/generic_enum_single.snap
+++ b/tests/spec/parse/snapshots/generic_enum_single.snap
@@ -21,6 +21,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,

--- a/tests/spec/parse/snapshots/generic_impl.snap
+++ b/tests/spec/parse/snapshots/generic_impl.snap
@@ -162,6 +162,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 6,

--- a/tests/spec/parse/snapshots/generic_mixed_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_mixed_bounds.snap
@@ -39,6 +39,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,
@@ -58,6 +59,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 32,
@@ -67,6 +69,7 @@ description: |
             Generic {
                 name: "V",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 42,

--- a/tests/spec/parse/snapshots/generic_multiple_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_bounds.snap
@@ -39,6 +39,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,

--- a/tests/spec/parse/snapshots/generic_multiple_params_with_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_params_with_bounds.snap
@@ -30,6 +30,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,
@@ -49,6 +50,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 24,

--- a/tests/spec/parse/snapshots/generic_multiple_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_unbounded.snap
@@ -20,6 +20,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 9,
@@ -29,6 +30,7 @@ description: |
             Generic {
                 name: "U",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,

--- a/tests/spec/parse/snapshots/generic_single_bound.snap
+++ b/tests/spec/parse/snapshots/generic_single_bound.snap
@@ -30,6 +30,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,

--- a/tests/spec/parse/snapshots/generic_single_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_single_unbounded.snap
@@ -20,6 +20,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,

--- a/tests/spec/parse/snapshots/generic_struct_bounded.snap
+++ b/tests/spec/parse/snapshots/generic_struct_bounded.snap
@@ -30,6 +30,7 @@ description: |
                         },
                     },
                 ],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 18,

--- a/tests/spec/parse/snapshots/generic_struct_instantiation.snap
+++ b/tests/spec/parse/snapshots/generic_struct_instantiation.snap
@@ -22,6 +22,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 18,

--- a/tests/spec/parse/snapshots/generic_struct_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_struct_unbounded.snap
@@ -20,6 +20,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 12,

--- a/tests/spec/parse/snapshots/impl_complex_return_type.snap
+++ b/tests/spec/parse/snapshots/impl_complex_return_type.snap
@@ -26,6 +26,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 18,
@@ -231,6 +232,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 48,

--- a/tests/spec/parse/snapshots/impl_multiple_type_params.snap
+++ b/tests/spec/parse/snapshots/impl_multiple_type_params.snap
@@ -31,6 +31,7 @@ description: |
             Generic {
                 name: "K",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,
@@ -40,6 +41,7 @@ description: |
             Generic {
                 name: "V",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,
@@ -393,6 +395,7 @@ description: |
             Generic {
                 name: "K",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 51,
@@ -402,6 +405,7 @@ description: |
             Generic {
                 name: "V",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 54,

--- a/tests/spec/parse/snapshots/impl_with_generics.snap
+++ b/tests/spec/parse/snapshots/impl_with_generics.snap
@@ -26,6 +26,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 18,
@@ -211,6 +212,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 43,

--- a/tests/spec/parse/snapshots/struct_complex_field_types.snap
+++ b/tests/spec/parse/snapshots/struct_complex_field_types.snap
@@ -22,6 +22,7 @@ description: |
             Generic {
                 name: "Body",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/struct_multiple_generics.snap
+++ b/tests/spec/parse/snapshots/struct_multiple_generics.snap
@@ -21,6 +21,7 @@ description: |
             Generic {
                 name: "K",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,
@@ -30,6 +31,7 @@ description: |
             Generic {
                 name: "V",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/struct_with_generic.snap
+++ b/tests/spec/parse/snapshots/struct_with_generic.snap
@@ -20,6 +20,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 18,

--- a/tests/spec/parse/snapshots/tuple_struct_multiple_generics.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_multiple_generics.snap
@@ -18,6 +18,7 @@ description: |
             Generic {
                 name: "A",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 13,
@@ -27,6 +28,7 @@ description: |
             Generic {
                 name: "B",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/tuple_struct_with_generics.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_with_generics.snap
@@ -18,6 +18,7 @@ description: |
             Generic {
                 name: "T",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/spec/parse/snapshots/type_alias_generic.snap
+++ b/tests/spec/parse/snapshots/type_alias_generic.snap
@@ -18,6 +18,7 @@ description: |
             Generic {
                 name: "V",
                 bounds: [],
+                resolved_bounds: [],
                 span: Span {
                     file_id: 0,
                     byte_offset: 16,

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8746,7 +8746,7 @@ struct Foo<T: Bar<E>, E> { value: T }
 fn infer_missing_transitive_bound_user_interface() {
     let input = r#"
 interface Shower {
-  fn show(self) -> string
+  fn show() -> string
 }
 
 interface Bar<E: Shower> {}
@@ -8790,7 +8790,7 @@ interface Foo<T: Wrapper<E>, E: Comparable> {}
 fn infer_missing_transitive_bound_distinguishes_type_args() {
     let input = r#"
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 interface Bar<E: Parent<string>> {}
@@ -8804,7 +8804,7 @@ interface Foo<T: Bar<E>, E: Parent<int>> {}
 fn infer_transitive_bound_matching_type_args_no_error() {
     let input = r#"
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 interface Bar<E: Parent<string>> {}
@@ -8823,7 +8823,7 @@ interface Foo<T: Bar<E>, E: Parent<string>> {}
 fn infer_missing_transitive_bound_substitutes_referenced_params() {
     let input = r#"
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 interface Bar<X, E: Parent<X>> {}
@@ -8837,7 +8837,7 @@ interface Foo<T: Bar<string, E>, E: Parent<int>> {}
 fn infer_transitive_bound_substituted_match_no_error() {
     let input = r#"
 interface Parent<T> {
-  fn p(self) -> T
+  fn p() -> T
 }
 
 interface Bar<X, E: Parent<X>> {}
@@ -8945,7 +8945,7 @@ fn foo<T: Outer<Slice<Inner<E>>>, E>(_x: T) {}
 fn infer_self_referential_transitive_bound_no_error() {
     let input = r#"
 interface Cloner<T: Cloner<T>> {
-  fn clone(self) -> T
+  fn clone() -> T
 }
 
 fn squiggle<A: Cloner<B>, B>(_a: A, _b: B) {}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8723,6 +8723,242 @@ fn user() -> bool { eq(1, 1) }
 }
 
 #[test]
+fn infer_missing_transitive_bound_on_interface() {
+    let input = r#"
+interface Bar<E: error> {}
+
+interface Foo<T: Bar<E>, E> {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_transitive_bound_on_struct() {
+    let input = r#"
+interface Bar<E: error> {}
+
+struct Foo<T: Bar<E>, E> { value: T }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_transitive_bound_user_interface() {
+    let input = r#"
+interface Shower {
+  fn show(self) -> string
+}
+
+interface Bar<E: Shower> {}
+
+interface Foo<T: Bar<E>, E> {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_transitive_bound_satisfied_no_error() {
+    let input = r#"
+interface Bar<E: error> {}
+
+interface Foo<T: Bar<E>, E: error> {}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_transitive_builtin_bound_declared_after_no_error() {
+    let input = r#"
+interface Wrapper<E: Comparable> {}
+
+interface Foo<T: Wrapper<E>, E: Comparable> {}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_missing_transitive_bound_distinguishes_type_args() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+interface Bar<E: Parent<string>> {}
+
+interface Foo<T: Bar<E>, E: Parent<int>> {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_transitive_bound_matching_type_args_no_error() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+interface Bar<E: Parent<string>> {}
+
+interface Foo<T: Bar<E>, E: Parent<string>> {}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_missing_transitive_bound_substitutes_referenced_params() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+interface Bar<X, E: Parent<X>> {}
+
+interface Foo<T: Bar<string, E>, E: Parent<int>> {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_transitive_bound_substituted_match_no_error() {
+    let input = r#"
+interface Parent<T> {
+  fn p(self) -> T
+}
+
+interface Bar<X, E: Parent<X>> {}
+
+interface Foo<T: Bar<string, E>, E: Parent<string>> {}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_missing_transitive_bound_function_type_argument() {
+    let input = r#"
+interface Inner<K: Comparable> {}
+
+interface Outer<X> {}
+
+fn foo<T: Outer<fn(Inner<E>)>, E>(x: T) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_transitive_bound_impl_level_param() {
+    let input = r#"
+interface Bar<E: error> {}
+
+struct W<E> {
+  v: E
+}
+
+impl<E> W<E> {
+  fn m<T: Bar<E>>(self, x: T) {}
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_transitive_bound_nested_argument() {
+    let input = r#"
+interface Inner<K: Comparable> {}
+
+interface Outer<X> {}
+
+fn foo<T: Outer<Inner<E>>, E>(x: T) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_transitive_bound_receiver_inherited_no_error() {
+    let input = r#"
+interface Bar<E: error> {}
+
+struct Box<E: error> {
+  value: E
+}
+
+impl<E> Box<E> {
+  fn m<T: Bar<E>>(self, _x: T) {}
+}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_missing_transitive_bound_impl_without_receiver_bound() {
+    let input = r#"
+interface Bar<E: error> {}
+
+struct W<E> {
+  value: E
+}
+
+impl<E> W<E> {
+  fn m<T: Bar<E>>(self, _x: T) {}
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_missing_transitive_bound_in_slice_argument() {
+    let input = r#"
+interface Inner<K: Comparable> {}
+
+interface Outer<X> {}
+
+fn foo<T: Outer<Slice<Inner<E>>>, E>(_x: T) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_referential_transitive_bound_no_error() {
+    let input = r#"
+interface Cloner<T: Cloner<T>> {
+  fn clone(self) -> T
+}
+
+fn squiggle<A: Cloner<B>, B>(_a: A, _b: B) {}
+"#;
+    let result = crate::_harness::infer::infer(input);
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn infer_shadowed_inner_generic_does_not_inherit_bound() {
     let input = r#"
 import "go:cmp"

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_distinguishes_type_args.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_distinguishes_type_args.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:8:26]
+ 7 │ 
+ 8 │ interface Foo<T: Bar<E>, E: Parent<int>> {}
+   ·                          ───────┬──────
+   ·                                 ╰── must satisfy `Parent<string>`
+   ╰────
+  help: `Bar` requires its type argument to satisfy `Parent<string>`. Add the bound: `E: Parent<string>` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_function_type_argument.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_function_type_argument.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:6:32]
+ 5 │ 
+ 6 │ fn foo<T: Outer<fn(Inner<E>)>, E>(x: T) {}
+   ·                                ┬
+   ·                                ╰── must satisfy `Comparable`
+   ╰────
+  help: `Inner` requires its type argument to satisfy `Comparable`. Add the bound: `E: Comparable` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_impl_level_param.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_impl_level_param.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+    ╭─[test.lis:9:3]
+  8 │ impl<E> W<E> {
+  9 │   fn m<T: Bar<E>>(self, x: T) {}
+    ·   ───────────────┬──────────────
+    ·                  ╰── must satisfy `error`
+ 10 │ }
+    ╰────
+  help: `Bar` requires its type argument to satisfy `error`. Add the bound: `E: error` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_impl_without_receiver_bound.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_impl_without_receiver_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+    ╭─[test.lis:9:3]
+  8 │ impl<E> W<E> {
+  9 │   fn m<T: Bar<E>>(self, _x: T) {}
+    ·   ───────────────┬───────────────
+    ·                  ╰── must satisfy `error`
+ 10 │ }
+    ╰────
+  help: `Bar` requires its type argument to satisfy `error`. Add the bound: `E: error` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_in_slice_argument.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_in_slice_argument.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:6:35]
+ 5 │ 
+ 6 │ fn foo<T: Outer<Slice<Inner<E>>>, E>(_x: T) {}
+   ·                                   ┬
+   ·                                   ╰── must satisfy `Comparable`
+   ╰────
+  help: `Inner` requires its type argument to satisfy `Comparable`. Add the bound: `E: Comparable` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_nested_argument.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_nested_argument.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:6:28]
+ 5 │ 
+ 6 │ fn foo<T: Outer<Inner<E>>, E>(x: T) {}
+   ·                            ┬
+   ·                            ╰── must satisfy `Comparable`
+   ╰────
+  help: `Inner` requires its type argument to satisfy `Comparable`. Add the bound: `E: Comparable` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_on_interface.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_on_interface.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:4:26]
+ 3 │ 
+ 4 │ interface Foo<T: Bar<E>, E> {}
+   ·                          ┬
+   ·                          ╰── must satisfy `error`
+   ╰────
+  help: `Bar` requires its type argument to satisfy `error`. Add the bound: `E: error` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_on_struct.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_on_struct.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:4:23]
+ 3 │ 
+ 4 │ struct Foo<T: Bar<E>, E> { value: T }
+   ·                       ┬
+   ·                       ╰── must satisfy `error`
+   ╰────
+  help: `Bar` requires its type argument to satisfy `error`. Add the bound: `E: error` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_substitutes_referenced_params.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_substitutes_referenced_params.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:8:34]
+ 7 │ 
+ 8 │ interface Foo<T: Bar<string, E>, E: Parent<int>> {}
+   ·                                  ───────┬──────
+   ·                                         ╰── must satisfy `Parent<string>`
+   ╰────
+  help: `Bar` requires its type argument to satisfy `Parent<string>`. Add the bound: `E: Parent<string>` · code: [infer.missing_transitive_bound]

--- a/tests/ui/errors/snapshots/infer_missing_transitive_bound_user_interface.snap
+++ b/tests/ui/errors/snapshots/infer_missing_transitive_bound_user_interface.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing bound on type parameter
+   ╭─[test.lis:8:26]
+ 7 │ 
+ 8 │ interface Foo<T: Bar<E>, E> {}
+   ·                          ┬
+   ·                          ╰── must satisfy `Shower`
+   ╰────
+  help: `Bar` requires its type argument to satisfy `Shower`. Add the bound: `E: Shower` · code: [infer.missing_transitive_bound]


### PR DESCRIPTION
Reject a generic declaration when one type param is passed as a type arg to another param's bound but does not itself carry the bound it requires.

To implement this cleanly, I refactored the handling of bounds such that they are now resolved once and stored on the param itself, for a single source of truth across compile phases. That lets the check see through nested type args, substitute sibling args, and resolve referenced types from other modules or the build cache.

Fix #1025
