### PR TITLE
fix: enforce generic bounds on indirect uses of bounded types

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3003,6 +3003,25 @@ pub fn cannot_infer_struct_type_argument(
         ))
 }
 
+pub fn cannot_infer_bounded_function_reference(
+    function_name: &str,
+    param_name: &str,
+    bound: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot infer type argument")
+        .with_infer_code("cannot_infer_bounded_function_reference")
+        .with_span_label(
+            &span,
+            format!(
+                "cannot infer `{param_name}` (bound by `{bound}`) for `{function_name}` used as a value"
+            ),
+        )
+        .with_help(format!(
+            "The type argument would default to `any`, which does not satisfy `{bound}`. Use `{function_name}` in a way that determines `{param_name}`, or call it directly."
+        ))
+}
+
 pub fn empty_slice_no_element_type(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot infer the element type of this empty slice")
         .with_infer_code("empty_slice_no_element_type")

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -21,12 +21,22 @@ pub(crate) fn run(store: &Store, facts: &mut Facts, sink: &LocalSink) {
     }
     for check in std::mem::take(&mut facts.struct_bound_checks) {
         if check.ty.has_unbound_variables() {
-            sink.push(diagnostics::infer::cannot_infer_struct_type_argument(
-                &check.struct_name,
-                &check.param_name,
-                &check.bound,
-                check.span,
-            ));
+            let diagnostic = if check.is_function_reference {
+                diagnostics::infer::cannot_infer_bounded_function_reference(
+                    &check.struct_name,
+                    &check.param_name,
+                    &check.bound,
+                    check.span,
+                )
+            } else {
+                diagnostics::infer::cannot_infer_struct_type_argument(
+                    &check.struct_name,
+                    &check.param_name,
+                    &check.bound,
+                    check.span,
+                )
+            };
+            sink.push(diagnostic);
             report_vars(&check.ty, &check.module_id);
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -743,8 +743,18 @@ impl InferCtx<'_, '_> {
         let (module_ty, _) = self.instantiate(&module_ty);
         let (member_ty, _) = self.instantiate(&member_type);
 
+        let coerced_to_unconstrained_value = !self.scopes.is_callee_context()
+            && !self.scopes.is_dot_access_base()
+            && args.expected_ty.resolve_in(&self.env).is_variable();
+
         self.unify(&args.deref_ty, &module_ty, args.span);
         self.unify(args.expected_ty, &member_ty, args.span);
+
+        if coerced_to_unconstrained_value {
+            let display_name = format!("{}.{}", type_name, args.member_name);
+            self.register_function_value_bound_checks(&display_name, &member_ty, *args.span);
+        }
+
         self.facts
             .resolved_definitions
             .insert(*args.span, resolved_definition);

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -321,7 +321,15 @@ impl InferCtx<'_, '_> {
 
         let (identifier_ty, _) = self.instantiate(&ty);
 
+        let coerced_to_unconstrained_value = !self.scopes.is_callee_context()
+            && !self.scopes.is_assignment_target_context()
+            && expected_ty.resolve_in(&self.env).is_variable();
+
         self.unify(expected_ty, &identifier_ty, &span);
+
+        if coerced_to_unconstrained_value {
+            self.register_function_value_bound_checks(&value, &identifier_ty, span);
+        }
 
         if let Some(enum_id) = self.enum_of_variant(store, &value) {
             let nominal = match &identifier_ty {

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -374,6 +374,34 @@ impl InferCtx<'_, '_> {
                     struct_name: display.clone(),
                     param_name: generic.name.to_string(),
                     bound: bound.to_string(),
+                    is_function_reference: false,
+                });
+        }
+    }
+
+    pub(super) fn register_function_value_bound_checks(
+        &mut self,
+        written_name: &str,
+        function_ty: &Type,
+        span: Span,
+    ) {
+        let store = self.store;
+        let display = unqualified_name(written_name).to_string();
+        let module_id = self.cursor.module_id.clone();
+        for bound in function_ty.get_bounds() {
+            let Some(bound_name) = failing_bound_name(store, &bound.ty) else {
+                continue;
+            };
+            self.facts
+                .struct_bound_checks
+                .push(crate::facts::StructBoundCheck {
+                    ty: bound.generic.clone(),
+                    span,
+                    module_id: module_id.clone(),
+                    struct_name: display.clone(),
+                    param_name: bound.param_name.to_string(),
+                    bound: bound_name.to_string(),
+                    is_function_reference: true,
                 });
         }
     }

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod addressability;
 mod carry_mut;
 mod context;
 pub(crate) mod expressions;
-mod interface;
+pub(crate) mod interface;
 mod unify;
 mod validation;
 

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -16,7 +16,21 @@ impl TaskState<'_> {
     ) {
         for generic in own_generics {
             for bound in &generic.resolved_bounds {
-                self.check_bound_type(store, own_generics, declaration_span, bound);
+                self.check_bound_type(store, own_generics, declaration_span, bound, true, false);
+            }
+        }
+    }
+
+    pub(crate) fn check_value_position_bounds(
+        &mut self,
+        store: &Store,
+        own_generics: &[Generic],
+        types: &[(Type, Span)],
+    ) {
+        let mut seen = rustc_hash::FxHashSet::default();
+        for (ty, span) in types {
+            if seen.insert(ty.to_string()) {
+                self.check_bound_type(store, own_generics, *span, ty, false, true);
             }
         }
     }
@@ -27,22 +41,39 @@ impl TaskState<'_> {
         own_generics: &[Generic],
         declaration_span: Span,
         ty: &Type,
+        check_map_keys: bool,
+        defer_to_interface_list: bool,
     ) {
         if let Type::Nominal { id, params, .. } = ty
             && !params.is_empty()
         {
-            self.check_nominal_arguments(store, own_generics, declaration_span, id, params);
+            self.check_nominal_arguments(
+                store,
+                own_generics,
+                declaration_span,
+                id,
+                params,
+                defer_to_interface_list,
+            );
         }
-        if let Type::Compound {
-            kind: CompoundKind::Map,
-            args,
-        } = ty
+        if check_map_keys
+            && let Type::Compound {
+                kind: CompoundKind::Map,
+                args,
+            } = ty
             && let Some(key) = args.first()
         {
             self.check_map_key_comparable(store, key, declaration_span);
         }
         for child in type_argument_children(ty) {
-            self.check_bound_type(store, own_generics, declaration_span, child);
+            self.check_bound_type(
+                store,
+                own_generics,
+                declaration_span,
+                child,
+                check_map_keys,
+                defer_to_interface_list,
+            );
         }
     }
 
@@ -53,6 +84,7 @@ impl TaskState<'_> {
         declaration_span: Span,
         referenced_id: &str,
         argument_types: &[Type],
+        defer_to_interface_list: bool,
     ) {
         let Some(definition) = store.get_definition(referenced_id) else {
             return;
@@ -71,6 +103,24 @@ impl TaskState<'_> {
                 }
                 let required = substitute(declared, &substitution);
                 if required.contains_error() {
+                    continue;
+                }
+                let resolved_required = store.deep_resolve_alias(&required);
+                if let Some(required_id) = resolved_required.get_qualified_id()
+                    && store.get_interface(required_id).is_some()
+                    && !crate::checker::infer::interface::interface_requires_methods(
+                        store,
+                        required_id,
+                    )
+                {
+                    continue;
+                }
+                if defer_to_interface_list
+                    && resolved_required
+                        .get_qualified_id()
+                        .and_then(BuiltinBound::from_qualified_id)
+                        .is_some()
+                {
                     continue;
                 }
                 let argument = store.deep_resolve_alias(&argument_type.resolve_in(&self.env));
@@ -106,8 +156,19 @@ impl TaskState<'_> {
                         .get_qualified_id()
                         .is_some_and(|id| store.get_interface(id).is_some())
                 {
-                    self.pending_generic_bound_checks
-                        .push((argument, required, declaration_span));
+                    if defer_to_interface_list {
+                        self.pending_interface_bound_checks.push((
+                            argument,
+                            required,
+                            declaration_span,
+                        ));
+                    } else {
+                        self.pending_generic_bound_checks.push((
+                            argument,
+                            required,
+                            declaration_span,
+                        ));
+                    }
                 }
             }
         }

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -260,6 +260,16 @@ impl TaskState<'_> {
                 fn_ty = fn_ty.with_replaced_first_param(&receiver_ty);
             }
 
+            let (method_signature_pairs, method_signature_bounds) =
+                super::function_signature_pairs(&fn_ty, &fn_sig.params, fn_span);
+            self.scopes.push();
+            self.put_in_scope(&fn_sig.generics);
+            for bound in &method_signature_bounds {
+                self.record_generic_bound(&bound.param_name, bound.ty.clone());
+            }
+            self.check_value_position_bounds(&*store, &[], &method_signature_pairs);
+            self.scopes.pop();
+
             let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
 
             let go_hints = extract_attribute_flags(fn_attrs, "go");
@@ -412,6 +422,21 @@ impl TaskState<'_> {
                 } else {
                     fn_ty
                 };
+
+                let (mut signature_pairs, signature_bounds) =
+                    super::function_signature_pairs(&fn_ty, &[], method_span);
+                if let Type::Function(f) = fn_ty.unwrap_forall() {
+                    signature_pairs.push(((*f.return_type).clone(), method_span));
+                }
+                self.scopes.push();
+                self.put_in_scope(&generics);
+                self.record_resolved_generic_bounds(&generics);
+                self.put_in_scope(&method_sig.generics);
+                for bound in &signature_bounds {
+                    self.record_generic_bound(&bound.param_name, bound.ty.clone());
+                }
+                self.check_value_position_bounds(&*store, &[], &signature_pairs);
+                self.scopes.pop();
 
                 let go_hints = extract_attribute_flags(fn_attrs, "go");
                 if go_hints.iter().any(|h| h == "unexported") {

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -17,13 +17,13 @@ use crate::call_classification::compute_module_ufcs;
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use syntax::ast::{
     Annotation, Attribute, AttributeArg, Binding, EnumVariant, Expression, Generic, Span,
-    StructKind, Visibility as SyntacticVisibility,
+    StructKind, VariantFields, Visibility as SyntacticVisibility,
 };
 use syntax::attributes::struct_attribute_forces_field_export;
 use syntax::program::{
     Attributes, Definition, DefinitionBody, File, FileImport, TypeAttribute, Visibility,
 };
-use syntax::types::{Symbol, Type};
+use syntax::types::{Bound, Symbol, Type, unqualified_name};
 
 use super::{FileContextKind, TaskState, resolved_generic_bounds};
 use crate::store::Store;
@@ -833,18 +833,18 @@ impl TaskState<'_> {
             let Some(definition) = store.get_definition(&self.qualify_name(name)) else {
                 continue;
             };
-            let Some(generics) = definition.body.generics().map(|generics| generics.to_vec())
-            else {
-                continue;
-            };
-            if generics.is_empty() {
-                continue;
-            }
+            let generics = definition
+                .body
+                .generics()
+                .map(<[Generic]>::to_vec)
+                .unwrap_or_default();
+            let value_types = declaration_value_position_types(definition);
 
             self.scopes.push();
             self.put_in_scope(&generics);
             self.record_resolved_generic_bounds(&generics);
             self.check_transitive_generic_bounds(store, &generics, span);
+            self.check_value_position_bounds(store, &generics, &value_types);
             self.scopes.pop();
         }
     }
@@ -945,6 +945,12 @@ impl TaskState<'_> {
         };
 
         let fn_ty = self.extract_signature_parts(store, generics, params, return_annotation, span);
+
+        let (signature_pairs, signature_bounds) = function_signature_pairs(&fn_ty, params, *span);
+        for bound in &signature_bounds {
+            self.record_generic_bound(&bound.param_name, bound.ty.clone());
+        }
+        self.check_value_position_bounds(store, &[], &signature_pairs);
 
         self.scopes.pop();
 
@@ -1209,6 +1215,67 @@ impl TaskState<'_> {
             }
         }
     }
+}
+
+fn declaration_value_position_types(definition: &Definition) -> Vec<(Type, Span)> {
+    match &definition.body {
+        DefinitionBody::Struct { fields, .. } => fields
+            .iter()
+            .map(|field| (field.ty.clone(), field.annotation.get_span()))
+            .collect(),
+        DefinitionBody::Enum { variants, .. } => variants
+            .iter()
+            .flat_map(|variant| variant_field_types(&variant.fields))
+            .collect(),
+        DefinitionBody::TypeAlias { annotation, .. } => alias_body_types(definition, annotation),
+        _ => Vec::new(),
+    }
+}
+
+fn function_signature_pairs(
+    fn_ty: &Type,
+    params: &[Binding],
+    fallback: Span,
+) -> (Vec<(Type, Span)>, Vec<Bound>) {
+    let Type::Function(function) = fn_ty.unwrap_forall() else {
+        return (Vec::new(), Vec::new());
+    };
+    let pairs: Vec<(Type, Span)> = function
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, param_ty)| {
+            let span = params
+                .get(index)
+                .and_then(|binding| binding.annotation.as_ref())
+                .map_or(fallback, Annotation::get_span);
+            (param_ty.clone(), span)
+        })
+        .collect();
+    (pairs, function.bounds.clone())
+}
+
+fn variant_field_types(fields: &VariantFields) -> Vec<(Type, Span)> {
+    match fields {
+        VariantFields::Unit => Vec::new(),
+        VariantFields::Tuple(fields) | VariantFields::Struct(fields) => fields
+            .iter()
+            .map(|field| (field.ty.clone(), field.annotation.get_span()))
+            .collect(),
+    }
+}
+
+fn alias_body_types(definition: &Definition, annotation: &Annotation) -> Vec<(Type, Span)> {
+    let body = definition.ty.unwrap_forall();
+    if let Type::Nominal { id, .. } = body
+        && definition
+            .name
+            .as_ref()
+            .is_some_and(|name| unqualified_name(id) == name.as_str())
+    {
+        return Vec::new();
+    }
+    vec![(body.clone(), annotation.get_span())]
 }
 
 fn populate_expression_generic_bounds(

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -104,6 +104,7 @@ pub struct StructBoundCheck {
     pub struct_name: String,
     pub param_name: String,
     pub bound: String,
+    pub is_function_reference: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2839,3 +2839,68 @@ fn main() {
 
     infer_module("main", fs).assert_infer_code("uninferable_generic_reference");
 }
+
+#[test]
+fn bounded_function_reference_with_uninferable_bound_rejected() {
+    infer(
+        r#"
+interface Show { fn show() -> string; }
+fn foo_f<T: Show>(x: T) {}
+fn main() { let _f = foo_f }
+"#,
+    )
+    .assert_infer_code("cannot_infer_bounded_function_reference");
+}
+
+#[test]
+fn bounded_phantom_function_reference_rejected() {
+    infer(
+        r#"
+interface Show { fn show() -> string; }
+fn foo_f<T: Show>() {}
+fn main() { let _f = foo_f }
+"#,
+    )
+    .assert_infer_code("cannot_infer_bounded_function_reference");
+}
+
+#[test]
+fn bounded_function_reference_in_tuple_rejected() {
+    infer(
+        r#"
+interface Show { fn show() -> string; }
+fn foo_f<T: Show>() {}
+fn main() { let _t = (foo_f, 1) }
+"#,
+    )
+    .assert_infer_code("cannot_infer_bounded_function_reference");
+}
+
+#[test]
+fn bounded_function_reference_pinned_by_later_call_succeeds() {
+    infer(
+        r#"
+interface Show { fn show() -> string; }
+struct W {}
+impl W { fn show(self) -> string { "w" } }
+fn foo_f<T: Show>(x: T) {}
+fn main() {
+  let f = foo_f
+  f(W {})
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_interface_bounded_function_reference_succeeds() {
+    infer(
+        r#"
+interface Empty {}
+fn foo_f<T: Empty>(x: T) { let _ = x }
+fn main() { let _f = foo_f }
+"#,
+    )
+    .assert_no_errors();
+}

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -968,3 +968,182 @@ fn main() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn transitive_bound_required_on_struct_field_parameter() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+struct Holder<T> { b: Bar<T> }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_required_on_enum_variant_parameter() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+enum Wrap<T> { W(Bar<T>) }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_required_on_function_parameter() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+fn f<T>(x: Bar<T>) { let _ = x }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_required_on_type_alias_body_parameter() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+type Alias<T> = Bar<T>
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_required_on_forward_referenced_struct_field() {
+    infer(
+        r#"
+struct Holder<T> { b: Bar<T> }
+struct Bar<E: error> { e: E }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn concrete_bound_violation_through_type_alias_errors() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+type Alias = Bar<int>
+fn use_alias(x: Alias) { let _ = x }
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn concrete_bound_violation_forward_referenced_struct_field_errors() {
+    infer(
+        r#"
+struct Holder { b: Bar<int> }
+struct Bar<E: error> { e: E }
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn transitive_bound_satisfied_on_struct_field_succeeds() {
+    infer(
+        r#"
+struct MyErr {}
+impl MyErr { fn Error(self) -> string { "e" } }
+struct Bar<E: error> { e: E }
+struct Holder<T: error> { b: Bar<T> }
+fn main() {
+  let h = Holder { b: Bar { e: MyErr {} } }
+  let _ = h
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn transitive_bound_required_on_method_parameter() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+struct Host {}
+impl Host {
+  fn m<T>(self, x: Bar<T>) { let _ = x }
+}
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_satisfied_on_method_via_impl_generic_succeeds() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+struct Host<E: error> {}
+impl<E: error> Host<E> {
+  fn m(self, x: Bar<E>) { let _ = x }
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn empty_interface_bound_needs_no_transitive_bound_succeeds() {
+    infer(
+        r#"
+interface Empty {}
+struct Bar<E: Empty> { e: E }
+struct Holder<T> { b: Bar<T> }
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn two_level_transitive_bound_required() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+struct Mid<X: error> { b: Bar<X> }
+struct Holder<T> { m: Mid<T> }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_required_in_interface_method_signature() {
+    infer(
+        r#"
+struct Bar<E: error> { e: E }
+interface Foo<T> { fn get() -> Bar<T>; }
+"#,
+    )
+    .assert_infer_code("missing_transitive_bound");
+}
+
+#[test]
+fn transitive_bound_satisfied_in_interface_method_signature_succeeds() {
+    infer(
+        r#"
+struct MyErr {}
+impl MyErr { fn Error(self) -> string { "e" } }
+struct Bar<E: error> { e: E }
+impl<E: error> Bar<E> { fn inner(self) -> E { self.e } }
+interface Foo<T: error> { fn get() -> Bar<T>; }
+struct Holder { b: Bar<MyErr> }
+impl Holder { fn get(self) -> Bar<MyErr> { self.b } }
+fn use_foo(f: Foo<MyErr>) { let _ = f.get().inner() }
+fn main() {
+  let h = Holder { b: Bar { e: MyErr {} } }
+  use_foo(h)
+}
+"#,
+    )
+    .assert_no_errors();
+}


### PR DESCRIPTION
Enforces that a type param that reaches a bounded generic must now carry that bound.

```rs
struct Bar<E: error> { e: E }
struct Holder<T> { b: Bar<T> } // rejected: needs `Holder<T: error>`
```

This applies wherever a type param reaches a bounded place: struct fields, enum variant fields, type-alias bodies, fn and method params, and interface method signatures.