### PR TITLE
fix: interface satisfaction for generic `Result` methods

### DIFF
--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -27,7 +27,6 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) test_index: &'a TestIndex,
     pub(crate) go_package_names: &'a HashMap<String, String>,
     pub(crate) go_module_ids: &'a HashSet<String>,
-    pub(crate) bound_types: &'a HashMap<Span, Type>,
     pub(crate) entry_module: ModuleId,
     pub(crate) go_module: String,
     pub(crate) options: EmitOptions,
@@ -47,7 +46,6 @@ pub(crate) struct EmitFacts<'a> {
     test_index: &'a TestIndex,
     go_package_names: &'a HashMap<String, String>,
     go_module_ids: &'a HashSet<String>,
-    bound_types: &'a HashMap<Span, Type>,
     entry_module: ModuleId,
     go_module: String,
     options: EmitOptions,
@@ -69,7 +67,6 @@ impl<'a> EmitFacts<'a> {
             test_index: config.test_index,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
-            bound_types: config.bound_types,
             entry_module: config.entry_module,
             go_module: config.go_module,
             options: config.options,
@@ -285,10 +282,6 @@ impl<'a> EmitFacts<'a> {
 
     pub(crate) fn is_go_imported_type(&self, qualified_name: &str) -> bool {
         self.globals.go_abi_catalog.is_imported_type(qualified_name)
-    }
-
-    pub(crate) fn resolved_bound_type(&self, span: Span) -> Option<&'a Type> {
-        self.bound_types.get(&span)
     }
 
     pub(crate) fn sourcemap_enabled(&self) -> bool {

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -14,7 +14,7 @@ use syntax::EcoString;
 use syntax::ast::{
     Annotation, Binding, Expression, FunctionDefinitionView, Generic, Pattern, Span, TypedPattern,
 };
-use syntax::types::Type;
+use syntax::types::{Type, build_substitution_map, substitute};
 
 /// Owned param-destructure record: temp var, pattern, typed pattern, param type.
 type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
@@ -270,6 +270,11 @@ impl Planner<'_> {
             return String::new();
         }
 
+        let generic_context = self.function_generic_context(
+            function_definition.generics,
+            receiver.as_ref().map(|(_, ty)| ty),
+            resolved_generic_bounds,
+        );
         let directive = self.maybe_line_directive(&function_definition.name_span);
         let return_ctx = self.return_context_for_type(function_definition.return_type.clone());
         let return_shape = return_ctx.lowered_shape();
@@ -307,9 +312,11 @@ impl Planner<'_> {
         }
 
         let mut body = String::new();
-        let signature = self.with_absorbed_ref_generics(
+        let signature = self.with_function_state(
             params_to_process,
+            &generic_context,
             function_definition.generics,
+            resolved_generic_bounds,
             |this| {
                 let (params_string, return_ty, deferred_patterns) = this.build_signature_tail(
                     function_definition,
@@ -451,21 +458,82 @@ impl Planner<'_> {
         (Some(receiver_var), Some(receiver_part))
     }
 
-    fn with_absorbed_ref_generics<F, R>(
+    fn function_generic_context(
+        &self,
+        function_generics: &[Generic],
+        receiver_ty: Option<&Type>,
+        resolved_generic_bounds: Option<&[(EcoString, Vec<Type>)]>,
+    ) -> Vec<(EcoString, Vec<Type>)> {
+        let mut context = receiver_ty
+            .map(|ty| self.receiver_generic_context(ty))
+            .unwrap_or_default();
+        if let Some(resolved) = resolved_generic_bounds {
+            context.extend_from_slice(resolved);
+        } else {
+            context.extend(
+                function_generics
+                    .iter()
+                    .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone())),
+            );
+        }
+        context
+    }
+
+    fn receiver_generic_context(&self, receiver_ty: &Type) -> Vec<(EcoString, Vec<Type>)> {
+        let stripped = receiver_ty.strip_refs();
+        let Type::Nominal { id, params, .. } = &stripped else {
+            return Vec::new();
+        };
+        let Some(generics) = self
+            .facts
+            .definition(id)
+            .and_then(|definition| definition.body.generics())
+        else {
+            return Vec::new();
+        };
+        let substitution = build_substitution_map(generics, params);
+        generics
+            .iter()
+            .zip(params)
+            .filter_map(|(generic, param)| {
+                let Type::Parameter(name) = param else {
+                    return None;
+                };
+                let bounds = generic
+                    .resolved_bounds
+                    .iter()
+                    .map(|bound| substitute(bound, &substitution))
+                    .collect();
+                Some((name.clone(), bounds))
+            })
+            .collect()
+    }
+
+    fn with_function_state<F, R>(
         &mut self,
         params: &[Binding],
-        generics: &[Generic],
+        generic_context: &[(EcoString, Vec<Type>)],
+        signature_generics: &[Generic],
+        resolved_signature_generics: Option<&[(EcoString, Vec<Type>)]>,
         f: F,
     ) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {
         let saved = std::mem::take(&mut self.function_state);
-        let bounded_generics: HashSet<&str> = generics
-            .iter()
-            .filter(|g| !g.bounds.is_empty())
-            .map(|g| g.name.as_ref())
-            .collect();
+        self.function_state.set_generic_context(generic_context);
+        let bounded_generics: HashSet<&str> = match resolved_signature_generics {
+            Some(generics) => generics
+                .iter()
+                .filter(|(_, bounds)| !bounds.is_empty())
+                .map(|(name, _)| name.as_str())
+                .collect(),
+            None => signature_generics
+                .iter()
+                .filter(|generic| !generic.resolved_bounds.is_empty())
+                .map(|generic| generic.name.as_str())
+                .collect(),
+        };
         for param in params.iter() {
             if param.ty.is_ref()
                 && let Some(inner) = param.ty.inner()

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -3,7 +3,6 @@ use crate::expressions::top_items::emit_doc;
 use crate::names::go_name;
 use syntax::EcoString;
 use syntax::ast::{Expression, FunctionDefinitionView, Generic, Pattern, Visibility};
-use syntax::program::DefinitionBody;
 use syntax::types::{Type, build_substitution_map, substitute, type_args_match_params};
 
 struct ImplContext<'a> {
@@ -101,14 +100,11 @@ impl Planner<'_> {
         ctx: &ImplContext<'_>,
         method_generics: &[Generic],
     ) -> Option<Vec<(EcoString, Vec<Type>)>> {
-        let receiver_generics = self.facts.definition(&ctx.qualified_type).and_then(
-            |definition| match &definition.body {
-                DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
-                    Some(generics)
-                }
-                _ => None,
-            },
-        )?;
+        let receiver_generics = self
+            .facts
+            .definition(&ctx.qualified_type)?
+            .body
+            .generics()?;
         if receiver_generics.len() != ctx.generics.len()
             || !type_args_match_params(
                 ctx.ty.get_type_params().unwrap_or_default(),
@@ -127,32 +123,18 @@ impl Planner<'_> {
             .zip(ctx.generics)
             .map(|(receiver_generic, impl_generic)| {
                 let bounds = receiver_generic
-                    .bounds
+                    .resolved_bounds
                     .iter()
-                    .map(|bound| {
-                        let resolved = self
-                            .facts
-                            .resolved_bound_type(bound.get_span())
-                            .expect("checker records every receiver bound");
-                        substitute(resolved, &substitution)
-                    })
+                    .map(|bound| substitute(bound, &substitution))
                     .collect();
                 (impl_generic.name.clone(), bounds)
             })
             .collect::<Vec<_>>();
-        generic_bounds.extend(method_generics.iter().map(|generic| {
-            let bounds = generic
-                .bounds
+        generic_bounds.extend(
+            method_generics
                 .iter()
-                .map(|bound| {
-                    self.facts
-                        .resolved_bound_type(bound.get_span())
-                        .cloned()
-                        .expect("checker records every method bound")
-                })
-                .collect();
-            (generic.name.clone(), bounds)
-        }));
+                .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone())),
+        );
         Some(generic_bounds)
     }
 }

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
-use crate::abi::callable::{AbiTransition, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
-use crate::abi::transition::emit_return_adapter;
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
+use crate::abi::transition::render_lowered_result_return;
 use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::write_line;
@@ -12,6 +12,7 @@ pub(crate) struct AdapterPlan {
     pub(crate) interface_id: EcoString,
     pub(crate) concrete_ty: Type,
     pub(crate) methods: Vec<AdapterMethod>,
+    pub(crate) generic_context: Vec<(EcoString, Vec<Type>)>,
 }
 
 pub(crate) struct AdapterMethod {
@@ -20,6 +21,8 @@ pub(crate) struct AdapterMethod {
     pub(crate) return_type: Type,
     pub(crate) user_abi: CallableReturnAbi,
     pub(crate) interface_abi: CallableReturnAbi,
+    pub(crate) user_returns_void: bool,
+    pub(crate) interface_returns_void: bool,
 }
 
 impl Planner<'_> {
@@ -93,9 +96,8 @@ impl Planner<'_> {
         result
     }
 
-    /// Adapter is needed when any method's natural emit shape differs
-    /// from the interface's hint-shifted shape (e.g. `#[go(comma_ok)]`
-    /// shifts `*T` to `(*T, bool)`).
+    /// Build an adapter when the implementation and interface expose different
+    /// physical Go return signatures for the same logical methods.
     pub(crate) fn needs_adapter(&self, source_ty: &Type, target_ty: &Type) -> Option<AdapterPlan> {
         let target = self.facts.peel_alias(target_ty);
         let Type::Nominal { id: target_id, .. } = &target else {
@@ -110,12 +112,7 @@ impl Planner<'_> {
         };
 
         let source_stripped = source_ty.strip_refs();
-        let Type::Nominal {
-            id: source_id,
-            params: source_params,
-            ..
-        } = &source_stripped
-        else {
+        let Type::Nominal { id: source_id, .. } = &source_stripped else {
             return None;
         };
         if source_id.starts_with(GO_IMPORT_PREFIX) {
@@ -124,7 +121,6 @@ impl Planner<'_> {
         let Some(Definition {
             body:
                 DefinitionBody::Struct {
-                    generics: struct_generics,
                     methods: struct_methods,
                     ..
                 },
@@ -134,16 +130,19 @@ impl Planner<'_> {
             return None;
         };
 
-        let subst_map = build_substitution_map(struct_generics, source_params);
-
         let all_interface_methods = self.collect_all_interface_methods(target_id, definition);
         let mut methods = Vec::with_capacity(all_interface_methods.len());
         let mut any_adapted = false;
 
-        for (method_name, _interface_method_ty, declaring_id) in &all_interface_methods {
+        for (method_name, interface_method_ty, declaring_id) in &all_interface_methods {
             let impl_ty = struct_methods.get(method_name)?;
-            let (method, adapted) =
-                self.build_adapter_method(method_name, declaring_id, impl_ty, &subst_map)?;
+            let (method, adapted) = self.build_adapter_method(
+                method_name,
+                declaring_id,
+                interface_method_ty,
+                impl_ty,
+                &source_stripped,
+            )?;
             if adapted {
                 any_adapted = true;
             }
@@ -154,104 +153,64 @@ impl Planner<'_> {
             return None;
         }
 
+        let generic_context = self.function_state.generic_context();
+        let generic_context = if generic_context
+            .iter()
+            .any(|(name, _)| adapter_uses_type_parameter(source_ty, &methods, name))
+        {
+            generic_context.to_vec()
+        } else {
+            Vec::new()
+        };
+
         Some(AdapterPlan {
             concrete_id: source_id.as_eco().clone(),
             interface_id: target_id.as_eco().clone(),
             concrete_ty: source_ty.clone(),
             methods,
+            generic_context,
         })
     }
 
-    /// Returns `(method, meaningful)`; `meaningful` is set when the user
-    /// shape differs from the hint-shifted interface shape.
+    /// Returns the method plan and whether its physical Go signature differs.
     fn build_adapter_method(
         &self,
         method_name: &EcoString,
         declaring_id: &EcoString,
+        interface_method_ty: &Type,
         impl_ty: &Type,
-        subst_map: &SubstitutionMap,
+        concrete_ty: &Type,
     ) -> Option<(AdapterMethod, bool)> {
         let f = impl_ty.as_function_type()?;
-        let params = &f.params;
-        let param_types: Vec<Type> = if params.is_empty() {
-            Vec::new()
-        } else {
-            params[1..]
-                .iter()
-                .map(|p| substitute(p, subst_map))
-                .collect()
-        };
-        let return_type = substitute(&f.return_type, subst_map);
+        let (receiver_ty, params) = f.params.split_first()?;
+        let substitution = method_receiver_substitution(receiver_ty, concrete_ty)?;
+        let param_types = params
+            .iter()
+            .map(|param| substitute(param, &substitution))
+            .collect();
+        let return_type = substitute(&f.return_type, &substitution);
 
-        // Compute the natural shape once and shift it for the interface side
-        // if a `#[go(...)]` hint applies, instead of re-walking `peel_alias`
-        // twice via two `classify_direct_emission` calls.
-        let user_abi = self.callable_return_abi(&return_type);
+        let user_abi = self.callable_return_abi(&f.return_type);
         let interface_hints = self.go_interface_method_hints(declaring_id, method_name);
-        let interface_abi = match &user_abi {
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                payload,
-            } if interface_hints.iter().any(|h| h == "comma_ok") => CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                payload: *payload,
-            },
-            other => other.clone(),
+        let interface_return = &interface_method_ty.as_function_type()?.return_type;
+        let interface_abi =
+            self.callable_return_abi_with_go_hints(interface_return, &interface_hints);
+        let interface_returns_void = self
+            .lowered_return_go_type(&interface_abi, interface_return)
+            .code
+            == "struct{}";
+        let method = AdapterMethod {
+            name: method_name.clone(),
+            param_types,
+            return_type,
+            user_abi,
+            interface_abi,
+            user_returns_void: f.return_type.is_unit(),
+            interface_returns_void,
         };
-        let adapted = user_abi != interface_abi;
+        let adapted = self.adapter_needs_conversion(&method);
 
-        Some((
-            AdapterMethod {
-                name: method_name.clone(),
-                param_types,
-                return_type,
-                user_abi,
-                interface_abi,
-            },
-            adapted,
-        ))
-    }
-
-    /// `NullableReturn` → `CommaOk` bridge for `#[go(comma_ok)]` methods.
-    fn emit_hint_shift_bridge(
-        &mut self,
-        inner_call: &str,
-        return_ty: &Type,
-        user_abi: &CallableReturnAbi,
-        interface_abi: &CallableReturnAbi,
-    ) -> Option<(String, String)> {
-        let (
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                ..
-            },
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                ..
-            },
-        ) = (user_abi, interface_abi)
-        else {
-            return None;
-        };
-        let inner = self.facts.peel_alias(return_ty).ok_type();
-        let is_interface = self.facts.is_interface(&inner);
-        let val = self.fresh_var(Some("val"));
-        self.declare(&val);
-        let nil_check = if is_interface {
-            self.require_stdlib();
-            format!("!lisette.IsNilInterface({})", val)
-        } else {
-            format!("{} != nil", val)
-        };
-        let go_ret = self.render_lowered_return_ty(
-            &CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                payload: PayloadLayout::Packed,
-            },
-            return_ty,
-        );
-        let body = format!("{val} := {inner_call}\nreturn {val}, {nil_check}\n");
-        Some((go_ret, body))
+        Some((method, adapted))
     }
 
     /// `#[go(...)]` hints on an interface method (user-defined or
@@ -268,8 +227,8 @@ impl Planner<'_> {
             .unwrap_or_default()
     }
 
-    /// Classify with `#[go(...)]` hints — `comma_ok` shifts the default
-    /// `NullableReturn` to `CommaOk` for nilable `Option`s.
+    /// Classify with `#[go(...)]` hints — `comma_ok` shifts a nullable
+    /// `Option` return to comma-ok form.
     pub(crate) fn callable_return_abi_with_go_hints(
         &self,
         return_ty: &Type,
@@ -295,45 +254,81 @@ impl Planner<'_> {
             concrete_dedup_key(&plan.concrete_ty, &plan.concrete_id),
             plan.interface_id.clone(),
         );
-        if let Some(name) = self.adapter_registry.lookup(&key) {
+        let cacheable = plan.generic_context.is_empty();
+        if cacheable
+            && let Some(name) = self.adapter_registry.lookup(&key)
+            && !self.is_declared(name)
+        {
             return name.clone();
         }
 
         let index = self.adapter_registry.next_index();
-        let adapter_name = adapter_type_name(&plan, index);
+        let mut base_name = adapter_type_name(&plan, index);
+        while self.is_declared(&base_name) {
+            base_name.push('_');
+        }
+        let (generics_decl, generics_use) = self.adapter_generics(&plan);
+        let adapter_type = format!("{}{}", base_name, generics_use);
 
         let concrete_go_ty = self.go_type_string(&plan.concrete_ty);
 
         let mut declaration = String::new();
-        write_line!(declaration, "type {} struct {{", adapter_name);
+        write_line!(declaration, "type {}{} struct {{", base_name, generics_decl);
         write_line!(declaration, "inner {}", concrete_go_ty);
         write_line!(declaration, "}}");
         declaration.push('\n');
 
         for method in &plan.methods {
-            self.emit_adapter_method(&mut declaration, &adapter_name, method);
+            self.emit_adapter_method(
+                &mut declaration,
+                &adapter_type,
+                &plan.generic_context,
+                method,
+            );
             declaration.push('\n');
         }
 
-        self.adapter_registry
-            .insert(key, adapter_name.clone(), declaration);
-        adapter_name
+        if cacheable {
+            self.adapter_registry
+                .insert(key, adapter_type.clone(), declaration);
+        } else {
+            self.adapter_registry.push_declaration(declaration);
+        }
+        adapter_type
+    }
+
+    fn adapter_generics(&mut self, plan: &AdapterPlan) -> (String, String) {
+        if plan.generic_context.is_empty() {
+            return (String::new(), String::new());
+        }
+
+        let names: Vec<String> = plan
+            .generic_context
+            .iter()
+            .map(|(name, _)| self.generic_go_name(name).into_owned())
+            .collect();
+        let decl = self.resolved_generics_to_string(&plan.generic_context);
+        let use_str = format!("[{}]", names.join(", "));
+        (decl, use_str)
     }
 
     fn emit_adapter_method(
         &mut self,
         declaration: &mut String,
         adapter_name: &str,
+        generic_context: &[(EcoString, Vec<Type>)],
         method: &AdapterMethod,
     ) {
         self.enter_scope();
 
-        let param_names: Vec<String> = (0..method.param_types.len())
-            .map(|i| format!("arg{}", i))
-            .collect();
-        for name in &param_names {
-            self.declare(name);
+        for (name, _) in generic_context {
+            let go_name = self.generic_go_name(name).into_owned();
+            self.declare(&go_name);
         }
+        let receiver_name = self.declare_adapter_method_binding("a".to_string());
+        let param_names: Vec<String> = (0..method.param_types.len())
+            .map(|i| self.declare_adapter_method_binding(format!("arg{}", i)))
+            .collect();
 
         let params_str = param_names
             .iter()
@@ -347,70 +342,102 @@ impl Planner<'_> {
         } else {
             go_name::escape_keyword(&method.name).into_owned()
         };
-        let inner_call = format!("a.inner.{}({})", go_method_name, param_names.join(", "));
+        let inner_call = format!(
+            "{}.inner.{}({})",
+            receiver_name,
+            go_method_name,
+            param_names.join(", ")
+        );
 
         let (go_ret, body) = self.build_adapter_body(method, &inner_call);
-        self.finish_adapter_method(
+        write_method_header(
             declaration,
+            &receiver_name,
             adapter_name,
             &go_method_name,
             &params_str,
             &go_ret,
-            &body,
         );
+        declaration.push_str(&body);
+        write_line!(declaration, "}}");
+        self.exit_scope();
+    }
+
+    fn declare_adapter_method_binding(&mut self, preferred: String) -> String {
+        if self.try_declare(&preferred) {
+            return preferred;
+        }
+        let name = self.fresh_var(Some(&preferred));
+        self.declare(&name);
+        name
+    }
+
+    fn adapter_needs_conversion(&self, method: &AdapterMethod) -> bool {
+        if method.user_returns_void != method.interface_returns_void {
+            return true;
+        }
+        if method.interface_returns_void {
+            return false;
+        }
+
+        let peeled = self.facts.peel_alias(&method.return_type);
+        if !abi_matches_type(&method.interface_abi, &peeled) {
+            return false;
+        }
+        self.lowered_return_go_type(&method.user_abi, &method.return_type)
+            .code
+            != self
+                .lowered_return_go_type(&method.interface_abi, &method.return_type)
+                .code
     }
 
     fn build_adapter_body(&mut self, method: &AdapterMethod, inner_call: &str) -> (String, String) {
         let user_abi = &method.user_abi;
         let interface_abi = &method.interface_abi;
+        let return_type = &method.return_type;
 
-        if user_abi == interface_abi {
-            if user_abi.is_lowered() {
-                let go_ret = self.render_lowered_return_ty(user_abi, &method.return_type);
-                return (go_ret, format!("return {}\n", inner_call));
-            }
-            if method.return_type.is_unit() {
+        if method.user_returns_void != method.interface_returns_void {
+            if method.interface_returns_void {
                 return (String::new(), format!("{}\n", inner_call));
             }
-            let go_ret = self.go_type_string(&method.return_type);
+            let go_ret = self.go_type_string(return_type);
+            let (zero, packages) = self.zero_value(return_type);
+            self.require_packages(&packages);
+            return (go_ret, format!("{}\nreturn {}\n", inner_call, zero));
+        }
+
+        if !self.adapter_needs_conversion(method) {
+            if method.interface_returns_void {
+                return (String::new(), format!("{}\n", inner_call));
+            }
+            let peeled = self.facts.peel_alias(return_type);
+            let go_ret_abi = if abi_matches_type(interface_abi, &peeled) {
+                interface_abi
+            } else {
+                user_abi
+            };
+            let go_ret = self.render_lowered_return_ty(go_ret_abi, return_type);
             return (go_ret, format!("return {}\n", inner_call));
         }
 
-        if let Some(bridge) =
-            self.emit_hint_shift_bridge(inner_call, &method.return_type, user_abi, interface_abi)
-        {
-            return bridge;
-        }
-
-        if matches!(
-            user_abi.transition_to(interface_abi),
-            AbiTransition::LowerFromTagged
-        ) && let Some(adapter) = emit_return_adapter(self, inner_call, &method.return_type)
-        {
-            return adapter;
-        }
-
-        if method.return_type.is_unit() {
-            (String::new(), format!("{}\n", inner_call))
+        let logical_ty = self.facts.peel_alias(return_type);
+        let go_ret = self.render_lowered_return_ty(interface_abi, return_type);
+        let (setup, tagged) = self.lower_abi_to_tagged(inner_call, user_abi, &logical_ty);
+        let mut body = crate::Renderer.render_setup(&setup);
+        if interface_abi.is_passthrough() {
+            write_line!(body, "return {}", tagged);
         } else {
-            let ret = self.go_type_string(&method.return_type);
-            (ret, format!("return {}\n", inner_call))
+            let subject = if user_abi.is_passthrough() {
+                let res = self.fresh_var(Some("res"));
+                self.declare(&res);
+                write_line!(body, "{} := {}", res, tagged);
+                res
+            } else {
+                tagged
+            };
+            render_lowered_result_return(self, &mut body, &subject, &logical_ty, interface_abi);
         }
-    }
-
-    fn finish_adapter_method(
-        &mut self,
-        declaration: &mut String,
-        adapter_name: &str,
-        method_name: &str,
-        params: &str,
-        go_ret: &str,
-        body: &str,
-    ) {
-        write_method_header(declaration, adapter_name, method_name, params, go_ret);
-        declaration.push_str(body);
-        write_line!(declaration, "}}");
-        self.exit_scope();
+        (go_ret, body)
     }
 
     pub(crate) fn resolve_tuple_slot_types(
@@ -454,6 +481,7 @@ impl Planner<'_> {
 
 fn write_method_header(
     declaration: &mut String,
+    receiver_name: &str,
     adapter_name: &str,
     method_name: &str,
     params: &str,
@@ -466,12 +494,47 @@ fn write_method_header(
     };
     write_line!(
         declaration,
-        "func (a {}) {}({}){} {{",
+        "func ({} {}) {}({}){} {{",
+        receiver_name,
         adapter_name,
         method_name,
         params,
         ret_suffix
     );
+}
+
+fn method_receiver_substitution(receiver_ty: &Type, concrete_ty: &Type) -> Option<SubstitutionMap> {
+    let receiver = receiver_ty.strip_refs();
+    let concrete = concrete_ty.strip_refs();
+    let (
+        Type::Nominal {
+            id: receiver_id,
+            params: receiver_params,
+            ..
+        },
+        Type::Nominal {
+            id: concrete_id,
+            params: concrete_params,
+            ..
+        },
+    ) = (&receiver, &concrete)
+    else {
+        return None;
+    };
+    if receiver_id != concrete_id || receiver_params.len() != concrete_params.len() {
+        return None;
+    }
+
+    receiver_params
+        .iter()
+        .zip(concrete_params)
+        .map(|(receiver_param, concrete_param)| {
+            let Type::Parameter(name) = receiver_param else {
+                return None;
+            };
+            Some((name.clone(), concrete_param.clone()))
+        })
+        .collect()
 }
 
 fn concrete_dedup_key(concrete_ty: &Type, concrete_id: &EcoString) -> EcoString {
@@ -522,4 +585,30 @@ fn adapter_type_name(plan: &AdapterPlan, index: usize) -> String {
         iface_name,
         index
     )
+}
+
+fn adapter_uses_type_parameter(
+    concrete_ty: &Type,
+    methods: &[AdapterMethod],
+    name: &EcoString,
+) -> bool {
+    let parameter = Type::Parameter(name.clone());
+    concrete_ty.contains_type(&parameter)
+        || methods.iter().any(|method| {
+            method.return_type.contains_type(&parameter)
+                || method
+                    .param_types
+                    .iter()
+                    .any(|param| param.contains_type(&parameter))
+        })
+}
+
+fn abi_matches_type(abi: &CallableReturnAbi, peeled: &Type) -> bool {
+    match abi {
+        CallableReturnAbi::Tagged | CallableReturnAbi::Direct => true,
+        CallableReturnAbi::Result { .. } => peeled.is_result(),
+        CallableReturnAbi::Partial { .. } => peeled.is_partial(),
+        CallableReturnAbi::Option { .. } => peeled.is_option(),
+        CallableReturnAbi::Tuple { .. } => peeled.tuple_arity().is_some_and(|arity| arity >= 2),
+    }
 }

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -221,7 +221,6 @@ pub struct TestEmitConfig<'a> {
     pub test_index: &'a TestIndex,
     pub go_package_names: &'a HashMap<String, String>,
     pub go_module_ids: &'a HashSet<String>,
-    pub bound_types: &'a HashMap<Span, Type>,
     pub resolved_definitions: &'a ResolvedDefinitions,
 }
 
@@ -390,7 +389,6 @@ impl<'a> Planner<'a> {
             test_index: config.test_index,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
-            bound_types: config.bound_types,
             resolved_definitions: config.resolved_definitions,
             entry_module: config.module_id.to_string(),
             go_module: config.go_module.to_string(),
@@ -652,7 +650,6 @@ fn emit_module<'a>(
         test_index: &analysis.test_index,
         go_package_names: &analysis.go_package_names,
         go_module_ids: &analysis.go_module_ids,
-        bound_types: &analysis.bound_types,
         resolved_definitions: &analysis.resolved_definitions,
         entry_module: analysis.entry_module_id.to_string(),
         go_module: go_module.to_string(),

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -51,19 +51,7 @@ impl Planner<'_> {
     pub(crate) fn generics_to_string(&mut self, generics: &[Generic]) -> String {
         let resolved_generics = generics
             .iter()
-            .map(|generic| {
-                let bounds = generic
-                    .bounds
-                    .iter()
-                    .map(|bound| {
-                        self.facts
-                            .resolved_bound_type(bound.get_span())
-                            .cloned()
-                            .expect("checker records a resolved type for every generic bound")
-                    })
-                    .collect::<Vec<_>>();
-                (generic.name.clone(), bounds)
-            })
+            .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone()))
             .collect::<Vec<_>>();
         self.resolved_generics_to_string(&resolved_generics)
     }

--- a/crates/emit/src/state/adapter_registry.rs
+++ b/crates/emit/src/state/adapter_registry.rs
@@ -14,7 +14,7 @@ impl AdapterRegistry {
     }
 
     pub(crate) fn next_index(&self) -> usize {
-        self.synthesized.len()
+        self.declarations.len()
     }
 
     pub(crate) fn insert(
@@ -24,6 +24,10 @@ impl AdapterRegistry {
         declaration: String,
     ) {
         self.synthesized.insert(key, name);
+        self.declarations.push(declaration);
+    }
+
+    pub(crate) fn push_declaration(&mut self, declaration: String) {
         self.declarations.push(declaration);
     }
 

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -1,8 +1,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use ecow::EcoString;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
+use syntax::types::Type;
 
 use crate::EnumLayout;
 
@@ -87,6 +89,7 @@ impl ModuleState {
 #[derive(Default)]
 pub(crate) struct FunctionEmissionState {
     absorbed_ref_generics: HashSet<String>,
+    generic_context: Vec<(EcoString, Vec<Type>)>,
 }
 
 impl FunctionEmissionState {
@@ -96,5 +99,13 @@ impl FunctionEmissionState {
 
     pub(crate) fn record_absorbed_ref_generic(&mut self, name: impl Into<String>) {
         self.absorbed_ref_generics.insert(name.into());
+    }
+
+    pub(crate) fn set_generic_context(&mut self, context: &[(EcoString, Vec<Type>)]) {
+        self.generic_context = context.to_vec();
+    }
+
+    pub(crate) fn generic_context(&self) -> &[(EcoString, Vec<Type>)] {
+        &self.generic_context
     }
 }

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -314,6 +314,14 @@ impl TaskState<'_> {
         }
     }
 
+    /// Fill `resolved_bounds` on each item's generics, mirroring the per-module
+    /// pass. Test harnesses that emit a typed AST directly bypass that pass.
+    pub fn populate_item_generic_bounds(&self, items: &mut [Expression]) {
+        for item in items {
+            populate_expression_generic_bounds(item, &self.facts.bound_types);
+        }
+    }
+
     /// Register a Go module (stdlib or third-party). Unlike regular modules,
     /// Go modules export everything as public and do not put their own module
     /// in scope (no self-references like `MyModule.Type`). `cache_path` is the

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -55,7 +55,6 @@ fn emit_inner(
         test_index: &test_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
-        bound_types: &result.bound_types,
         resolved_definitions: &result.resolved_definitions,
     };
     let mut emitter = Planner::new_for_tests(&config, source_for_sourcemap);

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -112,7 +112,6 @@ impl CompiledTest {
             mutations,
             ufcs_methods,
             equality_index,
-            bound_types,
             go_package_names,
             go_module_ids,
             resolved_definitions,
@@ -217,6 +216,7 @@ impl CompiledTest {
             }
             typed_ast = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store)
                 .freeze_items(typed_ast);
+            checker.populate_item_generic_bounds(&mut typed_ast);
 
             if !checker.failed() {
                 // Overwrite the stored file with the typed AST so passes::run
@@ -297,7 +297,6 @@ impl CompiledTest {
 
             let ufcs_methods = std::mem::take(&mut checker.ufcs_methods);
             let equality_index = std::mem::take(&mut store.equality_index);
-            let bound_types = std::mem::take(&mut checker.facts.bound_types);
             let resolved_definitions = std::mem::take(&mut checker.facts.resolved_definitions);
             let go_package_names = store.go_package_names.clone();
             let go_module_ids: HashSet<String> = store
@@ -315,7 +314,6 @@ impl CompiledTest {
                 mutations,
                 ufcs_methods,
                 equality_index,
-                bound_types,
                 go_package_names,
                 go_module_ids,
                 resolved_definitions,
@@ -332,7 +330,6 @@ impl CompiledTest {
             mutations,
             ufcs_methods,
             equality_index,
-            bound_types,
             go_package_names,
             go_module_ids,
             resolved_definitions,
@@ -350,7 +347,6 @@ pub struct InferenceResult {
     pub mutations: MutationInfo,
     pub ufcs_methods: HashSet<(String, String)>,
     pub equality_index: EqualityIndex,
-    pub bound_types: HashMap<syntax::ast::Span, syntax::types::Type>,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
     pub resolved_definitions: ResolvedDefinitions,

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -68,7 +68,6 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         test_index: &test_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
-        bound_types: &result.bound_types,
         resolved_definitions: &result.resolved_definitions,
     };
     let mut emitter = Planner::new_for_tests(&config, None);

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -5906,6 +5906,213 @@ fn main() {
 }
 
 #[test]
+fn generic_adapter_uses_validated_receiver_context() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+struct Keyed<K: Comparable> {
+  key: K,
+}
+
+impl<K: Comparable> Keyed<K> {
+  fn get(self) -> Option<K> {
+    Some(self.key)
+  }
+}
+
+interface Box<T> {
+  fn get() -> T
+}
+
+fn consume<T: Comparable>(_box: Box<Option<Array<T, 2>>>) {}
+
+struct Runner<T: Comparable> {
+  marker: T,
+}
+
+impl<T: Comparable> Runner<T> {
+  fn pass(self, keyed: Keyed<Array<T, 2>>) {
+    consume(keyed)
+  }
+}
+
+fn main() {
+  let key: Array<int, 2> = [1, 2]
+  let runner = Runner { marker: 0 }
+  runner.pass(Keyed { key: key })
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn generic_adapter_instantiates_renamed_impl_parameters() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar<T> {
+  value: Option<T>,
+}
+
+impl<Item> Bar<Item> {
+  fn get(self) -> Option<Item> {
+    self.value
+  }
+}
+
+fn consume<T>(_box: Box<Option<T>>) {}
+
+fn main() {
+  consume(Bar { value: Some(1) })
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn generic_adapter_freshens_method_names_against_type_parameters() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+interface Box<T> {
+  fn get(index: int) -> T
+}
+
+struct Bar<T> {
+  value: T,
+}
+
+impl<T> Bar<T> {
+  fn get(self, _index: int) -> Option<T> {
+    Some(self.value)
+  }
+}
+
+fn consume<T>(_box: Box<Option<T>>) {}
+
+fn pass<a, arg0>(bar: Bar<a>, _marker: arg0) {
+  consume(bar)
+}
+
+fn main() {
+  pass(Bar { value: 1 }, true)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn adapter_type_name_freshens_against_active_scope() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar<T> {
+  value: Option<T>,
+}
+
+impl<T> Bar<T> {
+  fn get(self) -> Option<T> {
+    self.value
+  }
+}
+
+fn consume<T>(_box: Box<Option<T>>) {}
+
+fn generic_collision<_lisAdapter_Bar_Box_0>(bar: Bar<_lisAdapter_Bar_Box_0>) {
+  consume(bar)
+}
+
+fn prime_cache(bar: Bar<int>) {
+  consume(bar)
+}
+
+fn cached_collision(bar: Bar<int>) {
+  let _lisAdapter_Bar_Box_1 = 1
+  consume(bar)
+  let _ = _lisAdapter_Bar_Box_1
+}
+
+fn main() {
+  generic_collision(Bar { value: Some(1) })
+  prime_cache(Bar { value: Some(2) })
+  cached_collision(Bar { value: Some(3) })
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn receiver_generic_ref_parameter_keeps_pointer_shape() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+interface Marker {
+  fn get() -> int
+}
+
+struct Item {
+  n: int,
+}
+
+impl Item {
+  fn get(self) -> int {
+    self.n
+  }
+}
+
+struct Holder<T: Marker> {
+  item: T,
+}
+
+impl<T: Marker> Holder<T> {
+  fn read(self, value: Ref<T>) -> int {
+    value.*.get()
+  }
+}
+
+fn main() {
+  let holder = Holder { item: Item { n: 1 } }
+  let value = Item { n: 2 }
+  let _ = holder.read(&value)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn result_with_pointer_error_lowers_to_native_tuple() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
+++ b/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
@@ -1,0 +1,72 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar[T any] struct {
+	value lisette.Option[T]
+}
+
+func (b Bar[T]) get() (T, bool) {
+	v_1 := b.value
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(T), false
+}
+
+func consume[T any](_ Box[lisette.Option[T]]) {}
+
+func generic_collision[_lisAdapter_Bar_Box_0 any](bar Bar[_lisAdapter_Bar_Box_0]) {
+	consume(_lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0]{inner: bar})
+}
+
+func prime_cache(bar Bar[int]) {
+	consume(_lisAdapter_Bar_Box_1{inner: bar})
+}
+
+func cached_collision(bar Bar[int]) {
+	_lisAdapter_Bar_Box_1 := 1
+	consume(_lisAdapter_Bar_Box_2{inner: bar})
+	_ = _lisAdapter_Bar_Box_1
+}
+
+func main() {
+	generic_collision(Bar[int]{value: lisette.MakeOptionSome(1)})
+	prime_cache(Bar[int]{value: lisette.MakeOptionSome(2)})
+	cached_collision(Bar[int]{value: lisette.MakeOptionSome(3)})
+}
+
+type _lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0 any] struct {
+	inner Bar[_lisAdapter_Bar_Box_0]
+}
+
+func (a _lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0]) get() lisette.Option[_lisAdapter_Bar_Box_0] {
+	option_1 := lisette.OptionFromCommaOk[_lisAdapter_Bar_Box_0](a.inner.get())
+	return option_1
+}
+
+type _lisAdapter_Bar_Box_1 struct {
+	inner Bar[int]
+}
+
+func (a _lisAdapter_Bar_Box_1) get() lisette.Option[int] {
+	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
+	return option_1
+}
+
+type _lisAdapter_Bar_Box_2 struct {
+	inner Bar[int]
+}
+
+func (a _lisAdapter_Bar_Box_2) get() lisette.Option[int] {
+	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
+++ b/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
@@ -4,7 +4,10 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	lisette "github.com/ivov/lisette/prelude"
+)
 
 type MyCache struct{}
 
@@ -30,6 +33,10 @@ func (a _lisAdapter_MyCache_ClientSessionCache_0) Put(arg0 string, arg1 *tls.Cli
 }
 
 func (a _lisAdapter_MyCache_ClientSessionCache_0) Get(arg0 string) (*tls.ClientSessionState, bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*tls.ClientSessionState](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/build/snapshots/generic_adapter_freshens_method_names_against_type_parameters.snap
+++ b/tests/spec/build/snapshots/generic_adapter_freshens_method_names_against_type_parameters.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[T any] interface {
+	get(int) T
+}
+
+type Bar[T any] struct {
+	value T
+}
+
+func (b Bar[T]) get(_ int) (T, bool) {
+	return b.value, true
+}
+
+func consume[T any](_ Box[lisette.Option[T]]) {}
+
+func pass[a any, arg0 any](bar Bar[a], _ arg0) {
+	consume(_lisAdapter_Bar_Box_0[a, arg0]{inner: bar})
+}
+
+func main() {
+	pass(Bar[int]{value: 1}, true)
+}
+
+type _lisAdapter_Bar_Box_0[a any, arg0 any] struct {
+	inner Bar[a]
+}
+
+func (a_1 _lisAdapter_Bar_Box_0[a, arg0]) get(arg0_2 int) lisette.Option[a] {
+	option_3 := lisette.OptionFromCommaOk[a](a_1.inner.get(arg0_2))
+	return option_3
+}

--- a/tests/spec/build/snapshots/generic_adapter_instantiates_renamed_impl_parameters.snap
+++ b/tests/spec/build/snapshots/generic_adapter_instantiates_renamed_impl_parameters.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar[T any] struct {
+	value lisette.Option[T]
+}
+
+func (b Bar[Item]) get() (Item, bool) {
+	v_1 := b.value
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(Item), false
+}
+
+func consume[T any](_ Box[lisette.Option[T]]) {}
+
+func main() {
+	consume(_lisAdapter_Bar_Box_0{inner: Bar[int]{value: lisette.MakeOptionSome(1)}})
+}
+
+type _lisAdapter_Bar_Box_0 struct {
+	inner Bar[int]
+}
+
+func (a _lisAdapter_Bar_Box_0) get() lisette.Option[int] {
+	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/build/snapshots/generic_adapter_uses_validated_receiver_context.snap
+++ b/tests/spec/build/snapshots/generic_adapter_uses_validated_receiver_context.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Keyed[K comparable] struct {
+	key K
+}
+
+func (k Keyed[K]) get() (K, bool) {
+	return k.key, true
+}
+
+type Box[T any] interface {
+	get() T
+}
+
+func consume[T comparable](_ Box[lisette.Option[[2]T]]) {}
+
+type Runner[T comparable] struct {
+	marker T
+}
+
+func (r Runner[T]) pass(keyed Keyed[[2]T]) {
+	consume(_lisAdapter_Keyed_Box_0[T]{inner: keyed})
+}
+
+func main() {
+	key := [2]int{1, 2}
+	runner := Runner[int]{marker: 0}
+	runner.pass(Keyed[[2]int]{key: key})
+}
+
+type _lisAdapter_Keyed_Box_0[T comparable] struct {
+	inner Keyed[[2]T]
+}
+
+func (a _lisAdapter_Keyed_Box_0[T]) get() lisette.Option[[2]T] {
+	option_1 := lisette.OptionFromCommaOk[[2]T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
+++ b/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
@@ -4,6 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry[T any] struct {
 	value T
 }
@@ -36,8 +38,12 @@ type _lisAdapter_MyCache_Cache_0 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry[int], bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry[int]](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }
 
 type _lisAdapter_MyCache_Cache_1 struct {
@@ -45,6 +51,10 @@ type _lisAdapter_MyCache_Cache_1 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_1) Get(arg0 string) (*Entry[string], bool) {
-	val_2 := a.inner.Get(arg0)
-	return val_2, val_2 != nil
+	raw_3 := a.inner.Get(arg0)
+	option_4 := lisette.OptionFromNilable[*Entry[string]](raw_3, raw_3 == nil)
+	if option_4.Tag == lisette.OptionSome {
+		return option_4.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
+++ b/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
@@ -4,6 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry struct {
 	name string
 }
@@ -41,6 +43,10 @@ func (a _lisAdapter_MyCache_ExtendedCache_0) Touch() {
 }
 
 func (a _lisAdapter_MyCache_ExtendedCache_0) Get(arg0 string) (*Entry, bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/build/snapshots/receiver_generic_ref_parameter_keeps_pointer_shape.snap
+++ b/tests/spec/build/snapshots/receiver_generic_ref_parameter_keeps_pointer_shape.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+type Marker interface {
+	get() int
+}
+
+type Item struct {
+	n int
+}
+
+func (i Item) get() int {
+	return i.n
+}
+
+type Holder[T Marker] struct {
+	item T
+}
+
+func (h Holder[T]) read(value *T) int {
+	return value.get()
+}
+
+func main() {
+	holder := Holder[Item]{item: Item{n: 1}}
+	value := Item{n: 2}
+	_ = holder.read(&value)
+}

--- a/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
+++ b/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
@@ -4,6 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry struct {
 	name string
 }
@@ -30,6 +32,10 @@ type _lisAdapter_MyCache_Cache_0 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_0) GetSession(arg0 string) (*Entry, bool) {
-	val_1 := a.inner.GetSession(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.GetSession(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
+++ b/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
@@ -4,6 +4,8 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry struct {
 	name string
 }
@@ -30,6 +32,10 @@ type _lisAdapter_MyCache_Cache_0 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry, bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -399,6 +399,40 @@ pub interface Storage {
 }
 
 #[test]
+fn ref_impl_satisfies_option_ref_go_interface_without_adapter() {
+    let input = r#"
+import "go:example.com/store"
+
+struct Store {}
+
+impl Store {
+  fn Find(self, key: string) -> Ref<store.Entry> {
+    store.NewEntry()
+  }
+}
+
+fn use_store(s: store.Storage) {
+  let _ = s
+}
+
+fn main() {
+  let s = Store {}
+  use_store(s as store.Storage)
+}
+"#;
+    let typedef = r#"
+pub struct Entry { pub Name: string }
+
+pub fn NewEntry() -> Ref<Entry>
+
+pub interface Storage {
+  fn Find(key: string) -> Option<Ref<Entry>>
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/store", typedef)]);
+}
+
+#[test]
 fn go_named_function_alias_preserved_through_option_tuple_return() {
     let input = r#"
 import "go:example.com/tea"

--- a/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
+++ b/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
@@ -1,0 +1,65 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:errors"
+  
+  type R = Result<int, error>
+  
+  interface Foo<E: error> {
+    fn get() -> Result<int, E>
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) -> R {
+      Err(errors.New("x"))
+    }
+  }
+  
+  fn use_foo(_foo: Foo<error>) {}
+  
+  fn main() {
+    use_foo(Bar {})
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type R = lisette.Result[int, error]
+
+type Foo[E error] interface {
+	get() lisette.Result[int, E]
+}
+
+type Bar struct{}
+
+func (b Bar) get() (int, error) {
+	return 0, errors.New("x")
+}
+
+func use_foo(_ Foo[error]) {}
+
+func main() {
+	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Foo_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
+	ret_1, ret_2 := a.inner.get()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	return result_3
+}

--- a/tests/spec/emit/snapshots/bare_param_interface_matches_generic_result_impl_without_adapter.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_matches_generic_result_impl_without_adapter.snap
@@ -1,0 +1,70 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:errors"
+  
+  interface Box<T> {
+    fn get() -> T
+  }
+  
+  struct Bar<E: error> {
+    e: E,
+  }
+  
+  impl<E: error> Bar<E> {
+    fn get(self) -> Result<int, E> {
+      Err(self.e)
+    }
+  }
+  
+  fn consume<E: error>(box: Box<Result<int, E>>) {
+    match box.get() {
+      Ok(v) => { let _ = v },
+      Err(e) => { let _ = e },
+    }
+  }
+  
+  fn pass<E: error>(b: Bar<E>) {
+    consume(b)
+  }
+  
+  fn main() {
+    pass(Bar { e: errors.New("x") })
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar[E error] struct {
+	e E
+}
+
+func (b Bar[E]) get() lisette.Result[int, E] {
+	return lisette.MakeResultErr[int, E](b.e)
+}
+
+func consume[E error](box Box[lisette.Result[int, E]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal
+	} else {
+		_ = subject_1.ErrVal
+	}
+}
+
+func pass[E error](b Bar[E]) {
+	consume(b)
+}
+
+func main() {
+	pass(Bar[error]{e: errors.New("x")})
+}

--- a/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
@@ -1,0 +1,68 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Foo<T> {
+    fn get() -> T
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) -> Result<int, error> {
+      Ok(1)
+    }
+  }
+  
+  fn use_foo(foo: Foo<Result<int, error>>) {
+    match foo.get() {
+      Ok(v) => { let _ = v },
+      Err(e) => { let _ = e },
+    }
+  }
+  
+  fn main() {
+    use_foo(Bar {})
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Foo[T any] interface {
+	get() T
+}
+
+type Bar struct{}
+
+func (b Bar) get() (int, error) {
+	return 1, nil
+}
+
+func use_foo(foo Foo[lisette.Result[int, error]]) {
+	subject_1 := foo.get()
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal
+	} else {
+		_ = subject_1.ErrVal
+	}
+}
+
+func main() {
+	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Foo_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
+	ret_1, ret_2 := a.inner.get()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	return result_3
+}

--- a/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
@@ -1,0 +1,69 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Thing {
+    v: int,
+  }
+  
+  interface Box<T> {
+    fn get() -> T
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) -> Option<Ref<Thing>> {
+      None
+    }
+  }
+  
+  fn use_box(box: Box<Option<Ref<Thing>>>) {
+    match box.get() {
+      Some(t) => { let _ = t },
+      None => {},
+    }
+  }
+  
+  fn main() {
+    use_box(Bar {})
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Thing struct {
+	v int
+}
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar struct{}
+
+func (b Bar) get() *Thing {
+	return nil
+}
+
+func use_box(box Box[lisette.Option[*Thing]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func main() {
+	use_box(_lisAdapter_Bar_Box_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Box_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Box_0) get() lisette.Option[*Thing] {
+	raw_1 := a.inner.get()
+	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
+	return option_2
+}

--- a/tests/spec/emit/snapshots/bare_param_interface_wraps_void_impl_as_unit_value.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_wraps_void_impl_as_unit_value.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<T> {
+    fn get() -> T
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) {}
+  }
+  
+  fn consume(box: Box<()>) {
+    let _ = box.get()
+  }
+  
+  fn main() {
+    consume(Bar {})
+  }
+---
+package main
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar struct{}
+
+func (b Bar) get() {}
+
+func consume(box Box[struct{}]) {
+	box.get()
+}
+
+func main() {
+	consume(_lisAdapter_Bar_Box_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Box_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Box_0) get() struct{} {
+	a.inner.get()
+	return struct{}{}
+}

--- a/tests/spec/emit/snapshots/generic_adapter_captures_alias_parameter_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_alias_parameter_bound.snap
@@ -1,0 +1,77 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type Wrapped<T: Comparable> = Slice<T>
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<T: Comparable>(box: Box<Option<Wrapped<T>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T: Comparable>(b: Bar<Wrapped<T>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    let w: Wrapped<int> = [1, 2]
+    pass(Bar { m: w })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Wrapped[T comparable] = []T
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[T comparable](box Box[lisette.Option[Wrapped[T]]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T comparable](b Bar[Wrapped[T]]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	w := []int{1, 2}
+	pass(Bar[Wrapped[int]]{m: w})
+}
+
+type _lisAdapter_Bar_Box_0[T comparable] struct {
+	inner Bar[Wrapped[T]]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[Wrapped[T]] {
+	option_1 := lisette.OptionFromCommaOk[Wrapped[T]](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_captures_complete_caller_context.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_complete_caller_context.snap
@@ -1,0 +1,93 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Holder<X> {
+    fn h() -> X
+  }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    s: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.s)
+    }
+  }
+  
+  struct IntHolder {}
+  
+  impl IntHolder {
+    fn h(self) -> int {
+      1
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<T>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<U, T: Holder<U>>(b: Bar<T>) {
+    consume(b)
+  }
+  
+  fn main() {
+    pass<int, IntHolder>(Bar { s: IntHolder {} })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Holder[X any] interface {
+	h() X
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	s S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.s, true
+}
+
+type IntHolder struct{}
+
+func (i IntHolder) h() int {
+	return 1
+}
+
+func consume[T any](box Box[lisette.Option[T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[U any, T Holder[U]](b Bar[T]) {
+	consume(_lisAdapter_Bar_Box_0[U, T]{inner: b})
+}
+
+func main() {
+	pass[int, IntHolder](Bar[IntHolder]{s: IntHolder{}})
+}
+
+type _lisAdapter_Bar_Box_0[U any, T Holder[U]] struct {
+	inner Bar[T]
+}
+
+func (a _lisAdapter_Bar_Box_0[U, T]) get() lisette.Option[T] {
+	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_captures_interface_parameter_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_interface_parameter_bound.snap
@@ -1,0 +1,101 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Foo<T: Comparable> {
+    fn f() -> T
+  }
+  
+  struct IntFoo {}
+  
+  impl IntFoo {
+    fn f(self) -> int {
+      1
+    }
+  }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<T: Comparable>(box: Box<Option<Foo<T>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T: Comparable>(b: Bar<Foo<T>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    let f: Foo<int> = IntFoo {}
+    pass(Bar { m: f })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Foo[T comparable] interface {
+	f() T
+}
+
+type IntFoo struct{}
+
+func (i IntFoo) f() int {
+	return 1
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[T comparable](box Box[lisette.Option[Foo[T]]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T comparable](b Bar[Foo[T]]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	var f Foo[int] = IntFoo{}
+	pass(Bar[Foo[int]]{m: f})
+}
+
+type _lisAdapter_Bar_Box_0[T comparable] struct {
+	inner Bar[Foo[T]]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[Foo[T]] {
+	ret_1, ret_2 := a.inner.get()
+	var option_3 lisette.Option[Foo[T]]
+	if ret_2 && !lisette.IsNilInterface(ret_1) {
+		option_3 = lisette.MakeOptionSome[Foo[T]](ret_1)
+	} else {
+		option_3 = lisette.MakeOptionNone[Foo[T]]()
+	}
+	return option_3
+}

--- a/tests/spec/emit/snapshots/generic_adapter_copies_context_bound_for_composite_arg.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_copies_context_bound_for_composite_arg.snap
@@ -1,0 +1,73 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Keyed<K: Comparable> {
+    k: K,
+  }
+  
+  impl<K: Comparable> Keyed<K> {
+    fn get(self) -> Option<K> {
+      Some(self.k)
+    }
+  }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  fn consume<T: Comparable>(box: Box<Option<Array<T, 2>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T: Comparable>(k: Keyed<Array<T, 2>>) {
+    consume(k)
+  }
+  
+  fn main() {
+    let a: Array<int, 2> = [1, 2]
+    pass(Keyed { k: a })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Keyed[K comparable] struct {
+	k K
+}
+
+func (k Keyed[K]) get() (K, bool) {
+	return k.k, true
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+func consume[T comparable](box Box[lisette.Option[[2]T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T comparable](k Keyed[[2]T]) {
+	consume(_lisAdapter_Keyed_Box_0[T]{inner: k})
+}
+
+func main() {
+	a := [2]int{1, 2}
+	pass(Keyed[[2]int]{k: a})
+}
+
+type _lisAdapter_Keyed_Box_0[T comparable] struct {
+	inner Keyed[[2]T]
+}
+
+func (a _lisAdapter_Keyed_Box_0[T]) get() lisette.Option[[2]T] {
+	option_1 := lisette.OptionFromCommaOk[[2]T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
@@ -1,0 +1,98 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Holder<T> {
+    fn item() -> T
+  }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct IntHolder {}
+  
+  impl IntHolder {
+    fn item(self) -> int {
+      5
+    }
+  }
+  
+  struct Wrap<A, B: Holder<A>> {
+    a: A,
+    b: B,
+  }
+  
+  impl<A, B: Holder<A>> Wrap<A, B> {
+    fn get(self) -> Option<A> {
+      Some(self.a)
+    }
+  }
+  
+  fn consume<A>(box: Box<Option<A>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn use_wrap<A, B: Holder<A>>(w: Wrap<A, B>) {
+    consume(w)
+  }
+  
+  fn main() {
+    use_wrap(Wrap { a: 3, b: IntHolder {} })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Holder[T any] interface {
+	item() T
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+type IntHolder struct{}
+
+func (i IntHolder) item() int {
+	return 5
+}
+
+type Wrap[A any, B Holder[A]] struct {
+	a A
+	b B
+}
+
+func (w Wrap[A, B]) get() (A, bool) {
+	return w.a, true
+}
+
+func consume[A any](box Box[lisette.Option[A]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func use_wrap[A any, B Holder[A]](w Wrap[A, B]) {
+	consume(_lisAdapter_Wrap_Box_0[A, B]{inner: w})
+}
+
+func main() {
+	use_wrap(Wrap[int, IntHolder]{
+		a: 3,
+		b: IntHolder{},
+	})
+}
+
+type _lisAdapter_Wrap_Box_0[A any, B Holder[A]] struct {
+	inner Wrap[A, B]
+}
+
+func (a _lisAdapter_Wrap_Box_0[A, B]) get() lisette.Option[A] {
+	option_1 := lisette.OptionFromCommaOk[A](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_declares_nested_type_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_declares_nested_type_parameter.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    xs: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.xs)
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<Slice<T>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T>(b: Bar<Slice<T>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    pass(Bar { xs: [1, 2] })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	xs S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.xs, true
+}
+
+func consume[T any](box Box[lisette.Option[[]T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T any](b Bar[[]T]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	pass(Bar[[]int]{xs: []int{1, 2}})
+}
+
+type _lisAdapter_Bar_Box_0[T any] struct {
+	inner Bar[[]T]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[[]T] {
+	option_1 := lisette.OptionFromCommaOk[[]T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_declares_repeated_type_parameter_once.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_declares_repeated_type_parameter_once.snap
@@ -1,0 +1,76 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Pair<A, B> {
+    a: A,
+    b: B,
+  }
+  
+  impl<A, B> Pair<A, B> {
+    fn get(self) -> Option<A> {
+      Some(self.a)
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<T>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T>(p: Pair<T, T>) {
+    consume(p)
+  }
+  
+  fn main() {
+    pass(Pair { a: 1, b: 2 })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func (p Pair[A, B]) get() (A, bool) {
+	return p.a, true
+}
+
+func consume[T any](box Box[lisette.Option[T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T any](p Pair[T, T]) {
+	consume(_lisAdapter_Pair_Box_0[T]{inner: p})
+}
+
+func main() {
+	pass(Pair[int, int]{
+		a: 1,
+		b: 2,
+	})
+}
+
+type _lisAdapter_Pair_Box_0[T any] struct {
+	inner Pair[T, T]
+}
+
+func (a _lisAdapter_Pair_Box_0[T]) get() lisette.Option[T] {
+	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
@@ -1,0 +1,98 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Maybe<T> {
+    Just(T),
+    Nothing,
+  }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<T: Comparable>(box: Box<Option<Map<Maybe<T>, int>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T: Comparable>(b: Bar<Map<Maybe<T>, int>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    let m: Map<Maybe<int>, int> = Map.new()
+    pass(Bar { m: m })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func MakeMaybeJust[T any](arg0 T) Maybe[T] {
+	return Maybe[T]{Tag: MaybeJust, Just: arg0}
+}
+
+func MakeMaybeNothing[T any]() Maybe[T] {
+	return Maybe[T]{Tag: MaybeNothing}
+}
+
+type MaybeTag int
+
+const (
+	MaybeJust MaybeTag = iota
+	MaybeNothing
+)
+
+type Maybe[T any] struct {
+	Tag  MaybeTag
+	Just T
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[T comparable](box Box[lisette.Option[map[Maybe[T]]int]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T comparable](b Bar[map[Maybe[T]]int]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	m := make(map[Maybe[int]]int)
+	pass(Bar[map[Maybe[int]]int]{m: m})
+}
+
+type _lisAdapter_Bar_Box_0[T comparable] struct {
+	inner Bar[map[Maybe[T]]int]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[map[Maybe[T]]int] {
+	option_1 := lisette.OptionFromCommaOk[map[Maybe[T]]int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_pointer_map_key_stays_unconstrained.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_pointer_map_key_stays_unconstrained.snap
@@ -1,0 +1,79 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Thing { v: int }
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<Map<Ref<T>, int>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T>(b: Bar<Map<Ref<T>, int>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    let m: Map<Ref<Thing>, int> = Map.new()
+    pass(Bar { m: m })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Thing struct {
+	v int
+}
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[T any](box Box[lisette.Option[map[*T]int]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T any](b Bar[map[*T]int]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	m := make(map[*Thing]int)
+	pass(Bar[map[*Thing]int]{m: m})
+}
+
+type _lisAdapter_Bar_Box_0[T any] struct {
+	inner Bar[map[*T]int]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[map[*T]int] {
+	option_1 := lisette.OptionFromCommaOk[map[*T]int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<K: Comparable, V>(box: Box<Option<Map<K, V>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<K: Comparable, V>(b: Bar<Map<K, V>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    pass(Bar { m: Map.from([("a", 1)]) })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[K comparable, V any](box Box[lisette.Option[map[K]V]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[K comparable, V any](b Bar[map[K]V]) {
+	consume(_lisAdapter_Bar_Box_0[K, V]{inner: b})
+}
+
+func main() {
+	pass(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})})
+}
+
+type _lisAdapter_Bar_Box_0[K comparable, V any] struct {
+	inner Bar[map[K]V]
+}
+
+func (a _lisAdapter_Bar_Box_0[K, V]) get() lisette.Option[map[K]V] {
+	option_1 := lisette.OptionFromCommaOk[map[K]V](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_struct_map_key_requires_field_comparability.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_struct_map_key_requires_field_comparability.snap
@@ -1,0 +1,83 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  struct Pair<A, B> {
+    a: A,
+    b: B,
+  }
+  
+  fn consume<A: Comparable, B: Comparable>(box: Box<Option<Map<Pair<A, B>, int>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<A: Comparable, B: Comparable>(b: Bar<Map<Pair<A, B>, int>>) {
+    consume(b)
+  }
+  
+  fn main() {
+    let m: Map<Pair<int, int>, int> = Map.new()
+    pass(Bar { m: m })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+type Pair[A any, B any] struct {
+	a A
+	b B
+}
+
+func consume[A comparable, B comparable](box Box[lisette.Option[map[Pair[A, B]]int]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[A comparable, B comparable](b Bar[map[Pair[A, B]]int]) {
+	consume(_lisAdapter_Bar_Box_0[A, B]{inner: b})
+}
+
+func main() {
+	m := make(map[Pair[int, int]]int)
+	pass(Bar[map[Pair[int, int]]int]{m: m})
+}
+
+type _lisAdapter_Bar_Box_0[A comparable, B comparable] struct {
+	inner Bar[map[Pair[A, B]]int]
+}
+
+func (a _lisAdapter_Bar_Box_0[A, B]) get() lisette.Option[map[Pair[A, B]]int] {
+	option_1 := lisette.OptionFromCommaOk[map[Pair[A, B]]int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
@@ -1,0 +1,83 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<S> {
+    m: S,
+  }
+  
+  impl<S> Bar<S> {
+    fn get(self) -> Option<S> {
+      Some(self.m)
+    }
+  }
+  
+  fn consume<K: Comparable>(box: Box<Option<Map<K, int>>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  struct Runner<K: Comparable> {
+    k: K,
+  }
+  
+  impl<K: Comparable> Runner<K> {
+    fn run(self, b: Bar<Map<K, int>>) {
+      consume(b)
+    }
+  }
+  
+  fn main() {
+    let r = Runner { k: "x" }
+    r.run(Bar { m: Map.from([("a", 1)]) })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[S any] struct {
+	m S
+}
+
+func (b Bar[S]) get() (S, bool) {
+	return b.m, true
+}
+
+func consume[K comparable](box Box[lisette.Option[map[K]int]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+type Runner[K comparable] struct {
+	k K
+}
+
+func (r Runner[K]) Run(b Bar[map[K]int]) {
+	consume(_lisAdapter_Bar_Box_0[K]{inner: b})
+}
+
+func main() {
+	r := Runner[string]{k: "x"}
+	r.Run(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})})
+}
+
+type _lisAdapter_Bar_Box_0[K comparable] struct {
+	inner Bar[map[K]int]
+}
+
+func (a _lisAdapter_Bar_Box_0[K]) get() lisette.Option[map[K]int] {
+	option_1 := lisette.OptionFromCommaOk[map[K]int](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_adapter_uses_separate_caller_contexts.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_separate_caller_contexts.snap
@@ -1,0 +1,94 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<T> {
+    x: Option<T>,
+  }
+  
+  impl<T> Bar<T> {
+    fn get(self) -> Option<T> {
+      self.x
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<T>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn strong<T: Comparable>(b: Bar<T>) {
+    consume(b)
+  }
+  
+  fn weak<T>(b: Bar<T>) {
+    consume(b)
+  }
+  
+  fn main() {
+    strong(Bar { x: Some(1) })
+    weak(Bar { x: Some(2) })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[T any] struct {
+	x lisette.Option[T]
+}
+
+func (b Bar[T]) get() (T, bool) {
+	v_1 := b.x
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(T), false
+}
+
+func consume[T any](box Box[lisette.Option[T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func strong[T comparable](b Bar[T]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func weak[T any](b Bar[T]) {
+	consume(_lisAdapter_Bar_Box_1[T]{inner: b})
+}
+
+func main() {
+	strong(Bar[int]{x: lisette.MakeOptionSome(1)})
+	weak(Bar[int]{x: lisette.MakeOptionSome(2)})
+}
+
+type _lisAdapter_Bar_Box_0[T comparable] struct {
+	inner Bar[T]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[T] {
+	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
+	return option_1
+}
+
+type _lisAdapter_Bar_Box_1[T any] struct {
+	inner Bar[T]
+}
+
+func (a _lisAdapter_Bar_Box_1[T]) get() lisette.Option[T] {
+	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
@@ -1,0 +1,61 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:errors"
+  
+  interface Foo<E: error> {
+    fn get() -> Result<int, E>
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) -> Result<int, error> {
+      Err(errors.New("failure"))
+    }
+  }
+  
+  fn use_foo(_foo: Foo<error>) {}
+  
+  fn main() {
+    use_foo(Bar {})
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Foo[E error] interface {
+	get() lisette.Result[int, E]
+}
+
+type Bar struct{}
+
+func (b Bar) get() (int, error) {
+	return 0, errors.New("failure")
+}
+
+func use_foo(_ Foo[error]) {}
+
+func main() {
+	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Foo_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
+	ret_1, ret_2 := a.inner.get()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	return result_3
+}

--- a/tests/spec/emit/snapshots/generic_error_interface_consumed_generically.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_consumed_generically.snap
@@ -1,0 +1,76 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:errors"
+  
+  interface Foo<E: error> {
+    fn get(fail: bool) -> Result<int, E>
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self, fail: bool) -> Result<int, error> {
+      if fail { Err(errors.New("boom")) } else { Ok(42) }
+    }
+  }
+  
+  fn run<E: error>(foo: Foo<E>) {
+    match foo.get(false) {
+      Ok(v) => { let _ = v },
+      Err(e) => { let _ = e },
+    }
+  }
+  
+  fn main() {
+    run(Bar {})
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Foo[E error] interface {
+	get(bool) lisette.Result[int, E]
+}
+
+type Bar struct{}
+
+func (b Bar) get(fail bool) (int, error) {
+	if fail {
+		return 0, errors.New("boom")
+	}
+	return 42, nil
+}
+
+func run[E error](foo Foo[E]) {
+	subject_1 := foo.get(false)
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal
+	} else {
+		_ = subject_1.ErrVal
+	}
+}
+
+func main() {
+	run(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+}
+
+type _lisAdapter_Bar_Foo_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Foo_0) get(arg0 bool) lisette.Result[int, error] {
+	ret_1, ret_2 := a.inner.get(arg0)
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	return result_3
+}

--- a/tests/spec/emit/snapshots/generic_error_interface_generic_impl_needs_no_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_generic_impl_needs_no_adapter.snap
@@ -1,0 +1,65 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  import "go:errors"
+  
+  interface Foo<E: error> {
+    fn get(fail: bool) -> Result<int, E>
+  }
+  
+  struct Bar<E: error> {
+    e: E,
+  }
+  
+  impl<E: error> Bar<E> {
+    fn get(self, fail: bool) -> Result<int, E> {
+      if fail { Err(self.e) } else { Ok(42) }
+    }
+  }
+  
+  fn run<E: error>(foo: Foo<E>) {
+    match foo.get(false) {
+      Ok(v) => { let _ = v },
+      Err(e) => { let _ = e },
+    }
+  }
+  
+  fn main() {
+    run(Bar { e: errors.New("boom") })
+  }
+---
+package main
+
+import (
+	"errors"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Foo[E error] interface {
+	get(bool) lisette.Result[int, E]
+}
+
+type Bar[E error] struct {
+	e E
+}
+
+func (b Bar[E]) get(fail bool) lisette.Result[int, E] {
+	if fail {
+		return lisette.MakeResultErr[int, E](b.e)
+	}
+	return lisette.MakeResultOk[int, E](42)
+}
+
+func run[E error](foo Foo[E]) {
+	subject_1 := foo.get(false)
+	if subject_1.Tag == lisette.ResultOk {
+		_ = subject_1.OkVal
+	} else {
+		_ = subject_1.ErrVal
+	}
+}
+
+func main() {
+	run(Bar[error]{e: errors.New("boom")})
+}

--- a/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_named_field_struct_constructor_inserts_adapter.snap
@@ -28,6 +28,8 @@ description: |
 ---
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry struct {
 	name string
 }
@@ -56,6 +58,10 @@ type _lisAdapter_MyCache_Cache_0 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry, bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/emit/snapshots/generic_struct_adapter_declares_its_type_parameters.snap
+++ b/tests/spec/emit/snapshots/generic_struct_adapter_declares_its_type_parameters.snap
@@ -1,0 +1,75 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Box<U> {
+    fn get() -> U
+  }
+  
+  struct Bar<T> {
+    x: Option<T>,
+  }
+  
+  impl<T> Bar<T> {
+    fn get(self) -> Option<T> {
+      self.x
+    }
+  }
+  
+  fn consume<T>(box: Box<Option<T>>) {
+    if let Some(v) = box.get() {
+      let _ = v
+    }
+  }
+  
+  fn pass<T>(b: Bar<T>) {
+    consume(b)
+  }
+  
+  fn main() {
+    pass(Bar { x: Some(3) })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box[U any] interface {
+	get() U
+}
+
+type Bar[T any] struct {
+	x lisette.Option[T]
+}
+
+func (b Bar[T]) get() (T, bool) {
+	v_1 := b.x
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(T), false
+}
+
+func consume[T any](box Box[lisette.Option[T]]) {
+	subject_1 := box.get()
+	if subject_1.Tag == lisette.OptionSome {
+		_ = subject_1.SomeVal
+	}
+}
+
+func pass[T any](b Bar[T]) {
+	consume(_lisAdapter_Bar_Box_0[T]{inner: b})
+}
+
+func main() {
+	pass(Bar[int]{x: lisette.MakeOptionSome(3)})
+}
+
+type _lisAdapter_Bar_Box_0[T any] struct {
+	inner Bar[T]
+}
+
+func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[T] {
+	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
+	return option_1
+}

--- a/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
+++ b/tests/spec/emit/snapshots/generic_tuple_struct_constructor_inserts_adapter.snap
@@ -26,6 +26,8 @@ description: |
 ---
 package main
 
+import lisette "github.com/ivov/lisette/prelude"
+
 type Entry struct {
 	name string
 }
@@ -54,6 +56,10 @@ type _lisAdapter_MyCache_Cache_0 struct {
 }
 
 func (a _lisAdapter_MyCache_Cache_0) Get(arg0 string) (*Entry, bool) {
-	val_1 := a.inner.Get(arg0)
-	return val_1, val_1 != nil
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
 }

--- a/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
+++ b/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
@@ -1,0 +1,86 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Thing {
+    v: int,
+  }
+  
+  interface Opt {
+    fn find() -> Option<Ref<Thing>>
+  }
+  
+  struct Bar<T> {
+    x: Option<T>,
+  }
+  
+  impl<T> Bar<T> {
+    fn find(self) -> Option<T> {
+      self.x
+    }
+  }
+  
+  fn use_opt(o: Opt) {
+    match o.find() {
+      Some(t) => { let _ = t },
+      None => {},
+    }
+  }
+  
+  fn main() {
+    use_opt(Bar { x: None })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Thing struct {
+	v int
+}
+
+type Opt interface {
+	find() *Thing
+}
+
+type Bar[T any] struct {
+	x lisette.Option[T]
+}
+
+func (b Bar[T]) find() (T, bool) {
+	v_1 := b.x
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(T), false
+}
+
+func use_opt(o Opt) {
+	raw_2 := o.find()
+	option_3 := lisette.OptionFromNilable[*Thing](raw_2, raw_2 == nil)
+	if option_3.Tag == lisette.OptionSome {
+		_ = option_3.SomeVal
+	}
+}
+
+func main() {
+	use_opt(_lisAdapter_Bar_Opt_0{inner: Bar[*Thing]{x: lisette.MakeOptionNone[*Thing]()}})
+}
+
+type _lisAdapter_Bar_Opt_0 struct {
+	inner Bar[*Thing]
+}
+
+func (a _lisAdapter_Bar_Opt_0) find() *Thing {
+	ret_1, ret_2 := a.inner.find()
+	var option_3 lisette.Option[*Thing]
+	if ret_2 && ret_1 != nil {
+		option_3 = lisette.MakeOptionSome[*Thing](ret_1)
+	} else {
+		option_3 = lisette.MakeOptionNone[*Thing]()
+	}
+	if option_3.Tag == lisette.OptionSome {
+		return option_3.SomeVal
+	}
+	return nil
+}

--- a/tests/spec/emit/snapshots/ref_impl_satisfies_option_ref_go_interface_without_adapter.snap
+++ b/tests/spec/emit/snapshots/ref_impl_satisfies_option_ref_go_interface_without_adapter.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  import "go:example.com/store"
+  
+  struct Store {}
+  
+  impl Store {
+    fn Find(self, key: string) -> Ref<store.Entry> {
+      store.NewEntry()
+    }
+  }
+  
+  fn use_store(s: store.Storage) {
+    let _ = s
+  }
+  
+  fn main() {
+    let s = Store {}
+    use_store(s as store.Storage)
+  }
+---
+package main
+
+import "example.com/store"
+
+type Store struct{}
+
+func (s Store) Find(_ string) *store.Entry {
+	return store.NewEntry()
+}
+
+func use_store(s store.Storage) {
+	_ = s
+}
+
+func main() {
+	s := Store{}
+	use_store(s)
+}

--- a/tests/spec/emit/snapshots/void_interface_discards_generic_unit_value_and_preserves_value_method.snap
+++ b/tests/spec/emit/snapshots/void_interface_discards_generic_unit_value_and_preserves_value_method.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Mixed<T> {
+    fn run()
+    fn value() -> T
+  }
+  
+  struct Bar<T> {
+    item: T,
+  }
+  
+  impl<T> Bar<T> {
+    fn run(self) -> T {
+      self.item
+    }
+  
+    fn value(self) -> T {
+      self.item
+    }
+  }
+  
+  fn consume(mixed: Mixed<()>) {
+    mixed.run()
+    let _ = mixed.value()
+  }
+  
+  fn main() {
+    consume(Bar { item: () })
+  }
+---
+package main
+
+type Mixed[T any] interface {
+	Run()
+	value() T
+}
+
+type Bar[T any] struct {
+	item T
+}
+
+func (b Bar[T]) Run() T {
+	return b.item
+}
+
+func (b Bar[T]) value() T {
+	return b.item
+}
+
+func consume(mixed Mixed[struct{}]) {
+	mixed.Run()
+	mixed.value()
+}
+
+func main() {
+	consume(_lisAdapter_Bar_Mixed_0{inner: Bar[struct{}]{item: struct{}{}}})
+}
+
+type _lisAdapter_Bar_Mixed_0 struct {
+	inner Bar[struct{}]
+}
+
+func (a _lisAdapter_Bar_Mixed_0) value() struct{} {
+	return a.inner.value()
+}
+
+func (a _lisAdapter_Bar_Mixed_0) Run() {
+	a.inner.Run()
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -5390,3 +5390,859 @@ fn test() -> int {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn generic_error_interface_adapts_concrete_result_impl() {
+    let input = r#"
+import "go:errors"
+
+interface Foo<E: error> {
+  fn get() -> Result<int, E>
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) -> Result<int, error> {
+    Err(errors.New("failure"))
+  }
+}
+
+fn use_foo(_foo: Foo<error>) {}
+
+fn main() {
+  use_foo(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_error_interface_generic_impl_needs_no_adapter() {
+    let input = r#"
+import "go:errors"
+
+interface Foo<E: error> {
+  fn get(fail: bool) -> Result<int, E>
+}
+
+struct Bar<E: error> {
+  e: E,
+}
+
+impl<E: error> Bar<E> {
+  fn get(self, fail: bool) -> Result<int, E> {
+    if fail { Err(self.e) } else { Ok(42) }
+  }
+}
+
+fn run<E: error>(foo: Foo<E>) {
+  match foo.get(false) {
+    Ok(v) => { let _ = v },
+    Err(e) => { let _ = e },
+  }
+}
+
+fn main() {
+  run(Bar { e: errors.New("boom") })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_error_interface_consumed_generically() {
+    let input = r#"
+import "go:errors"
+
+interface Foo<E: error> {
+  fn get(fail: bool) -> Result<int, E>
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self, fail: bool) -> Result<int, error> {
+    if fail { Err(errors.New("boom")) } else { Ok(42) }
+  }
+}
+
+fn run<E: error>(foo: Foo<E>) {
+  match foo.get(false) {
+    Ok(v) => { let _ = v },
+    Err(e) => { let _ = e },
+  }
+}
+
+fn main() {
+  run(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn bare_param_interface_return_wraps_concrete_result_impl() {
+    let input = r#"
+interface Foo<T> {
+  fn get() -> T
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) -> Result<int, error> {
+    Ok(1)
+  }
+}
+
+fn use_foo(foo: Foo<Result<int, error>>) {
+  match foo.get() {
+    Ok(v) => { let _ = v },
+    Err(e) => { let _ = e },
+  }
+}
+
+fn main() {
+  use_foo(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn aliased_result_return_adapts_to_generic_interface() {
+    let input = r#"
+import "go:errors"
+
+type R = Result<int, error>
+
+interface Foo<E: error> {
+  fn get() -> Result<int, E>
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) -> R {
+    Err(errors.New("x"))
+  }
+}
+
+fn use_foo(_foo: Foo<error>) {}
+
+fn main() {
+  use_foo(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn bare_param_interface_matches_generic_result_impl_without_adapter() {
+    let input = r#"
+import "go:errors"
+
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar<E: error> {
+  e: E,
+}
+
+impl<E: error> Bar<E> {
+  fn get(self) -> Result<int, E> {
+    Err(self.e)
+  }
+}
+
+fn consume<E: error>(box: Box<Result<int, E>>) {
+  match box.get() {
+    Ok(v) => { let _ = v },
+    Err(e) => { let _ = e },
+  }
+}
+
+fn pass<E: error>(b: Bar<E>) {
+  consume(b)
+}
+
+fn main() {
+  pass(Bar { e: errors.New("x") })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn bare_param_interface_wraps_nullable_option_impl() {
+    let input = r#"
+struct Thing {
+  v: int,
+}
+
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) -> Option<Ref<Thing>> {
+    None
+  }
+}
+
+fn use_box(box: Box<Option<Ref<Thing>>>) {
+  match box.get() {
+    Some(t) => { let _ = t },
+    None => {},
+  }
+}
+
+fn main() {
+  use_box(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn bare_param_interface_wraps_void_impl_as_unit_value() {
+    let input = r#"
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) {}
+}
+
+fn consume(box: Box<()>) {
+  let _ = box.get()
+}
+
+fn main() {
+  consume(Bar {})
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn void_interface_discards_generic_unit_value_and_preserves_value_method() {
+    let input = r#"
+interface Mixed<T> {
+  fn run()
+  fn value() -> T
+}
+
+struct Bar<T> {
+  item: T,
+}
+
+impl<T> Bar<T> {
+  fn run(self) -> T {
+    self.item
+  }
+
+  fn value(self) -> T {
+    self.item
+  }
+}
+
+fn consume(mixed: Mixed<()>) {
+  mixed.run()
+  let _ = mixed.value()
+}
+
+fn main() {
+  consume(Bar { item: () })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_struct_adapter_declares_its_type_parameters() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<T> {
+  x: Option<T>,
+}
+
+impl<T> Bar<T> {
+  fn get(self) -> Option<T> {
+    self.x
+  }
+}
+
+fn consume<T>(box: Box<Option<T>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T>(b: Bar<T>) {
+  consume(b)
+}
+
+fn main() {
+  pass(Bar { x: Some(3) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_declares_nested_type_parameter() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  xs: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.xs)
+  }
+}
+
+fn consume<T>(box: Box<Option<Slice<T>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T>(b: Bar<Slice<T>>) {
+  consume(b)
+}
+
+fn main() {
+  pass(Bar { xs: [1, 2] })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_declares_repeated_type_parameter_once() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Pair<A, B> {
+  a: A,
+  b: B,
+}
+
+impl<A, B> Pair<A, B> {
+  fn get(self) -> Option<A> {
+    Some(self.a)
+  }
+}
+
+fn consume<T>(box: Box<Option<T>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T>(p: Pair<T, T>) {
+  consume(p)
+}
+
+fn main() {
+  pass(Pair { a: 1, b: 2 })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_preserves_nested_parameter_constraint() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<K: Comparable, V>(box: Box<Option<Map<K, V>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<K: Comparable, V>(b: Bar<Map<K, V>>) {
+  consume(b)
+}
+
+fn main() {
+  pass(Bar { m: Map.from([("a", 1)]) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_uses_receiver_generic_bounds() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<K: Comparable>(box: Box<Option<Map<K, int>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+struct Runner<K: Comparable> {
+  k: K,
+}
+
+impl<K: Comparable> Runner<K> {
+  fn run(self, b: Bar<Map<K, int>>) {
+    consume(b)
+  }
+}
+
+fn main() {
+  let r = Runner { k: "x" }
+  r.run(Bar { m: Map.from([("a", 1)]) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_uses_separate_caller_contexts() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<T> {
+  x: Option<T>,
+}
+
+impl<T> Bar<T> {
+  fn get(self) -> Option<T> {
+    self.x
+  }
+}
+
+fn consume<T>(box: Box<Option<T>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn strong<T: Comparable>(b: Bar<T>) {
+  consume(b)
+}
+
+fn weak<T>(b: Bar<T>) {
+  consume(b)
+}
+
+fn main() {
+  strong(Bar { x: Some(1) })
+  weak(Bar { x: Some(2) })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_captures_complete_caller_context() {
+    let input = r#"
+interface Holder<X> {
+  fn h() -> X
+}
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  s: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.s)
+  }
+}
+
+struct IntHolder {}
+
+impl IntHolder {
+  fn h(self) -> int {
+    1
+  }
+}
+
+fn consume<T>(box: Box<Option<T>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<U, T: Holder<U>>(b: Bar<T>) {
+  consume(b)
+}
+
+fn main() {
+  pass<int, IntHolder>(Bar { s: IntHolder {} })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_pointer_map_key_stays_unconstrained() {
+    let input = r#"
+struct Thing { v: int }
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<T>(box: Box<Option<Map<Ref<T>, int>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T>(b: Bar<Map<Ref<T>, int>>) {
+  consume(b)
+}
+
+fn main() {
+  let m: Map<Ref<Thing>, int> = Map.new()
+  pass(Bar { m: m })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_struct_map_key_requires_field_comparability() {
+    let input = r#"
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+struct Pair<A, B> {
+  a: A,
+  b: B,
+}
+
+fn consume<A: Comparable, B: Comparable>(box: Box<Option<Map<Pair<A, B>, int>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<A: Comparable, B: Comparable>(b: Bar<Map<Pair<A, B>, int>>) {
+  consume(b)
+}
+
+fn main() {
+  let m: Map<Pair<int, int>, int> = Map.new()
+  pass(Bar { m: m })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_captures_interface_parameter_bound() {
+    let input = r#"
+interface Foo<T: Comparable> {
+  fn f() -> T
+}
+
+struct IntFoo {}
+
+impl IntFoo {
+  fn f(self) -> int {
+    1
+  }
+}
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<T: Comparable>(box: Box<Option<Foo<T>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T: Comparable>(b: Bar<Foo<T>>) {
+  consume(b)
+}
+
+fn main() {
+  let f: Foo<int> = IntFoo {}
+  pass(Bar { m: f })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_captures_alias_parameter_bound() {
+    let input = r#"
+type Wrapped<T: Comparable> = Slice<T>
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<T: Comparable>(box: Box<Option<Wrapped<T>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T: Comparable>(b: Bar<Wrapped<T>>) {
+  consume(b)
+}
+
+fn main() {
+  let w: Wrapped<int> = [1, 2]
+  pass(Bar { m: w })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_copies_context_bound_for_composite_arg() {
+    let input = r#"
+struct Keyed<K: Comparable> {
+  k: K,
+}
+
+impl<K: Comparable> Keyed<K> {
+  fn get(self) -> Option<K> {
+    Some(self.k)
+  }
+}
+
+interface Box<U> {
+  fn get() -> U
+}
+
+fn consume<T: Comparable>(box: Box<Option<Array<T, 2>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T: Comparable>(k: Keyed<Array<T, 2>>) {
+  consume(k)
+}
+
+fn main() {
+  let a: Array<int, 2> = [1, 2]
+  pass(Keyed { k: a })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_enum_map_key_requires_payload_comparability() {
+    let input = r#"
+enum Maybe<T> {
+  Just(T),
+  Nothing,
+}
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct Bar<S> {
+  m: S,
+}
+
+impl<S> Bar<S> {
+  fn get(self) -> Option<S> {
+    Some(self.m)
+  }
+}
+
+fn consume<T: Comparable>(box: Box<Option<Map<Maybe<T>, int>>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn pass<T: Comparable>(b: Bar<Map<Maybe<T>, int>>) {
+  consume(b)
+}
+
+fn main() {
+  let m: Map<Maybe<int>, int> = Map.new()
+  pass(Bar { m: m })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_adapter_copies_sibling_referencing_bound() {
+    let input = r#"
+interface Holder<T> {
+  fn item() -> T
+}
+
+interface Box<U> {
+  fn get() -> U
+}
+
+struct IntHolder {}
+
+impl IntHolder {
+  fn item(self) -> int {
+    5
+  }
+}
+
+struct Wrap<A, B: Holder<A>> {
+  a: A,
+  b: B,
+}
+
+impl<A, B: Holder<A>> Wrap<A, B> {
+  fn get(self) -> Option<A> {
+    Some(self.a)
+  }
+}
+
+fn consume<A>(box: Box<Option<A>>) {
+  if let Some(v) = box.get() {
+    let _ = v
+  }
+}
+
+fn use_wrap<A, B: Holder<A>>(w: Wrap<A, B>) {
+  consume(w)
+}
+
+fn main() {
+  use_wrap(Wrap { a: 3, b: IntHolder {} })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nullable_interface_reencodes_comma_ok_option_impl() {
+    let input = r#"
+struct Thing {
+  v: int,
+}
+
+interface Opt {
+  fn find() -> Option<Ref<Thing>>
+}
+
+struct Bar<T> {
+  x: Option<T>,
+}
+
+impl<T> Bar<T> {
+  fn find(self) -> Option<T> {
+    self.x
+  }
+}
+
+fn use_opt(o: Opt) {
+  match o.find() {
+    Some(t) => { let _ = t },
+    None => {},
+  }
+}
+
+fn main() {
+  use_opt(Bar { x: None })
+}
+"#;
+    assert_emit_snapshot!(input);
+}


### PR DESCRIPTION
A method returning `Result<T, E>` now satisfies a generic interface that declares the same method. Previously, passing this implementation where the interface was expected produced a Go compile error bcause the implementation and the generic interface disagreed on how `Result` is represented in the generated Go.

```rs
interface Fetcher<E> {
  fn fetch() -> Result<int, E>
}

struct Client {}
impl Client {
  fn fetch(self) -> Result<int, string> { Ok(42) }
}

fn run(f: Fetcher<string>) -> Result<int, string> { f.fetch() }
```

Fix #1024
