### PR TITLE
refactor: simplify inference flows

### DIFF
--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -6,6 +6,7 @@ use diagnostics::SemanticResult;
 use syntax::program::{ModuleInfo, MutationInfo, UnusedInfo};
 
 use semantics::cache::{EmitStamp, compute_emit_artifact_hash, save_module_cache};
+use semantics::facts::BindingMutation;
 use semantics::facts::Facts;
 use semantics::inference::AnalyzeInput;
 use semantics::inference::{InferenceOutput, PARALLEL_THRESHOLD, run_inference};
@@ -49,10 +50,12 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
     }
     let mut mutations = MutationInfo::default();
     for (&binding_id, b) in facts.bindings.iter() {
-        if b.alias_mutated {
-            mutations.mark_binding_alias_mutated(binding_id);
-        } else if b.mutated {
-            mutations.mark_binding_mutated(binding_id);
+        match b.mutation {
+            BindingMutation::Unchanged => {}
+            BindingMutation::Direct => mutations.mark_binding_mutated(binding_id),
+            BindingMutation::ThroughAlias => {
+                mutations.mark_binding_alias_mutated(binding_id);
+            }
         }
     }
 

--- a/crates/passes/src/passes/checks/unchanging_loop_condition.rs
+++ b/crates/passes/src/passes/checks/unchanging_loop_condition.rs
@@ -45,7 +45,7 @@ fn is_invariant(
             binding_id: Some(id),
             ..
         } => match bindings.get(id) {
-            Some(fact) if !fact.mutated => {
+            Some(fact) if !fact.mutation.happened() => {
                 *references_binding = true;
                 true
             }

--- a/crates/passes/src/passes/fact_producers/generics.rs
+++ b/crates/passes/src/passes/fact_producers/generics.rs
@@ -1,21 +1,21 @@
 //! Generic-parameter fact producers for the lint layer.
 //!
-//! Records facts via `LocalFacts`; rendering happens later in `lints::from_facts`.
+//! Records facts for later rendering by `lints::from_facts`.
 
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Annotation, Binding, Expression, Generic};
 use syntax::types::Type;
 
-use semantics::facts::LocalFacts;
+use super::ProducedFacts;
 
-pub(crate) fn run(typed_ast: &[Expression], local: &mut LocalFacts) {
+pub(crate) fn run(typed_ast: &[Expression], local: &mut ProducedFacts) {
     for item in typed_ast {
         visit_expression(item, local);
     }
 }
 
-fn visit_expression(expression: &Expression, local: &mut LocalFacts) {
+fn visit_expression(expression: &Expression, local: &mut ProducedFacts) {
     match expression {
         Expression::ImplBlock { methods, .. } => {
             for method in methods {
@@ -62,7 +62,7 @@ fn check_unused_type_parameters(
     params: &[Binding],
     return_type: &Type,
     found_in_body: &HashSet<EcoString>,
-    local: &mut LocalFacts,
+    local: &mut ProducedFacts,
 ) {
     let mut remaining: HashSet<EcoString> = generics.iter().map(|g| g.name.clone()).collect();
     for param in params {
@@ -92,7 +92,7 @@ fn check_type_params_only_in_bound(
     params: &[Binding],
     return_type: &Type,
     found_in_body: &HashSet<EcoString>,
-    local: &mut LocalFacts,
+    local: &mut ProducedFacts,
 ) {
     if generics.iter().all(|g| g.bounds.is_empty()) {
         return;

--- a/crates/passes/src/passes/fact_producers/mod.rs
+++ b/crates/passes/src/passes/fact_producers/mod.rs
@@ -1,16 +1,78 @@
 mod generics;
 mod unused_expressions;
 
+use diagnostics::UnusedExpressionKind;
 use rayon::prelude::*;
 use std::sync::Arc;
+use syntax::ast::Span;
 use syntax::program::{File, Module};
 
 use semantics::context::AnalysisContext;
-use semantics::facts::LocalFacts;
 
 use super::PARALLEL_THRESHOLD;
 
-pub(crate) fn run_all(analysis: &AnalysisContext) -> LocalFacts {
+#[derive(Debug, Default)]
+pub(crate) struct ProducedFacts {
+    pub(crate) items: Vec<ProducedFact>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ProducedFact {
+    UnusedExpression {
+        span: Span,
+        kind: UnusedExpressionKind,
+    },
+    DiscardedTail {
+        span: Span,
+        return_type: String,
+        expected_span: Span,
+        expected_type: String,
+    },
+    UnusedTypeParam {
+        span: Span,
+    },
+    TypeParamOnlyInBound {
+        name: String,
+        span: Span,
+    },
+}
+
+impl ProducedFacts {
+    fn merge(&mut self, other: Self) {
+        self.items.extend(other.items);
+    }
+
+    pub(super) fn add_unused_expression(&mut self, span: Span, kind: UnusedExpressionKind) {
+        self.items
+            .push(ProducedFact::UnusedExpression { span, kind });
+    }
+
+    pub(super) fn add_discarded_tail(
+        &mut self,
+        span: Span,
+        return_type: String,
+        expected_span: Span,
+        expected_type: String,
+    ) {
+        self.items.push(ProducedFact::DiscardedTail {
+            span,
+            return_type,
+            expected_span,
+            expected_type,
+        });
+    }
+
+    pub(super) fn add_unused_type_param(&mut self, span: Span) {
+        self.items.push(ProducedFact::UnusedTypeParam { span });
+    }
+
+    pub(super) fn add_type_param_only_in_bound(&mut self, name: String, span: Span) {
+        self.items
+            .push(ProducedFact::TypeParamOnlyInBound { name, span });
+    }
+}
+
+pub(crate) fn run_all(analysis: &AnalysisContext) -> ProducedFacts {
     let store = analysis.store;
 
     let mut work: Vec<(&Module, &File)> = store
@@ -27,7 +89,7 @@ pub(crate) fn run_all(analysis: &AnalysisContext) -> LocalFacts {
     });
 
     if work.len() < PARALLEL_THRESHOLD {
-        let mut local = LocalFacts::default();
+        let mut local = ProducedFacts::default();
         for (module, file) in &work {
             generics::run(&file.items, &mut local);
             unused_expressions::run(&file.items, &module.id, store, &mut local);
@@ -35,17 +97,17 @@ pub(crate) fn run_all(analysis: &AnalysisContext) -> LocalFacts {
         return local;
     }
 
-    let locals: Vec<LocalFacts> = work
+    let locals: Vec<ProducedFacts> = work
         .par_iter()
         .map(|(module, file)| {
-            let mut local = LocalFacts::default();
+            let mut local = ProducedFacts::default();
             generics::run(&file.items, &mut local);
             unused_expressions::run(&file.items, &module.id, store, &mut local);
             local
         })
         .collect();
 
-    let mut merged = LocalFacts::default();
+    let mut merged = ProducedFacts::default();
     for local in locals {
         merged.merge(local);
     }

--- a/crates/passes/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/fact_producers/unused_expressions.rs
@@ -4,8 +4,9 @@ use syntax::program::{CallKind, NativeTypeKind};
 use syntax::types::{Symbol, Type};
 
 use diagnostics::infer::MismatchedTailKind;
-use semantics::facts::LocalFacts;
 use semantics::store::Store;
+
+use super::ProducedFacts;
 
 struct TailContext<'a> {
     expected_span: Span,
@@ -16,7 +17,7 @@ pub(crate) fn run(
     typed_ast: &[Expression],
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     for item in typed_ast {
         visit_expression(item, None, module_id, store, facts);
@@ -28,7 +29,7 @@ fn visit_expression(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     match expression {
         Expression::Block { items, ty, .. }
@@ -123,7 +124,7 @@ fn visit_expression(
     }
 }
 
-fn visit_loop_body(body: &Expression, module_id: &str, store: &Store, facts: &mut LocalFacts) {
+fn visit_loop_body(body: &Expression, module_id: &str, store: &Store, facts: &mut ProducedFacts) {
     let items = match body {
         Expression::Block { items, .. }
         | Expression::TryBlock { items, .. }
@@ -155,7 +156,7 @@ fn visit_block_items(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     let len = items.len();
     for (i, item) in items.iter().enumerate() {
@@ -186,7 +187,7 @@ fn descend_discarded(
     mode: &DiscardMode<'_>,
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     match expression.unwrap_parens() {
         Expression::Block { items, .. }
@@ -262,7 +263,7 @@ fn descend_loop_break_values(
     mode: &DiscardMode<'_>,
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     match expression {
         Expression::Break {
@@ -286,7 +287,12 @@ fn descend_loop_break_values(
     }
 }
 
-fn emit_unused_at_leaf(leaf: &Expression, module_id: &str, store: &Store, facts: &mut LocalFacts) {
+fn emit_unused_at_leaf(
+    leaf: &Expression,
+    module_id: &str,
+    store: &Store,
+    facts: &mut ProducedFacts,
+) {
     let span = leaf.get_span();
     let is_literal = is_literal_or_negated_literal(leaf);
     let ty = leaf.get_type();
@@ -333,7 +339,7 @@ fn check_discarded_tail(
     tail_ctx: Option<&TailContext<'_>>,
     module_id: &str,
     store: &Store,
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     let unwrapped = item.unwrap_parens();
     let reported_ty = get_call_return_type(unwrapped).unwrap_or_else(|| unwrapped.get_type());
@@ -379,7 +385,7 @@ fn emit_unused_expression(
     ty: &Type,
     is_literal: bool,
     allowed_lints: &[String],
-    facts: &mut LocalFacts,
+    facts: &mut ProducedFacts,
 ) {
     let kind = if is_literal {
         Some(UnusedExpressionKind::Literal)

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
@@ -52,7 +52,7 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
         .facts
         .bindings
         .get(outer_id)
-        .is_some_and(|b| !b.kind.is_mutable() && !b.mutated);
+        .is_some_and(|b| !b.kind.is_mutable() && !b.mutation.happened());
     if !outer_is_stable {
         return;
     }
@@ -61,7 +61,7 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
         .facts
         .bindings
         .values()
-        .any(|b| b.span == *new_span && b.used && !b.mutated);
+        .any(|b| b.span == *new_span && b.used && !b.mutation.happened());
     if !new_is_plain_use {
         return;
     }

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -9,6 +9,8 @@ use semantics::facts::Facts;
 use syntax::ast::Span;
 use syntax::program::UnusedInfo;
 
+use super::super::fact_producers::{ProducedFact, ProducedFacts};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Lint {
     UnusedVariable,
@@ -74,6 +76,7 @@ impl LintConfig {
 pub(crate) fn run(
     analysis: &AnalysisContext,
     facts: &Facts,
+    produced: &ProducedFacts,
     unused: &mut UnusedInfo,
     sink: &LocalSink,
 ) {
@@ -90,11 +93,8 @@ pub(crate) fn run(
     );
     collect_dead_code(facts, &mut diagnostics);
     collect_pattern_issues(facts, &mut diagnostics);
-    collect_unused_expressions(facts, &mut diagnostics);
-    collect_discarded_tail_expressions(facts, &mut diagnostics);
+    collect_produced_facts(produced, &mut diagnostics);
     collect_overused_references(facts, &mut diagnostics);
-    collect_unused_type_params(facts, &mut diagnostics);
-    collect_type_params_only_in_bound(facts, &mut diagnostics);
     collect_always_failing_try_blocks(facts, &mut diagnostics);
     collect_expression_only_fstrings(facts, &sources, &mut diagnostics);
 
@@ -174,27 +174,29 @@ fn collect_bindings(
 ) {
     for b in facts.bindings.values() {
         let is_anon = b.name.starts_with('_');
-        let written_but_not_read = b.kind.is_mutable() && b.mutated && !b.used && !is_anon;
+        let written_but_not_read =
+            b.kind.is_mutable() && b.mutation.happened() && !b.used && !is_anon;
         let is_write_only_param = written_but_not_read && b.kind.is_param();
 
         if !b.used && !is_write_only_param {
-            if !is_anon && b.kind.is_param() && !b.is_typedef && b.name != "self" {
+            if !is_anon && b.kind.is_param() && !b.origin.is_typedef() && b.name != "self" {
                 out.push(diagnostics::lint::unused_parameter(&b.span, &b.name));
             } else if !written_but_not_read
                 && !is_anon
                 && !b.kind.is_param()
-                && (!b.kind.is_pattern_position() || b.is_as_alias)
+                && (!b.kind.is_pattern_position() || b.origin.is_as_alias())
             {
                 out.push(diagnostics::lint::unused_variable(
                     &b.span,
                     &b.name,
-                    b.is_struct_field,
+                    b.origin.is_struct_field(),
                 ));
             }
             unused.mark_binding_unused(b.span);
         }
 
-        if b.kind.is_mutable() && !b.mutated && !within_any(erroring_functions, b.span) {
+        if b.kind.is_mutable() && !b.mutation.happened() && !within_any(erroring_functions, b.span)
+        {
             let mut diagnostic = diagnostics::lint::unused_mut(&b.span);
             if let Some(deletion) = mut_keyword_deletion(sources, b.span) {
                 diagnostic =
@@ -221,20 +223,31 @@ fn collect_pattern_issues(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
     }
 }
 
-fn collect_unused_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
-    for fact in &facts.unused_expressions {
-        out.push(diagnostics::lint::unused_expression(&fact.span, fact.kind));
-    }
-}
-
-fn collect_discarded_tail_expressions(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
-    for fact in &facts.discarded_tail_expressions {
-        out.push(diagnostics::infer::mismatched_tail_value(
-            &fact.span,
-            &fact.return_type,
-            &fact.expected_span,
-            &fact.expected_type,
-        ));
+fn collect_produced_facts(produced: &ProducedFacts, out: &mut Vec<LisetteDiagnostic>) {
+    for fact in &produced.items {
+        let diagnostic = match fact {
+            ProducedFact::UnusedExpression { span, kind } => {
+                diagnostics::lint::unused_expression(span, *kind)
+            }
+            ProducedFact::DiscardedTail {
+                span,
+                return_type,
+                expected_span,
+                expected_type,
+            } => diagnostics::infer::mismatched_tail_value(
+                span,
+                return_type,
+                expected_span,
+                expected_type,
+            ),
+            ProducedFact::UnusedTypeParam { span } => {
+                diagnostics::lint::unused_type_parameter(span)
+            }
+            ProducedFact::TypeParamOnlyInBound { name, span } => {
+                diagnostics::lint::type_param_only_in_bound(span, name)
+            }
+        };
+        out.push(diagnostic);
     }
 }
 
@@ -248,20 +261,6 @@ fn collect_overused_references(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) 
                 ),
             ),
         );
-    }
-}
-
-fn collect_unused_type_params(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
-    for fact in &facts.unused_type_params {
-        out.push(diagnostics::lint::unused_type_parameter(&fact.span));
-    }
-}
-
-fn collect_type_params_only_in_bound(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
-    for fact in &facts.type_params_only_in_bound {
-        out.push(diagnostics::lint::type_param_only_in_bound(
-            &fact.span, &fact.name,
-        ));
     }
 }
 

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -35,32 +35,31 @@ pub fn run(
     run_lints: bool,
 ) {
     let facts_ref: &Facts = facts;
-    let (((checks_diagnostics, pattern_issues), producer_facts), lint_outputs) = rayon::join(
-        || {
-            rayon::join(
-                || checks::run_all(analysis, facts_ref),
-                || fact_producers::run_all(analysis),
-            )
-        },
+    let ((checks_diagnostics, pattern_issues), lint_outputs) = rayon::join(
+        || checks::run_all(analysis, facts_ref),
         || {
             run_lints.then(|| {
-                rayon::join(
-                    || lints::ast_walk::run(analysis, facts_ref),
-                    || lints::ref_graph::run(analysis, facts_ref),
-                )
+                let (produced_facts, (ast_walk_diagnostics, ref_graph_output)) = rayon::join(
+                    || fact_producers::run_all(analysis),
+                    || {
+                        rayon::join(
+                            || lints::ast_walk::run(analysis, facts_ref),
+                            || lints::ref_graph::run(analysis, facts_ref),
+                        )
+                    },
+                );
+                (produced_facts, ast_walk_diagnostics, ref_graph_output)
             })
         },
     );
 
     facts.pattern_issues = pattern_issues;
-    facts.absorb_local_facts(producer_facts);
 
     sink.extend(checks_diagnostics);
     deferred::run(analysis.store, facts, sink);
-    if run_lints {
-        lints::from_facts::run(analysis, facts, unused, sink);
-    }
-    if let Some((ast_walk_diagnostics, (ref_graph_diagnostics, ref_graph_unused))) = lint_outputs {
+    if let Some((produced_facts, ast_walk_diagnostics, ref_graph_output)) = lint_outputs {
+        lints::from_facts::run(analysis, facts, &produced_facts, unused, sink);
+        let (ref_graph_diagnostics, ref_graph_unused) = ref_graph_output;
         sink.extend(ast_walk_diagnostics);
         sink.extend(ref_graph_diagnostics);
         unused.merge(ref_graph_unused);

--- a/crates/semantics/src/cache/bounds.rs
+++ b/crates/semantics/src/cache/bounds.rs
@@ -20,8 +20,8 @@ pub(crate) fn restore_cached_generic_bounds(
     sink: &LocalSink,
     cached_modules: &FxHashSet<String>,
 ) {
-    let mut checker = TaskState::with_fresh_allocator(sink);
-    let module_ids = store.module_ids.clone();
+    let mut checker = TaskState::with_fresh_allocator();
+    let module_ids: Vec<String> = store.modules.keys().cloned().collect();
     for module_id in module_ids {
         restore_module_bounds(
             &mut checker,
@@ -30,6 +30,7 @@ pub(crate) fn restore_cached_generic_bounds(
             cached_modules.contains(&module_id),
         );
     }
+    sink.extend(checker.sink.take());
 }
 
 fn restore_module_bounds(

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -40,7 +40,7 @@ impl CachedSpan {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedGeneric {
-    name: String,
+    name: EcoString,
     bounds: Vec<Annotation>,
     span: CachedSpan,
 }
@@ -48,7 +48,7 @@ pub struct CachedGeneric {
 impl CachedGeneric {
     fn from_generic(generic: &Generic, file_id_to_index: &HashMap<u32, u32>) -> Self {
         Self {
-            name: generic.name.to_string(),
+            name: generic.name.clone(),
             bounds: generic.bounds.clone(),
             span: CachedSpan::from_span(&generic.span, file_id_to_index),
         }
@@ -56,7 +56,7 @@ impl CachedGeneric {
 
     fn to_generic(&self, file_ids: &[u32]) -> Generic {
         Generic {
-            name: EcoString::from(self.name.as_str()),
+            name: self.name.clone(),
             bounds: self.bounds.clone(),
             resolved_bounds: vec![],
             span: self.span.to_span(file_ids),
@@ -87,7 +87,7 @@ impl CachedLiteral {
             },
             Literal::Boolean(v) => CachedLiteral::Boolean(*v),
             Literal::String { value, raw } => {
-                debug_assert!(
+                assert!(
                     !raw,
                     "cached const literals are canonicalized to non-raw strings"
                 );
@@ -96,10 +96,7 @@ impl CachedLiteral {
             Literal::Char(v) => CachedLiteral::Char(v.clone()),
             // Canonical const literals are never one of these kinds.
             Literal::Imaginary(_) | Literal::FormatString(_) | Literal::Slice(_) => {
-                CachedLiteral::Integer {
-                    value: 0,
-                    text: None,
-                }
+                unreachable!("only canonical const literals can be cached")
             }
         }
     }
@@ -150,7 +147,7 @@ impl CachedAttribute {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedStructField {
-    name: String,
+    name: EcoString,
     name_span: CachedSpan,
     ty: Type,
     visibility: FieldVisibility,
@@ -165,7 +162,7 @@ impl CachedStructField {
         file_id_to_index: &HashMap<u32, u32>,
     ) -> Self {
         Self {
-            name: field.name.to_string(),
+            name: field.name.clone(),
             name_span: CachedSpan::from_span(&field.name_span, file_id_to_index),
             ty: Clone::clone(&field.ty),
             visibility: field.visibility,
@@ -182,7 +179,7 @@ impl CachedStructField {
     fn to_field(&self, file_ids: &[u32]) -> syntax::ast::StructFieldDefinition {
         syntax::ast::StructFieldDefinition {
             doc: self.doc.clone(),
-            name: self.name.clone().into(),
+            name: self.name.clone(),
             name_span: self.name_span.to_span(file_ids),
             ty: self.ty.clone(),
             visibility: self.visibility,
@@ -195,7 +192,7 @@ impl CachedStructField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedEnumVariant {
-    name: String,
+    name: EcoString,
     name_span: CachedSpan,
     fields: CachedVariantFields,
     doc: Option<String>,
@@ -240,7 +237,7 @@ impl CachedEnumVariant {
         file_id_to_index: &HashMap<u32, u32>,
     ) -> Self {
         Self {
-            name: variant.name.to_string(),
+            name: variant.name.clone(),
             name_span: CachedSpan::from_span(&variant.name_span, file_id_to_index),
             fields: CachedVariantFields::from_variant_fields(&variant.fields),
             doc: variant.doc.clone(),
@@ -250,7 +247,7 @@ impl CachedEnumVariant {
     fn to_variant(&self, file_ids: &[u32]) -> syntax::ast::EnumVariant {
         syntax::ast::EnumVariant {
             doc: self.doc.clone(),
-            name: self.name.clone().into(),
+            name: self.name.clone(),
             name_span: self.name_span.to_span(file_ids),
             fields: self.fields.to_variant_fields(),
         }
@@ -259,21 +256,21 @@ impl CachedEnumVariant {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedEnumField {
-    name: String,
+    name: EcoString,
     ty: Type,
 }
 
 impl CachedEnumField {
     fn from_field(field: &syntax::ast::EnumFieldDefinition) -> Self {
         Self {
-            name: field.name.to_string(),
+            name: field.name.clone(),
             ty: Clone::clone(&field.ty),
         }
     }
 
     fn to_field(&self) -> syntax::ast::EnumFieldDefinition {
         syntax::ast::EnumFieldDefinition {
-            name: self.name.clone().into(),
+            name: self.name.clone(),
             name_span: Span::dummy(),
             ty: self.ty.clone(),
             annotation: Annotation::Unknown,
@@ -283,44 +280,36 @@ impl CachedEnumField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedInterface {
-    name: String,
+    name: EcoString,
     generics: Vec<CachedGeneric>,
     parents: Vec<Type>,
-    pub methods: HashMap<String, Type>,
+    pub methods: MethodSignatures,
 }
 
 impl CachedInterface {
     fn from_interface(iface: &Interface, file_id_to_index: &HashMap<u32, u32>) -> Self {
         Self {
-            name: iface.name.to_string(),
+            name: iface.name.clone(),
             generics: iface
                 .generics
                 .iter()
                 .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
                 .collect(),
             parents: iface.parents.iter().map(Clone::clone).collect(),
-            methods: iface
-                .methods
-                .iter()
-                .map(|(k, v)| (k.to_string(), Clone::clone(v)))
-                .collect(),
+            methods: iface.methods.clone(),
         }
     }
 
     fn to_interface(&self, file_ids: &[u32]) -> Interface {
         Interface {
-            name: EcoString::from(self.name.as_str()),
+            name: self.name.clone(),
             generics: self
                 .generics
                 .iter()
                 .map(|g| g.to_generic(file_ids))
                 .collect(),
             parents: self.parents.to_vec(),
-            methods: self
-                .methods
-                .iter()
-                .map(|(k, v)| (EcoString::from(k.as_str()), v.clone()))
-                .collect(),
+            methods: self.methods.clone(),
         }
     }
 }
@@ -331,7 +320,7 @@ impl CachedInterface {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedDefinition {
     ty: Type,
-    name: Option<String>,
+    name: Option<EcoString>,
     name_span: Option<CachedSpan>,
     doc: Option<String>,
     pub body: CachedDefinitionBody,
@@ -342,21 +331,21 @@ pub struct CachedDefinition {
 pub enum CachedDefinitionBody {
     TypeAlias {
         generics: Vec<CachedGeneric>,
-        methods: HashMap<String, Type>,
+        methods: MethodSignatures,
         is_opaque: bool,
         attributes: Attributes,
     },
     Enum {
         generics: Vec<CachedGeneric>,
         variants: Vec<CachedEnumVariant>,
-        methods: HashMap<String, Type>,
+        methods: MethodSignatures,
         attributes: Attributes,
     },
     Struct {
         generics: Vec<CachedGeneric>,
         fields: Vec<CachedStructField>,
         kind: StructKind,
-        methods: HashMap<String, Type>,
+        methods: MethodSignatures,
         constructor: Option<Type>,
         attributes: Attributes,
     },
@@ -399,7 +388,7 @@ impl CachedDefinition {
                     .iter()
                     .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
                     .collect(),
-                methods: Self::convert_methods(methods),
+                methods: methods.clone(),
                 is_opaque: annotation.is_opaque(),
                 attributes: attributes.clone(),
             },
@@ -417,7 +406,7 @@ impl CachedDefinition {
                     .iter()
                     .map(|v| CachedEnumVariant::from_variant(v, file_id_to_index))
                     .collect(),
-                methods: Self::convert_methods(methods),
+                methods: methods.clone(),
                 attributes: attributes.clone(),
             },
             DefinitionBody::Struct {
@@ -437,7 +426,7 @@ impl CachedDefinition {
                     .map(|f| CachedStructField::from_field(f, file_id_to_index))
                     .collect(),
                 kind: *kind,
-                methods: Self::convert_methods(methods),
+                methods: methods.clone(),
                 constructor: constructor.clone(),
                 attributes: attributes.clone(),
             },
@@ -460,26 +449,12 @@ impl CachedDefinition {
         };
         CachedDefinition {
             ty: ty.clone(),
-            name: name.as_ref().map(|n| n.to_string()),
+            name: name.clone(),
             name_span: name_span.map(|s| CachedSpan::from_span(&s, file_id_to_index)),
             doc: doc.clone(),
             body,
             is_const,
         }
-    }
-
-    fn convert_methods(methods: &MethodSignatures) -> HashMap<String, Type> {
-        methods
-            .iter()
-            .map(|(k, v)| (k.to_string(), Clone::clone(v)))
-            .collect()
-    }
-
-    fn restore_methods(methods: &HashMap<String, Type>) -> MethodSignatures {
-        methods
-            .iter()
-            .map(|(k, v)| (EcoString::from(k.as_str()), v.clone()))
-            .collect()
     }
 
     pub(crate) fn install_into(
@@ -511,7 +486,7 @@ impl CachedDefinition {
                 } else {
                     Annotation::Unknown
                 },
-                methods: Self::restore_methods(methods),
+                methods: methods.clone(),
                 attributes: attributes.clone(),
             },
             CachedDefinitionBody::Enum {
@@ -522,7 +497,7 @@ impl CachedDefinition {
             } => DefinitionBody::Enum {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 variants: variants.iter().map(|v| v.to_variant(file_ids)).collect(),
-                methods: Self::restore_methods(methods),
+                methods: methods.clone(),
                 attributes: attributes.clone(),
             },
             CachedDefinitionBody::Struct {
@@ -536,7 +511,7 @@ impl CachedDefinition {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
                 fields: fields.iter().map(|f| f.to_field(file_ids)).collect(),
                 kind: *kind,
-                methods: Self::restore_methods(methods),
+                methods: methods.clone(),
                 constructor: constructor.clone(),
                 attributes: attributes.clone(),
             },
@@ -560,7 +535,7 @@ impl CachedDefinition {
         Definition {
             visibility: Visibility::Public,
             ty: self.ty.clone(),
-            name: self.name.as_ref().map(|n| EcoString::from(n.as_str())),
+            name: self.name.clone(),
             name_span: self.name_span.as_ref().map(|s| s.to_span(file_ids)),
             doc: self.doc.clone(),
             body,

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -3,26 +3,26 @@ use std::ops::{Deref, DerefMut};
 use crate::checker::TaskState;
 use crate::store::Store;
 
-pub struct InferCtx<'a, 's> {
-    state: &'a mut TaskState<'s>,
+pub struct InferCtx<'a> {
+    state: &'a mut TaskState,
     pub(crate) store: &'a Store,
 }
 
-impl<'a, 's> InferCtx<'a, 's> {
-    pub fn new(state: &'a mut TaskState<'s>, store: &'a Store) -> Self {
+impl<'a> InferCtx<'a> {
+    pub fn new(state: &'a mut TaskState, store: &'a Store) -> Self {
         Self { state, store }
     }
 }
 
-impl<'s> Deref for InferCtx<'_, 's> {
-    type Target = TaskState<'s>;
+impl Deref for InferCtx<'_> {
+    type Target = TaskState;
 
     fn deref(&self) -> &Self::Target {
         self.state
     }
 }
 
-impl DerefMut for InferCtx<'_, '_> {
+impl DerefMut for InferCtx<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.state
     }

--- a/crates/semantics/src/checker/infer/expressions/aliasing.rs
+++ b/crates/semantics/src/checker/infer/expressions/aliasing.rs
@@ -12,12 +12,16 @@ use crate::checker::infer::carry_mut::{
 struct AliasFinding {
     source: String,
     span: Span,
-    via_non_severing_clone: bool,
-    clone_severs: bool,
+    kind: AliasKind,
     addressable: bool,
 }
 
-impl InferCtx<'_, '_> {
+enum AliasKind {
+    Direct { clone_severs: bool },
+    NonSeveringClone,
+}
+
+impl InferCtx<'_> {
     /// Reject a mutable binding that would share the backing store of a live one.
     pub(super) fn check_mut_binding_alias(&mut self, binding_name: &str, value: &Expression) {
         let Some(finding) = self.find_alias(value, true) else {
@@ -34,21 +38,20 @@ impl InferCtx<'_, '_> {
     }
 
     fn push_binding_alias(&mut self, binding_name: &str, finding: AliasFinding) {
-        let diagnostic = if finding.via_non_severing_clone {
-            diagnostics::infer::mut_binding_clone_does_not_sever(
+        let diagnostic = match finding.kind {
+            AliasKind::NonSeveringClone => diagnostics::infer::mut_binding_clone_does_not_sever(
                 binding_name,
                 &finding.source,
                 finding.addressable,
                 finding.span,
-            )
-        } else {
-            diagnostics::infer::mut_binding_aliases(
+            ),
+            AliasKind::Direct { clone_severs } => diagnostics::infer::mut_binding_aliases(
                 binding_name,
                 &finding.source,
                 finding.addressable,
-                finding.clone_severs,
+                clone_severs,
                 finding.span,
-            )
+            ),
         };
         self.sink.push(diagnostic);
     }
@@ -139,14 +142,18 @@ impl InferCtx<'_, '_> {
             return None;
         }
         let clone_severs = clone_severs_alias(&ty, &self.env, self.store);
-        if via_clone && clone_severs {
-            return None;
-        }
+        let kind = if via_clone {
+            if clone_severs {
+                return None;
+            }
+            AliasKind::NonSeveringClone
+        } else {
+            AliasKind::Direct { clone_severs }
+        };
         Some(AliasFinding {
             source: render_place(place),
             span,
-            via_non_severing_clone: via_clone,
-            clone_severs,
+            kind,
             addressable: check_is_non_addressable(place, &self.env).is_none(),
         })
     }

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -1,7 +1,6 @@
 use crate::checker::EnvResolve;
-use ecow::EcoString;
 use syntax::ast::BindingKind;
-use syntax::ast::{Annotation, Binding, Expression, Literal, Span, Visibility};
+use syntax::ast::{Binding, Expression, Literal};
 use syntax::program::DefinitionBody;
 use syntax::types::{Symbol, Type};
 
@@ -12,7 +11,7 @@ enum ConstInitReject {
     Composite,
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     fn classify_const_init(&self, expression: &Expression) -> Option<ConstInitReject> {
         match expression.unwrap_parens() {
             Expression::Literal { literal, .. } => match literal {
@@ -49,17 +48,20 @@ impl InferCtx<'_, '_> {
         self.store.is_const(qualified.as_str())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn infer_const_binding(
-        &mut self,
-        doc: Option<String>,
-        annotation: Option<Annotation>,
-        expression: Box<Expression>,
-        identifier: EcoString,
-        identifier_span: Span,
-        visibility: Visibility,
-        span: Span,
-    ) -> Expression {
+    pub(super) fn infer_const_binding(&mut self, expression: Expression) -> Expression {
+        let Expression::Const {
+            doc,
+            annotation,
+            expression,
+            identifier,
+            identifier_span,
+            visibility,
+            span,
+            ..
+        } = expression
+        else {
+            unreachable!("infer_const_binding called with non-Const expression");
+        };
         let store = self.store;
         let ty = if let Some(annotation) = &annotation {
             let ty = self.convert_to_type(store, annotation, &span);
@@ -107,19 +109,26 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_let_binding(
         &mut self,
-        binding: Binding,
-        value: Box<Expression>,
-        mutable: bool,
-        mut_span: Option<Span>,
-        else_block: Option<Box<Expression>>,
-        else_span: Option<Span>,
-        assert: bool,
-        span: Span,
+        expression: Expression,
         expected_ty: &Type,
     ) -> Expression {
+        let Expression::Let {
+            binding,
+            value,
+            mutable,
+            mut_span,
+            else_block,
+            else_span,
+            assert,
+            span,
+            ..
+        } = expression
+        else {
+            unreachable!("infer_let_binding called with non-Let expression");
+        };
+        let binding = *binding;
         let store = self.store;
         let has_annotation = binding.annotation.is_some();
         let binding_name = binding.pattern.get_identifier();

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -491,7 +491,7 @@ pub(crate) fn param_is_comparable(scopes: &Scopes, env: &TypeEnv, param_name: &s
     found
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     fn is_comparable_with_param_bounds(&self, ty: &Type) -> bool {
         let resolved = ty.resolve_in(&self.env);
         check_not_comparable_with_bounds(&self.env, self.store, &resolved, &mut |parameter| {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::facts::BranchSubsumption;
 use syntax::ast::BindingKind;
-use syntax::ast::{Binding, BindingId, Expression, MatchArm, Pattern, Span, TypedPattern};
+use syntax::ast::{Binding, BindingId, Expression, MatchArm, Pattern, Span};
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
@@ -30,7 +30,7 @@ fn iter_seq_kind(ty: &Type) -> Option<IterSeqKind> {
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(crate) fn reconcile_and_unify(
         &mut self,
         result_ty: &Type,
@@ -247,11 +247,8 @@ impl InferCtx<'_, '_> {
         }
 
         // Branch bodies are tail-like contexts where Never calls are valid.
-        let saved_subexpression = self.scopes.set_in_subexpression(false);
-        let new_consequence = self.infer_expression(*consequence, &consequence_ty);
-        self.scopes.set_in_subexpression(false);
-        let new_alternative = self.infer_expression(*alternative, &alternative_ty);
-        self.scopes.set_in_subexpression(saved_subexpression);
+        let new_consequence = self.infer_root_expression(*consequence, &consequence_ty);
+        let new_alternative = self.infer_root_expression(*alternative, &alternative_ty);
 
         if has_no_else {
             // An `if` without `else` always has type () (unit), like Rust.
@@ -317,18 +314,24 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_if_let(
         &mut self,
-        pattern: Pattern,
-        scrutinee: Box<Expression>,
-        consequence: Box<Expression>,
-        alternative: Box<Expression>,
-        typed_pattern: Option<TypedPattern>,
-        else_span: Option<Span>,
-        span: Span,
+        expression: Expression,
         expected_ty: &Type,
     ) -> Expression {
+        let Expression::IfLet {
+            pattern,
+            scrutinee,
+            consequence,
+            alternative,
+            typed_pattern,
+            else_span,
+            span,
+            ..
+        } = expression
+        else {
+            unreachable!("infer_if_let called with non-IfLet expression");
+        };
         let is_if_let_without_else = else_span.is_none();
         let arms = vec![
             MatchArm {
@@ -427,8 +430,7 @@ impl InferCtx<'_, '_> {
                     &result_ty
                 };
                 // Arm body is a tail-like context where Never calls are valid.
-                self.scopes.set_in_subexpression(false);
-                let new_expression = self.infer_expression(*a.expression, arm_expected);
+                let new_expression = self.infer_root_expression(*a.expression, arm_expected);
 
                 self.scopes.pop();
 
@@ -744,9 +746,9 @@ impl InferCtx<'_, '_> {
         &mut self,
         expression: Box<Expression>,
         span: Span,
-        parent_is_subexpression: bool,
+        is_subexpression: bool,
     ) -> Expression {
-        if parent_is_subexpression {
+        if is_subexpression {
             self.sink
                 .push(diagnostics::infer::control_flow_in_expression(
                     "return", span,
@@ -772,7 +774,6 @@ impl InferCtx<'_, '_> {
             }
             _ => {}
         }
-        self.scopes.set_in_subexpression(false);
         self.infer_return(expression, span)
     }
 
@@ -788,7 +789,7 @@ impl InferCtx<'_, '_> {
             });
 
         let new_expression =
-            self.with_value_context(|s| s.infer_expression(*expression, &return_ty));
+            self.with_value_context(|s| s.infer_root_expression(*expression, &return_ty));
 
         Expression::Return {
             expression: new_expression.into(),
@@ -874,9 +875,9 @@ impl InferCtx<'_, '_> {
         &mut self,
         value: Option<Box<Expression>>,
         span: Span,
-        parent_is_subexpression: bool,
+        is_subexpression: bool,
     ) -> Expression {
-        if parent_is_subexpression {
+        if is_subexpression {
             self.sink
                 .push(diagnostics::infer::control_flow_in_expression(
                     "break", span,
@@ -913,12 +914,8 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    pub(super) fn infer_continue(
-        &mut self,
-        span: Span,
-        parent_is_subexpression: bool,
-    ) -> Expression {
-        if parent_is_subexpression {
+    pub(super) fn infer_continue(&mut self, span: Span, is_subexpression: bool) -> Expression {
+        if is_subexpression {
             self.sink
                 .push(diagnostics::infer::control_flow_in_expression(
                     "continue", span,

--- a/crates/semantics/src/checker/infer/expressions/definitions.rs
+++ b/crates/semantics/src/checker/infer/expressions/definitions.rs
@@ -3,7 +3,7 @@ use syntax::program::{Definition, DefinitionBody};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_struct_definition(&mut self, expression: Expression) -> Expression {
         let store = self.store;
         let Expression::Struct {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -14,7 +14,7 @@ use super::primitives::contains_deref;
 use crate::checker::infer::InferCtx;
 use crate::checker::promotion::{self, MemberKind, Resolution};
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_dot_access_or_qualified_path(
         &mut self,
         expression: Box<Expression>,
@@ -32,7 +32,7 @@ impl InferCtx<'_, '_> {
                 && let Some(path) = inner.as_dotted_path()
                 && inner.root_identifier().is_some_and(|root| {
                     self.lookup_qualified_name(store, root).is_some()
-                        || self.imports.imported_modules.contains_key(root)
+                        || self.imports.namespace(root).is_some()
                 })
             {
                 self.sink.push(diagnostics::infer::parenthesized_qualifier(
@@ -204,7 +204,7 @@ impl DotAccessResolutionArgs<'_> {
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     fn normalize_aliased_ref(&self, ty: Type) -> Type {
         if ty.is_ref() {
             return ty;
@@ -370,7 +370,7 @@ impl InferCtx<'_, '_> {
             .is_some_and(|methods| methods.contains_key(member))
     }
 
-    fn get_available_member_names(&self, ty: &Type) -> Vec<String> {
+    fn get_available_member_names(&mut self, ty: &Type) -> Vec<String> {
         let store = self.store;
         let deref_ty = ty.strip_refs();
         let mut names = Vec::new();
@@ -389,7 +389,7 @@ impl InferCtx<'_, '_> {
     }
 
     fn compute_unwrap_hint(
-        &self,
+        &mut self,
         ty: &Type,
         member: &str,
     ) -> Option<diagnostics::infer::UnwrapHint> {
@@ -412,7 +412,7 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    fn has_member(&self, ty: &Type, member: &str) -> bool {
+    fn has_member(&mut self, ty: &Type, member: &str) -> bool {
         let store = self.store;
         let deref_ty = ty.strip_refs();
 
@@ -616,20 +616,21 @@ impl InferCtx<'_, '_> {
         // Look up by type-derived name first (works for non-aliased imports).
         // For aliased imports (e.g. `import u "utils"`), the map key is "u" but
         // the type name is "utils", so fall back to matching by import module id.
-        let (module_fields, module_ty) = self
+        let (module_id, module_fields) = self
             .imports
-            .imported_modules
-            .get(type_name)
-            .filter(|(_, ty)| namespace_id.is_none() || ty.as_import_namespace() == namespace_id)
-            .cloned()
+            .namespace(type_name)
+            .filter(|(module_id, _)| {
+                namespace_id.is_none_or(|namespace_id| *module_id == namespace_id)
+            })
             .or_else(|| {
                 let module_id = namespace_id?;
                 self.imports
-                    .imported_modules
-                    .values()
-                    .find(|(_, ty)| ty.as_import_namespace() == Some(module_id))
-                    .cloned()
+                    .namespaces()
+                    .find(|(imported_module_id, _)| *imported_module_id == module_id)
             })?;
+        let module_fields = module_fields.clone();
+        let module_id = module_id.to_string();
+        let module_ty = Type::ImportNamespace(module_id.clone().into());
 
         let kind = DotAccessKind::ModuleMember;
 
@@ -646,8 +647,7 @@ impl InferCtx<'_, '_> {
             return Some((args.build_dot_access(Type::Error, Some(kind), None), kind));
         };
 
-        let module_id = module_ty.as_import_namespace()?;
-        let resolved_definition = Symbol::from_parts(module_id, args.member_name);
+        let resolved_definition = Symbol::from_parts(&module_id, args.member_name);
         if let Some(definition_span) = self.get_definition_name_span(store, &resolved_definition) {
             self.facts.add_usage(*args.span, definition_span);
         }
@@ -1142,7 +1142,7 @@ impl InferCtx<'_, '_> {
         if !is_deref
             && !binding_is_ref
             && !self.scopes.lookup_mutable(&var_name)
-            && !self.imports.imported_modules.contains_key(&var_name)
+            && self.imports.namespace(&var_name).is_none()
         {
             let self_type_name = if var_name == "self" {
                 self.lookup_type(store, "self")

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -19,7 +19,18 @@ use crate::checker::registration::test_functions::normalize_test_params;
 use crate::inference::ProjectKind;
 use crate::store::ENTRY_MODULE_ID;
 
-impl InferCtx<'_, '_> {
+struct TypeConversionCall {
+    callee: Expression,
+    target_ty: Type,
+    underlying_fn: Type,
+    args: Vec<Expression>,
+    spread: Box<Option<Expression>>,
+    raw_type_args: Vec<Annotation>,
+    resolved_type_args: Vec<Type>,
+    span: Span,
+}
+
+impl InferCtx<'_> {
     fn check_call_arity(
         &mut self,
         param_types: &[Type],
@@ -65,7 +76,7 @@ impl InferCtx<'_, '_> {
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     fn ty_is_test_context(&self, ty: &Type) -> bool {
         let resolved = ty.resolve_in(&self.env).strip_refs();
         resolved.get_qualified_id().is_some_and(|id| {
@@ -289,16 +300,22 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_function_call(
         &mut self,
-        expression: Box<Expression>,
-        args: Vec<Expression>,
-        spread: Box<Option<Expression>>,
-        type_args: Vec<Annotation>,
-        span: Span,
+        call: Expression,
         expected_ty: &Type,
     ) -> Expression {
+        let Expression::Call {
+            expression,
+            args,
+            spread,
+            raw_type_args: type_args,
+            span,
+            ..
+        } = call
+        else {
+            unreachable!("infer_function_call called with non-Call expression");
+        };
         let callee_path = expression.unwrap_parens().as_dotted_path();
 
         // `Array.new` has no prelude signature (no const generics), so resolve inline.
@@ -343,14 +360,16 @@ impl InferCtx<'_, '_> {
 
         if let Some(underlying_fn) = self.try_as_type_conversion(&callee_expression, &callee_ty) {
             return self.infer_type_conversion_call(
-                callee_expression,
-                callee_ty,
-                underlying_fn,
-                args,
-                spread,
-                raw_type_args,
-                resolved_type_args,
-                span,
+                TypeConversionCall {
+                    callee: callee_expression,
+                    target_ty: callee_ty,
+                    underlying_fn,
+                    args,
+                    spread,
+                    raw_type_args,
+                    resolved_type_args,
+                    span,
+                },
                 expected_ty,
             );
         }
@@ -735,7 +754,7 @@ impl InferCtx<'_, '_> {
         self.declared_callee_type(expression)
     }
 
-    fn declared_callee_type(&self, expression: &Expression) -> Type {
+    fn declared_callee_type(&mut self, expression: &Expression) -> Type {
         let store = self.store;
         match expression {
             Expression::Identifier { value, .. } => self
@@ -777,11 +796,11 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    fn is_generic_callee(&self, expression: &Expression) -> bool {
+    fn is_generic_callee(&mut self, expression: &Expression) -> bool {
         matches!(self.declared_callee_type(expression), Type::Forall { .. })
     }
 
-    fn callee_has_phantom_type_param(&self, expression: &Expression) -> bool {
+    fn callee_has_phantom_type_param(&mut self, expression: &Expression) -> bool {
         !phantom_type_params(&self.declared_callee_type(expression)).is_empty()
     }
 
@@ -1056,19 +1075,21 @@ impl InferCtx<'_, '_> {
         Some(underlying.as_ref().clone())
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_type_conversion_call(
         &mut self,
-        callee_expression: Expression,
-        named_ty: Type,
-        underlying_fn: Type,
-        args: Vec<Expression>,
-        spread: Box<Option<Expression>>,
-        raw_type_args: Vec<Annotation>,
-        resolved_type_args: Vec<Type>,
-        span: Span,
+        call: TypeConversionCall,
         expected_ty: &Type,
     ) -> Expression {
+        let TypeConversionCall {
+            callee: callee_expression,
+            target_ty: named_ty,
+            underlying_fn,
+            args,
+            spread,
+            raw_type_args,
+            resolved_type_args,
+            span,
+        } = call;
         if let Some(spread_expr) = *spread {
             self.sink
                 .push(diagnostics::infer::spread_on_non_variadic(span));
@@ -1384,7 +1405,7 @@ impl InferCtx<'_, '_> {
                 let receiver_ty = receiver.get_type().resolve_in(&self.env).strip_refs();
                 let peeled = store.deep_resolve_alias(&receiver_ty);
 
-                let ufcs_methods = self.effective_ufcs_methods();
+                let ufcs_methods = self.ufcs_methods();
                 let is_ufcs_member = |ty: &Type| {
                     matches!(ty, Type::Nominal { id, .. }
                         if ufcs_methods.contains(&(id.to_string(), member.to_string())))
@@ -1504,7 +1525,7 @@ impl InferCtx<'_, '_> {
 
         // If it's a UFCS-lowered method, skip — the emitter handles it differently
         if self
-            .effective_ufcs_methods()
+            .ufcs_methods()
             .contains(&(qualified_name.to_string(), method.to_string()))
         {
             return None;
@@ -1605,7 +1626,7 @@ impl InferCtx<'_, '_> {
         if !is_deref
             && !binding_is_ref
             && !self.scopes.lookup_mutable(&var_name)
-            && !self.imports.imported_modules.contains_key(&var_name)
+            && self.imports.namespace(&var_name).is_none()
         {
             let is_pattern_binding = self
                 .scopes

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -5,7 +5,7 @@ use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_impl_block(
         &mut self,
         annotation: Annotation,
@@ -38,7 +38,7 @@ impl InferCtx<'_, '_> {
         };
 
         let scope = self.scopes.current_mut();
-        scope.values.insert(receiver_name.to_string(), receiver_ty);
+        scope.insert_value(receiver_name.to_string(), receiver_ty);
 
         // If this is a tuple struct with a constructor, the receiver_name (which is the
         // type name) shadows the constructor function in the parent scope. Re-insert the
@@ -56,8 +56,7 @@ impl InferCtx<'_, '_> {
             let ctor_ty = ctor_ty.clone();
             self.scopes
                 .current_mut()
-                .values
-                .insert(receiver_name.to_string(), ctor_ty);
+                .insert_value(receiver_name.to_string(), ctor_ty);
         }
 
         self.scopes.set_impl_receiver_type(Some(impl_ty.clone()));

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -4,7 +4,7 @@ use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Returns `true` if valid (no error emitted), `false` if an error was emitted.
     fn check_slice_index_type(&mut self, type_name: &str, index_ty: &Type, span: Span) -> bool {
         if type_name != "Slice" || index_ty.is_variable() || index_ty.is_error() {

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -5,7 +5,7 @@ use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_literal(
         &mut self,
         literal: Literal,

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -20,23 +20,26 @@ use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
+    /// Infer an expression nested inside another expression.
     pub fn infer_expression(&mut self, expression: Expression, expected_ty: &Type) -> Expression {
-        // Track sub-expression depth: `infer_block_items` resets this to false
-        // for each top-level statement, so any nested call sees `true`.
-        let parent_is_subexpression = self.scopes.set_in_subexpression(true);
-
-        let result = self.infer_expression_inner(expression, expected_ty, parent_is_subexpression);
-
-        self.scopes.set_in_subexpression(parent_is_subexpression);
-        result
+        self.infer_expression_at(expression, expected_ty, true)
     }
 
-    fn infer_expression_inner(
+    /// Infer a statement or tail expression, where direct control flow is valid.
+    pub fn infer_root_expression(
         &mut self,
         expression: Expression,
         expected_ty: &Type,
-        parent_is_subexpression: bool,
+    ) -> Expression {
+        self.infer_expression_at(expression, expected_ty, false)
+    }
+
+    pub(super) fn infer_expression_at(
+        &mut self,
+        expression: Expression,
+        expected_ty: &Type,
+        is_subexpression: bool,
     ) -> Expression {
         match expression {
             Expression::Literal { literal, span, .. } => {
@@ -61,47 +64,17 @@ impl InferCtx<'_, '_> {
                 ref value, span, ..
             } => self.infer_identifier(value.clone(), span, expected_ty),
 
-            Expression::Let {
-                binding,
-                value,
-                mutable,
-                mut_span,
-                else_block,
-                else_span,
-                assert,
-                span,
-                typed_pattern: _,
-                ty: _,
-            } => self.infer_let_binding(
-                *binding,
-                value,
-                mutable,
-                mut_span,
-                else_block,
-                else_span,
-                assert,
-                span,
-                expected_ty,
-            ),
+            Expression::Let { .. } => self.infer_let_binding(expression, expected_ty),
 
             Expression::Call {
-                expression,
-                args: call_args,
-                spread,
-                raw_type_args,
+                expression: ref callee,
                 span,
                 ..
             } => {
-                let is_panic = matches!(&*expression, Expression::Identifier { value, .. } if value == "panic");
-                let result = self.infer_function_call(
-                    expression,
-                    call_args,
-                    spread,
-                    raw_type_args,
-                    span,
-                    expected_ty,
-                );
-                if parent_is_subexpression && is_panic {
+                let is_panic =
+                    matches!(&**callee, Expression::Identifier { value, .. } if value == "panic");
+                let result = self.infer_function_call(expression, expected_ty);
+                if is_subexpression && is_panic {
                     self.sink
                         .push(diagnostics::infer::never_call_in_expression(span));
                 }
@@ -116,25 +89,7 @@ impl InferCtx<'_, '_> {
                 ..
             } => self.infer_if(condition, consequence, alternative, span, expected_ty),
 
-            Expression::IfLet {
-                pattern,
-                scrutinee,
-                consequence,
-                alternative,
-                typed_pattern,
-                else_span,
-                span,
-                ..
-            } => self.infer_if_let(
-                pattern,
-                scrutinee,
-                consequence,
-                alternative,
-                typed_pattern,
-                else_span,
-                span,
-                expected_ty,
-            ),
+            Expression::IfLet { .. } => self.infer_if_let(expression, expected_ty),
 
             Expression::Match {
                 subject,
@@ -147,13 +102,7 @@ impl InferCtx<'_, '_> {
                 self.infer_tuple(elements, span, expected_ty)
             }
 
-            Expression::StructCall {
-                name,
-                field_assignments,
-                spread,
-                span,
-                ..
-            } => self.infer_struct_call(name, field_assignments, spread, span, expected_ty),
+            Expression::StructCall { .. } => self.infer_struct_call(expression, expected_ty),
 
             Expression::DotAccess {
                 expression,
@@ -190,12 +139,12 @@ impl InferCtx<'_, '_> {
 
             Expression::Return {
                 expression, span, ..
-            } => self.infer_return_statement(expression, span, parent_is_subexpression),
+            } => self.infer_return_statement(expression, span, is_subexpression),
 
             Expression::Propagate {
                 expression, span, ..
             } => {
-                if parent_is_subexpression {
+                if is_subexpression {
                     self.check_failure_propagation_in_subexpression(&expression, span);
                 }
                 self.infer_propagate(expression, span, expected_ty)
@@ -225,7 +174,7 @@ impl InferCtx<'_, '_> {
 
             Expression::Paren {
                 expression, span, ..
-            } => self.infer_paren(expression, span, expected_ty, parent_is_subexpression),
+            } => self.infer_paren(expression, span, expected_ty, is_subexpression),
 
             Expression::Unary {
                 operator,
@@ -234,24 +183,7 @@ impl InferCtx<'_, '_> {
                 ..
             } => self.infer_unary(operator, expression, expected_ty, span),
 
-            Expression::Const {
-                doc,
-                annotation,
-                ty: _,
-                expression,
-                span,
-                identifier,
-                identifier_span,
-                visibility,
-            } => self.infer_const_binding(
-                doc,
-                annotation,
-                expression,
-                identifier,
-                identifier_span,
-                visibility,
-                span,
-            ),
+            Expression::Const { .. } => self.infer_const_binding(expression),
 
             Expression::Loop { body, span, .. } => self.infer_loop(body, span, expected_ty),
 
@@ -301,7 +233,7 @@ impl InferCtx<'_, '_> {
             } => {
                 // Only fire the generic ban when the dedicated
                 // `task_in_expression_position` check won't — avoids duplicates.
-                if parent_is_subexpression && !self.scopes.is_value_context() {
+                if is_subexpression && !self.scopes.is_value_context() {
                     self.sink
                         .push(diagnostics::infer::control_flow_in_expression("task", span));
                 }
@@ -311,7 +243,7 @@ impl InferCtx<'_, '_> {
             Expression::Defer {
                 expression, span, ..
             } => {
-                if parent_is_subexpression && !self.scopes.is_value_context() {
+                if is_subexpression && !self.scopes.is_value_context() {
                     self.sink
                         .push(diagnostics::infer::control_flow_in_expression(
                             "defer", span,
@@ -353,10 +285,8 @@ impl InferCtx<'_, '_> {
                 ..
             } => self.infer_cast(expression, target_type, span, expected_ty),
 
-            Expression::Break { value, span } => {
-                self.infer_break(value, span, parent_is_subexpression)
-            }
-            Expression::Continue { span } => self.infer_continue(span, parent_is_subexpression),
+            Expression::Break { value, span } => self.infer_break(value, span, is_subexpression),
+            Expression::Continue { span } => self.infer_continue(span, is_subexpression),
             Expression::RawGo { text } => Expression::RawGo { text },
             Expression::NoOp => Expression::NoOp,
         }

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -8,7 +8,28 @@ use UnaryOperator::*;
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+pub(super) struct InferredOperand {
+    pub(super) expression: Expression,
+    pub(super) ty: Type,
+}
+
+impl InferredOperand {
+    pub(super) fn new(expression: Expression, ty: Type) -> Self {
+        Self { expression, ty }
+    }
+}
+
+struct BinaryOperand<'a> {
+    ty: &'a Type,
+    span: Span,
+}
+
+struct BinaryOperands<'a> {
+    left: BinaryOperand<'a>,
+    right: BinaryOperand<'a>,
+}
+
+impl InferCtx<'_> {
     pub(super) fn infer_unary(
         &mut self,
         operator: UnaryOperator,
@@ -127,20 +148,18 @@ impl InferCtx<'_, '_> {
                 stack.push((op, right, s));
                 current = *left;
             }
-            let mut left_ty = self.new_type_var();
-            let mut left_inferred = self.infer_expression(current, &left_ty);
+            let left_ty = self.new_type_var();
+            let left_inferred = self.infer_expression(current, &left_ty);
+            let mut left = InferredOperand::new(left_inferred, left_ty);
             while let Some((op, right, s)) = stack.pop() {
                 let result_ty = if stack.is_empty() {
                     expected_ty.clone()
                 } else {
                     self.new_type_var()
                 };
-                let (inferred, ty) =
-                    self.infer_binary_with_left(op, left_inferred, left_ty, right, &result_ty, s);
-                left_inferred = inferred;
-                left_ty = ty;
+                left = self.infer_binary_with_left(op, left, right, &result_ty, s);
             }
-            return left_inferred;
+            return left.expression;
         }
 
         self.infer_binary_impl(operator, left_operand, right_operand, expected_ty, span)
@@ -148,20 +167,14 @@ impl InferCtx<'_, '_> {
 
     /// Infer a binary expression where the left operand is already inferred.
     /// Returns the inferred expression and its result type.
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn infer_binary_with_left(
         &mut self,
         operator: BinaryOperator,
-        left_inferred: Expression,
-        left_ty: Type,
+        left: InferredOperand,
         right_operand: Box<Expression>,
         expected_ty: &Type,
         span: Span,
-    ) -> (Expression, Type) {
-        let divisor_is_zero =
-            matches!(operator, Division | Remainder) && is_zero_literal(&right_operand);
-
-        let left_operand_ty = left_ty;
+    ) -> InferredOperand {
         let right_operand_ty = self.new_type_var();
 
         let right_literal_kind = literal_kind(&right_operand);
@@ -169,7 +182,7 @@ impl InferCtx<'_, '_> {
 
         let new_right_operand = self.with_value_context(|s| {
             if is_right_literal {
-                let left_resolved = left_operand_ty.resolve_in(&s.env);
+                let left_resolved = left.ty.resolve_in(&s.env);
                 if literal_can_adapt_to(&right_literal_kind, &left_resolved) {
                     let _ = s.try_unify(&right_operand_ty, &left_resolved, &span);
                 }
@@ -177,43 +190,8 @@ impl InferCtx<'_, '_> {
             s.infer_expression(*right_operand, &right_operand_ty)
         });
 
-        if divisor_is_zero {
-            self.report_zero_divisor(operator, &right_operand_ty, span);
-        }
-
-        if matches!(operator, And | Or)
-            && let Some(span) = Self::find_propagate(&new_right_operand)
-        {
-            self.sink
-                .push(diagnostics::infer::propagate_in_condition(span));
-        }
-
-        let left_span = left_inferred.get_span();
-        let right_span = new_right_operand.get_span();
-
-        let errors_before = self.sink.len();
-        let expression_ty = self.resolve_binary_type(
-            &operator,
-            &left_operand_ty,
-            &right_operand_ty,
-            &left_span,
-            &right_span,
-            span,
-        );
-        if self.sink.len() != errors_before {
-            self.facts.type_error_spans.insert(span);
-        }
-
-        self.unify(expected_ty, &expression_ty, &span);
-
-        let result = Expression::Binary {
-            operator,
-            left: Box::new(left_inferred),
-            right: Box::new(new_right_operand),
-            ty: expression_ty.clone(),
-            span,
-        };
-        (result, expression_ty)
+        let right = InferredOperand::new(new_right_operand, right_operand_ty);
+        self.finish_binary(operator, left, right, expected_ty, span)
     }
 
     fn infer_binary_impl(
@@ -224,9 +202,6 @@ impl InferCtx<'_, '_> {
         expected_ty: &Type,
         span: Span,
     ) -> Expression {
-        let divisor_is_zero =
-            matches!(operator, Division | Remainder) && is_zero_literal(&right_operand);
-
         let left_operand_ty = self.new_type_var();
         let right_operand_ty = self.new_type_var();
 
@@ -265,27 +240,43 @@ impl InferCtx<'_, '_> {
             }
         });
 
-        if divisor_is_zero {
-            self.report_zero_divisor(operator, &right_operand_ty, span);
-        }
+        let left = InferredOperand::new(new_left_operand, left_operand_ty);
+        let right = InferredOperand::new(new_right_operand, right_operand_ty);
+        self.finish_binary(operator, left, right, expected_ty, span)
+            .expression
+    }
 
+    fn finish_binary(
+        &mut self,
+        operator: BinaryOperator,
+        left: InferredOperand,
+        right: InferredOperand,
+        expected_ty: &Type,
+        span: Span,
+    ) -> InferredOperand {
+        if matches!(operator, Division | Remainder) && is_zero_literal(&right.expression) {
+            self.report_zero_divisor(operator, &right.ty, span);
+        }
         if matches!(operator, And | Or)
-            && let Some(span) = Self::find_propagate(&new_right_operand)
+            && let Some(span) = Self::find_propagate(&right.expression)
         {
             self.sink
                 .push(diagnostics::infer::propagate_in_condition(span));
         }
 
-        let left_span = new_left_operand.get_span();
-        let right_span = new_right_operand.get_span();
-
         let errors_before = self.sink.len();
         let expression_ty = self.resolve_binary_type(
             &operator,
-            &left_operand_ty,
-            &right_operand_ty,
-            &left_span,
-            &right_span,
+            BinaryOperands {
+                left: BinaryOperand {
+                    ty: &left.ty,
+                    span: left.expression.get_span(),
+                },
+                right: BinaryOperand {
+                    ty: &right.ty,
+                    span: right.expression.get_span(),
+                },
+            },
             span,
         );
         if self.sink.len() != errors_before {
@@ -294,26 +285,27 @@ impl InferCtx<'_, '_> {
 
         self.unify(expected_ty, &expression_ty, &span);
 
-        Expression::Binary {
+        let expression = Expression::Binary {
             operator,
-            left: new_left_operand.into(),
-            right: new_right_operand.into(),
-            ty: expression_ty,
+            left: left.expression.into(),
+            right: right.expression.into(),
+            ty: expression_ty.clone(),
             span,
-        }
+        };
+        InferredOperand::new(expression, expression_ty)
     }
 
     /// Resolve the result type of a binary operation given already-inferred operand types.
-    #[allow(clippy::too_many_arguments)]
     fn resolve_binary_type(
         &mut self,
         operator: &BinaryOperator,
-        left_operand_ty: &Type,
-        right_operand_ty: &Type,
-        left_span: &Span,
-        right_span: &Span,
+        operands: BinaryOperands<'_>,
         span: Span,
     ) -> Type {
+        let left_operand_ty = operands.left.ty;
+        let right_operand_ty = operands.right.ty;
+        let left_span = &operands.left.span;
+        let right_span = &operands.right.span;
         match operator {
             Equal | NotEqual => {
                 let resolved_left_operand = left_operand_ty.resolve_in(&self.env);

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -1,6 +1,5 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use ecow::EcoString;
 use syntax::ast::BindingKind;
 use syntax::ast::{
     EnumFieldDefinition, Expression, Literal, Pattern, RestPattern, Span, StructFieldPattern,
@@ -12,8 +11,9 @@ use syntax::types::{CompoundKind, Type, substitute, unqualified_name};
 use crate::checker::EnvResolve;
 
 use crate::checker::infer::InferCtx;
+use crate::facts::BindingOrigin;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_pattern(
         &mut self,
         pattern: Pattern,
@@ -39,9 +39,10 @@ impl InferCtx<'_, '_> {
                     span,
                     expected_ty,
                     kind,
-                    is_d_lis,
-                    is_struct_field,
-                    false,
+                    BindingOrigin::Name {
+                        in_typedef: is_d_lis,
+                        shorthand_field: is_struct_field,
+                    },
                 );
                 (
                     Pattern::Identifier { identifier, span },
@@ -100,21 +101,13 @@ impl InferCtx<'_, '_> {
                 (pattern, typed)
             }
 
-            Pattern::EnumVariant {
-                identifier,
-                fields,
-                rest,
-                span,
-                ..
-            } => self.infer_enum_variant_pattern(identifier, fields, rest, span, expected_ty, kind),
+            pattern @ Pattern::EnumVariant { .. } => {
+                self.infer_enum_variant_pattern(pattern, expected_ty, kind)
+            }
 
-            Pattern::Struct {
-                identifier,
-                fields,
-                rest,
-                span,
-                ..
-            } => self.infer_struct_pattern(identifier, fields, rest, span, expected_ty, kind),
+            pattern @ Pattern::Struct { .. } => {
+                self.infer_struct_pattern(pattern, expected_ty, kind)
+            }
 
             Pattern::WildCard { span } => (Pattern::WildCard { span }, TypedPattern::Wildcard),
 
@@ -124,15 +117,13 @@ impl InferCtx<'_, '_> {
                 (Pattern::Unit { ty: unit_ty, span }, TypedPattern::Wildcard)
             }
 
-            Pattern::Slice {
-                prefix, rest, span, ..
-            } => {
+            pattern @ Pattern::Slice { .. } => {
                 let resolved_ty = store.peel_alias(&expected_ty.resolve_in(&self.env));
                 if let Type::Array { length, element } = &resolved_ty {
                     let (length, element_ty) = (*length, element.as_ref().clone());
-                    self.infer_array_pattern(prefix, rest, span, length, element_ty, kind)
+                    self.infer_array_pattern(pattern, length, element_ty, kind)
                 } else {
-                    self.infer_slice_pattern(prefix, rest, span, resolved_ty, expected_ty, kind)
+                    self.infer_slice_pattern(pattern, resolved_ty, expected_ty, kind)
                 }
             }
 
@@ -186,9 +177,9 @@ impl InferCtx<'_, '_> {
                     name_span,
                     alias_ty,
                     kind,
-                    false,
-                    is_struct_field,
-                    true,
+                    BindingOrigin::AsAlias {
+                        shorthand_field: is_struct_field,
+                    },
                 );
                 (
                     Pattern::AsBinding {
@@ -203,48 +194,34 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn bind_name_in_scope(
         &mut self,
         name: String,
         span: Span,
         ty: Type,
         kind: BindingKind,
-        is_typedef: bool,
-        is_struct_field: bool,
-        is_as_alias: bool,
+        origin: BindingOrigin,
     ) {
-        self.check_binding_shadows_import(&name, span, is_typedef);
+        self.check_binding_shadows_import(&name, span, origin.is_typedef());
 
-        let binding_id = self.facts.add_binding(
-            name.clone(),
-            span,
-            kind,
-            is_typedef,
-            is_struct_field,
-            is_as_alias,
-        );
+        let binding_id = self.facts.add_binding(name.clone(), span, kind, origin);
         let scope = self.scopes.current_mut();
-        scope.values.insert(name.clone(), ty);
-        scope.name_to_binding.insert(name.clone(), binding_id);
-        if kind.is_mutable() {
-            scope
-                .mutables
-                .get_or_insert_with(HashSet::default)
-                .insert(name);
-        }
+        scope.insert_binding(name, ty, binding_id, kind.is_mutable());
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_array_pattern(
         &mut self,
-        prefix: Vec<Pattern>,
-        rest: RestPattern,
-        span: Span,
+        pattern: Pattern,
         length: u64,
         element_ty: Type,
         kind: BindingKind,
     ) -> (Pattern, TypedPattern) {
+        let Pattern::Slice {
+            prefix, rest, span, ..
+        } = pattern
+        else {
+            unreachable!("infer_array_pattern called with non-Slice pattern");
+        };
         let store = self.store;
         let (inferred_prefix, typed_prefix): (Vec<_>, Vec<_>) = prefix
             .into_iter()
@@ -275,13 +252,16 @@ impl InferCtx<'_, '_> {
                 self.type_array(remaining, element_ty.clone())
             };
             let is_typedef = self.is_d_lis(store);
-            self.check_binding_shadows_import(name, *span, is_typedef);
-            let binding_id =
-                self.facts
-                    .add_binding(name.to_string(), *span, kind, is_typedef, false, false);
-            let scope = self.scopes.current_mut();
-            scope.values.insert(name.to_string(), rest_ty);
-            scope.name_to_binding.insert(name.to_string(), binding_id);
+            self.bind_name_in_scope(
+                name.to_string(),
+                *span,
+                rest_ty,
+                kind,
+                BindingOrigin::Name {
+                    in_typedef: is_typedef,
+                    shorthand_field: false,
+                },
+            );
         }
 
         let pattern = Pattern::Slice {
@@ -298,16 +278,19 @@ impl InferCtx<'_, '_> {
         (pattern, typed)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_slice_pattern(
         &mut self,
-        prefix: Vec<Pattern>,
-        rest: RestPattern,
-        span: Span,
+        pattern: Pattern,
         resolved_ty: Type,
         expected_ty: Type,
         kind: BindingKind,
     ) -> (Pattern, TypedPattern) {
+        let Pattern::Slice {
+            prefix, rest, span, ..
+        } = pattern
+        else {
+            unreachable!("infer_slice_pattern called with non-Slice pattern");
+        };
         let store = self.store;
         let element_ty = match resolved_ty.as_compound() {
             Some((CompoundKind::Slice, args)) if args.len() == 1 => args[0].clone(),
@@ -331,13 +314,16 @@ impl InferCtx<'_, '_> {
                 self.type_slice(element_ty.clone())
             };
             let is_typedef = self.is_d_lis(store);
-            self.check_binding_shadows_import(name, *span, is_typedef);
-            let binding_id =
-                self.facts
-                    .add_binding(name.to_string(), *span, kind, is_typedef, false, false);
-            let scope = self.scopes.current_mut();
-            scope.values.insert(name.to_string(), rest_ty);
-            scope.name_to_binding.insert(name.to_string(), binding_id);
+            self.bind_name_in_scope(
+                name.to_string(),
+                *span,
+                rest_ty,
+                kind,
+                BindingOrigin::Name {
+                    in_typedef: is_typedef,
+                    shorthand_field: false,
+                },
+            );
         }
 
         let pattern = Pattern::Slice {
@@ -354,16 +340,22 @@ impl InferCtx<'_, '_> {
         (pattern, typed)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_enum_variant_pattern(
         &mut self,
-        identifier: EcoString,
-        fields: Vec<Pattern>,
-        rest: bool,
-        span: Span,
+        pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
     ) -> (Pattern, TypedPattern) {
+        let Pattern::EnumVariant {
+            identifier,
+            fields,
+            rest,
+            span,
+            ..
+        } = pattern
+        else {
+            unreachable!("infer_enum_variant_pattern called with non-EnumVariant pattern");
+        };
         let store = self.store;
         if fields.is_empty()
             && identifier.contains('.')
@@ -655,46 +647,40 @@ impl InferCtx<'_, '_> {
         Some((pattern, typed))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_struct_pattern(
         &mut self,
-        identifier: EcoString,
-        fields: Vec<StructFieldPattern>,
-        rest: bool,
-        span: Span,
+        pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
     ) -> (Pattern, TypedPattern) {
+        let Pattern::Struct {
+            identifier,
+            fields,
+            rest,
+            span,
+            ..
+        } = &pattern
+        else {
+            unreachable!("infer_struct_pattern called with non-Struct pattern");
+        };
+        let rest = *rest;
+        let span = *span;
         let store = self.store;
         if kind.is_match_arm()
             && self
-                .resolve_bare_variant_type(&identifier, &expected_ty)
+                .resolve_bare_variant_type(identifier, &expected_ty)
                 .is_some()
-            && let Some(result) = self.try_infer_enum_struct_variant(
-                &identifier,
-                &fields,
-                rest,
-                &span,
-                &expected_ty,
-                kind,
-            )
+            && let Some(result) = self.try_infer_enum_struct_variant(&pattern, &expected_ty, kind)
         {
             return result;
         }
 
-        let Some(qualified_name) = self.lookup_qualified_name(store, &identifier) else {
+        let Some(qualified_name) = self.lookup_qualified_name(store, identifier) else {
             return self
-                .try_infer_enum_struct_variant(
-                    &identifier,
-                    &fields,
-                    rest,
-                    &span,
-                    &expected_ty,
-                    kind,
-                )
+                .try_infer_enum_struct_variant(&pattern, &expected_ty, kind)
                 .unwrap_or_else(|| {
                     self.sink
-                        .push(diagnostics::infer::struct_not_found(&identifier, span));
+                        .push(diagnostics::infer::struct_not_found(identifier, span));
                     (Pattern::WildCard { span }, TypedPattern::Wildcard)
                 });
         };
@@ -709,17 +695,10 @@ impl InferCtx<'_, '_> {
         }) = store.get_definition(&qualified_name)
         else {
             return self
-                .try_infer_enum_struct_variant(
-                    &identifier,
-                    &fields,
-                    rest,
-                    &span,
-                    &expected_ty,
-                    kind,
-                )
+                .try_infer_enum_struct_variant(&pattern, &expected_ty, kind)
                 .unwrap_or_else(|| {
                     self.sink
-                        .push(diagnostics::infer::struct_not_found(&identifier, span));
+                        .push(diagnostics::infer::struct_not_found(identifier, span));
                     (Pattern::WildCard { span }, TypedPattern::Wildcard)
                 });
         };
@@ -816,7 +795,7 @@ impl InferCtx<'_, '_> {
         };
 
         let pattern = Pattern::Struct {
-            identifier,
+            identifier: identifier.clone(),
             fields: new_fields,
             rest,
             ty: struct_ty,
@@ -954,7 +933,7 @@ impl InferCtx<'_, '_> {
         {
             return simple.to_string();
         }
-        for (prefix, imported_module_id) in &self.imports.prefix_to_module {
+        for (prefix, imported_module_id) in self.imports.modules() {
             if imported_module_id == module_id {
                 return format!("{}.{}", prefix, simple);
             }
@@ -1030,16 +1009,23 @@ impl InferCtx<'_, '_> {
     }
 
     /// Tries to infer an enum struct variant pattern like `Move { x, y }`.
-    #[allow(clippy::too_many_arguments)]
     fn try_infer_enum_struct_variant(
         &mut self,
-        identifier: &str,
-        fields: &[StructFieldPattern],
-        rest: bool,
-        span: &Span,
+        pattern: &Pattern,
         expected_ty: &Type,
         kind: BindingKind,
     ) -> Option<(Pattern, TypedPattern)> {
+        let Pattern::Struct {
+            identifier,
+            fields,
+            rest,
+            span,
+            ..
+        } = pattern
+        else {
+            unreachable!("try_infer_enum_struct_variant called with non-Struct pattern");
+        };
+        let rest = *rest;
         let store = self.store;
         let bare_variant = if kind.is_match_arm() {
             self.resolve_bare_variant_type(identifier, expected_ty)

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -9,6 +9,7 @@ use super::super::addressability::{
     check_is_non_addressable, check_non_addressable_assignment_target,
 };
 use super::functions::phantom_type_params;
+use super::operators::InferredOperand;
 use crate::checker::infer::InferCtx;
 
 /// Checks whether an assignment target expression contains a deref (`.* `)
@@ -87,15 +88,15 @@ fn contains_stored_reference_to(expression: &Expression, var_name: &str) -> bool
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(super) fn infer_paren(
         &mut self,
         expression: Box<Expression>,
         span: Span,
         expected_ty: &Type,
-        parent_is_subexpression: bool,
+        is_subexpression: bool,
     ) -> Expression {
-        if !parent_is_subexpression {
+        if !is_subexpression {
             match &*expression {
                 Expression::Return { span: s, .. } => {
                     self.sink
@@ -115,8 +116,7 @@ impl InferCtx<'_, '_> {
             }
         }
 
-        self.scopes.set_in_subexpression(parent_is_subexpression);
-        let new_expression = self.infer_expression(*expression, expected_ty);
+        let new_expression = self.infer_expression_at(*expression, expected_ty, is_subexpression);
         let new_ty = new_expression.get_type();
 
         Expression::Paren {
@@ -395,18 +395,17 @@ impl InferCtx<'_, '_> {
         // get their types from a Map's value type).
         let value_expected = target_ty.resolve_in(&self.env);
         let (new_value, value_ty) = if let Some(operator) = compound_operator {
-            let (binary, result_ty) = self.infer_binary_with_left(
+            let inferred = self.infer_binary_with_left(
                 operator,
-                new_target.clone(),
-                target_ty.clone(),
+                InferredOperand::new(new_target.clone(), target_ty.clone()),
                 value,
                 &value_expected,
                 span,
             );
-            let Expression::Binary { right, .. } = binary else {
+            let Expression::Binary { right, .. } = inferred.expression else {
                 unreachable!("infer_binary_with_left always returns a binary")
             };
-            (*right, result_ty)
+            (*right, inferred.ty)
         } else {
             let new_value = self.infer_expression(*value, &value_expected);
             let value_ty = new_value.get_type();
@@ -443,7 +442,7 @@ impl InferCtx<'_, '_> {
 
             let can_mutate = is_mutable || is_deref || binding_is_ref;
 
-            if !can_mutate && !self.imports.imported_modules.contains_key(&var_name) {
+            if !can_mutate && self.imports.namespace(&var_name).is_none() {
                 let self_type_name = if var_name == "self" {
                     self.lookup_type(store, "self")
                         .and_then(|t| t.get_name().map(str::to_owned))
@@ -543,7 +542,7 @@ impl InferCtx<'_, '_> {
         for (i, item) in items.into_iter().enumerate() {
             if diverged_at.is_some() {
                 let dead_item_ty = self.new_type_var();
-                let inferred_item = self.infer_expression(item, &dead_item_ty);
+                let inferred_item = self.infer_root_expression(item, &dead_item_ty);
                 new_items.push(inferred_item);
                 continue;
             }
@@ -597,8 +596,7 @@ impl InferCtx<'_, '_> {
                 None
             };
 
-            self.scopes.set_in_subexpression(false);
-            let inferred_item = self.infer_expression(item, &expression_ty);
+            let inferred_item = self.infer_root_expression(item, &expression_ty);
 
             if let Some(ctx) = prev_ctx {
                 self.scopes.restore_use_context(ctx);
@@ -622,7 +620,7 @@ impl InferCtx<'_, '_> {
 
     fn error_name_not_found(&mut self, variable_name: &str, span: Span, expected_ty: &Type) {
         let store = self.store;
-        if self.imports.failed_imports.contains(variable_name) {
+        if self.imports.is_failed(variable_name) {
             return;
         }
 

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -1,13 +1,16 @@
-use std::cell::Cell;
-
 use crate::checker::EnvResolve;
-use crate::checker::scopes::{CarrierKind, DepthCounter, RecoverBlockContext, TryBlockContext};
+use crate::checker::scopes::{DepthCounter, RecoverBlockContext, TryBlockContext, TryCarrier};
 use syntax::ast::{Expression, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+struct TryBlockTypes {
+    ok: Type,
+    error: Type,
+}
+
+impl InferCtx<'_> {
     pub(super) fn infer_propagate(
         &mut self,
         expression: Box<Expression>,
@@ -30,27 +33,24 @@ impl InferCtx<'_, '_> {
                 .push(diagnostics::infer::propagate_on_partial(span));
         }
 
-        let try_block_types = if let Some(ctx) = self.scopes.lookup_try_block_context() {
+        let try_block_types = if self.scopes.lookup_try_block_context().is_some() {
             let is_result = resolved_tried_ty.is_result();
             let is_option = resolved_tried_ty.is_option();
-
-            ctx.has_question_mark.set(true);
-
-            let has_mismatch = match (is_result, is_option, ctx.carrier.get()) {
-                (true, _, None) => {
-                    ctx.carrier.set(Some(CarrierKind::Result));
-                    false
-                }
-                (_, true, None) => {
-                    ctx.carrier.set(Some(CarrierKind::Option));
-                    false
-                }
-                (true, _, Some(CarrierKind::Option)) | (_, true, Some(CarrierKind::Result)) => true,
-                _ => false,
+            let observed = if is_result {
+                Some(TryCarrier::Result)
+            } else if is_option {
+                Some(TryCarrier::Option)
+            } else {
+                None
             };
-
-            let ok_ty = ctx.ok_ty.clone();
-            let err_ty = ctx.err_ty.clone();
+            let (ok_ty, err_ty, has_mismatch) = {
+                let ctx = self
+                    .scopes
+                    .lookup_try_block_context_mut()
+                    .expect("try block context was just found");
+                let has_mismatch = ctx.carrier.observe(observed);
+                (ctx.ok_ty.clone(), ctx.err_ty.clone(), has_mismatch)
+            };
 
             if !is_result
                 && !is_option
@@ -65,17 +65,19 @@ impl InferCtx<'_, '_> {
                     .push(diagnostics::infer::mixed_carriers_in_try_block(span));
             }
 
-            Some((ok_ty, err_ty))
+            Some(TryBlockTypes {
+                ok: ok_ty,
+                error: err_ty,
+            })
         } else {
             None
         };
 
-        if let Some((try_ok_ty, try_err_ty)) = try_block_types {
+        if let Some(try_types) = try_block_types {
             return self.infer_propagate_in_block(
                 new_expression,
                 &resolved_tried_ty,
-                &try_ok_ty,
-                &try_err_ty,
+                &try_types,
                 span,
                 expected_ty,
             );
@@ -89,13 +91,11 @@ impl InferCtx<'_, '_> {
         Type::Error
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_propagate_in_block(
         &mut self,
         new_expression: Expression,
         tried_ty: &Type,
-        try_ok_ty: &Type,
-        try_err_ty: &Type,
+        try_types: &TryBlockTypes,
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
@@ -103,16 +103,16 @@ impl InferCtx<'_, '_> {
             self.propagate_as_error(expected_ty, span)
         } else if tried_ty.is_result() {
             let ok_ty = tried_ty.ok_type();
-            self.unify(try_err_ty, &tried_ty.err_type(), &span);
+            self.unify(&try_types.error, &tried_ty.err_type(), &span);
             if ok_ty.resolve_in(&self.env).is_variable() {
-                self.unify(try_ok_ty, &ok_ty, &span);
+                self.unify(&try_types.ok, &ok_ty, &span);
             }
             self.unify(expected_ty, &ok_ty, &span);
             ok_ty
         } else if tried_ty.is_option() {
             let some_ty = tried_ty.ok_type();
             if some_ty.resolve_in(&self.env).is_variable() {
-                self.unify(try_ok_ty, &some_ty, &span);
+                self.unify(&try_types.ok, &some_ty, &span);
             }
             self.unify(expected_ty, &some_ty, &span);
             some_ty
@@ -231,8 +231,7 @@ impl InferCtx<'_, '_> {
             scope.try_block_context = Some(TryBlockContext {
                 ok_ty: ok_ty.clone(),
                 err_ty: err_ty.clone(),
-                carrier: Cell::new(None),
-                has_question_mark: Cell::new(false),
+                carrier: TryCarrier::Unset,
                 loop_depth: DepthCounter::new(),
             });
         }
@@ -241,17 +240,17 @@ impl InferCtx<'_, '_> {
 
         let new_items = self.infer_block_items(items, ok_ty.clone());
 
-        let (has_question_mark, carrier) = {
+        let carrier = {
             let ctx = self
                 .scopes
                 .current()
                 .try_block_context
                 .as_ref()
                 .expect("try_block_context must exist");
-            (ctx.has_question_mark.get(), ctx.carrier.get())
+            ctx.carrier
         };
 
-        if !has_question_mark {
+        if !carrier.was_used() {
             self.sink
                 .push(diagnostics::infer::try_block_no_question_mark(
                     try_keyword_span,
@@ -287,15 +286,15 @@ impl InferCtx<'_, '_> {
         let inner_ty = last_item.get_type();
 
         let block_ty = match carrier {
-            Some(CarrierKind::Result) => {
+            TryCarrier::Result => {
                 self.unify(&ok_ty, &inner_ty, &span);
                 self.type_result(store, inner_ty, err_ty)
             }
-            Some(CarrierKind::Option) => {
+            TryCarrier::Option => {
                 self.unify(&ok_ty, &inner_ty, &span);
                 self.type_option(store, inner_ty)
             }
-            None => {
+            TryCarrier::Unset | TryCarrier::Unknown => {
                 let new_err_ty = self.new_type_var();
                 self.type_result(store, inner_ty, new_err_ty)
             }
@@ -313,13 +312,13 @@ impl InferCtx<'_, '_> {
     }
 
     pub(super) fn increment_try_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_try_block_context() {
+        if let Some(ctx) = self.scopes.lookup_try_block_context_mut() {
             ctx.loop_depth.increment();
         }
     }
 
     pub(super) fn decrement_try_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_try_block_context() {
+        if let Some(ctx) = self.scopes.lookup_try_block_context_mut() {
             ctx.loop_depth.decrement();
         }
     }
@@ -381,13 +380,13 @@ impl InferCtx<'_, '_> {
     }
 
     pub(super) fn increment_recover_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_recover_block_context() {
+        if let Some(ctx) = self.scopes.lookup_recover_block_context_mut() {
             ctx.loop_depth.increment();
         }
     }
 
     pub(super) fn decrement_recover_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_recover_block_context() {
+        if let Some(ctx) = self.scopes.lookup_recover_block_context_mut() {
             ctx.loop_depth.decrement();
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -17,7 +17,7 @@ fn select_arm_body_span(pattern: &SelectArmPattern) -> Span {
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub fn resolve_select_exhaustiveness(&mut self) {
         for check in std::mem::take(&mut self.facts.select_exhaustiveness_checks) {
             let resolved = check.result_ty.resolve_in(&self.env);
@@ -227,8 +227,7 @@ impl InferCtx<'_, '_> {
             syntax::ast::BindingKind::Let { mutable: false },
         );
 
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
+        let new_body = self.infer_root_expression(*body, result_ty);
 
         SelectArmPattern::Receive {
             binding: Box::new(new_binding),
@@ -257,8 +256,7 @@ impl InferCtx<'_, '_> {
             ));
         }
 
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
+        let new_body = self.infer_root_expression(*body, result_ty);
 
         SelectArmPattern::Send {
             send_expression: Box::new(new_send_expression),
@@ -328,8 +326,8 @@ impl InferCtx<'_, '_> {
                     result_ty
                 };
 
-                self.scopes.set_in_subexpression(false);
-                let new_expression = self.infer_expression(*match_arm.expression, arm_expected);
+                let new_expression =
+                    self.infer_root_expression(*match_arm.expression, arm_expected);
 
                 if needs_reconciliation {
                     arm_expression_types.push(arm_expected.clone());
@@ -372,8 +370,7 @@ impl InferCtx<'_, '_> {
         body: Box<Expression>,
         result_ty: &Type,
     ) -> SelectArmPattern {
-        self.scopes.set_in_subexpression(false);
-        let new_body = self.infer_expression(*body, result_ty);
+        let new_body = self.infer_root_expression(*body, result_ty);
         SelectArmPattern::WildCard {
             body: Box::new(new_body),
         }

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -21,17 +21,62 @@ struct StructishCtx<'a, 'b, F> {
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
-impl InferCtx<'_, '_> {
+struct StructLiteral {
+    name: EcoString,
+    fields: Vec<StructFieldAssignment>,
+    spread: StructSpread,
+    span: Span,
+}
+
+impl StructLiteral {
+    fn with_type(self, ty: Type) -> Expression {
+        Expression::StructCall {
+            name: self.name,
+            field_assignments: self.fields,
+            spread: self.spread,
+            ty,
+            span: self.span,
+        }
+    }
+}
+
+struct ResolvedStruct {
+    qualified_name: EcoString,
+    ty: Type,
+    fields: Vec<syntax::ast::StructFieldDefinition>,
+    alias_underlying: Option<Type>,
+}
+
+struct ResolvedVariant {
+    fields: Vec<syntax::ast::EnumFieldDefinition>,
+    substitutions: SubstitutionMap,
+    ty: Type,
+}
+
+impl InferCtx<'_> {
     pub(super) fn infer_struct_call(
         &mut self,
-        struct_name: EcoString,
-        field_assignments: Vec<StructFieldAssignment>,
-        spread: StructSpread,
-        span: Span,
+        expression: Expression,
         expected_ty: &Type,
     ) -> Expression {
+        let Expression::StructCall {
+            name,
+            field_assignments,
+            spread,
+            span,
+            ..
+        } = expression
+        else {
+            unreachable!("infer_struct_call called with non-StructCall expression");
+        };
+        let literal = StructLiteral {
+            name,
+            fields: field_assignments,
+            spread,
+            span,
+        };
         let store = self.store;
-        if let Some(qualified_name) = self.lookup_qualified_name(store, &struct_name)
+        if let Some(qualified_name) = self.lookup_qualified_name(store, &literal.name)
             && let Some(Definition {
                 ty: struct_ty,
                 body:
@@ -45,21 +90,25 @@ impl InferCtx<'_, '_> {
             let struct_ty = struct_ty.clone();
             let struct_fields = struct_fields.clone();
 
-            self.track_name_usage(store, &qualified_name, &span, struct_name.len() as u32);
+            self.track_name_usage(
+                store,
+                &qualified_name,
+                &literal.span,
+                literal.name.len() as u32,
+            );
             return self.infer_struct_call_for_struct(
-                struct_name,
-                qualified_name,
-                struct_ty,
-                struct_fields,
-                field_assignments,
-                spread,
-                span,
+                literal,
+                ResolvedStruct {
+                    qualified_name,
+                    ty: struct_ty,
+                    fields: struct_fields,
+                    alias_underlying: None,
+                },
                 expected_ty,
-                None,
             );
         }
 
-        if let Some(qualified_name) = self.lookup_qualified_name(store, &struct_name)
+        if let Some(qualified_name) = self.lookup_qualified_name(store, &literal.name)
             && let Some(Definition {
                 ty: alias_ty,
                 body: DefinitionBody::TypeAlias { annotation, .. },
@@ -93,34 +142,27 @@ impl InferCtx<'_, '_> {
                     Some(underlying)
                 };
                 return self.infer_struct_call_for_struct(
-                    struct_name,
-                    struct_id_str,
-                    struct_ty,
-                    struct_fields,
-                    field_assignments,
-                    spread,
-                    span,
+                    literal,
+                    ResolvedStruct {
+                        qualified_name: struct_id_str,
+                        ty: struct_ty,
+                        fields: struct_fields,
+                        alias_underlying,
+                    },
                     expected_ty,
-                    alias_underlying,
                 );
             }
 
             // Opaque types (e.g., Go's sync.WaitGroup) can be zero-value instantiated
             // with T{} even though they have no struct definition.
-            if is_opaque && field_assignments.is_empty() {
+            if is_opaque && literal.fields.is_empty() {
                 let (instantiated_ty, _) = self.instantiate(&alias_ty);
-                self.unify(expected_ty, &instantiated_ty, &span);
-                return Expression::StructCall {
-                    name: struct_name,
-                    field_assignments,
-                    spread,
-                    ty: instantiated_ty,
-                    span,
-                };
+                self.unify(expected_ty, &instantiated_ty, &literal.span);
+                return literal.with_type(instantiated_ty);
             }
         }
 
-        if let Some((type_part, variant_name)) = struct_name.rsplit_once('.')
+        if let Some((type_part, variant_name)) = literal.name.rsplit_once('.')
             && let Some(qualified_name) = self.lookup_qualified_name(store, type_part)
             && let Some(Definition {
                 ty: alias_ty,
@@ -151,40 +193,35 @@ impl InferCtx<'_, '_> {
                     _ => instantiated_ty,
                 };
                 return self.infer_struct_call_for_enum_variant(
-                    struct_name,
-                    variant_fields,
-                    map,
-                    field_assignments,
-                    spread,
-                    span,
+                    literal,
+                    ResolvedVariant {
+                        fields: variant_fields,
+                        substitutions: map,
+                        ty: enum_ty,
+                    },
                     expected_ty,
-                    enum_ty,
                 );
             }
         }
 
-        if let Some(ty) = self.lookup_type(store, &struct_name) {
+        if let Some(ty) = self.lookup_type(store, &literal.name) {
             let (value_constructor_type, map) = self.instantiate(&ty);
 
             let pattern_ty = match value_constructor_type {
                 Type::Function(f) => (*f.return_type).clone(),
                 Type::Nominal { .. } => value_constructor_type,
                 _ => {
-                    self.sink
-                        .push(diagnostics::infer::struct_not_found(&struct_name, span));
-                    self.unify(expected_ty, &Type::Error, &span);
-                    return Expression::StructCall {
-                        name: struct_name,
-                        field_assignments,
-                        spread,
-                        ty: Type::Error,
-                        span,
-                    };
+                    self.sink.push(diagnostics::infer::struct_not_found(
+                        &literal.name,
+                        literal.span,
+                    ));
+                    self.unify(expected_ty, &Type::Error, &literal.span);
+                    return literal.with_type(Type::Error);
                 }
             };
 
             let resolved_ty = pattern_ty.resolve_in(&self.env);
-            let variant_name = unqualified_name(&struct_name);
+            let variant_name = unqualified_name(&literal.name);
 
             if let Type::Nominal { id, .. } = &resolved_ty
                 && let Some(variants) = store.variants_of(id)
@@ -193,43 +230,43 @@ impl InferCtx<'_, '_> {
             {
                 let variant_fields: Vec<_> = variant.fields.iter().cloned().collect();
                 return self.infer_struct_call_for_enum_variant(
-                    struct_name,
-                    variant_fields,
-                    map,
-                    field_assignments,
-                    spread,
-                    span,
+                    literal,
+                    ResolvedVariant {
+                        fields: variant_fields,
+                        substitutions: map,
+                        ty: pattern_ty,
+                    },
                     expected_ty,
-                    pattern_ty,
                 );
             }
         }
 
-        self.sink
-            .push(diagnostics::infer::struct_not_found(&struct_name, span));
-        self.unify(expected_ty, &Type::Error, &span);
-        Expression::StructCall {
-            name: struct_name,
-            field_assignments,
-            spread,
-            ty: Type::Error,
-            span,
-        }
+        self.sink.push(diagnostics::infer::struct_not_found(
+            &literal.name,
+            literal.span,
+        ));
+        self.unify(expected_ty, &Type::Error, &literal.span);
+        literal.with_type(Type::Error)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_struct_call_for_struct(
         &mut self,
-        struct_name: EcoString,
-        qualified_name: EcoString,
-        struct_ty: Type,
-        struct_fields: Vec<syntax::ast::StructFieldDefinition>,
-        field_assignments: Vec<StructFieldAssignment>,
-        spread: StructSpread,
-        span: Span,
+        literal: StructLiteral,
+        target: ResolvedStruct,
         expected_ty: &Type,
-        alias_underlying: Option<Type>,
     ) -> Expression {
+        let StructLiteral {
+            name: struct_name,
+            fields: field_assignments,
+            spread,
+            span,
+        } = literal;
+        let ResolvedStruct {
+            qualified_name,
+            ty: struct_ty,
+            fields: struct_fields,
+            alias_underlying,
+        } = target;
         let store = self.store;
         let (struct_call_ty, map) = self.instantiate(&struct_ty);
 
@@ -252,7 +289,7 @@ impl InferCtx<'_, '_> {
         let is_cross_module = struct_module != self.cursor.module_id
             || struct_name
                 .split_once('.')
-                .is_some_and(|(prefix, _)| self.imports.imported_modules.contains_key(prefix));
+                .is_some_and(|(prefix, _)| self.imports.namespace(prefix).is_some());
         let is_go_imported = qualified_name.starts_with("go:");
 
         let (new_field_assignments, matched_fields) = self.infer_structish_fields(
@@ -335,18 +372,23 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn infer_struct_call_for_enum_variant(
         &mut self,
-        variant_name: EcoString,
-        variant_fields: Vec<syntax::ast::EnumFieldDefinition>,
-        map: SubstitutionMap,
-        field_assignments: Vec<StructFieldAssignment>,
-        spread: StructSpread,
-        span: Span,
+        literal: StructLiteral,
+        target: ResolvedVariant,
         expected_ty: &Type,
-        enum_ty: Type,
     ) -> Expression {
+        let StructLiteral {
+            name: variant_name,
+            fields: field_assignments,
+            spread,
+            span,
+        } = literal;
+        let ResolvedVariant {
+            fields: variant_fields,
+            substitutions: map,
+            ty: enum_ty,
+        } = target;
         let store = self.store;
         self.unify(expected_ty, &enum_ty, &span);
 

--- a/crates/semantics/src/checker/infer/generic_obligations.rs
+++ b/crates/semantics/src/checker/infer/generic_obligations.rs
@@ -5,7 +5,7 @@ use crate::checker::infer::InferCtx;
 use crate::facts::{GenericBoundObligation, GenericBoundOrigin};
 use crate::generics::{AppliedGenericBound, bound_requires_evidence, type_obligations};
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(crate) fn register_construction_obligations(
         &mut self,
         written_name: &str,

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -7,6 +7,21 @@ use syntax::types::{GO_IMPORT_PREFIX, SubstitutionMap, Type, substitute};
 
 use crate::checker::infer::InferCtx;
 
+struct PointerReceiverCheck<'a> {
+    methods: &'a MethodSignatures,
+    receiver: &'a Type,
+    found: Vec<String>,
+    visiting: rustc_hash::FxHashSet<String>,
+}
+
+struct ConformanceTraversal<'a> {
+    receiver: &'a Type,
+    span: Span,
+    adapter_capable: bool,
+    violations: Vec<InterfaceViolation>,
+    visiting: rustc_hash::FxHashSet<String>,
+}
+
 fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
     fn walk(
         store: &Store,
@@ -35,7 +50,7 @@ fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
     )
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(crate) fn check_concrete_bound(&mut self, ty: &Type, bound: &Type, span: &Span) {
         let bound = self.store.deep_resolve_alias(bound);
         let Type::Nominal { id, params, .. } = bound else {
@@ -93,19 +108,21 @@ impl InferCtx<'_, '_> {
         }
 
         let adapter_capable = self.adapter_capable_receiver(ty, interface, interface_qualified_id);
-        let mut violations = Vec::new();
-        let mut visited = rustc_hash::FxHashSet::default();
+        let mut check = ConformanceTraversal {
+            receiver: ty,
+            span: *span,
+            adapter_capable,
+            violations: Vec::new(),
+            visiting: rustc_hash::FxHashSet::default(),
+        };
         self.collect_interface_violations(
-            ty,
+            &mut check,
             interface,
             interface_qualified_id,
             type_args,
             None,
-            adapter_capable,
-            span,
-            &mut violations,
-            &mut visited,
         );
+        let violations = check.violations;
 
         self.satisfying_stack.remove(&pair);
 
@@ -193,7 +210,7 @@ impl InferCtx<'_, '_> {
     /// interface. Runs on direct value-to-interface assignment and bounds checking,
     /// minus generics absorbed via a `Ref<T>` param (see `generic_absorbed_via_ref_param`).
     pub(super) fn check_pointer_receivers(
-        &self,
+        &mut self,
         ty: &Type,
         interface: &Interface,
         interface_qualified_id: &str,
@@ -205,17 +222,14 @@ impl InferCtx<'_, '_> {
         }
 
         let methods = self.get_all_methods(store, ty);
-        let mut ptr_methods = Vec::new();
-        let mut visited = rustc_hash::FxHashSet::default();
-
-        self.collect_pointer_receiver_methods(
-            interface,
-            interface_qualified_id,
-            &methods,
-            ty,
-            &mut ptr_methods,
-            &mut visited,
-        );
+        let mut check = PointerReceiverCheck {
+            methods: &methods,
+            receiver: ty,
+            found: Vec::new(),
+            visiting: rustc_hash::FxHashSet::default(),
+        };
+        self.collect_pointer_receiver_methods(&mut check, interface, interface_qualified_id);
+        let ptr_methods = check.found;
 
         if ptr_methods.is_empty() {
             return Ok(());
@@ -232,18 +246,14 @@ impl InferCtx<'_, '_> {
         Err(vec![])
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn collect_pointer_receiver_methods(
         &self,
+        check: &mut PointerReceiverCheck<'_>,
         interface: &Interface,
         interface_qualified_id: &str,
-        methods: &MethodSignatures,
-        receiver: &Type,
-        out: &mut Vec<String>,
-        visited: &mut rustc_hash::FxHashSet<String>,
     ) {
         let store = self.store;
-        if !visited.insert(interface_qualified_id.to_string()) {
+        if !check.visiting.insert(interface_qualified_id.to_string()) {
             return;
         }
         let interface_is_public = store
@@ -251,11 +261,11 @@ impl InferCtx<'_, '_> {
             .is_some_and(|d| d.visibility.is_public());
         for name in interface.methods.keys() {
             if let Some((impl_name, method_ty)) = syntax::go_names::conformance_method(
-                methods,
+                check.methods,
                 interface_qualified_id,
                 interface_is_public,
                 name.as_str(),
-                &|candidate| self.conformance_candidate(receiver, candidate),
+                &|candidate| self.conformance_candidate(check.receiver, candidate),
             ) {
                 let func = match method_ty {
                     Type::Forall { body, .. } => body.as_ref(),
@@ -264,7 +274,7 @@ impl InferCtx<'_, '_> {
                 if let Type::Function(f) = func
                     && f.params.first().is_some_and(|p| p.is_ref())
                 {
-                    out.push(impl_name.to_string());
+                    check.found.push(impl_name.to_string());
                 }
             }
         }
@@ -272,16 +282,13 @@ impl InferCtx<'_, '_> {
             let parent_name = parent.get_qualified_name();
             if let Some(parent_interface) = store.get_interface(&parent_name) {
                 self.collect_pointer_receiver_methods(
+                    check,
                     parent_interface,
                     parent_name.as_str(),
-                    methods,
-                    receiver,
-                    out,
-                    visited,
                 );
             }
         }
-        visited.remove(interface_qualified_id);
+        check.visiting.remove(interface_qualified_id);
     }
 
     fn conformance_candidate(
@@ -469,23 +476,20 @@ impl InferCtx<'_, '_> {
             })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn collect_interface_violations(
         &mut self,
-        ty: &Type,
+        check: &mut ConformanceTraversal<'_>,
         interface: &Interface,
         interface_qualified_id: &str,
         type_args: &[Type],
         parent_of: Option<&str>,
-        adapter_capable: bool,
-        span: &Span,
-        violations: &mut Vec<InterfaceViolation>,
-        visited: &mut rustc_hash::FxHashSet<String>,
     ) {
         let store = self.store;
-        if !visited.insert(interface_qualified_id.to_string()) {
+        if !check.visiting.insert(interface_qualified_id.to_string()) {
             return;
         }
+        let ty = check.receiver;
+        let span = &check.span;
 
         let symbol_methods = self.get_all_methods(store, ty);
 
@@ -556,7 +560,7 @@ impl InferCtx<'_, '_> {
                 }
             };
 
-            let check = self.check_method_signature(
+            let signature = self.check_method_signature(
                 ty,
                 interface_qualified_id,
                 method_name.as_str(),
@@ -565,25 +569,23 @@ impl InferCtx<'_, '_> {
                 &map,
             );
 
-            if check.receiver_pinned && check.matched {
+            if signature.receiver_pinned && signature.matched {
                 self.validate_comma_ok_abi(
-                    ty,
+                    check,
                     interface,
                     interface_qualified_id,
                     method_name,
                     impl_method_name.as_str(),
-                    adapter_capable,
-                    span,
                 );
             }
 
-            if !check.receiver_pinned {
+            if !signature.receiver_pinned {
                 missing.push((method_name.to_string(), method_ty.clone()));
-            } else if !check.matched {
+            } else if !signature.matched {
                 incompatible.push((
                     method_name.to_string(),
-                    check.substituted_method,
-                    check.incompatible_impl,
+                    signature.substituted_method,
+                    signature.incompatible_impl,
                 ));
             } else {
                 let spelling_pinned = syntax::go_names::interface_matches_by_source_name(
@@ -595,7 +597,7 @@ impl InferCtx<'_, '_> {
         }
 
         if !missing.is_empty() || !incompatible.is_empty() {
-            violations.push(InterfaceViolation {
+            check.violations.push(InterfaceViolation {
                 interface_name: interface.name.to_string(),
                 parent_of: parent_of.map(String::from),
                 missing,
@@ -612,20 +614,16 @@ impl InferCtx<'_, '_> {
                     .map(|arg| substitute(arg, &map))
                     .collect();
                 self.collect_interface_violations(
-                    ty,
+                    check,
                     &parent_interface,
                     &parent_name,
                     &substituted_parent_args,
                     Some(&interface.name),
-                    adapter_capable,
-                    span,
-                    violations,
-                    visited,
                 );
             }
         }
 
-        visited.remove(interface_qualified_id);
+        check.visiting.remove(interface_qualified_id);
     }
 
     fn select_impl_method(
@@ -730,19 +728,16 @@ impl InferCtx<'_, '_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn validate_comma_ok_abi(
         &mut self,
-        ty: &Type,
+        check: &ConformanceTraversal<'_>,
         interface: &Interface,
         interface_qualified_id: &str,
         method_name: &str,
         impl_method_name: &str,
-        adapter_capable: bool,
-        span: &Span,
     ) {
         let store = self.store;
-        let resolved_ty = ty.strip_refs().resolve_in(&self.env);
+        let resolved_ty = check.receiver.strip_refs().resolve_in(&self.env);
         if resolved_ty.get_qualified_id().is_none() {
             return;
         }
@@ -754,12 +749,12 @@ impl InferCtx<'_, '_> {
         let interface_comma_ok = method_comma_ok(store, interface_qualified_id, method_name);
         let selected_comma_ok =
             method_comma_ok(store, member.declaring_type.as_str(), impl_method_name);
-        let adapter_reconciles = adapter_capable && interface_comma_ok && !selected_comma_ok;
+        let adapter_reconciles = check.adapter_capable && interface_comma_ok && !selected_comma_ok;
         if interface_comma_ok != selected_comma_ok && !adapter_reconciles {
             self.sink.push(diagnostics::embed::comma_ok_abi_mismatch(
                 &interface.name,
                 method_name,
-                *span,
+                check.span,
             ));
         }
     }

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -10,7 +10,7 @@ mod validation;
 pub use context::InferCtx;
 pub(crate) use unify::BuiltinBound;
 
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use super::freeze::FreezeFolder;
 use super::{FileContextKind, TaskState};
@@ -18,7 +18,7 @@ use crate::store::Store;
 use syntax::ast::{Expression, Span};
 use syntax::program::{File, FileImport};
 
-impl TaskState<'_> {
+impl TaskState {
     /// Extract a module's `.lis` files from the store.
     pub fn take_module_files(&mut self, store: &mut Store, module_id: &str) -> Vec<File> {
         self.with_module_cursor(module_id, |_this| {
@@ -30,7 +30,7 @@ impl TaskState<'_> {
     }
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Infer types for `files` belonging to `module_id`.
     pub fn infer_module(&mut self, module_id: &str, files: Vec<File>) {
         let items_per_file: Vec<&[Expression]> = files.iter().map(|f| f.items.as_slice()).collect();
@@ -61,7 +61,7 @@ impl InferCtx<'_, '_> {
                     .into_iter()
                     .map(|item| {
                         let type_var = ctx.new_type_var();
-                        ctx.infer_expression(item, &type_var)
+                        ctx.infer_root_expression(item, &type_var)
                     })
                     .collect();
 
@@ -141,7 +141,7 @@ impl InferCtx<'_, '_> {
     fn check_binding_shadows_import(&mut self, name: &str, span: Span, is_typedef: bool) {
         if !is_typedef
             && name != crate::prelude::PRELUDE_MODULE_ID
-            && let Some(import_path) = self.imports.prefix_to_module.get(name)
+            && let Some(import_path) = self.imports.module_id(name)
         {
             self.sink.push(diagnostics::infer::name_shadows_import(
                 name,
@@ -199,11 +199,7 @@ impl InferCtx<'_, '_> {
         self.sink.truncate(before);
 
         let scope = self.scopes.current_mut();
-        scope.values.insert(identifier.to_string(), const_ty);
-        scope
-            .consts
-            .get_or_insert_with(HashSet::default)
-            .insert(identifier.to_string());
+        scope.insert_const(identifier.to_string(), const_ty);
     }
 
     fn register_block_local_fn(&mut self, item: &Expression) {
@@ -225,6 +221,6 @@ impl InferCtx<'_, '_> {
         self.sink.truncate(before);
 
         let scope = self.scopes.current_mut();
-        scope.values.insert(name.to_string(), fn_ty);
+        scope.insert_value(name.to_string(), fn_ty);
     }
 }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -52,7 +52,7 @@ pub enum Dispatched {
     Fallthrough,
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Make two types equal. Returns `false` when they do not match.
     ///
     /// - For two concrete types, verifies that they match.

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -4,7 +4,7 @@ use syntax::types::{SimpleKind, Type, peel_alias};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Validates that a cast from source_ty to target_ty is allowed.
     /// Pushes a diagnostic if the cast is invalid.
     ///

--- a/crates/semantics/src/checker/infer/validation/const_cycles.rs
+++ b/crates/semantics/src/checker/infer/validation/const_cycles.rs
@@ -11,7 +11,7 @@ struct ConstEntry<'a> {
     body: &'a Expression,
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub fn check_const_cycles(&mut self, items_per_file: &[&[Expression]]) {
         let store = self.store;
         let module_const_names_empty = store
@@ -73,7 +73,7 @@ impl InferCtx<'_, '_> {
                     &mut color,
                     &mut path,
                     &mut reported,
-                    self.sink,
+                    &self.sink,
                 );
             }
         }

--- a/crates/semantics/src/checker/infer/validation/control_flow.rs
+++ b/crates/semantics/src/checker/infer/validation/control_flow.rs
@@ -11,7 +11,7 @@ fn is_sync_lock_type(ty: &Type) -> bool {
     )
 }
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(crate) fn check_deferred_lock(&mut self, deferred: &Expression) {
         let Expression::Call {
             expression: callee,

--- a/crates/semantics/src/checker/infer/validation/map_reads.rs
+++ b/crates/semantics/src/checker/infer/validation/map_reads.rs
@@ -4,7 +4,7 @@ use syntax::types::CompoundKind;
 use crate::checker::EnvResolve;
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Reject map bracket reads whose value type has no zero value. A missing
     /// key surfaces the Go zero value, which for types like `Ref<T>` is a nil
     /// pointer with no Lisette equivalent.

--- a/crates/semantics/src/checker/infer/validation/numeric.rs
+++ b/crates/semantics/src/checker/infer/validation/numeric.rs
@@ -4,7 +4,7 @@ use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Validates that an integer literal fits within the target numeric type.
     /// Note: value is u64 from the parser, so negative literals are handled via unary minus.
     pub(crate) fn check_integer_literal_overflow(

--- a/crates/semantics/src/checker/infer/validation/references.rs
+++ b/crates/semantics/src/checker/infer/validation/references.rs
@@ -4,7 +4,7 @@ use syntax::ast::{Expression, Span};
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     /// Reject `Err(x)?` and `None?` when used as sub-expressions of a larger
     /// expression (call arg, binary operand, etc.).  These always early-return
     /// and never produce a value, so the surrounding expression is dead code.

--- a/crates/semantics/src/checker/infer/validation/select.rs
+++ b/crates/semantics/src/checker/infer/validation/select.rs
@@ -3,7 +3,7 @@ use syntax::types::unqualified_name;
 
 use crate::checker::infer::InferCtx;
 
-impl InferCtx<'_, '_> {
+impl InferCtx<'_> {
     pub(crate) fn check_select_match_arms(
         &mut self,
         match_arms: &[syntax::ast::MatchArm],

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -7,7 +7,6 @@ mod sealing;
 pub mod type_env;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -15,6 +14,7 @@ use crate::facts::{BindingIdAllocator, Facts};
 use crate::store::Store;
 use diagnostics::LocalSink;
 use ecow::EcoString;
+use registration::derived_attributes::DerivedAttribute;
 use scopes::Scopes;
 use syntax::ast::Visibility as AstVisibility;
 use syntax::ast::{Annotation, Expression, Generic, ImportAlias, Span, StructFieldDefinition};
@@ -25,7 +25,7 @@ use syntax::program::{
 use syntax::types::{Bound, SubstitutionMap, Symbol, Type, substitute};
 
 pub use infer::expressions::comparison::{check_never_comparable, check_not_comparable};
-pub use type_env::{EnvResolve, Speculation, TypeEnv, VarState};
+pub use type_env::{EnvResolve, TypeEnv, VarState};
 
 #[derive(Debug, Clone)]
 pub struct Cursor {
@@ -50,21 +50,64 @@ impl Cursor {
 
 #[derive(Debug, Default)]
 pub struct ImportState {
-    /// Module prefix -> (struct fields, module type). Fields are `Arc`-shared
-    /// since the same module is put in scope once per file.
-    imported_modules: HashMap<String, (Arc<[StructFieldDefinition]>, Type)>,
-    /// Import prefix -> actual module_id in Store (e.g., "http" -> "go:net/http")
-    prefix_to_module: HashMap<String, String>,
+    prefixed: HashMap<String, PrefixedImport>,
     /// Modules whose exports are available without prefix (current module and prelude)
     unprefixed_imports: HashSet<String>,
-    /// Effective aliases (e.g. `mux`) of imports whose underlying module
-    /// failed to load (missing typedef, undeclared, module_not_found, etc.).
-    failed_imports: HashSet<String>,
+}
+
+#[derive(Debug)]
+enum PrefixedImport {
+    Namespace {
+        module_id: String,
+        fields: Arc<[StructFieldDefinition]>,
+    },
+    /// A typedef's self-prefix resolves qualified names but is not itself a value.
+    LookupOnly {
+        module_id: String,
+    },
+    Failed,
 }
 
 impl ImportState {
     fn new() -> Self {
         Self::default()
+    }
+
+    fn module_id(&self, prefix: &str) -> Option<&str> {
+        match self.prefixed.get(prefix)? {
+            PrefixedImport::Namespace { module_id, .. }
+            | PrefixedImport::LookupOnly { module_id } => Some(module_id),
+            PrefixedImport::Failed => None,
+        }
+    }
+
+    fn namespace(&self, prefix: &str) -> Option<(&str, &Arc<[StructFieldDefinition]>)> {
+        match self.prefixed.get(prefix)? {
+            PrefixedImport::Namespace { module_id, fields } => Some((module_id, fields)),
+            PrefixedImport::LookupOnly { .. } | PrefixedImport::Failed => None,
+        }
+    }
+
+    fn modules(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.prefixed.iter().filter_map(|(prefix, import)| {
+            let module_id = match import {
+                PrefixedImport::Namespace { module_id, .. }
+                | PrefixedImport::LookupOnly { module_id } => module_id,
+                PrefixedImport::Failed => return None,
+            };
+            Some((prefix.as_str(), module_id.as_str()))
+        })
+    }
+
+    fn namespaces(&self) -> impl Iterator<Item = (&str, &Arc<[StructFieldDefinition]>)> {
+        self.prefixed.values().filter_map(|import| match import {
+            PrefixedImport::Namespace { module_id, fields } => Some((module_id.as_str(), fields)),
+            PrefixedImport::LookupOnly { .. } | PrefixedImport::Failed => None,
+        })
+    }
+
+    fn is_failed(&self, prefix: &str) -> bool {
+        matches!(self.prefixed.get(prefix), Some(PrefixedImport::Failed))
     }
 }
 
@@ -82,38 +125,74 @@ struct SavedFileContext {
     imports: ImportState,
 }
 
+type ModuleFieldMap = HashMap<EcoString, Arc<[StructFieldDefinition]>>;
+type UfcsMethod = (String, String);
+
+/// The parts of a checker task that survive after its local inference state is
+/// discarded.
+pub(crate) struct TaskOutput {
+    facts: Facts,
+    module_fields: Arc<ModuleFieldMap>,
+    ufcs_methods: Arc<HashSet<UfcsMethod>>,
+    typed_files: Vec<(String, File)>,
+    pending_equality_attributes: Vec<DerivedAttribute>,
+    pending_generic_bound_checks: Vec<(Type, Type, Span)>,
+    pending_interface_bound_checks: Vec<(Type, Type, Span)>,
+    sink: LocalSink,
+}
+
+/// A consistent read-only snapshot from which parallel checker tasks start.
+pub(crate) struct TaskSeed {
+    binding_ids: Arc<BindingIdAllocator>,
+    module_fields: Arc<ModuleFieldMap>,
+    ufcs_methods: Arc<HashSet<UfcsMethod>>,
+}
+
+impl TaskSeed {
+    pub(crate) fn spawn(&self) -> TaskState {
+        let Self {
+            binding_ids,
+            module_fields,
+            ufcs_methods,
+        } = self;
+        let mut task = TaskState::new(binding_ids.clone(), LocalSink::new());
+        task.module_fields = module_fields.clone();
+        task.ufcs_methods = ufcs_methods.clone();
+        task
+    }
+}
+
 /// Per-task mutable state. Paired with `AnalysisContext` (shared read-only view).
-pub struct TaskState<'s> {
+pub struct TaskState {
     pub env: TypeEnv,
     pub(crate) scopes: Scopes,
     pub cursor: Cursor,
     imports: ImportState,
-    pub sink: &'s LocalSink,
+    pub sink: LocalSink,
     pub facts: Facts,
     /// Recursion guard for interface satisfaction. Prevents
     /// `collect_interface_violations` from diverging when a bound on `T`
     /// transitively requires checking `T` against the same interface.
     satisfying_stack: rustc_hash::FxHashSet<(String, String)>,
-    method_cache: RefCell<HashMap<EcoString, Rc<MethodSignatures>>>,
-    /// Per-module field projection, cached to avoid rebuilding it (and recloning
-    /// every type) on each file-context entry.
-    module_fields_cache: RefCell<HashMap<EcoString, Arc<[StructFieldDefinition]>>>,
-    /// Register-phase projections shared read-only with inference workers, so
-    /// workers reuse them instead of rebuilding.
-    pub(crate) module_fields_shared: Option<Arc<HashMap<EcoString, Arc<[StructFieldDefinition]>>>>,
-    pub ufcs_methods: HashSet<(String, String)>,
-    /// When set, parallel workers read UFCS methods from here instead of cloning into `ufcs_methods`.
-    pub(crate) ufcs_shared: Option<Arc<HashSet<(String, String)>>>,
+    method_cache: HashMap<EcoString, Rc<MethodSignatures>>,
+    /// Per-module projections. Workers share this copy-on-write, and the field
+    /// definitions themselves remain `Arc`-shared if a worker adds an entry.
+    module_fields: Arc<ModuleFieldMap>,
+    /// Canonical UFCS set. Workers share it copy-on-write, so reads stay cheap
+    /// while task-local additions are returned as part of their output.
+    ufcs_methods: Arc<HashSet<UfcsMethod>>,
     /// Typed files produced by inference.
     pub typed_files: Vec<(String, File)>,
+    /// Equality synthesis waits until registration has discovered all UFCS methods.
+    pub(crate) pending_equality_attributes: Vec<DerivedAttribute>,
     pub(crate) pending_generic_bound_checks: Vec<(Type, Type, Span)>,
     /// Interface bounds on concrete type arguments named in annotations. Drained
     /// once after inference, since body annotations register during it.
     pub(crate) pending_interface_bound_checks: Vec<(Type, Type, Span)>,
 }
 
-impl<'s> TaskState<'s> {
-    pub(crate) fn new(sink: &'s LocalSink, binding_ids: Arc<BindingIdAllocator>) -> Self {
+impl TaskState {
+    fn new(binding_ids: Arc<BindingIdAllocator>, sink: LocalSink) -> Self {
         Self {
             env: TypeEnv::new(),
             scopes: Scopes::new(),
@@ -122,27 +201,111 @@ impl<'s> TaskState<'s> {
             sink,
             facts: Facts::new(binding_ids),
             satisfying_stack: rustc_hash::FxHashSet::default(),
-            method_cache: RefCell::new(HashMap::default()),
-            module_fields_cache: RefCell::new(HashMap::default()),
-            module_fields_shared: None,
-            ufcs_methods: HashSet::default(),
-            ufcs_shared: None,
+            method_cache: HashMap::default(),
+            module_fields: Arc::default(),
+            ufcs_methods: Arc::default(),
             typed_files: Vec::new(),
+            pending_equality_attributes: Vec::new(),
             pending_generic_bound_checks: Vec::new(),
             pending_interface_bound_checks: Vec::new(),
         }
     }
 
-    pub fn with_fresh_allocator(sink: &'s LocalSink) -> Self {
-        Self::new(sink, Arc::new(BindingIdAllocator::new()))
+    pub fn with_fresh_allocator() -> Self {
+        Self::new(Arc::new(BindingIdAllocator::new()), LocalSink::new())
     }
 
-    fn effective_ufcs_methods(&self) -> &HashSet<(String, String)> {
-        self.ufcs_shared.as_deref().unwrap_or(&self.ufcs_methods)
+    pub(crate) fn with_sink(sink: LocalSink) -> Self {
+        Self::new(Arc::new(BindingIdAllocator::new()), sink)
+    }
+
+    pub(crate) fn worker_seed(&self) -> TaskSeed {
+        TaskSeed {
+            binding_ids: self.facts.allocator(),
+            module_fields: self.module_fields.clone(),
+            ufcs_methods: self.ufcs_methods.clone(),
+        }
+    }
+
+    pub fn ufcs_methods(&self) -> &HashSet<UfcsMethod> {
+        &self.ufcs_methods
+    }
+
+    pub fn extend_ufcs_methods(&mut self, methods: impl IntoIterator<Item = UfcsMethod>) {
+        Arc::make_mut(&mut self.ufcs_methods).extend(methods);
+    }
+
+    pub fn take_ufcs_methods(&mut self) -> HashSet<UfcsMethod> {
+        Arc::unwrap_or_clone(std::mem::take(&mut self.ufcs_methods))
+    }
+
+    pub fn shared_ufcs_methods(&self) -> Arc<HashSet<UfcsMethod>> {
+        self.ufcs_methods.clone()
+    }
+
+    pub(crate) fn into_output(self) -> TaskOutput {
+        let Self {
+            env: _,
+            scopes: _,
+            cursor: _,
+            imports: _,
+            sink,
+            facts,
+            satisfying_stack: _,
+            method_cache: _,
+            module_fields,
+            ufcs_methods,
+            typed_files,
+            pending_equality_attributes,
+            pending_generic_bound_checks,
+            pending_interface_bound_checks,
+        } = self;
+        TaskOutput {
+            facts,
+            module_fields,
+            ufcs_methods,
+            typed_files,
+            pending_equality_attributes,
+            pending_generic_bound_checks,
+            pending_interface_bound_checks,
+            sink,
+        }
+    }
+
+    pub(crate) fn absorb_outputs(&mut self, outputs: Vec<TaskOutput>) {
+        let mut sinks = Vec::with_capacity(outputs.len());
+        for output in outputs {
+            let TaskOutput {
+                facts,
+                module_fields,
+                ufcs_methods,
+                typed_files,
+                pending_equality_attributes,
+                pending_generic_bound_checks,
+                pending_interface_bound_checks,
+                sink,
+            } = output;
+            if !Arc::ptr_eq(&self.module_fields, &module_fields) {
+                Arc::make_mut(&mut self.module_fields).extend(Arc::unwrap_or_clone(module_fields));
+            }
+            if !Arc::ptr_eq(&self.ufcs_methods, &ufcs_methods) {
+                Arc::make_mut(&mut self.ufcs_methods).extend(Arc::unwrap_or_clone(ufcs_methods));
+            }
+            self.facts.merge(facts);
+            self.typed_files.extend(typed_files);
+            self.pending_equality_attributes
+                .extend(pending_equality_attributes);
+            self.pending_generic_bound_checks
+                .extend(pending_generic_bound_checks);
+            self.pending_interface_bound_checks
+                .extend(pending_interface_bound_checks);
+            sinks.push(sink);
+        }
+        self.sink.extend(LocalSink::merge(sinks));
     }
 
     fn is_ufcs_method(&self, type_id: &str, method: &str) -> bool {
-        self.effective_ufcs_methods()
+        self.ufcs_methods()
             .contains(&(type_id.to_string(), method.to_string()))
     }
 
@@ -411,7 +574,7 @@ impl<'s> TaskState<'s> {
         prefer_type: bool,
     ) -> Option<EcoString> {
         if let Some((prefix, simple_name)) = type_name.split_once('.')
-            && let Some(module_id) = self.imports.prefix_to_module.get(prefix)
+            && let Some(module_id) = self.imports.module_id(prefix)
             && let Some(imported_module) = store.get_module(module_id)
             && let Some((qualified_name, _)) =
                 self.resolve_in_imported_module(store, imported_module, simple_name)
@@ -460,11 +623,8 @@ impl<'s> TaskState<'s> {
     }
 
     fn is_const_var(&self, store: &Store, var_name: &str) -> bool {
-        if self.scopes.lookup_binding_id(var_name).is_some() {
-            return false;
-        }
-        if self.scopes.lookup_const(var_name) {
-            return true;
+        if self.scopes.lookup_value(var_name).is_some() {
+            return self.scopes.lookup_const(var_name);
         }
         self.lookup_qualified_name(store, var_name)
             .is_some_and(|qname| self.is_const_name(store, &qname))
@@ -528,12 +688,12 @@ impl<'s> TaskState<'s> {
             return Some(ty.clone());
         }
 
-        if let Some((_definition, ty)) = self.imports.imported_modules.get(value_name) {
-            return Some(ty.clone());
+        if let Some((module_id, _)) = self.imports.namespace(value_name) {
+            return Some(Type::ImportNamespace(module_id.into()));
         }
 
         if let Some((prefix, rest)) = value_name.split_once('.')
-            && let Some(module_id) = self.imports.prefix_to_module.get(prefix)
+            && let Some(module_id) = self.imports.module_id(prefix)
             && let Some(imported_module) = store.get_module(module_id)
             && let Some((_, definition)) =
                 self.resolve_in_imported_module(store, imported_module, rest)
@@ -592,7 +752,7 @@ impl<'s> TaskState<'s> {
         Some((qualified_name, ty))
     }
 
-    fn get_all_methods(&self, store: &Store, ty: &Type) -> Rc<MethodSignatures> {
+    fn get_all_methods(&mut self, store: &Store, ty: &Type) -> Rc<MethodSignatures> {
         if let Type::Parameter(name) = ty {
             let trait_bounds = self.scopes.collect_all_trait_bounds();
             let qualified_name = self.qualify_name(name);
@@ -622,7 +782,7 @@ impl<'s> TaskState<'s> {
         let is_generic = matches!(&resolved, Type::Nominal { params, .. } if !params.is_empty());
         let cacheable = !(is_embedder && is_generic);
 
-        if cacheable && let Some(cached) = self.method_cache.borrow().get(cache_key.as_str()) {
+        if cacheable && let Some(cached) = self.method_cache.get(cache_key.as_str()) {
             return cached.clone();
         }
 
@@ -633,9 +793,7 @@ impl<'s> TaskState<'s> {
             Rc::new(store.get_all_methods(&resolved, &empty))
         };
         if cacheable {
-            self.method_cache
-                .borrow_mut()
-                .insert(cache_key, methods.clone());
+            self.method_cache.insert(cache_key, methods.clone());
         }
         methods
     }
@@ -717,9 +875,12 @@ impl<'s> TaskState<'s> {
                     .get(module_id)
                     .cloned()
                     .unwrap_or_else(|| go_import_default_name(module_id).to_string());
-                self.imports
-                    .prefix_to_module
-                    .insert(self_alias, module_id.into());
+                self.imports.prefixed.insert(
+                    self_alias,
+                    PrefixedImport::LookupOnly {
+                        module_id: module_id.into(),
+                    },
+                );
             }
             FileContextKind::Prelude => {
                 self.put_unprefixed_module_in_scope(store, module_id);
@@ -746,7 +907,7 @@ impl<'s> TaskState<'s> {
 
     pub fn put_prelude_in_scope(&mut self, store: &Store) {
         self.put_unprefixed_module_in_scope(store, "prelude");
-        if self.imports.imported_modules.contains_key("prelude") {
+        if self.imports.namespace("prelude").is_some() {
             return;
         }
         self.put_module_in_scope(store, "prelude", Some("prelude".to_string()));
@@ -809,7 +970,9 @@ impl<'s> TaskState<'s> {
 
             let module = store.get_module(&import.name);
             if module.is_none() || module.is_some_and(Module::is_empty_stub) {
-                self.imports.failed_imports.insert(effective);
+                self.imports
+                    .prefixed
+                    .insert(effective, PrefixedImport::Failed);
                 continue;
             }
 
@@ -817,14 +980,13 @@ impl<'s> TaskState<'s> {
         }
     }
 
-    fn module_struct_fields(&self, store: &Store, module: &Module) -> Arc<[StructFieldDefinition]> {
-        if let Some(shared) = &self.module_fields_shared
-            && let Some(fields) = shared.get(module.id.as_str())
-        {
+    fn module_struct_fields(
+        &mut self,
+        store: &Store,
+        module: &Module,
+    ) -> Arc<[StructFieldDefinition]> {
+        if let Some(fields) = self.module_fields.get(module.id.as_str()) {
             return fields.clone();
-        }
-        if let Some(cached) = self.module_fields_cache.borrow().get(module.id.as_str()) {
-            return cached.clone();
         }
 
         let module_prefix = format!("{}.", module.id);
@@ -864,25 +1026,8 @@ impl<'s> TaskState<'s> {
             .collect();
 
         let shared: Arc<[StructFieldDefinition]> = fields.into();
-        self.module_fields_cache
-            .borrow_mut()
-            .insert(module.id.clone().into(), shared.clone());
+        Arc::make_mut(&mut self.module_fields).insert(module.id.clone().into(), shared.clone());
         shared
-    }
-
-    /// Cached projections so far, to seed workers' `module_fields_shared`.
-    pub(crate) fn module_fields_snapshot(
-        &self,
-    ) -> HashMap<EcoString, Arc<[StructFieldDefinition]>> {
-        self.module_fields_cache.borrow().clone()
-    }
-
-    /// Adopt projections built by registration workers so later phases reuse them.
-    pub(crate) fn merge_module_fields(
-        &mut self,
-        fields: HashMap<EcoString, Arc<[StructFieldDefinition]>>,
-    ) {
-        self.module_fields_cache.borrow_mut().extend(fields);
     }
 
     fn put_module_in_scope(&mut self, store: &Store, module_id: &str, prefix: Option<String>) {
@@ -901,22 +1046,21 @@ impl<'s> TaskState<'s> {
 
         let module_struct_fields = self.module_struct_fields(store, module);
 
-        let ty = Type::ImportNamespace(imported_module_id.clone().into());
-
-        self.imports
-            .imported_modules
-            .insert(prefix.clone(), (module_struct_fields, ty));
-        self.imports
-            .prefix_to_module
-            .insert(prefix, imported_module_id);
+        self.imports.prefixed.insert(
+            prefix,
+            PrefixedImport::Namespace {
+                module_id: imported_module_id,
+                fields: module_struct_fields,
+            },
+        );
     }
 
     /// Run a closure speculatively: if it returns `Err`, all type variable
     /// bindings performed during the closure are rolled back.
     fn speculatively<T, E>(&mut self, f: impl FnOnce(&mut Self) -> Result<T, E>) -> Result<T, E> {
-        let spec = self.env.begin_speculation();
+        self.env.begin_speculation();
         let result = f(self);
-        self.env.end_speculation(spec, result.is_err());
+        self.env.end_speculation(result.is_err());
         result
     }
 }

--- a/crates/semantics/src/checker/registration/builtins.rs
+++ b/crates/semantics/src/checker/registration/builtins.rs
@@ -4,7 +4,7 @@ use syntax::types::{CompoundKind, SimpleKind, Symbol, Type};
 use crate::checker::TaskState;
 use crate::store::Store;
 
-impl TaskState<'_> {
+impl TaskState {
     fn builtin_qualified_name(&mut self, store: &Store, type_name: &str) -> Symbol {
         self.lookup_qualified_name(store, type_name)
             .map(Symbol::from)

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -41,7 +41,7 @@ impl TypeArgumentChecks {
     }
 }
 
-impl TaskState<'_> {
+impl TaskState {
     /// Resolves a generic-bound annotation. Bound-only markers like
     /// `Comparable` are admitted here; the same names in value position
     /// are flagged inside `convert_to_type`.

--- a/crates/semantics/src/checker/registration/derived_attributes.rs
+++ b/crates/semantics/src/checker/registration/derived_attributes.rs
@@ -1,0 +1,198 @@
+use syntax::EcoString;
+use syntax::ast::{Attribute, Expression, Span, VariantFields};
+
+use super::TaskState;
+use crate::store::Store;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DerivedAttributeKind {
+    Display,
+    Equality,
+    Iterate,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DerivedAttributeTarget {
+    Struct {
+        name: EcoString,
+    },
+    Enum {
+        name: EcoString,
+        name_span: Span,
+        is_generic: bool,
+        payload_variant_span: Option<Span>,
+    },
+    Misplaced,
+}
+
+/// One source occurrence of an attribute that synthesizes a type capability.
+///
+/// Placement is classified once for all three attributes. This keeps additions to
+/// the AST from being accepted or rejected differently by parallel scanners.
+#[derive(Debug, Clone)]
+pub(crate) struct DerivedAttribute {
+    pub(crate) module_id: String,
+    pub(crate) kind: DerivedAttributeKind,
+    pub(crate) span: Span,
+    pub(crate) has_args: bool,
+    pub(crate) is_d_lis: bool,
+    pub(crate) target: DerivedAttributeTarget,
+}
+
+impl TaskState {
+    pub(super) fn register_item_derived_attributes(
+        &mut self,
+        store: &mut Store,
+        items: &[Expression],
+    ) {
+        let candidates =
+            collect_derived_attributes(&self.cursor.module_id, self.is_d_lis(store), items);
+        self.register_derived_attributes(store, candidates);
+    }
+
+    pub(super) fn register_module_derived_attributes(
+        &mut self,
+        store: &mut Store,
+        module_id: &str,
+    ) {
+        let candidates = {
+            let module = store.get_module(module_id).expect("module must exist");
+            module
+                .files
+                .values()
+                .chain(module.typedefs.values())
+                .flat_map(|file| {
+                    collect_derived_attributes(module_id, file.is_d_lis(), &file.items)
+                })
+                .collect()
+        };
+        self.register_derived_attributes(store, candidates);
+    }
+
+    fn register_derived_attributes(
+        &mut self,
+        store: &mut Store,
+        candidates: Vec<DerivedAttribute>,
+    ) {
+        self.register_iterate(store, &candidates);
+        self.register_display(store, &candidates);
+        self.pending_equality_attributes.extend(
+            candidates
+                .into_iter()
+                .filter(|candidate| candidate.kind == DerivedAttributeKind::Equality),
+        );
+    }
+}
+
+fn collect_derived_attributes(
+    module_id: &str,
+    is_d_lis: bool,
+    items: &[Expression],
+) -> Vec<DerivedAttribute> {
+    let mut out = Vec::new();
+    for item in items {
+        match item {
+            Expression::Struct {
+                attributes,
+                name,
+                fields,
+                ..
+            } => {
+                collect_attributes(
+                    module_id,
+                    is_d_lis,
+                    attributes,
+                    DerivedAttributeTarget::Struct { name: name.clone() },
+                    &mut out,
+                );
+                for field in fields {
+                    collect_attributes(
+                        module_id,
+                        is_d_lis,
+                        &field.attributes,
+                        DerivedAttributeTarget::Misplaced,
+                        &mut out,
+                    );
+                }
+            }
+            Expression::Enum {
+                attributes,
+                name,
+                name_span,
+                generics,
+                variants,
+                ..
+            } => collect_attributes(
+                module_id,
+                is_d_lis,
+                attributes,
+                DerivedAttributeTarget::Enum {
+                    name: name.clone(),
+                    name_span: *name_span,
+                    is_generic: !generics.is_empty(),
+                    payload_variant_span: variants
+                        .iter()
+                        .find(|variant| !matches!(variant.fields, VariantFields::Unit))
+                        .map(|variant| variant.name_span),
+                },
+                &mut out,
+            ),
+            Expression::Function { attributes, .. } | Expression::TypeAlias { attributes, .. } => {
+                collect_attributes(
+                    module_id,
+                    is_d_lis,
+                    attributes,
+                    DerivedAttributeTarget::Misplaced,
+                    &mut out,
+                )
+            }
+            Expression::ImplBlock { methods, .. }
+            | Expression::Interface {
+                method_signatures: methods,
+                ..
+            } => {
+                for method in methods {
+                    if let Expression::Function { attributes, .. } = method {
+                        collect_attributes(
+                            module_id,
+                            is_d_lis,
+                            attributes,
+                            DerivedAttributeTarget::Misplaced,
+                            &mut out,
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn collect_attributes(
+    module_id: &str,
+    is_d_lis: bool,
+    attributes: &[Attribute],
+    target: DerivedAttributeTarget,
+    out: &mut Vec<DerivedAttribute>,
+) {
+    const DERIVED: [(&str, DerivedAttributeKind); 3] = [
+        ("display", DerivedAttributeKind::Display),
+        ("equality", DerivedAttributeKind::Equality),
+        ("iterate", DerivedAttributeKind::Iterate),
+    ];
+
+    for (name, kind) in DERIVED {
+        let Some(attribute) = attributes.iter().find(|attribute| attribute.name == name) else {
+            continue;
+        };
+        out.push(DerivedAttribute {
+            module_id: module_id.to_string(),
+            kind,
+            span: attribute.span,
+            has_args: !attribute.args.is_empty(),
+            is_d_lis,
+            target: target.clone(),
+        });
+    }
+}

--- a/crates/semantics/src/checker/registration/display.rs
+++ b/crates/semantics/src/checker/registration/display.rs
@@ -1,82 +1,51 @@
-use syntax::ast::{Attribute, Expression, Span};
+use syntax::ast::Span;
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
 
 use super::{TaskState, wrap_with_impl_generics};
 use crate::call_classification::is_ufcs_method_type;
+use crate::checker::registration::derived_attributes::{
+    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+};
 use crate::store::Store;
 
-impl TaskState<'_> {
-    pub(super) fn register_display(&mut self, store: &mut Store, items: &[Expression]) {
-        let module_id = self.cursor.module_id.clone();
-        let is_d_lis = self.is_d_lis(store);
-        let mut candidates = Vec::new();
-        for item in items {
-            collect_display_candidates(item, is_d_lis, &mut candidates);
-        }
-        for candidate in candidates {
-            self.process_display_candidate(store, &module_id, candidate);
+impl TaskState {
+    pub(super) fn register_display(&mut self, store: &mut Store, candidates: &[DerivedAttribute]) {
+        for candidate in candidates
+            .iter()
+            .filter(|candidate| candidate.kind == DerivedAttributeKind::Display)
+        {
+            self.process_display_candidate(store, candidate);
         }
     }
 
-    pub(super) fn register_module_display(&mut self, store: &mut Store, module_id: &str) {
-        let candidates = {
-            let module = store.get_module(module_id).expect("module must exist");
-            let mut candidates = Vec::new();
-            for file in module.files.values() {
-                let is_d_lis = file.is_d_lis();
-                for item in &file.items {
-                    collect_display_candidates(item, is_d_lis, &mut candidates);
-                }
-            }
-            candidates
-        };
-
-        for candidate in candidates {
-            self.process_display_candidate(store, module_id, candidate);
-        }
-    }
-
-    fn process_display_candidate(
-        &mut self,
-        store: &mut Store,
-        module_id: &str,
-        candidate: DisplayCandidate,
-    ) {
-        let DisplayCandidate {
-            attribute_span,
-            kind,
-        } = candidate;
-        let TypeCandidate {
-            name,
-            is_struct,
-            is_d_lis,
-            has_args,
-        } = match kind {
-            CandidateKind::Misplaced => {
+    fn process_display_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
+        let (name, is_struct) = match &candidate.target {
+            DerivedAttributeTarget::Misplaced => {
                 self.sink
                     .push(diagnostics::attribute::display_not_a_struct_or_enum(
-                        &attribute_span,
+                        &candidate.span,
                     ));
                 return;
             }
-            CandidateKind::Type(type_candidate) => type_candidate,
+            DerivedAttributeTarget::Struct { name } => (name, true),
+            DerivedAttributeTarget::Enum { name, .. } => (name, false),
         };
 
-        if has_args {
+        if candidate.has_args {
             self.sink
                 .push(diagnostics::attribute::display_with_arguments(
-                    &attribute_span,
+                    &candidate.span,
                 ));
             return;
         }
-        if is_d_lis {
+        if candidate.is_d_lis {
             self.sink
-                .push(diagnostics::attribute::display_in_typedef(&attribute_span));
+                .push(diagnostics::attribute::display_in_typedef(&candidate.span));
             return;
         }
 
-        let qualified = Symbol::from_parts(module_id, &name);
+        let qualified = Symbol::from_parts(&candidate.module_id, name);
         if is_struct
             && let Some(definition) = store.get_definition(qualified.as_str())
             && definition.is_pointer_backed_newtype(|id| {
@@ -87,12 +56,12 @@ impl TaskState<'_> {
         {
             self.sink
                 .push(diagnostics::attribute::display_on_pointer_newtype(
-                    &attribute_span,
+                    &candidate.span,
                 ));
             return;
         }
 
-        self.synthesize_to_string(store, module_id, &attribute_span, &qualified);
+        self.synthesize_to_string(store, &candidate.module_id, &candidate.span, &qualified);
     }
 
     fn synthesize_to_string(
@@ -183,90 +152,5 @@ fn type_generics(definition: &Definition) -> Option<Vec<syntax::ast::Generic>> {
             Some(generics.clone())
         }
         _ => None,
-    }
-}
-
-struct DisplayCandidate {
-    attribute_span: Span,
-    kind: CandidateKind,
-}
-
-enum CandidateKind {
-    Type(TypeCandidate),
-    Misplaced,
-}
-
-struct TypeCandidate {
-    name: String,
-    is_struct: bool,
-    is_d_lis: bool,
-    has_args: bool,
-}
-
-fn display_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
-    attributes.iter().find(|a| a.name == "display")
-}
-
-fn misplaced_candidate(attribute: &Attribute) -> DisplayCandidate {
-    DisplayCandidate {
-        attribute_span: attribute.span,
-        kind: CandidateKind::Misplaced,
-    }
-}
-
-fn collect_method_attributes(methods: &[Expression], out: &mut Vec<DisplayCandidate>) {
-    for method in methods {
-        if let Expression::Function { attributes, .. } = method {
-            out.extend(display_attribute(attributes).map(misplaced_candidate));
-        }
-    }
-}
-
-fn collect_display_candidates(item: &Expression, is_d_lis: bool, out: &mut Vec<DisplayCandidate>) {
-    match item {
-        Expression::Struct {
-            attributes,
-            name,
-            fields,
-            ..
-        } => {
-            if let Some(attribute) = display_attribute(attributes) {
-                out.push(DisplayCandidate {
-                    attribute_span: attribute.span,
-                    kind: CandidateKind::Type(TypeCandidate {
-                        name: name.to_string(),
-                        is_struct: true,
-                        is_d_lis,
-                        has_args: !attribute.args.is_empty(),
-                    }),
-                });
-            }
-            for field in fields {
-                out.extend(display_attribute(&field.attributes).map(misplaced_candidate));
-            }
-        }
-        Expression::Enum {
-            attributes, name, ..
-        } => {
-            if let Some(attribute) = display_attribute(attributes) {
-                out.push(DisplayCandidate {
-                    attribute_span: attribute.span,
-                    kind: CandidateKind::Type(TypeCandidate {
-                        name: name.to_string(),
-                        is_struct: false,
-                        is_d_lis,
-                        has_args: !attribute.args.is_empty(),
-                    }),
-                });
-            }
-        }
-        Expression::Function { attributes, .. } => {
-            out.extend(display_attribute(attributes).map(misplaced_candidate));
-        }
-        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
-        Expression::Interface {
-            method_signatures, ..
-        } => collect_method_attributes(method_signatures, out),
-        _ => {}
     }
 }

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -1,12 +1,15 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use syntax::EcoString;
-use syntax::ast::{Attribute, Expression, Generic, Span, VariantFields};
+use syntax::ast::{Generic, Span, VariantFields};
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
 
 use super::{TaskState, resolved_generic_bounds, wrap_with_impl_generics};
 use crate::checker::infer::expressions::comparison::{check_not_equatable, param_is_comparable};
+use crate::checker::registration::derived_attributes::{
+    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+};
 use crate::store::Store;
 
 fn equals_visibility(store: &Store, id: &str) -> Option<String> {
@@ -30,80 +33,40 @@ enum UserEquals {
     Conflict,
 }
 
-impl TaskState<'_> {
-    pub fn register_equality(&mut self, store: &mut Store, items: &[Expression]) {
-        let module_id = self.cursor.module_id.clone();
-        let is_d_lis = self.is_d_lis(store);
-        let mut candidates = Vec::new();
-        for item in items {
-            collect_equality_candidates(item, is_d_lis, &mut candidates);
-        }
-        for candidate in candidates {
-            self.process_equality_candidate(store, &module_id, candidate);
-        }
-    }
-
-    pub(super) fn register_module_equality(&mut self, store: &mut Store, module_id: &str) {
-        let candidates = {
-            let module = store.get_module(module_id).expect("module must exist");
-            let mut candidates = Vec::new();
-            for file in module.files.values().chain(module.typedefs.values()) {
-                let is_d_lis = file.is_d_lis();
-                for item in &file.items {
-                    collect_equality_candidates(item, is_d_lis, &mut candidates);
-                }
-            }
-            candidates
-        };
-
-        for candidate in candidates {
-            self.process_equality_candidate(store, module_id, candidate);
-        }
-    }
-
-    fn process_equality_candidate(
-        &mut self,
-        store: &mut Store,
-        module_id: &str,
-        candidate: EqualityCandidate,
-    ) {
-        let EqualityCandidate {
-            attribute_span,
-            kind,
-        } = candidate;
-        let TypeCandidate {
-            name,
-            is_d_lis,
-            has_args,
-        } = match kind {
-            CandidateKind::Misplaced => {
+impl TaskState {
+    fn process_equality_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
+        debug_assert_eq!(candidate.kind, DerivedAttributeKind::Equality);
+        let name = match &candidate.target {
+            DerivedAttributeTarget::Misplaced => {
                 self.sink
                     .push(diagnostics::attribute::equality_not_a_struct_or_enum(
-                        &attribute_span,
+                        &candidate.span,
                     ));
                 return;
             }
-            CandidateKind::Type(type_candidate) => type_candidate,
+            DerivedAttributeTarget::Struct { name } | DerivedAttributeTarget::Enum { name, .. } => {
+                name
+            }
         };
 
-        if has_args {
+        if candidate.has_args {
             self.sink
                 .push(diagnostics::attribute::equality_with_arguments(
-                    &attribute_span,
+                    &candidate.span,
                 ));
             return;
         }
-        if is_d_lis {
+        if candidate.is_d_lis {
             self.sink
-                .push(diagnostics::attribute::equality_in_typedef(&attribute_span));
+                .push(diagnostics::attribute::equality_in_typedef(&candidate.span));
             return;
         }
 
-        let qualified = Symbol::from_parts(module_id, &name);
+        let qualified = Symbol::from_parts(&candidate.module_id, name);
         if is_tuple_struct(store, &qualified) {
             self.sink
                 .push(diagnostics::attribute::equality_on_tuple_struct(
-                    &attribute_span,
+                    &candidate.span,
                 ));
             return;
         }
@@ -113,7 +76,7 @@ impl TaskState<'_> {
                 if self.is_ufcs_method(qualified.as_str(), "equals") {
                     self.sink
                         .push(diagnostics::attribute::equality_specialized_equals(
-                            &attribute_span,
+                            &candidate.span,
                         ));
                     return;
                 }
@@ -122,14 +85,14 @@ impl TaskState<'_> {
             UserEquals::Conflict => {
                 self.sink
                     .push(diagnostics::attribute::equality_conflicting_equals(
-                        &attribute_span,
+                        &candidate.span,
                     ));
                 return;
             }
             UserEquals::Specialized => {
                 self.sink
                     .push(diagnostics::attribute::equality_specialized_equals(
-                        &attribute_span,
+                        &candidate.span,
                     ));
                 return;
             }
@@ -139,17 +102,22 @@ impl TaskState<'_> {
         if has_hidden_user_equals(store, &qualified) {
             self.sink
                 .push(diagnostics::attribute::equality_conflicting_equals(
-                    &attribute_span,
+                    &candidate.span,
                 ));
             return;
         }
 
-        self.synthesize_equals(store, module_id, &qualified);
+        self.synthesize_equals(store, &candidate.module_id, &qualified);
         self.facts.equality_derivations.push(qualified.to_string());
     }
 
-    /// Build the equality verdict and gate derivations. Run once after registration + UFCS.
+    /// Synthesize queued equality methods, build the verdict, and gate derivations.
+    /// Run once after registration has discovered every UFCS method.
     pub fn finalize_equality(&mut self, store: &mut Store) {
+        let candidates = std::mem::take(&mut self.pending_equality_attributes);
+        for candidate in &candidates {
+            self.process_equality_candidate(store, candidate);
+        }
         self.record_equality_index(store);
         self.validate_equality_derivations(store);
     }
@@ -391,94 +359,5 @@ fn type_generics(definition: &Definition) -> Option<Vec<Generic>> {
             Some(generics.clone())
         }
         _ => None,
-    }
-}
-
-struct EqualityCandidate {
-    attribute_span: Span,
-    kind: CandidateKind,
-}
-
-enum CandidateKind {
-    Type(TypeCandidate),
-    Misplaced,
-}
-
-struct TypeCandidate {
-    name: String,
-    is_d_lis: bool,
-    has_args: bool,
-}
-
-fn equality_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
-    attributes.iter().find(|a| a.name == "equality")
-}
-
-fn misplaced_candidate(attribute: &Attribute) -> EqualityCandidate {
-    EqualityCandidate {
-        attribute_span: attribute.span,
-        kind: CandidateKind::Misplaced,
-    }
-}
-
-fn collect_method_attributes(methods: &[Expression], out: &mut Vec<EqualityCandidate>) {
-    for method in methods {
-        if let Expression::Function { attributes, .. } = method {
-            out.extend(equality_attribute(attributes).map(misplaced_candidate));
-        }
-    }
-}
-
-fn collect_equality_candidates(
-    item: &Expression,
-    is_d_lis: bool,
-    out: &mut Vec<EqualityCandidate>,
-) {
-    match item {
-        Expression::Struct {
-            attributes,
-            name,
-            fields,
-            ..
-        } => {
-            if let Some(attribute) = equality_attribute(attributes) {
-                out.push(EqualityCandidate {
-                    attribute_span: attribute.span,
-                    kind: CandidateKind::Type(TypeCandidate {
-                        name: name.to_string(),
-                        is_d_lis,
-                        has_args: !attribute.args.is_empty(),
-                    }),
-                });
-            }
-            for field in fields {
-                out.extend(equality_attribute(&field.attributes).map(misplaced_candidate));
-            }
-        }
-        Expression::Enum {
-            attributes, name, ..
-        } => {
-            if let Some(attribute) = equality_attribute(attributes) {
-                out.push(EqualityCandidate {
-                    attribute_span: attribute.span,
-                    kind: CandidateKind::Type(TypeCandidate {
-                        name: name.to_string(),
-                        is_d_lis,
-                        has_args: !attribute.args.is_empty(),
-                    }),
-                });
-            }
-        }
-        Expression::Function { attributes, .. } => {
-            out.extend(equality_attribute(attributes).map(misplaced_candidate));
-        }
-        Expression::TypeAlias { attributes, .. } => {
-            out.extend(equality_attribute(attributes).map(misplaced_candidate));
-        }
-        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
-        Expression::Interface {
-            method_signatures, ..
-        } => collect_method_attributes(method_signatures, out),
-        _ => {}
     }
 }

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -7,7 +7,7 @@ use crate::checker::infer::{BuiltinBound, InferCtx};
 use crate::generics::{apply_bounds, bound_implied, type_argument_children};
 use crate::store::Store;
 
-impl TaskState<'_> {
+impl TaskState {
     pub(crate) fn check_transitive_generic_bounds(
         &mut self,
         store: &Store,

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -6,7 +6,7 @@ use super::TaskState;
 use crate::generics::{apply_bounds, bound_implied};
 use crate::store::Store;
 
-impl TaskState<'_> {
+impl TaskState {
     /// Make receiver-declaration bounds available inside a regular impl. The impl may state
     /// weaker bounds, but every valid receiver instantiation still satisfies these bounds.
     pub(crate) fn register_receiver_type_bounds(

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -1,90 +1,56 @@
-use syntax::ast::{Attribute, Expression, Span, VariantFields};
 use syntax::program::{Definition, DefinitionBody, Visibility};
 use syntax::types::{CompoundKind, Symbol, Type};
 
 use super::TaskState;
+use crate::checker::registration::derived_attributes::{
+    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+};
 use crate::store::Store;
 
-impl TaskState<'_> {
-    /// Register `#[iterate]` enums from a single items list (the `register_types_and_values` path).
-    pub(super) fn register_iterate(&mut self, store: &mut Store, items: &[Expression]) {
-        let module_id = self.cursor.module_id.clone();
-        let is_d_lis = self.is_d_lis(store);
-        let mut candidates = Vec::new();
-        for item in items {
-            collect_iterate_candidates(item, is_d_lis, &mut candidates);
-        }
-        for candidate in candidates {
-            self.process_iterate_candidate(store, &module_id, candidate);
+impl TaskState {
+    pub(super) fn register_iterate(&mut self, store: &mut Store, candidates: &[DerivedAttribute]) {
+        for candidate in candidates
+            .iter()
+            .filter(|candidate| candidate.kind == DerivedAttributeKind::Iterate)
+        {
+            self.process_iterate_candidate(store, candidate);
         }
     }
 
-    /// Register `#[iterate]` enums across all of the module's files (the `register_module`
-    /// path), after every file is registered so cross-file collisions are visible.
-    pub(super) fn register_module_iterate(&mut self, store: &mut Store, module_id: &str) {
-        let candidates = {
-            let module = store.get_module(module_id).expect("module must exist");
-            let mut candidates = Vec::new();
-            for file in module.files.values() {
-                let is_d_lis = file.is_d_lis();
-                for item in &file.items {
-                    collect_iterate_candidates(item, is_d_lis, &mut candidates);
-                }
-            }
-            candidates
-        };
-
-        for candidate in candidates {
-            self.process_iterate_candidate(store, module_id, candidate);
-        }
-    }
-
-    fn process_iterate_candidate(
-        &mut self,
-        store: &mut Store,
-        module_id: &str,
-        candidate: IterateCandidate,
-    ) {
-        let IterateCandidate {
-            attribute_span,
-            kind,
-        } = candidate;
-        let EnumCandidate {
+    fn process_iterate_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
+        let DerivedAttributeTarget::Enum {
             name,
             name_span,
             is_generic,
-            is_d_lis,
             payload_variant_span,
-        } = match kind {
-            CandidateKind::NotAnEnum => {
-                self.sink
-                    .push(diagnostics::attribute::iterate_not_an_enum(&attribute_span));
-                return;
-            }
-            CandidateKind::Enum(enum_candidate) => enum_candidate,
+        } = &candidate.target
+        else {
+            self.sink
+                .push(diagnostics::attribute::iterate_not_an_enum(&candidate.span));
+            return;
         };
 
-        if is_d_lis {
+        if candidate.is_d_lis {
             self.sink
-                .push(diagnostics::attribute::iterate_in_typedef(&attribute_span));
+                .push(diagnostics::attribute::iterate_in_typedef(&candidate.span));
             return;
         }
-        if is_generic {
+        if *is_generic {
             self.sink.push(diagnostics::attribute::iterate_generic_enum(
-                &attribute_span,
+                &candidate.span,
             ));
             return;
         }
         if let Some(variant_span) = payload_variant_span {
             self.sink
                 .push(diagnostics::attribute::iterate_non_unit_variant(
-                    &attribute_span,
-                    &variant_span,
+                    &candidate.span,
+                    variant_span,
                 ));
             return;
         }
 
-        let qualified = Symbol::from_parts(module_id, &name);
+        let qualified = Symbol::from_parts(&candidate.module_id, name);
         let variants_key = qualified.with_segment("variants");
 
         // A static method or a variant literally named `variants` both register
@@ -103,7 +69,7 @@ impl TaskState<'_> {
         if existing_span.is_some() || has_instance_variants {
             self.sink
                 .push(diagnostics::attribute::iterate_variants_conflict(
-                    &attribute_span,
+                    &candidate.span,
                     existing_span.as_ref(),
                 ));
             return;
@@ -119,14 +85,16 @@ impl TaskState<'_> {
         };
         let fn_ty = Type::function(vec![], vec![], Default::default(), Box::new(slice_ty));
 
-        let module = store.get_module_mut(module_id).expect("module must exist");
+        let module = store
+            .get_module_mut(&candidate.module_id)
+            .expect("module must exist");
         module.definitions.insert(
             variants_key,
             Definition {
                 visibility,
                 ty: fn_ty,
                 name: None,
-                name_span: Some(name_span),
+                name_span: Some(*name_span),
                 doc: None,
                 body: DefinitionBody::Value {
                     allowed_lints: vec![],
@@ -137,95 +105,5 @@ impl TaskState<'_> {
                 },
             },
         );
-    }
-}
-
-struct IterateCandidate {
-    attribute_span: Span,
-    kind: CandidateKind,
-}
-
-enum CandidateKind {
-    Enum(EnumCandidate),
-    NotAnEnum,
-}
-
-struct EnumCandidate {
-    name: String,
-    name_span: Span,
-    is_generic: bool,
-    is_d_lis: bool,
-    payload_variant_span: Option<Span>,
-}
-
-fn iterate_attribute_span(attributes: &[Attribute]) -> Option<Span> {
-    attributes
-        .iter()
-        .find(|a| a.name == "iterate")
-        .map(|a| a.span)
-}
-
-fn misplaced_candidate(span: Span) -> IterateCandidate {
-    IterateCandidate {
-        attribute_span: span,
-        kind: CandidateKind::NotAnEnum,
-    }
-}
-
-/// Record any `#[iterate]` on a method (impl or interface) as misplaced.
-fn collect_method_attributes(methods: &[Expression], out: &mut Vec<IterateCandidate>) {
-    for method in methods {
-        if let Expression::Function { attributes, .. } = method {
-            out.extend(iterate_attribute_span(attributes).map(misplaced_candidate));
-        }
-    }
-}
-
-/// Collect every `#[iterate]` occurrence on a top-level item: an enum to
-/// validate and synthesize, anything else (including fields and methods)
-/// recorded as misplaced so the attribute is never silently accepted off an enum.
-fn collect_iterate_candidates(item: &Expression, is_d_lis: bool, out: &mut Vec<IterateCandidate>) {
-    match item {
-        Expression::Enum {
-            attributes,
-            name,
-            name_span,
-            generics,
-            variants,
-            ..
-        } => {
-            if let Some(attribute_span) = iterate_attribute_span(attributes) {
-                let payload_variant_span = variants
-                    .iter()
-                    .find(|v| !matches!(v.fields, VariantFields::Unit))
-                    .map(|v| v.name_span);
-                out.push(IterateCandidate {
-                    attribute_span,
-                    kind: CandidateKind::Enum(EnumCandidate {
-                        name: name.to_string(),
-                        name_span: *name_span,
-                        is_generic: !generics.is_empty(),
-                        is_d_lis,
-                        payload_variant_span,
-                    }),
-                });
-            }
-        }
-        Expression::Struct {
-            attributes, fields, ..
-        } => {
-            out.extend(iterate_attribute_span(attributes).map(misplaced_candidate));
-            for field in fields {
-                out.extend(iterate_attribute_span(&field.attributes).map(misplaced_candidate));
-            }
-        }
-        Expression::Function { attributes, .. } => {
-            out.extend(iterate_attribute_span(attributes).map(misplaced_candidate));
-        }
-        Expression::ImplBlock { methods, .. } => collect_method_attributes(methods, out),
-        Expression::Interface {
-            method_signatures, ..
-        } => collect_method_attributes(method_signatures, out),
-        _ => {}
     }
 }

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -1,7 +1,6 @@
 use ecow::EcoString;
 use syntax::ast::{
-    Annotation, Expression, Generic, ParentInterface, Pattern, Span,
-    Visibility as SyntacticVisibility,
+    Annotation, Expression, Generic, Pattern, Span, Visibility as SyntacticVisibility,
 };
 use syntax::program::{Definition, DefinitionBody, Interface, Visibility};
 use syntax::types::{
@@ -12,25 +11,28 @@ use super::{extract_attribute_flags, has_recursive_instantiation, wrap_with_impl
 use crate::checker::{TaskState, resolved_generic_bounds};
 use crate::store::Store;
 
-impl TaskState<'_> {
+struct ImplReceiver<'a> {
+    module_id: &'a str,
+    qualified_name: &'a str,
+    display_name: &'a str,
+}
+
+impl TaskState {
     /// Register an instance method on the receiver type's definition.
     /// Returns `false` if the receiver was not found (caller should skip).
-    #[allow(clippy::too_many_arguments)]
     fn try_register_instance_method(
         &mut self,
         store: &mut Store,
-        module_id: &str,
-        receiver_qualified_name: &str,
-        type_name: &str,
+        receiver: &ImplReceiver<'_>,
         fn_name: &str,
         fn_name_span: Span,
         method_ty: &Type,
     ) -> bool {
         let module = store
-            .get_module_mut(module_id)
+            .get_module_mut(receiver.module_id)
             .expect("current module must exist in store");
 
-        let Some(definition) = module.definitions.get_mut(receiver_qualified_name) else {
+        let Some(definition) = module.definitions.get_mut(receiver.qualified_name) else {
             // Receiver type not found in current module (e.g. resolved
             // to a same-named type in another module). Skip registering
             // the method to avoid false duplicate errors.
@@ -41,7 +43,7 @@ impl TaskState<'_> {
             && fields.iter().any(|f| f.name == fn_name)
         {
             self.sink.push(diagnostics::infer::method_shadows_field(
-                type_name,
+                receiver.display_name,
                 fn_name,
                 fn_name_span,
             ));
@@ -51,7 +53,7 @@ impl TaskState<'_> {
             for variant in variants {
                 if variant.fields.is_struct() && variant.fields.iter().any(|f| f.name == fn_name) {
                     self.sink.push(diagnostics::infer::method_shadows_field(
-                        type_name,
+                        receiver.display_name,
                         fn_name,
                         fn_name_span,
                     ));
@@ -67,21 +69,19 @@ impl TaskState<'_> {
         true
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn check_duplicate_method(
         &self,
         store: &Store,
-        module_id: &str,
-        receiver_qualified_name: &str,
-        type_name: &str,
+        receiver: &ImplReceiver<'_>,
         fn_name: &str,
         fn_name_span: Span,
         impl_generics_empty: bool,
     ) {
-        let module_qualified_name = Symbol::from_parts(module_id, type_name).with_segment(fn_name);
+        let module_qualified_name =
+            Symbol::from_parts(receiver.module_id, receiver.display_name).with_segment(fn_name);
 
         let module = store
-            .get_module(module_id)
+            .get_module(receiver.module_id)
             .expect("current module must exist in store");
 
         if !module
@@ -93,7 +93,7 @@ impl TaskState<'_> {
 
         let is_cross_specialization = impl_generics_empty
             && matches!(
-                module.definitions.get(receiver_qualified_name).map(|d| &d.body),
+                module.definitions.get(receiver.qualified_name).map(|d| &d.body),
                 Some(DefinitionBody::Struct { generics: struct_generics, .. })
                     if !struct_generics.is_empty()
             );
@@ -101,7 +101,7 @@ impl TaskState<'_> {
         if is_cross_specialization {
             let struct_generic_names: Vec<String> = match module
                 .definitions
-                .get(receiver_qualified_name)
+                .get(receiver.qualified_name)
                 .map(|d| &d.body)
             {
                 Some(DefinitionBody::Struct { generics: g, .. }) => {
@@ -112,7 +112,7 @@ impl TaskState<'_> {
             self.sink.push(
                 diagnostics::infer::duplicate_method_across_specialized_impls(
                     fn_name,
-                    type_name,
+                    receiver.display_name,
                     &struct_generic_names,
                     fn_name_span,
                 ),
@@ -120,7 +120,7 @@ impl TaskState<'_> {
         } else {
             self.sink.push(diagnostics::infer::duplicate_impl_item(
                 fn_name,
-                type_name,
+                receiver.display_name,
                 fn_name_span,
             ));
         }
@@ -218,6 +218,11 @@ impl TaskState<'_> {
         }
         self.check_transitive_generic_bounds(&*store, &generics, *span);
 
+        let receiver = ImplReceiver {
+            module_id: &module_id,
+            qualified_name: receiver_qualified_name.as_str(),
+            display_name: type_name,
+        };
         let mut static_methods: Vec<(String, Type)> = Vec::new();
 
         for function in functions {
@@ -294,9 +299,7 @@ impl TaskState<'_> {
             if is_instance_method {
                 if !self.try_register_instance_method(
                     store,
-                    &module_id,
-                    &receiver_qualified_name,
-                    type_name,
+                    &receiver,
                     &method_key,
                     fn_sig.name_span,
                     &method_ty,
@@ -309,9 +312,7 @@ impl TaskState<'_> {
 
             self.check_duplicate_method(
                 &*store,
-                &module_id,
-                &receiver_qualified_name,
-                type_name,
+                &receiver,
                 &fn_sig.name,
                 fn_sig.name_span,
                 generics.is_empty(),
@@ -343,22 +344,24 @@ impl TaskState<'_> {
 
         let scope = self.scopes.current_mut();
         for (name, ty) in static_methods {
-            scope.values.insert(name, ty);
+            scope.insert_value(name, ty);
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn populate_interface(
-        &mut self,
-        store: &mut Store,
-        interface_name: &str,
-        name_span: &Span,
-        generics: &[Generic],
-        parents: &[ParentInterface],
-        fn_expressions: &[Expression],
-        span: &Span,
-        doc: &Option<String>,
-    ) {
+    pub(super) fn populate_interface(&mut self, store: &mut Store, expression: &Expression) {
+        let Expression::Interface {
+            name: interface_name,
+            name_span,
+            generics,
+            parents,
+            method_signatures: fn_expressions,
+            span,
+            doc,
+            ..
+        } = expression
+        else {
+            unreachable!("populate_interface called with non-Interface expression");
+        };
         self.scopes.push();
         self.put_in_scope(generics);
         let generics = self.resolve_generic_bounds(&*store, generics, span);

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod convert;
+pub(crate) mod derived_attributes;
 mod display;
 mod equality;
 mod generic_bounds;
@@ -244,7 +245,7 @@ fn seal_method_key(
     crate::checker::sealing::unexported_key(&id)
 }
 
-impl TaskState<'_> {
+impl TaskState {
     fn definition_exists(&self, store: &Store, qualified_name: &str) -> bool {
         self.current_module(store)
             .definitions
@@ -285,16 +286,14 @@ impl TaskState<'_> {
             self.register_file_values(store, id, *file_id, imports);
         }
 
-        self.register_module_iterate(store, id);
-        self.register_module_display(store, id);
+        self.register_module_derived_attributes(store, id);
         self.validate_module_embeds(store, id);
         self.check_module_recursive_types(store, id);
 
         let module = store.get_module(id).expect("module must exist");
         let ufcs_entries = compute_module_ufcs(module);
-        self.ufcs_methods.extend(ufcs_entries);
+        self.extend_ufcs_methods(ufcs_entries);
 
-        self.register_module_equality(store, id);
         self.register_module_tests(store, id);
         self.populate_module_generic_bounds(store, id);
     }
@@ -415,7 +414,7 @@ impl TaskState<'_> {
                                 standalone_mode: false,
                                 replace_importer,
                             },
-                            self.sink,
+                            &self.sink,
                         );
                     }
                 }
@@ -441,7 +440,6 @@ impl TaskState<'_> {
                         .items,
                 );
                 this.register_types_and_values(store, &items, &Visibility::Public);
-                this.register_equality(store, &items);
             },
         );
     }
@@ -578,11 +576,15 @@ impl TaskState<'_> {
         self.check_type_generic_bounds(store, items);
         self.register_impl_blocks(store, items);
         self.register_values(store, items, visibility);
-        self.register_iterate(store, items);
-        self.register_display(store, items);
+        self.register_item_derived_attributes(store, items);
         let module_id = self.cursor.module_id.clone();
         self.validate_module_embeds(store, &module_id);
         self.check_module_recursive_types(store, &module_id);
+
+        let module = store
+            .get_module(&module_id)
+            .expect("current module must exist after registration");
+        self.extend_ufcs_methods(compute_module_ufcs(module));
     }
 
     pub(crate) fn register_type_names(
@@ -727,7 +729,7 @@ impl TaskState<'_> {
                 | Expression::Struct { attributes, .. }
                 | Expression::TypeAlias { attributes, .. }
                 | Expression::Function { attributes, .. } => {
-                    check_go_hints(attributes, self.sink);
+                    check_go_hints(attributes, &self.sink);
                 }
                 Expression::ImplBlock {
                     methods: functions, ..
@@ -738,7 +740,7 @@ impl TaskState<'_> {
                 } => {
                     for function in functions {
                         if let Expression::Function { attributes, .. } = function {
-                            check_go_hints(attributes, self.sink);
+                            check_go_hints(attributes, &self.sink);
                         }
                     }
                 }
@@ -756,20 +758,8 @@ impl TaskState<'_> {
 
     fn register_type_aliases(&mut self, store: &mut Store, items: &[Expression]) {
         for item in items {
-            if let Expression::TypeAlias {
-                name,
-                name_span,
-                generics,
-                annotation,
-                attributes,
-                span,
-                doc,
-                ..
-            } = item
-            {
-                self.populate_type_alias(
-                    store, name, name_span, generics, annotation, attributes, span, doc,
-                );
+            if matches!(item, Expression::TypeAlias { .. }) {
+                self.populate_type_alias(store, item);
             }
         }
     }
@@ -778,65 +768,9 @@ impl TaskState<'_> {
         self.check_go_hints_in_items(items);
         for item in items {
             match item {
-                Expression::Enum {
-                    name,
-                    name_span,
-                    generics,
-                    variants,
-                    span,
-                    doc,
-                    attributes,
-                    ..
-                } => self.populate_enum(
-                    store,
-                    name,
-                    name_span,
-                    generics,
-                    variants,
-                    span,
-                    doc,
-                    collect_enum_attributes(attributes),
-                ),
-                Expression::Struct {
-                    name,
-                    name_span,
-                    generics,
-                    fields,
-                    kind,
-                    span,
-                    doc,
-                    attributes,
-                    ..
-                } => self.populate_struct(
-                    store,
-                    name,
-                    name_span,
-                    generics,
-                    fields,
-                    *kind,
-                    span,
-                    doc,
-                    collect_struct_attributes(attributes),
-                ),
-                Expression::Interface {
-                    name,
-                    name_span,
-                    generics,
-                    parents,
-                    method_signatures,
-                    span,
-                    doc,
-                    ..
-                } => self.populate_interface(
-                    store,
-                    name,
-                    name_span,
-                    generics,
-                    parents,
-                    method_signatures,
-                    span,
-                    doc,
-                ),
+                Expression::Enum { .. } => self.populate_enum(store, item),
+                Expression::Struct { .. } => self.populate_struct(store, item),
+                Expression::Interface { .. } => self.populate_interface(store, item),
                 _ => (),
             }
         }
@@ -1168,12 +1102,8 @@ impl TaskState<'_> {
             tuple_struct_constructor_type_from_fields(&field_types, &struct_ty, generics);
 
         let scope = self.scopes.current_mut();
-        scope
-            .values
-            .insert(qualified_name.to_string(), constructor_ty.clone());
-        scope
-            .values
-            .insert(name.to_string(), constructor_ty.clone());
+        scope.insert_value(qualified_name.to_string(), constructor_ty.clone());
+        scope.insert_value(name.to_string(), constructor_ty.clone());
 
         let module = self.current_module_mut(store);
         if let Some(def) = module.definitions.get_mut(qualified_name.as_str())

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -25,7 +25,7 @@ pub(crate) fn normalize_test_params(mut params: Vec<Binding>, is_test: bool) -> 
     params
 }
 
-impl TaskState<'_> {
+impl TaskState {
     /// Collect and validate a module's `#[test]` functions into `facts`
     /// (merge-safe, since this runs during parallel registration).
     pub(super) fn register_module_tests(&mut self, store: &Store, module_id: &str) {
@@ -41,7 +41,7 @@ impl TaskState<'_> {
                     in_test_file,
                     context_shadowed,
                     &mut records,
-                    self.sink,
+                    &self.sink,
                 );
             }
         }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -1,30 +1,33 @@
 use crate::checker::EnvResolve;
 use rustc_hash::{FxHashMap, FxHashSet};
 use syntax::ast::{
-    Annotation, Attribute, EnumFieldDefinition, EnumVariant, Generic, Span, StructFieldDefinition,
-    StructKind, VariantFields,
+    EnumFieldDefinition, EnumVariant, Expression, Generic, Span, StructFieldDefinition, StructKind,
+    VariantFields,
 };
 use syntax::containment::{EnumPayloads, definition_contains_by_value};
-use syntax::program::{Attributes, Definition, DefinitionBody, MethodSignatures, Visibility};
+use syntax::program::{Definition, DefinitionBody, MethodSignatures, Visibility};
 use syntax::types::{Symbol, Type};
 
 use super::enum_variant_constructor_type;
 use crate::checker::TaskState;
 use crate::store::Store;
 
-impl TaskState<'_> {
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn populate_enum(
-        &mut self,
-        store: &mut Store,
-        name: &str,
-        name_span: &Span,
-        generics: &[Generic],
-        variants: &[EnumVariant],
-        span: &Span,
-        doc: &Option<String>,
-        attributes: Attributes,
-    ) {
+impl TaskState {
+    pub(super) fn populate_enum(&mut self, store: &mut Store, expression: &Expression) {
+        let Expression::Enum {
+            name,
+            name_span,
+            generics,
+            variants,
+            span,
+            doc,
+            attributes,
+            ..
+        } = expression
+        else {
+            unreachable!("populate_enum called with non-Enum expression");
+        };
+        let attributes = super::collect_enum_attributes(attributes);
         let qualified_name = self.qualify_name(name);
         let enum_ty = store
             .get_type(&qualified_name)
@@ -261,29 +264,27 @@ impl TaskState<'_> {
 
         let scope = self.scopes.current_mut();
 
-        scope
-            .values
-            .insert(qualified_name.clone(), enum_variant_constructor_ty.clone());
+        scope.insert_value(qualified_name.clone(), enum_variant_constructor_ty.clone());
 
-        scope
-            .values
-            .entry(variant.name.to_string())
-            .or_insert(enum_variant_constructor_ty);
+        scope.insert_value_if_absent(variant.name.to_string(), enum_variant_constructor_ty);
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn populate_struct(
-        &mut self,
-        store: &mut Store,
-        name: &str,
-        name_span: &Span,
-        generics: &[Generic],
-        fields: &[StructFieldDefinition],
-        kind: StructKind,
-        span: &Span,
-        doc: &Option<String>,
-        attributes: Attributes,
-    ) {
+    pub(super) fn populate_struct(&mut self, store: &mut Store, expression: &Expression) {
+        let Expression::Struct {
+            name,
+            name_span,
+            generics,
+            fields,
+            kind,
+            span,
+            doc,
+            attributes,
+            ..
+        } = expression
+        else {
+            unreachable!("populate_struct called with non-Struct expression");
+        };
+        let attributes = super::collect_struct_attributes(attributes);
         let qualified_name = self.qualify_name(name);
         let struct_ty = store
             .get_type(&qualified_name)
@@ -316,19 +317,19 @@ impl TaskState<'_> {
         // Single-field non-generic tuple structs (e.g. `struct FileMode(uint32)`) are
         // emitted as Go type aliases (`type FileMode uint32`). Set underlying_ty so the
         // type checker allows numeric casts through them.
-        let struct_ty = if kind == StructKind::Tuple && new_fields.len() == 1 && generics.is_empty()
-        {
-            match struct_ty {
-                Type::Nominal { id, params, .. } => Type::Nominal {
-                    id,
-                    params,
-                    underlying_ty: Some(Box::new(new_fields[0].ty.clone())),
-                },
-                other => other,
-            }
-        } else {
-            struct_ty
-        };
+        let struct_ty =
+            if *kind == StructKind::Tuple && new_fields.len() == 1 && generics.is_empty() {
+                match struct_ty {
+                    Type::Nominal { id, params, .. } => Type::Nominal {
+                        id,
+                        params,
+                        underlying_ty: Some(Box::new(new_fields[0].ty.clone())),
+                    },
+                    other => other,
+                }
+            } else {
+                struct_ty
+            };
 
         let visibility = self
             .current_module(&*store)
@@ -354,7 +355,7 @@ impl TaskState<'_> {
                 body: DefinitionBody::Struct {
                     generics,
                     fields: new_fields,
-                    kind,
+                    kind: *kind,
                     methods: Default::default(),
                     constructor: None,
                     attributes,
@@ -518,18 +519,20 @@ impl TaskState<'_> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn populate_type_alias(
-        &mut self,
-        store: &mut Store,
-        name: &str,
-        name_span: &Span,
-        generics: &[Generic],
-        annotation: &Annotation,
-        attributes: &[Attribute],
-        span: &Span,
-        doc: &Option<String>,
-    ) {
+    pub(super) fn populate_type_alias(&mut self, store: &mut Store, expression: &Expression) {
+        let Expression::TypeAlias {
+            name,
+            name_span,
+            generics,
+            annotation,
+            attributes,
+            span,
+            doc,
+            ..
+        } = expression
+        else {
+            unreachable!("populate_type_alias called with non-TypeAlias expression");
+        };
         let qualified_name = self.qualify_name(name);
 
         self.scopes.push();

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -1,39 +1,38 @@
 use ecow::EcoString;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::cell::Cell;
+use rustc_hash::FxHashMap as HashMap;
 use syntax::ast::BindingId;
 use syntax::ast::Span;
 use syntax::types::{Symbol, Type};
 
 #[derive(Debug, Clone, Default)]
-pub struct DepthCounter(Cell<usize>);
+pub struct DepthCounter(usize);
 
 impl DepthCounter {
     pub(crate) fn new() -> Self {
-        Self(Cell::new(0))
-    }
-    fn with_value(n: usize) -> Self {
-        Self(Cell::new(n))
+        Self(0)
     }
     fn get(&self) -> usize {
-        self.0.get()
+        self.0
     }
-    pub(crate) fn increment(&self) {
-        self.0.set(self.0.get() + 1);
+    pub(crate) fn increment(&mut self) {
+        self.0 += 1;
     }
-    pub(crate) fn decrement(&self) {
-        self.0.set(self.0.get().saturating_sub(1));
+    pub(crate) fn decrement(&mut self) {
+        self.0 = self
+            .0
+            .checked_sub(1)
+            .expect("depth counter must be incremented before it is decremented");
     }
     pub(crate) fn is_active(&self) -> bool {
-        self.0.get() > 0
+        self.0 > 0
     }
-    fn reset(&self) -> usize {
-        let prev = self.0.get();
-        self.0.set(0);
+    fn reset(&mut self) -> usize {
+        let prev = self.0;
+        self.0 = 0;
         prev
     }
-    fn restore(&self, depth: usize) {
-        self.0.set(depth);
+    fn restore(&mut self, depth: usize) {
+        self.0 = depth;
     }
 }
 
@@ -46,18 +45,38 @@ pub enum UseContext {
     AssignmentTarget,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CarrierKind {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TryCarrier {
+    #[default]
+    Unset,
+    Unknown,
     Result,
     Option,
+}
+
+impl TryCarrier {
+    /// Record one `?` operand and report whether it conflicts with a carrier
+    /// already established by an earlier operand.
+    pub(crate) fn observe(&mut self, observed: Option<Self>) -> bool {
+        match (*self, observed) {
+            (Self::Unset, None) => *self = Self::Unknown,
+            (Self::Unset | Self::Unknown, Some(carrier)) => *self = carrier,
+            (Self::Result, Some(Self::Option)) | (Self::Option, Some(Self::Result)) => return true,
+            _ => {}
+        }
+        false
+    }
+
+    pub(crate) fn was_used(self) -> bool {
+        self != Self::Unset
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct TryBlockContext {
     pub(crate) ok_ty: Type,
     pub(crate) err_ty: Type,
-    pub(crate) carrier: Cell<Option<CarrierKind>>,
-    pub(crate) has_question_mark: Cell<bool>,
+    pub(crate) carrier: TryCarrier,
     pub(crate) loop_depth: DepthCounter,
 }
 
@@ -66,28 +85,42 @@ pub struct RecoverBlockContext {
     pub(crate) loop_depth: DepthCounter,
 }
 
+/// Traversal state inherited by nested lexical scopes and restored on pop.
+#[derive(Debug, Clone, Default)]
+struct InheritedContext {
+    loop_break_type: Option<Type>,
+    loop_depth: DepthCounter,
+    defer_block_depth: DepthCounter,
+    negation_depth: DepthCounter,
+    type_param_depth: DepthCounter,
+    use_context: UseContext,
+    in_test_handle: bool,
+    test_fn_name: Option<EcoString>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScopedValueKind {
+    Value,
+    Binding { id: BindingId, mutable: bool },
+    Const,
+}
+
+#[derive(Debug, Clone)]
+struct ScopedValue {
+    ty: Type,
+    kind: ScopedValueKind,
+}
+
 #[derive(Debug, Clone)]
 pub struct Scope {
-    /// variable name -> type
-    pub(crate) values: HashMap<String, Type>,
-    pub(crate) mutables: Option<HashSet<String>>,
-    pub(crate) consts: Option<HashSet<String>>,
+    values: HashMap<String, ScopedValue>,
     pub(crate) type_params: Option<HashMap<String, usize>>,
     pub(crate) trait_bounds: Option<HashMap<Symbol, Vec<Type>>>,
     pub(crate) fn_return_type: Option<Type>,
     deferred_map_key_checks: Vec<(Type, Span, bool)>,
     pub(crate) try_block_context: Option<TryBlockContext>,
     pub(crate) recover_block_context: Option<RecoverBlockContext>,
-    loop_break_type: Option<Type>,
-    loop_depth: DepthCounter,
-    defer_block_depth: DepthCounter,
-    negation_depth: DepthCounter,
-    type_param_depth: DepthCounter,
-    use_context: Cell<UseContext>,
-    in_test_handle: bool,
-    test_fn_name: Option<EcoString>,
-    /// variable name -> binding ID (for linting)
-    pub(crate) name_to_binding: HashMap<String, BindingId>,
+    inherited: InheritedContext,
 }
 
 impl Default for Scope {
@@ -100,41 +133,64 @@ impl Scope {
     fn new() -> Self {
         Scope {
             values: HashMap::default(),
-            mutables: None,
-            consts: None,
             type_params: None,
             trait_bounds: None,
             fn_return_type: None,
             deferred_map_key_checks: Vec::new(),
             try_block_context: None,
             recover_block_context: None,
-            loop_break_type: None,
-            loop_depth: DepthCounter::new(),
-            defer_block_depth: DepthCounter::new(),
-            negation_depth: DepthCounter::new(),
-            type_param_depth: DepthCounter::new(),
-            use_context: Cell::new(UseContext::Statement),
-            in_test_handle: false,
-            test_fn_name: None,
-            name_to_binding: HashMap::default(),
+            inherited: InheritedContext::default(),
         }
+    }
+
+    pub(crate) fn insert_value(&mut self, name: String, ty: Type) {
+        self.values.insert(
+            name,
+            ScopedValue {
+                ty,
+                kind: ScopedValueKind::Value,
+            },
+        );
+    }
+
+    pub(crate) fn insert_value_if_absent(&mut self, name: String, ty: Type) {
+        self.values.entry(name).or_insert(ScopedValue {
+            ty,
+            kind: ScopedValueKind::Value,
+        });
+    }
+
+    pub(crate) fn insert_binding(&mut self, name: String, ty: Type, id: BindingId, mutable: bool) {
+        self.values.insert(
+            name,
+            ScopedValue {
+                ty,
+                kind: ScopedValueKind::Binding { id, mutable },
+            },
+        );
+    }
+
+    pub(crate) fn insert_const(&mut self, name: String, ty: Type) {
+        self.values.insert(
+            name,
+            ScopedValue {
+                ty,
+                kind: ScopedValueKind::Const,
+            },
+        );
     }
 }
 
 pub struct Scopes {
     stack: Vec<Scope>,
-    /// True when inferring inside a compound expression (call arg, binary
-    /// operand, etc.). Used to reject `Err(x)?`/`None?` and similar control-flow
-    /// in positions where they can never produce a value.
-    in_subexpression: Cell<bool>,
     /// True when inferring the base of a dot-access chain. Suppresses the
     /// record-struct-as-value error when the struct name is a type qualifier
     /// (e.g. `lib.Point` in `lib.Point.sum`).
-    dot_access_base: Cell<bool>,
+    dot_access_base: bool,
     /// True while inferring a `let` binding's right-hand side. Suppresses the generic
     /// "used as a value" rejection there so `bindings.rs` can raise the specific
     /// "cannot bind a type or module to a variable" error instead.
-    let_binding_rhs: Cell<bool>,
+    let_binding_rhs: bool,
     /// The enclosing impl block's receiver type, used to resolve `self`
     /// parameter annotations inside the impl's methods. `None` outside impls.
     /// Singleton because Lisette does not allow nested impl blocks.
@@ -151,9 +207,8 @@ impl Scopes {
     pub(crate) fn new() -> Self {
         Scopes {
             stack: vec![Scope::new()],
-            in_subexpression: Cell::new(false),
-            dot_access_base: Cell::new(false),
-            let_binding_rhs: Cell::new(false),
+            dot_access_base: false,
+            let_binding_rhs: false,
             impl_receiver_type: None,
         }
     }
@@ -169,73 +224,66 @@ impl Scopes {
     }
 
     pub(crate) fn push(&mut self) {
-        let current = self.current();
-        let mut scope = Scope::new();
-        scope.loop_break_type = current.loop_break_type.clone();
-        scope.loop_depth = DepthCounter::with_value(current.loop_depth.get());
-        scope.defer_block_depth = DepthCounter::with_value(current.defer_block_depth.get());
-        scope.negation_depth = DepthCounter::with_value(current.negation_depth.get());
-        scope.type_param_depth = DepthCounter::with_value(current.type_param_depth.get());
-        scope.use_context = Cell::new(current.use_context.get());
-        scope.in_test_handle = current.in_test_handle;
-        scope.test_fn_name = current.test_fn_name.clone();
+        let scope = Scope {
+            inherited: self.current().inherited.clone(),
+            ..Scope::new()
+        };
         self.stack.push(scope);
     }
 
     pub(crate) fn pop(&mut self) {
-        if self.stack.len() > 1 {
-            self.stack.pop();
-        }
+        assert!(self.stack.len() > 1, "root scope cannot be popped");
+        self.stack.pop();
     }
 
     /// Look up a value by walking the scope stack from top to bottom.
     pub(crate) fn lookup_value(&self, name: &str) -> Option<&Type> {
-        for scope in self.stack.iter().rev() {
-            if let Some(ty) = scope.values.get(name) {
-                return Some(ty);
-            }
-        }
-        None
+        self.lookup_scoped_value(name).map(|value| &value.ty)
     }
 
-    /// Check if a variable is marked mutable in any enclosing scope.
+    /// Check whether the visible value is a mutable binding.
     pub(crate) fn lookup_mutable(&self, name: &str) -> bool {
-        self.stack
-            .iter()
-            .rev()
-            .any(|s| s.mutables.as_ref().is_some_and(|m| m.contains(name)))
+        matches!(
+            self.lookup_scoped_value(name).map(|value| value.kind),
+            Some(ScopedValueKind::Binding { mutable: true, .. })
+        )
     }
 
-    /// Whether `name` is a block-local `const` in any enclosing scope.
+    /// Whether the visible value is a block-local `const`.
     pub(crate) fn lookup_const(&self, name: &str) -> bool {
-        self.stack
-            .iter()
-            .rev()
-            .any(|s| s.consts.as_ref().is_some_and(|c| c.contains(name)))
+        matches!(
+            self.lookup_scoped_value(name).map(|value| value.kind),
+            Some(ScopedValueKind::Const)
+        )
     }
 
     /// Look up a binding ID by walking the scope stack from top to bottom.
     pub(crate) fn lookup_binding_id(&self, name: &str) -> Option<BindingId> {
-        for scope in self.stack.iter().rev() {
-            if let Some(id) = scope.name_to_binding.get(name) {
-                return Some(*id);
-            }
+        match self.lookup_scoped_value(name)?.kind {
+            ScopedValueKind::Binding { id, .. } => Some(id),
+            ScopedValueKind::Value | ScopedValueKind::Const => None,
         }
-        None
     }
 
     /// Whether resolving `name` crosses a function scope, meaning captured.
     pub(crate) fn binding_crosses_function_boundary(&self, name: &str) -> bool {
         let mut crossed = false;
         for scope in self.stack.iter().rev() {
-            if scope.name_to_binding.contains_key(name) {
-                return crossed;
+            if let Some(value) = scope.values.get(name) {
+                return crossed && matches!(value.kind, ScopedValueKind::Binding { .. });
             }
             if scope.fn_return_type.is_some() {
                 crossed = true;
             }
         }
         false
+    }
+
+    fn lookup_scoped_value(&self, name: &str) -> Option<&ScopedValue> {
+        self.stack
+            .iter()
+            .rev()
+            .find_map(|scope| scope.values.get(name))
     }
 
     /// Look up a type parameter by walking the scope stack from top to bottom.
@@ -288,11 +336,35 @@ impl Scopes {
         None
     }
 
+    pub(crate) fn lookup_try_block_context_mut(&mut self) -> Option<&mut TryBlockContext> {
+        for scope in self.stack.iter_mut().rev() {
+            if scope.try_block_context.is_some() {
+                return scope.try_block_context.as_mut();
+            }
+            if scope.fn_return_type.is_some() {
+                return None;
+            }
+        }
+        None
+    }
+
     /// Look up the enclosing recover block context, stopping at function boundaries.
     pub(crate) fn lookup_recover_block_context(&self) -> Option<&RecoverBlockContext> {
         for scope in self.stack.iter().rev() {
             if scope.recover_block_context.is_some() {
                 return scope.recover_block_context.as_ref();
+            }
+            if scope.fn_return_type.is_some() {
+                return None;
+            }
+        }
+        None
+    }
+
+    pub(crate) fn lookup_recover_block_context_mut(&mut self) -> Option<&mut RecoverBlockContext> {
+        for scope in self.stack.iter_mut().rev() {
+            if scope.recover_block_context.is_some() {
+                return scope.recover_block_context.as_mut();
             }
             if scope.fn_return_type.is_some() {
                 return None;
@@ -349,151 +421,147 @@ impl Scopes {
     }
 
     pub(crate) fn mark_test_handle(&mut self) {
-        self.current_mut().in_test_handle = true;
+        self.current_mut().inherited.in_test_handle = true;
     }
 
     pub(crate) fn has_test_handle(&self) -> bool {
-        self.current().in_test_handle
+        self.current().inherited.in_test_handle
     }
 
     pub(crate) fn set_test_fn_name(&mut self, name: EcoString) {
-        self.current_mut().test_fn_name = Some(name);
+        self.current_mut().inherited.test_fn_name = Some(name);
     }
 
     pub(crate) fn test_fn_name(&self) -> Option<&str> {
-        self.current().test_fn_name.as_deref()
+        self.current().inherited.test_fn_name.as_deref()
     }
 
-    pub(crate) fn increment_loop_depth(&self) {
-        self.current().loop_depth.increment();
+    pub(crate) fn increment_loop_depth(&mut self) {
+        self.current_mut().inherited.loop_depth.increment();
     }
 
-    pub(crate) fn decrement_loop_depth(&self) {
-        self.current().loop_depth.decrement();
+    pub(crate) fn decrement_loop_depth(&mut self) {
+        self.current_mut().inherited.loop_depth.decrement();
     }
 
     pub(crate) fn is_inside_loop(&self) -> bool {
-        self.current().loop_depth.is_active()
+        self.current().inherited.loop_depth.is_active()
     }
 
     pub(crate) fn set_loop_break_type(&mut self, ty: Type) {
-        self.current_mut().loop_break_type = Some(ty);
+        self.current_mut().inherited.loop_break_type = Some(ty);
     }
 
     pub(crate) fn clear_loop_break_type(&mut self) {
-        self.current_mut().loop_break_type = None;
+        self.current_mut().inherited.loop_break_type = None;
     }
 
     pub(crate) fn loop_break_type(&self) -> Option<&Type> {
-        self.current().loop_break_type.as_ref()
+        self.current().inherited.loop_break_type.as_ref()
     }
 
-    pub(crate) fn increment_defer_block_depth(&self) {
-        self.current().defer_block_depth.increment();
+    pub(crate) fn increment_defer_block_depth(&mut self) {
+        self.current_mut().inherited.defer_block_depth.increment();
     }
 
-    pub(crate) fn decrement_defer_block_depth(&self) {
-        self.current().defer_block_depth.decrement();
+    pub(crate) fn decrement_defer_block_depth(&mut self) {
+        self.current_mut().inherited.defer_block_depth.decrement();
     }
 
     pub(crate) fn is_inside_defer_block(&self) -> bool {
-        self.current().defer_block_depth.is_active()
+        self.current().inherited.defer_block_depth.is_active()
     }
 
     pub(crate) fn defer_block_loop_depth(&self) -> usize {
-        self.current().loop_depth.get()
+        self.current().inherited.loop_depth.get()
     }
 
-    pub(crate) fn increment_negation_depth(&self) {
-        self.current().negation_depth.increment();
+    pub(crate) fn increment_negation_depth(&mut self) {
+        self.current_mut().inherited.negation_depth.increment();
     }
 
-    pub(crate) fn decrement_negation_depth(&self) {
-        self.current().negation_depth.decrement();
+    pub(crate) fn decrement_negation_depth(&mut self) {
+        self.current_mut().inherited.negation_depth.decrement();
     }
 
     pub(crate) fn is_inside_negation(&self) -> bool {
-        self.current().negation_depth.is_active()
+        self.current().inherited.negation_depth.is_active()
     }
 
-    pub(crate) fn reset_loop_depth(&self) -> usize {
-        self.current().loop_depth.reset()
+    pub(crate) fn reset_loop_depth(&mut self) -> usize {
+        self.current_mut().inherited.loop_depth.reset()
     }
 
-    pub(crate) fn restore_loop_depth(&self, depth: usize) {
-        self.current().loop_depth.restore(depth);
+    pub(crate) fn restore_loop_depth(&mut self, depth: usize) {
+        self.current_mut().inherited.loop_depth.restore(depth);
     }
 
-    pub(crate) fn set_value_context(&self) -> UseContext {
-        let prev = self.current().use_context.get();
-        self.current().use_context.set(UseContext::Value);
+    pub(crate) fn set_value_context(&mut self) -> UseContext {
+        let prev = self.current().inherited.use_context;
+        self.current_mut().inherited.use_context = UseContext::Value;
         prev
     }
 
-    pub(crate) fn set_statement_context(&self) -> UseContext {
-        let prev = self.current().use_context.get();
-        self.current().use_context.set(UseContext::Statement);
+    pub(crate) fn set_statement_context(&mut self) -> UseContext {
+        let prev = self.current().inherited.use_context;
+        self.current_mut().inherited.use_context = UseContext::Statement;
         prev
     }
 
-    pub(crate) fn restore_use_context(&self, ctx: UseContext) {
-        self.current().use_context.set(ctx);
+    pub(crate) fn restore_use_context(&mut self, ctx: UseContext) {
+        self.current_mut().inherited.use_context = ctx;
     }
 
     pub(crate) fn is_value_context(&self) -> bool {
-        self.current().use_context.get() == UseContext::Value
+        self.current().inherited.use_context == UseContext::Value
     }
 
-    pub(crate) fn set_callee_context(&self) -> UseContext {
-        let prev = self.current().use_context.get();
-        self.current().use_context.set(UseContext::Callee);
+    pub(crate) fn set_callee_context(&mut self) -> UseContext {
+        let prev = self.current().inherited.use_context;
+        self.current_mut().inherited.use_context = UseContext::Callee;
         prev
     }
 
     pub(crate) fn is_callee_context(&self) -> bool {
-        self.current().use_context.get() == UseContext::Callee
+        self.current().inherited.use_context == UseContext::Callee
     }
 
-    pub(crate) fn set_assignment_target_context(&self) -> UseContext {
-        let prev = self.current().use_context.get();
-        self.current().use_context.set(UseContext::AssignmentTarget);
+    pub(crate) fn set_assignment_target_context(&mut self) -> UseContext {
+        let prev = self.current().inherited.use_context;
+        self.current_mut().inherited.use_context = UseContext::AssignmentTarget;
         prev
     }
 
     pub(crate) fn is_assignment_target_context(&self) -> bool {
-        self.current().use_context.get() == UseContext::AssignmentTarget
-    }
-
-    pub(crate) fn set_in_subexpression(&self, value: bool) -> bool {
-        self.in_subexpression.replace(value)
+        self.current().inherited.use_context == UseContext::AssignmentTarget
     }
 
     pub(crate) fn is_dot_access_base(&self) -> bool {
-        self.dot_access_base.get()
+        self.dot_access_base
     }
 
-    pub(crate) fn set_dot_access_base(&self, value: bool) -> bool {
-        self.dot_access_base.replace(value)
+    pub(crate) fn set_dot_access_base(&mut self, value: bool) -> bool {
+        std::mem::replace(&mut self.dot_access_base, value)
     }
 
     pub(crate) fn is_let_binding_rhs(&self) -> bool {
-        self.let_binding_rhs.get()
+        self.let_binding_rhs
     }
 
-    pub(crate) fn set_let_binding_rhs(&self, value: bool) -> bool {
-        self.let_binding_rhs.replace(value)
+    pub(crate) fn set_let_binding_rhs(&mut self, value: bool) -> bool {
+        std::mem::replace(&mut self.let_binding_rhs, value)
     }
 
-    pub(crate) fn increment_type_param_depth(&self) {
-        self.current().type_param_depth.increment();
+    pub(crate) fn increment_type_param_depth(&mut self) {
+        self.current_mut().inherited.type_param_depth.increment();
     }
 
-    pub(crate) fn decrement_type_param_depth(&self) {
-        self.current().type_param_depth.decrement();
+    pub(crate) fn decrement_type_param_depth(&mut self) {
+        self.current_mut().inherited.type_param_depth.decrement();
     }
 
     pub(crate) fn is_inside_type_param(&self) -> bool {
-        self.current().type_param_depth.is_active()
+        self.current().inherited.type_param_depth.is_active()
     }
 
     pub(crate) fn set_impl_receiver_type(&mut self, ty: Option<Type>) {
@@ -502,5 +570,52 @@ impl Scopes {
 
     pub(crate) fn impl_receiver_type(&self) -> Option<&Type> {
         self.impl_receiver_type.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shadowing_replaces_all_value_metadata() {
+        let mut scopes = Scopes::new();
+        scopes
+            .current_mut()
+            .insert_binding("value".into(), Type::Error, 1, true);
+
+        scopes.push();
+        scopes
+            .current_mut()
+            .insert_binding("value".into(), Type::Error, 2, false);
+
+        assert_eq!(scopes.lookup_binding_id("value"), Some(2));
+        assert!(!scopes.lookup_mutable("value"));
+        assert!(!scopes.lookup_const("value"));
+
+        scopes
+            .current_mut()
+            .insert_const("value".into(), Type::Error);
+
+        assert_eq!(scopes.lookup_binding_id("value"), None);
+        assert!(!scopes.lookup_mutable("value"));
+        assert!(scopes.lookup_const("value"));
+    }
+
+    #[test]
+    fn non_binding_shadow_stops_capture_lookup() {
+        let mut scopes = Scopes::new();
+        scopes
+            .current_mut()
+            .insert_binding("value".into(), Type::Error, 1, true);
+
+        scopes.push();
+        scopes.current_mut().fn_return_type = Some(Type::Error);
+        scopes
+            .current_mut()
+            .insert_value("value".into(), Type::Error);
+
+        assert_eq!(scopes.lookup_binding_id("value"), None);
+        assert!(!scopes.binding_crosses_function_boundary("value"));
     }
 }

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -5,12 +5,9 @@
 //! handle, so `Type` is a pure value (Clone / Eq / Hash / Serialize friendly)
 //! with no shared mutable state.
 //!
-//! Speculative unification works through the `undo_log`: a fresh log is
-//! pushed when entering speculation, bindings are recorded as they happen,
-//! and on Err the originals are restored in reverse order. On Ok the log is
-//! either discarded (no enclosing speculation) or appended to the parent log
-//! (nested speculation — the bindings are committed to the parent, but still
-//! reversible if the parent fails).
+//! Speculative unification uses a stack of undo logs. Bindings go into the
+//! innermost log; a successful nested region joins its parent, while a failed
+//! region restores its entries in reverse order.
 
 use ecow::EcoString;
 use syntax::types::{Bound, Type, TypeVarId};
@@ -23,9 +20,7 @@ pub enum VarState {
 
 pub struct TypeEnv {
     entries: Vec<VarState>,
-    /// When Some, bindings performed during the current speculative region
-    /// are logged here as `(id, prior_state)` so they can be reverted.
-    undo_log: Option<Vec<(TypeVarId, VarState)>>,
+    undo_logs: Vec<Vec<(TypeVarId, VarState)>>,
 }
 
 impl Default for TypeEnv {
@@ -38,7 +33,7 @@ impl TypeEnv {
     pub(crate) fn new() -> Self {
         Self {
             entries: Vec::new(),
-            undo_log: None,
+            undo_logs: Vec::new(),
         }
     }
 
@@ -69,7 +64,7 @@ impl TypeEnv {
         }
         let slot = Self::slot(id);
         let old = std::mem::replace(&mut self.entries[slot], VarState::Bound(ty));
-        if let Some(log) = &mut self.undo_log {
+        if let Some(log) = self.undo_logs.last_mut() {
             log.push((id, old));
         }
     }
@@ -248,36 +243,23 @@ impl TypeEnv {
         }
     }
 
-    /// Begin a speculative region. Caller holds the returned handle and
-    /// passes it back to `end_speculation` with the region's outcome.
-    pub(crate) fn begin_speculation(&mut self) -> Speculation {
-        let prev = self.undo_log.take();
-        self.undo_log = Some(Vec::new());
-        Speculation { prev }
+    pub(super) fn begin_speculation(&mut self) {
+        self.undo_logs.push(Vec::new());
     }
 
-    /// End a speculative region. If `is_err`, revert all bindings made
-    /// during the region. Otherwise, either commit them (no enclosing
-    /// region) or append them to the enclosing region's log (so it can
-    /// still revert them if it fails).
-    pub(crate) fn end_speculation(&mut self, spec: Speculation, is_err: bool) {
-        let log = self.undo_log.take().expect("speculation log must exist");
-        self.undo_log = spec.prev;
+    pub(super) fn end_speculation(&mut self, is_err: bool) {
+        let log = self
+            .undo_logs
+            .pop()
+            .expect("speculation must be started before it is ended");
         if is_err {
             for (id, original) in log.into_iter().rev() {
                 self.entries[Self::slot(id)] = original;
             }
-        } else if let Some(parent_log) = &mut self.undo_log {
+        } else if let Some(parent_log) = self.undo_logs.last_mut() {
             parent_log.extend(log);
         }
     }
-}
-
-/// Handle returned by `begin_speculation`, consumed by `end_speculation`.
-/// Not clonable — ensures each region is ended exactly once.
-#[must_use]
-pub struct Speculation {
-    prev: Option<Vec<(TypeVarId, VarState)>>,
 }
 
 /// Extension trait for `Type` giving env-aware resolve convenience methods.
@@ -317,5 +299,22 @@ mod tests {
         env.bind(ids[DEPTH - 1], Type::Simple(SimpleKind::Int));
 
         assert_eq!(env.resolve(&var(ids[0])), Type::Simple(SimpleKind::Int));
+    }
+
+    #[test]
+    fn outer_rollback_includes_committed_nested_bindings() {
+        let mut env = TypeEnv::new();
+        let outer = env.fresh(None);
+        let inner = env.fresh(None);
+
+        env.begin_speculation();
+        env.bind(outer, Type::Simple(SimpleKind::Int));
+        env.begin_speculation();
+        env.bind(inner, Type::Simple(SimpleKind::String));
+        env.end_speculation(false);
+        env.end_speculation(true);
+
+        assert!(matches!(env.state(outer), VarState::Unbound { .. }));
+        assert!(matches!(env.state(inner), VarState::Unbound { .. }));
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use diagnostics::{PatternIssue, UnusedExpressionKind};
+use diagnostics::PatternIssue;
 use syntax::EcoString;
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
 use syntax::program::{ResolvedDefinitions, TestFunction};
@@ -33,18 +33,12 @@ pub struct Facts {
 
     // LSP-consumed; reshaping these affects crates/lsp/.
     pub bindings: HashMap<BindingId, BindingFact>,
-    pub usages: Vec<Usage>,
-    usage_set: HashSet<(Span, Span)>,
+    pub usages: HashSet<Usage>,
 
-    // Lint-support facts: read by reference by passes::lints (mostly
-    // from_facts; interface_satisfied_methods by ref_graph).
+    // Lint-support facts recorded during semantic analysis and read by passes::lints.
     pub dead_code: Vec<DeadCodeFact>,
     pub pattern_issues: Vec<PatternIssue>,
-    pub unused_expressions: Vec<UnusedExpressionFact>,
-    pub discarded_tail_expressions: Vec<DiscardedTailFact>,
     pub overused_references: Vec<OverusedReferenceFact>,
-    pub unused_type_params: Vec<UnusedTypeParamFact>,
-    pub type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<InterfaceSatisfaction>>,
@@ -173,11 +167,7 @@ impl Facts {
             bindings: HashMap::default(),
             dead_code: Vec::new(),
             pattern_issues: Vec::new(),
-            unused_expressions: Vec::new(),
-            discarded_tail_expressions: Vec::new(),
             overused_references: Vec::new(),
-            unused_type_params: Vec::new(),
-            type_params_only_in_bound: Vec::new(),
             always_failing_try_blocks: Vec::new(),
             expression_only_fstrings: Vec::new(),
             generic_call_checks: Vec::new(),
@@ -191,8 +181,7 @@ impl Facts {
             or_pattern_error_spans: HashSet::default(),
             type_error_spans: HashSet::default(),
             function_spans: Vec::new(),
-            usages: Vec::new(),
-            usage_set: HashSet::default(),
+            usages: HashSet::default(),
             interface_satisfied_methods: HashMap::default(),
             equality_derivations: Vec::new(),
             test_functions: Vec::new(),
@@ -201,14 +190,16 @@ impl Facts {
         }
     }
 
+    pub(crate) fn allocator(&self) -> Arc<BindingIdAllocator> {
+        self.allocator.clone()
+    }
+
     pub(crate) fn add_binding(
         &mut self,
         name: String,
         span: Span,
         kind: BindingKind,
-        is_typedef: bool,
-        is_struct_field: bool,
-        is_as_alias: bool,
+        origin: BindingOrigin,
     ) -> BindingId {
         let id = self.allocator.reserve();
         self.bindings.insert(
@@ -218,11 +209,8 @@ impl Facts {
                 span,
                 kind,
                 used: false,
-                mutated: false,
-                alias_mutated: false,
-                is_typedef,
-                is_struct_field,
-                is_as_alias,
+                mutation: BindingMutation::Unchanged,
+                origin,
             },
         );
         id
@@ -235,8 +223,10 @@ impl Facts {
     }
 
     pub(crate) fn mark_mutated(&mut self, id: BindingId) {
-        if let Some(fact) = self.bindings.get_mut(&id) {
-            fact.mutated = true;
+        if let Some(fact) = self.bindings.get_mut(&id)
+            && fact.mutation == BindingMutation::Unchanged
+        {
+            fact.mutation = BindingMutation::Direct;
         }
     }
 
@@ -244,8 +234,7 @@ impl Facts {
     /// capture, mut argument or receiver), so a call can rebind it.
     pub(crate) fn mark_alias_mutated(&mut self, id: BindingId) {
         if let Some(fact) = self.bindings.get_mut(&id) {
-            fact.mutated = true;
-            fact.alias_mutated = true;
+            fact.mutation = BindingMutation::ThroughAlias;
         }
     }
 
@@ -280,12 +269,10 @@ impl Facts {
     }
 
     pub(crate) fn add_usage(&mut self, usage_span: Span, definition_span: Span) {
-        if self.usage_set.insert((usage_span, definition_span)) {
-            self.usages.push(Usage {
-                usage_span,
-                definition_span,
-            });
-        }
+        self.usages.insert(Usage {
+            usage_span,
+            definition_span,
+        });
     }
 
     pub(crate) fn mark_method_used_for_interface(
@@ -321,21 +308,6 @@ impl Facts {
             })
     }
 
-    pub fn absorb_local_facts(&mut self, local: LocalFacts) {
-        let LocalFacts {
-            unused_expressions,
-            discarded_tail_expressions,
-            unused_type_params,
-            type_params_only_in_bound,
-        } = local;
-        self.unused_expressions.extend(unused_expressions);
-        self.discarded_tail_expressions
-            .extend(discarded_tail_expressions);
-        self.unused_type_params.extend(unused_type_params);
-        self.type_params_only_in_bound
-            .extend(type_params_only_in_bound);
-    }
-
     pub(crate) fn merge(&mut self, other: Facts) {
         debug_assert!(
             Arc::ptr_eq(&self.allocator, &other.allocator),
@@ -347,11 +319,7 @@ impl Facts {
             bindings,
             dead_code,
             pattern_issues,
-            unused_expressions,
-            discarded_tail_expressions,
             overused_references,
-            unused_type_params,
-            type_params_only_in_bound,
             always_failing_try_blocks,
             expression_only_fstrings,
             generic_call_checks,
@@ -366,7 +334,6 @@ impl Facts {
             type_error_spans,
             function_spans,
             usages,
-            usage_set: _,
             interface_satisfied_methods,
             equality_derivations,
             test_functions,
@@ -381,13 +348,7 @@ impl Facts {
         self.bindings.extend(bindings);
         self.dead_code.extend(dead_code);
         self.pattern_issues.extend(pattern_issues);
-        self.unused_expressions.extend(unused_expressions);
-        self.discarded_tail_expressions
-            .extend(discarded_tail_expressions);
         self.overused_references.extend(overused_references);
-        self.unused_type_params.extend(unused_type_params);
-        self.type_params_only_in_bound
-            .extend(type_params_only_in_bound);
         self.always_failing_try_blocks
             .extend(always_failing_try_blocks);
         self.expression_only_fstrings
@@ -406,15 +367,7 @@ impl Facts {
         self.type_error_spans.extend(type_error_spans);
         self.function_spans.extend(function_spans);
 
-        self.usages.reserve(usages.len());
-        self.usage_set.reserve(usages.len());
-        for Usage {
-            usage_span,
-            definition_span,
-        } in usages
-        {
-            self.add_usage(usage_span, definition_span);
-        }
+        self.usages.extend(usages);
 
         for (key, impl_types) in interface_satisfied_methods {
             self.interface_satisfied_methods
@@ -422,60 +375,6 @@ impl Facts {
                 .or_default()
                 .extend(impl_types);
         }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct LocalFacts {
-    unused_expressions: Vec<UnusedExpressionFact>,
-    discarded_tail_expressions: Vec<DiscardedTailFact>,
-    unused_type_params: Vec<UnusedTypeParamFact>,
-    type_params_only_in_bound: Vec<TypeParamOnlyInBoundFact>,
-}
-
-impl LocalFacts {
-    pub fn merge(&mut self, other: LocalFacts) {
-        let LocalFacts {
-            unused_expressions,
-            discarded_tail_expressions,
-            unused_type_params,
-            type_params_only_in_bound,
-        } = other;
-        self.unused_expressions.extend(unused_expressions);
-        self.discarded_tail_expressions
-            .extend(discarded_tail_expressions);
-        self.unused_type_params.extend(unused_type_params);
-        self.type_params_only_in_bound
-            .extend(type_params_only_in_bound);
-    }
-
-    pub fn add_unused_expression(&mut self, span: Span, kind: UnusedExpressionKind) {
-        self.unused_expressions
-            .push(UnusedExpressionFact { span, kind });
-    }
-
-    pub fn add_discarded_tail(
-        &mut self,
-        span: Span,
-        return_type: String,
-        expected_span: Span,
-        expected_type: String,
-    ) {
-        self.discarded_tail_expressions.push(DiscardedTailFact {
-            span,
-            return_type,
-            expected_span,
-            expected_type,
-        });
-    }
-
-    pub fn add_unused_type_param(&mut self, span: Span) {
-        self.unused_type_params.push(UnusedTypeParamFact { span });
-    }
-
-    pub fn add_type_param_only_in_bound(&mut self, name: String, span: Span) {
-        self.type_params_only_in_bound
-            .push(TypeParamOnlyInBoundFact { name, span });
     }
 }
 
@@ -491,13 +390,57 @@ pub struct BindingFact {
     pub span: Span,
     pub kind: BindingKind,
     pub used: bool,
-    pub mutated: bool,
-    pub alias_mutated: bool,
-    pub is_typedef: bool,
-    /// If true, this binding is a shorthand in a struct pattern (e.g., `Point { x }`)
-    pub is_struct_field: bool,
-    /// If true, this binding was introduced by an `as` alias (e.g., `Point { .. } as p`)
-    pub is_as_alias: bool,
+    pub mutation: BindingMutation,
+    pub origin: BindingOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingMutation {
+    Unchanged,
+    Direct,
+    ThroughAlias,
+}
+
+impl BindingMutation {
+    pub fn happened(self) -> bool {
+        self != Self::Unchanged
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BindingOrigin {
+    Name {
+        in_typedef: bool,
+        shorthand_field: bool,
+    },
+    AsAlias {
+        shorthand_field: bool,
+    },
+}
+
+impl BindingOrigin {
+    pub fn is_typedef(self) -> bool {
+        matches!(
+            self,
+            Self::Name {
+                in_typedef: true,
+                ..
+            }
+        )
+    }
+
+    pub fn is_struct_field(self) -> bool {
+        match self {
+            Self::Name {
+                shorthand_field, ..
+            }
+            | Self::AsAlias { shorthand_field } => shorthand_field,
+        }
+    }
+
+    pub fn is_as_alias(self) -> bool {
+        matches!(self, Self::AsAlias { .. })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -507,39 +450,14 @@ pub struct DeadCodeFact {
 }
 
 #[derive(Debug, Clone)]
-pub struct UnusedExpressionFact {
-    pub span: Span,
-    pub kind: UnusedExpressionKind,
-}
-
-#[derive(Debug, Clone)]
-pub struct DiscardedTailFact {
-    pub span: Span,
-    pub return_type: String,
-    pub expected_span: Span,
-    pub expected_type: String,
-}
-
-#[derive(Debug, Clone)]
 pub struct OverusedReferenceFact {
     pub span: Span,
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-pub struct UnusedTypeParamFact {
-    pub span: Span,
-}
-
-#[derive(Debug, Clone)]
-pub struct TypeParamOnlyInBoundFact {
-    pub name: String,
-    pub span: Span,
-}
-
 /// Records a usage of a symbol, linking the usage location to its definition.
 /// Used by LSP for find-references.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Usage {
     pub usage_span: Span,
     pub definition_span: Span,
@@ -564,17 +482,19 @@ mod tests {
             "a".into(),
             span(0),
             BindingKind::Let { mutable: false },
-            false,
-            false,
-            false,
+            BindingOrigin::Name {
+                in_typedef: false,
+                shorthand_field: false,
+            },
         );
         let b_id = b.add_binding(
             "b".into(),
             span(1),
             BindingKind::Let { mutable: false },
-            false,
-            false,
-            false,
+            BindingOrigin::Name {
+                in_typedef: false,
+                shorthand_field: false,
+            },
         );
         assert_ne!(a_id, b_id);
 
@@ -582,6 +502,26 @@ mod tests {
         assert_eq!(a.bindings.len(), 2);
         assert!(a.bindings.contains_key(&a_id));
         assert!(a.bindings.contains_key(&b_id));
+    }
+
+    #[test]
+    fn direct_mutation_does_not_downgrade_alias_mutation() {
+        let allocator = Arc::new(BindingIdAllocator::new());
+        let mut facts = Facts::new(allocator);
+        let id = facts.add_binding(
+            "value".into(),
+            span(0),
+            BindingKind::Let { mutable: true },
+            BindingOrigin::Name {
+                in_typedef: false,
+                shorthand_field: false,
+            },
+        );
+
+        facts.mark_alias_mutated(id);
+        facts.mark_mutated(id);
+
+        assert_eq!(facts.bindings[&id].mutation, BindingMutation::ThroughAlias);
     }
 
     #[test]
@@ -624,25 +564,6 @@ mod tests {
 
         a.merge(b);
         assert_eq!(a.or_pattern_error_spans.len(), 2);
-    }
-
-    #[test]
-    fn absorb_local_facts_extends_all_four_streams() {
-        let allocator = Arc::new(BindingIdAllocator::new());
-        let mut facts = Facts::new(allocator);
-
-        let mut local = LocalFacts::default();
-        local.add_unused_expression(span(0), UnusedExpressionKind::Value);
-        local.add_discarded_tail(span(1), "Int".into(), span(2), "Unit".into());
-        local.add_unused_type_param(span(3));
-        local.add_type_param_only_in_bound("U".into(), span(4));
-
-        facts.absorb_local_facts(local);
-
-        assert_eq!(facts.unused_expressions.len(), 1);
-        assert_eq!(facts.discarded_tail_expressions.len(), 1);
-        assert_eq!(facts.unused_type_params.len(), 1);
-        assert_eq!(facts.type_params_only_in_bound.len(), 1);
     }
 
     #[test]

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -134,7 +134,7 @@ pub fn bound_display_name(store: &Store, bound: &Type) -> EcoString {
     )
 }
 
-impl TaskState<'_> {
+impl TaskState {
     pub(crate) fn visible_parameter_bounds(&self) -> Vec<(EcoString, Vec<Type>)> {
         self.scopes
             .collect_all_trait_bounds()

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -4,10 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use diagnostics::LocalSink;
-use ecow::EcoString;
-use syntax::ast::{Expression, Span, StructFieldDefinition};
+use syntax::ast::Expression;
 use syntax::program::{File, Module};
-use syntax::types::Type;
 
 use deps::TypedefLocator;
 
@@ -18,12 +16,12 @@ use crate::cache::{
     hash_module_source_pair, is_cache_disabled, prelude as prelude_cache,
     restore_cached_generic_bounds, try_load_cache,
 };
-use crate::checker::TaskState;
 use crate::checker::infer::InferCtx;
+use crate::checker::{TaskOutput, TaskState};
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
-use crate::facts::{BindingIdAllocator, Facts};
+use crate::facts::Facts;
 use crate::loader::{DiscoveredModules, Loader};
-use crate::module_graph::{Roots, build_module_graph};
+use crate::module_graph::{ModuleGraphOptions, Roots, build_module_graph};
 use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use crate::store::{ENTRY_MODULE_ID, Store};
 
@@ -75,20 +73,63 @@ pub struct AnalyzeInput<'a> {
 pub const PARALLEL_THRESHOLD: usize = 4;
 
 struct CacheCandidate {
+    compiled: CompiledModule,
+    files: Vec<File>,
+    topo_rank: usize,
+    expected_artifact_hash: Option<u64>,
+}
+
+struct PendingModule {
     module_id: String,
     topo_rank: usize,
-    files: Vec<File>,
-    full_hash: u64,
-    dep_hashes: HashMap<String, u64>,
-    expected_artifact_hash: Option<u64>,
-    module_hash: u64,
-    production_hash: u64,
 }
 
 struct CacheBuildJob {
     module_id: String,
     interface: ModuleInterface,
     file_id_base: u32,
+}
+
+struct RegistrationOutput {
+    modules: Vec<(String, Arc<Module>)>,
+    task: TaskOutput,
+}
+
+enum LazyGoStdlibCache {
+    Disabled,
+    Unloaded,
+    Missing,
+    Loaded(go_stdlib::GoStdlibCache),
+}
+
+impl LazyGoStdlibCache {
+    fn new(disabled: bool) -> Self {
+        if disabled {
+            Self::Disabled
+        } else {
+            Self::Unloaded
+        }
+    }
+
+    fn get_or_load(&mut self, target: stdlib::Target) -> Option<&go_stdlib::GoStdlibCache> {
+        if matches!(self, Self::Unloaded) {
+            *self = match go_stdlib::try_load_go_stdlib_cache(target) {
+                Some(cache) => Self::Loaded(cache),
+                None => Self::Missing,
+            };
+        }
+        match self {
+            Self::Loaded(cache) => Some(cache),
+            Self::Disabled | Self::Unloaded | Self::Missing => None,
+        }
+    }
+
+    fn into_module_ids(self) -> Option<HashSet<String>> {
+        match self {
+            Self::Loaded(cache) => Some(cache.modules.keys().cloned().collect()),
+            Self::Disabled | Self::Unloaded | Self::Missing => None,
+        }
+    }
 }
 
 pub struct InferenceOutput {
@@ -189,12 +230,14 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     };
     let mut graph_result = build_module_graph(
         &mut store,
-        Some(input.loader),
         roots,
-        &sink,
-        input.config.standalone_mode,
-        &input.locator,
-        include_tests,
+        ModuleGraphOptions {
+            loader: Some(input.loader),
+            sink: &sink,
+            standalone_mode: input.config.standalone_mode,
+            locator: &input.locator,
+            include_tests,
+        },
     );
 
     for cycle in &graph_result.cycles {
@@ -230,13 +273,9 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     let cache_enabled = input.project_root.is_some() && !cache_disabled && !input.disable_cache;
     let check_go_files = input.compile_phase == CompilePhase::Emit;
 
-    let binding_ids = Arc::new(BindingIdAllocator::new());
-
-    let (facts, cached_modules, compiled_modules, ufcs_methods) = {
-        let mut checker = TaskState::new(&sink, binding_ids.clone());
-        checker
-            .ufcs_methods
-            .extend(crate::prelude::compute_prelude_ufcs(&store));
+    let (facts, cached_modules, compiled_modules, ufcs_methods, sink) = {
+        let mut checker = TaskState::with_sink(sink);
+        checker.extend_ufcs_methods(crate::prelude::compute_prelude_ufcs(&store));
 
         let mut module_hashes: HashMap<String, u64> = HashMap::default();
         let mut cached_modules: HashSet<String> = HashSet::default();
@@ -246,12 +285,9 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         let edges = &graph_result.edges;
         let production_edges = &graph_result.production_edges;
 
-        // Outer `None` = not attempted: the deserialize costs milliseconds a
-        // project without stdlib imports should not pay.
-        let mut go_cache: Option<Option<go_stdlib::GoStdlibCache>> =
-            if cache_disabled { Some(None) } else { None };
+        let mut go_cache = LazyGoStdlibCache::new(cache_disabled);
 
-        let mut to_infer: Vec<(usize, String)> = Vec::new();
+        let mut to_infer: Vec<PendingModule> = Vec::new();
         let mut candidates: Vec<CacheCandidate> = Vec::new();
 
         let source_hashes: HashMap<String, (u64, u64)> =
@@ -277,7 +313,6 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
                 register_go_module(
                     &mut checker,
                     &mut store,
-                    &sink,
                     &module_id,
                     &input.locator,
                     input.config.standalone_mode,
@@ -305,40 +340,38 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
             let is_entry = module_id == ENTRY_MODULE_ID;
 
+            let compiled = (!is_entry).then(|| CompiledModule {
+                module_id: module_id.clone(),
+                module_hash,
+                production_hash,
+                full_hash,
+                dep_hashes,
+            });
+
             let expected_artifact_hash = check_go_files
                 .then(|| compute_emit_artifact_hash(production_hash, &input.go_module));
 
-            if cache_enabled && !is_entry {
-                candidates.push(CacheCandidate {
-                    module_id,
-                    topo_rank,
+            match (cache_enabled, compiled) {
+                (true, Some(compiled)) => candidates.push(CacheCandidate {
+                    compiled,
                     files,
-                    full_hash,
-                    dep_hashes,
+                    topo_rank,
                     expected_artifact_hash,
-                    module_hash,
-                    production_hash,
-                });
-                continue;
+                }),
+                (_, compiled) => {
+                    store.store_module(&module_id, files);
+                    if let Some(compiled) = compiled {
+                        compiled_modules.push(compiled);
+                    }
+                    to_infer.push(PendingModule {
+                        module_id,
+                        topo_rank,
+                    });
+                }
             }
-
-            store.store_module(&module_id, files);
-            if !is_entry {
-                compiled_modules.push(CompiledModule {
-                    module_id: module_id.clone(),
-                    module_hash,
-                    production_hash,
-                    full_hash,
-                    dep_hashes,
-                });
-            }
-            to_infer.push((topo_rank, module_id));
         }
 
-        let go_cache_module_ids: Option<HashSet<String>> = go_cache
-            .take()
-            .flatten()
-            .map(|cache| cache.modules.keys().cloned().collect());
+        let go_cache_module_ids = go_cache.into_module_ids();
 
         let cache_load = load_cache_candidates(
             &mut checker,
@@ -351,13 +384,16 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         cached_modules.extend(cache_load.cached);
         to_infer.extend(cache_load.to_infer);
 
-        for (_, module_id) in &to_infer {
-            checker.predeclare_module_types(&mut store, module_id);
+        for pending in &to_infer {
+            checker.predeclare_module_types(&mut store, &pending.module_id);
         }
-        restore_cached_generic_bounds(&mut store, &sink, &cached_modules);
+        restore_cached_generic_bounds(&mut store, &checker.sink, &cached_modules);
 
-        to_infer.sort_by_key(|(topo_rank, _)| *topo_rank);
-        let to_infer: Vec<String> = to_infer.into_iter().map(|(_, id)| id).collect();
+        to_infer.sort_by_key(|pending| pending.topo_rank);
+        let to_infer: Vec<String> = to_infer
+            .into_iter()
+            .map(|pending| pending.module_id)
+            .collect();
 
         let test_ids: Vec<u32> = to_infer
             .iter()
@@ -372,15 +408,8 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             .collect();
         store.test_file_ids.extend(test_ids);
 
-        register_modules(
-            &mut checker,
-            &mut store,
-            &sink,
-            &to_infer,
-            edges,
-            &binding_ids,
-        );
-        infer_modules(&mut checker, &mut store, &sink, &to_infer, &binding_ids);
+        register_modules(&mut checker, &mut store, &to_infer, edges);
+        infer_modules(&mut checker, &mut store, &to_infer);
 
         if !cache_disabled {
             let all_go_modules: Vec<String> = store
@@ -404,11 +433,14 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             prelude_cache::save_prelude_cache(&store);
         }
 
+        let ufcs_methods = checker.take_ufcs_methods();
+
         (
             checker.facts,
             cached_modules,
             compiled_modules,
-            checker.ufcs_methods,
+            ufcs_methods,
+            checker.sink,
         )
     };
 
@@ -429,16 +461,14 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 fn register_go_module(
     checker: &mut TaskState,
     store: &mut Store,
-    sink: &LocalSink,
     module_id: &str,
     locator: &TypedefLocator,
     standalone_mode: bool,
-    go_cache: &mut Option<Option<go_stdlib::GoStdlibCache>>,
+    go_cache: &mut LazyGoStdlibCache,
 ) {
     let go_pkg = module_id.strip_prefix("go:").unwrap_or(module_id);
     if deps::is_stdlib(go_pkg)
-        && let Some(ref cache) =
-            *go_cache.get_or_insert_with(|| go_stdlib::try_load_go_stdlib_cache(locator.target()))
+        && let Some(cache) = go_cache.get_or_load(locator.target())
     {
         load_cached_go_module(store, module_id, cache, locator.target());
         if store.is_visited(module_id) {
@@ -467,7 +497,7 @@ fn register_go_module(
                     standalone_mode,
                     replace_importer: None,
                 },
-                sink,
+                &checker.sink,
             );
         }
     }
@@ -476,8 +506,8 @@ fn register_go_module(
 #[derive(Default)]
 struct CacheLoad {
     compiled: Vec<CompiledModule>,
-    cached: Vec<String>,
-    to_infer: Vec<(usize, String)>,
+    cached: HashSet<String>,
+    to_infer: Vec<PendingModule>,
 }
 
 /// Merges cache hits into the store and returns the misses to register.
@@ -491,9 +521,9 @@ fn load_cache_candidates(
     let load = |c: &CacheCandidate| {
         project_root.and_then(|root| {
             try_load_cache(
-                &c.module_id,
-                c.full_hash,
-                &c.dep_hashes,
+                &c.compiled.module_id,
+                c.compiled.full_hash,
+                &c.compiled.dep_hashes,
                 c.expected_artifact_hash,
                 root,
                 check_go_files,
@@ -511,16 +541,13 @@ fn load_cache_candidates(
     let mut discarded: Vec<Vec<File>> = Vec::new();
     for (candidate, interface) in candidates.into_iter().zip(loaded) {
         let Some(interface) = interface else {
-            let module_id = candidate.module_id;
+            let module_id = candidate.compiled.module_id.clone();
             store.store_module(&module_id, candidate.files);
-            result.compiled.push(CompiledModule {
-                module_id: module_id.clone(),
-                module_hash: candidate.module_hash,
-                production_hash: candidate.production_hash,
-                full_hash: candidate.full_hash,
-                dep_hashes: candidate.dep_hashes,
+            result.compiled.push(candidate.compiled);
+            result.to_infer.push(PendingModule {
+                module_id,
+                topo_rank: candidate.topo_rank,
             });
-            result.to_infer.push((candidate.topo_rank, module_id));
             continue;
         };
         let file_id_base = store.reserve_file_ids(interface.files.len() as u32);
@@ -528,7 +555,7 @@ fn load_cache_candidates(
             discarded.push(candidate.files);
         }
         build_jobs.push(CacheBuildJob {
-            module_id: candidate.module_id,
+            module_id: candidate.compiled.module_id,
             interface,
             file_id_base,
         });
@@ -560,11 +587,11 @@ fn load_cache_candidates(
     };
 
     for build in built {
-        checker.ufcs_methods.extend(build.ufcs_methods);
+        checker.extend_ufcs_methods(build.ufcs_methods);
         let module_id = build.module_id;
         store.insert_prebuilt_module(module_id.clone(), build.module, build.file_map);
         checker.collect_cached_module_tests(store, &module_id);
-        result.cached.push(module_id);
+        result.cached.insert(module_id);
     }
 
     result
@@ -573,10 +600,8 @@ fn load_cache_candidates(
 fn register_modules(
     checker: &mut TaskState,
     store: &mut Store,
-    sink: &LocalSink,
     to_infer: &[String],
     edges: &HashMap<String, HashSet<String>>,
-    binding_ids: &Arc<BindingIdAllocator>,
 ) {
     if to_infer.len() < PARALLEL_THRESHOLD {
         for module_id in to_infer {
@@ -605,34 +630,14 @@ fn register_modules(
             .collect();
 
         let chunk_size = detached.len().div_ceil(rayon::current_num_threads()).max(1);
-        let mut chunks: Vec<Vec<(String, Arc<Module>)>> = Vec::new();
-        let mut remaining = detached.into_iter();
-        loop {
-            let chunk: Vec<_> = remaining.by_ref().take(chunk_size).collect();
-            if chunk.is_empty() {
-                break;
-            }
-            chunks.push(chunk);
-        }
-
-        let allocator = binding_ids.clone();
         let store_ref: &Store = store;
-        let fields_shared = Arc::new(checker.module_fields_snapshot());
+        let seed = checker.worker_seed();
 
-        type RegisterOutput = (
-            Vec<(String, Arc<Module>)>,
-            HashSet<(String, String)>,
-            HashMap<EcoString, Arc<[StructFieldDefinition]>>,
-            Facts,
-            Vec<(Type, Type, Span)>,
-            LocalSink,
-        );
-        let outputs: Vec<RegisterOutput> = chunks
+        let outputs: Vec<RegistrationOutput> = detached
             .into_par_iter()
+            .chunks(chunk_size)
             .map(|chunk| {
-                let local_sink = LocalSink::new();
-                let mut worker = TaskState::new(&local_sink, allocator.clone());
-                worker.module_fields_shared = Some(fields_shared.clone());
+                let mut worker = seed.spawn();
                 let mut view = store_ref.registration_view();
                 let mut registered = Vec::with_capacity(chunk.len());
                 for (module_id, module) in chunk {
@@ -644,41 +649,25 @@ fn register_modules(
                         .expect("registered module must remain in view");
                     registered.push((module_id, module));
                 }
-                let facts = std::mem::replace(&mut worker.facts, Facts::new(allocator.clone()));
-                (
-                    registered,
-                    std::mem::take(&mut worker.ufcs_methods),
-                    worker.module_fields_snapshot(),
-                    facts,
-                    std::mem::take(&mut worker.pending_generic_bound_checks),
-                    local_sink,
-                )
+                RegistrationOutput {
+                    modules: registered,
+                    task: worker.into_output(),
+                }
             })
             .collect();
 
-        let mut worker_sinks: Vec<LocalSink> = Vec::with_capacity(outputs.len());
-        for (registered, ufcs_methods, module_fields, facts, pending_bounds, sink_local) in outputs
-        {
-            for (module_id, module) in registered {
+        let mut task_outputs = Vec::with_capacity(outputs.len());
+        for output in outputs {
+            for (module_id, module) in output.modules {
                 store.modules.insert(module_id, module);
             }
-            checker.ufcs_methods.extend(ufcs_methods);
-            checker.merge_module_fields(module_fields);
-            checker.facts.merge(facts);
-            checker.pending_generic_bound_checks.extend(pending_bounds);
-            worker_sinks.push(sink_local);
+            task_outputs.push(output.task);
         }
-        sink.extend(LocalSink::merge(worker_sinks));
+        checker.absorb_outputs(task_outputs);
     }
 }
 
-fn infer_modules(
-    checker: &mut TaskState,
-    store: &mut Store,
-    sink: &LocalSink,
-    to_infer: &[String],
-    binding_ids: &Arc<BindingIdAllocator>,
-) {
+fn infer_modules(checker: &mut TaskState, store: &mut Store, to_infer: &[String]) {
     checker.finalize_equality(store);
     checker.check_pending_generic_bounds(store);
     checker.finalize_tests(store);
@@ -696,42 +685,19 @@ fn infer_modules(
             InferCtx::new(checker, store).infer_module(&module_id, files);
         }
     } else {
-        let allocator = binding_ids.clone();
-        let ufcs_shared = Arc::new(std::mem::take(&mut checker.ufcs_methods));
-        let fields_shared = Arc::new(checker.module_fields_snapshot());
+        let seed = checker.worker_seed();
         let store_ref: &Store = store;
 
-        type WorkerOutput = (
-            Vec<(String, File)>,
-            Facts,
-            Vec<(Type, Type, Span)>,
-            LocalSink,
-        );
-        let outputs: Vec<WorkerOutput> = module_files
+        let outputs: Vec<TaskOutput> = module_files
             .into_par_iter()
             .map(|(module_id, files)| {
-                let local_sink = LocalSink::new();
-                let mut worker = TaskState::new(&local_sink, allocator.clone());
-                worker.ufcs_shared = Some(ufcs_shared.clone());
-                worker.module_fields_shared = Some(fields_shared.clone());
+                let mut worker = seed.spawn();
                 InferCtx::new(&mut worker, store_ref).infer_module(&module_id, files);
-                let typed_files = std::mem::take(&mut worker.typed_files);
-                let facts = std::mem::replace(&mut worker.facts, Facts::new(allocator.clone()));
-                let pending = std::mem::take(&mut worker.pending_interface_bound_checks);
-                (typed_files, facts, pending, local_sink)
+                worker.into_output()
             })
             .collect();
 
-        checker.ufcs_methods = Arc::try_unwrap(ufcs_shared).unwrap_or_else(|arc| (*arc).clone());
-
-        let mut worker_sinks: Vec<LocalSink> = Vec::with_capacity(outputs.len());
-        for (typed_files, facts, pending, sink_local) in outputs {
-            checker.typed_files.extend(typed_files);
-            checker.facts.merge(facts);
-            checker.pending_interface_bound_checks.extend(pending);
-            worker_sinks.push(sink_local);
-        }
-        sink.extend(LocalSink::merge(worker_sinks));
+        checker.absorb_outputs(outputs);
     }
 
     for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -39,32 +39,72 @@ pub struct Roots {
     pub additional: Vec<ModuleId>,
 }
 
-#[allow(clippy::too_many_arguments)]
+pub struct ModuleGraphOptions<'a> {
+    pub loader: Option<&'a dyn Loader>,
+    pub sink: &'a LocalSink,
+    pub standalone_mode: bool,
+    pub locator: &'a TypedefLocator,
+    pub include_tests: bool,
+}
+
 pub fn build_module_graph(
     store: &mut Store,
-    loader: Option<&dyn Loader>,
-    mut roots: Roots,
-    sink: &LocalSink,
-    standalone_mode: bool,
-    locator: &TypedefLocator,
-    include_tests: bool,
+    roots: Roots,
+    options: ModuleGraphOptions<'_>,
 ) -> ModuleGraphResult {
-    let mut edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
-    let mut production_edges: HashMap<ModuleId, HashSet<ModuleId>> = HashMap::default();
-    let mut to_visit = roots.primary;
-    let mut visited: HashSet<ModuleId> = HashSet::default();
-    let mut files: HashMap<ModuleId, Vec<File>> = HashMap::default();
-    let mut import_spans: HashMap<ModuleId, Span> = HashMap::default();
-    let mut blank_tracker = BlankTracker::default();
+    let Roots {
+        primary,
+        additional,
+    } = roots;
+    let ModuleGraphOptions {
+        loader,
+        sink,
+        standalone_mode,
+        locator,
+        include_tests,
+    } = options;
+    let mut builder = GraphBuilder {
+        store,
+        loader,
+        sink,
+        standalone_mode,
+        locator,
+        include_tests,
+        edges: HashMap::default(),
+        production_edges: HashMap::default(),
+        visited: HashSet::default(),
+        files: HashMap::default(),
+        import_spans: HashMap::default(),
+        blank_tracker: BlankTracker::default(),
+    };
+    builder.visit(primary);
+    let primary_reachable = builder.visited.clone();
+    builder.visit(additional);
+    builder.finish(primary_reachable)
+}
 
-    let mut primary_reachable: HashSet<ModuleId> = HashSet::default();
-    let mut additional_injected = false;
-    loop {
+struct GraphBuilder<'a> {
+    store: &'a mut Store,
+    loader: Option<&'a dyn Loader>,
+    sink: &'a LocalSink,
+    standalone_mode: bool,
+    locator: &'a TypedefLocator,
+    include_tests: bool,
+    edges: HashMap<ModuleId, HashSet<ModuleId>>,
+    production_edges: HashMap<ModuleId, HashSet<ModuleId>>,
+    visited: HashSet<ModuleId>,
+    files: HashMap<ModuleId, Vec<File>>,
+    import_spans: HashMap<ModuleId, Span>,
+    blank_tracker: BlankTracker,
+}
+
+impl<'a> GraphBuilder<'a> {
+    fn visit(&mut self, mut to_visit: Vec<ModuleId>) {
         while !to_visit.is_empty() {
             let drained: Vec<ModuleId> = std::mem::take(&mut to_visit);
             let mut batch: Vec<ModuleId> = Vec::with_capacity(drained.len());
             for module_id in drained {
-                if visited.insert(module_id.clone()) {
+                if self.visited.insert(module_id.clone()) {
                     batch.push(module_id);
                 }
             }
@@ -74,13 +114,19 @@ pub fn build_module_graph(
 
             batch.sort();
 
-            let mut parsed = batch_parse_modules(&batch, store, loader, sink, include_tests);
+            let mut parsed = batch_parse_modules(
+                &batch,
+                self.store,
+                self.loader,
+                self.sink,
+                self.include_tests,
+            );
 
             for module_id in &batch {
                 let module_files = parsed.remove(module_id).unwrap_or_default();
                 let file_imports: Vec<_> = if !module_files.is_empty() {
                     module_files.iter().flat_map(|f| f.imports()).collect()
-                } else if let Some(module) = store.get_module(module_id) {
+                } else if let Some(module) = self.store.get_module(module_id) {
                     module.all_imports()
                 } else {
                     Vec::new()
@@ -94,48 +140,51 @@ pub fn build_module_graph(
                     .collect();
                 let imports_with_spans = process_file_imports(
                     file_imports,
-                    sink,
-                    standalone_mode,
-                    locator,
-                    &mut blank_tracker,
+                    self.sink,
+                    self.standalone_mode,
+                    self.locator,
+                    &mut self.blank_tracker,
                 );
 
                 let has_production_file = module_files.iter().any(|file| !file.is_test());
-                let module_exists =
-                    has_production_file || store.has(module_id) || module_id.starts_with("go:");
+                let module_exists = has_production_file
+                    || self.store.has(module_id)
+                    || module_id.starts_with("go:");
 
                 if !module_exists {
-                    if let Some(span) = import_spans.get(module_id) {
+                    if let Some(span) = self.import_spans.get(module_id) {
                         let is_go_stdlib =
-                            stdlib::get_go_stdlib_typedef(module_id, locator.target()).is_some();
+                            stdlib::get_go_stdlib_typedef(module_id, self.locator.target())
+                                .is_some();
 
                         let src_prefix_hint = module_id
                             .strip_prefix("src/")
                             .filter(|stripped| {
-                                loader.is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
+                                self.loader
+                                    .is_some_and(|fs| !fs.scan_folder(stripped).is_empty())
                             })
                             .map(String::from);
 
-                        sink.push(diagnostics::module_graph::module_not_found(
+                        self.sink.push(diagnostics::module_graph::module_not_found(
                             module_id,
                             *span,
                             is_go_stdlib,
-                            standalone_mode,
+                            self.standalone_mode,
                             src_prefix_hint,
                         ));
                     }
                     continue;
                 }
 
-                files.insert(module_id.clone(), module_files);
+                self.files.insert(module_id.clone(), module_files);
 
                 let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
 
                 for (import, span) in imports_with_spans {
-                    if !visited.contains(&import) {
+                    if !self.visited.contains(&import) {
                         to_visit.push(import.clone());
                     }
-                    import_spans.entry(import).or_insert(span);
+                    self.import_spans.entry(import).or_insert(span);
                 }
 
                 let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
@@ -147,57 +196,63 @@ pub fn build_module_graph(
                 } else {
                     imports.clone()
                 };
-                production_edges.insert(module_id.clone(), production_edge_set);
-                edges.insert(module_id.clone(), imports);
+                self.production_edges
+                    .insert(module_id.clone(), production_edge_set);
+                self.edges.insert(module_id.clone(), imports);
             }
         }
-
-        if !additional_injected {
-            primary_reachable = visited.clone();
-            to_visit.extend(std::mem::take(&mut roots.additional));
-            additional_injected = true;
-            continue;
-        }
-        break;
     }
 
-    let (order, cycles) = kahn::topological_sort(&edges);
+    fn finish(self, primary_reachable: HashSet<ModuleId>) -> ModuleGraphResult {
+        let (order, cycles) = kahn::topological_sort(&self.edges);
 
-    ModuleGraphResult {
-        order,
-        cycles,
-        files,
-        edges,
-        production_edges,
-        link_only_modules: blank_tracker.into_link_only_modules(),
-        primary_reachable,
+        ModuleGraphResult {
+            order,
+            cycles,
+            files: self.files,
+            edges: self.edges,
+            production_edges: self.production_edges,
+            link_only_modules: self.blank_tracker.into_link_only_modules(),
+            primary_reachable,
+        }
     }
 }
 
-#[derive(Clone, Copy)]
-enum SeenLookup {
-    OkBlank,
-    OkNonBlank,
-    Errored,
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ImportUse {
+    LinkOnly,
+    Referenced,
 }
 
 #[derive(Default)]
 struct BlankTracker {
-    blank: HashSet<ModuleId>,
-    non_blank: HashSet<ModuleId>,
+    modules: HashMap<ModuleId, ImportUse>,
 }
 
 impl BlankTracker {
-    fn record_blank(&mut self, module_id: &str) {
-        self.blank.insert(module_id.to_string());
-    }
-
-    fn record_non_blank(&mut self, module_id: &str) {
-        self.non_blank.insert(module_id.to_string());
+    fn record(&mut self, module_id: &str, is_blank: bool) {
+        let use_kind = if is_blank {
+            ImportUse::LinkOnly
+        } else {
+            ImportUse::Referenced
+        };
+        self.modules
+            .entry(module_id.to_string())
+            .and_modify(|prior| {
+                if use_kind == ImportUse::Referenced {
+                    *prior = ImportUse::Referenced;
+                }
+            })
+            .or_insert(use_kind);
     }
 
     fn into_link_only_modules(self) -> HashSet<ModuleId> {
-        self.blank.difference(&self.non_blank).cloned().collect()
+        self.modules
+            .into_iter()
+            .filter_map(|(module_id, use_kind)| {
+                (use_kind == ImportUse::LinkOnly).then_some(module_id)
+            })
+            .collect()
     }
 }
 
@@ -302,9 +357,16 @@ fn process_file_imports(
     blank_tracker: &mut BlankTracker,
 ) -> HashMap<ModuleId, Span> {
     let mut imports = HashMap::default();
-    let mut seen_go_imports: HashMap<String, SeenLookup> = HashMap::default();
+    let referenced_go_imports: HashSet<&str> = file_imports
+        .iter()
+        .filter(|import| {
+            import.name.starts_with("go:") && !matches!(import.alias, Some(ImportAlias::Blank(_)))
+        })
+        .map(|import| import.name.as_str())
+        .collect();
+    let mut go_import_results: HashMap<&str, bool> = HashMap::default();
 
-    for file_import in file_imports {
+    for file_import in &file_imports {
         if file_import.name == "prelude" {
             sink.push(diagnostics::module_graph::cannot_import_prelude(
                 file_import.span,
@@ -321,74 +383,41 @@ fn process_file_imports(
 
         if let Some(go_pkg) = file_import.name.strip_prefix("go:") {
             let is_blank = matches!(file_import.alias, Some(ImportAlias::Blank(_)));
-
-            let prior = seen_go_imports.get(file_import.name.as_str()).copied();
-            let needs_lookup = match (prior, is_blank) {
-                (None, _) => true,
-                (Some(SeenLookup::Errored), _) => false,
-                (Some(SeenLookup::OkNonBlank), _) => false,
-                (Some(SeenLookup::OkBlank), true) => false,
-                (Some(SeenLookup::OkBlank), false) => true,
-            };
-
-            if !needs_lookup {
-                if matches!(prior, Some(SeenLookup::OkBlank | SeenLookup::OkNonBlank)) {
-                    let module_key = file_import.name.to_string();
-                    if is_blank {
-                        blank_tracker.record_blank(&module_key);
+            let ok = *go_import_results
+                .entry(file_import.name.as_str())
+                .or_insert_with(|| {
+                    if referenced_go_imports.contains(file_import.name.as_str()) {
+                        let result = locator.find_typedef_content(go_pkg);
+                        emit_for_locator_result(
+                            &result,
+                            &GoImportSite {
+                                import_name: &file_import.name,
+                                go_pkg,
+                                name_span: Some(file_import.name_span),
+                                target: locator.target(),
+                                standalone_mode,
+                                replace_importer: None,
+                            },
+                            sink,
+                        )
                     } else {
-                        blank_tracker.record_non_blank(&module_key);
+                        let status = locator.validate_declaration(go_pkg);
+                        emit_for_declaration_status(
+                            &status,
+                            &file_import.name,
+                            go_pkg,
+                            file_import.name_span,
+                            locator.target(),
+                            standalone_mode,
+                            sink,
+                        )
                     }
-                    imports.insert(module_key, file_import.name_span);
-                }
-                continue;
-            }
-
-            let ok = if is_blank {
-                let status = locator.validate_declaration(go_pkg);
-                emit_for_declaration_status(
-                    &status,
-                    &file_import.name,
-                    go_pkg,
-                    file_import.name_span,
-                    locator.target(),
-                    standalone_mode,
-                    sink,
-                )
-            } else {
-                let result = locator.find_typedef_content(go_pkg);
-                emit_for_locator_result(
-                    &result,
-                    &GoImportSite {
-                        import_name: &file_import.name,
-                        go_pkg,
-                        name_span: Some(file_import.name_span),
-                        target: locator.target(),
-                        standalone_mode,
-                        replace_importer: None,
-                    },
-                    sink,
-                )
-            };
-
-            seen_go_imports.insert(
-                file_import.name.to_string(),
-                if !ok {
-                    SeenLookup::Errored
-                } else if is_blank {
-                    SeenLookup::OkBlank
-                } else {
-                    SeenLookup::OkNonBlank
-                },
-            );
+                });
             if ok {
-                let module_key = file_import.name.to_string();
-                if is_blank {
-                    blank_tracker.record_blank(&module_key);
-                } else {
-                    blank_tracker.record_non_blank(&module_key);
-                }
-                imports.insert(module_key, file_import.name_span);
+                blank_tracker.record(&file_import.name, is_blank);
+                imports
+                    .entry(file_import.name.to_string())
+                    .or_insert(file_import.name_span);
             }
             continue;
         }
@@ -427,4 +456,51 @@ fn process_file_imports(
     }
 
     imports
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::program::FileImport;
+
+    fn go_import(is_blank: bool, offset: u32) -> FileImport {
+        let span = Span::new(0, offset, 1);
+        FileImport {
+            name: "go:fmt".into(),
+            name_span: span,
+            alias: is_blank.then_some(ImportAlias::Blank(span)),
+            span,
+        }
+    }
+
+    fn is_link_only(imports: Vec<FileImport>) -> bool {
+        let sink = LocalSink::new();
+        let mut tracker = BlankTracker::default();
+        let resolved = process_file_imports(
+            imports,
+            &sink,
+            false,
+            &TypedefLocator::default(),
+            &mut tracker,
+        );
+
+        assert!(!sink.has_errors());
+        assert!(resolved.contains_key("go:fmt"));
+        tracker.into_link_only_modules().contains("go:fmt")
+    }
+
+    #[test]
+    fn blank_only_import_is_link_only() {
+        assert!(is_link_only(vec![go_import(true, 0)]));
+    }
+
+    #[test]
+    fn referenced_import_wins_regardless_of_order() {
+        assert!(!is_link_only(
+            vec![go_import(true, 0), go_import(false, 1),]
+        ));
+        assert!(!is_link_only(
+            vec![go_import(false, 0), go_import(true, 1),]
+        ));
+    }
 }

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -36,7 +36,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         store.typedef_paths.insert(PRELUDE_FILE_ID, path);
     }
 
-    let mut checker = TaskState::with_fresh_allocator(sink);
+    let mut checker = TaskState::with_fresh_allocator();
     let module = store
         .get_module(PRELUDE_MODULE_ID)
         .cloned()
@@ -61,6 +61,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
             checker.check_pending_generic_bounds(&*store);
         },
     );
+    sink.extend(checker.sink.take());
 }
 
 /// Registers the test-only prelude module (`TestContext`). Scopes the main prelude during
@@ -86,7 +87,7 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
         },
     );
 
-    let mut checker = TaskState::with_fresh_allocator(sink);
+    let mut checker = TaskState::with_fresh_allocator();
     let module = store
         .get_module(TEST_PRELUDE_MODULE_ID)
         .cloned()
@@ -111,6 +112,7 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
             checker.check_pending_generic_bounds(&*store);
         },
     );
+    sink.extend(checker.sink.take());
 }
 
 pub fn compute_prelude_ufcs(store: &Store) -> Vec<(String, String)> {

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -7,8 +7,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{EnumVariant, Expression, Literal, StructFieldDefinition};
 use syntax::program::{
-    Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, ModuleId,
-    TestIndex,
+    Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, TestIndex,
 };
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
@@ -101,7 +100,6 @@ pub struct Store {
     /// `Arc` so registration workers share a read view; [`Arc::make_mut`]
     /// writes stay zero-copy while a module has a single owner.
     pub modules: HashMap<String, Arc<Module>>,
-    pub module_ids: Vec<ModuleId>,
     /// file ID -> module ID
     files: HashMap<u32, String>,
     /// Go module ID -> package name from the typedef `// Package:` directive.
@@ -142,12 +140,9 @@ impl Store {
         .into_iter()
         .collect();
 
-        let module_ids = vec!["prelude".to_string()];
-
         Self {
             files: Default::default(),
             modules,
-            module_ids,
             go_package_names: Default::default(),
             typedef_paths: Default::default(),
             visited_modules: Default::default(),
@@ -261,7 +256,6 @@ impl Store {
 
         self.modules
             .insert(module_id.to_string(), Arc::new(Module::new(module_id)));
-        self.module_ids.push(module_id.to_string());
     }
 
     pub fn get_module_mut(&mut self, module_id: &str) -> Option<&mut Module> {
@@ -278,7 +272,6 @@ impl Store {
         for (file_id, owner) in file_map {
             self.files.insert(file_id, owner);
         }
-        self.module_ids.push(module_id.clone());
         self.modules.insert(module_id.clone(), Arc::new(module));
         self.visited_modules.insert(module_id);
     }
@@ -288,7 +281,6 @@ impl Store {
     pub(crate) fn registration_view(&self) -> Store {
         Store {
             modules: self.modules.clone(),
-            module_ids: self.module_ids.clone(),
             files: self.files.clone(),
             go_package_names: self.go_package_names.clone(),
             typedef_paths: HashMap::default(),

--- a/fuzz/fuzz_targets/infer.rs
+++ b/fuzz/fuzz_targets/infer.rs
@@ -23,10 +23,8 @@ fuzz_target!(|data: &[u8]| {
     store.add_module("fuzz");
     lisette_semantics::prelude::parse_and_register_prelude(&mut store, &sink);
 
-    let mut checker = lisette_semantics::checker::TaskState::with_fresh_allocator(&sink);
-    checker
-        .ufcs_methods
-        .extend(lisette_semantics::prelude::compute_prelude_ufcs(&store));
+    let mut checker = lisette_semantics::checker::TaskState::with_fresh_allocator();
+    checker.extend_ufcs_methods(lisette_semantics::prelude::compute_prelude_ufcs(&store));
     checker.cursor.module_id = "fuzz".to_string();
     checker.put_prelude_in_scope(&store);
 
@@ -35,11 +33,13 @@ fuzz_target!(|data: &[u8]| {
         &desugar_result.ast,
         &lisette_syntax::program::Visibility::Private,
     );
+    checker.finalize_equality(&mut store);
     checker.check_pending_generic_bounds(&store);
 
     for expression in desugar_result.ast {
         let type_var = checker.new_type_var();
-        let _ = InferCtx::new(&mut checker, &store).infer_expression(expression, &type_var);
+        let _ =
+            InferCtx::new(&mut checker, &store).infer_root_expression(expression, &type_var);
 
         if checker.failed() {
             break;

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -1,8 +1,11 @@
 use diagnostics::{LisetteDiagnostic, LocalSink};
 use semantics::loader::Loader;
 use semantics::{
-    checker::TaskState, checker::infer::InferCtx, module_graph::Roots,
-    module_graph::build_module_graph, store::Store,
+    checker::TaskState,
+    checker::infer::InferCtx,
+    module_graph::Roots,
+    module_graph::{ModuleGraphOptions, build_module_graph},
+    store::Store,
 };
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{ast::Expression, types::Type};
@@ -48,11 +51,7 @@ pub fn infer_with_go_typedefs(raw_source: &str, typedefs: &[(&str, &str)]) -> In
 }
 
 pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
-    let available_folders = fs.folders();
-
     let mut store = Store::new();
-
-    store.module_ids.extend(available_folders);
 
     let sink = LocalSink::new();
 
@@ -61,8 +60,17 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         primary: vec![module_name.to_string()],
         additional: fs.discover_modules().test_roots,
     };
-    let mut graph_result =
-        build_module_graph(&mut store, Some(&fs), roots, &sink, false, &locator, true);
+    let mut graph_result = build_module_graph(
+        &mut store,
+        roots,
+        ModuleGraphOptions {
+            loader: Some(&fs),
+            sink: &sink,
+            standalone_mode: false,
+            locator: &locator,
+            include_tests: true,
+        },
+    );
 
     if sink.has_errors() {
         return InferResult {
@@ -74,10 +82,8 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
     init_prelude(&mut store);
 
     let ast = {
-        let mut checker = TaskState::with_fresh_allocator(&sink);
-        checker
-            .ufcs_methods
-            .extend(semantics::prelude::compute_prelude_ufcs(&store));
+        let mut checker = TaskState::with_fresh_allocator();
+        checker.extend_ufcs_methods(semantics::prelude::compute_prelude_ufcs(&store));
         register_test_builtins(&mut store, &mut checker);
         checker.put_prelude_in_scope(&store);
 
@@ -147,17 +153,19 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
 
         if !checker.failed() {
             store.build_closed_domains();
-            let analysis = semantics::context::AnalysisContext::new(&store, &checker.ufcs_methods);
+            let ufcs_methods = checker.shared_ufcs_methods();
+            let analysis = semantics::context::AnalysisContext::new(&store, &ufcs_methods);
             let mut unused = syntax::program::UnusedInfo::default();
             passes::run(
                 &analysis,
                 &mut checker.facts,
-                checker.sink,
+                &checker.sink,
                 &mut unused,
                 false,
             );
         }
 
+        sink.extend(checker.sink.take());
         ast
     };
 

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -1,4 +1,4 @@
-use diagnostics::{Fix, LisetteDiagnostic, LocalSink, apply_fixes};
+use diagnostics::{Fix, LisetteDiagnostic, apply_fixes};
 use semantics::{checker::TaskState, checker::infer::InferCtx, store::Store};
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
@@ -18,8 +18,6 @@ use super::TEST_MODULE_ID;
 pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     let mut store = Store::new();
     store.add_module(TEST_MODULE_ID);
-
-    let sink = LocalSink::new();
 
     init_prelude(&mut store);
 
@@ -47,7 +45,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     }
     let ast = desugar_result.ast;
 
-    let mut checker = TaskState::with_fresh_allocator(&sink);
+    let mut checker = TaskState::with_fresh_allocator();
     checker.cursor.module_id = TEST_MODULE_ID.to_string();
     register_test_builtins(&mut store, &mut checker);
     checker.put_prelude_in_scope(&store);
@@ -81,7 +79,6 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     checker.put_imported_modules_in_scope(&store, &imports);
 
     checker.register_types_and_values(&mut store, &ast, &Visibility::Private);
-    checker.register_equality(&mut store, &ast);
     checker.finalize_equality(&mut store);
     checker.check_pending_generic_bounds(&store);
 
@@ -90,7 +87,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     for expression in ast {
         let type_var = checker.new_type_var();
         let typed_expression =
-            InferCtx::new(&mut checker, &store).infer_expression(expression, &type_var);
+            InferCtx::new(&mut checker, &store).infer_root_expression(expression, &type_var);
         typed_ast.push(typed_expression);
     }
 
@@ -120,11 +117,18 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     store.store_file(TEST_MODULE_ID, typed_file);
     store.build_closed_domains();
 
-    let inference_len = sink.len();
+    let inference_len = checker.sink.len();
 
-    let analysis = semantics::context::AnalysisContext::new(&store, &checker.ufcs_methods);
+    let ufcs_methods = checker.shared_ufcs_methods();
+    let analysis = semantics::context::AnalysisContext::new(&store, &ufcs_methods);
     let mut unused = UnusedInfo::default();
-    passes::run(&analysis, &mut checker.facts, &sink, &mut unused, true);
+    passes::run(
+        &analysis,
+        &mut checker.facts,
+        &checker.sink,
+        &mut unused,
+        true,
+    );
 
     // Deferred inference errors surface during passes::run, mixed in with
     // the error-severity lint diagnostics the tests assert on.
@@ -133,7 +137,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
         "infer.type_not_inferred",
         "infer.missing_type_argument",
     ];
-    let mut all_diagnostics = sink.take();
+    let mut all_diagnostics = checker.sink.take();
     let pass_diagnostics = all_diagnostics.split_off(inference_len);
     let mut diagnostics: Vec<LisetteDiagnostic> = all_diagnostics
         .into_iter()

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -2,8 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, LocalSink};
 use semantics::{
-    call_classification::compute_module_ufcs, checker::TaskState, checker::infer::InferCtx,
-    store::Store,
+    checker::TaskState, checker::infer::InferCtx, facts::BindingMutation, store::Store,
 };
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
@@ -116,10 +115,8 @@ impl CompiledTest {
             go_module_ids,
             resolved_definitions,
         ) = {
-            let mut checker = TaskState::with_fresh_allocator(&sink);
-            checker
-                .ufcs_methods
-                .extend(semantics::prelude::compute_prelude_ufcs(&store));
+            let mut checker = TaskState::with_fresh_allocator();
+            checker.extend_ufcs_methods(semantics::prelude::compute_prelude_ufcs(&store));
             checker.cursor.module_id = TEST_MODULE_ID.to_string();
             register_test_builtins(&mut store, &mut checker);
             checker.put_prelude_in_scope(&store);
@@ -178,15 +175,6 @@ impl CompiledTest {
                     test_file_id,
                 ),
             );
-            {
-                let module = store
-                    .get_module(TEST_MODULE_ID)
-                    .expect("test module must exist");
-                let ufcs_entries = compute_module_ufcs(module);
-                checker.ufcs_methods.extend(ufcs_entries);
-            }
-
-            checker.register_equality(&mut store, &self.ast);
             checker.finalize_equality(&mut store);
             checker.check_pending_generic_bounds(&store);
 
@@ -194,8 +182,8 @@ impl CompiledTest {
 
             for expression in self.ast {
                 let type_var = checker.new_type_var();
-                let typed_expression =
-                    InferCtx::new(&mut checker, &store).infer_expression(expression, &type_var);
+                let typed_expression = InferCtx::new(&mut checker, &store)
+                    .infer_root_expression(expression, &type_var);
                 typed_ast.push(typed_expression);
 
                 if checker.failed() {
@@ -235,13 +223,13 @@ impl CompiledTest {
                     ),
                 );
                 store.build_closed_domains();
-                let analysis =
-                    semantics::context::AnalysisContext::new(&store, &checker.ufcs_methods);
+                let ufcs_methods = checker.shared_ufcs_methods();
+                let analysis = semantics::context::AnalysisContext::new(&store, &ufcs_methods);
                 let mut harness_unused = UnusedInfo::default();
                 passes::run(
                     &analysis,
                     &mut checker.facts,
-                    checker.sink,
+                    &checker.sink,
                     &mut harness_unused,
                     false,
                 );
@@ -289,14 +277,16 @@ impl CompiledTest {
                 if !b.used {
                     unused.mark_binding_unused(b.span);
                 }
-                if b.alias_mutated {
-                    mutations.mark_binding_alias_mutated(binding_id);
-                } else if b.mutated {
-                    mutations.mark_binding_mutated(binding_id);
+                match b.mutation {
+                    BindingMutation::Unchanged => {}
+                    BindingMutation::Direct => mutations.mark_binding_mutated(binding_id),
+                    BindingMutation::ThroughAlias => {
+                        mutations.mark_binding_alias_mutated(binding_id);
+                    }
                 }
             }
 
-            let ufcs_methods = std::mem::take(&mut checker.ufcs_methods);
+            let ufcs_methods = checker.take_ufcs_methods();
             let equality_index = std::mem::take(&mut store.equality_index);
             let resolved_definitions = std::mem::take(&mut checker.facts.resolved_definitions);
             let go_package_names = store.go_package_names.clone();
@@ -306,6 +296,8 @@ impl CompiledTest {
                 .filter(|id| id.starts_with(syntax::types::GO_IMPORT_PREFIX))
                 .cloned()
                 .collect();
+
+            sink.extend(checker.sink.take());
 
             (
                 typed_ast,

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LocalSink;
 use semantics::module_graph::kahn::topological_sort;
-use semantics::module_graph::{Roots, build_module_graph};
+use semantics::module_graph::{ModuleGraphOptions, Roots, build_module_graph};
 use semantics::store::Store;
 
 use crate::_harness::filesystem::MockFileSystem;
@@ -15,6 +15,21 @@ fn roots(entry: &str) -> Roots {
     Roots {
         primary: vec![entry.to_string()],
         additional: vec![],
+    }
+}
+
+fn graph_options<'a>(
+    loader: &'a MockFileSystem,
+    sink: &'a LocalSink,
+    locator: &'a deps::TypedefLocator,
+    standalone_mode: bool,
+) -> ModuleGraphOptions<'a> {
+    ModuleGraphOptions {
+        loader: Some(loader),
+        sink,
+        standalone_mode,
+        locator,
+        include_tests: true,
     }
 }
 
@@ -103,19 +118,12 @@ fn test_only_imports_excluded_from_production_edges() {
     fs.add_file("fixture", "fixture.lis", "pub fn sample() -> int { 2 }");
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
-    store.module_ids.push("math".to_string());
-    store.module_ids.push("fixture".to_string());
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(
@@ -139,18 +147,12 @@ fn graph_simple_dependency() {
     fs.add_file("lib", "lib.lis", "fn foo() { 1 }");
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
-    store.module_ids.push("lib".to_string());
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(result.cycles.is_empty());
@@ -170,17 +172,12 @@ fn graph_missing_module() {
     fs.add_file("main", "main.lis", r#"import "missing""#);
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
 
     let sink = LocalSink::new();
     let _result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(sink.has_errors());
@@ -194,19 +191,12 @@ fn graph_cycle_detection() {
     fs.add_file("c", "c.lis", r#"import "a""#);
 
     let mut store = Store::new();
-    store.module_ids.push("a".to_string());
-    store.module_ids.push("b".to_string());
-    store.module_ids.push("c".to_string());
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("a"),
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(!result.cycles.is_empty());
@@ -220,22 +210,15 @@ fn additional_roots_widen_graph_but_not_reachable_set() {
     fs.add_file("orphan", "orphan.lis", "pub fn g() -> int { 2 }");
 
     let mut store = Store::new();
-    for m in ["main", "lib", "orphan"] {
-        store.module_ids.push(m.to_string());
-    }
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         Roots {
             primary: vec!["main".to_string()],
             additional: vec!["orphan".to_string()],
         },
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(result.order.iter().any(|m| m == "orphan"));
@@ -257,19 +240,12 @@ fn empty_additional_leaves_orphan_out_of_graph() {
     fs.add_file("orphan", "orphan.lis", "pub fn g() -> int { 2 }");
 
     let mut store = Store::new();
-    for m in ["main", "lib", "orphan"] {
-        store.module_ids.push(m.to_string());
-    }
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(!result.order.iter().any(|m| m == "orphan"));
@@ -281,20 +257,15 @@ fn zero_primary_roots_begins_with_additional() {
     fs.add_file("lib", "lib.lis", "pub fn f() -> int { 1 }");
 
     let mut store = Store::new();
-    store.module_ids.push("lib".to_string());
 
     let sink = LocalSink::new();
     let result = build_module_graph(
         &mut store,
-        Some(&fs),
         Roots {
             primary: vec![],
             additional: vec!["lib".to_string()],
         },
-        &sink,
-        false,
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(result.primary_reachable.is_empty());
@@ -412,17 +383,12 @@ fn graph_standalone_third_party_go_import_uses_module_not_found() {
     fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
 
     let sink = LocalSink::new();
     let _result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        true, // standalone mode
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), true),
     );
 
     assert!(sink.has_errors());
@@ -435,17 +401,12 @@ fn graph_project_third_party_go_import_undeclared() {
     fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
 
     let sink = LocalSink::new();
     let _result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false, // project mode
-        &default_resolver(),
-        true,
+        graph_options(&fs, &sink, &default_resolver(), false),
     );
 
     assert!(sink.has_errors());
@@ -460,7 +421,6 @@ fn graph_declared_dep_missing_typedef() {
     fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
 
     // Declare the dep in the resolver but do not place any .d.lis file on disk
     let mut go_deps = BTreeMap::new();
@@ -476,12 +436,8 @@ fn graph_declared_dep_missing_typedef() {
     let sink = LocalSink::new();
     let _result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &resolver,
-        true,
+        graph_options(&fs, &sink, &resolver, false),
     );
 
     assert!(sink.has_errors());
@@ -510,7 +466,6 @@ fn graph_subpackage_missing_typedef_points_at_add() {
     fs.add_file("main", "main.lis", r#"import "go:k8s.io/api/core/v1""#);
 
     let mut store = Store::new();
-    store.module_ids.push("main".to_string());
 
     let mut go_deps = BTreeMap::new();
     go_deps.insert(
@@ -525,12 +480,8 @@ fn graph_subpackage_missing_typedef_points_at_add() {
     let sink = LocalSink::new();
     let _result = build_module_graph(
         &mut store,
-        Some(&fs),
         roots("main"),
-        &sink,
-        false,
-        &resolver,
-        true,
+        graph_options(&fs, &sink, &resolver, false),
     );
 
     assert!(sink.has_errors());

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1289,6 +1289,20 @@ fn shadowing_changes_mutability() {
 }
 
 #[test]
+fn immutable_shadow_does_not_inherit_outer_mutability() {
+    infer(
+        r#"{
+    let mut x = 42;
+    {
+      let x = x + 1;
+      x = 10;
+    }
+  }"#,
+    )
+    .assert_infer_code("immutable");
+}
+
+#[test]
 fn function_parameter_immutable() {
     infer(
         r#"{

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1,7 +1,7 @@
 use crate::_harness::build::compile_check;
 use crate::_harness::filesystem::MockFileSystem;
 use crate::_harness::formatting::{format_diagnostic_for_snapshot, format_diagnostic_standalone};
-use crate::_harness::infer::infer_module;
+use crate::_harness::infer::{infer, infer_module};
 use crate::{
     assert_desugar_error_snapshot, assert_infer_error_snapshot, assert_lex_error_snapshot,
     assert_multimodule_infer_error_snapshot, assert_parse_error_snapshot,
@@ -11384,6 +11384,32 @@ struct Point { x: int, y: int }
 }
 
 #[test]
+fn iterate_on_type_alias() {
+    let result = infer("#[iterate]\ntype Count = int");
+    assert!(
+        has_code(&result, "iterate_not_an_enum"),
+        "an iterate attribute on an alias must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn iterate_in_typedef_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "colors",
+        "colors.d.lis",
+        "#[iterate]\npub enum Color { Red, Green }",
+    );
+    let result = infer_module("colors", fs);
+    assert!(
+        has_code(&result, "iterate_in_typedef"),
+        "an iterate attribute in a typedef must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn iterate_variants_method_collision() {
     let input = r#"
 #[iterate]
@@ -11459,6 +11485,32 @@ fn run() -> int {
 }
 "#;
     assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn display_on_type_alias() {
+    let result = infer("#[display]\ntype Count = int");
+    assert!(
+        has_code(&result, "display_not_a_struct_or_enum"),
+        "a display attribute on an alias must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn display_in_typedef_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "shapes",
+        "shapes.d.lis",
+        "#[display]\npub struct Point { pub x: int, pub y: int }",
+    );
+    let result = infer_module("shapes", fs);
+    assert!(
+        has_code(&result, "display_in_typedef"),
+        "a display attribute in a typedef must be rejected, got: {:?}",
+        result.errors
+    );
 }
 
 #[test]


### PR DESCRIPTION
Collapses duplicated state in the semantics pipeline into single representations that cannot drift: one merge path for parallel and sequential checker work, one scanner for derived attributes, one per-name scope table, and enums in place of boolean pairs in `BindingFact`.

