### PR TITLE
feat: `lis check` for orphan modules

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use semantics::cache::cache_file_name;
-use semantics::loader::{FileContent, Files, Loader};
+use semantics::loader::{DiscoveredModules, FileContent, Files, Loader};
 use semantics::path::DisplayPathBase;
 use semantics::store::ENTRY_MODULE_ID;
 
@@ -308,8 +308,9 @@ pub fn collect_lis_filepaths_recursive(dir: &Path) -> Vec<PathBuf> {
 
 fn entry_is_dir(entry: &std::fs::DirEntry, path: &Path) -> bool {
     match entry.file_type() {
-        Ok(file_type) if !file_type.is_symlink() => file_type.is_dir(),
-        _ => path.is_dir(),
+        Ok(file_type) if file_type.is_symlink() => false,
+        Ok(file_type) => file_type.is_dir(),
+        Err(_) => path.is_dir(),
     }
 }
 
@@ -332,12 +333,13 @@ impl Loader for LocalFileSystem {
         HashMap::default()
     }
 
-    fn test_module_ids(&self) -> Vec<String> {
+    fn discover_modules(&self) -> DiscoveredModules {
         let Some((root, _)) = self.search_paths.first() else {
-            return Vec::new();
+            return DiscoveredModules::default();
         };
         let mut with_test: HashSet<PathBuf> = HashSet::default();
-        let mut with_production: HashSet<PathBuf> = HashSet::default();
+        let mut with_test_root_file: HashSet<PathBuf> = HashSet::default();
+        let mut with_production_module: HashSet<PathBuf> = HashSet::default();
         for path in collect_lis_filepaths_recursive(root) {
             let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
@@ -348,15 +350,26 @@ impl Loader for LocalFileSystem {
             if name.ends_with(".test.lis") {
                 with_test.insert(dir.to_path_buf());
             } else {
-                with_production.insert(dir.to_path_buf());
+                with_test_root_file.insert(dir.to_path_buf());
+                if !name.ends_with(".d.lis") {
+                    with_production_module.insert(dir.to_path_buf());
+                }
             }
         }
-        with_test
+        let dir_to_id = |dir: &Path| dir.strip_prefix(root).ok().map(module_id_from_rel);
+        let production_modules = with_production_module
             .iter()
-            .filter(|dir| with_production.contains(*dir))
-            .filter_map(|dir| dir.strip_prefix(root).ok())
-            .map(module_id_from_rel)
-            .collect()
+            .filter_map(|d| dir_to_id(d))
+            .collect();
+        let test_roots = with_test
+            .iter()
+            .filter(|dir| with_test_root_file.contains(*dir))
+            .filter_map(|d| dir_to_id(d))
+            .collect();
+        DiscoveredModules {
+            production_modules,
+            test_roots,
+        }
     }
 }
 
@@ -751,9 +764,10 @@ mod tests {
     }
 
     #[test]
-    fn test_module_ids_finds_nested_modules_with_tests() {
+    fn discover_modules_separates_production_and_test_roots() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
+
         let with_both = root.join("alpha").join("beta");
         stdfs::create_dir_all(&with_both).unwrap();
         write_file(&with_both, "beta.lis", "pub fn x() {}\n");
@@ -767,9 +781,27 @@ mod tests {
         stdfs::create_dir_all(&prod_only).unwrap();
         write_file(&prod_only, "delta.lis", "pub fn x() {}\n");
 
+        let decl_only = root.join("epsilon");
+        stdfs::create_dir_all(&decl_only).unwrap();
+        write_file(&decl_only, "epsilon.d.lis", "pub fn ext() -> int\n");
+
         let fs = LocalFileSystem::new(root.to_str().unwrap());
-        let mut ids = fs.test_module_ids();
-        ids.sort();
-        assert_eq!(ids, vec!["alpha/beta".to_string()]);
+        let discovered = fs.discover_modules();
+
+        let mut production = discovered.production_modules;
+        production.sort();
+        assert_eq!(
+            production,
+            vec!["alpha/beta".to_string(), "delta".to_string()],
+            "production modules are non-test, non-declaration dirs"
+        );
+
+        let mut test_roots = discovered.test_roots;
+        test_roots.sort();
+        assert_eq!(
+            test_roots,
+            vec!["alpha/beta".to_string()],
+            "a test root needs both a test file and a production file"
+        );
     }
 }

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -413,7 +413,9 @@ pub(super) fn build_locked(prep: &BuildPrep, options: BuildOptions) -> BuildOutc
     go_cli::write_emit_manifest(&prep.target_dir, &emit.new_manifest);
 
     if !quiet {
-        eprintln!();
+        if counts.errors + counts.warnings + counts.info == 0 {
+            eprintln!();
+        }
         if crate::output::use_color() {
             use owo_colors::OwoColorize;
             eprintln!(

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -145,9 +145,6 @@ fn check_single_file(
 ) -> i32 {
     let start = Instant::now();
     let unix = matches!(options.format, OutputFormat::Unix);
-    if !unix {
-        eprintln!();
-    }
     let Some((result, source, filename)) = compile_single_file(file_path, load_siblings, locator)
     else {
         return 1; // Read error already reported by compile_single_file
@@ -190,6 +187,9 @@ fn check_single_file(
         )
     };
     if !unix {
+        if counts.errors + counts.warnings + counts.info == 0 {
+            eprintln!();
+        }
         render::print_summary(
             counts.files,
             start.elapsed(),
@@ -275,9 +275,6 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
 
     let unix = matches!(options.format, OutputFormat::Unix);
     let start = Instant::now();
-    if !unix {
-        eprintln!();
-    }
 
     let mut fix_summary = FixSummary::default();
 
@@ -346,6 +343,9 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
 
     let all_errors = total_errors + read_failures;
     if !unix {
+        if total_errors + total_warnings + total_info == 0 {
+            eprintln!();
+        }
         render::print_summary(total_files, elapsed, all_errors, total_warnings, total_info);
     }
 

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -102,6 +102,7 @@ pub fn compile(
     });
     let semantic_result = analyze_output.result;
     let emit_stamps = analyze_output.emit_stamps;
+    let unreachable_modules = analyze_output.unreachable_modules;
 
     let user_file_count: usize = semantic_result
         .modules
@@ -125,9 +126,15 @@ pub fn compile(
 
     let failed = semantic_result.failed();
     let mut errors = semantic_result.errors.clone();
-    let lints = semantic_result.lints.clone();
+    let mut lints = semantic_result.lints.clone();
     let live_modules: Vec<String> = semantic_result.modules.keys().cloned().collect();
     let test_index = semantic_result.test_index.clone();
+
+    if !unreachable_modules.is_empty() && !config.emit_tests {
+        lints.push(diagnostics::module_graph::unreachable_modules(
+            &unreachable_modules,
+        ));
+    }
 
     if failed || config.target_phase == CompilePhase::Check {
         return CompileResult {

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -207,6 +207,22 @@ pub fn bindgen_failed(
     ))
 }
 
+pub fn unreachable_modules(module_ids: &[String]) -> LisetteDiagnostic {
+    let list = module_ids.join("` · `");
+    let (message, help) = if module_ids.len() == 1 {
+        (
+            format!("Unreachable module: `{list}`"),
+            "This module is never imported. Use or remove it.",
+        )
+    } else {
+        (
+            format!("Unreachable modules: `{list}`"),
+            "These modules are never imported. Use or remove them.",
+        )
+    };
+    LisetteDiagnostic::warn(message).with_help(help)
+}
+
 pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
     let modules: Vec<_> = path[..path.len() - 1].to_vec();
 
@@ -274,4 +290,28 @@ pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("Import cycle detected\n\n{}", art))
         .with_resolve_code("import_cycle")
         .with_help(help)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unreachable_modules_singular_is_a_spanless_warning() {
+        let diagnostic = unreachable_modules(&["orphan".to_string()]);
+        assert!(diagnostic.is_warning());
+        assert_eq!(diagnostic.plain_message(), "Unreachable module: `orphan`");
+        assert_eq!(diagnostic.file_id(), None);
+        assert_eq!(diagnostic.code_str(), None);
+    }
+
+    #[test]
+    fn unreachable_modules_plural_joins_ids() {
+        let diagnostic = unreachable_modules(&["alpha".to_string(), "beta".to_string()]);
+        assert!(diagnostic.is_warning());
+        assert_eq!(
+            diagnostic.plain_message(),
+            "Unreachable modules: `alpha` · `beta`"
+        );
+    }
 }

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -19,6 +19,7 @@ pub struct AnalyzeOutput {
     pub result: SemanticResult,
     pub facts: Facts,
     pub emit_stamps: Vec<EmitStamp>,
+    pub unreachable_modules: Vec<String>,
 }
 
 pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
@@ -35,6 +36,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         compiled_modules,
         cached_modules,
         cache_enabled,
+        unreachable_modules,
     } = run_inference(input);
 
     store.build_closed_domains();
@@ -167,5 +169,6 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         result,
         facts,
         emit_stamps,
+        unreachable_modules,
     }
 }

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -22,8 +22,8 @@ use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use crate::facts::{BindingIdAllocator, Facts};
-use crate::loader::Loader;
-use crate::module_graph::build_module_graph;
+use crate::loader::{DiscoveredModules, Loader};
+use crate::module_graph::{Roots, build_module_graph};
 use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use crate::store::{ENTRY_MODULE_ID, Store};
 
@@ -92,6 +92,7 @@ pub struct InferenceOutput {
     pub compiled_modules: Vec<CompiledModule>,
     pub cached_modules: HashSet<String>,
     pub cache_enabled: bool,
+    pub unreachable_modules: Vec<String>,
 }
 
 /// Loads, registers, and infers every module, returning the artifacts the
@@ -158,21 +159,46 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     }
 
     let entry_module = store.entry_module_id().to_string();
-    let discover_test_modules = input.project_root.is_some();
+    let discovered = if input.project_root.is_some() {
+        input.loader.discover_modules()
+    } else {
+        DiscoveredModules::default()
+    };
+    let additional = match input.compile_phase {
+        // Test roots too, so a declaration-plus-test module is still checked.
+        CompilePhase::Check => {
+            let mut roots = discovered.production_modules.clone();
+            roots.extend(discovered.test_roots.iter().cloned());
+            roots
+        }
+        CompilePhase::Emit if input.emit_tests => discovered.test_roots.clone(),
+        CompilePhase::Emit => Vec::new(),
+    };
+    let roots = Roots {
+        primary: vec![entry_module],
+        additional,
+    };
     let mut graph_result = build_module_graph(
         &mut store,
         Some(input.loader),
-        &entry_module,
+        roots,
         &sink,
         input.config.standalone_mode,
         &input.locator,
         include_tests,
-        discover_test_modules,
     );
 
     for cycle in &graph_result.cycles {
         sink.push(diagnostics::module_graph::import_cycle(cycle));
     }
+
+    let mut unreachable_modules: Vec<String> = discovered
+        .production_modules
+        .iter()
+        .filter(|m| !graph_result.primary_reachable.contains(m.as_str()))
+        .cloned()
+        .collect();
+    unreachable_modules.sort();
 
     let has_pre_check_errors = sink.has_errors();
 
@@ -386,6 +412,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         compiled_modules,
         cached_modules,
         cache_enabled,
+        unreachable_modules,
     }
 }
 

--- a/crates/semantics/src/loader.rs
+++ b/crates/semantics/src/loader.rs
@@ -21,16 +21,26 @@ impl FileContent {
 
 pub type Files = HashMap<String, FileContent>;
 
-fn is_production_lis(name: &str) -> bool {
+fn counts_for_test_root(name: &str) -> bool {
     name.ends_with(".lis") && !name.ends_with(".test.lis")
+}
+
+fn is_production_module_file(name: &str) -> bool {
+    name.ends_with(".lis") && !name.ends_with(".test.lis") && !name.ends_with(".d.lis")
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DiscoveredModules {
+    pub production_modules: Vec<String>,
+    pub test_roots: Vec<String>,
 }
 
 pub trait Loader: Sync {
     /// Scans a folder and returns all `.lis` files keyed by bare filename.
     fn scan_folder(&self, folder: &str) -> Files;
 
-    fn test_module_ids(&self) -> Vec<String> {
-        Vec::new()
+    fn discover_modules(&self) -> DiscoveredModules {
+        DiscoveredModules::default()
     }
 }
 
@@ -76,14 +86,25 @@ impl Loader for MemoryLoader {
         self.folders.get(folder).cloned().unwrap_or_default()
     }
 
-    fn test_module_ids(&self) -> Vec<String> {
-        self.folders
+    fn discover_modules(&self) -> DiscoveredModules {
+        let production_modules = self
+            .folders
+            .iter()
+            .filter(|(_, files)| files.keys().any(|name| is_production_module_file(name)))
+            .map(|(folder, _)| folder.clone())
+            .collect();
+        let test_roots = self
+            .folders
             .iter()
             .filter(|(_, files)| {
                 files.keys().any(|name| name.ends_with(".test.lis"))
-                    && files.keys().any(|name| is_production_lis(name))
+                    && files.keys().any(|name| counts_for_test_root(name))
             })
             .map(|(folder, _)| folder.clone())
-            .collect()
+            .collect();
+        DiscoveredModules {
+            production_modules,
+            test_roots,
+        }
     }
 }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -28,131 +28,138 @@ pub struct ModuleGraphResult {
     pub production_edges: HashMap<ModuleId, HashSet<ModuleId>>,
     /// `go:` modules that are only ever blank-imported in the visited file set.
     pub link_only_modules: HashSet<ModuleId>,
+    /// Reachable from the primary roots, snapshotted before `additional` runs.
+    pub primary_reachable: HashSet<ModuleId>,
+}
+
+/// `primary` defines the target. `additional` widens what is analyzed.
+#[derive(Debug, Default)]
+pub struct Roots {
+    pub primary: Vec<ModuleId>,
+    pub additional: Vec<ModuleId>,
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_module_graph(
     store: &mut Store,
     loader: Option<&dyn Loader>,
-    entry_module: &str,
+    mut roots: Roots,
     sink: &LocalSink,
     standalone_mode: bool,
     locator: &TypedefLocator,
     include_tests: bool,
-    discover_test_modules: bool,
 ) -> ModuleGraphResult {
     let mut edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
     let mut production_edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
-    let mut to_visit = vec![entry_module.to_string()];
+    let mut to_visit = roots.primary;
     let mut visited: HashSet<ModuleId> = HashSet::default();
     let mut files: HashMap<ModuleId, Vec<File>> = HashMap::default();
     let mut import_spans: HashMap<ModuleId, Span> = HashMap::default();
     let mut blank_tracker = BlankTracker::default();
 
-    let walk_loader = (include_tests && discover_test_modules)
-        .then_some(loader)
-        .flatten();
-    std::thread::scope(|scope| {
-        let mut walk = walk_loader.map(|walk_loader| scope.spawn(|| walk_loader.test_module_ids()));
-        loop {
-            while !to_visit.is_empty() {
-                let drained: Vec<ModuleId> = std::mem::take(&mut to_visit);
-                let mut batch: Vec<ModuleId> = Vec::with_capacity(drained.len());
-                for module_id in drained {
-                    if visited.insert(module_id.clone()) {
-                        batch.push(module_id);
-                    }
+    let mut primary_reachable: HashSet<ModuleId> = HashSet::default();
+    let mut additional_injected = false;
+    loop {
+        while !to_visit.is_empty() {
+            let drained: Vec<ModuleId> = std::mem::take(&mut to_visit);
+            let mut batch: Vec<ModuleId> = Vec::with_capacity(drained.len());
+            for module_id in drained {
+                if visited.insert(module_id.clone()) {
+                    batch.push(module_id);
                 }
-                if batch.is_empty() {
+            }
+            if batch.is_empty() {
+                continue;
+            }
+
+            batch.sort();
+
+            let mut parsed = batch_parse_modules(&batch, store, loader, sink, include_tests);
+
+            for module_id in &batch {
+                let module_files = parsed.remove(module_id).unwrap_or_default();
+                let file_imports: Vec<_> = if !module_files.is_empty() {
+                    module_files.iter().flat_map(|f| f.imports()).collect()
+                } else if let Some(module) = store.get_module(module_id) {
+                    module.all_imports()
+                } else {
+                    Vec::new()
+                };
+                let has_parsed_files = !module_files.is_empty();
+                let production_import_names: HashSet<String> = module_files
+                    .iter()
+                    .filter(|f| !f.is_test())
+                    .flat_map(|f| f.imports())
+                    .map(|import| import.name.to_string())
+                    .collect();
+                let imports_with_spans = process_file_imports(
+                    file_imports,
+                    sink,
+                    standalone_mode,
+                    locator,
+                    &mut blank_tracker,
+                );
+
+                let has_production_file = module_files.iter().any(|file| !file.is_test());
+                let module_exists =
+                    has_production_file || store.has(module_id) || module_id.starts_with("go:");
+
+                if !module_exists {
+                    if let Some(span) = import_spans.get(module_id) {
+                        let is_go_stdlib =
+                            stdlib::get_go_stdlib_typedef(module_id, locator.target()).is_some();
+
+                        let src_prefix_hint = module_id
+                            .strip_prefix("src/")
+                            .filter(|stripped| {
+                                loader.is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
+                            })
+                            .map(String::from);
+
+                        sink.push(diagnostics::module_graph::module_not_found(
+                            module_id,
+                            *span,
+                            is_go_stdlib,
+                            standalone_mode,
+                            src_prefix_hint,
+                        ));
+                    }
                     continue;
                 }
 
-                batch.sort();
+                files.insert(module_id.clone(), module_files);
 
-                let mut parsed = batch_parse_modules(&batch, store, loader, sink, include_tests);
+                let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
 
-                for module_id in &batch {
-                    let module_files = parsed.remove(module_id).unwrap_or_default();
-                    let file_imports: Vec<_> = if !module_files.is_empty() {
-                        module_files.iter().flat_map(|f| f.imports()).collect()
-                    } else if let Some(module) = store.get_module(module_id) {
-                        module.all_imports()
-                    } else {
-                        Vec::new()
-                    };
-                    let has_parsed_files = !module_files.is_empty();
-                    let production_import_names: HashSet<String> = module_files
-                        .iter()
-                        .filter(|f| !f.is_test())
-                        .flat_map(|f| f.imports())
-                        .map(|import| import.name.to_string())
-                        .collect();
-                    let imports_with_spans = process_file_imports(
-                        file_imports,
-                        sink,
-                        standalone_mode,
-                        locator,
-                        &mut blank_tracker,
-                    );
-
-                    let has_production_file = module_files.iter().any(|file| !file.is_test());
-                    let module_exists = has_production_file
-                        || store.has(module_id)
-                        || module_id == entry_module
-                        || module_id.starts_with("go:");
-
-                    if !module_exists {
-                        if let Some(span) = import_spans.get(module_id) {
-                            let is_go_stdlib =
-                                stdlib::get_go_stdlib_typedef(module_id, locator.target())
-                                    .is_some();
-
-                            let src_prefix_hint = module_id
-                                .strip_prefix("src/")
-                                .filter(|stripped| {
-                                    loader.is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
-                                })
-                                .map(String::from);
-
-                            sink.push(diagnostics::module_graph::module_not_found(
-                                module_id,
-                                *span,
-                                is_go_stdlib,
-                                standalone_mode,
-                                src_prefix_hint,
-                            ));
-                        }
-                        continue;
+                for (import, span) in imports_with_spans {
+                    if !visited.contains(&import) {
+                        to_visit.push(import.clone());
                     }
-
-                    files.insert(module_id.clone(), module_files);
-
-                    let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
-
-                    for (import, span) in imports_with_spans {
-                        if !visited.contains(&import) {
-                            to_visit.push(import.clone());
-                        }
-                        import_spans.entry(import).or_insert(span);
-                    }
-
-                    let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
-                        imports
-                            .iter()
-                            .filter(|import| production_import_names.contains(import.as_str()))
-                            .cloned()
-                            .collect()
-                    } else {
-                        imports.clone()
-                    };
-                    production_edges.insert(module_id.clone(), production_edge_set);
-                    edges.insert(module_id.clone(), imports);
+                    import_spans.entry(import).or_insert(span);
                 }
+
+                let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
+                    imports
+                        .iter()
+                        .filter(|import| production_import_names.contains(import.as_str()))
+                        .cloned()
+                        .collect()
+                } else {
+                    imports.clone()
+                };
+                production_edges.insert(module_id.clone(), production_edge_set);
+                edges.insert(module_id.clone(), imports);
             }
-            let Some(handle) = walk.take() else { break };
-            to_visit.extend(handle.join().unwrap());
         }
-    });
+
+        if !additional_injected {
+            primary_reachable = visited.clone();
+            to_visit.extend(std::mem::take(&mut roots.additional));
+            additional_injected = true;
+            continue;
+        }
+        break;
+    }
 
     let (order, cycles) = kahn::topological_sort(&edges);
 
@@ -163,6 +170,7 @@ pub fn build_module_graph(
         edges,
         production_edges,
         link_only_modules: blank_tracker.into_link_only_modules(),
+        primary_reachable,
     }
 }
 

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -1,6 +1,8 @@
 use diagnostics::{LisetteDiagnostic, LocalSink};
+use semantics::loader::Loader;
 use semantics::{
-    checker::TaskState, checker::infer::InferCtx, module_graph::build_module_graph, store::Store,
+    checker::TaskState, checker::infer::InferCtx, module_graph::Roots,
+    module_graph::build_module_graph, store::Store,
 };
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{ast::Expression, types::Type};
@@ -55,16 +57,12 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
     let sink = LocalSink::new();
 
     let locator = deps::TypedefLocator::default();
-    let mut graph_result = build_module_graph(
-        &mut store,
-        Some(&fs),
-        module_name,
-        &sink,
-        false,
-        &locator,
-        true,
-        true,
-    );
+    let roots = Roots {
+        primary: vec![module_name.to_string()],
+        additional: fs.discover_modules().test_roots,
+    };
+    let mut graph_result =
+        build_module_graph(&mut store, Some(&fs), roots, &sink, false, &locator, true);
 
     if sink.has_errors() {
         return InferResult {

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1090,3 +1090,181 @@ fn t_log_renders_logged_values_in_a_logs_section() {
         "the report should show the logged value in a Logs section:\n{combined}"
     );
 }
+
+fn scaffold_orphan_project(root: &Path, orphan_body: &str) -> PathBuf {
+    let project = root.join("proj");
+    fs::create_dir_all(project.join("src/lib")).unwrap();
+    fs::create_dir_all(project.join("src/orphan")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/orphanproj\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/lib/lib.lis"), "pub fn f() -> int { 1 }\n").unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"lib\"\n\nfn main() {\n  let _ = lib.f()\n}\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/orphan/orphan.lis"), orphan_body).unwrap();
+    project
+}
+
+fn contains_file_named(dir: &Path, name: &str) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if contains_file_named(&path, name) {
+                return true;
+            }
+        } else if path.file_name().and_then(|n| n.to_str()) == Some(name) {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn broken_orphan_module_fails_check() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scaffold_orphan_project(
+        scratch.path(),
+        "pub fn broken(x: int) -> int {\n  x + \"boom\"\n}\n",
+    );
+
+    let output = lis(&project, "check");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !output.status.success(),
+        "a type error in an unimported module must fail check:\n{combined}"
+    );
+    assert!(
+        combined.contains("Type mismatch") && combined.contains("infer.type_mismatch"),
+        "the orphan's real type error should surface:\n{combined}"
+    );
+}
+
+#[test]
+fn clean_orphan_module_warns_at_check_but_passes() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scaffold_orphan_project(scratch.path(), "pub fn helper() -> int { 1 }\n");
+
+    let output = lis(&project, "check");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "a clean unreachable module is a warning, not an error:\n{combined}"
+    );
+    assert!(
+        combined.contains("Unreachable module: `orphan`"),
+        "check should warn about the unreachable module:\n{combined}"
+    );
+}
+
+#[test]
+fn build_excludes_and_notes_orphan_module() {
+    if !go_available() {
+        eprintln!("skipping build_excludes_and_notes_orphan_module: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scaffold_orphan_project(scratch.path(), "pub fn helper() -> int { 1 }\n");
+
+    let output = lis(&project, "build");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "the binary is sound, so build succeeds:\n{combined}"
+    );
+    assert!(
+        combined.contains("Unreachable module: `orphan`"),
+        "build should warn about the unreachable module:\n{combined}"
+    );
+    assert!(
+        !contains_file_named(&project.join("target"), "orphan.go"),
+        "the orphan module must not be emitted into target/"
+    );
+}
+
+fn target_contains_text(dir: &Path, needle: &str) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if target_contains_text(&path, needle) {
+                return true;
+            }
+        } else if let Ok(content) = fs::read_to_string(&path)
+            && content.contains(needle)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn lis_test_does_not_emit_production_orphan_or_its_dependency() {
+    if !go_available() {
+        eprintln!(
+            "skipping lis_test_does_not_emit_production_orphan_or_its_dependency: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src/lib")).unwrap();
+    fs::create_dir_all(project.join("src/orphan")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"github.com/user/orphantest\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/lib/lib.lis"), "pub fn f() -> int { 1 }\n").unwrap();
+    fs::write(
+        project.join("src/lib/lib.test.lis"),
+        "#[test]\nfn f_returns_one() {\n  assert f() == 1\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        "import \"lib\"\n\nfn main() {\n  let _ = lib.f()\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/orphan/orphan.lis"),
+        "import \"go:archive/tar\"\n\npub fn make() -> tar.Header {\n  tar.Header {}\n}\n",
+    )
+    .unwrap();
+
+    let output = lis(&project, "test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(output.status.success(), "lis test should pass:\n{combined}");
+    assert!(
+        !contains_file_named(&project.join("target"), "orphan.go"),
+        "lis test must not emit the production orphan into target/"
+    );
+    assert!(
+        !target_contains_text(&project.join("target"), "archive/tar"),
+        "the orphan's unique Go dependency must not leak into emitted output:\n{combined}"
+    );
+}

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -1,14 +1,21 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LocalSink;
-use semantics::module_graph::build_module_graph;
 use semantics::module_graph::kahn::topological_sort;
+use semantics::module_graph::{Roots, build_module_graph};
 use semantics::store::Store;
 
 use crate::_harness::filesystem::MockFileSystem;
 
 fn default_resolver() -> deps::TypedefLocator {
     deps::TypedefLocator::default()
+}
+
+fn roots(entry: &str) -> Roots {
+    Roots {
+        primary: vec![entry.to_string()],
+        additional: vec![],
+    }
 }
 
 fn host_module_cache_dir(project_root: &std::path::Path, module: &str) -> std::path::PathBuf {
@@ -104,12 +111,11 @@ fn test_only_imports_excluded_from_production_edges() {
     let result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false,
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(
@@ -140,12 +146,11 @@ fn graph_simple_dependency() {
     let result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false,
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(result.cycles.is_empty());
@@ -171,12 +176,11 @@ fn graph_missing_module() {
     let _result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false,
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(sink.has_errors());
@@ -198,15 +202,206 @@ fn graph_cycle_detection() {
     let result = build_module_graph(
         &mut store,
         Some(&fs),
-        "a",
+        roots("a"),
         &sink,
         false,
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(!result.cycles.is_empty());
+}
+
+#[test]
+fn additional_roots_widen_graph_but_not_reachable_set() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "lib""#);
+    fs.add_file("lib", "lib.lis", "pub fn f() -> int { 1 }");
+    fs.add_file("orphan", "orphan.lis", "pub fn g() -> int { 2 }");
+
+    let mut store = Store::new();
+    for m in ["main", "lib", "orphan"] {
+        store.module_ids.push(m.to_string());
+    }
+
+    let sink = LocalSink::new();
+    let result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        Roots {
+            primary: vec!["main".to_string()],
+            additional: vec!["orphan".to_string()],
+        },
+        &sink,
+        false,
+        &default_resolver(),
+        true,
+    );
+
+    assert!(result.order.iter().any(|m| m == "orphan"));
+    assert!(result.edges.contains_key("orphan"));
+    assert!(result.files.contains_key("orphan"));
+    assert!(
+        !result.primary_reachable.contains("orphan"),
+        "orphan is outside the primary reachable set"
+    );
+    assert!(result.primary_reachable.contains("main"));
+    assert!(result.primary_reachable.contains("lib"));
+}
+
+#[test]
+fn empty_additional_leaves_orphan_out_of_graph() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "lib""#);
+    fs.add_file("lib", "lib.lis", "pub fn f() -> int { 1 }");
+    fs.add_file("orphan", "orphan.lis", "pub fn g() -> int { 2 }");
+
+    let mut store = Store::new();
+    for m in ["main", "lib", "orphan"] {
+        store.module_ids.push(m.to_string());
+    }
+
+    let sink = LocalSink::new();
+    let result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        roots("main"),
+        &sink,
+        false,
+        &default_resolver(),
+        true,
+    );
+
+    assert!(!result.order.iter().any(|m| m == "orphan"));
+}
+
+#[test]
+fn zero_primary_roots_begins_with_additional() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("lib", "lib.lis", "pub fn f() -> int { 1 }");
+
+    let mut store = Store::new();
+    store.module_ids.push("lib".to_string());
+
+    let sink = LocalSink::new();
+    let result = build_module_graph(
+        &mut store,
+        Some(&fs),
+        Roots {
+            primary: vec![],
+            additional: vec!["lib".to_string()],
+        },
+        &sink,
+        false,
+        &default_resolver(),
+        true,
+    );
+
+    assert!(result.primary_reachable.is_empty());
+    assert!(result.order.iter().any(|m| m == "lib"));
+}
+
+#[test]
+fn check_analyzes_orphan_and_surfaces_its_error() {
+    use passes::analyze;
+    use semantics::inference::{AnalyzeInput, CompilePhase, SemanticConfig};
+    use semantics::loader::MemoryLoader;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fs = MemoryLoader::new();
+    fs.add_file("lib", "lib.lis", "pub fn f() -> int { 1 }");
+    fs.add_file(
+        "orphan",
+        "orphan.lis",
+        "pub fn broken(x: int) -> int { x + \"boom\" }",
+    );
+
+    let source = "import \"lib\"\n\nfn main() {\n  let _ = lib.f()\n}\n";
+    let build = syntax::build_ast(source, 0);
+    let output = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: true,
+            standalone_mode: false,
+            load_siblings: false,
+        },
+        loader: &fs,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
+        ast: build.ast,
+        file_comment: build.file_comment,
+        project_root: Some(tmp.path().to_path_buf()),
+        compile_phase: CompilePhase::Check,
+        emit_tests: false,
+        locator: deps::TypedefLocator::default(),
+        go_module: String::new(),
+        disable_cache: true,
+    });
+
+    assert!(
+        output.unreachable_modules.iter().any(|m| m == "orphan"),
+        "orphan must be reported as unreachable, got: {:?}",
+        output.unreachable_modules
+    );
+    assert!(
+        output
+            .result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.type_mismatch")),
+        "check must analyze the orphan and surface its error: {:?}",
+        output.result.errors
+    );
+}
+
+#[test]
+fn check_analyzes_tests_in_declaration_only_module() {
+    use passes::analyze;
+    use semantics::inference::{AnalyzeInput, CompilePhase, SemanticConfig};
+    use semantics::loader::MemoryLoader;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fs = MemoryLoader::new();
+    fs.add_file("decl", "decl.d.lis", "pub fn ext() -> int\n");
+    fs.add_file(
+        "decl",
+        "decl.test.lis",
+        "#[test]\nfn broken() {\n  let _ = 1 + \"x\"\n}\n",
+    );
+
+    let source = "fn main() {}\n";
+    let build = syntax::build_ast(source, 0);
+    let output = analyze(AnalyzeInput {
+        config: SemanticConfig {
+            run_lints: true,
+            standalone_mode: false,
+            load_siblings: false,
+        },
+        loader: &fs,
+        source: source.to_string(),
+        filename: "main.lis".to_string(),
+        display_path: "main.lis".to_string(),
+        ast: build.ast,
+        file_comment: build.file_comment,
+        project_root: Some(tmp.path().to_path_buf()),
+        compile_phase: CompilePhase::Check,
+        emit_tests: false,
+        locator: deps::TypedefLocator::default(),
+        go_module: String::new(),
+        disable_cache: true,
+    });
+
+    assert!(
+        output
+            .result
+            .errors
+            .iter()
+            .any(|e| e.code_str() == Some("infer.type_mismatch")),
+        "a test in a declaration-plus-test module must be checked: {:?}",
+        output.result.errors
+    );
 }
 
 #[test]
@@ -221,12 +416,11 @@ fn graph_standalone_third_party_go_import_uses_module_not_found() {
     let _result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         true, // standalone mode
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(sink.has_errors());
@@ -245,12 +439,11 @@ fn graph_project_third_party_go_import_undeclared() {
     let _result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false, // project mode
         &default_resolver(),
         true,
-        false,
     );
 
     assert!(sink.has_errors());
@@ -282,12 +475,11 @@ fn graph_declared_dep_missing_typedef() {
     let _result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false,
         &resolver,
         true,
-        false,
     );
 
     assert!(sink.has_errors());
@@ -332,12 +524,11 @@ fn graph_subpackage_missing_typedef_points_at_add() {
     let _result = build_module_graph(
         &mut store,
         Some(&fs),
-        "main",
+        roots("main"),
         &sink,
         false,
         &resolver,
         true,
-        false,
     );
 
     assert!(sink.has_errors());


### PR DESCRIPTION
Expands `lis check` to analyze modules that no other module imports.

```
▲ Unreachable modules: orphan · orphan2
help: These modules are never imported. Use or remove them.
```

`lis build`, `lis emit`, and `lis run` surface the same warning while still leaving the module out of the binary.
