### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.10.0](https://github.com/ivov/lisette/compare/lisette-v0.9.0...lisette-v0.10.0) - 2026-07-19
+
+### Fixes
+
+- fix: resolve forward-referenced type aliases [#1074](https://github.com/ivov/lisette/pull/1074) [`4564597`](https://github.com/ivov/lisette/commit/4564597d46c4198a8a0d36366652a11d25cc29b0)
+- fix: reject variable shadowing imported module [#1073](https://github.com/ivov/lisette/pull/1073) [`4e2c006`](https://github.com/ivov/lisette/commit/4e2c006122d0c979b5e152b6be8d506bc4ac5f4d)
+- fix: refresh LSP diagnostics in other open files post-edit [#1070](https://github.com/ivov/lisette/pull/1070) [`c2f92e5`](https://github.com/ivov/lisette/commit/c2f92e55641b849804c7c28e4299f3c5ed0dce8b)
+
+### Internals
+
+- refactor: unify generic bound handling [#1072](https://github.com/ivov/lisette/pull/1072) [`5a3f855`](https://github.com/ivov/lisette/commit/5a3f8554acf570c21727eb7a346db947a19a0a48)
+
+
 ## [0.9.0](https://github.com/ivov/lisette/compare/lisette-v0.8.0...lisette-v0.9.0) - 2026-07-19
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "fs2",
  "lisette-deps",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -627,11 +627,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,15 +20,15 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.9.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.9.0", path = "../passes" }
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../diagnostics" }
-format = { package = "lisette-format", version = "=0.9.0", path = "../format" }
-emit = { package = "lisette-emit", version = "=0.9.0", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "=0.9.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.9.0", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "=0.9.0", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "=0.10.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.10.0", path = "../passes" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
+format = { package = "lisette-format", version = "=0.10.0", path = "../format" }
+emit = { package = "lisette-emit", version = "=0.10.0", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "=0.10.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "=0.10.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "macros"] }
 tower-lsp = "0.20"
 fs2 = "0.4"

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "=0.9.0", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "=0.10.0", path = "../stdlib" }
 toml = "0.9.10"
 toml_edit = "0.22"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
 unicode-segmentation = "1.11"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "=0.9.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.9.0", path = "../passes" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "=0.9.0", path = "../deps" }
-format = { package = "lisette-format", version = "=0.9.0", path = "../format" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "=0.10.0", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.10.0", path = "../passes" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
+format = { package = "lisette-format", version = "=0.10.0", path = "../format" }
 tower = { version = "0.4", default-features = false }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.9.0", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../diagnostics" }
+semantics = { package = "lisette-semantics", version = "=0.10.0", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "=0.9.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.9.0", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "=0.10.0", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "=0.10.0", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -272,7 +272,13 @@ impl TaskState<'_> {
         let file_data = self.module_file_data(store, id);
 
         for (file_id, imports) in &file_data {
-            self.register_file_type_definitions(store, id, *file_id, imports);
+            self.register_file_type_aliases(store, id, *file_id, imports);
+        }
+
+        self.settle_module_aliases(store, id);
+
+        for (file_id, imports) in &file_data {
+            self.register_file_type_bodies(store, id, *file_id, imports);
         }
 
         for (file_id, imports) in &file_data {
@@ -491,12 +497,13 @@ impl TaskState<'_> {
             .collect()
     }
 
-    fn register_file_type_definitions(
+    fn with_file_items(
         &mut self,
         store: &mut Store,
         module_id: &str,
         file_id: u32,
         imports: &[FileImport],
+        register: impl FnOnce(&mut Self, &mut Store, &[Expression]),
     ) {
         self.with_file_context_mut(
             store,
@@ -512,7 +519,7 @@ impl TaskState<'_> {
                         .items,
                 );
 
-                this.register_type_definitions(store, &items);
+                register(this, store, &items);
 
                 store
                     .get_file_mut(file_id)
@@ -522,6 +529,30 @@ impl TaskState<'_> {
         );
     }
 
+    fn register_file_type_aliases(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+    ) {
+        self.with_file_items(store, module_id, file_id, imports, |this, store, items| {
+            this.register_type_aliases(store, items);
+        });
+    }
+
+    fn register_file_type_bodies(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+        file_id: u32,
+        imports: &[FileImport],
+    ) {
+        self.with_file_items(store, module_id, file_id, imports, |this, store, items| {
+            this.register_type_bodies(store, items);
+        });
+    }
+
     fn register_file_values(
         &mut self,
         store: &mut Store,
@@ -529,30 +560,11 @@ impl TaskState<'_> {
         file_id: u32,
         imports: &[FileImport],
     ) {
-        self.with_file_context_mut(
-            store,
-            module_id,
-            file_id,
-            imports,
-            FileContextKind::Standard,
-            |this, store| {
-                let items = std::mem::take(
-                    &mut store
-                        .get_file_mut(file_id)
-                        .expect("file must exist for registration")
-                        .items,
-                );
-
-                this.check_type_generic_bounds(store, &items);
-                this.register_impl_blocks(store, &items);
-                this.register_values(store, &items, &Visibility::Private);
-
-                store
-                    .get_file_mut(file_id)
-                    .expect("file must exist after registration")
-                    .items = items;
-            },
-        );
+        self.with_file_items(store, module_id, file_id, imports, |this, store, items| {
+            this.check_type_generic_bounds(store, items);
+            this.register_impl_blocks(store, items);
+            this.register_values(store, items, &Visibility::Private);
+        });
     }
 
     pub fn register_types_and_values(
@@ -736,7 +748,13 @@ impl TaskState<'_> {
     }
 
     pub fn register_type_definitions(&mut self, store: &mut Store, items: &[Expression]) {
-        self.check_go_hints_in_items(items);
+        self.register_type_aliases(store, items);
+        let module_id = self.cursor.module_id.clone();
+        self.settle_module_aliases(store, &module_id);
+        self.register_type_bodies(store, items);
+    }
+
+    fn register_type_aliases(&mut self, store: &mut Store, items: &[Expression]) {
         for item in items {
             if let Expression::TypeAlias {
                 name,
@@ -754,7 +772,10 @@ impl TaskState<'_> {
                 );
             }
         }
+    }
 
+    fn register_type_bodies(&mut self, store: &mut Store, items: &[Expression]) {
+        self.check_go_hints_in_items(items);
         for item in items {
             match item {
                 Expression::Enum {

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -6,7 +6,7 @@ use syntax::ast::{
 };
 use syntax::containment::{EnumPayloads, definition_contains_by_value};
 use syntax::program::{Attributes, Definition, DefinitionBody, MethodSignatures, Visibility};
-use syntax::types::Type;
+use syntax::types::{Symbol, Type};
 
 use super::enum_variant_constructor_type;
 use crate::checker::TaskState;
@@ -487,6 +487,37 @@ impl TaskState<'_> {
         }
     }
 
+    pub(super) fn settle_module_aliases(&self, store: &mut Store, module_id: &str) {
+        if module_id.starts_with("go:") {
+            return;
+        }
+        let Some(module) = store.get_module(module_id) else {
+            return;
+        };
+
+        let updates: Vec<(Symbol, Type)> = module
+            .definitions
+            .iter()
+            .filter(|(_, definition)| matches!(definition.body, DefinitionBody::TypeAlias { .. }))
+            .filter_map(|(name, definition)| {
+                let mut changed = false;
+                let mut in_progress = FxHashSet::default();
+                let filled =
+                    fill_alias_underlyings(definition.ty(), store, &mut changed, &mut in_progress);
+                changed.then(|| (name.clone(), filled))
+            })
+            .collect();
+
+        let Some(module) = store.get_module_mut(module_id) else {
+            return;
+        };
+        for (name, ty) in updates {
+            if let Some(definition) = module.definitions.get_mut(&name) {
+                definition.ty = ty;
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn populate_type_alias(
         &mut self,
@@ -815,6 +846,93 @@ fn is_pointer_backed_newtype(store: &Store, ty: &Type) -> bool {
         .get_type(id.as_str())
         .and_then(Type::get_underlying)
         .is_some_and(|underlying| store.deep_resolve_alias(underlying).is_ref())
+}
+
+fn fill_alias_underlyings(
+    ty: &Type,
+    store: &Store,
+    changed: &mut bool,
+    in_progress: &mut FxHashSet<Symbol>,
+) -> Type {
+    match ty {
+        Type::Nominal {
+            id,
+            params,
+            underlying_ty,
+        } => {
+            let params: Vec<Type> = params
+                .iter()
+                .map(|param| fill_alias_underlyings(param, store, changed, in_progress))
+                .collect();
+            let underlying = match underlying_ty {
+                Some(inner) => Some(Box::new(fill_alias_underlyings(
+                    inner,
+                    store,
+                    changed,
+                    in_progress,
+                ))),
+                None if in_progress.contains(id) => None,
+                None => {
+                    let probe = Type::Nominal {
+                        id: id.clone(),
+                        params: params.clone(),
+                        underlying_ty: None,
+                    };
+                    let resolved = store.deep_resolve_alias(&probe);
+                    if resolved.get_qualified_id() == Some(id.as_str()) {
+                        None
+                    } else {
+                        *changed = true;
+                        in_progress.insert(id.clone());
+                        let filled = fill_alias_underlyings(&resolved, store, changed, in_progress);
+                        in_progress.remove(id);
+                        Some(Box::new(filled))
+                    }
+                }
+            };
+            Type::Nominal {
+                id: id.clone(),
+                params,
+                underlying_ty: underlying,
+            }
+        }
+        Type::Compound { kind, args } => Type::Compound {
+            kind: *kind,
+            args: args
+                .iter()
+                .map(|arg| fill_alias_underlyings(arg, store, changed, in_progress))
+                .collect(),
+        },
+        Type::Array { length, element } => Type::Array {
+            length: *length,
+            element: Box::new(fill_alias_underlyings(element, store, changed, in_progress)),
+        },
+        Type::Tuple(elements) => Type::Tuple(
+            elements
+                .iter()
+                .map(|element| fill_alias_underlyings(element, store, changed, in_progress))
+                .collect(),
+        ),
+        Type::Forall { vars, body } => Type::Forall {
+            vars: vars.clone(),
+            body: Box::new(fill_alias_underlyings(body, store, changed, in_progress)),
+        },
+        Type::Function(function) => {
+            let params = function
+                .params
+                .iter()
+                .map(|param| fill_alias_underlyings(param, store, changed, in_progress))
+                .collect();
+            let return_type = Box::new(fill_alias_underlyings(
+                &function.return_type,
+                store,
+                changed,
+                in_progress,
+            ));
+            function.rebuild(params, function.bounds.clone(), return_type)
+        }
+        other => other.clone(),
+    }
 }
 
 // Mirror the written type's own visibility: peel storage (`Option`/`Ref`), not aliases.

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -9076,3 +9076,90 @@ fn main() {
     )
     .assert_infer_code_once("integer_in_type_position");
 }
+
+#[test]
+fn interface_method_return_expands_alias_from_sibling_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "aliases.lis", "pub type MyInt = int\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface Bar {
+  fn value() -> MyInt
+}
+
+fn baz(value: Bar) {
+  let _: int = value.value()
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn struct_field_expands_alias_from_sibling_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "aliases.lis", "pub type MyInt = int\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+struct Holder {
+  value: MyInt,
+}
+
+fn read(h: Holder) {
+  let _: int = h.value
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn interface_method_return_expands_chained_alias_across_files() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "base.lis", "pub type B = int\n");
+    fs.add_file("main", "middle.lis", "pub type A = B\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface Bar {
+  fn value() -> A
+}
+
+fn baz(value: Bar) {
+  let _: int = value.value()
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
+}
+
+#[test]
+fn interface_method_return_expands_chained_alias_declared_out_of_order() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+type A = B
+type B = int
+
+interface Bar {
+  fn value() -> A
+}
+
+fn baz(value: Bar) {
+  let _: int = value.value()
+}
+"#,
+    );
+
+    infer_module("main", fs).assert_no_errors();
+}


### PR DESCRIPTION
## 0.10.0 (upcoming)

### Fixes

- fix: resolve forward-referenced type aliases [#1074](https://github.com/ivov/lisette/pull/1074) [`4564597`](https://github.com/ivov/lisette/commit/4564597d46c4198a8a0d36366652a11d25cc29b0)
- fix: reject variable shadowing imported module [#1073](https://github.com/ivov/lisette/pull/1073) [`4e2c006`](https://github.com/ivov/lisette/commit/4e2c006122d0c979b5e152b6be8d506bc4ac5f4d)
- fix: refresh LSP diagnostics in other open files post-edit [#1070](https://github.com/ivov/lisette/pull/1070) [`c2f92e5`](https://github.com/ivov/lisette/commit/c2f92e55641b849804c7c28e4299f3c5ed0dce8b)

### Internals

- refactor: unify generic bound handling [#1072](https://github.com/ivov/lisette/pull/1072) [`5a3f855`](https://github.com/ivov/lisette/commit/5a3f8554acf570c21727eb7a346db947a19a0a48)

