### PR TITLE
refactor: unify generic bound handling

### DIFF
--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -4,32 +4,57 @@
 //! `passes::fact_producers::generics`.
 
 use diagnostics::LocalSink;
-use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::{Annotation, Expression, Generic, Span};
-use syntax::types::{Bound, Symbol, Type};
+use syntax::types::{Bound, Type};
 
-use semantics::prelude::PRELUDE_MODULE_ID;
+use semantics::generics::{bound_implied, bound_requires_evidence, type_obligations};
 use semantics::store::Store;
 
-pub(crate) fn run(typed_ast: &[Expression], module_id: &str, store: &Store, sink: &LocalSink) {
+#[derive(Clone, Copy)]
+struct GenericContext<'a> {
+    generics: &'a [Generic],
+    receiver: Option<&'a Type>,
+}
+
+pub(crate) fn run(typed_ast: &[Expression], store: &Store, sink: &LocalSink) {
     for item in typed_ast {
-        visit_expression(item, None, module_id, store, sink);
+        visit_expression(item, None, store, sink);
     }
 }
 
 fn visit_expression(
     expression: &Expression,
-    enclosing_impl_generics: Option<&[Generic]>,
-    module_id: &str,
+    enclosing: Option<GenericContext<'_>>,
     store: &Store,
     sink: &LocalSink,
 ) {
     match expression {
         Expression::ImplBlock {
-            methods, generics, ..
+            methods,
+            generics,
+            ty,
+            ..
         } => {
+            let context = GenericContext {
+                generics,
+                receiver: Some(ty),
+            };
             for method in methods {
-                visit_expression(method, Some(generics), module_id, store, sink);
+                visit_expression(method, Some(context), store, sink);
+            }
+            return;
+        }
+        Expression::Interface {
+            method_signatures,
+            generics,
+            ..
+        } => {
+            let context = GenericContext {
+                generics,
+                receiver: None,
+            };
+            for method in method_signatures {
+                visit_expression(method, Some(context), store, sink);
             }
             return;
         }
@@ -43,10 +68,9 @@ fn visit_expression(
             check_constrained_return_type(
                 return_type,
                 generics,
-                enclosing_impl_generics,
+                enclosing,
                 return_annotation,
                 name,
-                module_id,
                 store,
                 sink,
             );
@@ -66,7 +90,7 @@ fn visit_expression(
     }
 
     for child in expression.children() {
-        visit_expression(child, enclosing_impl_generics, module_id, store, sink);
+        visit_expression(child, enclosing, store, sink);
     }
 }
 
@@ -85,141 +109,63 @@ fn check_unconstrained_bounded(bounds: &[Bound], span: &Span, sink: &LocalSink) 
 fn check_constrained_return_type(
     return_ty: &Type,
     generics: &[Generic],
-    enclosing_impl_generics: Option<&[Generic]>,
+    enclosing: Option<GenericContext<'_>>,
     return_annotation: &Annotation,
     fn_name: &str,
-    module_id: &str,
     store: &Store,
     sink: &LocalSink,
 ) {
-    let Type::Nominal { id, params, .. } = return_ty else {
-        return;
-    };
-
-    if params.is_empty() {
-        return;
-    }
-
-    let qualified_id =
-        lookup_qualified_name(id, module_id, store).unwrap_or_else(|| id.to_string());
-    let Some(methods) = store.get_own_methods(&qualified_id) else {
-        return;
-    };
-
-    let mut required_bounds: HashMap<String, Vec<Type>> = HashMap::default();
-    for method_ty in methods.values() {
-        let fn_ty = match method_ty {
-            Type::Forall { body, .. } => body.as_ref(),
-            other => other,
-        };
-        if let Type::Function(f) = fn_ty {
-            for bound in &f.bounds {
-                if let Type::Parameter(param_name) = &bound.generic {
-                    let entry = required_bounds.entry(param_name.to_string()).or_default();
-                    if !entry.contains(&bound.ty) {
-                        entry.push(bound.ty.clone());
-                    }
-                }
-            }
-        }
-    }
-
     let span = return_annotation.get_span();
-    for return_param in params.iter() {
-        if let Type::Parameter(param_name) = return_param
-            && let Some(method_bounds) = required_bounds.get(param_name.as_str())
+    let mut seen = rustc_hash::FxHashSet::default();
+    for applied in type_obligations(store, return_ty) {
+        let Type::Parameter(param_name) = &applied.argument else {
+            continue;
+        };
+        if !bound_requires_evidence(store, &applied.required)
+            || !seen.insert((param_name.clone(), applied.required.to_string()))
         {
-            let fn_generic = generics
-                .iter()
-                .find(|g| g.name.as_str() == param_name.as_str());
-
-            if let Some(fn_gen) = fn_generic {
-                let fn_bounds: Vec<Type> = fn_gen
-                    .bounds
-                    .iter()
-                    .filter_map(|b| annotation_to_type(b, module_id, store))
-                    .collect();
-
-                for method_bound in method_bounds {
-                    if !fn_bounds.iter().any(|fb| fb == method_bound) {
-                        sink.push(
-                            diagnostics::infer::missing_constraint_on_generic_return_type(
-                                fn_name,
-                                param_name.as_ref(),
-                                method_bound,
-                                span,
-                            ),
-                        );
-                    }
-                }
-            } else if let Some(impl_generics) = enclosing_impl_generics {
-                let impl_bounds: Vec<Type> = impl_generics
-                    .iter()
-                    .filter(|g| g.name.as_str() == param_name.as_str())
-                    .flat_map(|g| g.bounds.iter())
-                    .filter_map(|b| annotation_to_type(b, module_id, store))
-                    .collect();
-                let all_covered = method_bounds.iter().all(|mb| impl_bounds.contains(mb));
-                if !all_covered {
-                    let bound_str = method_bounds
-                        .iter()
-                        .map(|b| b.to_string())
-                        .collect::<Vec<_>>()
-                        .join(" + ");
-                    sink.push(
-                        diagnostics::infer::missing_constraint_on_generic_return_type(
-                            fn_name,
-                            param_name.as_ref(),
-                            &Type::Parameter(bound_str.into()),
-                            span,
-                        ),
-                    );
-                }
-            } else {
-                let bound_str = method_bounds
-                    .iter()
-                    .map(|b| b.to_string())
-                    .collect::<Vec<_>>()
-                    .join(" + ");
-                sink.push(
-                    diagnostics::infer::missing_constraint_on_generic_return_type(
-                        fn_name,
-                        param_name.as_ref(),
-                        &Type::Parameter(bound_str.into()),
-                        span,
-                    ),
-                );
-            }
+            continue;
+        }
+        let available = generics
+            .iter()
+            .find(|generic| generic.name == *param_name)
+            .map(|generic| generic.resolved_bounds.clone())
+            .unwrap_or_else(|| enclosing_parameter_bounds(store, enclosing, param_name));
+        if !bound_implied(store, &available, &applied.required) {
+            sink.push(
+                diagnostics::infer::missing_constraint_on_generic_return_type(
+                    fn_name,
+                    param_name,
+                    &applied.required,
+                    span,
+                ),
+            );
         }
     }
 }
 
-fn lookup_qualified_name(id: &str, module_id: &str, store: &Store) -> Option<String> {
-    if id.contains('.') {
-        return Some(id.to_string());
-    }
-
-    for module in [module_id, PRELUDE_MODULE_ID] {
-        let candidate = Symbol::from_parts(module, id);
-        if store
-            .get_module(module)
-            .is_some_and(|m| m.definitions.contains_key(candidate.as_str()))
-        {
-            return Some(candidate.to_string());
-        }
-    }
-    None
-}
-
-fn annotation_to_type(annotation: &Annotation, module_id: &str, store: &Store) -> Option<Type> {
-    let Annotation::Constructor { name, params, .. } = annotation else {
-        return None;
+fn enclosing_parameter_bounds(
+    store: &Store,
+    context: Option<GenericContext<'_>>,
+    parameter: &str,
+) -> Vec<Type> {
+    let Some(context) = context else {
+        return Vec::new();
     };
-    let qualified = lookup_qualified_name(name, module_id, store)?;
-    let ty = store.get_type(&qualified)?.clone();
-    let instantiated = match &ty {
-        Type::Forall { body, .. } if params.is_empty() => (**body).clone(),
-        _ => ty,
-    };
-    Some(instantiated)
+    let mut available = context
+        .generics
+        .iter()
+        .find(|generic| generic.name == parameter)
+        .map_or_else(Vec::new, |generic| generic.resolved_bounds.clone());
+    if let Some(receiver) = context.receiver {
+        available.extend(
+            type_obligations(store, receiver)
+                .into_iter()
+                .filter_map(|obligation| {
+                    (obligation.argument == Type::Parameter(parameter.into()))
+                        .then_some(obligation.required)
+                }),
+        );
+    }
+    available
 }

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -147,7 +147,7 @@ fn run_file_checks(
     interpolation_stringer::run(&file.items, store, ufcs_methods, sink);
 
     prelude_shadowing::run(&file.items, store, sink);
-    generics::run(&file.items, &module.id, store, sink);
+    generics::run(&file.items, store, sink);
     native_value_usage::run(&file.items, &module.id, store, sink);
     json_serializable_fields::run(&file.items, sink);
     empty_select_default::run(&file.items, sink);

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -2,6 +2,8 @@ use diagnostics::LocalSink;
 use rustc_hash::FxHashSet as HashSet;
 
 use semantics::facts::Facts;
+use semantics::facts::GenericBoundOrigin;
+use semantics::generics::bound_display_name;
 use semantics::store::Store;
 use syntax::types::{CompoundKind, TypeVarId};
 
@@ -19,25 +21,29 @@ pub(crate) fn run(store: &Store, facts: &mut Facts, sink: &LocalSink) {
             report_vars(&check.ty, &check.module_id);
         }
     }
-    for check in std::mem::take(&mut facts.struct_bound_checks) {
-        if check.ty.has_unbound_variables() {
-            let diagnostic = if check.is_function_reference {
-                diagnostics::infer::cannot_infer_bounded_function_reference(
-                    &check.struct_name,
-                    &check.param_name,
-                    &check.bound,
-                    check.span,
-                )
-            } else {
-                diagnostics::infer::cannot_infer_struct_type_argument(
-                    &check.struct_name,
-                    &check.param_name,
-                    &check.bound,
-                    check.span,
-                )
+    for obligation in std::mem::take(&mut facts.generic_bound_obligations) {
+        if obligation.argument.has_unbound_variables() {
+            let required_name = bound_display_name(store, &obligation.required);
+            let diagnostic = match &obligation.origin {
+                GenericBoundOrigin::FunctionReference { name } => {
+                    diagnostics::infer::cannot_infer_bounded_function_reference(
+                        name,
+                        &obligation.param_name,
+                        &required_name,
+                        obligation.span,
+                    )
+                }
+                GenericBoundOrigin::Construction { name, .. } => {
+                    diagnostics::infer::cannot_infer_struct_type_argument(
+                        name,
+                        &obligation.param_name,
+                        &required_name,
+                        obligation.span,
+                    )
+                }
             };
             sink.push(diagnostic);
-            report_vars(&check.ty, &check.module_id);
+            report_vars(&obligation.argument, &obligation.module_id);
         }
     }
     for check in std::mem::take(&mut facts.empty_collection_checks) {

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -357,8 +357,21 @@ impl<'a> FreezeFolder<'a> {
         for check in &mut facts.generic_call_checks {
             self.env.resolve_in_place(&mut check.ty);
         }
-        for check in &mut facts.struct_bound_checks {
-            self.env.resolve_in_place(&mut check.ty);
+        for obligation in &mut facts.generic_bound_obligations {
+            self.env.resolve_in_place(&mut obligation.argument);
+            self.env.resolve_in_place(&mut obligation.required);
+            if let crate::facts::GenericBoundOrigin::Construction {
+                enclosing_return_type: Some(return_type),
+                ..
+            } = &mut obligation.origin
+            {
+                self.env.resolve_in_place(return_type);
+            }
+            for (_, bounds) in &mut obligation.available_bounds {
+                for bound in bounds {
+                    self.env.resolve_in_place(bound);
+                }
+            }
         }
         for check in &mut facts.empty_collection_checks {
             self.env.resolve_in_place(&mut check.ty);

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -752,7 +752,7 @@ impl InferCtx<'_, '_> {
 
         if coerced_to_unconstrained_value {
             let display_name = format!("{}.{}", type_name, args.member_name);
-            self.register_function_value_bound_checks(&display_name, &member_ty, *args.span);
+            self.register_function_value_obligations(&display_name, &member_ty, *args.span);
         }
 
         self.facts

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -469,6 +469,12 @@ impl InferCtx<'_, '_> {
         self.unify_trait_bounds(&bounds, &param_types, &new_args, &span);
 
         let resolved_return = store.deep_resolve_alias(&return_ty.resolve_in(&self.env));
+        if call_kind == CallKind::TupleStructConstructor
+            && let Type::Nominal { id, .. } = &resolved_return
+        {
+            let written_name = callee_path.as_deref().unwrap_or(id.as_str());
+            self.register_construction_obligations(written_name, &resolved_return, span);
+        }
         if let Some((CompoundKind::Map, arguments)) = resolved_return.as_compound()
             && let Some(key) = arguments.first()
         {

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -328,7 +328,7 @@ impl InferCtx<'_, '_> {
         self.unify(expected_ty, &identifier_ty, &span);
 
         if coerced_to_unconstrained_value {
-            self.register_function_value_bound_checks(&value, &identifier_ty, span);
+            self.register_function_value_obligations(&value, &identifier_ty, span);
         }
 
         if let Some(enum_id) = self.enum_of_variant(store, &value) {
@@ -341,7 +341,7 @@ impl InferCtx<'_, '_> {
                 _ => None,
             };
             if let Some(nominal) = nominal {
-                self.register_struct_bound_checks(&enum_id, &enum_id, nominal, span);
+                self.register_construction_obligations(&enum_id, nominal, span);
             }
         }
 

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -7,7 +7,7 @@ use syntax::ast::{Expression, Span, StructFieldAssignment, StructSpread};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
-use crate::checker::infer::{BuiltinBound, InferCtx};
+use crate::checker::infer::InferCtx;
 
 /// Inputs to `infer_structish_fields` shared between struct and enum-variant literals.
 struct StructishCtx<'a, 'b, F> {
@@ -324,7 +324,7 @@ impl InferCtx<'_, '_> {
         let final_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
         self.unify(&final_expected, &struct_call_ty, &span);
 
-        self.register_struct_bound_checks(&qualified_name, &struct_name, &struct_call_ty, span);
+        self.register_construction_obligations(&struct_name, &struct_call_ty, span);
 
         Expression::StructCall {
             name: struct_name,
@@ -332,77 +332,6 @@ impl InferCtx<'_, '_> {
             spread: new_spread,
             ty: struct_call_ty,
             span,
-        }
-    }
-
-    pub(super) fn register_struct_bound_checks(
-        &mut self,
-        qualified_name: &str,
-        written_name: &str,
-        call_ty: &Type,
-        span: Span,
-    ) {
-        let Type::Nominal { params, .. } = call_ty else {
-            return;
-        };
-        if params.is_empty() {
-            return;
-        }
-        let store = self.store;
-        let Some(generics) = store
-            .get_definition(qualified_name)
-            .and_then(|def| def.body.generics())
-        else {
-            return;
-        };
-        let module_id = self.cursor.module_id.clone();
-        let display = unqualified_name(written_name).to_string();
-        for (generic, arg) in generics.iter().zip(params) {
-            let Some(bound) = generic
-                .resolved_bounds
-                .iter()
-                .find_map(|bound| failing_bound_name(store, bound))
-            else {
-                continue;
-            };
-            self.facts
-                .struct_bound_checks
-                .push(crate::facts::StructBoundCheck {
-                    ty: arg.clone(),
-                    span,
-                    module_id: module_id.clone(),
-                    struct_name: display.clone(),
-                    param_name: generic.name.to_string(),
-                    bound: bound.to_string(),
-                    is_function_reference: false,
-                });
-        }
-    }
-
-    pub(super) fn register_function_value_bound_checks(
-        &mut self,
-        written_name: &str,
-        function_ty: &Type,
-        span: Span,
-    ) {
-        let store = self.store;
-        let display = unqualified_name(written_name).to_string();
-        let module_id = self.cursor.module_id.clone();
-        for bound in function_ty.get_bounds() {
-            let Some(bound_name) = failing_bound_name(store, &bound.ty) else {
-                continue;
-            };
-            self.facts
-                .struct_bound_checks
-                .push(crate::facts::StructBoundCheck {
-                    ty: bound.generic.clone(),
-                    span,
-                    module_id: module_id.clone(),
-                    struct_name: display.clone(),
-                    param_name: bound.param_name.to_string(),
-                    bound: bound_name.to_string(),
-                    is_function_reference: true,
-                });
         }
     }
 
@@ -471,7 +400,7 @@ impl InferCtx<'_, '_> {
 
         if let Type::Nominal { id, .. } = &resolved_enum {
             let enum_id = id.as_str();
-            self.register_struct_bound_checks(enum_id, enum_id, &enum_ty, span);
+            self.register_construction_obligations(enum_id, &enum_ty, span);
         }
 
         Expression::StructCall {
@@ -673,14 +602,6 @@ impl InferCtx<'_, '_> {
         let store = self.store;
         crate::zero::has_zero(store, ty, from_module)
     }
-}
-
-fn failing_bound_name(store: &crate::store::Store, bound: &Type) -> Option<EcoString> {
-    let resolved = store.deep_resolve_alias(bound);
-    let id = resolved.get_qualified_id()?;
-    let fails = BuiltinBound::from_qualified_id(id).is_some()
-        || crate::checker::infer::interface::interface_requires_methods(store, id);
-    fails.then(|| unqualified_name(id).into())
 }
 
 pub(super) fn same_nominal(a: &Type, b: &Type) -> bool {

--- a/crates/semantics/src/checker/infer/generic_obligations.rs
+++ b/crates/semantics/src/checker/infer/generic_obligations.rs
@@ -1,0 +1,69 @@
+use syntax::ast::Span;
+use syntax::types::{Bound, Type, unqualified_name};
+
+use crate::checker::infer::InferCtx;
+use crate::facts::{GenericBoundObligation, GenericBoundOrigin};
+use crate::generics::{AppliedGenericBound, bound_requires_evidence, type_obligations};
+
+impl InferCtx<'_, '_> {
+    pub(crate) fn register_construction_obligations(
+        &mut self,
+        written_name: &str,
+        constructed_ty: &Type,
+        span: Span,
+    ) {
+        let origin = GenericBoundOrigin::Construction {
+            name: unqualified_name(written_name).into(),
+            enclosing_return_type: self.scopes.lookup_fn_return_type().cloned(),
+        };
+        for bound in type_obligations(self.store, constructed_ty) {
+            self.register_generic_bound_obligation(bound, &origin, span);
+        }
+    }
+
+    pub(crate) fn register_function_value_obligations(
+        &mut self,
+        written_name: &str,
+        function_ty: &Type,
+        span: Span,
+    ) {
+        let origin = GenericBoundOrigin::FunctionReference {
+            name: unqualified_name(written_name).into(),
+        };
+        for bound in function_ty.get_bounds() {
+            self.register_generic_bound_obligation(applied_function_bound(bound), &origin, span);
+        }
+    }
+
+    fn register_generic_bound_obligation(
+        &mut self,
+        bound: AppliedGenericBound,
+        origin: &GenericBoundOrigin,
+        span: Span,
+    ) {
+        if !bound_requires_evidence(self.store, &bound.required) {
+            return;
+        }
+        let module_id = self.cursor.module_id.clone();
+        let available_bounds = self.visible_parameter_bounds();
+        self.facts
+            .generic_bound_obligations
+            .push(GenericBoundObligation {
+                argument: bound.argument,
+                required: bound.required,
+                span,
+                module_id,
+                param_name: bound.parameter_name,
+                available_bounds,
+                origin: origin.clone(),
+            });
+    }
+}
+
+fn applied_function_bound(bound: &Bound) -> AppliedGenericBound {
+    AppliedGenericBound {
+        parameter_name: bound.param_name.clone(),
+        argument: bound.generic.clone(),
+        required: bound.ty.clone(),
+    }
+}

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod addressability;
 mod carry_mut;
 mod context;
 pub(crate) mod expressions;
+mod generic_obligations;
 pub(crate) mod interface;
 mod unify;
 mod validation;

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -11,6 +11,7 @@ use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{SubstitutionMap, Symbol, Type, substitute, unqualified_name};
 
 use crate::checker::TaskState;
+use crate::generics::apply_bounds;
 use crate::prelude::PRELUDE_MODULE_ID;
 use crate::store::Store;
 
@@ -706,28 +707,21 @@ impl TaskState<'_> {
             return;
         };
         let generics = definition.body.generics().unwrap_or_default();
-        let substitution: SubstitutionMap = generics
-            .iter()
-            .map(|generic| generic.name.clone())
-            .zip(arguments.iter().cloned())
-            .collect();
-        for (generic, argument) in generics.iter().zip(arguments) {
-            for declared in &generic.resolved_bounds {
-                match declared
-                    .get_qualified_id()
-                    .and_then(BuiltinBound::from_qualified_id)
-                {
-                    Some(builtin) => {
-                        self.check_builtin_bound_argument(store, argument, builtin, span)
-                    }
-                    None => self.check_interface_type_argument(
-                        store,
-                        argument,
-                        declared,
-                        &substitution,
-                        span,
-                    ),
+        for applied in apply_bounds(generics, arguments) {
+            match applied
+                .required
+                .get_qualified_id()
+                .and_then(BuiltinBound::from_qualified_id)
+            {
+                Some(builtin) => {
+                    self.check_builtin_bound_argument(store, &applied.argument, builtin, span)
                 }
+                None => self.check_interface_type_argument(
+                    store,
+                    &applied.argument,
+                    &applied.required,
+                    span,
+                ),
             }
         }
     }
@@ -736,15 +730,13 @@ impl TaskState<'_> {
         &mut self,
         store: &Store,
         argument: &Type,
-        declared: &Type,
-        substitution: &SubstitutionMap,
+        required: &Type,
         span: Span,
     ) {
-        let required = substitute(declared, substitution);
         if required.contains_error() {
             return;
         }
-        let resolved_required = store.deep_resolve_alias(&required);
+        let resolved_required = store.deep_resolve_alias(required);
         let Some(required_id) = resolved_required.get_qualified_id() else {
             return;
         };
@@ -760,7 +752,7 @@ impl TaskState<'_> {
             return;
         }
         self.pending_interface_bound_checks
-            .push((argument, required, span));
+            .push((argument, required.clone(), span));
     }
 
     pub(crate) fn check_builtin_bound_argument(

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -1,10 +1,10 @@
 use syntax::ast::{Generic, Span};
-use syntax::types::{CompoundKind, SubstitutionMap, Type, substitute, unqualified_name};
+use syntax::types::{CompoundKind, Type, unqualified_name};
 
 use crate::checker::EnvResolve;
 use crate::checker::TaskState;
-use crate::checker::infer::expressions::comparison::bound_implied;
 use crate::checker::infer::{BuiltinBound, InferCtx};
+use crate::generics::{apply_bounds, bound_implied};
 use crate::store::Store;
 
 impl TaskState<'_> {
@@ -90,85 +90,65 @@ impl TaskState<'_> {
             return;
         };
         let referenced_generics = definition.body.generics().unwrap_or_default();
-        let substitution: SubstitutionMap = referenced_generics
-            .iter()
-            .map(|generic| generic.name.clone())
-            .zip(argument_types.iter().cloned())
-            .collect();
-
-        for (referenced_generic, argument_type) in referenced_generics.iter().zip(argument_types) {
-            for declared in &referenced_generic.resolved_bounds {
-                if declared.get_qualified_id() == Some(referenced_id) {
-                    continue;
-                }
-                let required = substitute(declared, &substitution);
-                if required.contains_error() {
-                    continue;
-                }
-                let resolved_required = store.deep_resolve_alias(&required);
-                if let Some(required_id) = resolved_required.get_qualified_id()
-                    && store.get_interface(required_id).is_some()
-                    && !crate::checker::infer::interface::interface_requires_methods(
-                        store,
-                        required_id,
-                    )
-                {
-                    continue;
-                }
-                if defer_to_interface_list
-                    && resolved_required
-                        .get_qualified_id()
-                        .and_then(BuiltinBound::from_qualified_id)
-                        .is_some()
-                {
-                    continue;
-                }
-                let argument = store.deep_resolve_alias(&argument_type.resolve_in(&self.env));
-                if let Type::Parameter(parameter_name) = &argument {
-                    let Some(parameter_bounds) =
-                        self.parameter_bounds(parameter_name, own_generics)
-                    else {
-                        continue;
-                    };
-                    if !bound_implied(store, &parameter_bounds, &required) {
-                        let span = own_generics
-                            .iter()
-                            .find(|generic| generic.name == *parameter_name)
-                            .map_or(declaration_span, |generic| generic.span);
-                        self.sink.push(diagnostics::infer::missing_transitive_bound(
-                            parameter_name,
-                            &type_bound_display(&required),
-                            unqualified_name(referenced_id),
-                            span,
-                        ));
-                    }
-                } else if let Some(required) = store
-                    .deep_resolve_alias(&required)
+        for applied in apply_bounds(referenced_generics, argument_types) {
+            let required = applied.required;
+            if required.get_qualified_id() == Some(referenced_id) || required.contains_error() {
+                continue;
+            }
+            let resolved_required = store.deep_resolve_alias(&required);
+            if let Some(required_id) = resolved_required.get_qualified_id()
+                && store.get_interface(required_id).is_some()
+                && !crate::checker::infer::interface::interface_requires_methods(store, required_id)
+            {
+                continue;
+            }
+            if defer_to_interface_list
+                && resolved_required
                     .get_qualified_id()
                     .and_then(BuiltinBound::from_qualified_id)
-                {
-                    self.check_builtin_bound_argument(store, &argument, required, declaration_span);
-                } else if !argument.contains_error()
-                    && !argument.contains_unknown()
-                    && !argument.is_variable()
-                    && store
-                        .deep_resolve_alias(&required)
-                        .get_qualified_id()
-                        .is_some_and(|id| store.get_interface(id).is_some())
-                {
-                    if defer_to_interface_list {
-                        self.pending_interface_bound_checks.push((
-                            argument,
-                            required,
-                            declaration_span,
-                        ));
-                    } else {
-                        self.pending_generic_bound_checks.push((
-                            argument,
-                            required,
-                            declaration_span,
-                        ));
-                    }
+                    .is_some()
+            {
+                continue;
+            }
+            let argument = store.deep_resolve_alias(&applied.argument.resolve_in(&self.env));
+            if let Type::Parameter(parameter_name) = &argument {
+                let Some(parameter_bounds) = self.parameter_bounds(parameter_name, own_generics)
+                else {
+                    continue;
+                };
+                if !bound_implied(store, &parameter_bounds, &required) {
+                    let span = own_generics
+                        .iter()
+                        .find(|generic| generic.name == *parameter_name)
+                        .map_or(declaration_span, |generic| generic.span);
+                    self.sink.push(diagnostics::infer::missing_transitive_bound(
+                        parameter_name,
+                        &type_bound_display(&required),
+                        unqualified_name(referenced_id),
+                        span,
+                    ));
+                }
+            } else if let Some(required) = resolved_required
+                .get_qualified_id()
+                .and_then(BuiltinBound::from_qualified_id)
+            {
+                self.check_builtin_bound_argument(store, &argument, required, declaration_span);
+            } else if !argument.contains_error()
+                && !argument.contains_unknown()
+                && !argument.is_variable()
+                && resolved_required
+                    .get_qualified_id()
+                    .is_some_and(|id| store.get_interface(id).is_some())
+            {
+                if defer_to_interface_list {
+                    self.pending_interface_bound_checks.push((
+                        argument,
+                        required,
+                        declaration_span,
+                    ));
+                } else {
+                    self.pending_generic_bound_checks
+                        .push((argument, required, declaration_span));
                 }
             }
         }
@@ -182,7 +162,7 @@ impl TaskState<'_> {
         }
     }
 
-    pub fn check_pending_interface_bounds(&mut self, store: &Store) {
+    pub(crate) fn check_pending_interface_bounds(&mut self, store: &Store) {
         let pending = std::mem::take(&mut self.pending_interface_bound_checks);
         let mut seen = rustc_hash::FxHashSet::default();
         let mut ctx = InferCtx::new(self, store);

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -1,12 +1,9 @@
-use rustc_hash::FxHashMap as HashMap;
-
-use syntax::EcoString;
 use syntax::ast::Generic;
 use syntax::program::DefinitionBody;
-use syntax::types::{Bound, Symbol, Type, substitute, unqualified_name};
+use syntax::types::{Bound, Symbol, Type, unqualified_name};
 
 use super::TaskState;
-use crate::checker::infer::expressions::comparison::bound_implied;
+use crate::generics::{apply_bounds, bound_implied};
 use crate::store::Store;
 
 impl TaskState<'_> {
@@ -27,24 +24,20 @@ impl TaskState<'_> {
             ) => generics.clone(),
             _ => return Vec::new(),
         };
-        let alpha: HashMap<EcoString, Type> = type_generics
+        let arguments: Vec<Type> = impl_generics
             .iter()
-            .zip(impl_generics)
-            .map(|(type_generic, impl_generic)| {
-                (
-                    type_generic.name.clone(),
-                    Type::Parameter(impl_generic.name.clone()),
-                )
-            })
+            .map(|generic| Type::Parameter(generic.name.clone()))
             .collect();
+        let applied = apply_bounds(&type_generics, &arguments);
 
         let mut bounds_by_position = Vec::with_capacity(type_generics.len());
         for generic in &type_generics {
-            let resolved_bounds: Vec<Type> = generic
-                .resolved_bounds
+            let resolved_bounds: Vec<Type> = applied
                 .iter()
-                .filter(|bound| !bound.contains_error())
-                .map(|bound| substitute(bound, &alpha))
+                .filter(|bound| {
+                    bound.parameter_name == generic.name && !bound.required.contains_error()
+                })
+                .map(|bound| bound.required.clone())
                 .collect();
             bounds_by_position.push(resolved_bounds);
         }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -321,9 +321,13 @@ impl Scopes {
     }
 
     pub fn collect_all_trait_bounds(&self) -> HashMap<Symbol, Vec<Type>> {
-        let mut all_bounds = HashMap::default();
+        let mut all_bounds: HashMap<Symbol, Vec<Type>> = HashMap::default();
         // Walk from bottom to top so inner scopes override outer
         for scope in &self.stack {
+            if let Some(type_params) = &scope.type_params {
+                all_bounds
+                    .retain(|parameter, _| !type_params.contains_key(parameter.last_segment()));
+            }
             if let Some(ref bounds) = scope.trait_bounds {
                 for (key, value) in bounds {
                     all_bounds.insert(key.clone(), value.clone());

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use diagnostics::{PatternIssue, UnusedExpressionKind};
+use syntax::EcoString;
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
 use syntax::program::{ResolvedDefinitions, TestFunction};
 use syntax::types::Type;
@@ -50,9 +51,8 @@ pub struct Facts {
     pub equality_derivations: Vec<String>,
     pub test_functions: Vec<TestFunction>,
 
-    // Drained by passes::deferred via mem::take.
     pub generic_call_checks: Vec<GenericCallCheck>,
-    pub struct_bound_checks: Vec<StructBoundCheck>,
+    pub generic_bound_obligations: Vec<GenericBoundObligation>,
     pub empty_collection_checks: Vec<EmptyCollectionCheck>,
     pub empty_literal_checks: Vec<EmptyLiteralCheck>,
     pub slice_make_checks: Vec<SliceMakeCheck>,
@@ -97,14 +97,25 @@ pub struct GenericCallCheck {
 }
 
 #[derive(Debug, Clone)]
-pub struct StructBoundCheck {
-    pub ty: Type,
+pub struct GenericBoundObligation {
+    pub argument: Type,
+    pub required: Type,
     pub span: Span,
     pub module_id: String,
-    pub struct_name: String,
-    pub param_name: String,
-    pub bound: String,
-    pub is_function_reference: bool,
+    pub param_name: EcoString,
+    pub available_bounds: Vec<(EcoString, Vec<Type>)>,
+    pub origin: GenericBoundOrigin,
+}
+
+#[derive(Debug, Clone)]
+pub enum GenericBoundOrigin {
+    Construction {
+        name: EcoString,
+        enclosing_return_type: Option<Type>,
+    },
+    FunctionReference {
+        name: EcoString,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -163,7 +174,7 @@ impl Facts {
             always_failing_try_blocks: Vec::new(),
             expression_only_fstrings: Vec::new(),
             generic_call_checks: Vec::new(),
-            struct_bound_checks: Vec::new(),
+            generic_bound_obligations: Vec::new(),
             empty_collection_checks: Vec::new(),
             empty_literal_checks: Vec::new(),
             slice_make_checks: Vec::new(),
@@ -329,7 +340,7 @@ impl Facts {
             always_failing_try_blocks,
             expression_only_fstrings,
             generic_call_checks,
-            struct_bound_checks,
+            generic_bound_obligations,
             empty_collection_checks,
             empty_literal_checks,
             slice_make_checks,
@@ -367,7 +378,8 @@ impl Facts {
         self.expression_only_fstrings
             .extend(expression_only_fstrings);
         self.generic_call_checks.extend(generic_call_checks);
-        self.struct_bound_checks.extend(struct_bound_checks);
+        self.generic_bound_obligations
+            .extend(generic_bound_obligations);
         self.empty_collection_checks.extend(empty_collection_checks);
         self.empty_literal_checks.extend(empty_literal_checks);
         self.slice_make_checks.extend(slice_make_checks);

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -1,0 +1,161 @@
+use ecow::EcoString;
+use syntax::ast::Generic;
+use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
+
+use crate::checker::infer::BuiltinBound;
+use crate::checker::infer::InferCtx;
+use crate::checker::infer::expressions::comparison;
+use crate::checker::{EnvResolve, TaskState};
+use crate::facts::GenericBoundOrigin;
+use crate::store::Store;
+
+#[derive(Debug, Clone)]
+pub struct AppliedGenericBound {
+    pub parameter_name: EcoString,
+    pub argument: Type,
+    pub required: Type,
+}
+
+pub fn apply_bounds(generics: &[Generic], arguments: &[Type]) -> Vec<AppliedGenericBound> {
+    let substitution = build_substitution_map(generics, arguments);
+    generics
+        .iter()
+        .zip(arguments)
+        .flat_map(|(generic, argument)| {
+            let substitution = &substitution;
+            generic
+                .resolved_bounds
+                .iter()
+                .map(move |bound| AppliedGenericBound {
+                    parameter_name: generic.name.clone(),
+                    argument: argument.clone(),
+                    required: substitute(bound, substitution),
+                })
+        })
+        .collect()
+}
+
+/// Instantiate the bounds declared by a nominal type.
+pub fn type_obligations(store: &Store, ty: &Type) -> Vec<AppliedGenericBound> {
+    let resolved = store.deep_resolve_alias(ty);
+    let Type::Nominal { id, params, .. } = &resolved else {
+        return Vec::new();
+    };
+    let Some(generics) = store
+        .get_definition(id)
+        .and_then(|definition| definition.body.generics())
+    else {
+        return Vec::new();
+    };
+    apply_bounds(generics, params)
+}
+
+pub fn bound_implied(store: &Store, available: &[Type], required: &Type) -> bool {
+    comparison::bound_implied(store, available, required)
+}
+
+pub fn bound_requires_evidence(store: &Store, bound: &Type) -> bool {
+    let resolved = store.deep_resolve_alias(bound);
+    resolved.get_qualified_id().is_some_and(|id| {
+        BuiltinBound::from_qualified_id(id).is_some()
+            || crate::checker::infer::interface::interface_requires_methods(store, id)
+    })
+}
+
+pub fn bound_display_name(store: &Store, bound: &Type) -> EcoString {
+    let resolved = store.deep_resolve_alias(bound);
+    resolved.get_qualified_id().map_or_else(
+        || resolved.to_string().into(),
+        |id| unqualified_name(id).into(),
+    )
+}
+
+impl TaskState<'_> {
+    pub(crate) fn visible_parameter_bounds(&self) -> Vec<(EcoString, Vec<Type>)> {
+        self.scopes
+            .collect_all_trait_bounds()
+            .into_iter()
+            .map(|(parameter, bounds)| (parameter.last_segment().into(), bounds))
+            .collect()
+    }
+
+    pub fn check_post_inference_bounds(&mut self, store: &Store) {
+        self.check_pending_interface_bounds(store);
+        self.check_resolved_generic_obligations(store);
+    }
+
+    fn check_resolved_generic_obligations(&mut self, store: &Store) {
+        let obligations = std::mem::take(&mut self.facts.generic_bound_obligations);
+        let mut unresolved = Vec::new();
+        let mut seen = rustc_hash::FxHashSet::default();
+
+        for obligation in obligations {
+            let argument = store.deep_resolve_alias(&obligation.argument.resolve_in(&self.env));
+            let required = store.deep_resolve_alias(&obligation.required.resolve_in(&self.env));
+            let key = (obligation.span, argument.to_string(), required.to_string());
+            if !seen.insert(key)
+                || argument.contains_error()
+                || argument.contains_unknown()
+                || required.contains_error()
+            {
+                continue;
+            }
+            if argument.has_unbound_variables() {
+                unresolved.push(obligation);
+                continue;
+            }
+            if let GenericBoundOrigin::Construction {
+                enclosing_return_type: Some(return_type),
+                ..
+            } = &obligation.origin
+                && return_type_declares_obligation(store, return_type, &argument, &required)
+            {
+                continue;
+            }
+            if let Type::Parameter(parameter) = &argument {
+                let available = obligation
+                    .available_bounds
+                    .iter()
+                    .find(|(name, _)| name == parameter)
+                    .map_or(&[][..], |(_, bounds)| bounds.as_slice());
+                if !bound_implied(store, available, &required) {
+                    let required_name = bound_display_name(store, &required);
+                    self.sink.push(diagnostics::infer::missing_bound_on_param(
+                        parameter,
+                        &required_name,
+                        obligation.span,
+                    ));
+                }
+                continue;
+            }
+
+            if let Some(builtin) = required
+                .get_qualified_id()
+                .and_then(BuiltinBound::from_qualified_id)
+            {
+                self.check_builtin_bound_argument(store, &argument, builtin, obligation.span);
+            } else {
+                InferCtx::new(self, store).check_concrete_bound(
+                    &argument,
+                    &required,
+                    &obligation.span,
+                );
+            }
+        }
+
+        self.facts.generic_bound_obligations = unresolved;
+    }
+}
+
+fn return_type_declares_obligation(
+    store: &Store,
+    return_type: &Type,
+    argument: &Type,
+    required: &Type,
+) -> bool {
+    type_obligations(store, return_type)
+        .into_iter()
+        .any(|applied| {
+            applied.argument == *argument && bound_implied(store, &[applied.required], required)
+        })
+}

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -702,7 +702,7 @@ fn infer_modules(
         store.store_file(&module_id, typed_file);
     }
 
-    checker.check_pending_interface_bounds(store);
+    checker.check_post_inference_bounds(store);
 }
 
 /// Groups topologically ordered modules into dependency waves, so a wave only

--- a/crates/semantics/src/lib.rs
+++ b/crates/semantics/src/lib.rs
@@ -4,6 +4,7 @@ pub mod checker;
 pub mod context;
 pub mod diagnostics;
 pub mod facts;
+pub mod generics;
 pub mod inference;
 pub mod loader;
 pub mod module_graph;

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -138,7 +138,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
             store.store_file(&module_id, typed_file);
         }
 
-        checker.check_pending_interface_bounds(&store);
+        checker.check_post_inference_bounds(&store);
 
         let module = store.get_module(module_name).unwrap();
         let ast: Vec<_> = module

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -210,14 +210,13 @@ impl CompiledTest {
                 ctx.resolve_select_exhaustiveness();
             }
 
-            checker.check_pending_interface_bounds(&store);
-
             {
                 let folder = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store);
                 folder.freeze_facts(&mut checker.facts);
             }
             typed_ast = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store)
                 .freeze_items(typed_ast);
+            checker.check_post_inference_bounds(&store);
             checker.populate_item_generic_bounds(&mut typed_ast);
 
             if !checker.failed() {

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -1147,3 +1147,89 @@ fn main() {
     )
     .assert_no_errors();
 }
+
+#[test]
+fn inferred_record_struct_argument_must_satisfy_bound() {
+    infer(
+        r#"
+interface Display { fn show() -> string }
+struct Box<T: Display> { value: T }
+
+fn main() {
+  let boxed = Box { value: 42 }
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("interface_not_implemented");
+}
+
+#[test]
+fn inferred_tuple_struct_argument_must_satisfy_bound() {
+    infer(
+        r#"
+interface Display { fn show() -> string }
+struct Box<T: Display>(T)
+
+fn main() {
+  let boxed = Box(42)
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("interface_not_implemented");
+}
+
+#[test]
+fn inferred_enum_argument_must_satisfy_bound() {
+    infer(
+        r#"
+interface Display { fn show() -> string }
+enum Box<T: Display> { Full(T) }
+
+fn main() {
+  let boxed = Box.Full(42)
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("interface_not_implemented");
+}
+
+#[test]
+fn generic_return_propagates_declared_type_bound_without_methods() {
+    infer(
+        r#"
+struct Box<T: error> {}
+
+fn make<T>() -> Box<T> {
+  Box {}
+}
+
+fn main() {
+  let boxed = make<int>()
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("missing_constraint_on_return_type");
+}
+
+#[test]
+fn shadowed_parameter_does_not_inherit_constructor_bound() {
+    infer(
+        r#"
+interface Display { fn show() -> string }
+struct Owner<T: Display> { value: T }
+struct Box<T: Display> { value: T }
+
+impl<T: Display> Owner<T> {
+  fn replace<T>(value: T) {
+    let boxed = Box { value: value }
+    let _ = boxed
+  }
+}
+"#,
+    )
+    .assert_infer_code_once("missing_bound_on_param");
+}


### PR DESCRIPTION
Generic bounds had accumulated several separate checking paths for declarations, constructors, fn values, impls, interfaces, and returns. This PR replaces those checks with shared bound substitution and typed obligations evaluated post-inference.