### PR TITLE
fix: tighten `reference_aliases_sibling` lint

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3649,18 +3649,17 @@ pub fn range_to_for_variadic(span: Span, var_name: Option<&str>) -> LisetteDiagn
         .with_help(suggestion)
 }
 
-pub fn reference_aliases_sibling(ref_span: Span, var_name: &str) -> LisetteDiagnostic {
-    LisetteDiagnostic::error("Reference aliases sibling expression")
+pub fn reference_aliases_sibling(
+    ref_span: Span,
+    read_span: Span,
+    var_name: &str,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Reference may mutate a value read in the same expression")
         .with_infer_code("reference_aliases_sibling")
-        .with_span_label(
-            &ref_span,
-            format!(
-                "`&{}` could mutate `{}` used by a sibling",
-                var_name, var_name
-            ),
-        )
+        .with_span_label(&ref_span, format!("may mutate `{}`", var_name))
+        .with_span_label(&read_span, "may see the mutated value")
         .with_help(format!(
-            "Bind `{}` to a `let` before this expression to make evaluation order explicit",
+            "Copy `{0}` into a separate variable first: `let before = {0}`, then read `before` instead",
             var_name
         ))
 }

--- a/crates/semantics/src/checker/infer/validation/references.rs
+++ b/crates/semantics/src/checker/infer/validation/references.rs
@@ -116,12 +116,12 @@ impl InferCtx<'_, '_> {
         self.check_sibling_ref_aliasing_refs(&refs);
     }
 
-    /// Given a list of sibling expressions, check that no `&v` in one sibling
-    /// conflicts with a bare read of `v` in another sibling.
+    /// In evaluation order, flag a read of `v` when an *earlier* sibling takes
+    /// `&v`, so the read may see the mutation. A `&v` after the read is fine.
     fn check_sibling_ref_aliasing_refs(&mut self, siblings: &[&Expression]) {
         let mut ref_vars: HashSet<String> = HashSet::default();
         for sib in siblings {
-            collect_ref_targets(sib, &mut ref_vars);
+            collect_ref_targets(sib, &mut ref_vars, false);
         }
         if ref_vars.is_empty() {
             return;
@@ -132,17 +132,22 @@ impl InferCtx<'_, '_> {
             collect_read_vars(sib, &mut reads, false);
             for var in reads.intersection(&ref_vars) {
                 let mut ref_in_same = HashSet::default();
-                collect_ref_targets(sib, &mut ref_in_same);
+                collect_ref_targets(sib, &mut ref_in_same, false);
                 if ref_in_same.contains(var.as_str()) {
                     continue; // `&v` and `v` in the same operand is fine
                 }
+                let Some(read_span) = find_read_span(sib, var, false) else {
+                    continue;
+                };
                 for (j, other) in siblings.iter().enumerate() {
-                    if i == j {
-                        continue;
+                    if j >= i {
+                        continue; // only a `&v` before the read can affect it
                     }
-                    if let Some(span) = find_ref_span(other, var) {
+                    if let Some(ref_span) = find_ref_span(other, var) {
                         self.sink
-                            .push(diagnostics::infer::reference_aliases_sibling(span, var));
+                            .push(diagnostics::infer::reference_aliases_sibling(
+                                ref_span, read_span, var,
+                            ));
                         return; // One error per compound expression is enough
                     }
                 }
@@ -151,18 +156,25 @@ impl InferCtx<'_, '_> {
     }
 }
 
-/// Collect all variable names that appear under `&` anywhere in the expression tree.
-fn collect_ref_targets(expression: &Expression, out: &mut HashSet<String>) {
+/// Collect `v` for each `&v` passed into a call, which executes and may mutate
+/// `v`. A bare `&v` that is only captured never mutates before a sibling read.
+fn collect_ref_targets(expression: &Expression, out: &mut HashSet<String>, inside_call: bool) {
     match expression.unwrap_parens() {
         Expression::Reference { expression, .. } => {
-            if let Expression::Identifier { value, .. } = expression.unwrap_parens() {
+            if inside_call && let Expression::Identifier { value, .. } = expression.unwrap_parens()
+            {
                 out.insert(value.to_string());
             }
-            collect_ref_targets(expression, out);
+            collect_ref_targets(expression, out, inside_call);
+        }
+        node @ Expression::Call { .. } => {
+            for child in node.children() {
+                collect_ref_targets(child, out, true);
+            }
         }
         other => {
             for child in other.children() {
-                collect_ref_targets(child, out);
+                collect_ref_targets(child, out, inside_call);
             }
         }
     }
@@ -184,6 +196,19 @@ fn collect_read_vars(expression: &Expression, out: &mut HashSet<String>, inside_
                 collect_read_vars(child, out, false);
             }
         }
+    }
+}
+
+fn find_read_span(expression: &Expression, var_name: &str, inside_ref: bool) -> Option<Span> {
+    match expression.unwrap_parens() {
+        Expression::Identifier { value, span, .. } => {
+            (!inside_ref && value.as_str() == var_name).then_some(*span)
+        }
+        Expression::Reference { expression, .. } => find_read_span(expression, var_name, true),
+        other => other
+            .children()
+            .into_iter()
+            .find_map(|child| find_read_span(child, var_name, false)),
     }
 }
 

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -2466,3 +2466,102 @@ fn complex_division_by_zero_rejected() {
     )
     .assert_infer_code("division_by_zero");
 }
+
+fn assert_not_sibling_flagged(source: &str) {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", source);
+    let result = infer_module("main", fs);
+    assert!(
+        !result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.reference_aliases_sibling")),
+        "must not flag reference_aliases_sibling, got:\n{:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn sibling_ref_read_before_ampersand_is_ok() {
+    assert_not_sibling_flagged(
+        r#"
+        struct Options { port: string }
+        fn configure(o: Ref<Options>) -> bool {
+          o.port = "8080"
+          true
+        }
+        fn main() {
+          let mut options = Options{ port: "" }
+          if options.port.is_empty() && !configure(&options) { () }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn sibling_ref_bare_ampersand_before_read_is_ok() {
+    assert_not_sibling_flagged(
+        r#"
+        fn g(p: Ref<int>, v: int) -> int { v }
+        fn main() {
+          let mut a = 1
+          let _ = g(&a, a)
+        }
+        "#,
+    );
+}
+
+#[test]
+fn sibling_ref_read_inside_closure_is_ok() {
+    assert_not_sibling_flagged(
+        r#"
+        fn h(p: Ref<int>, f: fn() -> int) -> int { f() }
+        fn main() {
+          let mut a = 1
+          let _ = h(&a, || a)
+        }
+        "#,
+    );
+}
+
+#[test]
+fn sibling_ref_ampersand_before_read_in_tuple_is_flagged() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+        fn inc(n: Ref<int>) -> int {
+          n.* = n.* + 1
+          n.*
+        }
+        fn main() {
+          let mut n = 1
+          let pair = (inc(&n), n)
+          let _ = pair
+        }
+        "#,
+    );
+    infer_module("main", fs).assert_infer_code("reference_aliases_sibling");
+}
+
+#[test]
+fn sibling_ref_ampersand_before_read_in_short_circuit_is_flagged() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+        struct Options { port: string }
+        fn configure(o: Ref<Options>) -> bool {
+          o.port = "8080"
+          true
+        }
+        fn main() {
+          let mut options = Options{ port: "" }
+          if configure(&options) && options.port.is_empty() { () }
+        }
+        "#,
+    );
+    infer_module("main", fs).assert_infer_code("reference_aliases_sibling");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -12983,3 +12983,25 @@ fn run() {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn infer_reference_aliases_sibling() {
+    let mut fs = MockFileSystem::new();
+
+    let source = r#"
+fn store(dst: Ref<int>, value: int) -> int {
+  dst.* = value
+  value
+}
+
+fn main() {
+  let mut total = 1
+  let pair = (store(&total, 5), total)
+  let _ = pair
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}

--- a/tests/ui/errors/snapshots/infer_reference_aliases_sibling.snap
+++ b/tests/ui/errors/snapshots/infer_reference_aliases_sibling.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Reference may mutate a value read in the same expression
+    ╭─[main.lis:9:21]
+  8 │   let mut total = 1
+  9 │   let pair = (store(&total, 5), total)
+    ·                     ───┬──      ──┬──
+    ·                        │          ╰── may see the mutated value
+    ·                        ╰── may mutate `total`
+ 10 │   let _ = pair
+    ╰────
+  help: Copy `total` into a separate variable first: `let before = total`, then read `before` instead · code: [infer.reference_aliases_sibling]


### PR DESCRIPTION
Tighten the conditions and wording for this lint:

```
  ✕ Reference may mutate a value read in the same expression
    ╭─[main.lis:9:21]
  8 │   let mut total = 1
  9 │   let pair = (store(&total, 5), total)
    ·                     ───┬──      ──┬──
    ·                        │          ╰── may see the mutated value
    ·                        ╰── may mutate `total`
 10 │   let _ = pair
    ╰────
  help: Copy `total` into a separate variable first: `let before = total`, then read `before` instead · code: [infer.reference_aliases_sibling]
```

Close #1047