### PR TITLE
fix: false positives in lints

### DIFF
--- a/crates/passes/src/passes/fact_producers/generics.rs
+++ b/crates/passes/src/passes/fact_producers/generics.rs
@@ -27,10 +27,27 @@ fn visit_expression(expression: &Expression, local: &mut LocalFacts) {
             generics,
             params,
             return_type,
+            body,
             ..
         } => {
-            check_unused_type_parameters(generics, params, return_type, local);
-            check_type_params_only_in_bound(generics, params, return_type, local);
+            if !generics.is_empty() {
+                let mut still_missing: HashSet<EcoString> =
+                    generics.iter().map(|g| g.name.clone()).collect();
+                body_remove_found_type_names(body, &mut still_missing);
+                let found_in_body: HashSet<EcoString> = generics
+                    .iter()
+                    .map(|g| g.name.clone())
+                    .filter(|name| !still_missing.contains(name))
+                    .collect();
+                check_unused_type_parameters(generics, params, return_type, &found_in_body, local);
+                check_type_params_only_in_bound(
+                    generics,
+                    params,
+                    return_type,
+                    &found_in_body,
+                    local,
+                );
+            }
         }
         _ => {}
     }
@@ -44,12 +61,9 @@ fn check_unused_type_parameters(
     generics: &[Generic],
     params: &[Binding],
     return_type: &Type,
+    found_in_body: &HashSet<EcoString>,
     local: &mut LocalFacts,
 ) {
-    if generics.is_empty() {
-        return;
-    }
-
     let mut remaining: HashSet<EcoString> = generics.iter().map(|g| g.name.clone()).collect();
     for param in params {
         param.ty.remove_found_type_names(&mut remaining);
@@ -60,6 +74,7 @@ fn check_unused_type_parameters(
             annotation_remove_names(bound, &mut remaining);
         }
     }
+    remaining.retain(|name| !found_in_body.contains(name));
 
     for generic in generics {
         if generic.name.starts_with('_') {
@@ -76,16 +91,15 @@ fn check_type_params_only_in_bound(
     generics: &[Generic],
     params: &[Binding],
     return_type: &Type,
+    found_in_body: &HashSet<EcoString>,
     local: &mut LocalFacts,
 ) {
-    if generics.is_empty() {
-        return;
-    }
     if generics.iter().all(|g| g.bounds.is_empty()) {
         return;
     }
 
-    let only_in_bound = collect_type_params_only_in_bound(generics, params, return_type);
+    let only_in_bound =
+        collect_type_params_only_in_bound(generics, params, return_type, found_in_body);
     if only_in_bound.is_empty() {
         return;
     }
@@ -102,6 +116,7 @@ fn collect_type_params_only_in_bound(
     generics: &[Generic],
     params: &[Binding],
     return_type: &Type,
+    found_in_body: &HashSet<EcoString>,
 ) -> HashSet<EcoString> {
     let mut unseen_outside_bound_rhs: HashSet<EcoString> =
         generics.iter().map(|g| g.name.clone()).collect();
@@ -111,6 +126,7 @@ fn collect_type_params_only_in_bound(
             .remove_found_type_names(&mut unseen_outside_bound_rhs);
     }
     return_type.remove_found_type_names(&mut unseen_outside_bound_rhs);
+    unseen_outside_bound_rhs.retain(|name| !found_in_body.contains(name));
 
     let mut unseen_anywhere = unseen_outside_bound_rhs.clone();
     for generic in generics {
@@ -123,6 +139,29 @@ fn collect_type_params_only_in_bound(
         .into_iter()
         .filter(|name| !unseen_anywhere.contains(name))
         .collect()
+}
+
+/// Stops at nested function/lambda boundaries, which may shadow the name.
+fn body_remove_found_type_names(expression: &Expression, names: &mut HashSet<EcoString>) {
+    if names.is_empty() {
+        return;
+    }
+    match expression {
+        Expression::Function { .. } | Expression::Lambda { .. } => return,
+        Expression::Let { binding, .. } => binding.ty.remove_found_type_names(names),
+        Expression::Call {
+            resolved_type_args, ..
+        } => {
+            for ty in resolved_type_args {
+                ty.remove_found_type_names(names);
+            }
+        }
+        Expression::Cast { ty, .. } => ty.remove_found_type_names(names),
+        _ => {}
+    }
+    for child in expression.children() {
+        body_remove_found_type_names(child, names);
+    }
 }
 
 fn annotation_remove_names(annotation: &Annotation, names: &mut HashSet<EcoString>) {

--- a/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
@@ -119,12 +119,57 @@ fn first_use(expression: &Expression, binding_id: BindingId) -> Option<FirstUse>
     if is_binding(expression, binding_id) {
         return Some(FirstUse::Other);
     }
+    if let Some((unconditional, branches)) = branch_parts(expression) {
+        for part in unconditional {
+            if let Some(found) = first_use(part, binding_id) {
+                return Some(found);
+            }
+        }
+        return first_use_across_branches(&branches, binding_id);
+    }
     for child in expression.children() {
         if let Some(found) = first_use(child, binding_id) {
             return Some(found);
         }
     }
     None
+}
+
+/// The condition/scrutinee and the mutually exclusive branch bodies, if any.
+fn branch_parts(expression: &Expression) -> Option<(Vec<&Expression>, Vec<&Expression>)> {
+    match expression {
+        Expression::If {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => Some((vec![condition], vec![consequence, alternative])),
+        Expression::IfLet {
+            scrutinee,
+            consequence,
+            alternative,
+            ..
+        } => Some((vec![scrutinee], vec![consequence, alternative])),
+        Expression::Match { subject, arms, .. } => Some((
+            vec![subject.as_ref()],
+            arms.iter().map(|arm| arm.expression.as_ref()).collect(),
+        )),
+        _ => None,
+    }
+}
+
+fn first_use_across_branches(branches: &[&Expression], binding_id: BindingId) -> Option<FirstUse> {
+    let mut append_span = None;
+    for branch in branches {
+        match first_use(branch, binding_id) {
+            Some(FirstUse::Other) => return Some(FirstUse::Other),
+            Some(FirstUse::AppendReceiver(span)) => {
+                append_span.get_or_insert(span);
+            }
+            None => {}
+        }
+    }
+    append_span.map(FirstUse::AppendReceiver)
 }
 
 /// The receiver of a `receiver.append(...)` or `Slice.append(receiver, ...)`

--- a/crates/passes/src/passes/lints/ast_walk/checks/identical_if_branches.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/identical_if_branches.rs
@@ -1,10 +1,11 @@
 use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
-use super::helpers::{expressions_equivalent, is_empty_block};
+use super::helpers::{expressions_equivalent, is_empty_block, is_side_effect_free};
 
 pub fn check_identical_if_branches(expression: &Expression, ctx: &NodeCtx) {
     let Expression::If {
+        condition,
         consequence,
         alternative,
         span,
@@ -26,6 +27,11 @@ pub fn check_identical_if_branches(expression: &Expression, ctx: &NodeCtx) {
     // Empty blocks are usually in-progress stubs; do not add noise on top of
     // other lints that already cover that case.
     if is_empty_block(consequence) || is_empty_block(alternative) {
+        return;
+    }
+
+    // Removing the `if` also drops the condition, so it must be safe to drop.
+    if !is_side_effect_free(condition) {
         return;
     }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/invisible_in_string.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/invisible_in_string.rs
@@ -37,8 +37,30 @@ pub fn check_invisible_in_string_pattern(pattern: &Pattern, ctx: &NodeCtx) {
 }
 
 fn first_invisible(text: &str) -> Option<(u32, &'static str, bool)> {
-    text.chars()
-        .find_map(|c| classify_invisible(c).map(|(name, is_bidi)| (c as u32, name, is_bidi)))
+    let mut prev: Option<char> = None;
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{200D}' {
+            let next = chars.peek().copied();
+            if prev.is_some_and(is_emoji) && next.is_some_and(is_emoji) {
+                prev = Some(c);
+                continue;
+            }
+        }
+        if let Some((name, is_bidi)) = classify_invisible(c) {
+            return Some((c as u32, name, is_bidi));
+        }
+        prev = Some(c);
+    }
+    None
+}
+
+fn is_emoji(c: char) -> bool {
+    matches!(c as u32,
+        0x1F300..=0x1FAFF
+            | 0x2600..=0x27BF
+            | 0x1F1E6..=0x1F1FF
+            | 0xFE0F)
 }
 
 fn classify_invisible(c: char) -> Option<(&'static str, bool)> {

--- a/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
@@ -34,11 +34,13 @@ pub fn check_misrefactored_assign_op(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    // The mirror form `a op= b op a` only collapses to `a op= b` for a commutative
-    // `op`; a non-commutative one (`a -= b - a`) would get a wrong rewrite.
+    // `a op= a op b` only collapses to `a op= b` when `op` is idempotent.
+    if !is_idempotent(*compound) {
+        return;
+    }
     let other = if expressions_equivalent(target, rhs_left) {
         rhs_right
-    } else if is_commutative(*compound) && expressions_equivalent(target, rhs_right) {
+    } else if expressions_equivalent(target, rhs_right) {
         rhs_left
     } else {
         return;
@@ -61,10 +63,9 @@ pub fn check_misrefactored_assign_op(expression: &Expression, ctx: &NodeCtx) {
     ));
 }
 
-fn is_commutative(operator: BinaryOperator) -> bool {
-    use BinaryOperator::*;
+fn is_idempotent(operator: BinaryOperator) -> bool {
     matches!(
         operator,
-        Addition | Multiplication | BitwiseAnd | BitwiseOr | BitwiseXor
+        BinaryOperator::BitwiseAnd | BinaryOperator::BitwiseOr
     )
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
@@ -10,30 +10,31 @@ pub fn check_waitgroup_add_in_task(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let mut waited: FxHashSet<BindingId> = FxHashSet::default();
+    let mut covered: FxHashSet<BindingId> = FxHashSet::default();
     let mut adds: Vec<(BindingId, Span)> = Vec::new();
-    collect(body, false, &mut waited, &mut adds);
+    collect(body, false, &mut waited, &mut covered, &mut adds);
 
     for (binding, span) in adds {
-        if waited.contains(&binding) {
+        if waited.contains(&binding) && !covered.contains(&binding) {
             ctx.sink
                 .push(diagnostics::lint::waitgroup_add_in_task(&span));
         }
     }
 }
 
-/// Gather every `WaitGroup` `Wait` reached outside a `task`, and every positive
-/// `Add` reached inside one. Nested functions and lambdas are their own roots,
-/// so descent stops at their boundary.
+/// A positive `Add` outside a `task` happens-before any task it spawns, so it
+/// covers `Add`s inside them. Nested functions/lambdas are their own roots.
 fn collect(
     expression: &Expression,
     in_task: bool,
     waited: &mut FxHashSet<BindingId>,
+    covered: &mut FxHashSet<BindingId>,
     adds: &mut Vec<(BindingId, Span)>,
 ) {
     match expression {
         Expression::Function { .. } | Expression::Lambda { .. } => return,
         Expression::Task { expression, .. } => {
-            collect(expression, true, waited, adds);
+            collect(expression, true, waited, covered, adds);
             return;
         }
         Expression::Call {
@@ -47,12 +48,16 @@ fn collect(
                     "Wait" if !in_task => {
                         waited.insert(binding);
                     }
-                    "Add" if in_task => {
-                        if args
+                    "Add" => {
+                        let positive = args
                             .first()
-                            .is_some_and(|delta| !is_nonpositive_literal(delta))
-                        {
-                            adds.push((binding, *span));
+                            .is_some_and(|delta| !is_nonpositive_literal(delta));
+                        if positive {
+                            if in_task {
+                                adds.push((binding, *span));
+                            } else {
+                                covered.insert(binding);
+                            }
                         }
                     }
                     _ => {}
@@ -63,7 +68,7 @@ fn collect(
     }
 
     for child in expression.children() {
-        collect(child, in_task, waited, adds);
+        collect(child, in_task, waited, covered, adds);
     }
 }
 

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -14,7 +14,7 @@ use diagnostics::{Edit, Fix};
 use semantics::context::AnalysisContext;
 use semantics::facts::Facts;
 use semantics::store::Store;
-use syntax::ast::{AttributeArg, Expression, ImportAlias, Span, Visibility};
+use syntax::ast::{Attribute, AttributeArg, Expression, ImportAlias, Span, Visibility};
 use syntax::program::EqualityIndex;
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
@@ -295,12 +295,15 @@ fn collect_items(
                     name,
                     name_span,
                     variants,
+                    attributes,
                     visibility,
                     ..
                 } => {
                     let id = ModuleItemId::new(name);
                     let is_public = *visibility == Visibility::Public;
                     graph.add_item(id, *name_span, ItemKind::Type, is_public);
+
+                    let has_serialization_attr = has_serialization_attr(attributes);
 
                     for enum_variant in variants {
                         let variant_id = EnumVariantId::new(name, &enum_variant.name);
@@ -309,6 +312,7 @@ fn collect_items(
                             EnumVariantInfo {
                                 span: enum_variant.name_span,
                                 parent_is_public: is_public,
+                                parent_has_serialization_attr: has_serialization_attr,
                             },
                         );
                     }
@@ -325,24 +329,7 @@ fn collect_items(
                     let is_public = *visibility == Visibility::Public;
                     graph.add_item(id, *name_span, ItemKind::Type, is_public);
 
-                    let has_serialization_attr = attributes.iter().any(|a| {
-                        if SERIALIZATION_KEYS.contains(&a.name.as_str()) {
-                            return true;
-                        }
-                        if a.name == "tag" {
-                            return match a.args.first() {
-                                Some(AttributeArg::String(key)) => {
-                                    SERIALIZATION_KEYS.contains(&key.as_str())
-                                }
-                                Some(AttributeArg::Raw(raw)) => raw
-                                    .split(':')
-                                    .next()
-                                    .is_some_and(|k| SERIALIZATION_KEYS.contains(&k)),
-                                _ => false,
-                            };
-                        }
-                        false
-                    });
+                    let has_serialization_attr = has_serialization_attr(attributes);
 
                     let has_display_attr = attributes.iter().any(|a| a.name == "display");
                     let qualified_name = format!("{module_id}.{name}");
@@ -420,6 +407,25 @@ fn collect_items(
             }
         }
     }
+}
+
+fn has_serialization_attr(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|a| {
+        if SERIALIZATION_KEYS.contains(&a.name.as_str()) {
+            return true;
+        }
+        if a.name == "tag" {
+            return match a.args.first() {
+                Some(AttributeArg::String(key)) => SERIALIZATION_KEYS.contains(&key.as_str()),
+                Some(AttributeArg::Raw(raw)) => raw
+                    .split(':')
+                    .next()
+                    .is_some_and(|k| SERIALIZATION_KEYS.contains(&k)),
+                _ => false,
+            };
+        }
+        false
+    })
 }
 
 fn create_unused_diagnostic(

--- a/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
@@ -75,6 +75,7 @@ impl EnumVariantId {
 pub struct EnumVariantInfo {
     pub span: Span,
     pub parent_is_public: bool,
+    pub parent_has_serialization_attr: bool,
 }
 
 #[derive(Debug, Default)]
@@ -219,7 +220,11 @@ impl ReferenceGraph {
     pub fn get_unused_enum_variants(&self) -> Vec<(&EnumVariantId, &EnumVariantInfo)> {
         self.enum_variants
             .iter()
-            .filter(|(id, info)| !info.parent_is_public && !self.used_enum_variants.contains(*id))
+            .filter(|(id, info)| {
+                !info.parent_is_public
+                    && !info.parent_has_serialization_attr
+                    && !self.used_enum_variants.contains(*id)
+            })
             .collect()
     }
 }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -160,6 +160,48 @@ fn main() {
 }
 
 #[test]
+fn append_to_zero_filled_silent_when_other_branch_reads_zero_fill() {
+    assert_no_lint_warnings!(
+        r#"
+fn run(flag: bool) {
+  let mut ids = Slice.make<int>(5)
+  if flag {
+    ids = ids.append(7)
+  } else {
+    let _ = ids[0]
+  }
+  let _ = ids
+}
+
+fn main() {
+  run(true)
+}
+"#
+    );
+}
+
+#[test]
+fn append_to_zero_filled_fires_when_both_branches_append() {
+    assert_lint_snapshot!(
+        r#"
+fn run(flag: bool) {
+  let mut ids = Slice.make<int>(5)
+  if flag {
+    ids = ids.append(1)
+  } else {
+    ids = ids.append(2)
+  }
+  let _ = ids
+}
+
+fn main() {
+  run(true)
+}
+"#
+    );
+}
+
+#[test]
 fn reserve_discarded_output_warns() {
     assert_lint_snapshot!(
         r#"
@@ -871,8 +913,59 @@ fn main() {
 }
 
 #[test]
-fn misrefactored_assign_op_addition() {
+fn misrefactored_assign_op_bitand() {
     assert_lint_snapshot!(
+        r#"
+fn scale(b: int) {
+  let mut a = 2
+  a &= a & b
+  let _ = a
+}
+
+fn main() {
+  scale(2)
+}
+"#
+    );
+}
+
+#[test]
+fn misrefactored_assign_op_bitor_target_on_right() {
+    assert_lint_snapshot!(
+        r#"
+fn combine(b: int) {
+  let mut a = 1
+  a |= b | a
+  let _ = a
+}
+
+fn main() {
+  combine(2)
+}
+"#
+    );
+}
+
+#[test]
+fn misrefactored_assign_op_field() {
+    assert_lint_snapshot!(
+        r#"
+struct Counter { count: int }
+
+fn main() {
+  let mut c = Counter { count: 0 }
+  c.count &= c.count & 1
+  let _ = c.count
+}
+"#
+    );
+}
+
+// `+`, `*`, and `^` are commutative but not idempotent: `a op (a op b) != a op b`
+// in general, so a rewrite to `a op= b` would silently change the computed value.
+#[test]
+fn misrefactored_assign_op_addition_no_warning() {
+    assert_no_lint_warnings!(
         r#"
 fn add(b: int) {
   let mut a = 1
@@ -888,8 +981,8 @@ fn main() {
 }
 
 #[test]
-fn misrefactored_assign_op_multiplication() {
-    assert_lint_snapshot!(
+fn misrefactored_assign_op_multiplication_no_warning() {
+    assert_no_lint_warnings!(
         r#"
 fn scale(b: int) {
   let mut a = 2
@@ -905,32 +998,34 @@ fn main() {
 }
 
 #[test]
-fn misrefactored_assign_op_target_on_right() {
-    assert_lint_snapshot!(
+fn misrefactored_assign_op_xor_no_warning() {
+    assert_no_lint_warnings!(
         r#"
-fn add(b: int) {
+fn toggle(b: int) {
   let mut a = 1
-  a += b + a
+  a ^= a ^ b
   let _ = a
 }
 
 fn main() {
-  add(2)
+  toggle(2)
 }
 "#
     );
 }
 
 #[test]
-fn misrefactored_assign_op_field() {
-    assert_lint_snapshot!(
+fn misrefactored_assign_op_subtraction_target_on_left_no_warning() {
+    assert_no_lint_warnings!(
         r#"
-struct Counter { count: int }
+fn sub(b: int) {
+  let mut a = 10
+  a -= a - b
+  let _ = a
+}
 
 fn main() {
-  let mut c = Counter { count: 0 }
-  c.count += c.count + 1
-  let _ = c.count
+  sub(3)
 }
 "#
     );
@@ -5563,6 +5658,25 @@ fn main() {
 }
 
 #[test]
+fn identical_if_branches_side_effecting_condition_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn log_and_true() -> bool {
+  fmt.Println("side effect")
+  true
+}
+
+fn main() {
+  let x = if log_and_true() { 42 } else { 42 };
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
 fn collapsible_if() {
     assert_lint_snapshot!(
         r#"
@@ -7584,6 +7698,27 @@ fn main() {
 }
 
 #[test]
+fn unused_enum_variant_serialization_attr_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+#[json]
+enum Status {
+  Active,
+  Inactive,
+  Archived,
+}
+
+fn main() {
+  let s = Status.Active
+  fmt.Println(s)
+}
+"#
+    );
+}
+
+#[test]
 fn public_enum_variants_not_unused() {
     assert_no_lint_warnings!(
         r#"
@@ -8525,6 +8660,22 @@ fn main() {
 }
 
 #[test]
+fn type_parameter_used_only_in_body_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub fn make_empty_len<T>() -> int {
+  let s: Slice<T> = Slice.new<T>()
+  s.length()
+}
+
+fn main() {
+  let _ = make_empty_len<int>()
+}
+"#
+    );
+}
+
+#[test]
 fn type_param_only_in_bound_warns() {
     assert_lint_snapshot!(
         r#"
@@ -8576,6 +8727,33 @@ impl Foo {
 
 pub fn squiggle<A: Cloner<B>, B>(a: A) -> B {
   a.clone()
+}
+
+fn main() {
+  let _ = squiggle(Foo{})
+}
+"#
+    );
+}
+
+#[test]
+fn type_param_in_bound_and_used_in_body_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+pub interface Cloner<T: Cloner<T>> {
+  fn clone() -> T
+}
+
+struct Foo{}
+
+impl Foo {
+  fn clone(self) -> Foo { Foo{} }
+}
+
+pub fn squiggle<A: Cloner<B>, B>(a: A) -> int {
+  let x: B = a.clone()
+  let _ = x
+  0
 }
 
 fn main() {
@@ -12060,6 +12238,28 @@ fn main() {
 }
 
 #[test]
+fn invisible_in_string_emoji_zwj_sequence_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = "👨‍👩‍👧"
+}
+"#
+    );
+}
+
+#[test]
+fn invisible_in_string_zwj_between_plain_text_still_warns() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = "admin‍user"
+}
+"#
+    );
+}
+
+#[test]
 fn verbose_failure_propagation_option_match() {
     assert_lint_snapshot!(
         r#"
@@ -13536,6 +13736,47 @@ fn main() {
     wg1.Add(1)
   }
   wg2.Wait()
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_add_in_task_covered_by_prior_add_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  wg.Add(1)
+  task {
+    defer wg.Done()
+    wg.Add(1)
+  }
+  wg.Wait()
+}
+"#
+    );
+}
+
+#[test]
+fn waitgroup_add_in_nested_task_covered_by_prior_add_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:sync"
+
+fn main() {
+  let mut wg = sync.WaitGroup {}
+  wg.Add(1)
+  task {
+    defer wg.Done()
+    wg.Add(1)
+    task {
+      defer wg.Done()
+    }
+  }
+  wg.Wait()
 }
 "#
     );

--- a/tests/ui/lint/snapshots/append_to_zero_filled_fires_when_both_branches_append.snap
+++ b/tests/ui/lint/snapshots/append_to_zero_filled_fires_when_both_branches_append.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Appending to a zero-filled slice
+   ╭─[test.lis:3:17]
+ 2 │ fn run(flag: bool) {
+ 3 │   let mut ids = Slice.make<int>(5)
+   ·                 ─────────┬────────
+   ·                          ╰── every element is already a zero value
+ 4 │   if flag {
+ 5 │     ids = ids.append(1)
+   ·           ──────┬──────
+   ·                 ╰── `append` adds element 6 here
+ 6 │   } else {
+   ╰────
+  help: For an empty slice with room for 5, use `Slice.new<int>().reserve(5)` · code: [lint.append_to_zero_filled]

--- a/tests/ui/lint/snapshots/invisible_in_string_zwj_between_plain_text_still_warns.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_zwj_between_plain_text_still_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Invisible character in string
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = "admin‍user"
+   ·           ─────┬─────
+   ·                ╰── contains U+200D (zero-width joiner)
+ 4 │ }
+   ╰────
+  help: Invisible characters in strings can hide bugs and silently shift meaning. Remove the character, or replace it with the visible character you meant · code: [lint.invisible_in_string]

--- a/tests/ui/lint/snapshots/misrefactored_assign_op_bitand.snap
+++ b/tests/ui/lint/snapshots/misrefactored_assign_op_bitand.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Compound assignment repeats `a`
+   ╭─[test.lis:4:3]
+ 3 │   let mut a = 2
+ 4 │   a &= a & b
+   ·   ─────┬────
+   ·        ╰── uses `a` twice
+ 5 │   let _ = a
+   ╰────
+  help: The `&=` operator already includes `a`, so naming `a` again on the right applies it twice. To apply `b` once, write `a &= b` · code: [lint.misrefactored_assign_op]

--- a/tests/ui/lint/snapshots/misrefactored_assign_op_bitor_target_on_right.snap
+++ b/tests/ui/lint/snapshots/misrefactored_assign_op_bitor_target_on_right.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Compound assignment repeats `a`
+   ╭─[test.lis:4:3]
+ 3 │   let mut a = 1
+ 4 │   a |= b | a
+   ·   ─────┬────
+   ·        ╰── uses `a` twice
+ 5 │   let _ = a
+   ╰────
+  help: The `|=` operator already includes `a`, so naming `a` again on the right applies it twice. To apply `b` once, write `a |= b` · code: [lint.misrefactored_assign_op]

--- a/tests/ui/lint/snapshots/misrefactored_assign_op_field.snap
+++ b/tests/ui/lint/snapshots/misrefactored_assign_op_field.snap
@@ -4,9 +4,9 @@ source: tests/ui/lint/mod.rs
   ▲ Compound assignment repeats `c.count`
    ╭─[test.lis:6:3]
  5 │   let mut c = Counter { count: 0 }
- 6 │   c.count += c.count + 1
+ 6 │   c.count &= c.count & 1
    ·   ───────────┬──────────
    ·              ╰── uses `c.count` twice
  7 │   let _ = c.count
    ╰────
-  help: The `+=` operator already includes `c.count`, so naming `c.count` again on the right applies it twice. To apply `1` once, write `c.count += 1` · code: [lint.misrefactored_assign_op]
+  help: The `&=` operator already includes `c.count`, so naming `c.count` again on the right applies it twice. To apply `1` once, write `c.count &= 1` · code: [lint.misrefactored_assign_op]


### PR DESCRIPTION
- `append_to_zero_filled` no longer fires when a sibling `if... else` or `match` arm still depends on the zero-filled slice.
- `waitgroup_add_in_task` no longer fires when a prior `Add` outside the `task` already covers it.
- `misrefactored_assign_op` no longer suggests a rewrite for `+=`, `*=`, and `^=`, since collapsing `a op= a op b` to `a op= b` only holds for `&=` and `|=`.
- `identical_if_branches` no longer suggests dropping an `if` whose condition has a side effect.
- `invisible_in_string` no longer flags a zero-width joiner inside an emoji sequence.
- `unused_type_param` and `type_param_only_in_bound` now recognize a type param used only in the fn body, through a local annotation, an explicit `<T>` call, or a cast.
- `unused_enum_variant` now respects `#[json]` and other serialization attributes the same way `unused_struct_field` already does, so variants only produced by deserialization are not flagged.
