### PR TITLE
fix: reject generic function used as a value with uninferable type

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2964,6 +2964,28 @@ pub fn cannot_infer_type_argument(span: Span) -> LisetteDiagnostic {
         .with_help("Supply a type argument for the call, e.g. `Channel.new<int>()`")
 }
 
+pub fn uninferable_generic_reference(
+    function: &str,
+    params: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    let joined = format_list(params, |param| format!("`{param}`"));
+    let noun = if params.len() == 1 {
+        "type parameter"
+    } else {
+        "type parameters"
+    };
+    LisetteDiagnostic::error("Cannot infer type argument")
+        .with_infer_code("uninferable_generic_reference")
+        .with_span_label(
+            &span,
+            format!("cannot infer {joined} for `{function}` used as a value"),
+        )
+        .with_help(format!(
+            "A generic function used as a value cannot have its type arguments inferred. Give `{function}` a signature that uses {joined}, or remove the unused {noun}."
+        ))
+}
+
 pub fn cannot_infer_struct_type_argument(
     struct_name: &str,
     param_name: &str,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -9,6 +9,7 @@ use syntax::program::{
 use syntax::types::{Symbol, Type, substitute, unqualified_name};
 
 use super::super::addressability::check_is_non_addressable;
+use super::functions::phantom_type_params;
 use super::primitives::contains_deref;
 use crate::checker::infer::InferCtx;
 use crate::checker::promotion::{self, MemberKind, Resolution};
@@ -725,6 +726,20 @@ impl InferCtx<'_, '_> {
                 _ => {}
             }
         }
+
+        if !self.scopes.is_callee_context() && !self.scopes.is_dot_access_base() {
+            let phantom = phantom_type_params(&member_type);
+            if !phantom.is_empty() {
+                let display_name = format!("{}.{}", type_name, args.member_name);
+                self.sink
+                    .push(diagnostics::infer::uninferable_generic_reference(
+                        &display_name,
+                        &phantom,
+                        *args.span,
+                    ));
+            }
+        }
+
         let (module_ty, _) = self.instantiate(&module_ty);
         let (member_ty, _) = self.instantiate(&member_type);
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -774,19 +774,7 @@ impl InferCtx<'_, '_> {
     }
 
     fn callee_has_phantom_type_param(&self, expression: &Expression) -> bool {
-        let Type::Forall { vars, body } = self.declared_callee_type(expression) else {
-            return false;
-        };
-        let Type::Function(f) = body.as_ref() else {
-            return false;
-        };
-        vars.iter().any(|var| {
-            let param = Type::Parameter(var.clone());
-            let in_signature = f.params.iter().any(|pt| pt.contains_type(&param))
-                || f.return_type.contains_type(&param);
-            let is_bounded = f.bounds.iter().any(|bound| bound.param_name == *var);
-            !in_signature && !is_bounded
-        })
+        !phantom_type_params(&self.declared_callee_type(expression)).is_empty()
     }
 
     fn instantiate_callee_type(
@@ -1728,6 +1716,25 @@ impl InferCtx<'_, '_> {
                 .is_some_and(|n| n == "Range")
         })
     }
+}
+
+pub(crate) fn phantom_type_params(ty: &Type) -> Vec<String> {
+    let Type::Forall { vars, body } = ty else {
+        return Vec::new();
+    };
+    let Type::Function(f) = body.as_ref() else {
+        return Vec::new();
+    };
+    vars.iter()
+        .filter(|var| {
+            let param = Type::Parameter((**var).clone());
+            let in_signature = f.params.iter().any(|pt| pt.contains_type(&param))
+                || f.return_type.contains_type(&param);
+            let is_bounded = f.bounds.iter().any(|bound| bound.param_name == **var);
+            !in_signature && !is_bounded
+        })
+        .map(|var| var.to_string())
+        .collect()
 }
 
 fn receiver_inferred_prefix_count(body: &Type, vars: &[EcoString]) -> usize {

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -8,6 +8,7 @@ use syntax::types::Type;
 use super::super::addressability::{
     check_is_non_addressable, check_non_addressable_assignment_target,
 };
+use super::functions::phantom_type_params;
 use crate::checker::infer::InferCtx;
 
 /// Checks whether an assignment target expression contains a deref (`.* `)
@@ -306,6 +307,16 @@ impl InferCtx<'_, '_> {
                 .push(diagnostics::infer::module_namespace_used_as_value(
                     &value, span,
                 ));
+        }
+
+        if !self.scopes.is_callee_context() && !self.scopes.is_assignment_target_context() {
+            let phantom = phantom_type_params(&ty);
+            if !phantom.is_empty() {
+                self.sink
+                    .push(diagnostics::infer::uninferable_generic_reference(
+                        &value, &phantom, span,
+                    ));
+            }
         }
 
         let (identifier_ty, _) = self.instantiate(&ty);

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2695,3 +2695,147 @@ fn main() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn generic_function_with_phantom_param_passed_as_argument_rejected() {
+    infer(
+        r#"
+fn bar(f: fn() -> ()) {}
+
+fn foo_f<T>() {}
+
+fn main() {
+  let _ = bar(foo_f)
+}
+"#,
+    )
+    .assert_infer_code_once("uninferable_generic_reference");
+}
+
+#[test]
+fn generic_function_with_phantom_param_bound_to_let_rejected() {
+    infer(
+        r#"
+fn foo_f<T>() {}
+
+fn main() {
+  let _f = foo_f
+}
+"#,
+    )
+    .assert_infer_code("uninferable_generic_reference");
+}
+
+#[test]
+fn generic_function_with_phantom_param_returned_rejected() {
+    infer(
+        r#"
+fn foo_f<T>() {}
+
+fn make() -> fn() -> () {
+  foo_f
+}
+"#,
+    )
+    .assert_infer_code("uninferable_generic_reference");
+}
+
+#[test]
+fn generic_function_with_partially_inferable_params_as_argument_rejected() {
+    infer(
+        r#"
+fn bar(f: fn(int) -> ()) {
+  f(1)
+}
+
+fn foo_f<T, U>(x: T) {}
+
+fn main() {
+  bar(foo_f)
+}
+"#,
+    )
+    .assert_infer_code("uninferable_generic_reference");
+}
+
+#[test]
+fn generic_function_reference_with_inferable_param_ok() {
+    infer(
+        r#"
+fn apply(f: fn(int) -> int) -> int {
+  f(1)
+}
+
+fn identity<T>(x: T) -> T {
+  x
+}
+
+fn main() {
+  let _ = apply(identity)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn imported_generic_function_reference_with_inferable_param_ok() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub fn identity<T>(x: T) -> T {
+  x
+}
+"#,
+    );
+
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "util"
+
+fn apply(f: fn(int) -> int) -> int {
+  f(1)
+}
+
+fn main() {
+  let _ = apply(util.identity)
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn imported_generic_function_with_phantom_param_reference_rejected() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub fn weird<T>() {}
+"#,
+    );
+
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+import "util"
+
+fn bar(f: fn() -> ()) {}
+
+fn main() {
+  let _ = bar(util.weird)
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_infer_code("uninferable_generic_reference");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1260,6 +1260,47 @@ fn main() {
 }
 
 #[test]
+fn infer_phantom_type_param_function_passed_as_argument_rejected() {
+    let input = r#"
+fn bar(f: fn() -> ()) {}
+
+fn foo_f<T>() {}
+
+fn main() {
+  let _ = bar(foo_f)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_phantom_type_param_imported_function_passed_as_argument_rejected() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        "util",
+        "util.lis",
+        r#"
+pub fn weird<T>() {}
+"#,
+    );
+
+    let source = r#"
+import "util"
+
+fn bar(f: fn() -> ()) {}
+
+fn main() {
+  let _ = bar(util.weird)
+}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
 fn infer_imported_function_shortened_type_args_rejected() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/ui/errors/snapshots/infer_phantom_type_param_function_passed_as_argument_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_phantom_type_param_function_passed_as_argument_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot infer type argument
+   ╭─[test.lis:7:15]
+ 6 │ fn main() {
+ 7 │   let _ = bar(foo_f)
+   ·               ──┬──
+   ·                 ╰── cannot infer `T` for `foo_f` used as a value
+ 8 │ }
+   ╰────
+  help: A generic function used as a value cannot have its type arguments inferred. Give `foo_f` a signature that uses `T`, or remove the unused type parameter · code: [infer.uninferable_generic_reference]

--- a/tests/ui/errors/snapshots/infer_phantom_type_param_imported_function_passed_as_argument_rejected.snap
+++ b/tests/ui/errors/snapshots/infer_phantom_type_param_imported_function_passed_as_argument_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot infer type argument
+   ╭─[main.lis:7:15]
+ 6 │ fn main() {
+ 7 │   let _ = bar(util.weird)
+   ·               ─────┬────
+   ·                    ╰── cannot infer `T` for `util.weird` used as a value
+ 8 │ }
+   ╰────
+  help: A generic function used as a value cannot have its type arguments inferred. Give `util.weird` a signature that uses `T`, or remove the unused type parameter · code: [infer.uninferable_generic_reference]


### PR DESCRIPTION
Fix #1049