### PR TITLE
fix: make `#[json]` struct field capitalization consistent

### DIFF
--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::Planner;
 use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
-use crate::definitions::structs::is_raw_function_type;
+use crate::definitions::structs::{field_go_name_is_exported, is_raw_function_type};
 use crate::names::go_name;
 use syntax::ast::{Pattern, RestPattern, StructKind};
 use syntax::containment::enum_payload_pointer_wrapped;
@@ -58,12 +58,7 @@ impl Planner<'_> {
         match &resolved.definition.body {
             DefinitionBody::Struct { fields, .. } => {
                 if let Some(field) = fields.iter().find(|f| f.name == field_name) {
-                    if field.visibility.is_public() {
-                        return true;
-                    }
-                    // Also export fields that have serialization tags (e.g. #[json])
-                    let tag_key = format!("{}.{}", id, field_name);
-                    return self.module.is_tag_exported_field(&tag_key);
+                    return field_go_name_is_exported(field, resolved.definition.is_serialized());
                 }
                 let method_key = format!("{}.{}", id, field_name);
                 self.facts

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -1,6 +1,8 @@
 use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
-use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
+use crate::definitions::tags::{
+    field_has_export_forcing_attribute, format_tag_string, interpret_field_attributes,
+};
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name::{self, prelude_qualifier};
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
@@ -31,7 +33,7 @@ impl Planner<'_> {
         let mut field_strings: Vec<String> = Vec::with_capacity(fields.len());
         let mut stringer_fields: Vec<StringerField> = Vec::with_capacity(fields.len());
         for f in fields {
-            let (field_string, stringer_field) = self.emit_struct_field(f, name, struct_attrs);
+            let (field_string, stringer_field) = self.emit_struct_field(f, struct_attrs);
             field_strings.push(field_string);
             stringer_fields.push(stringer_field);
         }
@@ -219,7 +221,6 @@ impl Planner<'_> {
     fn emit_struct_field(
         &mut self,
         f: &StructFieldDefinition,
-        struct_name: &str,
         struct_attrs: &[Attribute],
     ) -> (String, StringerField) {
         if f.embedded {
@@ -236,13 +237,7 @@ impl Planner<'_> {
         let is_option = is_option_type(&f.ty);
         let tag_string = format_tag_string(&f.name, &tag_configs, is_option);
 
-        let has_tags = !tag_configs.is_empty();
         let field_name = struct_field_go_name(f, struct_attrs);
-
-        if has_tags && !f.visibility.is_public() {
-            let key = self.facts.qualified_current_member(struct_name, &f.name);
-            self.module.record_tag_exported_field(key);
-        }
 
         let field_definition = if let Some(tags) = tag_string {
             format!("{} {} {}", field_name, self.go_type_string(&f.ty), tags)
@@ -516,17 +511,21 @@ pub(crate) fn struct_field_go_name(
 }
 
 fn field_go_name(field: &StructFieldDefinition, struct_forces_export: bool) -> Cow<'_, str> {
-    if field.embedded {
-        return go_name::escape_keyword(&field.name);
-    }
-    let exported = field.visibility.is_public()
-        || struct_forces_export
-        || !interpret_field_attributes(field, &[]).is_empty();
-    if exported {
+    if field_go_name_is_exported(field, struct_forces_export) {
         Cow::Owned(go_name::make_exported(&field.name))
     } else {
         go_name::escape_keyword(&field.name)
     }
+}
+
+pub(crate) fn field_go_name_is_exported(
+    field: &StructFieldDefinition,
+    struct_forces_export: bool,
+) -> bool {
+    !field.embedded
+        && (field.visibility.is_public()
+            || struct_forces_export
+            || field_has_export_forcing_attribute(field))
 }
 
 pub(crate) struct StringerField {

--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -41,6 +41,19 @@ pub(super) enum CaseTransform {
     CamelCase,
 }
 
+pub(super) fn field_has_export_forcing_attribute(field: &StructFieldDefinition) -> bool {
+    field.attributes.iter().any(|attribute| {
+        if attribute.name == "tag" {
+            matches!(
+                attribute.args.first(),
+                Some(AttributeArg::String(_) | AttributeArg::Raw(_))
+            )
+        } else {
+            is_serialization_key(&attribute.name)
+        }
+    })
+}
+
 pub(super) fn interpret_field_attributes(
     field: &StructFieldDefinition,
     struct_attrs: &[Attribute],

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -9,7 +9,6 @@ use crate::EnumLayout;
 #[derive(Default)]
 pub(crate) struct ModuleState {
     enum_layouts: RefCell<HashMap<u32, HashMap<String, Rc<EnumLayout>>>>,
-    tag_exported_fields: HashSet<String>,
     exported_method_names: HashSet<String>,
     user_to_string_types: HashSet<String>,
     escape_remap: HashMap<String, String>,
@@ -31,14 +30,6 @@ impl ModuleState {
             .get(&file_id)?
             .get(enum_id)
             .cloned()
-    }
-
-    pub(crate) fn record_tag_exported_field(&mut self, key: String) {
-        self.tag_exported_fields.insert(key);
-    }
-
-    pub(crate) fn is_tag_exported_field(&self, key: &str) -> bool {
-        self.tag_exported_fields.contains(key)
     }
 
     pub(crate) fn record_exported_method_name(&mut self, name: impl Into<String>) {

--- a/tests/spec/emit/snapshots/json_tagged_struct_field_access_before_definition.snap
+++ b/tests/spec/emit/snapshots/json_tagged_struct_field_access_before_definition.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn test() -> string {
+    let u = User { name: "Alice", age: 30 };
+    u.name
+  }
+  
+  #[json]
+  struct User {
+    name: string,
+    age: int,
+  }
+---
+package main
+
+func test() string {
+	u := User{
+		Name: "Alice",
+		Age:  30,
+	}
+	return u.Name
+}
+
+type User struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -3460,6 +3460,23 @@ fn test() -> string {
 }
 
 #[test]
+fn json_tagged_struct_field_access_before_definition() {
+    let input = r#"
+fn test() -> string {
+  let u = User { name: "Alice", age: 30 };
+  u.name
+}
+
+#[json]
+struct User {
+  name: string,
+  age: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn assoc_fn_returning_option_self() {
     let input = r#"
 struct Thing {


### PR DESCRIPTION
A `#[json]` struct field accessed from a different file in the same package could be emitted with its lowercase source name instead of the exported Go name, producing invalid Go. Whether it happened depended on the arrangement of files in the package.

```rs
// api/bar.lis
#[json]
struct Bar { bar: string }

// api/foo.test.lis
#[test]
fn bar_test(t: TestContext) {
  let input = Bar { bar: "bar" }
  assert input.bar == "bar"
}
```

The field `bar` is emitted as the exported Go field `Bar` in the struct definition, so the access must use `Bar` too. Previously the access could come out as `input.bar`, which Go rejects. Field capitalization is now derived from the struct declaration, so the definition and every use always agree.

Fix #1041
