### PR TITLE
fix: shadowed variable in `else` leaking past diverging `if`

### DIFF
--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1022,7 +1022,9 @@ impl Planner<'_> {
                 }))
             }
         } else if preceding_diverges {
+            self.scope.push_binding_frame();
             let body = self.lower_block_to_place(alternative, place);
+            self.scope.pop_binding_frame();
             ElseArm::Else { body, inline: true }
         } else {
             self.enter_scope();

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -3460,6 +3460,23 @@ fn test() {
 }
 
 #[test]
+fn diverging_if_shadowed_else_binding_does_not_leak() {
+    let input = r#"
+fn test(c: bool) -> int {
+  let count = 10
+  if c {
+    return 0
+  } else {
+    let count = 5
+    let _ = count
+  }
+  count
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_loop_map_alias_tuple_destructuring() {
     let input = r#"
 type Table = Map<string, int>

--- a/tests/spec/emit/snapshots/diverging_if_shadowed_else_binding_does_not_leak.snap
+++ b/tests/spec/emit/snapshots/diverging_if_shadowed_else_binding_does_not_leak.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(c: bool) -> int {
+    let count = 10
+    if c {
+      return 0
+    } else {
+      let count = 5
+      let _ = count
+    }
+    count
+  }
+---
+package main
+
+func test(c bool) int {
+	count := 10
+	if c {
+		return 0
+	}
+	count_1 := 5
+	_ = count_1
+	return count
+}


### PR DESCRIPTION
Fixes a miscompilation where a variable shadowed inside the `else` of an `if... else` leaked its rnamed value past the block, when the `if` branch always diverges (returns, panics, etc.)

```rs
pub fn check(c: bool) -> int {
  let count = 10
  if c {
    return 0
  } else {
    let count = 5
    fmt.Println("inner:", count)
  }
  count
}
```

`check(false)` previously returned `5` instead of the correct `10`, because the outer `count` binding was not restored after the `else` block.