### PR TITLE
fix: preserve tuple type aliases at use sites

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -589,7 +589,8 @@ impl InferCtx<'_, '_> {
     ) -> Option<(Expression, DotAccessKind)> {
         let index: usize = args.member_name.parse().ok()?;
 
-        let Type::Tuple(elements) = &args.deref_ty else {
+        let peeled = self.store.peel_alias(&args.deref_ty);
+        let Type::Tuple(elements) = &peeled else {
             return None;
         };
 

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -63,7 +63,8 @@ impl InferCtx<'_, '_> {
             }
 
             Pattern::Tuple { elements, span } => {
-                let element_types: Vec<Type> = match &expected_ty {
+                let peeled = self.store.peel_alias(&expected_ty.resolve_in(&self.env));
+                let element_types: Vec<Type> = match &peeled {
                     Type::Tuple(types) if types.len() == elements.len() => types.clone(),
                     Type::Tuple(types) => {
                         self.sink.push(diagnostics::infer::tuple_arity_mismatch(

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -137,17 +137,17 @@ impl InferCtx<'_, '_> {
             // Go-level aliases for scalar types: byte <-> uint8, rune <-> int32.
             (Type::Simple(k1), Type::Simple(k2)) if simple_kinds_are_go_aliases(*k1, *k2) => Ok(()),
 
-            // Alias follow-through: `type MyFoo = Foo` stores a Nominal
-            // alias with Foo as `underlying_ty`. When the other side is a
-            // Simple/Compound/Array, follow the alias to the underlying type.
+            // Alias follow-through: `type MyFoo = Foo` stores a Nominal with
+            // `Foo` as `underlying_ty`; when unifying against a structural
+            // body, peel to the underlying type.
             (
                 Nominal {
                     id,
                     underlying_ty: Some(underlying),
                     ..
                 },
-                other @ (Type::Simple(_) | Type::Compound { .. } | Type::Array { .. }),
-            ) => {
+                other,
+            ) if other.is_structural_alias_body() => {
                 if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
@@ -157,13 +157,13 @@ impl InferCtx<'_, '_> {
             }
 
             (
-                other @ (Type::Simple(_) | Type::Compound { .. } | Type::Array { .. }),
+                other,
                 Nominal {
                     id,
                     underlying_ty: Some(underlying),
                     ..
                 },
-            ) => {
+            ) if other.is_structural_alias_body() => {
                 if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -337,8 +337,7 @@ impl TaskState<'_> {
                 // id already matches (function aliases are pre-wrapped by populate_type_alias).
                 let body_differs = match &resolved_ty {
                     Type::Nominal { id, .. } => id.as_str() != qualified_name.as_str(),
-                    Type::Simple(_) | Type::Compound { .. } | Type::Array { .. } => true,
-                    _ => false,
+                    other => other.is_structural_alias_body(),
                 };
                 if body_differs
                     && let Some(Definition {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1191,6 +1191,15 @@ impl Type {
         matches!(self, Type::Var { .. })
     }
 
+    /// A transparent alias over this keeps its name, wrapped in a `Nominal`
+    /// that unification peels back to it.
+    pub fn is_structural_alias_body(&self) -> bool {
+        matches!(
+            self,
+            Type::Simple(_) | Type::Compound { .. } | Type::Array { .. } | Type::Tuple(_)
+        )
+    }
+
     pub fn is_numeric(&self) -> bool {
         self.as_simple().is_some_and(SimpleKind::is_arithmetic)
     }

--- a/tests/spec/emit/snapshots/direct_tuple_field_stays_expanded.snap
+++ b/tests/spec/emit/snapshots/direct_tuple_field_stays_expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/types.rs
+description: "\nstruct Holder { p: (int, int) }\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Holder struct {
+	p lisette.Tuple2[int, int]
+}

--- a/tests/spec/emit/snapshots/direct_tuple_field_stays_expanded.snap
+++ b/tests/spec/emit/snapshots/direct_tuple_field_stays_expanded.snap
@@ -1,6 +1,8 @@
 ---
 source: tests/spec/emit/types.rs
-description: "\nstruct Holder { p: (int, int) }\n"
+description: |
+  
+  struct Holder { p: (int, int) }
 ---
 package main
 

--- a/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
+++ b/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: "\ntype Pair = (int, int)\n\nstruct Holder { p: Pair }\n\nfn use_it(h: Holder, x: Pair) -> int { h.p.0 + x.1 }\n"
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Pair = lisette.Tuple2[int, int]
+
+type Holder struct {
+	p Pair
+}
+
+func use_it(h Holder, x Pair) int {
+	return h.p.First + x.Second
+}

--- a/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
+++ b/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
@@ -1,6 +1,12 @@
 ---
 source: tests/spec/emit/types.rs
-description: "\ntype Pair = (int, int)\n\nstruct Holder { p: Pair }\n\nfn use_it(h: Holder, x: Pair) -> int { h.p.0 + x.1 }\n"
+description: |
+  
+  type Pair = (int, int)
+  
+  struct Holder { p: Pair }
+  
+  fn use_it(h: Holder, x: Pair) -> int { h.p.0 + x.1 }
 ---
 package main
 

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1307,6 +1307,26 @@ fn get_val(o: Outer) -> int {
 }
 
 #[test]
+fn tuple_type_alias_preserved_at_use_sites() {
+    let input = r#"
+type Pair = (int, int)
+
+struct Holder { p: Pair }
+
+fn use_it(h: Holder, x: Pair) -> int { h.p.0 + x.1 }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn direct_tuple_field_stays_expanded() {
+    let input = r#"
+struct Holder { p: (int, int) }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn type_alias_chained() {
     let input = r#"
 struct Point { pub x: int, pub y: int }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -6086,6 +6086,38 @@ fn main() {
 }
 
 #[test]
+fn tuple_alias_destructure() {
+    infer(
+        r#"
+type Pair = (int, string)
+
+fn main() {
+  let p: Pair = (1, "x")
+  let (a, b) = p
+  let _: int = a
+  let _: string = b
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn tuple_alias_destructure_arity_mismatch() {
+    infer(
+        r#"
+type Pair = (int, int)
+
+fn main() {
+  let p: Pair = (1, 2)
+  let (a, b, c) = p
+}
+"#,
+    )
+    .assert_infer_code("tuple_element_count_mismatch");
+}
+
+#[test]
 fn cast_through_generic_alias_to_underlying_generic() {
     infer(
         r#"


### PR DESCRIPTION
Currently a tuple type alias is expanded to `lisette.TupleN` at its use sites instead of being kept by name, leaving its own declaration unreferenced. Other aliases (Slice, Map, Ref, Array) are already preserved.

```rust
type Pair = (int, int)
struct Holder { p: Pair }
```

Before / after: (generated Go code)

```go
type Pair = lisette.Tuple2[int, int]

type Holder struct {
	p lisette.Tuple2[int, int]   // before
	p Pair                       // after
}
```

Also added a small refactor that centralizes the set behind a common function.