### PR TITLE
feat: flag safe-to-rename interface-satisfying methods

### DIFF
--- a/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
@@ -183,7 +183,7 @@ fn go_method_name_exempt(
     if let Some(type_name) = impl_type
         && ctx
             .facts
-            .method_satisfies_interface(ctx.module_id, name, type_name)
+            .method_spelling_pinned_by_interface(ctx.module_id, name, type_name)
     {
         return true;
     }
@@ -195,7 +195,7 @@ fn go_method_name_exempt(
 }
 
 fn is_builtin_interface_method(name: &str) -> bool {
-    matches!(name, "Error" | "String")
+    name == "Error"
 }
 
 fn check_type_parameter(generic: &Generic, sink: &LocalSink) {

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -174,13 +174,13 @@ fn run_ref_lints(
         }
     }
 
-    for ((method_module_id, method_name), impl_types) in &facts.interface_satisfied_methods {
+    for ((method_module_id, method_name), satisfactions) in &facts.interface_satisfied_methods {
         if method_module_id != &module.id {
             continue;
         }
         if method_name == "equals" {
-            for type_name in impl_types {
-                graph.mark_as_used(ModuleItemId::equals_method(type_name));
+            for satisfaction in satisfactions {
+                graph.mark_as_used(ModuleItemId::equals_method(&satisfaction.impl_type_name));
             }
         } else {
             graph.mark_as_used(ModuleItemId::new(method_name));

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -586,7 +586,11 @@ impl InferCtx<'_, '_> {
                     check.incompatible_impl,
                 ));
             } else {
-                self.record_conformance_use(ty, impl_method_name.as_str());
+                let spelling_pinned = syntax::go_names::interface_matches_by_source_name(
+                    interface_qualified_id,
+                    interface_is_public,
+                );
+                self.record_conformance_use(ty, impl_method_name.as_str(), spelling_pinned);
             }
         }
 
@@ -760,7 +764,7 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    fn record_conformance_use(&mut self, ty: &Type, impl_method_name: &str) {
+    fn record_conformance_use(&mut self, ty: &Type, impl_method_name: &str, spelling_pinned: bool) {
         let store = self.store;
         if let Type::Nominal { id, .. } = ty.strip_refs().resolve_in(&self.env)
             && let Some(module) = store.module_for_qualified_name(id.as_str())
@@ -771,6 +775,7 @@ impl InferCtx<'_, '_> {
                 module.to_string(),
                 impl_method_name.to_string(),
                 type_name.to_string(),
+                spelling_pinned,
             );
         }
     }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -47,7 +47,7 @@ pub struct Facts {
     pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
-    pub interface_satisfied_methods: HashMap<(String, String), Vec<String>>,
+    pub interface_satisfied_methods: HashMap<(String, String), Vec<InterfaceSatisfaction>>,
     pub equality_derivations: Vec<String>,
     pub test_functions: Vec<TestFunction>,
 
@@ -84,6 +84,13 @@ pub struct Facts {
     /// Canonical definition selected for resolved dot accesses, keyed by the
     /// dot expression's span.
     pub resolved_definitions: ResolvedDefinitions,
+}
+
+#[derive(Debug, Clone)]
+pub struct InterfaceSatisfaction {
+    pub impl_type_name: String,
+    /// The interface matches by source spelling, so renaming breaks it.
+    pub spelling_pinned: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -286,16 +293,20 @@ impl Facts {
         module_id: String,
         method_name: String,
         impl_type_name: String,
+        spelling_pinned: bool,
     ) {
         self.interface_satisfied_methods
             .entry((module_id, method_name))
             .or_default()
-            .push(impl_type_name);
+            .push(InterfaceSatisfaction {
+                impl_type_name,
+                spelling_pinned,
+            });
     }
 
-    /// Whether `type_name`'s `method_name` was found to satisfy an interface method,
-    /// so the naming lint keeps its conformance-required spelling.
-    pub fn method_satisfies_interface(
+    /// Whether `type_name`'s `method_name` satisfies an interface that matches
+    /// by source spelling, so the naming lint must not suggest a rename.
+    pub fn method_spelling_pinned_by_interface(
         &self,
         module_id: &str,
         method_name: &str,
@@ -303,7 +314,11 @@ impl Facts {
     ) -> bool {
         self.interface_satisfied_methods
             .get(&(module_id.to_string(), method_name.to_string()))
-            .is_some_and(|types| types.iter().any(|t| t == type_name))
+            .is_some_and(|satisfactions| {
+                satisfactions
+                    .iter()
+                    .any(|s| s.spelling_pinned && s.impl_type_name == type_name)
+            })
     }
 
     pub fn absorb_local_facts(&mut self, local: LocalFacts) {
@@ -638,9 +653,9 @@ mod tests {
         let mut a = Facts::new(allocator.clone());
         let mut b = Facts::new(allocator);
 
-        a.mark_method_used_for_interface("m".into(), "f".into(), "A".into());
-        b.mark_method_used_for_interface("m".into(), "f".into(), "B".into());
-        b.mark_method_used_for_interface("m".into(), "g".into(), "C".into());
+        a.mark_method_used_for_interface("m".into(), "f".into(), "A".into(), true);
+        b.mark_method_used_for_interface("m".into(), "f".into(), "B".into(), false);
+        b.mark_method_used_for_interface("m".into(), "g".into(), "C".into(), true);
 
         a.merge(b);
         assert_eq!(a.interface_satisfied_methods.len(), 2);

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -167,6 +167,13 @@ pub struct ConformanceCandidate {
     pub shadowed: bool,
 }
 
+/// Whether an interface's requirements match implementations by exact source
+/// spelling rather than by emitted Go name.
+pub fn interface_matches_by_source_name(interface_id: &str, interface_is_public: bool) -> bool {
+    !interface_id.starts_with(GO_IMPORT_PREFIX)
+        && (interface_id.starts_with("prelude.") || !interface_is_public)
+}
+
 /// Resolve which implementing method satisfies an interface requirement, by
 /// emitted Go name under Go's selector rules.
 pub fn conformance_method<'a>(
@@ -176,10 +183,11 @@ pub fn conformance_method<'a>(
     method_name: &str,
     candidate: &dyn Fn(&str) -> ConformanceCandidate,
 ) -> Option<(&'a EcoString, &'a Type)> {
+    if interface_matches_by_source_name(interface_id, interface_is_public) {
+        return methods.get_key_value(method_name);
+    }
     let want = if interface_id.starts_with(GO_IMPORT_PREFIX) {
         Cow::Borrowed(method_name)
-    } else if interface_id.starts_with("prelude.") || !interface_is_public {
-        return methods.get_key_value(method_name);
     } else {
         Cow::Owned(snake_to_camel(method_name))
     };

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -11287,8 +11287,8 @@ fn main() {
 }
 
 #[test]
-fn interface_method_pascal_case_no_warning() {
-    assert_no_lint_warnings!(
+fn interface_string_method_warns() {
+    assert_lint_snapshot!(
         r#"
 pub interface Stringer {
   fn String() -> string
@@ -11353,7 +11353,6 @@ fn builtin_interface_method_names_no_warning() {
     assert_no_lint_warnings!(
         r#"
 pub interface Printable {
-  fn String() -> string
   fn Error() -> string
 }
 "#
@@ -11392,8 +11391,8 @@ fn main() {
 }
 
 #[test]
-fn pub_impl_method_satisfying_go_interface_no_warning() {
-    assert_no_lint_warnings!(
+fn pub_impl_method_satisfying_go_interface_warns() {
+    assert_lint_snapshot!(
         r#"
 import "go:encoding"
 
@@ -11408,6 +11407,71 @@ impl Widget {
 fn main() {
   let w = Widget {}
   let _: encoding.TextMarshaler = w
+}
+"#
+    );
+}
+
+#[test]
+fn snake_case_method_satisfying_go_interface_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:encoding"
+
+pub struct Widget {}
+
+impl Widget {
+  pub fn marshal_text(self) -> Result<Slice<byte>, error> {
+    Ok("custom" as Slice<byte>)
+  }
+}
+
+fn main() {
+  let w = Widget {}
+  let _: encoding.TextMarshaler = w
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_method_satisfying_public_interface_warns() {
+    assert_lint_snapshot!(
+        r#"
+pub interface Runner {
+  fn run() -> int
+}
+
+pub struct Job {}
+
+impl Job {
+  pub fn Run(self) -> int { 1 }
+}
+
+fn use_it(r: Runner) -> int { r.run() }
+
+fn main() {
+  let _ = use_it(Job {})
+}
+"#
+    );
+}
+
+#[test]
+fn pub_impl_string_method_satisfying_stringer_warns() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+pub struct Point { pub x: int }
+
+impl Point {
+  pub fn String(self) -> string { "point" }
+}
+
+fn main() {
+  let p = Point { x: 1 }
+  let _: fmt.Stringer = p
 }
 "#
     );

--- a/tests/ui/lint/snapshots/interface_string_method_warns.snap
+++ b/tests/ui/lint/snapshots/interface_string_method_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:3:6]
+ 2 │ pub interface Stringer {
+ 3 │   fn String() -> string
+   ·      ───┬──
+   ·         ╰── expected snake_case
+ 4 │ }
+   ╰────
+  help: Rename to `string` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/pub_impl_method_satisfying_go_interface_warns.snap
+++ b/tests/ui/lint/snapshots/pub_impl_method_satisfying_go_interface_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:7:10]
+ 6 │ impl Widget {
+ 7 │   pub fn MarshalText(self) -> Result<Slice<byte>, error> {
+   ·          ─────┬─────
+   ·               ╰── expected snake_case
+ 8 │     Ok("custom" as Slice<byte>)
+   ╰────
+  help: Rename to `marshal_text` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/pub_impl_method_satisfying_public_interface_warns.snap
+++ b/tests/ui/lint/snapshots/pub_impl_method_satisfying_public_interface_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+    ╭─[test.lis:9:10]
+  8 │ impl Job {
+  9 │   pub fn Run(self) -> int { 1 }
+    ·          ─┬─
+    ·           ╰── expected snake_case
+ 10 │ }
+    ╰────
+  help: Rename to `run` · code: [lint.non_snake_case_function]

--- a/tests/ui/lint/snapshots/pub_impl_string_method_satisfying_stringer_warns.snap
+++ b/tests/ui/lint/snapshots/pub_impl_string_method_satisfying_stringer_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Miscased name
+   ╭─[test.lis:7:10]
+ 6 │ impl Point {
+ 7 │   pub fn String(self) -> string { "point" }
+   ·          ───┬──
+   ·             ╰── expected snake_case
+ 8 │ }
+   ╰────
+  help: Rename to `string` · code: [lint.non_snake_case_function]


### PR DESCRIPTION
The naming lint now flags PascalCase methods that satisfy Go or public Lisette interfaces. Before, every interface-satisfying method was exempt from the lint because a rename would have silently broken satisfaction. This blanket exemption was keeping PascalCase spellings unflagged even where the idiomatic name works.

```rs
import "go:fmt"

pub struct Point { pub x: int }

impl Point {
  pub fn String(self) -> string { "point" } // now warns: rename to `string`
}

fn main() {
  let _: fmt.Stringer = Point { x: 1 } // still satisfied after the rename
}
```

Follow-up to #1092