### PR TITLE
feat: interface satisfaction by emitted Go name

### DIFF
--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::Planner;
 use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
-use crate::definitions::structs::{field_go_name_is_exported, is_raw_function_type};
+use crate::definitions::structs::is_raw_function_type;
 use crate::names::go_name;
 use syntax::ast::{Pattern, RestPattern, StructKind};
 use syntax::containment::enum_payload_pointer_wrapped;
@@ -58,7 +58,10 @@ impl Planner<'_> {
         match &resolved.definition.body {
             DefinitionBody::Struct { fields, .. } => {
                 if let Some(field) = fields.iter().find(|f| f.name == field_name) {
-                    return field_go_name_is_exported(field, resolved.definition.is_serialized());
+                    return syntax::go_names::struct_field_is_exported(
+                        field,
+                        resolved.definition.is_serialized(),
+                    );
                 }
                 let method_key = format!("{}.{}", id, field_name);
                 self.facts

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -7,7 +7,9 @@ use crate::write_line;
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::program::{Definition, DefinitionBody, Interface};
-use syntax::types::{SubstitutionMap, Type, build_substitution_map, substitute, unqualified_name};
+use syntax::types::{
+    SubstitutionMap, Symbol, Type, build_substitution_map, substitute, unqualified_name,
+};
 pub(crate) struct AdapterPlan {
     pub(crate) concrete_id: EcoString,
     pub(crate) interface_id: EcoString,
@@ -69,11 +71,17 @@ impl Planner<'_> {
         iface: &Interface,
     ) -> Vec<(EcoString, Type, EcoString)> {
         let mut result: Vec<(EcoString, Type, EcoString)> = Vec::new();
-        let mut seen: HashSet<EcoString> = HashSet::default();
+        let mut seen: HashSet<String> = HashSet::default();
         let mut queue: Vec<(&Interface, EcoString)> = vec![(iface, EcoString::from(root_id))];
         while let Some((current, current_id)) = queue.pop() {
             for (name, ty) in &current.methods {
-                if seen.insert(name.clone()) {
+                // Parents may spell one Go method with different source names.
+                let selector = if self.method_needs_export(name) {
+                    go_name::snake_to_camel(name)
+                } else {
+                    go_name::escape_keyword(name).into_owned()
+                };
+                if seen.insert(selector) {
                     result.push((name.clone(), ty.clone(), current_id.clone()));
                 }
             }
@@ -111,66 +119,91 @@ impl Planner<'_> {
         else {
             return None;
         };
-
-        let source_stripped = source_ty.strip_refs();
+        let source_stripped = self.facts.peel_alias(&source_ty.strip_refs());
         let Type::Nominal { id: source_id, .. } = &source_stripped else {
             return None;
         };
+        let methods =
+            self.adapted_methods(source_id, &source_stripped, target_id.as_str(), definition)?;
+        Some(AdapterPlan {
+            concrete_id: source_id.as_eco().clone(),
+            interface_id: target_id.as_eco().clone(),
+            concrete_ty: source_ty.clone(),
+            generic_context: self.adapter_generic_context(source_ty, &methods),
+            methods,
+        })
+    }
+
+    /// The adapter's method plans, or None when the source cannot implement
+    /// the interface or no method needs adapting.
+    fn adapted_methods(
+        &self,
+        source_id: &Symbol,
+        source_stripped: &Type,
+        target_id: &str,
+        definition: &Interface,
+    ) -> Option<Vec<AdapterMethod>> {
         if source_id.starts_with(GO_IMPORT_PREFIX) {
             return None;
         }
-        let Some(Definition {
-            body:
-                DefinitionBody::Struct {
-                    methods: struct_methods,
-                    ..
-                },
-            ..
-        }) = self.facts.definition(source_id.as_str())
-        else {
-            return None;
+        let impl_methods = match &self.facts.definition(source_id.as_str())?.body {
+            DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. } => {
+                methods
+            }
+            _ => return None,
         };
 
-        let all_interface_methods = self.collect_all_interface_methods(target_id, definition);
-        let mut methods = Vec::with_capacity(all_interface_methods.len());
-        let mut any_adapted = false;
+        let is_public_definition = |id: &str| {
+            self.facts
+                .definition(id)
+                .is_some_and(|d| d.visibility.is_public())
+        };
+        let own_candidate = |name: &str| syntax::go_names::ConformanceCandidate {
+            exported: is_public_definition(&format!("{source_id}.{name}")),
+            depth: 0,
+            owner: Some(source_id.as_eco().clone()),
+            shadowed: self.facts.is_ufcs_method(source_id.as_str(), name),
+        };
 
-        for (method_name, interface_method_ty, declaring_id) in &all_interface_methods {
-            let impl_ty = struct_methods.get(method_name)?;
+        let mut methods = Vec::new();
+        let mut any_adapted = false;
+        for (method_name, interface_method_ty, declaring_id) in
+            &self.collect_all_interface_methods(target_id, definition)
+        {
+            let (_, impl_ty) = syntax::go_names::conformance_method(
+                impl_methods,
+                declaring_id.as_str(),
+                is_public_definition(declaring_id.as_str()),
+                method_name.as_str(),
+                &own_candidate,
+            )?;
             let (method, adapted) = self.build_adapter_method(
                 method_name,
                 declaring_id,
                 interface_method_ty,
                 impl_ty,
-                &source_stripped,
+                source_stripped,
             )?;
-            if adapted {
-                any_adapted = true;
-            }
+            any_adapted |= adapted;
             methods.push(method);
         }
+        any_adapted.then_some(methods)
+    }
 
-        if !any_adapted {
-            return None;
-        }
-
-        let generic_context = self.function_state.generic_context();
-        let generic_context = if generic_context
+    fn adapter_generic_context(
+        &self,
+        source_ty: &Type,
+        methods: &[AdapterMethod],
+    ) -> Vec<(EcoString, Vec<Type>)> {
+        let context = self.function_state.generic_context();
+        if context
             .iter()
-            .any(|(name, _)| adapter_uses_type_parameter(source_ty, &methods, name))
+            .any(|(name, _)| adapter_uses_type_parameter(source_ty, methods, name))
         {
-            generic_context.to_vec()
+            context.to_vec()
         } else {
             Vec::new()
-        };
-
-        Some(AdapterPlan {
-            concrete_id: source_id.as_eco().clone(),
-            interface_id: target_id.as_eco().clone(),
-            concrete_ty: source_ty.clone(),
-            methods,
-            generic_context,
-        })
+        }
     }
 
     /// Returns the method plan and whether its physical Go signature differs.

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -1,13 +1,10 @@
 use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD};
-use crate::definitions::tags::{
-    field_has_export_forcing_attribute, format_tag_string, interpret_field_attributes,
-};
+use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name::{self, prelude_qualifier};
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::borrow::Cow;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructKind};
 use syntax::attributes::struct_attribute_forces_field_export;
 use syntax::program::{Definition, DefinitionBody, Interface, MethodSignatures};
@@ -507,25 +504,7 @@ pub(crate) fn struct_field_go_name(
     let struct_forces_export = struct_attrs
         .iter()
         .any(struct_attribute_forces_field_export);
-    field_go_name(field, struct_forces_export).into_owned()
-}
-
-fn field_go_name(field: &StructFieldDefinition, struct_forces_export: bool) -> Cow<'_, str> {
-    if field_go_name_is_exported(field, struct_forces_export) {
-        Cow::Owned(go_name::make_exported(&field.name))
-    } else {
-        go_name::escape_keyword(&field.name)
-    }
-}
-
-pub(crate) fn field_go_name_is_exported(
-    field: &StructFieldDefinition,
-    struct_forces_export: bool,
-) -> bool {
-    !field.embedded
-        && (field.visibility.is_public()
-            || struct_forces_export
-            || field_has_export_forcing_attribute(field))
+    syntax::go_names::struct_field_go_name(field, struct_forces_export).into_owned()
 }
 
 pub(crate) struct StringerField {
@@ -608,9 +587,9 @@ fn definition_emits_go_string_field(definition: &Definition) -> bool {
         return false;
     };
     let forces_export = definition.is_serialized();
-    fields
-        .iter()
-        .any(|field| field_go_name(field, forces_export) == ENUM_STRINGER_METHOD)
+    fields.iter().any(|field| {
+        syntax::go_names::struct_field_go_name(field, forces_export) == ENUM_STRINGER_METHOD
+    })
 }
 
 fn type_methods(definition: &Definition) -> Option<&MethodSignatures> {

--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -41,19 +41,6 @@ pub(super) enum CaseTransform {
     CamelCase,
 }
 
-pub(super) fn field_has_export_forcing_attribute(field: &StructFieldDefinition) -> bool {
-    field.attributes.iter().any(|attribute| {
-        if attribute.name == "tag" {
-            matches!(
-                attribute.args.first(),
-                Some(AttributeArg::String(_) | AttributeArg::Raw(_))
-            )
-        } else {
-            is_serialization_key(&attribute.name)
-        }
-    })
-}
-
 pub(super) fn interpret_field_attributes(
     field: &StructFieldDefinition,
     struct_attrs: &[Attribute],

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -92,6 +92,7 @@ impl InferCtx<'_, '_> {
             return Ok(());
         }
 
+        let adapter_capable = self.adapter_capable_receiver(ty, interface, interface_qualified_id);
         let mut violations = Vec::new();
         let mut visited = rustc_hash::FxHashSet::default();
         self.collect_interface_violations(
@@ -100,6 +101,7 @@ impl InferCtx<'_, '_> {
             interface_qualified_id,
             type_args,
             None,
+            adapter_capable,
             span,
             &mut violations,
             &mut visited,
@@ -210,6 +212,7 @@ impl InferCtx<'_, '_> {
             interface,
             interface_qualified_id,
             &methods,
+            ty,
             &mut ptr_methods,
             &mut visited,
         );
@@ -229,11 +232,13 @@ impl InferCtx<'_, '_> {
         Err(vec![])
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn collect_pointer_receiver_methods(
         &self,
         interface: &Interface,
         interface_qualified_id: &str,
         methods: &MethodSignatures,
+        receiver: &Type,
         out: &mut Vec<String>,
         visited: &mut rustc_hash::FxHashSet<String>,
     ) {
@@ -241,8 +246,17 @@ impl InferCtx<'_, '_> {
         if !visited.insert(interface_qualified_id.to_string()) {
             return;
         }
+        let interface_is_public = store
+            .get_definition(interface_qualified_id)
+            .is_some_and(|d| d.visibility.is_public());
         for name in interface.methods.keys() {
-            if let Some(method_ty) = methods.get(name) {
+            if let Some((impl_name, method_ty)) = syntax::go_names::conformance_method(
+                methods,
+                interface_qualified_id,
+                interface_is_public,
+                name.as_str(),
+                &|candidate| self.conformance_candidate(receiver, candidate),
+            ) {
                 let func = match method_ty {
                     Type::Forall { body, .. } => body.as_ref(),
                     other => other,
@@ -250,7 +264,7 @@ impl InferCtx<'_, '_> {
                 if let Type::Function(f) = func
                     && f.params.first().is_some_and(|p| p.is_ref())
                 {
-                    out.push(name.to_string());
+                    out.push(impl_name.to_string());
                 }
             }
         }
@@ -261,12 +275,198 @@ impl InferCtx<'_, '_> {
                     parent_interface,
                     parent_name.as_str(),
                     methods,
+                    receiver,
                     out,
                     visited,
                 );
             }
         }
         visited.remove(interface_qualified_id);
+    }
+
+    fn conformance_candidate(
+        &self,
+        receiver: &Type,
+        method: &str,
+    ) -> syntax::go_names::ConformanceCandidate {
+        let resolved = self
+            .store
+            .deep_resolve_alias(&receiver.strip_refs().resolve_in(&self.env));
+        self.own_candidate(&resolved, method)
+            .or_else(|| self.promoted_candidate(&resolved, method))
+            .or_else(|| self.bound_candidate(&resolved, method))
+            .unwrap_or(syntax::go_names::ConformanceCandidate {
+                exported: false,
+                depth: 0,
+                owner: None,
+                shadowed: false,
+            })
+    }
+
+    fn own_candidate(
+        &self,
+        resolved: &Type,
+        method: &str,
+    ) -> Option<syntax::go_names::ConformanceCandidate> {
+        let id = resolved.get_qualified_id()?;
+        let public = method_definition_public(
+            self.store,
+            id,
+            method,
+            &mut rustc_hash::FxHashSet::default(),
+        )?;
+        // UFCS-lowered methods emit as free functions, not selectors.
+        Some(syntax::go_names::ConformanceCandidate {
+            exported: public,
+            depth: 0,
+            owner: Some(id.into()),
+            shadowed: self.is_ufcs_method(id, method),
+        })
+    }
+
+    fn promoted_candidate(
+        &self,
+        resolved: &Type,
+        method: &str,
+    ) -> Option<syntax::go_names::ConformanceCandidate> {
+        use crate::checker::promotion;
+        let store = self.store;
+        resolved.get_qualified_id()?;
+        let promotion::Resolution::Found(member) =
+            promotion::resolve_selector(store, resolved, method)
+        else {
+            return None;
+        };
+        let public = method_definition_public(
+            store,
+            member.declaring_type.as_str(),
+            method,
+            &mut rustc_hash::FxHashSet::default(),
+        )
+        .unwrap_or(false);
+        let selector = if public {
+            syntax::go_names::snake_to_camel(method)
+        } else {
+            method.to_string()
+        };
+        let shadowed = promotion::field_selector_depth(store, resolved, &selector)
+            .is_some_and(|field_depth| field_depth <= member.depth);
+        Some(syntax::go_names::ConformanceCandidate {
+            exported: public,
+            depth: member.depth,
+            owner: Some(member.declaring_type.as_eco().clone()),
+            shadowed,
+        })
+    }
+
+    // Bound method sets merge as one Go constraint interface.
+    fn bound_candidate(
+        &self,
+        resolved: &Type,
+        method: &str,
+    ) -> Option<syntax::go_names::ConformanceCandidate> {
+        let Type::Parameter(name) = resolved else {
+            return None;
+        };
+        let bounds = self.scopes.collect_all_trait_bounds();
+        let qualified = self.qualify_name(name);
+        bounds.get(&qualified)?.iter().find_map(|bound| {
+            let iface_id = self
+                .store
+                .deep_resolve_alias(bound)
+                .get_qualified_id()?
+                .to_string();
+            let public = method_definition_public(
+                self.store,
+                &iface_id,
+                method,
+                &mut rustc_hash::FxHashSet::default(),
+            )?;
+            Some(syntax::go_names::ConformanceCandidate {
+                exported: public,
+                depth: 0,
+                owner: Some(qualified.as_eco().clone()),
+                shadowed: false,
+            })
+        })
+    }
+
+    /// Mirror of emit's `needs_adapter` precondition.
+    fn adapter_capable_receiver(
+        &self,
+        ty: &Type,
+        interface: &Interface,
+        interface_qualified_id: &str,
+    ) -> bool {
+        let store = self.store;
+        let resolved = store.deep_resolve_alias(&ty.strip_refs().resolve_in(&self.env));
+        let Some(id) = resolved.get_qualified_id() else {
+            return false;
+        };
+        if id.starts_with(GO_IMPORT_PREFIX) {
+            return false;
+        }
+        let own = match store.get_definition(id).map(|d| &d.body) {
+            Some(DefinitionBody::Struct { methods, .. })
+            | Some(DefinitionBody::Enum { methods, .. }) => methods,
+            _ => return false,
+        };
+        self.own_methods_cover_interface(
+            own,
+            id,
+            interface,
+            interface_qualified_id,
+            &mut rustc_hash::FxHashSet::default(),
+        )
+    }
+
+    fn own_methods_cover_interface(
+        &self,
+        own: &MethodSignatures,
+        own_id: &str,
+        interface: &Interface,
+        interface_qualified_id: &str,
+        seen: &mut rustc_hash::FxHashSet<String>,
+    ) -> bool {
+        let store = self.store;
+        if !seen.insert(interface_qualified_id.to_string()) {
+            return true;
+        }
+        let interface_is_public = store
+            .get_definition(interface_qualified_id)
+            .is_some_and(|d| d.visibility.is_public());
+        let own_candidate = |name: &str| syntax::go_names::ConformanceCandidate {
+            exported: store
+                .get_definition(&format!("{own_id}.{name}"))
+                .is_some_and(|d| d.visibility.is_public()),
+            depth: 0,
+            owner: Some(own_id.into()),
+            shadowed: self.is_ufcs_method(own_id, name),
+        };
+        let covered = interface.methods.keys().all(|method| {
+            syntax::go_names::conformance_method(
+                own,
+                interface_qualified_id,
+                interface_is_public,
+                method.as_str(),
+                &own_candidate,
+            )
+            .is_some()
+        });
+        covered
+            && interface.parents.iter().all(|parent| {
+                let parent_name = parent.get_qualified_name();
+                match store.get_interface(&parent_name) {
+                    Some(parent_interface) => self.own_methods_cover_interface(
+                        own,
+                        own_id,
+                        parent_interface,
+                        parent_name.as_str(),
+                        seen,
+                    ),
+                    None => true,
+                }
+            })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -277,6 +477,7 @@ impl InferCtx<'_, '_> {
         interface_qualified_id: &str,
         type_args: &[Type],
         parent_of: Option<&str>,
+        adapter_capable: bool,
         span: &Span,
         violations: &mut Vec<InterfaceViolation>,
         visited: &mut rustc_hash::FxHashSet<String>,
@@ -316,141 +517,76 @@ impl InferCtx<'_, '_> {
             })
             .unwrap_or_default();
 
+        let interface_is_public = store
+            .get_definition(interface_qualified_id)
+            .is_some_and(|d| d.visibility.is_public());
+
         for (method_name, method_ty) in &interface.methods {
-            let Some(symbol_method) = symbol_methods.get(method_name.as_str()) else {
-                missing.push((method_name.to_string(), method_ty.clone()));
-                continue;
-            };
-
-            if let Some(ref id) = receiver_id
-                && self.is_ufcs_method(id.as_str(), method_name.as_str())
-            {
-                if !receiver_generics.is_empty() {
-                    let type_name = resolved_receiver
-                        .get_name()
-                        .map_or_else(|| resolved_receiver.to_string(), str::to_owned);
-                    self.sink.push(
-                        diagnostics::infer::specialized_impl_cannot_satisfy_interface(
-                            &type_name,
-                            &interface.name,
-                            method_name,
-                            &receiver_generics,
-                            *span,
-                        ),
-                    );
+            let selected = self.select_impl_method(
+                ty,
+                &symbol_methods,
+                interface_qualified_id,
+                interface_is_public,
+                method_name.as_str(),
+                receiver_id.as_ref().map(|id| id.as_str()),
+            );
+            let (impl_method_name, symbol_method) = match selected {
+                SelectedMethod::Found(name, method) => (name, method),
+                SelectedMethod::UfcsOnly => {
+                    if !receiver_generics.is_empty() {
+                        let type_name = resolved_receiver
+                            .get_name()
+                            .map_or_else(|| resolved_receiver.to_string(), str::to_owned);
+                        self.sink.push(
+                            diagnostics::infer::specialized_impl_cannot_satisfy_interface(
+                                &type_name,
+                                &interface.name,
+                                method_name,
+                                &receiver_generics,
+                                *span,
+                            ),
+                        );
+                    }
+                    missing.push((method_name.to_string(), method_ty.clone()));
+                    continue;
                 }
-                missing.push((method_name.to_string(), method_ty.clone()));
-                continue;
-            }
-
-            let substituted_method = substitute(method_ty, &map);
-
-            // Instantiate Forall impl methods before removing receiver
-            let instantiated_method = match symbol_method {
-                Type::Forall { .. } => self.instantiate(symbol_method).0,
-                _ => symbol_method.clone(),
-            };
-            let receiver_to_pin = match symbol_method {
-                Type::Forall { .. } => match &instantiated_method {
-                    Type::Function(f) => f
-                        .params
-                        .first()
-                        .filter(|p| !p.is_receiver_placeholder())
-                        .map(Type::strip_refs),
-                    _ => None,
-                },
-                _ => None,
-            };
-            let impl_method_without_receiver = Self::remove_first_param(&instantiated_method);
-
-            // Strip bounds before comparing - bounds are checked separately via bounds_equivalent
-            let strip_bounds = |ty: &Type| match ty {
-                Type::Function(f) => f.rebuild(f.params.clone(), vec![], f.return_type.clone()),
-                other => other.clone(),
+                SelectedMethod::Missing => {
+                    missing.push((method_name.to_string(), method_ty.clone()));
+                    continue;
+                }
             };
 
-            // Go-imported interfaces allow narrow covariance: impl returning T
-            // satisfies Option<T> in the top-level return position, when both
-            // sides lower to the same Go ABI shape.
-            let impl_for_unify = covariant_return_adjustment(
+            let check = self.check_method_signature(
+                ty,
                 interface_qualified_id,
                 method_name.as_str(),
-                &substituted_method,
-                &impl_method_without_receiver,
-                store,
-            )
-            .unwrap_or_else(|| impl_method_without_receiver.clone());
+                method_ty,
+                &symbol_method,
+                &map,
+            );
 
-            let candidate_ty = ty.strip_refs().resolve_in(&self.env);
-            let mut receiver_pinned = true;
-            let mut resolved_impl_method = None;
-            self.scopes.increment_type_param_depth();
-            let sig_match = self.speculatively(|this| {
-                let mut ctx = InferCtx::new(this, store);
-                if let Some(receiver) = &receiver_to_pin {
-                    ctx.try_unify(receiver, &candidate_ty, &Span::dummy())
-                        .inspect_err(|_| receiver_pinned = false)?;
-                }
-                let result = ctx.try_unify(
-                    &strip_bounds(&substituted_method),
-                    &strip_bounds(&impl_for_unify),
-                    &Span::dummy(),
+            if check.receiver_pinned && check.matched {
+                self.validate_comma_ok_abi(
+                    ty,
+                    interface,
+                    interface_qualified_id,
+                    method_name,
+                    impl_method_name.as_str(),
+                    adapter_capable,
+                    span,
                 );
-                if result.is_err() {
-                    resolved_impl_method = Some(impl_method_without_receiver.resolve_in(&ctx.env));
-                }
-                result
-            });
-            self.scopes.decrement_type_param_depth();
-
-            if receiver_pinned
-                && sig_match.is_ok()
-                && interface_qualified_id.starts_with(GO_IMPORT_PREFIX)
-            {
-                let resolved_ty = ty.strip_refs().resolve_in(&self.env);
-                if let Some(ty_id) = resolved_ty.get_qualified_id()
-                    && let crate::checker::promotion::Resolution::Found(member) =
-                        crate::checker::promotion::resolve_selector(
-                            store,
-                            &resolved_ty,
-                            method_name.as_str(),
-                        )
-                {
-                    let interface_comma_ok =
-                        method_comma_ok(store, interface_qualified_id, method_name);
-                    let selected_comma_ok =
-                        method_comma_ok(store, member.declaring_type.as_str(), method_name);
-                    let native_direct = member.depth == 0 && !ty_id.starts_with(GO_IMPORT_PREFIX);
-                    let adapter_reconciles =
-                        native_direct && interface_comma_ok && !selected_comma_ok;
-                    if interface_comma_ok != selected_comma_ok && !adapter_reconciles {
-                        self.sink.push(diagnostics::embed::comma_ok_abi_mismatch(
-                            &interface.name,
-                            method_name,
-                            *span,
-                        ));
-                    }
-                }
             }
 
-            if !receiver_pinned {
+            if !check.receiver_pinned {
                 missing.push((method_name.to_string(), method_ty.clone()));
-            } else if sig_match.is_err() {
+            } else if !check.matched {
                 incompatible.push((
                     method_name.to_string(),
-                    substituted_method,
-                    resolved_impl_method.unwrap_or(impl_method_without_receiver),
+                    check.substituted_method,
+                    check.incompatible_impl,
                 ));
-            } else if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
-                && let Some(module) = store.module_for_qualified_name(id.as_str())
-                && let Some(type_name) = id.as_str().get(module.len() + 1..)
-                && !type_name.contains('.')
-            {
-                self.facts.mark_method_used_for_interface(
-                    module.to_string(),
-                    method_name.to_string(),
-                    type_name.to_string(),
-                );
+            } else {
+                self.record_conformance_use(ty, impl_method_name.as_str());
             }
         }
 
@@ -467,9 +603,6 @@ impl InferCtx<'_, '_> {
             let parent_name = parent.get_qualified_name();
             if let Some(parent_interface) = store.get_interface(&parent_name).cloned() {
                 let parent_type_args = parent.get_type_params().unwrap_or_default();
-                // Substitute parent type arguments using the current interface's substitution map.
-                // E.g., if Processor<T> embeds Mapper<T> and we're checking Processor<string>,
-                // we need to substitute T with string before checking the embedded Mapper.
                 let substituted_parent_args: Vec<Type> = parent_type_args
                     .iter()
                     .map(|arg| substitute(arg, &map))
@@ -480,6 +613,7 @@ impl InferCtx<'_, '_> {
                     &parent_name,
                     &substituted_parent_args,
                     Some(&interface.name),
+                    adapter_capable,
                     span,
                     violations,
                     visited,
@@ -490,12 +624,194 @@ impl InferCtx<'_, '_> {
         visited.remove(interface_qualified_id);
     }
 
+    fn select_impl_method(
+        &self,
+        ty: &Type,
+        symbol_methods: &MethodSignatures,
+        interface_qualified_id: &str,
+        interface_is_public: bool,
+        method_name: &str,
+        receiver_id: Option<&str>,
+    ) -> SelectedMethod {
+        let selected = syntax::go_names::conformance_method(
+            symbol_methods,
+            interface_qualified_id,
+            interface_is_public,
+            method_name,
+            &|name| self.conformance_candidate(ty, name),
+        );
+        let ufcs_probe = match &selected {
+            Some((name, _)) => name.as_str(),
+            None => method_name,
+        };
+        if receiver_id.is_some_and(|id| self.is_ufcs_method(id, ufcs_probe)) {
+            return SelectedMethod::UfcsOnly;
+        }
+        match selected {
+            Some((name, method)) => SelectedMethod::Found(name.clone(), method.clone()),
+            None => SelectedMethod::Missing,
+        }
+    }
+
+    fn check_method_signature(
+        &mut self,
+        ty: &Type,
+        interface_qualified_id: &str,
+        method_name: &str,
+        method_ty: &Type,
+        symbol_method: &Type,
+        map: &SubstitutionMap,
+    ) -> SignatureCheck {
+        let store = self.store;
+        let substituted_method = substitute(method_ty, map);
+
+        let instantiated_method = match symbol_method {
+            Type::Forall { .. } => self.instantiate(symbol_method).0,
+            _ => symbol_method.clone(),
+        };
+        let receiver_to_pin = match symbol_method {
+            Type::Forall { .. } => match &instantiated_method {
+                Type::Function(f) => f
+                    .params
+                    .first()
+                    .filter(|p| !p.is_receiver_placeholder())
+                    .map(Type::strip_refs),
+                _ => None,
+            },
+            _ => None,
+        };
+        let impl_method_without_receiver = Self::remove_first_param(&instantiated_method);
+
+        let strip_bounds = |ty: &Type| match ty {
+            Type::Function(f) => f.rebuild(f.params.clone(), vec![], f.return_type.clone()),
+            other => other.clone(),
+        };
+
+        let impl_for_unify = covariant_return_adjustment(
+            interface_qualified_id,
+            method_name,
+            &substituted_method,
+            &impl_method_without_receiver,
+            store,
+        )
+        .unwrap_or_else(|| impl_method_without_receiver.clone());
+
+        let candidate_ty = ty.strip_refs().resolve_in(&self.env);
+        let mut receiver_pinned = true;
+        let mut resolved_impl_method = None;
+        self.scopes.increment_type_param_depth();
+        let sig_match = self.speculatively(|this| {
+            let mut ctx = InferCtx::new(this, store);
+            if let Some(receiver) = &receiver_to_pin {
+                ctx.try_unify(receiver, &candidate_ty, &Span::dummy())
+                    .inspect_err(|_| receiver_pinned = false)?;
+            }
+            let result = ctx.try_unify(
+                &strip_bounds(&substituted_method),
+                &strip_bounds(&impl_for_unify),
+                &Span::dummy(),
+            );
+            if result.is_err() {
+                resolved_impl_method = Some(impl_method_without_receiver.resolve_in(&ctx.env));
+            }
+            result
+        });
+        self.scopes.decrement_type_param_depth();
+
+        SignatureCheck {
+            receiver_pinned,
+            matched: sig_match.is_ok(),
+            substituted_method,
+            incompatible_impl: resolved_impl_method.unwrap_or(impl_method_without_receiver),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_comma_ok_abi(
+        &mut self,
+        ty: &Type,
+        interface: &Interface,
+        interface_qualified_id: &str,
+        method_name: &str,
+        impl_method_name: &str,
+        adapter_capable: bool,
+        span: &Span,
+    ) {
+        let store = self.store;
+        let resolved_ty = ty.strip_refs().resolve_in(&self.env);
+        if resolved_ty.get_qualified_id().is_none() {
+            return;
+        }
+        let crate::checker::promotion::Resolution::Found(member) =
+            crate::checker::promotion::resolve_selector(store, &resolved_ty, impl_method_name)
+        else {
+            return;
+        };
+        let interface_comma_ok = method_comma_ok(store, interface_qualified_id, method_name);
+        let selected_comma_ok =
+            method_comma_ok(store, member.declaring_type.as_str(), impl_method_name);
+        let adapter_reconciles = adapter_capable && interface_comma_ok && !selected_comma_ok;
+        if interface_comma_ok != selected_comma_ok && !adapter_reconciles {
+            self.sink.push(diagnostics::embed::comma_ok_abi_mismatch(
+                &interface.name,
+                method_name,
+                *span,
+            ));
+        }
+    }
+
+    fn record_conformance_use(&mut self, ty: &Type, impl_method_name: &str) {
+        let store = self.store;
+        if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
+            && let Some(module) = store.module_for_qualified_name(id.as_str())
+            && let Some(type_name) = id.as_str().get(module.len() + 1..)
+            && !type_name.contains('.')
+        {
+            self.facts.mark_method_used_for_interface(
+                module.to_string(),
+                impl_method_name.to_string(),
+                type_name.to_string(),
+            );
+        }
+    }
+
     fn remove_first_param(ty: &Type) -> Type {
         match ty {
             Type::Function(f) => f.without_receiver(),
             _ => ty.clone(),
         }
     }
+}
+
+enum SelectedMethod {
+    Found(syntax::EcoString, Type),
+    UfcsOnly,
+    Missing,
+}
+
+struct SignatureCheck {
+    receiver_pinned: bool,
+    matched: bool,
+    substituted_method: Type,
+    incompatible_impl: Type,
+}
+
+fn method_definition_public(
+    store: &Store,
+    owner: &str,
+    method: &str,
+    seen: &mut rustc_hash::FxHashSet<String>,
+) -> Option<bool> {
+    if !seen.insert(owner.to_string()) {
+        return None;
+    }
+    if let Some(def) = store.get_definition(&format!("{owner}.{method}")) {
+        return Some(def.visibility.is_public());
+    }
+    let interface = store.get_interface(owner)?;
+    interface.parents.iter().find_map(|parent| {
+        method_definition_public(store, parent.get_qualified_name().as_str(), method, seen)
+    })
 }
 
 pub(crate) fn interface_requires_methods(store: &Store, id: &str) -> bool {

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -72,6 +72,30 @@ pub fn promoted_method_set(store: &Store, outer: &Type) -> MethodSignatures {
     result
 }
 
+/// Shallowest depth at which any field of `outer` emits `selector` as its Go name.
+pub fn field_selector_depth(store: &Store, outer: &Type, selector: &str) -> Option<usize> {
+    let mut min: Option<usize> = None;
+    for entry in walk(store, outer) {
+        let Some(id) = entry.ty.get_qualified_id() else {
+            continue;
+        };
+        let Some(definition) = store.get_definition(id) else {
+            continue;
+        };
+        let DefinitionBody::Struct { fields, .. } = &definition.body else {
+            continue;
+        };
+        let forces_export = definition.is_serialized();
+        let claimed = fields
+            .iter()
+            .any(|field| syntax::go_names::struct_field_go_name(field, forces_export) == selector);
+        if claimed && min.is_none_or(|m| entry.depth < m) {
+            min = Some(entry.depth);
+        }
+    }
+    min
+}
+
 #[derive(Clone)]
 struct Entry {
     ty: Type,

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -131,6 +131,16 @@ pub fn struct_attribute_forces_field_export(attribute: &crate::ast::Attribute) -
     is_serialization_key(&attribute.name)
 }
 
+pub fn field_attribute_forces_export(attribute: &crate::ast::Attribute) -> bool {
+    if attribute.name == "tag" {
+        return matches!(
+            attribute.args.first(),
+            Some(crate::ast::AttributeArg::String(_) | crate::ast::AttributeArg::Raw(_))
+        );
+    }
+    is_serialization_key(&attribute.name)
+}
+
 pub fn known_attribute_names() -> Vec<&'static str> {
     ATTRIBUTES.iter().map(|a| a.name).collect()
 }

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -3,6 +3,10 @@
 
 use std::borrow::Cow;
 
+use crate::EcoString;
+use crate::program::MethodSignatures;
+use crate::types::{GO_IMPORT_PREFIX, Type};
+
 /// Go reserved keywords that cannot be used as identifiers.
 /// See: https://go.dev/ref/spec#Keywords
 pub const GO_KEYWORDS: &[&str] = &[
@@ -128,6 +132,85 @@ pub fn escape_type_name(name: &str) -> Cow<'_, str> {
     }
 }
 
+/// Whether a struct field emits its camelized Go name.
+pub fn struct_field_is_exported(
+    field: &crate::ast::StructFieldDefinition,
+    struct_forces_export: bool,
+) -> bool {
+    !field.embedded
+        && (field.visibility.is_public()
+            || struct_forces_export
+            || field
+                .attributes
+                .iter()
+                .any(crate::attributes::field_attribute_forces_export))
+}
+
+/// A struct field's emitted Go name under the shared export policy.
+pub fn struct_field_go_name(
+    field: &crate::ast::StructFieldDefinition,
+    struct_forces_export: bool,
+) -> Cow<'_, str> {
+    if struct_field_is_exported(field, struct_forces_export) {
+        Cow::Owned(escape_keyword(&snake_to_camel(&field.name)).into_owned())
+    } else {
+        escape_keyword(&field.name)
+    }
+}
+
+/// A candidate method's standing, resolved by the caller on its declaring owner.
+#[derive(Clone)]
+pub struct ConformanceCandidate {
+    pub exported: bool,
+    pub depth: usize,
+    pub owner: Option<EcoString>,
+    pub shadowed: bool,
+}
+
+/// Resolve which implementing method satisfies an interface requirement, by
+/// emitted Go name under Go's selector rules.
+pub fn conformance_method<'a>(
+    methods: &'a MethodSignatures,
+    interface_id: &str,
+    interface_is_public: bool,
+    method_name: &str,
+    candidate: &dyn Fn(&str) -> ConformanceCandidate,
+) -> Option<(&'a EcoString, &'a Type)> {
+    let want = if interface_id.starts_with(GO_IMPORT_PREFIX) {
+        Cow::Borrowed(method_name)
+    } else if interface_id.starts_with("prelude.") || !interface_is_public {
+        return methods.get_key_value(method_name);
+    } else {
+        Cow::Owned(snake_to_camel(method_name))
+    };
+    let mut matches: Vec<(usize, bool, Option<EcoString>, &EcoString, &Type)> = Vec::new();
+    for (name, ty) in methods {
+        let exact = name == method_name;
+        let info = candidate(name);
+        if info.shadowed {
+            continue;
+        }
+        let emitted = if info.exported {
+            Cow::Owned(snake_to_camel(name))
+        } else {
+            Cow::Borrowed(name.as_str())
+        };
+        if !exact && emitted != *want {
+            continue;
+        }
+        matches.push((info.depth, exact, info.owner, name, ty));
+    }
+    let depth = matches.iter().map(|m| m.0).min()?;
+    matches.retain(|m| m.0 == depth);
+    if matches.iter().any(|m| m.2 != matches[0].2) {
+        return None;
+    }
+    matches
+        .into_iter()
+        .min_by_key(|(_, exact, _, name, _)| (!exact, (*name).clone()))
+        .map(|(_, _, _, name, ty)| (name, ty))
+}
+
 /// Go struct field name for an enum variant field. Emit's enum layout and
 /// the checker's cross-variant conflict check must both use this single
 /// authority so their notions of a field's Go name cannot drift.
@@ -222,6 +305,124 @@ mod tests {
             enum_field_go_name("Click", "go_string", 0, true, true, "Event"),
             "ClickGoString"
         );
+    }
+
+    fn exported_at(depth: usize) -> impl Fn(&str) -> ConformanceCandidate {
+        move |_| ConformanceCandidate {
+            exported: true,
+            depth,
+            owner: Some("main.T".into()),
+            shadowed: false,
+        }
+    }
+
+    const UNEXPORTED: fn(&str) -> ConformanceCandidate = |_| ConformanceCandidate {
+        exported: false,
+        depth: 0,
+        owner: Some("main.T".into()),
+        shadowed: false,
+    };
+
+    #[test]
+    fn conformance_method_matches_source_then_emitted_name() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("read".into(), Type::Error);
+        methods.insert("close".into(), Type::Error);
+
+        let via_emitted = conformance_method(&methods, "go:io", true, "Read", &exported_at(0));
+        assert_eq!(via_emitted.map(|(name, _)| name.as_str()), Some("read"));
+
+        let private_method = conformance_method(&methods, "go:io", true, "Read", &UNEXPORTED);
+        assert_eq!(private_method, None);
+
+        let initialism =
+            conformance_method(&methods, "go:net/http", true, "ServeHTTP", &exported_at(0));
+        assert_eq!(initialism, None);
+
+        methods.insert("Read".into(), Type::Error);
+        let via_source = conformance_method(&methods, "go:io", true, "Read", &UNEXPORTED);
+        assert_eq!(via_source.map(|(name, _)| name.as_str()), Some("Read"));
+    }
+
+    #[test]
+    fn conformance_method_prefers_shallow_over_exact() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("describe".into(), Type::Error);
+        methods.insert("Describe".into(), Type::Error);
+        let candidate = |name: &str| ConformanceCandidate {
+            exported: true,
+            depth: if name == "Describe" { 1 } else { 0 },
+            owner: Some(
+                if name == "Describe" {
+                    "main.Base"
+                } else {
+                    "main.Outer"
+                }
+                .into(),
+            ),
+            shadowed: false,
+        };
+
+        let shallow = conformance_method(&methods, "go:reg", true, "Describe", &candidate);
+        assert_eq!(shallow.map(|(name, _)| name.as_str()), Some("describe"));
+
+        let same_depth = conformance_method(&methods, "go:reg", true, "Describe", &exported_at(0));
+        assert_eq!(same_depth.map(|(name, _)| name.as_str()), Some("Describe"));
+    }
+
+    #[test]
+    fn conformance_method_rejects_equal_depth_cross_owner_ambiguity() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("get_item".into(), Type::Error);
+        methods.insert("getItem".into(), Type::Error);
+        let promoted = |name: &str| ConformanceCandidate {
+            exported: true,
+            depth: 1,
+            owner: Some(
+                if name == "get_item" {
+                    "main.A"
+                } else {
+                    "main.B"
+                }
+                .into(),
+            ),
+            shadowed: false,
+        };
+
+        let ambiguous = conformance_method(&methods, "go:reg", true, "GetItem", &promoted);
+        assert_eq!(ambiguous, None);
+    }
+
+    #[test]
+    fn conformance_method_skips_field_shadowed_candidates() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("getItem".into(), Type::Error);
+        let shadowed = |_: &str| ConformanceCandidate {
+            exported: true,
+            depth: 1,
+            owner: Some("main.Base".into()),
+            shadowed: true,
+        };
+
+        let hidden = conformance_method(&methods, "go:reg", true, "GetItem", &shadowed);
+        assert_eq!(hidden, None);
+    }
+
+    #[test]
+    fn conformance_method_gates_on_interface_kind() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("run".into(), Type::Error);
+
+        let public_lisette =
+            conformance_method(&methods, "main.Runner", true, "Run", &exported_at(0));
+        assert_eq!(public_lisette.map(|(name, _)| name.as_str()), Some("run"));
+
+        let private_lisette =
+            conformance_method(&methods, "main.Runner", false, "Run", &exported_at(0));
+        assert_eq!(private_lisette, None);
+
+        let prelude = conformance_method(&methods, "prelude.Runner", true, "Run", &exported_at(0));
+        assert_eq!(prelude, None);
     }
 
     #[test]

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -8861,3 +8861,161 @@ fn main() {
 
     assert_build_snapshot!(fs, "github.com/user/myproject");
 }
+
+#[test]
+fn snake_case_impl_satisfies_comma_ok_go_iface_via_adapter() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:crypto/tls"
+
+struct MyCache {}
+
+impl MyCache {
+  pub fn get(self, _key: string) -> Option<Ref<tls.ClientSessionState>> {
+    None
+  }
+  pub fn put(self, _key: string, _cs: Ref<tls.ClientSessionState>) {}
+}
+
+fn use_cache(_c: tls.ClientSessionCache) {}
+
+fn main() {
+  let c = MyCache {}
+  use_cache(c as tls.ClientSessionCache)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn snake_case_impl_satisfies_pascal_case_lisette_iface() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub interface Runner {
+  fn Run() -> int
+}
+
+struct Job {}
+
+impl Job {
+  pub fn run(self) -> int { 1 }
+}
+
+fn use_it(r: Runner) -> int { r.Run() }
+
+fn main() {
+  let _ = use_it(Job {})
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:crypto/tls"
+
+enum CacheKind { Mem }
+
+impl CacheKind {
+  pub fn get(self, _key: string) -> Option<Ref<tls.ClientSessionState>> {
+    None
+  }
+  pub fn put(self, _key: string, _cs: Ref<tls.ClientSessionState>) {}
+}
+
+fn use_cache(_c: tls.ClientSessionCache) {}
+
+fn main() {
+  use_cache(CacheKind.Mem as tls.ClientSessionCache)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn snake_case_alias_typed_value_gets_comma_ok_adapter() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:crypto/tls"
+
+pub struct CacheBase {}
+impl CacheBase {
+  pub fn get(self, _key: string) -> Option<Ref<tls.ClientSessionState>> {
+    None
+  }
+  pub fn put(self, _key: string, _cs: Ref<tls.ClientSessionState>) {}
+}
+pub type MyCache = CacheBase
+
+fn main() {
+  let c: MyCache = CacheBase {}
+  let _ = c as tls.ClientSessionCache
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn adapter_dedups_parent_methods_sharing_go_selector() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub struct Entry { pub name: string }
+
+pub interface ParentA {
+  #[go(comma_ok)]
+  fn get_item(key: string) -> Option<Ref<Entry>>
+}
+
+pub interface ParentB {
+  #[go(comma_ok)]
+  fn getItem(key: string) -> Option<Ref<Entry>>
+}
+
+pub interface Combined {
+  embed ParentA
+  embed ParentB
+}
+
+struct S {}
+impl S {
+  pub fn get_item(self, _key: string) -> Option<Ref<Entry>> { None }
+}
+
+fn main() {
+  let _ = S {} as Combined
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}

--- a/tests/spec/build/snapshots/adapter_dedups_parent_methods_sharing_go_selector.snap
+++ b/tests/spec/build/snapshots/adapter_dedups_parent_methods_sharing_go_selector.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Entry struct {
+	Name string
+}
+
+type ParentA interface {
+	GetItem(string) (*Entry, bool)
+}
+
+type ParentB interface {
+	GetItem(string) (*Entry, bool)
+}
+
+type Combined interface {
+	ParentA
+	ParentB
+}
+
+type S struct{}
+
+func (s S) GetItem(_ string) *Entry {
+	return nil
+}
+
+func main() {
+	_ = _lisAdapter_S_Combined_0{inner: S{}}
+}
+
+type _lisAdapter_S_Combined_0 struct {
+	inner S
+}
+
+func (a _lisAdapter_S_Combined_0) GetItem(arg0 string) (*Entry, bool) {
+	raw_1 := a.inner.GetItem(arg0)
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}

--- a/tests/spec/build/snapshots/snake_case_alias_typed_value_gets_comma_ok_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_alias_typed_value_gets_comma_ok_adapter.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"crypto/tls"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type CacheBase struct{}
+
+func (c CacheBase) Get(_ string) *tls.ClientSessionState {
+	return nil
+}
+
+func (c CacheBase) Put(_ string, _ *tls.ClientSessionState) {}
+
+type MyCache = CacheBase
+
+func main() {
+	c := CacheBase{}
+	_ = _lisAdapter_CacheBase_ClientSessionCache_0{inner: c}
+}
+
+type _lisAdapter_CacheBase_ClientSessionCache_0 struct {
+	inner MyCache
+}
+
+func (a _lisAdapter_CacheBase_ClientSessionCache_0) Put(arg0 string, arg1 *tls.ClientSessionState) {
+	a.inner.Put(arg0, arg1)
+}
+
+func (a _lisAdapter_CacheBase_ClientSessionCache_0) Get(arg0 string) (*tls.ClientSessionState, bool) {
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*tls.ClientSessionState](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}

--- a/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
@@ -1,0 +1,53 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"crypto/tls"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func MakeCacheKindMem() CacheKind {
+	return CacheKind{Tag: CacheKindMem}
+}
+
+type CacheKindTag int
+
+const (
+	CacheKindMem CacheKindTag = iota
+)
+
+type CacheKind struct {
+	Tag CacheKindTag
+}
+
+func (c CacheKind) Get(_ string) *tls.ClientSessionState {
+	return nil
+}
+
+func (c CacheKind) Put(_ string, _ *tls.ClientSessionState) {}
+
+func use_cache(_ tls.ClientSessionCache) {}
+
+func main() {
+	use_cache(_lisAdapter_CacheKind_ClientSessionCache_0{inner: MakeCacheKindMem()})
+}
+
+type _lisAdapter_CacheKind_ClientSessionCache_0 struct {
+	inner CacheKind
+}
+
+func (a _lisAdapter_CacheKind_ClientSessionCache_0) Put(arg0 string, arg1 *tls.ClientSessionState) {
+	a.inner.Put(arg0, arg1)
+}
+
+func (a _lisAdapter_CacheKind_ClientSessionCache_0) Get(arg0 string) (*tls.ClientSessionState, bool) {
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*tls.ClientSessionState](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}

--- a/tests/spec/build/snapshots/snake_case_impl_satisfies_comma_ok_go_iface_via_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_impl_satisfies_comma_ok_go_iface_via_adapter.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"crypto/tls"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type MyCache struct{}
+
+func (m MyCache) Get(_ string) *tls.ClientSessionState {
+	return nil
+}
+
+func (m MyCache) Put(_ string, _ *tls.ClientSessionState) {}
+
+func use_cache(_ tls.ClientSessionCache) {}
+
+func main() {
+	c := MyCache{}
+	use_cache(_lisAdapter_MyCache_ClientSessionCache_0{inner: c})
+}
+
+type _lisAdapter_MyCache_ClientSessionCache_0 struct {
+	inner MyCache
+}
+
+func (a _lisAdapter_MyCache_ClientSessionCache_0) Put(arg0 string, arg1 *tls.ClientSessionState) {
+	a.inner.Put(arg0, arg1)
+}
+
+func (a _lisAdapter_MyCache_ClientSessionCache_0) Get(arg0 string) (*tls.ClientSessionState, bool) {
+	raw_1 := a.inner.Get(arg0)
+	option_2 := lisette.OptionFromNilable[*tls.ClientSessionState](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}

--- a/tests/spec/build/snapshots/snake_case_impl_satisfies_pascal_case_lisette_iface.snap
+++ b/tests/spec/build/snapshots/snake_case_impl_satisfies_pascal_case_lisette_iface.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+type Runner interface {
+	Run() int
+}
+
+type Job struct{}
+
+func (j Job) Run() int {
+	return 1
+}
+
+func use_it(r Runner) int {
+	return r.Run()
+}
+
+func main() {
+	_ = use_it(Job{})
+}

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -9195,3 +9195,675 @@ fn baz(value: Bar) {
 
     infer_module("main", fs).assert_no_errors();
 }
+
+#[test]
+fn snake_case_method_satisfies_go_interface() {
+    let typedef = r#"
+pub struct Widget { pub id: int }
+
+pub interface HasWidget {
+  fn GetWidget() -> Ref<Widget>
+}
+"#;
+    let input = r#"
+import "go:example.com/ui"
+
+struct MyBox { value: ui.Widget }
+
+impl MyBox {
+  pub fn get_widget(self: Ref<MyBox>) -> Ref<ui.Widget> { &self.value }
+}
+
+fn use_it(_: ui.HasWidget) {}
+
+fn main() {
+  let b = MyBox { value: ui.Widget { id: 0 } }
+  use_it(&b)
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/ui", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn private_snake_case_method_does_not_satisfy_go_interface() {
+    let typedef = r#"
+pub struct Widget { pub id: int }
+
+pub interface HasWidget {
+  fn GetWidget() -> Ref<Widget>
+}
+"#;
+    let input = r#"
+import "go:example.com/ui"
+
+struct MyBox { value: ui.Widget }
+
+impl MyBox {
+  fn get_widget(self: Ref<MyBox>) -> Ref<ui.Widget> { &self.value }
+}
+
+fn use_it(_: ui.HasWidget) {}
+
+fn main() {
+  let b = MyBox { value: ui.Widget { id: 0 } }
+  use_it(&b)
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/ui", typedef)])
+        .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn snake_case_method_satisfies_pascal_case_lisette_interface() {
+    infer(
+        r#"
+    pub interface Runner {
+      fn Run() -> int;
+    }
+
+    struct Job {}
+
+    impl Job {
+      pub fn run(self) -> int { 1 }
+    }
+
+    fn use_it(_: Runner) {}
+
+    fn main() {
+      use_it(Job {});
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn pascal_case_method_satisfies_snake_case_public_interface() {
+    infer(
+        r#"
+    pub interface Runner {
+      fn run() -> int;
+    }
+
+    struct Job {}
+
+    impl Job {
+      pub fn Run(self) -> int { 1 }
+    }
+
+    fn use_it(_: Runner) {}
+
+    fn main() {
+      use_it(Job {});
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn private_lisette_interface_requires_source_name_match() {
+    infer(
+        r#"
+    interface Runner {
+      fn Run() -> int;
+    }
+
+    struct Job {}
+
+    impl Job {
+      pub fn run(self) -> int { 1 }
+    }
+
+    fn use_it(_: Runner) {}
+
+    fn main() {
+      use_it(Job {});
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn initialism_method_does_not_satisfy_go_interface() {
+    let typedef = r#"
+pub interface Handler {
+  fn ServeHTTP(code: int)
+}
+"#;
+    let input = r#"
+import "go:example.com/web"
+
+struct MyHandler {}
+
+impl MyHandler {
+  pub fn serve_http(self, _code: int) {}
+}
+
+fn use_it(_: web.Handler) {}
+
+fn main() {
+  use_it(MyHandler {})
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/web", typedef)])
+        .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn snake_case_pointer_receiver_method_rejected_for_value_coercion() {
+    let typedef = r#"
+pub struct Widget { pub id: int }
+
+pub interface HasWidget {
+  fn GetWidget() -> Ref<Widget>
+}
+"#;
+    let input = r#"
+import "go:example.com/ui"
+
+struct MyBox { value: ui.Widget }
+
+impl MyBox {
+  pub fn get_widget(self: Ref<MyBox>) -> Ref<ui.Widget> { &self.value }
+}
+
+fn use_it(_: ui.HasWidget) {}
+
+fn main() {
+  let b = MyBox { value: ui.Widget { id: 0 } }
+  use_it(b)
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/ui", typedef)])
+        .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn snake_case_method_satisfies_comma_ok_go_interface() {
+    let typedef = r#"
+pub struct Session { pub key: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Session>>
+}
+"#;
+    let input = r#"
+import "go:example.com/cache"
+
+struct MyCache {}
+
+impl MyCache {
+  pub fn get(self: Ref<MyCache>, key: string) -> Option<Ref<cache.Session>> { None }
+}
+
+fn use_it(_: cache.Cache) {}
+
+fn main() { use_it(&MyCache {}) }
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn exact_source_name_match_preferred_over_emitted_match() {
+    infer(
+        r#"
+    pub interface Runner {
+      fn Run() -> int;
+    }
+
+    struct Job {}
+
+    impl Job {
+      pub fn Run(self) -> int { 1 }
+      pub fn run(self) -> int { 2 }
+    }
+
+    fn use_it(_: Runner) {}
+
+    fn main() {
+      use_it(Job {});
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn promoted_snake_case_method_satisfies_go_interface() {
+    let typedef = r#"
+pub interface Named {
+  fn Describe() -> string
+}
+"#;
+    let input = r#"
+import "go:example.com/reg"
+
+pub struct Base {}
+impl Base {
+  pub fn describe(self) -> string { "base" }
+}
+struct Outer { embed Base }
+
+fn use_it(_: reg.Named) {}
+
+fn main() {
+  use_it(Outer { Base: Base {} })
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/reg", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn promoted_private_snake_case_method_does_not_satisfy_go_interface() {
+    let typedef = r#"
+pub interface Named {
+  fn Describe() -> string
+}
+"#;
+    let input = r#"
+import "go:example.com/reg"
+
+pub struct Base {}
+impl Base {
+  fn describe(self) -> string { "base" }
+}
+struct Outer { embed Base }
+
+fn use_it(_: reg.Named) {}
+
+fn main() {
+  use_it(Outer { Base: Base {} })
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/reg", typedef)])
+        .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn promoted_snake_case_method_rejected_for_comma_ok_go_interface() {
+    let typedef = r#"
+pub struct Session { pub key: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Session>>
+}
+"#;
+    let input = r#"
+import "go:example.com/cache"
+
+pub struct Base {}
+impl Base {
+  pub fn get(self, _key: string) -> Option<Ref<cache.Session>> { None }
+}
+struct Outer { embed Base }
+
+fn main() {
+  let _ = Outer { Base: Base {} } as cache.Cache
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)])
+        .assert_infer_code("comma_ok_abi_mismatch");
+}
+
+#[test]
+fn aliased_receiver_snake_case_method_satisfies_go_interface() {
+    let typedef = r#"
+pub interface Named {
+  fn Describe() -> string
+}
+"#;
+    let input = r#"
+import "go:example.com/reg"
+
+pub struct Base {}
+impl Base {
+  pub fn describe(self) -> string { "base" }
+}
+pub type Wrap = Base
+
+fn use_it(_: reg.Named) {}
+
+fn main() {
+  let w: Wrap = Base {}
+  use_it(w)
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/reg", typedef)]).assert_no_errors();
+}
+
+#[test]
+fn direct_snake_case_method_shadows_promoted_pascal_case() {
+    infer(
+        r#"
+    pub struct Base {}
+    impl Base {
+      pub fn Describe(self) -> int { 1 }
+    }
+    struct Outer { embed Base }
+    impl Outer {
+      pub fn describe(self) -> string { "outer" }
+    }
+    pub interface Named {
+      fn Describe() -> string
+    }
+    fn use_it(n: Named) -> string { n.Describe() }
+    fn main() {
+      let _ = use_it(Outer { Base: Base {} })
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn shadowing_direct_method_rejected_when_incompatible() {
+    infer(
+        r#"
+    pub struct Base {}
+    impl Base {
+      pub fn Describe(self) -> string { "base" }
+    }
+    struct Outer { embed Base }
+    impl Outer {
+      pub fn describe(self) -> int { 1 }
+    }
+    pub interface Named {
+      fn Describe() -> string
+    }
+    fn use_it(_n: Named) {}
+    fn main() {
+      use_it(Outer { Base: Base {} })
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn interface_value_rejected_for_comma_ok_go_interface() {
+    let typedef = r#"
+pub struct Session { pub key: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Session>>
+}
+"#;
+    let input = r#"
+import "go:example.com/cache"
+
+pub interface MyCache {
+  fn Get(key: string) -> Option<Ref<cache.Session>>
+}
+
+fn coerce(c: MyCache) {
+  let _ = c as cache.Cache
+}
+
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)])
+        .assert_infer_code("comma_ok_abi_mismatch");
+}
+
+#[test]
+fn mixed_promoted_method_rejected_for_comma_ok_go_interface() {
+    let typedef = r#"
+pub struct Session { pub key: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Session>>
+  fn Put(key: string, s: Ref<Session>)
+}
+"#;
+    let input = r#"
+import "go:example.com/cache"
+
+pub struct Base {}
+impl Base {
+  pub fn put(self, _key: string, _s: Ref<cache.Session>) {}
+}
+struct S { embed Base }
+impl S {
+  pub fn get(self, _key: string) -> Option<Ref<cache.Session>> { None }
+}
+
+fn main() {
+  let _ = S { Base: Base {} } as cache.Cache
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)])
+        .assert_infer_code("comma_ok_abi_mismatch");
+}
+
+#[test]
+fn interface_value_rejected_for_user_comma_ok_interface() {
+    infer(
+        r#"
+    pub struct Entry { pub name: string }
+    pub interface Cache {
+      #[go(comma_ok)]
+      fn Get(key: string) -> Option<Ref<Entry>>
+    }
+    pub interface Impl {
+      fn Get(key: string) -> Option<Ref<Entry>>
+    }
+    fn coerce(i: Impl) {
+      let _ = i as Cache
+    }
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code("comma_ok_abi_mismatch");
+}
+
+#[test]
+fn inherited_interface_method_satisfies_pascal_case_requirement() {
+    infer(
+        r#"
+    pub interface Parent {
+      fn describe() -> string
+    }
+    pub interface Child {
+      embed Parent
+    }
+    pub interface Named {
+      fn Describe() -> string
+    }
+    fn coerce(c: Child) {
+      let _ = c as Named
+    }
+    fn main() {}
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn bounded_parameter_snake_case_bound_method_satisfies_pascal_requirement() {
+    infer(
+        r#"
+    pub interface Describer {
+      fn describe() -> string
+    }
+    pub interface Named {
+      fn Describe() -> string
+    }
+    fn needs_named<T: Named>(_v: T) {}
+    fn outer<U: Describer>(v: U) {
+      needs_named(v)
+    }
+    fn main() {}
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn equal_depth_promoted_go_name_ambiguity_rejected() {
+    infer(
+        r#"
+    pub struct A {}
+    impl A {
+      pub fn get_item(self) -> string { "a" }
+    }
+    pub struct B {}
+    impl B {
+      pub fn getItem(self) -> string { "b" }
+    }
+    struct Outer { embed A, embed B }
+    pub interface Getter {
+      fn GetItem() -> string
+    }
+    fn use_it(_g: Getter) {}
+    fn main() {
+      use_it(Outer { A: A {}, B: B {} })
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn field_claiming_go_selector_shadows_promoted_method() {
+    infer(
+        r#"
+    pub struct Base {}
+    impl Base {
+      pub fn getItem(self) -> string { "base" }
+    }
+    struct Outer { embed Base, pub get_item: string }
+    pub interface Getter {
+      fn GetItem() -> string
+    }
+    fn use_it(_g: Getter) {}
+    fn main() {
+      use_it(Outer { Base: Base {}, get_item: "f" })
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn promoted_field_selector_shadows_promoted_method() {
+    infer(
+        r#"
+    pub struct FieldSide { pub get_item: string }
+    pub struct MethodSide {}
+    impl MethodSide {
+      pub fn getItem(self) -> string { "m" }
+    }
+    struct Outer { embed FieldSide, embed MethodSide }
+    pub interface Getter {
+      fn GetItem() -> string
+    }
+    fn use_it(_g: Getter) {}
+    fn main() {
+      use_it(Outer { FieldSide: FieldSide { get_item: "f" }, MethodSide: MethodSide {} })
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn serialized_field_export_shadows_promoted_method() {
+    infer(
+        r#"
+    #[json]
+    pub struct FieldSide { get_item: string }
+    pub struct MethodSide {}
+    impl MethodSide {
+      pub fn getItem(self) -> string { "m" }
+    }
+    struct Outer { embed FieldSide, embed MethodSide }
+    pub interface Getter {
+      fn GetItem() -> string
+    }
+    fn use_it(_g: Getter) {}
+    fn main() {
+      use_it(Outer { FieldSide: FieldSide { get_item: "f" }, MethodSide: MethodSide {} })
+    }
+        "#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
+fn constraint_intersection_merges_shared_go_selector() {
+    infer(
+        r#"
+    pub interface A {
+      fn get_item() -> string
+    }
+    pub interface B {
+      fn getItem() -> string
+    }
+    pub interface Getter {
+      fn GetItem() -> string
+    }
+    fn needs_getter<T: Getter>(_v: T) {}
+    fn outer<U: A + B>(v: U) {
+      needs_getter(v)
+    }
+    fn main() {}
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_receiver_method_wins_over_specialized_ufcs_selector() {
+    infer(
+        r#"
+    pub struct Box<T> { pub value: T }
+    impl Box<int> {
+      pub fn Describe(self) -> string { "int box" }
+    }
+    impl<T> Box<T> {
+      pub fn describe(self) -> string { "any box" }
+    }
+    pub interface Named {
+      fn Describe() -> string
+    }
+    fn use_it(n: Named) -> string { n.Describe() }
+    fn main() {
+      let _ = use_it(Box { value: 1 })
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn comma_ok_interface_value_rejected_for_plain_user_interface() {
+    let typedef = r#"
+pub struct Session { pub key: string }
+
+pub interface Cache {
+  #[go(comma_ok)]
+  fn Get(key: string) -> Option<Ref<Session>>
+}
+"#;
+    let input = r#"
+import "go:example.com/cache"
+
+pub interface Plain {
+  fn Get(key: string) -> Option<Ref<cache.Session>>
+}
+
+fn coerce(c: cache.Cache) {
+  let _ = c as Plain
+}
+
+fn main() {}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)])
+        .assert_infer_code("comma_ok_abi_mismatch");
+}


### PR DESCRIPTION
Interface satisfaction now matches methods by the Go name they emit (i.e. the name the Go compiler checks) instead of by their Lis source spelling. Selection follows Go's rules: exact spellings win, shallower embedded methods beat deeper ones, and fields shadow methods.

```rust
import "go:io"

struct File { ... }

impl File {
  pub fn read(self, p: Slice<byte>) -> Result<int, error> { ... } // emits Read
}

fn consume(r: io.Reader) { ... }

fn main() {
  consume(File { ... }) // now works, previously required `fn Read` in Lis source
}
```

PascalCase conformance keeps working as usual. Initialism names do not round-trip (`serve_http` → `ServeHttp`), so interfaces such as `http.Handler` still take the `ServeHTTP` spelling.