### PR TITLE
fix: stack overflow on circular aliases with growing arguments

### DIFF
--- a/crates/passes/src/passes/checks/map_key.rs
+++ b/crates/passes/src/passes/checks/map_key.rs
@@ -3,8 +3,8 @@ use rustc_hash::FxHashSet as HashSet;
 use semantics::checker::{TypeEnv, check_never_comparable};
 use semantics::store::Store;
 use syntax::ast::{Expression, Span};
-use syntax::program::{CallKind, NativeTypeKind};
-use syntax::types::{CompoundKind, Type};
+use syntax::program::{CallKind, Definition, NativeTypeKind};
+use syntax::types::{CompoundKind, Symbol, Type};
 
 use crate::passes::walk::NodeCtx;
 
@@ -44,23 +44,44 @@ fn report_bad_map_key(
     ty: &Type,
     span: Span,
     sink: &LocalSink,
-    visited: &mut HashSet<String>,
+    expanding: &mut HashSet<Symbol>,
 ) -> bool {
-    let resolved = store.deep_resolve_alias(ty);
-    if !visited.insert(format!("{resolved:?}")) {
-        return false;
+    let alias_head = match ty {
+        Type::Nominal { id, .. }
+            if store
+                .get_definition(id.as_str())
+                .is_some_and(Definition::is_type_alias) =>
+        {
+            Some(id.clone())
+        }
+        _ => None,
+    };
+    if let Some(id) = &alias_head
+        && !expanding.insert(id.clone())
+    {
+        return ty
+            .get_type_params()
+            .unwrap_or_default()
+            .iter()
+            .any(|child| report_bad_map_key(store, child, span, sink, expanding));
     }
-    if let Some((CompoundKind::Map, args)) = resolved.as_compound()
+    let resolved = store.deep_resolve_alias(ty);
+    let found = if let Some((CompoundKind::Map, args)) = resolved.as_compound()
         && let Some(key_ty) = args.first()
         && let Some(reason) = check_never_comparable(&TypeEnv::default(), store, key_ty)
     {
         sink.push(diagnostics::infer::non_comparable_map_key(
             key_ty, reason, span,
         ));
-        return true;
+        true
+    } else {
+        resolved
+            .children()
+            .iter()
+            .any(|child| report_bad_map_key(store, child, span, sink, expanding))
+    };
+    if let Some(id) = alias_head {
+        expanding.remove(&id);
     }
-    resolved
-        .children()
-        .iter()
-        .any(|child| report_bad_map_key(store, child, span, sink, visited))
+    found
 }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -623,10 +623,15 @@ impl TaskState<'_> {
         let body_ty = self.convert_to_type(&*store, annotation, span);
         let is_function_body = matches!(body_ty, Type::Function(_));
 
-        if !is_function_body && self.is_alias_body_circular(&*store, &body_ty, &qualified_name) {
+        let body_ty = if !is_function_body
+            && self.is_alias_body_circular(&*store, &body_ty, &qualified_name)
+        {
             self.sink
                 .push(diagnostics::infer::circular_type_alias(name, *span));
-        }
+            Type::Error
+        } else {
+            body_ty
+        };
 
         let body_ty = if is_function_body {
             let params: Vec<Type> = generics

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -200,6 +200,29 @@ fn main() {
 }
 
 #[test]
+fn growing_circular_alias_rejected_at_check() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"growingalias\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"type A<T> = Option<A<Option<T>>>
+type M = Map<A<int>, int>
+
+fn main() {}
+"#,
+    )
+    .unwrap();
+
+    assert_rejected_at_check(&lis(&project, "check"), "Circular type alias");
+}
+
+#[test]
 fn cached_aliased_interface_bound_keeps_its_identity() {
     let scratch = tempfile::tempdir().expect("create temp dir");
     let project = scratch.path().join("proj");

--- a/tests/spec/infer/basics.rs
+++ b/tests/spec/infer/basics.rs
@@ -1067,6 +1067,35 @@ fn circular_type_alias_result_param() {
 }
 
 #[test]
+fn circular_type_alias_growing_argument() {
+    infer(
+        r#"
+    type A<T> = Option<A<Option<T>>>
+
+    fn test(x: A<int>) -> A<int> {
+      return x;
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
+fn circular_type_alias_growing_argument_as_map_key() {
+    infer(
+        r#"
+    type A<T> = Option<A<Option<T>>>
+    type M = Map<A<int>, int>
+
+    fn test(m: M) -> M {
+      return m;
+    }
+        "#,
+    )
+    .assert_circular_type();
+}
+
+#[test]
 fn circular_type_alias_mutual_function_allowed() {
     infer(
         r#"


### PR DESCRIPTION
`lis check` aborted with a stack overflow on a circular generic type alias whose type arg grows on each expansion. These aliases now report the existing `circular_type_alias` error instead.

```rs
type A<T> = Option<A<Option<T>>>
```
