### PR TITLE
feat: `lis check --deny warnings`

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -28,6 +28,7 @@ pub enum Command {
         path: Option<String>,
         errors_only: bool,
         warnings_only: bool,
+        deny_warnings: bool,
         format: OutputFormat,
         fix: bool,
     },
@@ -142,6 +143,17 @@ fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
             message: format!("unexpected value `{}` for `--output`", other),
             reason: "`--output` accepts `unix`".to_string(),
             hint: "Use `lis check --output unix`".to_string(),
+        }),
+    }
+}
+
+fn parse_deny(value: &str) -> Result<bool, ParseError> {
+    match value {
+        "warnings" => Ok(true),
+        other => Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected value `{}` for `--deny`", other),
+            reason: "`--deny` accepts `warnings`".to_string(),
+            hint: "Use `lis check --deny warnings`".to_string(),
         }),
     }
 }
@@ -271,6 +283,7 @@ impl Command {
                 let mut path = None;
                 let mut errors_only = false;
                 let mut warnings_only = false;
+                let mut deny_warnings = false;
                 let mut format = OutputFormat::Graphical;
                 let mut fix = false;
 
@@ -291,6 +304,18 @@ impl Command {
                         s if s.starts_with("--output=") => {
                             format = parse_format(s.split_once('=').unwrap().1)?;
                         }
+                        "--deny" => {
+                            let Some(value) = arguments.next() else {
+                                return Err(ParseError::MissingArgument {
+                                    command: "check",
+                                    argument: "--deny <value>",
+                                });
+                            };
+                            deny_warnings = parse_deny(&value)?;
+                        }
+                        s if s.starts_with("--deny=") => {
+                            deny_warnings = parse_deny(s.split_once('=').unwrap().1)?;
+                        }
                         s if s.starts_with('-') => {
                             return Err(ParseError::UnknownFlag(s.to_string()));
                         }
@@ -307,10 +332,31 @@ impl Command {
                     });
                 }
 
+                if errors_only && deny_warnings {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: "`--errors-only` and `--deny warnings` cannot be used together"
+                            .to_string(),
+                        reason: "`--errors-only` hides warnings, so `--deny warnings` would have nothing to act on"
+                            .to_string(),
+                        hint: "Drop `--errors-only` to make warnings fail the check".to_string(),
+                    });
+                }
+
+                if fix && deny_warnings {
+                    return Err(ParseError::UnexpectedArgument {
+                        message: "`--fix` and `--deny warnings` cannot be used together".to_string(),
+                        reason: "`--fix` reports what it rewrote, not which warnings remain, so it cannot fail on leftover warnings"
+                            .to_string(),
+                        hint: "Run `lis check --fix` first, then `lis check --deny warnings`"
+                            .to_string(),
+                    });
+                }
+
                 Ok(Command::Check {
                     path,
                     errors_only,
                     warnings_only,
+                    deny_warnings,
                     format,
                     fix,
                 })
@@ -677,6 +723,82 @@ mod tests {
     fn check_rejects_both_filter_flags() {
         assert!(matches!(
             parse(&["lis", "check", "--errors-only", "--warnings-only"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn check_deny_defaults_off() {
+        let Ok(Command::Check { deny_warnings, .. }) = parse(&["lis", "check"]) else {
+            panic!("expected Check command");
+        };
+        assert!(!deny_warnings);
+    }
+
+    #[test]
+    fn check_deny_warnings_space_form() {
+        let Ok(Command::Check { deny_warnings, .. }) =
+            parse(&["lis", "check", "--deny", "warnings"])
+        else {
+            panic!("expected Check command");
+        };
+        assert!(deny_warnings);
+    }
+
+    #[test]
+    fn check_deny_warnings_equals_form() {
+        let Ok(Command::Check { deny_warnings, .. }) = parse(&["lis", "check", "--deny=warnings"])
+        else {
+            panic!("expected Check command");
+        };
+        assert!(deny_warnings);
+    }
+
+    #[test]
+    fn check_deny_missing_value() {
+        assert!(matches!(
+            parse(&["lis", "check", "--deny"]),
+            Err(ParseError::MissingArgument {
+                command: "check",
+                argument: "--deny <value>",
+            })
+        ));
+    }
+
+    #[test]
+    fn check_deny_invalid_value() {
+        assert!(matches!(
+            parse(&["lis", "check", "--deny", "errors"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn check_deny_warnings_composes_with_warnings_only() {
+        let Ok(Command::Check {
+            deny_warnings,
+            warnings_only,
+            ..
+        }) = parse(&["lis", "check", "--deny", "warnings", "--warnings-only"])
+        else {
+            panic!("expected Check command");
+        };
+        assert!(deny_warnings);
+        assert!(warnings_only);
+    }
+
+    #[test]
+    fn check_rejects_deny_warnings_with_errors_only() {
+        assert!(matches!(
+            parse(&["lis", "check", "--errors-only", "--deny", "warnings"]),
+            Err(ParseError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn check_rejects_deny_warnings_with_fix() {
+        assert!(matches!(
+            parse(&["lis", "check", "--fix", "--deny", "warnings"]),
             Err(ParseError::UnexpectedArgument { .. })
         ));
     }

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -15,10 +15,18 @@ use crate::cli_error;
 use crate::lock::acquire_target_lock;
 use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 
+struct CheckOptions {
+    filter: Filter,
+    format: OutputFormat,
+    fix: bool,
+    deny_warnings: bool,
+}
+
 pub fn check(
     path: Option<String>,
     errors_only: bool,
     warnings_only: bool,
+    deny_warnings: bool,
     format: OutputFormat,
     fix: bool,
 ) -> i32 {
@@ -34,30 +42,28 @@ pub fn check(
         return 1;
     }
 
-    let filter = Filter {
-        errors_only,
-        warnings_only,
+    let options = CheckOptions {
+        filter: Filter {
+            errors_only,
+            warnings_only,
+        },
+        format,
+        fix,
+        deny_warnings,
     };
 
     if !target_path.is_dir() {
-        return check_single_file(
-            target_path,
-            &filter,
-            false,
-            TypedefLocator::default(),
-            format,
-            fix,
-        );
+        return check_single_file(target_path, &options, false, TypedefLocator::default());
     }
 
     if target_path.join("lisette.toml").exists() {
-        return check_project(target_path, &filter, format, fix);
+        return check_project(target_path, &options);
     }
 
-    check_loose_dir(target_path, &filter, format, fix)
+    check_loose_dir(target_path, &options)
 }
 
-fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat, fix: bool) -> i32 {
+fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
     let root_main = project_path.join("main.lis");
     let src_main = project_path.join("src/main.lis");
 
@@ -126,21 +132,19 @@ fn check_project(project_path: &Path, filter: &Filter, format: OutputFormat, fix
     ));
     let locator = locator.with_bindgen(bindgen);
 
-    let result = check_single_file(&src_main, filter, true, locator, format, fix);
+    let result = check_single_file(&src_main, options, true, locator);
     drop(target_lock);
     result
 }
 
 fn check_single_file(
     file_path: &Path,
-    filter: &Filter,
+    options: &CheckOptions,
     load_siblings: bool,
     locator: TypedefLocator,
-    format: OutputFormat,
-    fix: bool,
 ) -> i32 {
     let start = Instant::now();
-    let unix = matches!(format, OutputFormat::Unix);
+    let unix = matches!(options.format, OutputFormat::Unix);
     if !unix {
         eprintln!();
     }
@@ -149,7 +153,7 @@ fn check_single_file(
         return 1; // Read error already reported by compile_single_file
     };
 
-    if fix {
+    if options.fix {
         let mut summary = FixSummary::default();
         apply_result_fixes(&result, &mut summary);
         print_fix_summary(&summary, start.elapsed());
@@ -168,7 +172,7 @@ fn check_single_file(
             &result.lints,
             get_source,
             result.user_file_count,
-            filter,
+            &options.filter,
             &source,
             &filename,
         );
@@ -180,7 +184,7 @@ fn check_single_file(
             &result.lints,
             get_source,
             result.user_file_count,
-            filter,
+            &options.filter,
             &source,
             &filename,
         )
@@ -194,7 +198,7 @@ fn check_single_file(
             counts.info,
         );
     }
-    counts.errors
+    exit_code(counts.errors, counts.warnings, options.deny_warnings)
 }
 
 fn compile_single_file(
@@ -241,7 +245,7 @@ fn compile_single_file(
     Some((result, source, entry_display))
 }
 
-fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool) -> i32 {
+fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
     let mut files = lisette::fs::collect_lis_filepaths_recursive(dir);
     files.sort();
 
@@ -269,7 +273,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
     let mut total_files = 0;
     let mut read_failures = 0;
 
-    let unix = matches!(format, OutputFormat::Unix);
+    let unix = matches!(options.format, OutputFormat::Unix);
     let start = Instant::now();
     if !unix {
         eprintln!();
@@ -293,7 +297,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
             continue;
         };
 
-        if fix {
+        if options.fix {
             apply_result_fixes(&result, &mut fix_summary);
             continue;
         }
@@ -310,7 +314,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
                 &result.lints,
                 get_source,
                 result.user_file_count,
-                filter,
+                &options.filter,
                 &source,
                 &filename,
             );
@@ -322,7 +326,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
                 &result.lints,
                 get_source,
                 result.user_file_count,
-                filter,
+                &options.filter,
                 &source,
                 &filename,
             )
@@ -335,7 +339,7 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
 
     let elapsed = start.elapsed();
 
-    if fix {
+    if options.fix {
         print_fix_summary(&fix_summary, elapsed);
         return i32::from(fix_summary.write_failures > 0);
     }
@@ -345,7 +349,11 @@ fn check_loose_dir(dir: &Path, filter: &Filter, format: OutputFormat, fix: bool)
         render::print_summary(total_files, elapsed, all_errors, total_warnings, total_info);
     }
 
-    all_errors
+    exit_code(all_errors, total_warnings, options.deny_warnings)
+}
+
+fn exit_code(errors: i32, warnings: i32, deny_warnings: bool) -> i32 {
+    i32::from(errors > 0 || (deny_warnings && warnings > 0))
 }
 
 #[derive(Default)]
@@ -431,5 +439,34 @@ fn print_fix_summary(summary: &FixSummary, elapsed: std::time::Duration) {
             "  ✓ Applied {} {} {} {}",
             summary.applied, fix_word, location, time_display
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exit_code;
+
+    #[test]
+    fn warnings_are_ignored_without_deny() {
+        assert_eq!(exit_code(0, 3, false), 0);
+        assert_eq!(exit_code(2, 3, false), 1);
+    }
+
+    #[test]
+    fn deny_makes_warnings_fail_the_check() {
+        assert_eq!(exit_code(0, 1, true), 1);
+        assert_eq!(exit_code(0, 3, true), 1);
+    }
+
+    #[test]
+    fn deny_with_no_warnings_still_passes() {
+        assert_eq!(exit_code(0, 0, true), 0);
+    }
+
+    #[test]
+    fn diagnostic_totals_never_wrap_to_a_false_success() {
+        assert_eq!(exit_code(0, 256, true), 1);
+        assert_eq!(exit_code(256, 0, false), 1);
+        assert_eq!(exit_code(128, 128, true), 1);
     }
 }

--- a/crates/cli/src/handlers/completions.rs
+++ b/crates/cli/src/handlers/completions.rs
@@ -68,11 +68,15 @@ fn bash_completions() -> &'static str {
             return 0
             ;;
         check)
-            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --fix --output" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--errors-only --warnings-only --deny --fix --output" -- "$cur") )
             return 0
             ;;
         --output)
             COMPREPLY=( $(compgen -W "unix" -- "$cur") )
+            return 0
+            ;;
+        --deny)
+            COMPREPLY=( $(compgen -W "warnings" -- "$cur") )
             return 0
             ;;
         doc)
@@ -156,6 +160,7 @@ _lis() {
                     _arguments \
                         '--errors-only[Show only errors]' \
                         '--warnings-only[Show only warnings]' \
+                        '--deny[Fail check if warnings found]:group:(warnings)' \
                         '--fix[Apply lint fixes in place]' \
                         '--output[Machine-readable output]:output:(unix)'
                     ;;
@@ -209,6 +214,7 @@ complete -c lis -n '__fish_seen_subcommand_from test' -l go-flags -r -d 'Flags p
 complete -c lis -n '__fish_seen_subcommand_from format' -l check -d 'Check formatting without modifying'
 complete -c lis -n '__fish_seen_subcommand_from check' -l errors-only -d 'Show only errors'
 complete -c lis -n '__fish_seen_subcommand_from check' -l warnings-only -d 'Show only warnings'
+complete -c lis -n '__fish_seen_subcommand_from check' -l deny -r -a warnings -d 'Fail check if warnings found'
 complete -c lis -n '__fish_seen_subcommand_from check' -l fix -d 'Apply lint fixes in place'
 complete -c lis -n '__fish_seen_subcommand_from check' -l output -r -a unix -d 'Machine-readable output'
 complete -c lis -n '__fish_seen_subcommand_from doc' -s s -l search -d 'Search across prelude and Go stdlib'

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -151,6 +151,7 @@ Arguments:
 Flags:
     {--errors-only:b}                Show only errors
     {--warnings-only:b}              Show only warnings
+    {--deny:b} {warnings}              Fail check if warnings found
     {--fix:b}                        Apply lint fixes in place
     {--output:b} {unix}                Machine-readable output
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -76,9 +76,10 @@ fn main() {
             path,
             errors_only,
             warnings_only,
+            deny_warnings,
             format,
             fix,
-        } => handlers::check(path, errors_only, warnings_only, format, fix),
+        } => handlers::check(path, errors_only, warnings_only, deny_warnings, format, fix),
         Command::Test {
             path,
             go_flags,


### PR DESCRIPTION
Adds `lis check --deny warnings`, which treats warnings as errors and so fails the check (exits non-zero) when any warning is found. Without the `--deny` flag, `lis check` exits 0 with warnings, so a script cannot distinguish a clean project from one that merely compiles. Similar to: `cargo clippy -- -D warnings`

Close #1034
