### PR TITLE
fix: enforce generic bounds on nested return types

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3290,7 +3290,7 @@ pub fn missing_constraint_on_generic_return_type(
             format!(
                 "Constrain the generic: `{}<{}: {}>()`",
                 fn_name, param_name, constraint
-            ) + ". The function returns a type whose methods depend on the constraint",
+            ) + ". The function returns a type that requires this constraint",
         )
 }
 

--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -7,7 +7,9 @@ use diagnostics::LocalSink;
 use syntax::ast::{Annotation, Expression, Generic, Span};
 use syntax::types::{Bound, Type};
 
-use semantics::generics::{bound_implied, bound_requires_evidence, type_obligations};
+use semantics::generics::{
+    bound_implied, bound_requires_evidence, nested_type_obligations, type_obligations,
+};
 use semantics::store::Store;
 
 #[derive(Clone, Copy)]
@@ -117,7 +119,7 @@ fn check_constrained_return_type(
 ) {
     let span = return_annotation.get_span();
     let mut seen = rustc_hash::FxHashSet::default();
-    for applied in type_obligations(store, return_ty) {
+    for applied in nested_type_obligations(store, return_ty) {
         let Type::Parameter(param_name) = &applied.argument else {
             continue;
         };

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -4,7 +4,7 @@ use syntax::types::{CompoundKind, Type, unqualified_name};
 use crate::checker::EnvResolve;
 use crate::checker::TaskState;
 use crate::checker::infer::{BuiltinBound, InferCtx};
-use crate::generics::{apply_bounds, bound_implied};
+use crate::generics::{apply_bounds, bound_implied, type_argument_children};
 use crate::store::Store;
 
 impl TaskState<'_> {
@@ -191,21 +191,6 @@ impl TaskState<'_> {
             .find(|generic| generic.name == parameter_name)?;
         (!generic.resolved_bounds.iter().any(Type::contains_error))
             .then(|| generic.resolved_bounds.clone())
-    }
-}
-
-fn type_argument_children(ty: &Type) -> Vec<&Type> {
-    match ty {
-        Type::Nominal { params, .. } => params.iter().collect(),
-        Type::Compound { args, .. } => args.iter().collect(),
-        Type::Array { element, .. } => vec![element],
-        Type::Tuple(elements) => elements.iter().collect(),
-        Type::Function(function) => function
-            .params
-            .iter()
-            .chain(std::iter::once(function.return_type.as_ref()))
-            .collect(),
-        _ => Vec::new(),
     }
 }
 

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -1,6 +1,6 @@
 use ecow::EcoString;
 use syntax::ast::Generic;
-use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
+use syntax::types::{Symbol, Type, build_substitution_map, substitute, unqualified_name};
 
 use crate::checker::infer::BuiltinBound;
 use crate::checker::infer::InferCtx;
@@ -37,8 +37,57 @@ pub fn apply_bounds(generics: &[Generic], arguments: &[Type]) -> Vec<AppliedGene
 
 /// Instantiate the bounds declared by a nominal type.
 pub fn type_obligations(store: &Store, ty: &Type) -> Vec<AppliedGenericBound> {
+    node_obligations(store, &store.deep_resolve_alias(ty))
+}
+
+pub fn nested_type_obligations(store: &Store, ty: &Type) -> Vec<AppliedGenericBound> {
+    let mut obligations = Vec::new();
+    collect_nested_obligations(
+        store,
+        ty,
+        &mut rustc_hash::FxHashSet::default(),
+        &mut obligations,
+    );
+    obligations
+}
+
+fn collect_nested_obligations(
+    store: &Store,
+    ty: &Type,
+    active_aliases: &mut rustc_hash::FxHashSet<Symbol>,
+    out: &mut Vec<AppliedGenericBound>,
+) {
+    let guarded_alias = alias_head(store, ty);
+    if let Some(id) = &guarded_alias
+        && !active_aliases.insert(id.clone())
+    {
+        for child in type_argument_children(ty) {
+            collect_nested_obligations(store, child, active_aliases, out);
+        }
+        return;
+    }
     let resolved = store.deep_resolve_alias(ty);
-    let Type::Nominal { id, params, .. } = &resolved else {
+    out.extend(node_obligations(store, &resolved));
+    for child in type_argument_children(&resolved) {
+        collect_nested_obligations(store, child, active_aliases, out);
+    }
+    if let Some(id) = &guarded_alias {
+        active_aliases.remove(id);
+    }
+}
+
+fn alias_head(store: &Store, ty: &Type) -> Option<Symbol> {
+    let Type::Nominal { id, .. } = ty else {
+        return None;
+    };
+    store
+        .get_definition(id.as_str())
+        .is_some_and(|definition| definition.is_type_alias())
+        .then(|| id.clone())
+}
+
+fn node_obligations(store: &Store, resolved: &Type) -> Vec<AppliedGenericBound> {
+    let Type::Nominal { id, params, .. } = resolved else {
         return Vec::new();
     };
     let Some(generics) = store
@@ -48,6 +97,21 @@ pub fn type_obligations(store: &Store, ty: &Type) -> Vec<AppliedGenericBound> {
         return Vec::new();
     };
     apply_bounds(generics, params)
+}
+
+pub(crate) fn type_argument_children(ty: &Type) -> Vec<&Type> {
+    match ty {
+        Type::Nominal { params, .. } => params.iter().collect(),
+        Type::Compound { args, .. } => args.iter().collect(),
+        Type::Array { element, .. } => vec![element],
+        Type::Tuple(elements) => elements.iter().collect(),
+        Type::Function(function) => function
+            .params
+            .iter()
+            .chain(std::iter::once(function.return_type.as_ref()))
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 pub fn bound_implied(store: &Store, available: &[Type], required: &Type) -> bool {
@@ -153,9 +217,67 @@ fn return_type_declares_obligation(
     argument: &Type,
     required: &Type,
 ) -> bool {
-    type_obligations(store, return_type)
+    nested_type_obligations(store, return_type)
         .into_iter()
         .any(|applied| {
             applied.argument == *argument && bound_implied(store, &[applied.required], required)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::ast::{Annotation, Span};
+    use syntax::program::{Definition, DefinitionBody, Visibility};
+
+    fn nominal(id: &str, params: Vec<Type>) -> Type {
+        Type::Nominal {
+            id: Symbol::from_raw(id),
+            params,
+            underlying_ty: None,
+        }
+    }
+
+    fn self_referential_alias() -> Definition {
+        Definition {
+            visibility: Visibility::Public,
+            ty: Type::Forall {
+                vars: vec!["T".into()],
+                body: Box::new(nominal(
+                    "Option",
+                    vec![nominal("m.A", vec![Type::Parameter("T".into())])],
+                )),
+            },
+            name: None,
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::TypeAlias {
+                generics: vec![Generic {
+                    name: "T".into(),
+                    bounds: vec![],
+                    resolved_bounds: vec![],
+                    span: Span::new(0, 0, 0),
+                }],
+                annotation: Annotation::Unknown,
+                methods: Default::default(),
+                attributes: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn nested_type_obligations_terminates_on_self_referential_alias() {
+        let mut store = Store::new();
+        store.add_module("m");
+        store
+            .get_module_mut("m")
+            .unwrap()
+            .definitions
+            .insert(Symbol::from_raw("m.A"), self_referential_alias());
+
+        let obligations =
+            nested_type_obligations(&store, &nominal("m.A", vec![Type::Parameter("E".into())]));
+
+        assert!(obligations.is_empty());
+    }
 }

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -1216,6 +1216,45 @@ fn main() {
 }
 
 #[test]
+fn generic_return_propagates_nested_declared_type_bound() {
+    infer(
+        r#"
+struct Box<T: error> {}
+
+fn make<T>() -> Option<Box<T>> {
+  None
+}
+
+fn main() {
+  let boxed = make<int>()
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("missing_constraint_on_return_type");
+}
+
+#[test]
+fn generic_return_propagates_bound_through_nested_alias_reuse() {
+    infer(
+        r#"
+struct Box<T: error> {}
+type Wrap<T> = Option<T>
+
+fn make<T>() -> Wrap<Wrap<Box<T>>> {
+  None
+}
+
+fn main() {
+  let boxed = make<int>()
+  let _ = boxed
+}
+"#,
+    )
+    .assert_infer_code_once("missing_constraint_on_return_type");
+}
+
+#[test]
 fn shadowed_parameter_does_not_inherit_constructor_bound() {
     infer(
         r#"

--- a/tests/ui/errors/snapshots/infer_missing_constraint_duplicate_bounds_deduped.snap
+++ b/tests/ui/errors/snapshots/infer_missing_constraint_duplicate_bounds_deduped.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                                     ╰── expected `T` to be constrained
  26 │   Box { val: item }
     ╰────
-  help: Constrain the generic: `create_box<T: Summable>()`. The function returns a type whose methods depend on the constraint · code: [infer.missing_constraint_on_return_type]
+  help: Constrain the generic: `create_box<T: Summable>()`. The function returns a type that requires this constraint · code: [infer.missing_constraint_on_return_type]

--- a/tests/ui/errors/snapshots/infer_missing_constraint_on_generic_return_type.snap
+++ b/tests/ui/errors/snapshots/infer_missing_constraint_on_generic_return_type.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                                 ╰── expected `T` to be constrained
  17 │   Wrapper { inner: item }
     ╰────
-  help: Constrain the generic: `wrap<T: Displayable>()`. The function returns a type whose methods depend on the constraint · code: [infer.missing_constraint_on_return_type]
+  help: Constrain the generic: `wrap<T: Displayable>()`. The function returns a type that requires this constraint · code: [infer.missing_constraint_on_return_type]


### PR DESCRIPTION
Rejects a function whose return type applies an unconstrained type param to a bounded generic nested inside a compound type, instead of accepting it and failing later at `go build`.

```rs
struct Foo<E: error> {}

fn make<E>() -> Option<Foo<E>> { None }
```

`Foo<E>` requires `E: error`, so this needs `fn make<E: error>()`. The direct `-> Foo<E>` form was already caught. ThisPR  extends the check through `Option<...>`, arrays, tuples, and type aliases, including when the body never constructs the inner type.
