### PR TITLE
fix: parse `fn` types in tuple struct fields

### DIFF
--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -287,15 +287,23 @@ impl<'source> Parser<'source> {
         VariantFields::Unit
     }
 
+    fn at_tuple_fields_end(&self) -> bool {
+        if self.at_eof() {
+            return true;
+        }
+
+        if self.is(Function) {
+            return self.stream.peek_ahead(1).kind != LeftParen;
+        }
+
+        !self.can_start_annotation()
+    }
+
     fn parse_tuple_variant_fields(&mut self) -> VariantFields {
         let mut fields = vec![];
 
         loop {
-            if self.at_eof()
-                || self.is(RightParen)
-                || self.is(RightCurlyBrace)
-                || !self.can_start_annotation()
-            {
+            if self.at_tuple_fields_end() {
                 break;
             }
 
@@ -440,7 +448,7 @@ impl<'source> Parser<'source> {
         let mut index = 0;
 
         while self.is_not(RightParen) {
-            if self.at_eof() || self.at_item_boundary() || !self.can_start_annotation() {
+            if self.at_tuple_fields_end() {
                 break;
             }
 

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -2314,6 +2314,40 @@ struct Marker()
 }
 
 #[test]
+fn tuple_struct_function_type_field() {
+    let input = r#"
+struct WriterFunc(fn(byte) -> Option<string>)
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn tuple_struct_function_type_field_after_other_field() {
+    let input = r#"
+struct Handler(int, fn(int) -> int)
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn tuple_struct_multiple_function_type_fields() {
+    let input = r#"
+struct Callbacks(fn() -> int, fn(int))
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn enum_tuple_variant_function_type_field() {
+    let input = r#"
+enum E {
+  V(fn(int) -> int)
+}
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
 fn brace_after_call_is_block() {
     let input = r#"
 fn get_value() -> int { 1 }

--- a/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
+++ b/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
@@ -1,0 +1,83 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  enum E {
+    V(fn(int) -> int)
+  }
+---
+[
+    Enum {
+        doc: None,
+        attributes: [],
+        name: "E",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 6,
+            byte_length: 1,
+        },
+        generics: [],
+        variants: [
+            EnumVariant {
+                doc: None,
+                name: "V",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 12,
+                    byte_length: 1,
+                },
+                fields: Tuple(
+                    [
+                        EnumFieldDefinition {
+                            name: "field0",
+                            name_span: Span {
+                                file_id: 0,
+                                byte_offset: 0,
+                                byte_length: 0,
+                            },
+                            annotation: Function {
+                                params: [
+                                    Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 17,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                ],
+                                param_mutability: [
+                                    false,
+                                ],
+                                return_type: Constructor {
+                                    name: "int",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 25,
+                                        byte_length: 3,
+                                    },
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 14,
+                                    byte_length: 14,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                    ],
+                ),
+            },
+        ],
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 30,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/tuple_struct_function_type_field.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_function_type_field.snap
@@ -1,0 +1,83 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  struct WriterFunc(fn(byte) -> Option<string>)
+---
+[
+    Struct {
+        doc: None,
+        attributes: [],
+        name: "WriterFunc",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 8,
+            byte_length: 10,
+        },
+        generics: [],
+        fields: [
+            StructFieldDefinition {
+                doc: None,
+                attributes: [],
+                name: "_0",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 19,
+                    byte_length: 26,
+                },
+                annotation: Function {
+                    params: [
+                        Constructor {
+                            name: "byte",
+                            params: [],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 22,
+                                byte_length: 4,
+                            },
+                        },
+                    ],
+                    param_mutability: [
+                        false,
+                    ],
+                    return_type: Constructor {
+                        name: "Option",
+                        params: [
+                            Constructor {
+                                name: "string",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 38,
+                                    byte_length: 6,
+                                },
+                            },
+                        ],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 31,
+                            byte_length: 14,
+                        },
+                    },
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 19,
+                        byte_length: 26,
+                    },
+                },
+                visibility: Private,
+                ty: Var {
+                    id: uninferred,
+                },
+                embedded: false,
+            },
+        ],
+        kind: Tuple,
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 45,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/tuple_struct_function_type_field_after_other_field.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_function_type_field_after_other_field.snap
@@ -1,0 +1,97 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  struct Handler(int, fn(int) -> int)
+---
+[
+    Struct {
+        doc: None,
+        attributes: [],
+        name: "Handler",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 8,
+            byte_length: 7,
+        },
+        generics: [],
+        fields: [
+            StructFieldDefinition {
+                doc: None,
+                attributes: [],
+                name: "_0",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 16,
+                    byte_length: 3,
+                },
+                annotation: Constructor {
+                    name: "int",
+                    params: [],
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 16,
+                        byte_length: 3,
+                    },
+                },
+                visibility: Private,
+                ty: Var {
+                    id: uninferred,
+                },
+                embedded: false,
+            },
+            StructFieldDefinition {
+                doc: None,
+                attributes: [],
+                name: "_1",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 14,
+                },
+                annotation: Function {
+                    params: [
+                        Constructor {
+                            name: "int",
+                            params: [],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 24,
+                                byte_length: 3,
+                            },
+                        },
+                    ],
+                    param_mutability: [
+                        false,
+                    ],
+                    return_type: Constructor {
+                        name: "int",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 3,
+                        },
+                    },
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 21,
+                        byte_length: 14,
+                    },
+                },
+                visibility: Private,
+                ty: Var {
+                    id: uninferred,
+                },
+                embedded: false,
+            },
+        ],
+        kind: Tuple,
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 35,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/tuple_struct_multiple_function_type_fields.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_multiple_function_type_fields.snap
@@ -1,0 +1,98 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  struct Callbacks(fn() -> int, fn(int))
+---
+[
+    Struct {
+        doc: None,
+        attributes: [],
+        name: "Callbacks",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 8,
+            byte_length: 9,
+        },
+        generics: [],
+        fields: [
+            StructFieldDefinition {
+                doc: None,
+                attributes: [],
+                name: "_0",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 18,
+                    byte_length: 11,
+                },
+                annotation: Function {
+                    params: [],
+                    param_mutability: [],
+                    return_type: Constructor {
+                        name: "int",
+                        params: [],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 26,
+                            byte_length: 3,
+                        },
+                    },
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 18,
+                        byte_length: 11,
+                    },
+                },
+                visibility: Private,
+                ty: Var {
+                    id: uninferred,
+                },
+                embedded: false,
+            },
+            StructFieldDefinition {
+                doc: None,
+                attributes: [],
+                name: "_1",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 31,
+                    byte_length: 7,
+                },
+                annotation: Function {
+                    params: [
+                        Constructor {
+                            name: "int",
+                            params: [],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 34,
+                                byte_length: 3,
+                            },
+                        },
+                    ],
+                    param_mutability: [
+                        false,
+                    ],
+                    return_type: Unknown,
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 31,
+                        byte_length: 7,
+                    },
+                },
+                visibility: Private,
+                ty: Var {
+                    id: uninferred,
+                },
+                embedded: false,
+            },
+        ],
+        kind: Tuple,
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 38,
+        },
+    },
+]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -12918,6 +12918,15 @@ fn main() {
 }
 
 #[test]
+fn parse_unclosed_tuple_struct_recovers_at_fn_definition() {
+    let input = r#"
+struct Foo(int,
+fn main() {}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn infer_error_type_does_not_cascade_to_unused_value_lint() {
     let mut fs = MockFileSystem::new();
     let source = r#"

--- a/tests/ui/errors/snapshots/parse_unclosed_tuple_struct_recovers_at_fn_definition.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_tuple_struct_recovers_at_fn_definition.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:1]
+ 2 │ struct Foo(int,
+ 3 │ fn main() {}
+   · ─┬
+   ·  ╰── expected `)`
+   ╰────
+  help:  · code: [parse.unexpected_token]


### PR DESCRIPTION
Fixes parser to accept a bare fn type in a tuple struct's positional field list.

```rs
struct WriterFunc(fn(byte) -> Option<string>)
```