### PR TITLE
fix: emit idiomatic Go casing for constants and private names

### DIFF
--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -53,15 +53,24 @@ impl Planner<'_> {
         }
     }
 
-    /// Detect free top-level private Lisette names (free functions and
-    /// constants) whose natural Go form would collide after `escape_reserved`
-    /// — e.g. `len` escapes to `len_` and clashes with a sibling `len_`. The
-    /// verbatim name claims its Go form; each escaped collider is remapped
-    /// to `name_2`, `name_3`, etc. until unique. Public functions go through
-    /// `snake_to_camel` and a separate identifier path, so they are not
-    /// considered here.
+    /// Record the emitted Go names of top-level private functions and
+    /// constants that differ from their source spelling. Colliding private
+    /// functions freshen to `name_2`, `name_3`, etc. Constants never
+    /// freshen: cross-module references derive a constant's Go name from
+    /// the source name alone, so converging constants surface as a Go name
+    /// collision instead.
     pub(crate) fn collect_escape_remap(&mut self, files: &[&File]) {
-        let entries: Vec<(&str, String)> = files
+        for item in files.iter().flat_map(|f| &f.items) {
+            if let Expression::Const { identifier, .. } = item {
+                let natural = go_name::screaming_snake_to_camel(identifier);
+                if natural != identifier.as_str() {
+                    self.module
+                        .record_escape_remap(identifier.to_string(), natural);
+                }
+            }
+        }
+
+        let entries: Vec<(&str, String, String)> = files
             .iter()
             .flat_map(|f| &f.items)
             .filter_map(|item| match item {
@@ -69,27 +78,32 @@ impl Planner<'_> {
                     name,
                     visibility: Visibility::Private,
                     ..
-                } => Some((name.as_str(), go_name::escape_reserved(name).into_owned())),
-                Expression::Const { identifier, .. } => Some((
-                    identifier.as_str(),
-                    go_name::escape_reserved(identifier).into_owned(),
-                )),
+                } => {
+                    let base = go_name::snake_to_lower_camel(name);
+                    let natural = go_name::escape_reserved(&base).into_owned();
+                    Some((name.as_str(), base, natural))
+                }
                 _ => None,
             })
             .collect();
 
         let mut taken: HashSet<String> = entries
             .iter()
-            .filter(|(name, natural)| *name == natural)
-            .map(|(_, natural)| natural.clone())
+            .filter(|(name, _, natural)| *name == natural)
+            .map(|(_, _, natural)| natural.clone())
             .collect();
 
-        for (name, natural) in &entries {
-            if *name == natural || taken.insert(natural.clone()) {
+        for (name, base, natural) in &entries {
+            if *name == natural {
+                continue;
+            }
+            if taken.insert(natural.clone()) {
+                self.module
+                    .record_escape_remap((*name).to_string(), natural.clone());
                 continue;
             }
             let fresh = (2..)
-                .map(|n| format!("{}_{}", name, n))
+                .map(|n| format!("{}_{}", base, n))
                 .find(|c| !taken.contains(c))
                 .expect("freshening counter is unbounded");
             taken.insert(fresh.clone());

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -135,6 +135,7 @@ impl Planner<'_> {
         }
         self.check_reserved_qualifier_generics(generics, diagnostics);
         let go = self.free_function_go_name(name, visibility);
+        self.check_reserved_prefix(name, name_span, diagnostics);
         self.check_reserved_prefix(&go, name_span, diagnostics);
         package_block.entry(go).or_default().push(*name_span);
         if syntax::attributes::has_test_attribute(attributes) {
@@ -158,6 +159,7 @@ impl Planner<'_> {
             return;
         };
         let go = self.const_go_name(identifier);
+        self.check_reserved_prefix(identifier, identifier_span, diagnostics);
         self.check_reserved_prefix(&go, identifier_span, diagnostics);
         package_block.entry(go).or_default().push(*identifier_span);
     }
@@ -468,7 +470,7 @@ impl Planner<'_> {
                 let method_go = if is_public || self.method_needs_export(method_name) {
                     go_name::snake_to_camel(method_name)
                 } else {
-                    go_name::escape_keyword(method_name).into_owned()
+                    go_name::unexported_method_go_name(method_name)
                 };
                 methods.entry(method_go).or_default().push(*method_span);
             }
@@ -521,8 +523,9 @@ impl Planner<'_> {
                 let method_go = if should_export {
                     go_name::snake_to_camel(name)
                 } else {
-                    go_name::escape_keyword(name).into_owned()
+                    go_name::unexported_method_go_name(name)
                 };
+                self.check_reserved_prefix(name, name_span, diagnostics);
                 self.check_reserved_prefix(&method_go, name_span, diagnostics);
                 selectors
                     .entry(type_go.clone())
@@ -536,7 +539,7 @@ impl Planner<'_> {
                 let method_go = if should_export {
                     go_name::snake_to_camel(name)
                 } else {
-                    name.to_string()
+                    go_name::snake_to_lower_camel(name)
                 };
                 let base = format!("{}_{}", receiver_name, method_go);
                 let go = self
@@ -544,6 +547,7 @@ impl Planner<'_> {
                     .escape_remap(&base)
                     .map(str::to_string)
                     .unwrap_or_else(|| go_name::escape_reserved(&base).into_owned());
+                self.check_reserved_prefix(name, name_span, diagnostics);
                 self.check_reserved_prefix(&go, name_span, diagnostics);
                 package_block.entry(go).or_default().push(*name_span);
             }

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -320,7 +320,7 @@ impl Planner<'_> {
         let go_method = if is_public {
             go_name::snake_to_camel(method)
         } else {
-            go_name::escape_keyword(method).into_owned()
+            go_name::unexported_method_go_name(method)
         };
 
         let stages: Vec<ValuePlan> = args

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -367,7 +367,7 @@ impl Planner<'_> {
         if is_public {
             go_name::snake_to_camel(function_definition.name)
         } else if has_receiver {
-            go_name::escape_keyword(function_definition.name).into_owned()
+            go_name::unexported_method_go_name(function_definition.name)
         } else if let Some(remapped) = self.module.escape_remap(function_definition.name.as_str()) {
             remapped.to_string()
         } else {

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -67,7 +67,7 @@ impl Planner<'_> {
             let method_name = if should_export {
                 go_name::snake_to_camel(function.name)
             } else {
-                function.name.to_string()
+                go_name::snake_to_lower_camel(function.name)
             };
             let free_name = format!("{}_{}", ctx.receiver_name, method_name).into();
             let mut combined_generics = ctx.generics.to_vec();

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -79,7 +79,7 @@ impl Planner<'_> {
                 let selector = if self.method_needs_export(name) {
                     go_name::snake_to_camel(name)
                 } else {
-                    go_name::escape_keyword(name).into_owned()
+                    go_name::unexported_method_go_name(name)
                 };
                 if seen.insert(selector) {
                     result.push((name.clone(), ty.clone(), current_id.clone()));
@@ -374,7 +374,7 @@ impl Planner<'_> {
         let go_method_name = if self.method_needs_export(&method.name) {
             go_name::snake_to_camel(&method.name)
         } else {
-            go_name::escape_keyword(&method.name).into_owned()
+            go_name::unexported_method_go_name(&method.name)
         };
         let inner_call = format!(
             "{}.inner.{}({})",

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -69,7 +69,7 @@ impl Planner<'_> {
         let method_name = if is_public || self.method_needs_export(func.name) {
             go_name::snake_to_camel(func.name)
         } else {
-            go_name::escape_keyword(func.name).into_owned()
+            go_name::unexported_method_go_name(func.name)
         };
 
         if return_type == "struct{}" {

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -419,7 +419,7 @@ impl Planner<'_> {
         if self.method_needs_export(method) {
             go_name::snake_to_camel(method)
         } else {
-            go_name::escape_keyword(method).into_owned()
+            go_name::unexported_method_go_name(method)
         }
     }
 

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -75,8 +75,8 @@ impl Planner<'_> {
         let target_name = self
             .module
             .escape_remap(identifier)
-            .unwrap_or(identifier)
-            .to_string();
+            .map(str::to_string)
+            .unwrap_or_else(|| go_name::screaming_snake_to_camel(identifier));
         let initial_go_name = self.scope.bind(identifier, target_name);
         let go_identifier = if self.try_declare(&initial_go_name) {
             initial_go_name
@@ -136,7 +136,10 @@ impl Planner<'_> {
                 match self.scope.resolve_identifier_binding(value.as_str()) {
                     Some(BindingValue::GoName(name)) => self.is_go_const_binding(name),
                     Some(BindingValue::InlineExpr(_)) => false,
-                    None => self.is_go_const_binding(value.as_str()),
+                    None => {
+                        let go = self.module.escape_remap(value).unwrap_or(value);
+                        self.is_go_const_binding(go)
+                    }
                 }
             }
             Expression::Binary { left, right, .. } => {

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -75,9 +75,10 @@ impl Planner<'_> {
 
         let is_exported =
             self.resolve_is_exported(expression, &expression_ty, member, dot_access_kind);
+        let is_embedded = self.field_is_embedded(&expression_ty, member);
         let field = self
             .try_resolve_cross_module_const(&expression_ty, member)
-            .unwrap_or_else(|| go_field_name(&expression_ty, member, is_exported));
+            .unwrap_or_else(|| go_field_name(&expression_ty, member, is_exported, is_embedded));
 
         if let Some(s) = self.plan_nullable_field_access(
             &mut setup,
@@ -413,15 +414,21 @@ impl Planner<'_> {
         if is_function {
             return None;
         }
-        Some(member.to_string())
+        Some(go_name::screaming_snake_to_camel(member))
     }
 }
 
 /// Pick the Go-side name for a struct field or method. Exported members on
 /// prelude types follow snake_case → camelCase (matching the stdlib
 /// convention); exported members elsewhere get first-letter capitalization;
-/// non-exported members are escaped to avoid Go keywords.
-fn go_field_name(expression_ty: &Type, member: &str, is_exported: bool) -> String {
+/// non-exported members become lower camelCase, embedded fields keep their
+/// type's name.
+fn go_field_name(
+    expression_ty: &Type,
+    member: &str,
+    is_exported: bool,
+    is_embedded: bool,
+) -> String {
     if expression_ty
         .as_import_namespace()
         .is_some_and(go_name::is_go_import)
@@ -435,7 +442,10 @@ fn go_field_name(expression_ty: &Type, member: &str, is_exported: bool) -> Strin
         .is_some_and(|id| id.starts_with(go_name::PRELUDE_PREFIX));
 
     if !is_exported {
-        return go_name::escape_keyword(member).into_owned();
+        if is_embedded {
+            return go_name::escape_keyword(member).into_owned();
+        }
+        return go_name::unexported_method_go_name(member);
     }
     if is_prelude_type {
         go_name::snake_to_camel(member)

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -363,8 +363,10 @@ impl Planner<'_> {
                         format!("F{}", index)
                     } else if self.struct_field_is_exported(ty, &name) {
                         go_name::make_exported(&name)
-                    } else {
+                    } else if self.field_is_embedded(ty, &name) {
                         go_name::escape_keyword(&name).into_owned()
+                    } else {
+                        go_name::unexported_method_go_name(&name)
                     };
                     (go_name, self.lisette_zero(&field_ty))
                 })
@@ -555,7 +557,7 @@ impl Planner<'_> {
         } else if self.struct_field_is_exported(ty, field_name) {
             go_name::make_exported(field_name)
         } else {
-            go_name::escape_keyword(field_name).into_owned()
+            go_name::unexported_method_go_name(field_name)
         }
     }
 

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -157,7 +157,7 @@ impl Planner<'_> {
         let resolved_name = format!("{}.{}", real_type, member);
 
         let capitalized = self.capitalize_static_method_if_public(&resolved_name);
-        let go_name = self.resolve_go_name(&capitalized, None);
+        let go_name = self.resolve_go_name(&capitalized, None, false);
 
         Some(go_name)
     }
@@ -176,7 +176,7 @@ impl Planner<'_> {
             let go_method = if is_exported {
                 go_name::snake_to_camel(member)
             } else {
-                go_name::escape_keyword(member).into_owned()
+                go_name::unexported_method_go_name(member)
             };
             let type_name = self
                 .resolve_alias_type_name(value)
@@ -215,7 +215,7 @@ impl Planner<'_> {
         let go_method = if is_exported {
             go_name::snake_to_camel(member)
         } else {
-            go_name::escape_keyword(member).into_owned()
+            go_name::unexported_method_go_name(member)
         };
 
         let pkg = self.require_module_import(module_name);

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -54,14 +54,14 @@ impl Planner<'_> {
             IdentifierKind::UnitConstructor { name, type_args } => GoExpression::call(
                 GoExpression::opaque(format!(
                     "{}{}",
-                    self.resolve_go_name(&name, None),
+                    self.resolve_go_name(&name, None, false),
                     type_args
                 )),
                 Vec::new(),
             ),
             IdentifierKind::ConstructorFunction { name, type_args } => GoExpression::name(format!(
                 "{}{}",
-                self.resolve_go_name(&name, None),
+                self.resolve_go_name(&name, None, false),
                 type_args
             )),
             IdentifierKind::Regular { name } => {
@@ -69,7 +69,7 @@ impl Planner<'_> {
                     return GoExpression::opaque(expression);
                 }
                 let resolved = self.capitalize_static_method_if_public(&name);
-                let go_name = self.resolve_go_name(&resolved, qualified);
+                let go_name = self.resolve_go_name(&resolved, qualified, bound_go_name.is_some());
                 if !ctx.is_callee()
                     && let Some(type_args) = self.format_generic_value_type_args(&name, ty)
                 {
@@ -295,7 +295,7 @@ impl Planner<'_> {
         let go_method = if should_export {
             go_name::snake_to_camel(method_part)
         } else {
-            go_name::escape_keyword(method_part).into_owned()
+            go_name::unexported_method_go_name(method_part)
         };
 
         let type_args = if let Type::Nominal { ref params, .. } = stripped {

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -391,7 +391,10 @@ impl Planner<'_> {
             Some(binding) => binding
                 .as_go_name()
                 .is_some_and(|name| self.is_go_const_binding(name)),
-            None => self.is_go_const_binding(value),
+            None => {
+                let go = self.module.escape_remap(value).unwrap_or(value);
+                self.is_go_const_binding(go)
+            }
         }
     }
 

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -41,7 +41,8 @@ pub const TESTKIT_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude/testkit";
 const TESTKIT_PKG: &str = "testkit";
 
 pub(crate) use syntax::go_names::{
-    GO_BUILTINS, GO_KEYWORDS, escape_keyword, escape_type_name, is_go_reserved_word, snake_to_camel,
+    GO_BUILTINS, GO_KEYWORDS, escape_keyword, escape_type_name, is_go_reserved_word,
+    screaming_snake_to_camel, snake_to_camel, snake_to_lower_camel, unexported_method_go_name,
 };
 pub(crate) use syntax::types::unqualified_name;
 
@@ -298,7 +299,7 @@ pub(crate) fn qualify_method(
         let method_name = if is_public {
             snake_to_camel(method)
         } else {
-            method.to_string()
+            snake_to_lower_camel(method)
         };
         return ResolvedName::local(format!("{}_{}", type_name, method_name));
     };
@@ -314,7 +315,7 @@ pub(crate) fn qualify_method(
         let method_name = if is_public {
             snake_to_camel(method)
         } else {
-            method.to_string()
+            snake_to_lower_camel(method)
         };
         ResolvedName::local(format!("{}_{}", type_name, method_name))
     } else {

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -5,8 +5,16 @@ use crate::names::go_name;
 use crate::names::packages::{PackageRequirements, PackageUse};
 
 impl Planner<'_> {
-    pub(crate) fn resolve_go_name(&mut self, name: &str, qualified: Option<&str>) -> String {
-        if !name.contains('.')
+    /// A `locally_bound` name must not be rewritten by a module-level remap
+    /// of the same text.
+    pub(crate) fn resolve_go_name(
+        &mut self,
+        name: &str,
+        qualified: Option<&str>,
+        locally_bound: bool,
+    ) -> String {
+        if !locally_bound
+            && !name.contains('.')
             && let Some(remapped) = self.module.escape_remap(name)
         {
             return remapped.to_string();
@@ -82,8 +90,22 @@ impl Planner<'_> {
         if is_public {
             format!("{}.{}", type_part, go_name::snake_to_camel(method_part))
         } else {
-            name.to_string()
+            format!(
+                "{}.{}",
+                type_part,
+                go_name::snake_to_lower_camel(method_part)
+            )
         }
+    }
+
+    pub(crate) fn reference_go_name(&self, lisette_name: &str) -> String {
+        if let Some(bound) = self.scope.resolve_binding_go_name(lisette_name) {
+            return bound.to_string();
+        }
+        self.module
+            .escape_remap(lisette_name)
+            .map(str::to_string)
+            .unwrap_or_else(|| go_name::escape_reserved(lisette_name).into_owned())
     }
 
     /// Record `module`'s Go import and return the package

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -981,8 +981,10 @@ fn compute_struct_field_path(
             })
     } else if planner.struct_field_is_exported(ty, &field.name) {
         go_name::make_exported(&field.name)
-    } else {
+    } else if planner.field_is_embedded(ty, &field.name) {
         go_name::escape_keyword(&field.name).into_owned()
+    } else {
+        go_name::unexported_method_go_name(&field.name)
     };
 
     if let Some((_, variant_name)) = enum_info

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -395,7 +395,7 @@ impl Planner<'_> {
                 Some(BindingValue::InlineExpr(_))
             );
             if !has_collision && !name.contains('.') && !bound_to_inline {
-                let var = self.scope.resolve_or_escape_go_name(&name);
+                let var = self.reference_go_name(&name);
                 return (var.clone(), SubjectDeclaration::PlainDiscard { var });
             }
         }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -118,7 +118,7 @@ impl Planner<'_> {
                         Some(BindingValue::InlineExpr(_))
                     )
                 {
-                    let var = self.scope.resolve_or_escape_go_name(value);
+                    let var = self.reference_go_name(value);
                     return ResolvedSubject::Existing { var };
                 }
                 let var = self.fresh_var(temp_hint);
@@ -244,7 +244,7 @@ impl Planner<'_> {
                 Some(BindingValue::InlineExpr(_))
             );
             if !has_collision && !value.contains('.') && !bound_to_inline {
-                return (self.scope.resolve_or_escape_go_name(value), Vec::new());
+                return (self.reference_go_name(value), Vec::new());
             }
         }
         let var = self.fresh_var(Some("subject"));

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use crate::Bindings;
 use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
-use crate::escape_reserved;
 use crate::plan::bodies::LoopId;
 use crate::state::bindings::{BindingValue, InlineExpr};
 
@@ -112,13 +111,6 @@ impl ScopeState {
 
     /// Falls back to the keyword-escaped form when the name is unbound or
     /// inline-bound; callers needing a usable local must hoist a fresh temp.
-    pub(crate) fn resolve_or_escape_go_name(&self, lisette_name: &str) -> String {
-        self.bindings
-            .get_go_name(lisette_name)
-            .map(String::from)
-            .unwrap_or_else(|| escape_reserved(lisette_name).into_owned())
-    }
-
     pub(crate) fn has_binding_for_go_name(&self, go_name: &str) -> bool {
         self.bindings.has_go_name(go_name)
     }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -276,8 +276,10 @@ impl Planner<'_> {
         }
         let field = if self.struct_field_is_exported(expression_ty, member) {
             go_name::make_exported(member)
-        } else {
+        } else if self.field_is_embedded(expression_ty, member) {
             go_name::escape_keyword(member).into_owned()
+        } else {
+            go_name::unexported_method_go_name(member)
         };
         format!("{}.{}", base_str, field)
     }

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -354,7 +354,7 @@ impl InferCtx<'_> {
         let selector = if public {
             syntax::go_names::snake_to_camel(method)
         } else {
-            method.to_string()
+            syntax::go_names::unexported_method_go_name(method)
         };
         let shadowed = promotion::field_selector_depth(store, resolved, &selector)
             .is_some_and(|field_depth| field_depth <= member.depth);

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -112,6 +112,48 @@ pub fn snake_to_camel(s: &str) -> String {
     }
 }
 
+fn split_underscore_prefix(s: &str) -> (&str, &str) {
+    s.split_at(s.len() - s.trim_start_matches('_').len())
+}
+
+fn camel_segment(segment: &str) -> String {
+    if segment.chars().any(char::is_lowercase) {
+        return capitalize_first(segment);
+    }
+    let mut chars = segment.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first
+            .to_uppercase()
+            .chain(chars.flat_map(char::to_lowercase))
+            .collect(),
+    }
+}
+
+pub fn screaming_snake_to_camel(s: &str) -> String {
+    let (prefix, rest) = split_underscore_prefix(s);
+    let converted: String = rest.split('_').map(camel_segment).collect();
+    format!("{}{}", prefix, converted)
+}
+
+pub fn snake_to_lower_camel(s: &str) -> String {
+    let (prefix, rest) = split_underscore_prefix(s);
+    let mut segments = rest.split('_');
+    let mut out = String::from(prefix);
+    if let Some(first) = segments.next() {
+        out.push_str(first);
+    }
+    for segment in segments {
+        out.push_str(&capitalize_first(segment));
+    }
+    out
+}
+
+/// The emitted Go name of an unexported method.
+pub fn unexported_method_go_name(name: &str) -> String {
+    escape_keyword(&snake_to_lower_camel(name)).into_owned()
+}
+
 pub fn escape_keyword(name: &str) -> Cow<'_, str> {
     if GO_KEYWORDS.contains(&name) {
         Cow::Owned(format!("{}_", name))
@@ -153,8 +195,10 @@ pub fn struct_field_go_name(
 ) -> Cow<'_, str> {
     if struct_field_is_exported(field, struct_forces_export) {
         Cow::Owned(escape_keyword(&snake_to_camel(&field.name)).into_owned())
-    } else {
+    } else if field.embedded {
         escape_keyword(&field.name)
+    } else {
+        Cow::Owned(escape_keyword(&snake_to_lower_camel(&field.name)).into_owned())
     }
 }
 
@@ -201,7 +245,7 @@ pub fn conformance_method<'a>(
         let emitted = if info.exported {
             Cow::Owned(snake_to_camel(name))
         } else {
-            Cow::Borrowed(name.as_str())
+            Cow::Owned(snake_to_lower_camel(name))
         };
         if !exact && emitted != *want {
             continue;
@@ -268,6 +312,43 @@ mod tests {
         assert_eq!(snake_to_camel("fooBar"), "FooBar");
         assert_eq!(snake_to_camel("x"), "X");
         assert_eq!(snake_to_camel("x_"), "X");
+    }
+
+    #[test]
+    fn screaming_snake_to_camel_converts_constants() {
+        assert_eq!(screaming_snake_to_camel("MAX_SIZE"), "MaxSize");
+        assert_eq!(screaming_snake_to_camel("HTTP_TIMEOUT"), "HttpTimeout");
+        assert_eq!(screaming_snake_to_camel("A"), "A");
+        assert_eq!(screaming_snake_to_camel("MAX_SIZE_2"), "MaxSize2");
+        assert_eq!(screaming_snake_to_camel("max_size"), "MaxSize");
+    }
+
+    #[test]
+    fn screaming_snake_to_camel_preserves_visibility_and_tails() {
+        assert_eq!(screaming_snake_to_camel("_INTERNAL"), "_Internal");
+        assert_eq!(screaming_snake_to_camel("HTTPTimeout"), "HTTPTimeout");
+        assert_eq!(screaming_snake_to_camel("定数"), "定数");
+    }
+
+    #[test]
+    fn snake_to_lower_camel_converts_private_names() {
+        assert_eq!(snake_to_lower_camel("retry_count"), "retryCount");
+        assert_eq!(snake_to_lower_camel("used_private"), "usedPrivate");
+        assert_eq!(snake_to_lower_camel("helper"), "helper");
+        assert_eq!(snake_to_lower_camel("foo_bar_"), "fooBar");
+    }
+
+    #[test]
+    fn snake_to_lower_camel_preserves_prefix_and_first_segment() {
+        assert_eq!(snake_to_lower_camel("_temp_val"), "_tempVal");
+        assert_eq!(snake_to_lower_camel("挨拶_する"), "挨拶する");
+        assert_eq!(snake_to_lower_camel("Read"), "Read");
+    }
+
+    #[test]
+    fn unexported_method_go_name_escapes_keywords() {
+        assert_eq!(unexported_method_go_name("select"), "select_");
+        assert_eq!(unexported_method_go_name("do_select"), "doSelect");
     }
 
     #[test]

--- a/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
+++ b/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
@@ -24,24 +24,24 @@ func (b Bar[T]) get() (T, bool) {
 
 func consume[T any](_ Box[lisette.Option[T]]) {}
 
-func generic_collision[_lisAdapter_Bar_Box_0 any](bar Bar[_lisAdapter_Bar_Box_0]) {
+func genericCollision[_lisAdapter_Bar_Box_0 any](bar Bar[_lisAdapter_Bar_Box_0]) {
 	consume(_lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0]{inner: bar})
 }
 
-func prime_cache(bar Bar[int]) {
+func primeCache(bar Bar[int]) {
 	consume(_lisAdapter_Bar_Box_1{inner: bar})
 }
 
-func cached_collision(bar Bar[int]) {
+func cachedCollision(bar Bar[int]) {
 	_lisAdapter_Bar_Box_1 := 1
 	consume(_lisAdapter_Bar_Box_2{inner: bar})
 	_ = _lisAdapter_Bar_Box_1
 }
 
 func main() {
-	generic_collision(Bar[int]{value: lisette.MakeOptionSome(1)})
-	prime_cache(Bar[int]{value: lisette.MakeOptionSome(2)})
-	cached_collision(Bar[int]{value: lisette.MakeOptionSome(3)})
+	genericCollision(Bar[int]{value: lisette.MakeOptionSome(1)})
+	primeCache(Bar[int]{value: lisette.MakeOptionSome(2)})
+	cachedCollision(Bar[int]{value: lisette.MakeOptionSome(3)})
 }
 
 type _lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0 any] struct {

--- a/tests/spec/build/snapshots/builtin_named_module_qualifier_consistent_in_match.snap
+++ b/tests/spec/build/snapshots/builtin_named_module_qualifier_consistent_in_match.snap
@@ -47,7 +47,7 @@ type Level struct {
 	Tag LevelTag
 }
 
-const LIMIT int = 9
+const Limit int = 9
 
 func Pick() Level {
 	return MakeLevelHigh()

--- a/tests/spec/build/snapshots/cast_shift_imported_module_const_count_needs_no_pin.snap
+++ b/tests/spec/build/snapshots/cast_shift_imported_module_const_count_needs_no_pin.snap
@@ -4,7 +4,7 @@ source: tests/spec/build/mod.rs
 // === config/config.go ===
 package config
 
-const SHIFT int = 60 + 8
+const Shift int = 60 + 8
 
 
 // === main.go ===
@@ -16,5 +16,5 @@ import (
 )
 
 func main() {
-	fmt.Println(float64((1 << config.SHIFT)))
+	fmt.Println(float64((1 << config.Shift)))
 }

--- a/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
+++ b/tests/spec/build/snapshots/comma_ok_hint_on_iface_method_synthesizes_adapter_bridge.snap
@@ -17,11 +17,11 @@ func (m MyCache) Get(_ string) *tls.ClientSessionState {
 
 func (m MyCache) Put(_ string, _ *tls.ClientSessionState) {}
 
-func use_cache(_ tls.ClientSessionCache) {}
+func useCache(_ tls.ClientSessionCache) {}
 
 func main() {
 	c := MyCache{}
-	use_cache(_lisAdapter_MyCache_ClientSessionCache_0{inner: c})
+	useCache(_lisAdapter_MyCache_ClientSessionCache_0{inner: c})
 }
 
 type _lisAdapter_MyCache_ClientSessionCache_0 struct {

--- a/tests/spec/build/snapshots/cross_module_interface_method_casing.snap
+++ b/tests/spec/build/snapshots/cross_module_interface_method_casing.snap
@@ -13,13 +13,13 @@ type Describable interface {
 	Describe() string
 }
 
-func print_it(item Describable) {
+func printIt(item Describable) {
 	fmt.Println(item.Describe())
 }
 
 func main() {
 	u := models.User{Name: "Alice"}
-	print_it(u)
+	printIt(u)
 }
 
 

--- a/tests/spec/build/snapshots/cross_module_pub_const_screaming_snake_preserves_underscores.snap
+++ b/tests/spec/build/snapshots/cross_module_pub_const_screaming_snake_preserves_underscores.snap
@@ -4,7 +4,7 @@ source: tests/spec/build/mod.rs
 // === config/config.go ===
 package config
 
-const MAX_RETRIES int = 3
+const MaxRetries int = 3
 
 
 // === main.go ===
@@ -13,5 +13,5 @@ package main
 import "github.com/user/myproject/config"
 
 func main() {
-	_ = config.MAX_RETRIES
+	_ = config.MaxRetries
 }

--- a/tests/spec/build/snapshots/entry_module_named_primitive_alias_const_patterns.snap
+++ b/tests/spec/build/snapshots/entry_module_named_primitive_alias_const_patterns.snap
@@ -11,7 +11,7 @@ import (
 
 type K = reflect.Kind
 
-func name_of(k K) string {
+func nameOf(k K) string {
 	switch k {
 	case reflect.String:
 		return "string"
@@ -23,5 +23,5 @@ func name_of(k K) string {
 }
 
 func main() {
-	fmt.Println(name_of(reflect.String))
+	fmt.Println(nameOf(reflect.String))
 }

--- a/tests/spec/build/snapshots/fixed_size_array_lowers.snap
+++ b/tests/spec/build/snapshots/fixed_size_array_lowers.snap
@@ -14,14 +14,14 @@ func first(xs [3]int) int {
 	return xs[0]
 }
 
-func make_arr() [3]int {
+func makeArr() [3]int {
 	return [3]int{10, 20, 30}
 }
 
 func main() {
 	xs := [3]int{1, 2, 3}
 	g := Grid{cells: [3]int{4, 5, 6}}
-	same := xs == make_arr()
+	same := xs == makeArr()
 	_arg_1 := len(xs)
 	_arg_2 := xs[0]
 	fmt.Println(_arg_1, _arg_2, same, first(g.cells))

--- a/tests/spec/build/snapshots/generated_fmt_import_coexists_with_private_fmt_function.snap
+++ b/tests/spec/build/snapshots/generated_fmt_import_coexists_with_private_fmt_function.snap
@@ -14,7 +14,7 @@ func (t Thing) String() string {
 	return fmt.Sprintf("Thing { x: %v }", t.X)
 }
 
-func (t Thing) to_string() string {
+func (t Thing) toString() string {
 	return t.String()
 }
 

--- a/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
+++ b/tests/spec/build/snapshots/generic_interface_embedding_type_substitution.snap
@@ -32,7 +32,7 @@ func (s Score) Keep() bool {
 	return s.val > 50
 }
 
-func process_score(item Score) string {
+func processScore(item Score) string {
 	if item.Keep() {
 		return item.MapVal()
 	}
@@ -44,5 +44,5 @@ func main() {
 		name: "hello",
 		val:  42,
 	}
-	fmt.Println(process_score(s))
+	fmt.Println(processScore(s))
 }

--- a/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
+++ b/tests/spec/build/snapshots/generic_struct_adapter_substitutes_and_deduplicates_per_instantiation.snap
@@ -22,15 +22,15 @@ func (m MyCache[T]) Get(_ string) *Entry[T] {
 	return nil
 }
 
-func use_int(_ Cache[int]) {}
+func useInt(_ Cache[int]) {}
 
-func use_string(_ Cache[string]) {}
+func useString(_ Cache[string]) {}
 
 func main() {
 	ci := MyCache[int]{entry: Entry[int]{value: 1}}
 	cs := MyCache[string]{entry: Entry[string]{value: "x"}}
-	use_int(_lisAdapter_MyCache_Cache_0{inner: ci})
-	use_string(_lisAdapter_MyCache_Cache_1{inner: cs})
+	useInt(_lisAdapter_MyCache_Cache_0{inner: ci})
+	useString(_lisAdapter_MyCache_Cache_1{inner: cs})
 }
 
 type _lisAdapter_MyCache_Cache_0 struct {

--- a/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
+++ b/tests/spec/build/snapshots/inherited_comma_ok_hint_propagates_to_child_iface_cast.snap
@@ -27,11 +27,11 @@ func (m MyCache) Get(_ string) *Entry {
 
 func (m MyCache) Touch() {}
 
-func use_extended(_ ExtendedCache) {}
+func useExtended(_ ExtendedCache) {}
 
 func main() {
 	c := MyCache{}
-	use_extended(_lisAdapter_MyCache_ExtendedCache_0{inner: c})
+	useExtended(_lisAdapter_MyCache_ExtendedCache_0{inner: c})
 }
 
 type _lisAdapter_MyCache_ExtendedCache_0 struct {

--- a/tests/spec/build/snapshots/multimodule_tuple_struct_field_access.snap
+++ b/tests/spec/build/snapshots/multimodule_tuple_struct_field_access.snap
@@ -6,11 +6,11 @@ package main
 
 import "github.com/user/myproject/types"
 
-func get_raw_id(id types.UserId) int {
+func getRawId(id types.UserId) int {
 	return int(id)
 }
 
-func get_x(p types.Point) int {
+func getX(p types.Point) int {
 	return p.F0
 }
 
@@ -24,7 +24,7 @@ func main() {
 		F0: 1,
 		F1: "hello",
 	}
-	_ = get_raw_id(id) + get_x(p) + pair.F0
+	_ = getRawId(id) + getX(p) + pair.F0
 }
 
 

--- a/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
+++ b/tests/spec/build/snapshots/multimodule_type_alias_field_access.snap
@@ -17,7 +17,7 @@ package main
 
 import "github.com/user/myproject/geo"
 
-func get_x(c geo.Coordinate) int {
+func getX(c geo.Coordinate) int {
 	return c.X
 }
 
@@ -26,5 +26,5 @@ func main() {
 		X: 10,
 		Y: 20,
 	}
-	_ = get_x(c)
+	_ = getX(c)
 }

--- a/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
+++ b/tests/spec/build/snapshots/pub_interface_method_accessible_cross_module.snap
@@ -6,13 +6,13 @@ package main
 
 import "github.com/user/myproject/types"
 
-func greet_anyone(g types.Greetable) string {
+func greetAnyone(g types.Greetable) string {
 	return g.Greet()
 }
 
 func main() {
 	p := types.Person{Name: "Alice"}
-	_ = greet_anyone(p)
+	_ = greetAnyone(p)
 }
 
 

--- a/tests/spec/build/snapshots/same_module_pub_const_use_matches_definition.snap
+++ b/tests/spec/build/snapshots/same_module_pub_const_use_matches_definition.snap
@@ -4,11 +4,11 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-const MAX_RETRIES int = 3
+const MaxRetries int = 3
 
-const MAX_TIMEOUT int = 60
+const MaxTimeout int = 60
 
 func main() {
-	_ = MAX_RETRIES
-	_ = MAX_TIMEOUT
+	_ = MaxRetries
+	_ = MaxTimeout
 }

--- a/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
@@ -29,10 +29,10 @@ func (c CacheKind) Get(_ string) *tls.ClientSessionState {
 
 func (c CacheKind) Put(_ string, _ *tls.ClientSessionState) {}
 
-func use_cache(_ tls.ClientSessionCache) {}
+func useCache(_ tls.ClientSessionCache) {}
 
 func main() {
-	use_cache(_lisAdapter_CacheKind_ClientSessionCache_0{inner: MakeCacheKindMem()})
+	useCache(_lisAdapter_CacheKind_ClientSessionCache_0{inner: MakeCacheKindMem()})
 }
 
 type _lisAdapter_CacheKind_ClientSessionCache_0 struct {

--- a/tests/spec/build/snapshots/snake_case_impl_satisfies_comma_ok_go_iface_via_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_impl_satisfies_comma_ok_go_iface_via_adapter.snap
@@ -17,11 +17,11 @@ func (m MyCache) Get(_ string) *tls.ClientSessionState {
 
 func (m MyCache) Put(_ string, _ *tls.ClientSessionState) {}
 
-func use_cache(_ tls.ClientSessionCache) {}
+func useCache(_ tls.ClientSessionCache) {}
 
 func main() {
 	c := MyCache{}
-	use_cache(_lisAdapter_MyCache_ClientSessionCache_0{inner: c})
+	useCache(_lisAdapter_MyCache_ClientSessionCache_0{inner: c})
 }
 
 type _lisAdapter_MyCache_ClientSessionCache_0 struct {

--- a/tests/spec/build/snapshots/snake_case_impl_satisfies_pascal_case_lisette_iface.snap
+++ b/tests/spec/build/snapshots/snake_case_impl_satisfies_pascal_case_lisette_iface.snap
@@ -14,10 +14,10 @@ func (j Job) Run() int {
 	return 1
 }
 
-func use_it(r Runner) int {
+func useIt(r Runner) int {
 	return r.Run()
 }
 
 func main() {
-	_ = use_it(Job{})
+	_ = useIt(Job{})
 }

--- a/tests/spec/build/snapshots/struct_satisfies_inherited_methods_via_lowering.snap
+++ b/tests/spec/build/snapshots/struct_satisfies_inherited_methods_via_lowering.snap
@@ -16,11 +16,11 @@ func (d Dev) Write(_ []uint8) (int, error) {
 	return 0, nil
 }
 
-func use_rw(_ io.ReadWriter) int {
+func useRw(_ io.ReadWriter) int {
 	return 0
 }
 
 func main() {
 	d := Dev{}
-	_ = use_rw(d)
+	_ = useRw(d)
 }

--- a/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
+++ b/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
@@ -11,7 +11,7 @@ import (
 
 type Callback func() int
 
-func maybe_get() Callback {
+func maybeGet() Callback {
 	return func() int {
 		return 42
 	}
@@ -25,7 +25,7 @@ func run(cb lisette.Option[Callback]) int {
 }
 
 func main() {
-	raw_1 := maybe_get()
+	raw_1 := maybeGet()
 	option_2 := lisette.OptionFromNilable[Callback](raw_1, raw_1 == nil)
 	cb := option_2
 	fmt.Println(run(cb))

--- a/tests/spec/build/snapshots/user_fmt_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_fmt_alias_preserved_alongside_generated_import.snap
@@ -17,7 +17,7 @@ func (t Thing) String() string {
 	return fmt.Sprintf("Thing { x: %v }", t.X)
 }
 
-func (t Thing) to_string() string {
+func (t Thing) toString() string {
 	return t.String()
 }
 

--- a/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
+++ b/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
@@ -9,12 +9,12 @@ import (
 	"strconv"
 )
 
-func parse_int(s string) (int, error) {
+func parseInt(s string) (int, error) {
 	return strconv.Atoi(s)
 }
 
 func main() {
-	ret_1, ret_2 := parse_int("42")
+	ret_1, ret_2 := parseInt("42")
 	if ret_2 == nil {
 		n := ret_1
 		fmt.Println(n)

--- a/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
+++ b/tests/spec/build/snapshots/user_iface_adapter_uses_exported_go_method_name_for_snake_case.snap
@@ -20,11 +20,11 @@ func (m MyCache) GetSession(_ string) *Entry {
 	return nil
 }
 
-func use_cache(_ Cache) {}
+func useCache(_ Cache) {}
 
 func main() {
 	c := MyCache{}
-	use_cache(_lisAdapter_MyCache_Cache_0{inner: c})
+	useCache(_lisAdapter_MyCache_Cache_0{inner: c})
 }
 
 type _lisAdapter_MyCache_Cache_0 struct {

--- a/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
+++ b/tests/spec/build/snapshots/user_iface_method_comma_ok_hint_applied_in_emission.snap
@@ -20,11 +20,11 @@ func (m MyCache) Get(_ string) *Entry {
 	return nil
 }
 
-func use_cache(_ Cache) {}
+func useCache(_ Cache) {}
 
 func main() {
 	c := MyCache{}
-	use_cache(_lisAdapter_MyCache_Cache_0{inner: c})
+	useCache(_lisAdapter_MyCache_Cache_0{inner: c})
 }
 
 type _lisAdapter_MyCache_Cache_0 struct {

--- a/tests/spec/build/snapshots/user_read_lowers_partial_to_io_reader.snap
+++ b/tests/spec/build/snapshots/user_read_lowers_partial_to_io_reader.snap
@@ -12,12 +12,12 @@ func (r Reader) Read(_ []uint8) (int, error) {
 	return 0, io.EOF
 }
 
-func use_reader(r io.Reader) int {
+func useReader(r io.Reader) int {
 	_ = r
 	return 0
 }
 
 func main() {
 	r := Reader{}
-	_ = use_reader(r)
+	_ = useReader(r)
 }

--- a/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_index_write.snap
+++ b/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_index_write.snap
@@ -4,11 +4,11 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-func index_write(items []int) {
+func indexWrite(items []int) {
 	items[0] = 99
 }
 
 func main() {
 	data := []int{1, 2, 3}
-	index_write(data)
+	indexWrite(data)
 }

--- a/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_reassignment.snap
+++ b/tests/spec/build/snapshots/write_only_mut_param_keeps_name_in_codegen_via_reassignment.snap
@@ -4,11 +4,11 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-func reassign_only(items []int) {
+func reassignOnly(items []int) {
 	items = []int{99, 99, 99}
 }
 
 func main() {
 	data := []int{1, 2, 3}
-	reassign_only(data)
+	reassignOnly(data)
 }

--- a/tests/spec/emit/snapshots/address_of_function_call.snap
+++ b/tests/spec/emit/snapshots/address_of_function_call.snap
@@ -23,15 +23,15 @@ type Foo struct {
 	value int
 }
 
-func make_foo() Foo {
+func makeFoo() Foo {
 	return Foo{value: 42}
 }
 
-func takes_ref(f *Foo) int {
+func takesRef(f *Foo) int {
 	return f.value
 }
 
 func test() int {
-	tmp := make_foo()
-	return takes_ref(&tmp)
+	tmp := makeFoo()
+	return takesRef(&tmp)
 }

--- a/tests/spec/emit/snapshots/alias_free_base_not_pinned_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/alias_free_base_not_pinned_before_call_rhs.snap
@@ -12,12 +12,12 @@ description: |
 ---
 package main
 
-func pure_add(a int) int {
+func pureAdd(a int) int {
 	return a + 100
 }
 
 func run() int {
 	ws := []int{1, 2, 3}
-	ws[0] = pure_add(7)
+	ws[0] = pureAdd(7)
 	return ws[0]
 }

--- a/tests/spec/emit/snapshots/alias_free_target_keeps_compound_assign_with_call_rhs.snap
+++ b/tests/spec/emit/snapshots/alias_free_target_keeps_compound_assign_with_call_rhs.snap
@@ -12,12 +12,12 @@ description: |
 ---
 package main
 
-func pure_add(a int) int {
+func pureAdd(a int) int {
 	return a + 100
 }
 
 func run() int {
 	x := 5
-	x += pure_add(1)
+	x += pureAdd(1)
 	return x
 }

--- a/tests/spec/emit/snapshots/alias_specialized_impl_ufcs_call.snap
+++ b/tests/spec/emit/snapshots/alias_specialized_impl_ufcs_call.snap
@@ -21,7 +21,7 @@ type Box[T any] struct {
 	value T
 }
 
-func Box_only_int(self Box[int]) int {
+func Box_onlyInt(self Box[int]) int {
 	return self.value
 }
 
@@ -29,5 +29,5 @@ type IntBox = Box[int]
 
 func test() int {
 	b := Box[int]{value: 7}
-	return Box_only_int(b)
+	return Box_onlyInt(b)
 }

--- a/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
+++ b/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
@@ -43,10 +43,10 @@ func (b Bar) get() (int, error) {
 	return 0, errors.New("x")
 }
 
-func use_foo(_ Foo[error]) {}
+func useFoo(_ Foo[error]) {}
 
 func main() {
-	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+	useFoo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
 }
 
 type _lisAdapter_Bar_Foo_0 struct {

--- a/tests/spec/emit/snapshots/array_in_containers.snap
+++ b/tests/spec/emit/snapshots/array_in_containers.snap
@@ -17,9 +17,9 @@ package main
 type Addr = [4]byte
 
 type Holder struct {
-	slice_of_arr [][3]int
-	map_val_arr  map[string][3]int
-	ptr_to_arr   *[3]int
-	multidim     [2][3]int
-	aliased      Addr
+	sliceOfArr [][3]int
+	mapValArr  map[string][3]int
+	ptrToArr   *[3]int
+	multidim   [2][3]int
+	aliased    Addr
 }

--- a/tests/spec/emit/snapshots/array_methods_through_type_alias.snap
+++ b/tests/spec/emit/snapshots/array_methods_through_type_alias.snap
@@ -41,7 +41,7 @@ func at(a Addr, i int) (byte, bool) {
 	return 0, false
 }
 
-func to_slice(a Addr) []byte {
+func toSlice(a Addr) []byte {
 	return slices.Clone(a[:])
 }
 

--- a/tests/spec/emit/snapshots/array_to_slice_copies_into_new_slice.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_copies_into_new_slice.snap
@@ -10,6 +10,6 @@ package main
 
 import "slices"
 
-func to_slice(a [3]int) []int {
+func toSlice(a [3]int) []int {
 	return slices.Clone(a[:])
 }

--- a/tests/spec/emit/snapshots/assignment_lvalue_side_effects_with_temp_rhs.snap
+++ b/tests/spec/emit/snapshots/assignment_lvalue_side_effects_with_temp_rhs.snap
@@ -12,21 +12,21 @@ description: |
 ---
 package main
 
-func make_a() int {
+func makeA() int {
 	return 0
 }
 
-func make_b() int {
+func makeB() int {
 	return 1
 }
 
 func main() {
 	s := []int{0, 0, 0}
 	base_2 := s
-	idx_3 := make_a()
+	idx_3 := makeA()
 	var tmp_1 int
 	if true {
-		tmp_1 = make_b()
+		tmp_1 = makeB()
 	} else {
 		tmp_1 = 0
 	}

--- a/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
+++ b/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
@@ -23,7 +23,7 @@ type Thing struct {
 	name string
 }
 
-func Thing_maybe_create(name string) (Thing, bool) {
+func Thing_maybeCreate(name string) (Thing, bool) {
 	if len(name) > 0 {
 		return Thing{name: name}, true
 	}
@@ -31,5 +31,5 @@ func Thing_maybe_create(name string) (Thing, bool) {
 }
 
 func test() (Thing, bool) {
-	return Thing_maybe_create("hello")
+	return Thing_maybeCreate("hello")
 }

--- a/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_empty_struct_literal_receiver.snap
@@ -16,8 +16,8 @@ package main
 
 type Foo struct{}
 
-func (f *Foo) need_ref() {}
+func (f *Foo) needRef() {}
 
 func test() {
-	(&Foo{}).need_ref()
+	(&Foo{}).needRef()
 }

--- a/tests/spec/emit/snapshots/auto_address_function_call_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_function_call_receiver.snap
@@ -28,11 +28,11 @@ func (f *Foo) increment() {
 	f.value++
 }
 
-func make_foo() Foo {
+func makeFoo() Foo {
 	return Foo{value: 42}
 }
 
 func test() {
-	ref_1 := make_foo()
+	ref_1 := makeFoo()
 	ref_1.increment()
 }

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
@@ -28,11 +28,11 @@ func (f *Foo) increment() {
 	f.value++
 }
 
-func make_foo() Foo {
+func makeFoo() Foo {
 	return Foo{value: 42}
 }
 
 func test() {
-	ref_1 := (make_foo())
+	ref_1 := (makeFoo())
 	ref_1.increment()
 }

--- a/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
@@ -33,12 +33,12 @@ func (b *Box) inc() int {
 	return b.x
 }
 
-func make_box() Box {
+func makeBox() Box {
 	return Box{x: 1}
 }
 
 func main() {
-	ref_1 := make_box()
+	ref_1 := makeBox()
 	v := ref_1.inc()
 	ref_1_2 := 7
 	_ = v

--- a/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
@@ -39,7 +39,7 @@ func (b Bar) get() (int, error) {
 	return 1, nil
 }
 
-func use_foo(foo Foo[lisette.Result[int, error]]) {
+func useFoo(foo Foo[lisette.Result[int, error]]) {
 	subject_1 := foo.get()
 	if subject_1.Tag == lisette.ResultOk {
 		_ = subject_1.OkVal
@@ -49,7 +49,7 @@ func use_foo(foo Foo[lisette.Result[int, error]]) {
 }
 
 func main() {
-	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+	useFoo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
 }
 
 type _lisAdapter_Bar_Foo_0 struct {

--- a/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
@@ -47,7 +47,7 @@ func (b Bar) get() *Thing {
 	return nil
 }
 
-func use_box(box Box[lisette.Option[*Thing]]) {
+func useBox(box Box[lisette.Option[*Thing]]) {
 	subject_1 := box.get()
 	if subject_1.Tag == lisette.OptionSome {
 		_ = subject_1.SomeVal
@@ -55,7 +55,7 @@ func use_box(box Box[lisette.Option[*Thing]]) {
 }
 
 func main() {
-	use_box(_lisAdapter_Bar_Box_0{inner: Bar{}})
+	useBox(_lisAdapter_Bar_Box_0{inner: Bar{}})
 }
 
 type _lisAdapter_Bar_Box_0 struct {

--- a/tests/spec/emit/snapshots/bare_tag_does_not_force_export_so_outer_still_shadows.snap
+++ b/tests/spec/emit/snapshots/bare_tag_does_not_force_export_so_outer_still_shadows.snap
@@ -28,7 +28,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/block_expr_unit_returning_call.snap
+++ b/tests/spec/emit/snapshots/block_expr_unit_returning_call.snap
@@ -11,11 +11,11 @@ description: |
 ---
 package main
 
-func do_nothing() {}
+func doNothing() {}
 
 func main() {
 	var x struct{}
-	do_nothing()
+	doNothing()
 	x = struct{}{}
 	_ = x
 }

--- a/tests/spec/emit/snapshots/block_vs_struct_disambiguation.snap
+++ b/tests/spec/emit/snapshots/block_vs_struct_disambiguation.snap
@@ -20,7 +20,7 @@ type Point struct {
 	x int
 }
 
-func test_if() int {
+func testIf() int {
 	x := 1
 	if true {
 		return x
@@ -28,7 +28,7 @@ func test_if() int {
 	return 0
 }
 
-func test_struct() Point {
+func testStruct() Point {
 	x := 42
 	return Point{x: x}
 }

--- a/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
@@ -15,7 +15,7 @@ description: |
 ---
 package main
 
-func find_first_negative(items []int) int {
+func findFirstNegative(items []int) int {
 	result := 0
 loop_1:
 	for _, item := range items {

--- a/tests/spec/emit/snapshots/call_callee_eval_order_propagate_arg.snap
+++ b/tests/spec/emit/snapshots/call_callee_eval_order_propagate_arg.snap
@@ -21,7 +21,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func make_f(_ *int) func(int) int {
+func makeF(_ *int) func(int) int {
 	return func(x int) int {
 		return x
 	}
@@ -34,7 +34,7 @@ func get(i *int) lisette.Result[int, string] {
 
 func run() lisette.Result[int, string] {
 	i := 0
-	callee_2 := make_f(&i)
+	callee_2 := makeF(&i)
 	check_1 := get(&i)
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)

--- a/tests/spec/emit/snapshots/call_returning_go_interface_widens_into_option_field.snap
+++ b/tests/spec/emit/snapshots/call_returning_go_interface_widens_into_option_field.snap
@@ -16,13 +16,13 @@ package main
 
 import "example.com/srv"
 
-func setup_handler() srv.Handler {
+func setupHandler() srv.Handler {
 	return srv.NewHandler()
 }
 
 func main() {
 	_ = &srv.Server{
 		Addr:    ":8000",
-		Handler: setup_handler(),
+		Handler: setupHandler(),
 	}
 }

--- a/tests/spec/emit/snapshots/cast_fn_to_type_alias.snap
+++ b/tests/spec/emit/snapshots/cast_fn_to_type_alias.snap
@@ -16,10 +16,10 @@ package main
 
 type Handler func(int) string
 
-func my_handler(_ int) string {
+func myHandler(_ int) string {
 	return "ok"
 }
 
 func test() Handler {
-	return Handler(my_handler)
+	return Handler(myHandler)
 }

--- a/tests/spec/emit/snapshots/cast_shift_forward_alias_const_emitted_as_var_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_forward_alias_const_emitted_as_var_pins.snap
@@ -11,10 +11,10 @@ description: |
 ---
 package main
 
-var SHIFT int = LATER
+var Shift int = Later
 
-const LATER int = 60 + 8
+const Later int = 60 + 8
 
 func scale() float64 {
-	return float64(int((1 << SHIFT)))
+	return float64(int((1 << Shift)))
 }

--- a/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
@@ -20,10 +20,10 @@ import (
 	"runtime"
 )
 
-func const_count() float64 {
+func constCount() float64 {
 	return float64((1 << math.MaxInt8))
 }
 
-func var_count() float64 {
+func varCount() float64 {
 	return float64(int((1 << runtime.MemProfileRate)))
 }

--- a/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
@@ -10,8 +10,8 @@ description: |
 ---
 package main
 
-const SHIFT int = 60 + 8
+const Shift int = 60 + 8
 
 func scale() float64 {
-	return float64((1 << SHIFT))
+	return float64((1 << Shift))
 }

--- a/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func scale() float64 {
-	const SHIFT int = 60 + 8
-	return float64((1 << SHIFT))
+	const Shift int = 60 + 8
+	return float64((1 << Shift))
 }

--- a/tests/spec/emit/snapshots/cast_type_alias_to_fn.snap
+++ b/tests/spec/emit/snapshots/cast_type_alias_to_fn.snap
@@ -17,11 +17,11 @@ package main
 
 type Handler func(int) string
 
-func my_handler(_ int) string {
+func myHandler(_ int) string {
 	return "ok"
 }
 
 func test() func(int) string {
-	h := Handler(my_handler)
+	h := Handler(myHandler)
 	return (func(int) string)(h)
 }

--- a/tests/spec/emit/snapshots/chained_option_construction.snap
+++ b/tests/spec/emit/snapshots/chained_option_construction.snap
@@ -15,12 +15,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() (int, bool) {
+func getValue() (int, bool) {
 	return 42, true
 }
 
 func test() (int, bool) {
-	option_1 := lisette.OptionFromCommaOk[int](get_value())
+	option_1 := lisette.OptionFromCommaOk[int](getValue())
 	x := option_1
 	v_2 := x
 	if v_2.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/chained_propagate_option.snap
+++ b/tests/spec/emit/snapshots/chained_propagate_option.snap
@@ -12,7 +12,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_nested(outer lisette.Option[lisette.Option[int]]) (int, bool) {
+func getNested(outer lisette.Option[lisette.Option[int]]) (int, bool) {
 	if outer.Tag != lisette.OptionSome {
 		return 0, false
 	}

--- a/tests/spec/emit/snapshots/chained_propagate_result.snap
+++ b/tests/spec/emit/snapshots/chained_propagate_result.snap
@@ -12,7 +12,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_nested(outer lisette.Result[lisette.Result[int, string], string]) lisette.Result[int, string] {
+func getNested(outer lisette.Result[lisette.Result[int, string], string]) lisette.Result[int, string] {
 	if outer.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](outer.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/chained_result_construction.snap
+++ b/tests/spec/emit/snapshots/chained_result_construction.snap
@@ -15,11 +15,11 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() lisette.Result[int, string] {
+func getValue() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
 func test() lisette.Result[int, string] {
-	x := get_value()
+	x := getValue()
 	return x
 }

--- a/tests/spec/emit/snapshots/closure_tail_expr_captures_mutable.snap
+++ b/tests/spec/emit/snapshots/closure_tail_expr_captures_mutable.snap
@@ -12,7 +12,7 @@ description: |
 ---
 package main
 
-func make_counter(start int) func() int {
+func makeCounter(start int) func() int {
 	n := start
 	return func() int {
 		n++

--- a/tests/spec/emit/snapshots/comma_ok_hinted_nullable_tail_call_wraps_in_wrapper_fn.snap
+++ b/tests/spec/emit/snapshots/comma_ok_hinted_nullable_tail_call_wraps_in_wrapper_fn.snap
@@ -19,7 +19,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func build_info() *info.BuildInfo {
+func buildInfo() *info.BuildInfo {
 	ret_1, ret_2 := info.Read()
 	var option_3 lisette.Option[*info.BuildInfo]
 	if ret_2 && ret_1 != nil {
@@ -34,5 +34,5 @@ func build_info() *info.BuildInfo {
 }
 
 func main() {
-	build_info()
+	buildInfo()
 }

--- a/tests/spec/emit/snapshots/const_expression.snap
+++ b/tests/spec/emit/snapshots/const_expression.snap
@@ -10,8 +10,8 @@ description: |
 ---
 package main
 
-const RESULT int = 10 + 20
+const Result int = 10 + 20
 
 func test() int {
-	return RESULT * 2
+	return Result * 2
 }

--- a/tests/spec/emit/snapshots/const_imported_constant_stays_const.snap
+++ b/tests/spec/emit/snapshots/const_imported_constant_stays_const.snap
@@ -18,8 +18,8 @@ import (
 	"time"
 )
 
-const DELAY time.Duration = time.Second / 12
+const Delay time.Duration = time.Second / 12
 
 func main() {
-	fmt.Println(DELAY)
+	fmt.Println(Delay)
 }

--- a/tests/spec/emit/snapshots/const_imported_nonliteral_constant_stays_const.snap
+++ b/tests/spec/emit/snapshots/const_imported_nonliteral_constant_stays_const.snap
@@ -14,8 +14,8 @@ package main
 
 import "example.com/consts"
 
-const DELAY int = consts.SHIFT / 12
+const Delay int = consts.SHIFT / 12
 
 func main() {
-	_ = DELAY
+	_ = Delay
 }

--- a/tests/spec/emit/snapshots/const_inside_function_body.snap
+++ b/tests/spec/emit/snapshots/const_inside_function_body.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func main() {
-	const MAX int = 100
-	_ = MAX + 1
+	const Max int = 100
+	_ = Max + 1
 }

--- a/tests/spec/emit/snapshots/const_simple.snap
+++ b/tests/spec/emit/snapshots/const_simple.snap
@@ -10,8 +10,8 @@ description: |
 ---
 package main
 
-const MAX_SIZE int = 100
+const MaxSize int = 100
 
 func test() int {
-	return MAX_SIZE
+	return MaxSize
 }

--- a/tests/spec/emit/snapshots/const_string.snap
+++ b/tests/spec/emit/snapshots/const_string.snap
@@ -14,8 +14,8 @@ package main
 
 import "fmt"
 
-const GREETING string = "Hello, World!"
+const Greeting string = "Hello, World!"
 
 func test() {
-	fmt.Print(GREETING)
+	fmt.Print(Greeting)
 }

--- a/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
@@ -15,7 +15,7 @@ description: |
 ---
 package main
 
-func sum_positives(items []int) int {
+func sumPositives(items []int) int {
 	sum := 0
 loop_1:
 	for _, item := range items {

--- a/tests/spec/emit/snapshots/deeper_promoted_stringer_does_not_block_shallower_display_shadow.snap
+++ b/tests/spec/emit/snapshots/deeper_promoted_stringer_does_not_block_shallower_display_shadow.snap
@@ -35,7 +35,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
@@ -12,12 +12,12 @@ description: |
 ---
 package main
 
-func get_items() []int {
+func getItems() []int {
 	return []int{1}
 }
 
 func test() {
-	_arg_1 := get_items()
+	_arg_1 := getItems()
 	defer func() {
 		_ = len(_arg_1)
 	}()

--- a/tests/spec/emit/snapshots/deref_self_in_ref_receiver.snap
+++ b/tests/spec/emit/snapshots/deref_self_in_ref_receiver.snap
@@ -17,7 +17,7 @@ type Foo struct {
 	x int
 }
 
-func (f *Foo) copy_out() Foo {
+func (f *Foo) copyOut() Foo {
 	copy_ := *f
 	return Foo{x: copy_.x}
 }

--- a/tests/spec/emit/snapshots/discard_unit_function_call.snap
+++ b/tests/spec/emit/snapshots/discard_unit_function_call.snap
@@ -12,8 +12,8 @@ description: |
 ---
 package main
 
-func do_something() {}
+func doSomething() {}
 
 func test() {
-	do_something()
+	doSomething()
 }

--- a/tests/spec/emit/snapshots/display_empty_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/display_empty_struct_to_string.snap
@@ -13,6 +13,6 @@ func (b Blank) String() string {
 	return "Blank"
 }
 
-func (b Blank) to_string() string {
+func (b Blank) toString() string {
 	return b.String()
 }

--- a/tests/spec/emit/snapshots/display_enum_synthesizes_to_string.snap
+++ b/tests/spec/emit/snapshots/display_enum_synthesizes_to_string.snap
@@ -50,6 +50,6 @@ func (c Color) GoString() string {
 	}
 }
 
-func (c Color) to_string() string {
+func (c Color) toString() string {
 	return c.String()
 }

--- a/tests/spec/emit/snapshots/display_generic_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/display_generic_struct_to_string.snap
@@ -17,6 +17,6 @@ func (b Box[T]) String() string {
 	return fmt.Sprintf("Box { value: %v }", b.value)
 }
 
-func (b Box[T]) to_string() string {
+func (b Box[T]) toString() string {
 	return b.String()
 }

--- a/tests/spec/emit/snapshots/display_outer_over_embedded_display_needs_no_shadow.snap
+++ b/tests/spec/emit/snapshots/display_outer_over_embedded_display_needs_no_shadow.snap
@@ -23,7 +23,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 
@@ -36,6 +36,6 @@ func (s Server) String() string {
 	return fmt.Sprintf("Server { Logger: %v, port: %v }", s.Logger, s.Port)
 }
 
-func (s Server) to_string() string {
+func (s Server) toString() string {
 	return s.String()
 }

--- a/tests/spec/emit/snapshots/display_satisfies_display_interface.snap
+++ b/tests/spec/emit/snapshots/display_satisfies_display_interface.snap
@@ -22,7 +22,7 @@ package main
 import "fmt"
 
 type Display interface {
-	to_string() string
+	toString() string
 }
 
 type Point struct {
@@ -34,15 +34,15 @@ func (p Point) String() string {
 	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
-func (p Point) to_string() string {
+func (p Point) toString() string {
 	return p.String()
 }
 
 func render(d Display) string {
-	return d.to_string()
+	return d.toString()
 }
 
-func use_it() string {
+func useIt() string {
 	return render(Point{
 		x: 1,
 		y: 2,

--- a/tests/spec/emit/snapshots/display_struct_synthesizes_to_string.snap
+++ b/tests/spec/emit/snapshots/display_struct_synthesizes_to_string.snap
@@ -18,6 +18,6 @@ func (p Point) String() string {
 	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
-func (p Point) to_string() string {
+func (p Point) toString() string {
 	return p.String()
 }

--- a/tests/spec/emit/snapshots/display_to_string_delegates_to_user_stringer.snap
+++ b/tests/spec/emit/snapshots/display_to_string_delegates_to_user_stringer.snap
@@ -24,7 +24,7 @@ func (p Point) GoString() string {
 	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
-func (p Point) to_string() string {
+func (p Point) toString() string {
 	return p.String()
 }
 

--- a/tests/spec/emit/snapshots/display_tuple_struct_to_string.snap
+++ b/tests/spec/emit/snapshots/display_tuple_struct_to_string.snap
@@ -15,6 +15,6 @@ func (u UserId) String() string {
 	return fmt.Sprintf("UserId(%v)", int(u))
 }
 
-func (u UserId) to_string() string {
+func (u UserId) toString() string {
 	return u.String()
 }

--- a/tests/spec/emit/snapshots/display_user_to_string_suppresses_synthesis.snap
+++ b/tests/spec/emit/snapshots/display_user_to_string_suppresses_synthesis.snap
@@ -24,6 +24,6 @@ func (p Point) String() string {
 	return fmt.Sprintf("Point { x: %v, y: %v }", p.x, p.y)
 }
 
-func (p Point) to_string() string {
+func (p Point) toString() string {
 	return "p"
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_const.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_const.snap
@@ -8,4 +8,4 @@ description: |
 package main
 
 // The maximum number of connections.
-const MAX_CONNECTIONS int = 100
+const MaxConnections int = 100

--- a/tests/spec/emit/snapshots/embedded_alias_of_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_alias_of_display_gets_shadow.snap
@@ -24,7 +24,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_alias_to_ref_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_alias_to_ref_display_gets_shadow.snap
@@ -24,7 +24,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_display_and_user_stringer_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_and_user_stringer_are_ambiguous_no_shadow.snap
@@ -30,7 +30,7 @@ func (a A) String() string {
 	return fmt.Sprintf("A { a: %v }", a.A)
 }
 
-func (a A) to_string() string {
+func (a A) toString() string {
 	return a.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_display_pointer_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_pointer_gets_shadow.snap
@@ -22,7 +22,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_display_shadow_is_transitive.snap
+++ b/tests/spec/emit/snapshots/embedded_display_shadow_is_transitive.snap
@@ -27,7 +27,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_display_struct_gets_shadow_stringer.snap
+++ b/tests/spec/emit/snapshots/embedded_display_struct_gets_shadow_stringer.snap
@@ -22,7 +22,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_display_with_user_stringer_promotes_without_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_display_with_user_stringer_promotes_without_shadow.snap
@@ -28,7 +28,7 @@ func (l Logger) GoString() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_generic_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_generic_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -27,7 +27,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_generic_parent_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_generic_parent_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -32,7 +32,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_imported_non_stringer_string_method_blocks_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_imported_non_stringer_string_method_blocks_shadow.snap
@@ -28,7 +28,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_interface_non_stringer_string_method_is_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_non_stringer_string_method_is_ambiguous_no_shadow.snap
@@ -27,7 +27,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_interface_parent_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_parent_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -32,7 +32,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_interface_stringer_and_display_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_stringer_and_display_are_ambiguous_no_shadow.snap
@@ -27,7 +27,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_interface_without_stringer_leaves_display_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_interface_without_stringer_leaves_display_shadow.snap
@@ -27,7 +27,7 @@ func (d D) String() string {
 	return fmt.Sprintf("D { x: %v }", d.X)
 }
 
-func (d D) to_string() string {
+func (d D) toString() string {
 	return d.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_intermediate_user_stringer_stops_shadow_walk.snap
+++ b/tests/spec/emit/snapshots/embedded_intermediate_user_stringer_stops_shadow_walk.snap
@@ -33,7 +33,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/embedded_ref_to_alias_display_gets_shadow.snap
+++ b/tests/spec/emit/snapshots/embedded_ref_to_alias_display_gets_shadow.snap
@@ -24,7 +24,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
@@ -16,13 +16,13 @@ description: |
 ---
 package main
 
-func make_bound() int {
+func makeBound() int {
 	return 3
 }
 
 func main() {
 	sum := 0
-	_bound_1 := make_bound()
+	_bound_1 := makeBound()
 	for i := 0; i < _bound_1; i++ {
 		sum += i
 	}

--- a/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
@@ -16,7 +16,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func make_range() lisette.Range[int] {
+func makeRange() lisette.Range[int] {
 	return lisette.Range[int]{
 		Start: 0,
 		End:   2,
@@ -26,7 +26,7 @@ func make_range() lisette.Range[int] {
 func main() {
 	s := []int{1, 2, 3}
 	_base_2 := s
-	range_1 := make_range()
+	range_1 := makeRange()
 	sub := _base_2[range_1.Start:range_1.End:range_1.End]
 	range_1_3 := 7
 	_ = sub

--- a/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
@@ -20,7 +20,7 @@ func side() int {
 	return 1
 }
 
-func get_x() (int, error) {
+func getX() (int, error) {
 	return 2, nil
 }
 
@@ -29,7 +29,7 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	ret_1, ret_2 := get_x()
+	ret_1, ret_2 := getX()
 	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
 		result_3 = lisette.MakeResultErr[int, error](ret_2)

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -20,7 +20,7 @@ func side() int {
 	return 1
 }
 
-func get_y() (int, error) {
+func getY() (int, error) {
 	return 2, nil
 }
 
@@ -30,7 +30,7 @@ func add(_, _ int) int {
 
 func run() (int, error) {
 	_arg_5 := side()
-	ret_1, ret_2 := get_y()
+	ret_1, ret_2 := getY()
 	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
 		result_3 = lisette.MakeResultErr[int, error](ret_2)

--- a/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
@@ -41,7 +41,7 @@ type Cursor struct {
 	W   int
 }
 
-func make_base() Cursor {
+func makeBase() Cursor {
 	fmt.Println("base")
 	return Cursor{
 		Tag: CursorPoint,
@@ -51,7 +51,7 @@ func make_base() Cursor {
 }
 
 func test() Cursor {
-	_ = make_base()
+	_ = makeBase()
 	return Cursor{
 		Tag: CursorArea,
 		Id:  4,

--- a/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
@@ -41,7 +41,7 @@ type Cursor struct {
 	W   int
 }
 
-func make_base() Cursor {
+func makeBase() Cursor {
 	fmt.Println("base")
 	return Cursor{
 		Tag: CursorPoint,
@@ -51,7 +51,7 @@ func make_base() Cursor {
 }
 
 func test() Cursor {
-	spread_1 := make_base()
+	spread_1 := makeBase()
 	return Cursor{
 		Tag: CursorArea,
 		W:   3,

--- a/tests/spec/emit/snapshots/err_with_errors_new.snap
+++ b/tests/spec/emit/snapshots/err_with_errors_new.snap
@@ -15,7 +15,7 @@ package main
 
 import "errors"
 
-func might_fail(n int) (int, error) {
+func mightFail(n int) (int, error) {
 	if n < 0 {
 		return 0, errors.New("negative")
 	}

--- a/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
+++ b/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
@@ -11,14 +11,14 @@ description: |
 ---
 package main
 
-func get_items() []int {
+func getItems() []int {
 	return []int{1, 2, 3}
 }
 
 func main() {
 	items := []int{0, 0, 0}
 	base_2 := items
-	_base_3 := get_items()
+	_base_3 := getItems()
 	idx_4 := _base_3[0]
 	var tmp_1 int
 	if true {

--- a/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
+++ b/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
@@ -37,9 +37,9 @@ type List[T any] struct {
 	Cons1 *List[T]
 }
 
-func list_len[T any](list List[T]) int {
+func listLen[T any](list List[T]) int {
 	if list.Tag == ListNil {
 		return 0
 	}
-	return 1 + list_len(*list.Cons1)
+	return 1 + listLen(*list.Cons1)
 }

--- a/tests/spec/emit/snapshots/float32_parameter_and_return.snap
+++ b/tests/spec/emit/snapshots/float32_parameter_and_return.snap
@@ -8,6 +8,6 @@ description: |
 ---
 package main
 
-func accept_float32(x float32) float32 {
+func acceptFloat32(x float32) float32 {
 	return x
 }

--- a/tests/spec/emit/snapshots/for_loop_range_from_call.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_from_call.snap
@@ -16,7 +16,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_range() lisette.Range[int] {
+func getRange() lisette.Range[int] {
 	return lisette.Range[int]{
 		Start: 0,
 		End:   5,
@@ -25,7 +25,7 @@ func get_range() lisette.Range[int] {
 
 func test() int {
 	sum := 0
-	_range_1 := get_range()
+	_range_1 := getRange()
 	for i := _range_1.Start; i < _range_1.End; i++ {
 		sum += i
 	}

--- a/tests/spec/emit/snapshots/for_loop_range_wildcard.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_wildcard.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func do_work() {}
+func doWork() {}
 
 func test() {
 	for _i_1 := 0; _i_1 < 3; _i_1++ {
-		do_work()
+		doWork()
 	}
 }

--- a/tests/spec/emit/snapshots/for_loop_range_with_call.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_with_call.snap
@@ -14,13 +14,13 @@ description: |
 ---
 package main
 
-func get_end() int {
+func getEnd() int {
 	return 5
 }
 
 func test() int {
 	sum := 0
-	_bound_1 := get_end()
+	_bound_1 := getEnd()
 	for i := 0; i < _bound_1; i++ {
 		sum += i
 	}

--- a/tests/spec/emit/snapshots/for_pair_pattern_on_go_interface_asserts_value_type.snap
+++ b/tests/spec/emit/snapshots/for_pair_pattern_on_go_interface_asserts_value_type.snap
@@ -16,7 +16,7 @@ package main
 
 import "example.com/shapes"
 
-func sum_areas(items map[string]shapes.Shape) int {
+func sumAreas(items map[string]shapes.Shape) int {
 	total := 0
 	for key_1, value_2 := range items {
 		_ = key_1

--- a/tests/spec/emit/snapshots/format_string_display_rune_newtype_keeps_stringer.snap
+++ b/tests/spec/emit/snapshots/format_string_display_rune_newtype_keeps_stringer.snap
@@ -23,7 +23,7 @@ func (g Grade) String() string {
 	return fmt.Sprintf("Grade(%v)", rune(g))
 }
 
-func (g Grade) to_string() string {
+func (g Grade) toString() string {
 	return g.String()
 }
 

--- a/tests/spec/emit/snapshots/function_call_no_args.snap
+++ b/tests/spec/emit/snapshots/function_call_no_args.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func get_value() int {
+func getValue() int {
 	return 42
 }
 
 func test() int {
-	return get_value()
+	return getValue()
 }

--- a/tests/spec/emit/snapshots/function_returning_bool.snap
+++ b/tests/spec/emit/snapshots/function_returning_bool.snap
@@ -8,6 +8,6 @@ description: |
 ---
 package main
 
-func is_positive(x int) bool {
+func isPositive(x int) bool {
 	return x > 0
 }

--- a/tests/spec/emit/snapshots/function_type_as_return.snap
+++ b/tests/spec/emit/snapshots/function_type_as_return.snap
@@ -13,13 +13,13 @@ description: |
 ---
 package main
 
-func make_adder(n int) func(int) int {
+func makeAdder(n int) func(int) int {
 	return func(x int) int {
 		return x + n
 	}
 }
 
 func test() int {
-	add5 := make_adder(5)
+	add5 := makeAdder(5)
 	return add5(10)
 }

--- a/tests/spec/emit/snapshots/function_type_with_mut_parameter.snap
+++ b/tests/spec/emit/snapshots/function_type_with_mut_parameter.snap
@@ -20,7 +20,7 @@ description: |
 package main
 
 type Counter struct {
-	times_called int
+	timesCalled int
 }
 
 func run(counter Counter, action func(Counter)) {
@@ -28,10 +28,10 @@ func run(counter Counter, action func(Counter)) {
 }
 
 func bump(counter Counter) {
-	counter.times_called++
+	counter.timesCalled++
 }
 
 func test() {
-	counter := Counter{times_called: 0}
+	counter := Counter{timesCalled: 0}
 	run(counter, bump)
 }

--- a/tests/spec/emit/snapshots/function_with_return_type.snap
+++ b/tests/spec/emit/snapshots/function_with_return_type.snap
@@ -8,6 +8,6 @@ description: |
 ---
 package main
 
-func get_value() int {
+func getValue() int {
 	return 42
 }

--- a/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
@@ -23,7 +23,7 @@ import (
 	"os"
 )
 
-func write_all(file *os.File) {
+func writeAll(file *os.File) {
 	ret_1, ret_2 := file.Write([]byte{'h', 'i'})
 	if ret_2 == nil {
 		n := ret_1

--- a/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
@@ -77,12 +77,12 @@ func consume[A any](box Box[lisette.Option[A]]) {
 	}
 }
 
-func use_wrap[A any, B Holder[A]](w Wrap[A, B]) {
+func useWrap[A any, B Holder[A]](w Wrap[A, B]) {
 	consume(_lisAdapter_Wrap_Box_0[A, B]{inner: w})
 }
 
 func main() {
-	use_wrap(Wrap[int, IntHolder]{
+	useWrap(Wrap[int, IntHolder]{
 		a: 3,
 		b: IntHolder{},
 	})

--- a/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
+++ b/tests/spec/emit/snapshots/generic_call_with_named_function_alias_arg.snap
@@ -41,11 +41,11 @@ type Wrap struct {
 	B Box[Handler]
 }
 
-func make_box[T any](x T) Box[T] {
+func makeBox[T any](x T) Box[T] {
 	return Box[T]{V: x}
 }
 
 func main() {
-	_w := Wrap{B: make_box[Handler](double)}
+	_w := Wrap{B: makeBox[Handler](double)}
 	_ = _w.B
 }

--- a/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
@@ -39,10 +39,10 @@ func (b Bar) get() (int, error) {
 	return 0, errors.New("failure")
 }
 
-func use_foo(_ Foo[error]) {}
+func useFoo(_ Foo[error]) {}
 
 func main() {
-	use_foo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
+	useFoo(_lisAdapter_Bar_Foo_0{inner: Bar{}})
 }
 
 type _lisAdapter_Bar_Foo_0 struct {

--- a/tests/spec/emit/snapshots/generic_function_type_alias.snap
+++ b/tests/spec/emit/snapshots/generic_function_type_alias.snap
@@ -16,12 +16,12 @@ package main
 
 type Transform[T any] func(T) T
 
-func apply_transform[T any](val T, f Transform[T]) T {
+func applyTransform[T any](val T, f Transform[T]) T {
 	return f(val)
 }
 
 func test() int {
-	return apply_transform(42, func(x int) int {
+	return applyTransform(42, func(x int) int {
 		return x + 1
 	})
 }

--- a/tests/spec/emit/snapshots/generic_function_with_map_key_type_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_function_with_map_key_type_parameter.snap
@@ -10,7 +10,7 @@ description: |
 ---
 package main
 
-func put_in_map[K comparable, V any](key K, value V) map[K]V {
+func putInMap[K comparable, V any](key K, value V) map[K]V {
 	m := make(map[K]V)
 	m[key] = value
 	return m

--- a/tests/spec/emit/snapshots/generic_interface_constraint_with_type_args.snap
+++ b/tests/spec/emit/snapshots/generic_interface_constraint_with_type_args.snap
@@ -13,9 +13,9 @@ description: |
 package main
 
 type Mapper[A any, B any] interface {
-	map_value(A) B
+	mapValue(A) B
 }
 
-func apply_mapper[M Mapper[int, string]](m M, val int) string {
-	return m.map_value(val)
+func applyMapper[M Mapper[int, string]](m M, val int) string {
+	return m.mapValue(val)
 }

--- a/tests/spec/emit/snapshots/generic_map_key_in_task_body.snap
+++ b/tests/spec/emit/snapshots/generic_map_key_in_task_body.snap
@@ -11,7 +11,7 @@ description: |
 ---
 package main
 
-func use_map_in_task[K comparable, V any](key K, value V) {
+func useMapInTask[K comparable, V any](key K, value V) {
 	go func() {
 		m := make(map[K]V)
 		m[key] = value

--- a/tests/spec/emit/snapshots/generic_param_shadows_module_struct.snap
+++ b/tests/spec/emit/snapshots/generic_param_shadows_module_struct.snap
@@ -31,13 +31,13 @@ type T struct {
 	v int
 }
 
-func make_t() T {
+func makeT() T {
 	return T{v: 7}
 }
 
 func f[T_2 any](_ T_2) int {
 	opt := lisette.MakeOptionNone[T]()
-	opt = lisette.MakeOptionSome(make_t())
+	opt = lisette.MakeOptionSome(makeT())
 	if opt.Tag == lisette.OptionSome {
 		return opt.SomeVal.v
 	}

--- a/tests/spec/emit/snapshots/generic_return_only_type_param.snap
+++ b/tests/spec/emit/snapshots/generic_return_only_type_param.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func default_value[T any]() (T, bool) {
+func defaultValue[T any]() (T, bool) {
 	return *new(T), false
 }
 
 func test() (int, bool) {
-	return default_value[int]()
+	return defaultValue[int]()
 }

--- a/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
+++ b/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
@@ -47,21 +47,21 @@ type Validated[T any] struct {
 }
 
 type ValidationResult[T any] struct {
-	value      Validated[T]
-	field_name string
+	value     Validated[T]
+	fieldName string
 }
 
-func ValidationResult_new_invalid[T any](field, msg string) ValidationResult[T] {
+func ValidationResult_newInvalid[T any](field, msg string) ValidationResult[T] {
 	return ValidationResult[T]{
-		value:      MakeValidatedInvalid[T](msg),
-		field_name: field,
+		value:     MakeValidatedInvalid[T](msg),
+		fieldName: field,
 	}
 }
 
-func validate_positive(field string, _ int) ValidationResult[int] {
-	return ValidationResult_new_invalid[int](field, "must be positive")
+func validatePositive(field string, _ int) ValidationResult[int] {
+	return ValidationResult_newInvalid[int](field, "must be positive")
 }
 
-func validate_non_empty(field, _ string) ValidationResult[string] {
-	return ValidationResult_new_invalid[string](field, "must not be empty")
+func validateNonEmpty(field, _ string) ValidationResult[string] {
+	return ValidationResult_newInvalid[string](field, "must not be empty")
 }

--- a/tests/spec/emit/snapshots/generic_struct_param_shadows_module_type.snap
+++ b/tests/spec/emit/snapshots/generic_struct_param_shadows_module_type.snap
@@ -38,7 +38,7 @@ type T struct {
 	v int
 }
 
-func make_t() T {
+func makeT() T {
 	return T{v: 7}
 }
 
@@ -48,7 +48,7 @@ type Box[T_2 any] struct {
 
 func (b Box[T_2]) probe() int {
 	opt := lisette.MakeOptionNone[T]()
-	opt = lisette.MakeOptionSome(make_t())
+	opt = lisette.MakeOptionSome(makeT())
 	if opt.Tag == lisette.OptionSome {
 		return opt.SomeVal.v
 	}

--- a/tests/spec/emit/snapshots/go_call_result_as_tail_expression.snap
+++ b/tests/spec/emit/snapshots/go_call_result_as_tail_expression.snap
@@ -12,6 +12,6 @@ package main
 
 import "fmt"
 
-func print_hello() (int, error) {
+func printHello() (int, error) {
 	return fmt.Println("hello")
 }

--- a/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
+++ b/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
@@ -24,7 +24,7 @@ import (
 	"strconv"
 )
 
-func parse_with(f func(string) (int, error), s string) int {
+func parseWith(f func(string) (int, error), s string) int {
 	ret_1, ret_2 := f(s)
 	if ret_2 == nil {
 		n := ret_1
@@ -35,6 +35,6 @@ func parse_with(f func(string) (int, error), s string) int {
 }
 
 func main() {
-	n := parse_with(strconv.Atoi, "42")
+	n := parseWith(strconv.Atoi, "42")
 	fmt.Println(n)
 }

--- a/tests/spec/emit/snapshots/go_keyword_function_parameter.snap
+++ b/tests/spec/emit/snapshots/go_keyword_function_parameter.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func use_map(map_, range_ int) int {
+func useMap(map_, range_ int) int {
 	return map_ + range_
 }
 
 func test() int {
-	return use_map(10, 20)
+	return useMap(10, 20)
 }

--- a/tests/spec/emit/snapshots/go_method_value_receiver_hoisted.snap
+++ b/tests/spec/emit/snapshots/go_method_value_receiver_hoisted.snap
@@ -33,13 +33,13 @@ func make_(counter *int) *bytes.Buffer {
 	return bytes.NewBufferString("a\nb\n")
 }
 
-func use_fn(f func(uint8) (string, error)) {
+func useFn(f func(uint8) (string, error)) {
 	f(10)
 	f(10)
 }
 
 func main() {
 	count := 0
-	use_fn(make_(&count).ReadString)
+	useFn(make_(&count).ReadString)
 	fmt.Println(count)
 }

--- a/tests/spec/emit/snapshots/go_tuple_partial_fn_value_adapts_to_lowered_slot.snap
+++ b/tests/spec/emit/snapshots/go_tuple_partial_fn_value_adapts_to_lowered_slot.snap
@@ -19,12 +19,12 @@ import (
 	"mime"
 )
 
-func use_fn(f func(string) (lisette.Tuple2[string, map[string]string], error)) {
+func useFn(f func(string) (lisette.Tuple2[string, map[string]string], error)) {
 	f("text/plain")
 }
 
 func main() {
-	use_fn(func(arg0 string) (lisette.Tuple2[string, map[string]string], error) {
+	useFn(func(arg0 string) (lisette.Tuple2[string, map[string]string], error) {
 		ret_1, ret_2, ret_3 := mime.ParseMediaType(arg0)
 		tup_4 := lisette.MakeTuple2(ret_1, ret_2)
 		return tup_4, ret_3

--- a/tests/spec/emit/snapshots/if_else_branch_with_statements_before_result_return.snap
+++ b/tests/spec/emit/snapshots/if_else_branch_with_statements_before_result_return.snap
@@ -18,7 +18,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func checked_sqrt(n int) lisette.Result[int, string] {
+func checkedSqrt(n int) lisette.Result[int, string] {
 	if n < 0 {
 		return lisette.MakeResultErr[int, string]("negative input")
 	}

--- a/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
@@ -21,7 +21,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func try_parse(s string) lisette.Result[int, string] {
+func tryParse(s string) lisette.Result[int, string] {
 	if s == "42" {
 		return lisette.MakeResultOk[int, string](42)
 	}
@@ -29,7 +29,7 @@ func try_parse(s string) lisette.Result[int, string] {
 }
 
 func test() {
-	subject_1 := try_parse("42")
+	subject_1 := tryParse("42")
 	if subject_1.Tag == lisette.ResultOk {
 		x := subject_1.OkVal
 		fmt.Printf("Parsed: %d\n", x)

--- a/tests/spec/emit/snapshots/if_returning_option_with_function_call.snap
+++ b/tests/spec/emit/snapshots/if_returning_option_with_function_call.snap
@@ -12,7 +12,7 @@ description: |
 ---
 package main
 
-func get_value() (int, bool) {
+func getValue() (int, bool) {
 	return 99, true
 }
 
@@ -20,5 +20,5 @@ func test(flag bool) (int, bool) {
 	if flag {
 		return 42, true
 	}
-	return get_value()
+	return getValue()
 }

--- a/tests/spec/emit/snapshots/impl_method_map_key_return_uses_declared_receiver_bound.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_return_uses_declared_receiver_bound.snap
@@ -23,11 +23,11 @@ type Box[T comparable] struct {
 	value T
 }
 
-func (b Box[T]) make_map() map[T]int {
+func (b Box[T]) makeMap() map[T]int {
 	return make(map[T]int)
 }
 
 func main() {
 	b := Box[string]{value: "a"}
-	_ = b.make_map()
+	_ = b.makeMap()
 }

--- a/tests/spec/emit/snapshots/imported_types_named_like_prelude_wrappers_are_not_confused.snap
+++ b/tests/spec/emit/snapshots/imported_types_named_like_prelude_wrappers_are_not_confused.snap
@@ -34,23 +34,23 @@ package main
 
 import "example.com/box"
 
-func use_ref(r box.Ref[int]) int {
+func useRef(r box.Ref[int]) int {
 	return r.Inner
 }
 
-func use_slice(s box.Slice[int]) int {
+func useSlice(s box.Slice[int]) int {
 	return s.Value
 }
 
-func use_map(m box.Map[string, int]) int {
+func useMap(m box.Map[string, int]) int {
 	return m.Val
 }
 
-func make_ref() box.Ref[int] {
+func makeRef() box.Ref[int] {
 	return box.Ref[int]{Inner: 1}
 }
 
-func maybe_ref(r box.Ref[int]) (box.Ref[int], bool) {
+func maybeRef(r box.Ref[int]) (box.Ref[int], bool) {
 	return r, true
 }
 

--- a/tests/spec/emit/snapshots/indexed_field_assignment_no_temp_for_trivial_rhs.snap
+++ b/tests/spec/emit/snapshots/indexed_field_assignment_no_temp_for_trivial_rhs.snap
@@ -28,7 +28,7 @@ type Snake struct {
 	head  int
 }
 
-func (s *Snake) set_head(x, y int) {
+func (s *Snake) setHead(x, y int) {
 	s.parts[s.head].x = x
 	s.parts[s.head].y = y
 }

--- a/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
@@ -16,7 +16,7 @@ description: |
 ---
 package main
 
-func bump_and_make(i *int) []int {
+func bumpAndMake(i *int) []int {
 	*i = 1
 	return []int{99}
 }
@@ -25,6 +25,6 @@ func test() int {
 	xss := [][]int{[]int{10}, []int{20}}
 	i := 0
 	recv_1 := xss[i]
-	ys := append(recv_1[:len(recv_1):len(recv_1)], bump_and_make(&i)...)
+	ys := append(recv_1[:len(recv_1):len(recv_1)], bumpAndMake(&i)...)
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/interface_bound_method_call.snap
+++ b/tests/spec/emit/snapshots/interface_bound_method_call.snap
@@ -18,10 +18,10 @@ package main
 import "fmt"
 
 type Stringer interface {
-	string_value() string
+	stringValue() string
 }
 
-func print_it[T Stringer](x T) {
-	s := x.string_value()
+func printIt[T Stringer](x T) {
+	s := x.stringValue()
 	fmt.Printf("%s\n", s)
 }

--- a/tests/spec/emit/snapshots/interop_aliased_native_receiver_wraps_result_callback.snap
+++ b/tests/spec/emit/snapshots/interop_aliased_native_receiver_wraps_result_callback.snap
@@ -19,7 +19,7 @@ import (
 
 type Ints = []int
 
-func convert_all(xs Ints) {
+func convertAll(xs Ints) {
 	_ = lisette.SliceMap(xs, func(arg0 int) lisette.Result[string, error] {
 		ret_1, ret_2 := ext.Parse(arg0)
 		if ret_2 != nil {

--- a/tests/spec/emit/snapshots/interop_aliased_option_receiver_wraps_callback.snap
+++ b/tests/spec/emit/snapshots/interop_aliased_option_receiver_wraps_callback.snap
@@ -19,7 +19,7 @@ import (
 
 type MyOpt = lisette.Option[int]
 
-func use_it(o MyOpt) {
+func useIt(o MyOpt) {
 	lisette.OptionAndThen(o, func(arg0 int) lisette.Option[string] {
 		return lisette.OptionFromCommaOk[string](ext.Lookup(arg0))
 	})

--- a/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
@@ -24,12 +24,12 @@ import (
 	"os"
 )
 
-func make_lookup() func(string) (string, bool) {
+func makeLookup() func(string) (string, bool) {
 	return os.LookupEnv
 }
 
 func main() {
-	f := make_lookup()
+	f := makeLookup()
 	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_lisette_fn_into_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_into_go_callback_param.snap
@@ -19,7 +19,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_it() []lisette.Option[string] {
+func makeIt() []lisette.Option[string] {
 	return []lisette.Option[string]{
 		lisette.MakeOptionSome("hi"),
 		lisette.MakeOptionNone[string](),
@@ -27,7 +27,7 @@ func make_it() []lisette.Option[string] {
 }
 
 func main() {
-	cb_1 := make_it
+	cb_1 := makeIt
 	aws.Use(func() []*string {
 		src_2 := cb_1()
 		unwrapped_3 := make([]*string, len(src_2))

--- a/tests/spec/emit/snapshots/interop_lisette_nested_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_nested_option_return.snap
@@ -28,7 +28,7 @@ func make_() ([]lisette.Option[string], bool) {
 	}, true
 }
 
-func use_it(o lisette.Option[[]lisette.Option[string]]) {
+func useIt(o lisette.Option[[]lisette.Option[string]]) {
 	if o.Tag == lisette.OptionSome {
 		for _, x := range o.SomeVal {
 			_ = x
@@ -38,5 +38,5 @@ func use_it(o lisette.Option[[]lisette.Option[string]]) {
 
 func main() {
 	option_1 := lisette.OptionFromCommaOk[[]lisette.Option[string]](make_())
-	use_it(option_1)
+	useIt(option_1)
 }

--- a/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
@@ -24,12 +24,12 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_lookup() func(string) *flag.Flag {
+func makeLookup() func(string) *flag.Flag {
 	return flag.Lookup
 }
 
 func main() {
-	f := make_lookup()
+	f := makeLookup()
 	raw_1 := f("verbose")
 	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	r := option_2

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -26,7 +26,7 @@ import (
 	"strconv"
 )
 
-func sum_parsed(a, b string) (int, error) {
+func sumParsed(a, b string) (int, error) {
 	tryResult_1 := func() lisette.Result[int, error] {
 		ret_2, ret_3 := strconv.Atoi(a)
 		if ret_3 != nil {
@@ -48,7 +48,7 @@ func sum_parsed(a, b string) (int, error) {
 }
 
 func main() {
-	ret_1, ret_2 := sum_parsed("3", "4")
+	ret_1, ret_2 := sumParsed("3", "4")
 	if ret_2 == nil {
 		n := ret_1
 		_ = n

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -29,7 +29,7 @@ import (
 	"strconv"
 )
 
-func open_and_check(path, n string) (int, error) {
+func openAndCheck(path, n string) (int, error) {
 	tryResult_1 := func() lisette.Result[int, error] {
 		ret_2, ret_3 := os.Open(path)
 		if ret_3 != nil {
@@ -60,7 +60,7 @@ func open_and_check(path, n string) (int, error) {
 }
 
 func main() {
-	ret_1, ret_2 := open_and_check("/tmp/x", "7")
+	ret_1, ret_2 := openAndCheck("/tmp/x", "7")
 	if ret_2 == nil {
 		v := ret_1
 		_ = v

--- a/tests/spec/emit/snapshots/interop_result_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_result_return_pos.snap
@@ -24,12 +24,12 @@ import (
 	"strconv"
 )
 
-func make_parser() func(string) (int, error) {
+func makeParser() func(string) (int, error) {
 	return strconv.Atoi
 }
 
 func main() {
-	f := make_parser()
+	f := makeParser()
 	ret_1, ret_2 := f("42")
 	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {

--- a/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
@@ -24,7 +24,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_finder() func(string, string) (int, bool) {
+func makeFinder() func(string, string) (int, bool) {
 	return func(arg0 string, arg1 string) (int, bool) {
 		ret_1 := idx.Find(arg0, arg1)
 		return ret_1, ret_1 != -1
@@ -32,7 +32,7 @@ func make_finder() func(string, string) (int, bool) {
 }
 
 func main() {
-	f := make_finder()
+	f := makeFinder()
 	option_1 := lisette.OptionFromCommaOk[int](f("hello", "ll"))
 	r := option_1
 	if r.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_slice_map_keeps_result_callback_tagged.snap
+++ b/tests/spec/emit/snapshots/interop_slice_map_keeps_result_callback_tagged.snap
@@ -15,7 +15,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func convert_all(xs []int) {
+func convertAll(xs []int) {
 	_ = lisette.SliceMap(xs, func(arg0 int) lisette.Result[string, error] {
 		ret_1, ret_2 := ext.Parse(arg0)
 		if ret_2 != nil {

--- a/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
@@ -22,7 +22,7 @@ import (
 	"path"
 )
 
-func use_split(f func(string) (string, string), p string) string {
+func useSplit(f func(string) (string, string), p string) string {
 	ret_2, ret_3 := f(p)
 	tup_4 := lisette.MakeTuple2(ret_2, ret_3)
 	tmp_1 := tup_4
@@ -32,6 +32,6 @@ func use_split(f func(string) (string, string), p string) string {
 }
 
 func main() {
-	r := use_split(path.Split, "/foo/bar.txt")
+	r := useSplit(path.Split, "/foo/bar.txt")
 	_ = r
 }

--- a/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_explicit_return_concrete_in_go_interface_slot.snap
@@ -33,7 +33,7 @@ func (c Counter) String() string {
 	return fmt.Sprint(c.count)
 }
 
-func make_pair(c Counter, positive bool) (fmt.Stringer, int) {
+func makePair(c Counter, positive bool) (fmt.Stringer, int) {
 	if positive {
 		return Counter{count: c.count + 1}, c.count
 	}

--- a/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
@@ -21,12 +21,12 @@ import (
 	"path"
 )
 
-func make_splitter() func(string) (string, string) {
+func makeSplitter() func(string) (string, string) {
 	return path.Split
 }
 
 func main() {
-	f := make_splitter()
+	f := makeSplitter()
 	ret_1, ret_2 := f("/foo/bar.txt")
 	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
 	r := tup_3

--- a/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_tail_concrete_in_go_interface_slot.snap
@@ -30,6 +30,6 @@ func (c Counter) String() string {
 	return fmt.Sprint(c.count)
 }
 
-func make_pair(c Counter) (fmt.Stringer, int) {
+func makePair(c Counter) (fmt.Stringer, int) {
 	return c, c.count
 }

--- a/tests/spec/emit/snapshots/keyed_tag_forces_export_so_string_field_blocks_outer_shadow.snap
+++ b/tests/spec/emit/snapshots/keyed_tag_forces_export_so_string_field_blocks_outer_shadow.snap
@@ -28,7 +28,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/let_bind_unit_returning_call.snap
+++ b/tests/spec/emit/snapshots/let_bind_unit_returning_call.snap
@@ -11,10 +11,10 @@ description: |
 ---
 package main
 
-func do_nothing() {}
+func doNothing() {}
 
 func test() {
-	do_nothing()
+	doNothing()
 	r := struct{}{}
 	_ = r
 }

--- a/tests/spec/emit/snapshots/let_binding_from_option_function.snap
+++ b/tests/spec/emit/snapshots/let_binding_from_option_function.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func get_value() (int, bool) {
+func getValue() (int, bool) {
 	return 42, true
 }
 
 func test() {
-	get_value()
+	getValue()
 }

--- a/tests/spec/emit/snapshots/let_else_option_direct_call.snap
+++ b/tests/spec/emit/snapshots/let_else_option_direct_call.snap
@@ -15,7 +15,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value(s string) (int, bool) {
+func getValue(s string) (int, bool) {
 	if s == "ok" {
 		return 42, true
 	}
@@ -23,7 +23,7 @@ func get_value(s string) (int, bool) {
 }
 
 func test() int {
-	option_2 := lisette.OptionFromCommaOk[int](get_value("ok"))
+	option_2 := lisette.OptionFromCommaOk[int](getValue("ok"))
 	subject_1 := option_2
 	if subject_1.Tag != lisette.OptionSome {
 		return 0

--- a/tests/spec/emit/snapshots/let_else_struct_pattern_on_go_interface_uses_comma_ok.snap
+++ b/tests/spec/emit/snapshots/let_else_struct_pattern_on_go_interface_uses_comma_ok.snap
@@ -13,7 +13,7 @@ package main
 
 import "example.com/shapes"
 
-func try_area(s shapes.Shape) int {
+func tryArea(s shapes.Shape) int {
 	asserted_1, ok_2 := s.(shapes.Rect)
 	if !ok_2 {
 		return -1

--- a/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
+++ b/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
@@ -21,7 +21,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_i() int {
+func makeI() int {
 	fmt.Println("i")
 	return 0
 }
@@ -29,7 +29,7 @@ func make_i() int {
 func main() {
 	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(0, 0)}
 	base_2 := items
-	idx_3 := make_i()
+	idx_3 := makeI()
 	var tmp_1 int
 	if true {
 		tmp_1 = 1

--- a/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_map_expr_evaluated_once.snap
@@ -27,14 +27,14 @@ type Box struct {
 	items []int
 }
 
-func get_map(m map[string]Box) map[string]Box {
+func getMap(m map[string]Box) map[string]Box {
 	return m
 }
 
 func main() {
 	m := make(map[string]Box)
 	m["a"] = Box{items: []int{}}
-	map_ := get_map(m)
+	map_ := getMap(m)
 	entry := Box{items: slices.Clone(map_["a"].items)}
 	entry.items = append(entry.items, 1)
 	map_["a"] = entry

--- a/tests/spec/emit/snapshots/map_field_assign_captures_key.snap
+++ b/tests/spec/emit/snapshots/map_field_assign_captures_key.snap
@@ -26,7 +26,7 @@ type Pair struct {
 	x int
 }
 
-func set_key(k *string) int {
+func setKey(k *string) int {
 	*k = "b"
 	return 1
 }
@@ -37,7 +37,7 @@ func main() {
 	k := "a"
 	captured_key := k
 	entry := m[captured_key]
-	entry.x = set_key(&k)
+	entry.x = setKey(&k)
 	m[captured_key] = entry
 	_ = m
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
@@ -37,7 +37,7 @@ type Box struct {
 	x int
 }
 
-func make_key(counter *int) Key {
+func makeKey(counter *int) Key {
 	*counter++
 	return Key{k: "a"}
 }
@@ -45,7 +45,7 @@ func make_key(counter *int) Key {
 func main() {
 	counter := 0
 	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("a", Box{x: 1})})
-	key := make_key(&counter).k
+	key := makeKey(&counter).k
 	entry := m[key]
 	entry.x = 2
 	m[key] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_key_evaluated_once.snap
@@ -28,7 +28,7 @@ type C struct {
 	value int
 }
 
-func make_key() string {
+func makeKey() string {
 	fmt.Println("key")
 	return "a"
 }
@@ -36,7 +36,7 @@ func make_key() string {
 func main() {
 	m := make(map[string]C)
 	m["a"] = C{value: 1}
-	key := make_key()
+	key := makeKey()
 	entry := m[key]
 	entry.value = 2
 	m[key] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
@@ -30,7 +30,7 @@ type Box struct {
 	x int
 }
 
-func make_i() int {
+func makeI() int {
 	fmt.Println("i")
 	return 0
 }
@@ -40,7 +40,7 @@ func main() {
 	inner := make(map[string]Box)
 	inner["k"] = Box{x: 0}
 	maps_[0] = inner
-	i := make_i()
+	i := makeI()
 	entry := maps_[i]["k"]
 	entry.x = 1
 	maps_[i]["k"] = entry

--- a/tests/spec/emit/snapshots/map_key_generic_in_expression_comparable.snap
+++ b/tests/spec/emit/snapshots/map_key_generic_in_expression_comparable.snap
@@ -13,7 +13,7 @@ package main
 
 func foo[U any](_ U) {}
 
-func make_map[T comparable](_ T) int {
+func makeMap[T comparable](_ T) int {
 	foo(make(map[T]int))
 	return 0
 }

--- a/tests/spec/emit/snapshots/map_key_use_in_let_initializer_uses_declared_bound.snap
+++ b/tests/spec/emit/snapshots/map_key_use_in_let_initializer_uses_declared_bound.snap
@@ -13,11 +13,11 @@ description: |
 ---
 package main
 
-func is_empty[T comparable]() bool {
+func isEmpty[T comparable]() bool {
 	empty := len(make(map[T]int)) == 0
 	return empty
 }
 
 func main() {
-	_ = is_empty[int]()
+	_ = isEmpty[int]()
 }

--- a/tests/spec/emit/snapshots/map_key_use_in_tail_expression_uses_declared_bound.snap
+++ b/tests/spec/emit/snapshots/map_key_use_in_tail_expression_uses_declared_bound.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func is_empty[T comparable]() bool {
+func isEmpty[T comparable]() bool {
 	return len(make(map[T]int)) == 0
 }
 
 func main() {
-	_ = is_empty[int]()
+	_ = isEmpty[int]()
 }

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -21,16 +21,16 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func safe_divide(a, b float64) (float64, bool) {
+func safeDivide(a, b float64) (float64, bool) {
 	if b == 0.0 {
 		return 0.0, false
 	}
 	return a / b, true
 }
 
-func parse_and_divide(a, b float64) lisette.Result[string, string] {
+func parseAndDivide(a, b float64) lisette.Result[string, string] {
 	var result float64
-	option_2 := lisette.OptionFromCommaOk[float64](safe_divide(a, b))
+	option_2 := lisette.OptionFromCommaOk[float64](safeDivide(a, b))
 	if option_2.Tag == lisette.OptionSome {
 		result = option_2.SomeVal
 	} else {

--- a/tests/spec/emit/snapshots/match_call_subject_catchall.snap
+++ b/tests/spec/emit/snapshots/match_call_subject_catchall.snap
@@ -21,7 +21,7 @@ type Point struct {
 	y int
 }
 
-func make_point() Point {
+func makePoint() Point {
 	return Point{
 		x: 1,
 		y: 2,
@@ -29,6 +29,6 @@ func make_point() Point {
 }
 
 func test() int {
-	_ = make_point()
+	_ = makePoint()
 	return 1
 }

--- a/tests/spec/emit/snapshots/match_guard_cannot_mutate_inlined_identifier_subject.snap
+++ b/tests/spec/emit/snapshots/match_guard_cannot_mutate_inlined_identifier_subject.snap
@@ -18,7 +18,7 @@ description: |
 ---
 package main
 
-func bump_false(r *int) bool {
+func bumpFalse(r *int) bool {
 	*r = 1
 	return false
 }
@@ -27,7 +27,7 @@ func test() int {
 	x := 0
 	subject_1 := x
 	if subject_1 == 0 {
-		if bump_false(&x) {
+		if bumpFalse(&x) {
 			return -1
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_on_option_call.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_option_call.snap
@@ -16,12 +16,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_option() (int, bool) {
+func getOption() (int, bool) {
 	return 42, true
 }
 
 func test() int {
-	option_2 := lisette.OptionFromCommaOk[int](get_option())
+	option_2 := lisette.OptionFromCommaOk[int](getOption())
 	subject_1 := option_2
 	if subject_1.Tag == lisette.OptionSome {
 		x := subject_1.SomeVal

--- a/tests/spec/emit/snapshots/match_guard_on_result_call.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_result_call.snap
@@ -16,12 +16,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() lisette.Result[int, string] {
+func getValue() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
 func test() int {
-	subject_1 := get_value()
+	subject_1 := getValue()
 	if subject_1.Tag == lisette.ResultOk {
 		x := subject_1.OkVal
 		if x > 0 {

--- a/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_statement_result_with_binding.snap
@@ -19,7 +19,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func use_value(_ int) {}
+func useValue(_ int) {}
 
 func divide(a, b int) lisette.Result[int, string] {
 	if b == 0 {
@@ -31,8 +31,8 @@ func divide(a, b int) lisette.Result[int, string] {
 func test() {
 	subject_1 := divide(10, 2)
 	if subject_1.Tag == lisette.ResultOk {
-		use_value(subject_1.OkVal)
+		useValue(subject_1.OkVal)
 	} else {
-		use_value(0)
+		useValue(0)
 	}
 }

--- a/tests/spec/emit/snapshots/method_call.snap
+++ b/tests/spec/emit/snapshots/method_call.snap
@@ -21,10 +21,10 @@ type Point struct {
 	y int
 }
 
-func (p Point) get_x() int {
+func (p Point) getX() int {
 	return p.x
 }
 
 func test(p Point) int {
-	return p.get_x()
+	return p.getX()
 }

--- a/tests/spec/emit/snapshots/method_with_reference_self.snap
+++ b/tests/spec/emit/snapshots/method_with_reference_self.snap
@@ -16,6 +16,6 @@ type Counter struct {
 	count int
 }
 
-func (c *Counter) get_count() int {
+func (c *Counter) getCount() int {
 	return c.count
 }

--- a/tests/spec/emit/snapshots/multiple_methods.snap
+++ b/tests/spec/emit/snapshots/multiple_methods.snap
@@ -28,6 +28,6 @@ func Point_new(x, y int) Point {
 	}
 }
 
-func (p Point) get_x() int {
+func (p Point) getX() int {
 	return p.x
 }

--- a/tests/spec/emit/snapshots/never_bodied_lambda_into_unknown_emits_unit_return.snap
+++ b/tests/spec/emit/snapshots/never_bodied_lambda_into_unknown_emits_unit_return.snap
@@ -10,10 +10,10 @@ description: |
 ---
 package main
 
-func take_any(_ any) {}
+func takeAny(_ any) {}
 
 func test() {
-	take_any(func() {
+	takeAny(func() {
 		panic("boom")
 	})
 }

--- a/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
+++ b/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
@@ -55,7 +55,7 @@ func (b Bar[T]) find() (T, bool) {
 	return *new(T), false
 }
 
-func use_opt(o Opt) {
+func useOpt(o Opt) {
 	raw_2 := o.find()
 	option_3 := lisette.OptionFromNilable[*Thing](raw_2, raw_2 == nil)
 	if option_3.Tag == lisette.OptionSome {
@@ -64,7 +64,7 @@ func use_opt(o Opt) {
 }
 
 func main() {
-	use_opt(_lisAdapter_Bar_Opt_0{inner: Bar[*Thing]{x: lisette.MakeOptionNone[*Thing]()}})
+	useOpt(_lisAdapter_Bar_Opt_0{inner: Bar[*Thing]{x: lisette.MakeOptionNone[*Thing]()}})
 }
 
 type _lisAdapter_Bar_Opt_0 struct {

--- a/tests/spec/emit/snapshots/numeric_explicit_float64_to_float32.snap
+++ b/tests/spec/emit/snapshots/numeric_explicit_float64_to_float32.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func get_float64() float64 {
+func getFloat64() float64 {
 	return 3.14
 }
 
 func test() float32 {
-	return float32(get_float64())
+	return float32(getFloat64())
 }

--- a/tests/spec/emit/snapshots/numeric_explicit_float64_to_int.snap
+++ b/tests/spec/emit/snapshots/numeric_explicit_float64_to_int.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func get_float() float64 {
+func getFloat() float64 {
 	return 3.14
 }
 
 func test() int {
-	return int(get_float())
+	return int(getFloat())
 }

--- a/tests/spec/emit/snapshots/numeric_explicit_int_to_float64.snap
+++ b/tests/spec/emit/snapshots/numeric_explicit_int_to_float64.snap
@@ -16,14 +16,14 @@ description: |
 ---
 package main
 
-func get_int() int {
+func getInt() int {
 	return 42
 }
 
-func accept_float(x float64) float64 {
+func acceptFloat(x float64) float64 {
 	return x
 }
 
 func test() float64 {
-	return accept_float(float64(get_int()))
+	return acceptFloat(float64(getInt()))
 }

--- a/tests/spec/emit/snapshots/numeric_int_literal_to_float64.snap
+++ b/tests/spec/emit/snapshots/numeric_int_literal_to_float64.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func accept_float(x float64) float64 {
+func acceptFloat(x float64) float64 {
 	return x
 }
 
 func test() float64 {
-	return accept_float(42)
+	return acceptFloat(42)
 }

--- a/tests/spec/emit/snapshots/numeric_int_literals_to_mixed_params.snap
+++ b/tests/spec/emit/snapshots/numeric_int_literals_to_mixed_params.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func mixed_params(a float64, _ int, c float64) float64 {
+func mixedParams(a float64, _ int, c float64) float64 {
 	return a + c
 }
 
 func test() float64 {
-	return mixed_params(1, 2, 3)
+	return mixedParams(1, 2, 3)
 }

--- a/tests/spec/emit/snapshots/option_assignment_from_function_call.snap
+++ b/tests/spec/emit/snapshots/option_assignment_from_function_call.snap
@@ -15,11 +15,11 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() (int, bool) {
+func getValue() (int, bool) {
 	return 42, true
 }
 
 func test() {
 	_ = lisette.MakeOptionNone[int]()
-	get_value()
+	getValue()
 }

--- a/tests/spec/emit/snapshots/option_constructor_as_argument_no_binding.snap
+++ b/tests/spec/emit/snapshots/option_constructor_as_argument_no_binding.snap
@@ -14,7 +14,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func unwrap_or(o lisette.Option[int], fallback int) int {
+func unwrapOr(o lisette.Option[int], fallback int) int {
 	if o.Tag == lisette.OptionSome {
 		return o.SomeVal
 	}
@@ -22,5 +22,5 @@ func unwrap_or(o lisette.Option[int], fallback int) int {
 }
 
 func test() int {
-	return unwrap_or(lisette.MakeOptionSome(42), 0)
+	return unwrapOr(lisette.MakeOptionSome(42), 0)
 }

--- a/tests/spec/emit/snapshots/option_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/option_direct_as_argument.snap
@@ -18,14 +18,14 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func maybe_int(b bool) (int, bool) {
+func maybeInt(b bool) (int, bool) {
 	if b {
 		return 42, true
 	}
 	return 0, false
 }
 
-func unwrap_or(o lisette.Option[int], fallback int) int {
+func unwrapOr(o lisette.Option[int], fallback int) int {
 	if o.Tag == lisette.OptionSome {
 		return o.SomeVal
 	}
@@ -33,6 +33,6 @@ func unwrap_or(o lisette.Option[int], fallback int) int {
 }
 
 func test() int {
-	option_1 := lisette.OptionFromCommaOk[int](maybe_int(true))
-	return unwrap_or(option_1, 0)
+	option_1 := lisette.OptionFromCommaOk[int](maybeInt(true))
+	return unwrapOr(option_1, 0)
 }

--- a/tests/spec/emit/snapshots/option_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/option_in_tuple_literal.snap
@@ -18,14 +18,14 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func maybe_int(x int) (int, bool) {
+func maybeInt(x int) (int, bool) {
 	if x > 0 {
 		return x, true
 	}
 	return 0, false
 }
 
-func maybe_string(s string) (string, bool) {
+func maybeString(s string) (string, bool) {
 	if s != "" {
 		return s, true
 	}
@@ -33,7 +33,7 @@ func maybe_string(s string) (string, bool) {
 }
 
 func test() {
-	option_1 := lisette.OptionFromCommaOk[int](maybe_int(5))
-	option_2 := lisette.OptionFromCommaOk[string](maybe_string("hello"))
+	option_1 := lisette.OptionFromCommaOk[int](maybeInt(5))
+	option_2 := lisette.OptionFromCommaOk[string](maybeString("hello"))
 	_ = lisette.MakeTuple2(option_1, option_2)
 }

--- a/tests/spec/emit/snapshots/option_int_vs_option_string.snap
+++ b/tests/spec/emit/snapshots/option_int_vs_option_string.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func test_int() (int, bool) {
+func testInt() (int, bool) {
 	return 42, true
 }
 
-func test_string() (string, bool) {
+func testString() (string, bool) {
 	return "hello", true
 }

--- a/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
+++ b/tests/spec/emit/snapshots/option_interface_type_param_in_match.snap
@@ -46,7 +46,7 @@ func (c Circle) ToString() string {
 	return "circle"
 }
 
-func find_it(n int) Printable {
+func findIt(n int) Printable {
 	switch n {
 	case 1:
 		return Box{label: "found"}

--- a/tests/spec/emit/snapshots/option_ref_lowers_to_bare_nilable_pointer_in_interface_impl.snap
+++ b/tests/spec/emit/snapshots/option_ref_lowers_to_bare_nilable_pointer_in_interface_impl.snap
@@ -31,11 +31,11 @@ func (s Store) Find(_ string) *store.Entry {
 	return nil
 }
 
-func use_store(s store.Storage) {
+func useStore(s store.Storage) {
 	_ = s
 }
 
 func main() {
 	s := Store{}
-	use_store(s)
+	useStore(s)
 }

--- a/tests/spec/emit/snapshots/option_with_interface_type_param.snap
+++ b/tests/spec/emit/snapshots/option_with_interface_type_param.snap
@@ -21,14 +21,14 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 type Printable interface {
-	to_string() string
+	toString() string
 }
 
 type Text struct {
 	content string
 }
 
-func (t Text) to_string() string {
+func (t Text) toString() string {
 	return t.content
 }
 

--- a/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
@@ -43,7 +43,7 @@ type Shape struct {
 	Triangle int
 }
 
-func shape_size(s Shape) int {
+func shapeSize(s Shape) int {
 	switch s.Tag {
 	case ShapeCircle:
 		return s.Circle

--- a/tests/spec/emit/snapshots/or_pattern_let_else_on_go_interface_per_alternative_comma_ok.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_on_go_interface_per_alternative_comma_ok.snap
@@ -13,7 +13,7 @@ package main
 
 import "example.com/shapes"
 
-func area_or_neg(s shapes.Shape) int {
+func areaOrNeg(s shapes.Shape) int {
 	var w int
 	var h int
 	asserted_1, ok_2 := s.(shapes.Rect)

--- a/tests/spec/emit/snapshots/prelude_wrappers_still_lower_to_native_go_forms.snap
+++ b/tests/spec/emit/snapshots/prelude_wrappers_still_lower_to_native_go_forms.snap
@@ -14,7 +14,7 @@ description: |
 ---
 package main
 
-func use_ref(r *int) *int {
+func useRef(r *int) *int {
 	return r
 }
 

--- a/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
+++ b/tests/spec/emit/snapshots/propagate_direct_err_lowered_bare_error.snap
@@ -17,10 +17,10 @@ package main
 
 import "errors"
 
-func fail_unit() error {
+func failUnit() error {
 	return errors.New("boom")
 }
 
 func main() {
-	fail_unit()
+	failUnit()
 }

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
@@ -16,7 +16,7 @@ import (
 	"os"
 )
 
-func open_first(path string) (int, error) {
+func openFirst(path string) (int, error) {
 	ret_1, ret_2 := os.Open(path)
 	if ret_2 != nil {
 		return 0, ret_2

--- a/tests/spec/emit/snapshots/propagate_in_expression.snap
+++ b/tests/spec/emit/snapshots/propagate_in_expression.snap
@@ -15,12 +15,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() lisette.Result[int, string] {
+func getValue() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](100)
 }
 
 func test() lisette.Result[int, string] {
-	check_1 := get_value()
+	check_1 := getValue()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_field.snap
@@ -26,20 +26,20 @@ type User struct {
 	name string
 }
 
-func get_id() lisette.Result[int, string] {
+func getId() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](1)
 }
 
-func get_name() lisette.Result[string, string] {
+func getName() lisette.Result[string, string] {
 	return lisette.MakeResultOk[string, string]("Ada")
 }
 
-func make_user() lisette.Result[User, string] {
-	check_1 := get_id()
+func makeUser() lisette.Result[User, string] {
+	check_1 := getId()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[User, string](check_1.ErrVal)
 	}
-	check_2 := get_name()
+	check_2 := getName()
 	if check_2.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[User, string](check_2.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
+++ b/tests/spec/emit/snapshots/propagate_in_struct_literal_spread_base.snap
@@ -24,15 +24,15 @@ type User struct {
 	name string
 }
 
-func get_base() lisette.Result[User, string] {
+func getBase() lisette.Result[User, string] {
 	return lisette.MakeResultOk[User, string](User{
 		id:   1,
 		name: "a",
 	})
 }
 
-func override_id() lisette.Result[User, string] {
-	check_1 := get_base()
+func overrideId() lisette.Result[User, string] {
+	check_1 := getBase()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[User, string](check_1.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/propagate_option_in_function.snap
+++ b/tests/spec/emit/snapshots/propagate_option_in_function.snap
@@ -15,12 +15,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func maybe_get() (int, bool) {
+func maybeGet() (int, bool) {
 	return 0, false
 }
 
 func process() (int, bool) {
-	option_1 := lisette.OptionFromCommaOk[int](maybe_get())
+	option_1 := lisette.OptionFromCommaOk[int](maybeGet())
 	check_2 := option_1
 	if check_2.Tag != lisette.OptionSome {
 		return 0, false

--- a/tests/spec/emit/snapshots/propagate_simple.snap
+++ b/tests/spec/emit/snapshots/propagate_simple.snap
@@ -15,12 +15,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func might_fail() lisette.Result[int, string] {
+func mightFail() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
-func get_value() lisette.Result[int, string] {
-	check_1 := might_fail()
+func getValue() lisette.Result[int, string] {
+	check_1 := mightFail()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/propagate_to_unit_result.snap
+++ b/tests/spec/emit/snapshots/propagate_to_unit_result.snap
@@ -15,12 +15,12 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func returns_int() lisette.Result[int, string] {
+func returnsInt() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
-func returns_unit() lisette.Result[struct{}, string] {
-	check_1 := returns_int()
+func returnsUnit() lisette.Result[struct{}, string] {
+	check_1 := returnsInt()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/range_index_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/range_index_evaluated_once.snap
@@ -22,7 +22,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_range() lisette.Range[int] {
+func makeRange() lisette.Range[int] {
 	fmt.Println("range")
 	return lisette.Range[int]{
 		Start: 1,
@@ -33,7 +33,7 @@ func make_range() lisette.Range[int] {
 func main() {
 	items := []int{0, 1, 2, 3, 4}
 	_base_2 := items
-	range_1 := make_range()
+	range_1 := makeRange()
 	sub := _base_2[range_1.Start:range_1.End:range_1.End]
 	fmt.Println(len(sub))
 }

--- a/tests/spec/emit/snapshots/range_ref_field_access.snap
+++ b/tests/spec/emit/snapshots/range_ref_field_access.snap
@@ -10,6 +10,6 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_start(r *lisette.Range[int]) int {
+func getStart(r *lisette.Range[int]) int {
 	return r.Start
 }

--- a/tests/spec/emit/snapshots/recover_block_basic.snap
+++ b/tests/spec/emit/snapshots/recover_block_basic.snap
@@ -12,13 +12,13 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func may_panic() int {
+func mayPanic() int {
 	return 42
 }
 
 func test() {
 	recoverResult_1 := lisette.RecoverBlock(func() int {
-		return may_panic()
+		return mayPanic()
 	})
 	_ = recoverResult_1
 }

--- a/tests/spec/emit/snapshots/recover_block_in_function_returning_result.snap
+++ b/tests/spec/emit/snapshots/recover_block_in_function_returning_result.snap
@@ -12,13 +12,13 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func may_panic() int {
+func mayPanic() int {
 	return 42
 }
 
 func test() lisette.Result[int, lisette.PanicValue] {
 	recoverResult_1 := lisette.RecoverBlock(func() int {
-		return may_panic()
+		return mayPanic()
 	})
 	return recoverResult_1
 }

--- a/tests/spec/emit/snapshots/recover_block_with_match.snap
+++ b/tests/spec/emit/snapshots/recover_block_with_match.snap
@@ -16,13 +16,13 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func may_panic() int {
+func mayPanic() int {
 	return 42
 }
 
 func test() int {
 	recoverResult_1 := lisette.RecoverBlock(func() int {
-		return may_panic()
+		return mayPanic()
 	})
 	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -37,9 +37,9 @@ type List struct {
 	Cons1 *List
 }
 
-func list_sum(l List) int {
+func listSum(l List) int {
 	if l.Tag == ListCons {
-		return l.Cons0 + list_sum((*l.Cons1))
+		return l.Cons0 + listSum((*l.Cons1))
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -38,10 +38,10 @@ type Tree[T any] struct {
 	Right *Tree[T]
 }
 
-func count_leaves[T any](tree Tree[T]) int {
+func countLeaves[T any](tree Tree[T]) int {
 	if tree.Tag == TreeLeaf {
 		return 1
 	}
 	right := *tree.Right
-	return count_leaves((*tree.Left)) + count_leaves(right)
+	return countLeaves((*tree.Left)) + countLeaves(right)
 }

--- a/tests/spec/emit/snapshots/ref_bounded_generic_absorbs_ref_into_type_param.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_absorbs_ref_into_type_param.snap
@@ -39,11 +39,11 @@ func (b *Box) mutate(val string) {
 	b.content = val
 }
 
-func apply_mutation[T Mutable](item T, val string) {
+func applyMutation[T Mutable](item T, val string) {
 	item.mutate(val)
 }
 
 func test() {
 	b := Box{content: "original"}
-	apply_mutation(&b, "changed")
+	applyMutation(&b, "changed")
 }

--- a/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
@@ -37,11 +37,11 @@ func (p Person) greet() string {
 	return fmt.Sprintf("Hello, %s", p.name)
 }
 
-func greet_ref[T Greetable](item T) string {
+func greetRef[T Greetable](item T) string {
 	return item.greet()
 }
 
 func test() {
 	p := Person{name: "Alice"}
-	_ = greet_ref(&p)
+	_ = greetRef(&p)
 }

--- a/tests/spec/emit/snapshots/ref_impl_satisfies_option_ref_go_interface_without_adapter.snap
+++ b/tests/spec/emit/snapshots/ref_impl_satisfies_option_ref_go_interface_without_adapter.snap
@@ -31,11 +31,11 @@ func (s Store) Find(_ string) *store.Entry {
 	return store.NewEntry()
 }
 
-func use_store(s store.Storage) {
+func useStore(s store.Storage) {
 	_ = s
 }
 
 func main() {
 	s := Store{}
-	use_store(s)
+	useStore(s)
 }

--- a/tests/spec/emit/snapshots/ref_of_call_in_call_args.snap
+++ b/tests/spec/emit/snapshots/ref_of_call_in_call_args.snap
@@ -12,20 +12,20 @@ description: |
 ---
 package main
 
-func make_int() int {
+func makeInt() int {
 	return 1
 }
 
-func read_ref(r *int) int {
+func readRef(r *int) int {
 	return *r
 }
 
-func side_effect() int {
+func sideEffect() int {
 	return 1
 }
 
 func test() int {
-	_left_2 := side_effect()
-	ref_1 := make_int()
-	return _left_2 + read_ref(&ref_1)
+	_left_2 := sideEffect()
+	ref_1 := makeInt()
+	return _left_2 + readRef(&ref_1)
 }

--- a/tests/spec/emit/snapshots/ref_of_call_no_hoist_when_no_side_effects.snap
+++ b/tests/spec/emit/snapshots/ref_of_call_no_hoist_when_no_side_effects.snap
@@ -11,15 +11,15 @@ description: |
 ---
 package main
 
-func takes_two(a int, b *int) int {
+func takesTwo(a int, b *int) int {
 	return a + *b
 }
 
-func make_int() int {
+func makeInt() int {
 	return 2
 }
 
 func test() int {
-	ref_1 := make_int()
-	return takes_two(1, &ref_1)
+	ref_1 := makeInt()
+	return takesTwo(1, &ref_1)
 }

--- a/tests/spec/emit/snapshots/ref_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/ref_temp_var_no_collision.snap
@@ -24,12 +24,12 @@ type Box struct {
 	x int
 }
 
-func make_box() Box {
+func makeBox() Box {
 	return Box{x: 1}
 }
 
 func main() {
-	ref_1 := make_box()
+	ref_1 := makeBox()
 	r := &ref_1
 	ref_1_2 := 3
 	fmt.Println(r.x, ref_1_2)

--- a/tests/spec/emit/snapshots/repeated_cast_to_go_interface_uses_lowered_struct_directly.snap
+++ b/tests/spec/emit/snapshots/repeated_cast_to_go_interface_uses_lowered_struct_directly.snap
@@ -36,16 +36,16 @@ func (d Doubler) Read(_ []uint8) (int, error) {
 	return 0, nil
 }
 
-func consume_a(r io.Reader) {
+func consumeA(r io.Reader) {
 	_ = r
 }
 
-func consume_b(r io.Reader) {
+func consumeB(r io.Reader) {
 	_ = r
 }
 
 func main() {
 	d := Doubler{}
-	consume_a(d)
-	consume_b(d)
+	consumeA(d)
+	consumeB(d)
 }

--- a/tests/spec/emit/snapshots/result_assignment_from_function_call.snap
+++ b/tests/spec/emit/snapshots/result_assignment_from_function_call.snap
@@ -15,11 +15,11 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_value() lisette.Result[int, string] {
+func getValue() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
 func test() {
 	_ = lisette.MakeResultErr[int, string]("initial")
-	_ = get_value()
+	_ = getValue()
 }

--- a/tests/spec/emit/snapshots/result_different_error_types.snap
+++ b/tests/spec/emit/snapshots/result_different_error_types.snap
@@ -14,10 +14,10 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func test_string_error() lisette.Result[int, string] {
+func testStringError() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
-func test_int_error() lisette.Result[string, int] {
+func testIntError() lisette.Result[string, int] {
 	return lisette.MakeResultOk[string, int]("hello")
 }

--- a/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
+++ b/tests/spec/emit/snapshots/result_err_with_interface_error_type.snap
@@ -22,6 +22,6 @@ func (m MyError) Error() string {
 	return m.msg
 }
 
-func might_fail() (int, error) {
+func mightFail() (int, error) {
 	return 0, MyError{msg: "oops"}
 }

--- a/tests/spec/emit/snapshots/result_in_array_literal.snap
+++ b/tests/spec/emit/snapshots/result_in_array_literal.snap
@@ -14,7 +14,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func try_value(x int) lisette.Result[int, string] {
+func tryValue(x int) lisette.Result[int, string] {
 	if x > 0 {
 		return lisette.MakeResultOk[int, string](x)
 	}
@@ -22,5 +22,5 @@ func try_value(x int) lisette.Result[int, string] {
 }
 
 func test() {
-	_ = []lisette.Result[int, string]{try_value(1), try_value(-1), try_value(3)}
+	_ = []lisette.Result[int, string]{tryValue(1), tryValue(-1), tryValue(3)}
 }

--- a/tests/spec/emit/snapshots/result_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/result_in_tuple_literal.snap
@@ -14,7 +14,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func try_int(x int) lisette.Result[int, string] {
+func tryInt(x int) lisette.Result[int, string] {
 	if x > 0 {
 		return lisette.MakeResultOk[int, string](x)
 	}
@@ -22,5 +22,5 @@ func try_int(x int) lisette.Result[int, string] {
 }
 
 func test() {
-	_ = lisette.MakeTuple2(try_int(5), try_int(10))
+	_ = lisette.MakeTuple2(tryInt(5), tryInt(10))
 }

--- a/tests/spec/emit/snapshots/select_hoist_channel_temp_declared_before_user_binding.snap
+++ b/tests/spec/emit/snapshots/select_hoist_channel_temp_declared_before_user_binding.snap
@@ -17,13 +17,13 @@ description: |
 ---
 package main
 
-func get_ch() chan int {
+func getCh() chan int {
 	return make(chan int, 1)
 }
 
 func test() int {
 	var result int
-	ch_1 := get_ch()
+	ch_1 := getCh()
 	for {
 		select {
 		case v, ok := <-ch_1:

--- a/tests/spec/emit/snapshots/select_hoist_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/select_hoist_temp_no_collision.snap
@@ -17,13 +17,13 @@ description: |
 ---
 package main
 
-func get_ch() chan int {
+func getCh() chan int {
 	return make(chan int, 1)
 }
 
 func main() int {
 	var result int
-	ch_1 := get_ch()
+	ch_1 := getCh()
 	for {
 		select {
 		case v, ok := <-ch_1:

--- a/tests/spec/emit/snapshots/select_match_receive.snap
+++ b/tests/spec/emit/snapshots/select_match_receive.snap
@@ -20,7 +20,7 @@ package main
 
 func process(_ int) {}
 
-func handle_close() {}
+func handleClose() {}
 
 func test() {
 	ch := make(chan int)
@@ -29,7 +29,7 @@ func test() {
 		if ok {
 			process(v)
 		} else {
-			handle_close()
+			handleClose()
 		}
 	default:
 	}

--- a/tests/spec/emit/snapshots/select_match_receive_ref_call_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_ref_call_channel_operand.snap
@@ -18,13 +18,13 @@ description: |
 ---
 package main
 
-func get_channel(ch *chan int) *chan int {
+func getChannel(ch *chan int) *chan int {
 	return ch
 }
 
 func test(ch *chan int) {
 	select {
-	case v, ok := <-*get_channel(ch):
+	case v, ok := <-*getChannel(ch):
 		if ok {
 			_ = v
 		}

--- a/tests/spec/emit/snapshots/select_match_receive_wildcard_some.snap
+++ b/tests/spec/emit/snapshots/select_match_receive_wildcard_some.snap
@@ -17,14 +17,14 @@ description: |
 ---
 package main
 
-func process_close() {}
+func processClose() {}
 
 func test() {
 	ch := make(chan int)
 	select {
 	case _, ok := <-ch:
 		if !ok {
-			process_close()
+			processClose()
 		}
 	default:
 	}

--- a/tests/spec/emit/snapshots/select_receive_discard.snap
+++ b/tests/spec/emit/snapshots/select_receive_discard.snap
@@ -15,13 +15,13 @@ description: |
 ---
 package main
 
-func do_work() {}
+func doWork() {}
 
 func test() {
 	ch := make(chan int)
 	select {
 	case <-ch:
-		do_work()
+		doWork()
 	default:
 	}
 }

--- a/tests/spec/emit/snapshots/select_receive_ref_call_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_ref_call_channel_operand.snap
@@ -17,12 +17,12 @@ description: |
 ---
 package main
 
-func get_channel(ch *chan int) *chan int {
+func getChannel(ch *chan int) *chan int {
 	return ch
 }
 
 func test(ch *chan int) {
-	ch_1 := *get_channel(ch)
+	ch_1 := *getChannel(ch)
 	for {
 		select {
 		case v, ok := <-ch_1:

--- a/tests/spec/emit/snapshots/select_send_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/select_send_value_eval_order.snap
@@ -13,7 +13,7 @@ description: |
 ---
 package main
 
-func make_ch() chan int {
+func makeCh() chan int {
 	return make(chan int)
 }
 
@@ -25,6 +25,6 @@ func main() {
 		to_send = 0
 	}
 	select {
-	case make_ch() <- to_send:
+	case makeCh() <- to_send:
 	}
 }

--- a/tests/spec/emit/snapshots/single_embedded_display_beside_plain_embed_shadows.snap
+++ b/tests/spec/emit/snapshots/single_embedded_display_beside_plain_embed_shadows.snap
@@ -24,7 +24,7 @@ func (a A) String() string {
 	return fmt.Sprintf("A { a: %v }", a.A)
 }
 
-func (a A) to_string() string {
+func (a A) toString() string {
 	return a.String()
 }
 

--- a/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
+++ b/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
@@ -11,14 +11,14 @@ description: |
 ---
 package main
 
-func make_i() int {
+func makeI() int {
 	return 0
 }
 
 func main() {
 	outer := [][]int{[]int{1}, []int{2}, []int{3}}
 	base_2 := outer
-	idx_3 := make_i()
-	recv_1 := outer[make_i()]
+	idx_3 := makeI()
+	recv_1 := outer[makeI()]
 	base_2[idx_3] = append(recv_1[:len(recv_1):len(recv_1)], 4)
 }

--- a/tests/spec/emit/snapshots/slice_of_option_interface.snap
+++ b/tests/spec/emit/snapshots/slice_of_option_interface.snap
@@ -29,7 +29,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 type Printable interface {
-	to_string() string
+	toString() string
 }
 
 type Text struct {
@@ -40,11 +40,11 @@ type Number struct {
 	value int
 }
 
-func (t Text) to_string() string {
+func (t Text) toString() string {
 	return t.content
 }
 
-func (n Number) to_string() string {
+func (n Number) toString() string {
 	return "number"
 }
 

--- a/tests/spec/emit/snapshots/slice_pattern_in_function.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_in_function.snap
@@ -15,7 +15,7 @@ description: |
 ---
 package main
 
-func sum_pair(pair []int) int {
+func sumPair(pair []int) int {
 	if len(pair) == 2 {
 		return pair[0] + pair[1]
 	}
@@ -23,5 +23,5 @@ func sum_pair(pair []int) int {
 }
 
 func test() int {
-	return sum_pair([]int{10, 20})
+	return sumPair([]int{10, 20})
 }

--- a/tests/spec/emit/snapshots/slice_range_capped_open_base_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/slice_range_capped_open_base_evaluated_once.snap
@@ -11,12 +11,12 @@ description: |
 ---
 package main
 
-func make_items() []int {
+func makeItems() []int {
 	return []int{10, 20, 30}
 }
 
 func test() int {
-	base_1 := make_items()
+	base_1 := makeItems()
 	len_2 := len(base_1)
 	ys := base_1[1:len_2:len_2]
 	return len(ys)

--- a/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
@@ -26,12 +26,12 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_items() []int {
+func makeItems() []int {
 	fmt.Println("receiver")
 	return []int{10, 20, 30, 40}
 }
 
-func make_range() lisette.Range[int] {
+func makeRange() lisette.Range[int] {
 	fmt.Println("range")
 	return lisette.Range[int]{
 		Start: 1,
@@ -40,8 +40,8 @@ func make_range() lisette.Range[int] {
 }
 
 func main() {
-	_base_1 := make_items()
-	range_2 := make_range()
+	_base_1 := makeItems()
+	range_2 := makeRange()
 	xs := _base_1[range_2.Start:range_2.End:range_2.End]
 	fmt.Println(len(xs))
 }

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -16,11 +16,11 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func side_a() int {
+func sideA() int {
 	return 1
 }
 
-func get_xs() ([]int, error) {
+func getXs() ([]int, error) {
 	return []int{1, 2, 3}, nil
 }
 
@@ -29,8 +29,8 @@ func variadic(_ int, _ ...int) int {
 }
 
 func run() (int, error) {
-	_arg_5 := side_a()
-	ret_1, ret_2 := get_xs()
+	_arg_5 := sideA()
+	ret_1, ret_2 := getXs()
 	var result_3 lisette.Result[[]int, error]
 	if ret_2 != nil {
 		result_3 = lisette.MakeResultErr[[]int, error](ret_2)

--- a/tests/spec/emit/snapshots/string_field_beside_embedded_display_blocks_shadow.snap
+++ b/tests/spec/emit/snapshots/string_field_beside_embedded_display_blocks_shadow.snap
@@ -22,7 +22,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
@@ -25,12 +25,12 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func make_s() string {
+func makeS() string {
 	fmt.Println("receiver")
 	return "hello"
 }
 
-func make_range() lisette.Range[int] {
+func makeRange() lisette.Range[int] {
 	fmt.Println("range")
 	return lisette.Range[int]{
 		Start: 1,
@@ -39,7 +39,7 @@ func make_range() lisette.Range[int] {
 }
 
 func main() {
-	_arg_2 := make_s()
-	range_1 := make_range()
+	_arg_2 := makeS()
+	range_1 := makeRange()
 	fmt.Println(lisette.Substring(_arg_2, range_1.Start, range_1.End))
 }

--- a/tests/spec/emit/snapshots/struct_field_init_option_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_option_function.snap
@@ -22,7 +22,7 @@ type Wrapper struct {
 	opt lisette.Option[int]
 }
 
-func get_opt(b bool) (int, bool) {
+func getOpt(b bool) (int, bool) {
 	if b {
 		return 42, true
 	}
@@ -30,6 +30,6 @@ func get_opt(b bool) (int, bool) {
 }
 
 func test() {
-	option_1 := lisette.OptionFromCommaOk[int](get_opt(true))
+	option_1 := lisette.OptionFromCommaOk[int](getOpt(true))
 	_ = Wrapper{opt: option_1}
 }

--- a/tests/spec/emit/snapshots/struct_field_init_result_function.snap
+++ b/tests/spec/emit/snapshots/struct_field_init_result_function.snap
@@ -22,7 +22,7 @@ type Container struct {
 	res lisette.Result[int, string]
 }
 
-func get_res(b bool) lisette.Result[int, string] {
+func getRes(b bool) lisette.Result[int, string] {
 	if b {
 		return lisette.MakeResultOk[int, string](42)
 	}
@@ -30,5 +30,5 @@ func get_res(b bool) lisette.Result[int, string] {
 }
 
 func test() {
-	_ = Container{res: get_res(true)}
+	_ = Container{res: getRes(true)}
 }

--- a/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
+++ b/tests/spec/emit/snapshots/struct_multiple_field_init_option_functions.snap
@@ -31,14 +31,14 @@ type MultiWrapper struct {
 	second lisette.Option[string]
 }
 
-func get_int(x int) (int, bool) {
+func getInt(x int) (int, bool) {
 	if x > 0 {
 		return x, true
 	}
 	return 0, false
 }
 
-func get_string(s string) (string, bool) {
+func getString(s string) (string, bool) {
 	if s != "" {
 		return s, true
 	}
@@ -46,8 +46,8 @@ func get_string(s string) (string, bool) {
 }
 
 func test() {
-	option_1 := lisette.OptionFromCommaOk[int](get_int(5))
-	option_2 := lisette.OptionFromCommaOk[string](get_string("hello"))
+	option_1 := lisette.OptionFromCommaOk[int](getInt(5))
+	option_2 := lisette.OptionFromCommaOk[string](getString("hello"))
 	_ = MultiWrapper{
 		first:  option_1,
 		second: option_2,

--- a/tests/spec/emit/snapshots/struct_pattern_param_public_field.snap
+++ b/tests/spec/emit/snapshots/struct_pattern_param_public_field.snap
@@ -15,7 +15,7 @@ type Point struct {
 	Y int
 }
 
-func get_x(arg_1 Point) int {
+func getX(arg_1 Point) int {
 	x := arg_1.X
 	return x
 }

--- a/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_inherited_methods.snap
+++ b/tests/spec/emit/snapshots/struct_satisfies_go_interface_with_inherited_methods.snap
@@ -38,11 +38,11 @@ func (d Dev) Write(_ []uint8) (int, error) {
 	return 0, nil
 }
 
-func use_rw(target rw.ReadWriter) {
+func useRw(target rw.ReadWriter) {
 	_ = target
 }
 
 func main() {
 	d := Dev{}
-	use_rw(d)
+	useRw(d)
 }

--- a/tests/spec/emit/snapshots/struct_spread_field_before_base_eval_order.snap
+++ b/tests/spec/emit/snapshots/struct_spread_field_before_base_eval_order.snap
@@ -22,12 +22,12 @@ type Point struct {
 	y int
 }
 
-func make_x() int {
+func makeX() int {
 	fmt.Println("x")
 	return 1
 }
 
-func make_base() Point {
+func makeBase() Point {
 	fmt.Println("base")
 	return Point{
 		x: 0,
@@ -36,8 +36,8 @@ func make_base() Point {
 }
 
 func main() {
-	field_1 := make_x()
-	copy_2 := make_base()
+	field_1 := makeX()
+	copy_2 := makeBase()
 	copy_2.x = field_1
 	_ = copy_2
 }

--- a/tests/spec/emit/snapshots/struct_variant_construction.snap
+++ b/tests/spec/emit/snapshots/struct_variant_construction.snap
@@ -28,7 +28,7 @@ type Message struct {
 	Y   int
 }
 
-func make_move() Message {
+func makeMove() Message {
 	return Message{
 		Tag: MessageMove,
 		X:   10,

--- a/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
@@ -101,11 +101,11 @@ func (bb *Box[b]) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("empty Box JSON object")
 }
 
-func (bb Box[b]) to_string() string {
+func (bb Box[b]) toString() string {
 	return bb.String()
 }
 
 func test() string {
 	x := MakeBoxFull(7)
-	return x.to_string()
+	return x.toString()
 }

--- a/tests/spec/emit/snapshots/synthesized_struct_methods_freshen_receiver_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_struct_methods_freshen_receiver_against_type_param.snap
@@ -26,7 +26,7 @@ func (bb Box[b]) String() string {
 	return fmt.Sprintf("Box { item: %v }", bb.Item)
 }
 
-func (bb Box[b]) to_string() string {
+func (bb Box[b]) toString() string {
 	return bb.String()
 }
 

--- a/tests/spec/emit/snapshots/tag_exported_string_field_on_embed_blocks_outer_shadow.snap
+++ b/tests/spec/emit/snapshots/tag_exported_string_field_on_embed_blocks_outer_shadow.snap
@@ -28,7 +28,7 @@ func (l Logger) String() string {
 	return fmt.Sprintf("Logger { prefix: %v }", l.Prefix)
 }
 
-func (l Logger) to_string() string {
+func (l Logger) toString() string {
 	return l.String()
 }
 

--- a/tests/spec/emit/snapshots/top_level_reference_not_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/top_level_reference_not_pinned_before_call.snap
@@ -17,7 +17,7 @@ description: |
 ---
 package main
 
-const BASE int = 10
+const Base int = 10
 
 func eff(x *int) int {
 	*x = 1
@@ -26,6 +26,6 @@ func eff(x *int) int {
 
 func run() int {
 	i := 0
-	r := []int{BASE, eff(&i)}
+	r := []int{Base, eff(&i)}
 	return r[0] + r[1]
 }

--- a/tests/spec/emit/snapshots/try_block_loop_inside.snap
+++ b/tests/spec/emit/snapshots/try_block_loop_inside.snap
@@ -26,14 +26,14 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_items() lisette.Result[[]int, string] {
+func getItems() lisette.Result[[]int, string] {
 	return lisette.MakeResultOk[[]int, string]([]int{1, 2, 3})
 }
 
 func test() int {
 	var result lisette.Result[int, string]
 	tryResult_1 := func() lisette.Result[int, string] {
-		check_2 := get_items()
+		check_2 := getItems()
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}

--- a/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
+++ b/tests/spec/emit/snapshots/try_block_multiple_question_marks.snap
@@ -21,23 +21,23 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_a() lisette.Result[int, string] {
+func getA() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](10)
 }
 
-func get_b() lisette.Result[int, string] {
+func getB() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](20)
 }
 
 func test() int {
 	var result lisette.Result[int, string]
 	tryResult_1 := func() lisette.Result[int, string] {
-		check_2 := get_a()
+		check_2 := getA()
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}
 		a := check_2.OkVal
-		check_3 := get_b()
+		check_3 := getB()
 		if check_3.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_3.ErrVal)
 		}

--- a/tests/spec/emit/snapshots/try_block_nested.snap
+++ b/tests/spec/emit/snapshots/try_block_nested.snap
@@ -26,11 +26,11 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func risky_a() lisette.Result[int, string] {
+func riskyA() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](1)
 }
 
-func risky_b() lisette.Result[int, string] {
+func riskyB() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](2)
 }
 
@@ -39,7 +39,7 @@ func test() int {
 	tryResult_1 := func() lisette.Result[int, string] {
 		var inner lisette.Result[int, string]
 		tryResult_2 := func() lisette.Result[int, string] {
-			check_3 := risky_a()
+			check_3 := riskyA()
 			if check_3.Tag != lisette.ResultOk {
 				return lisette.MakeResultErr[int, string](check_3.ErrVal)
 			}
@@ -53,7 +53,7 @@ func test() int {
 			inner_val = 0
 		}
 		_left_5 := inner_val
-		check_4 := risky_b()
+		check_4 := riskyB()
 		if check_4.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_4.ErrVal)
 		}

--- a/tests/spec/emit/snapshots/try_block_option.snap
+++ b/tests/spec/emit/snapshots/try_block_option.snap
@@ -21,14 +21,14 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func maybe_get() (int, bool) {
+func maybeGet() (int, bool) {
 	return 42, true
 }
 
 func test() int {
 	var opt lisette.Option[int]
 	tryResult_1 := func() lisette.Option[int] {
-		option_2 := lisette.OptionFromCommaOk[int](maybe_get())
+		option_2 := lisette.OptionFromCommaOk[int](maybeGet())
 		check_3 := option_2
 		if check_3.Tag != lisette.OptionSome {
 			return lisette.MakeOptionNone[int]()

--- a/tests/spec/emit/snapshots/try_block_task_as_statement.snap
+++ b/tests/spec/emit/snapshots/try_block_task_as_statement.snap
@@ -22,7 +22,7 @@ func risky() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](1)
 }
 
-func do_something() {}
+func doSomething() {}
 
 func test() {
 	var r lisette.Result[int, string]
@@ -33,7 +33,7 @@ func test() {
 		}
 		x := check_2.OkVal
 		go func() {
-			do_something()
+			doSomething()
 		}()
 		return lisette.MakeResultOk[int, string](x)
 	}()

--- a/tests/spec/emit/snapshots/try_block_with_semicolon.snap
+++ b/tests/spec/emit/snapshots/try_block_with_semicolon.snap
@@ -15,14 +15,14 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func do_thing() lisette.Result[int, string] {
+func doThing() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](1)
 }
 
 func test() {
 	var result lisette.Result[int, string]
 	tryResult_1 := func() lisette.Result[int, string] {
-		check_2 := do_thing()
+		check_2 := doThing()
 		if check_2.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_2.ErrVal)
 		}

--- a/tests/spec/emit/snapshots/tuple_return_annotation.snap
+++ b/tests/spec/emit/snapshots/tuple_return_annotation.snap
@@ -12,10 +12,10 @@ description: |
 ---
 package main
 
-func get_pair() (int, string) {
+func getPair() (int, string) {
 	return 42, "hello"
 }
 
 func test() {
-	get_pair()
+	getPair()
 }

--- a/tests/spec/emit/snapshots/tuple_struct_function_vs_constructor.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_function_vs_constructor.snap
@@ -23,7 +23,7 @@ type Point struct {
 	F1 int
 }
 
-func add_points(a, b Point) Point {
+func addPoints(a, b Point) Point {
 	x1 := a.F0
 	y1 := a.F1
 	x2 := b.F0
@@ -43,5 +43,5 @@ func test() Point {
 		F0: 3,
 		F1: 4,
 	}
-	return add_points(p1, p2)
+	return addPoints(p1, p2)
 }

--- a/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
+++ b/tests/spec/emit/snapshots/tuple_type_alias_preserved_at_use_sites.snap
@@ -18,6 +18,6 @@ type Holder struct {
 	p Pair
 }
 
-func use_it(h Holder, x Pair) int {
+func useIt(h Holder, x Pair) int {
 	return h.p.First + x.Second
 }

--- a/tests/spec/emit/snapshots/two_embedded_display_stringers_are_ambiguous_no_shadow.snap
+++ b/tests/spec/emit/snapshots/two_embedded_display_stringers_are_ambiguous_no_shadow.snap
@@ -25,7 +25,7 @@ func (a A) String() string {
 	return fmt.Sprintf("A { a: %v }", a.A)
 }
 
-func (a A) to_string() string {
+func (a A) toString() string {
 	return a.String()
 }
 
@@ -37,7 +37,7 @@ func (b B) String() string {
 	return fmt.Sprintf("B { b: %v }", b.B)
 }
 
-func (b B) to_string() string {
+func (b B) toString() string {
 	return b.String()
 }
 

--- a/tests/spec/emit/snapshots/type_alias_field_access.snap
+++ b/tests/spec/emit/snapshots/type_alias_field_access.snap
@@ -19,6 +19,6 @@ type Point struct {
 
 type Location = Point
 
-func get_x(loc Location) int {
+func getX(loc Location) int {
 	return loc.X
 }

--- a/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/type_alias_in_struct_field.snap
@@ -24,6 +24,6 @@ type Outer struct {
 	Item Wrapper
 }
 
-func get_val(o Outer) int {
+func getVal(o Outer) int {
 	return o.Item.Val
 }

--- a/tests/spec/emit/snapshots/typed_function_alias_from_named_function_declares_alias_type.snap
+++ b/tests/spec/emit/snapshots/typed_function_alias_from_named_function_declares_alias_type.snap
@@ -19,15 +19,15 @@ package main
 
 type Handler func() int
 
-func make_handler() int {
+func makeHandler() int {
 	return 1
 }
 
-func use_ref(r *Handler) int {
+func useRef(r *Handler) int {
 	return (*r)()
 }
 
 func test() int {
-	var h Handler = make_handler
-	return use_ref(&h)
+	var h Handler = makeHandler
+	return useRef(&h)
 }

--- a/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
+++ b/tests/spec/emit/snapshots/typed_let_propagate_interface_declares_annotated_type.snap
@@ -41,13 +41,13 @@ func (b B) text() string {
 	return "b"
 }
 
-func make_a() lisette.Result[A, string] {
+func makeA() lisette.Result[A, string] {
 	return lisette.MakeResultOk[A, string](A{})
 }
 
 func run() lisette.Result[struct{}, string] {
 	var p Printable
-	check_1 := make_a()
+	check_1 := makeA()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
 	}

--- a/tests/spec/emit/snapshots/ufcs_call_receiver_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_receiver_eval_order_captured.snap
@@ -31,7 +31,7 @@ func (c Counter) get() int {
 	return c.n
 }
 
-func bump_and_get(c *Counter) int {
+func bumpAndGet(c *Counter) int {
 	c.n++
 	return c.n
 }
@@ -42,6 +42,6 @@ func sum(a, b int) int {
 
 func main() {
 	c := Counter{n: 0}
-	v := sum(c.get(), bump_and_get(&c))
+	v := sum(c.get(), bumpAndGet(&c))
 	_ = v
 }

--- a/tests/spec/emit/snapshots/ufcs_call_to_receiver_method.snap
+++ b/tests/spec/emit/snapshots/ufcs_call_to_receiver_method.snap
@@ -25,11 +25,11 @@ func (b Box) add(y int) int {
 	return b.x + y
 }
 
-func make_box() Box {
+func makeBox() Box {
 	return Box{x: 1}
 }
 
 func main() {
-	v := make_box().add(1)
+	v := makeBox().add(1)
 	_ = v
 }

--- a/tests/spec/emit/snapshots/ufcs_receiver_method_deref_parenthesized.snap
+++ b/tests/spec/emit/snapshots/ufcs_receiver_method_deref_parenthesized.snap
@@ -24,10 +24,10 @@ func (b Box) add(y int) int {
 	return b.x + y
 }
 
-func make_ref() *Box {
+func makeRef() *Box {
 	return &Box{x: 1}
 }
 
 func main() {
-	_ = (*make_ref()).add(1)
+	_ = (*makeRef()).add(1)
 }

--- a/tests/spec/emit/snapshots/unary_not_does_not_flip_comparison_inside_call_argument.snap
+++ b/tests/spec/emit/snapshots/unary_not_does_not_flip_comparison_inside_call_argument.snap
@@ -10,10 +10,10 @@ description: |
 ---
 package main
 
-func always_false(_ bool) bool {
+func alwaysFalse(_ bool) bool {
 	return false
 }
 
 func test(x, y int) bool {
-	return !always_false(x == y)
+	return !alwaysFalse(x == y)
 }

--- a/tests/spec/emit/snapshots/underscore_prefixed_let_with_option_result_call.snap
+++ b/tests/spec/emit/snapshots/underscore_prefixed_let_with_option_result_call.snap
@@ -14,10 +14,10 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func get_result() lisette.Result[int, string] {
+func getResult() lisette.Result[int, string] {
 	return lisette.MakeResultOk[int, string](42)
 }
 
 func test() {
-	_ = get_result()
+	_ = getResult()
 }

--- a/tests/spec/emit/snapshots/unit_returning_call_in_tuple.snap
+++ b/tests/spec/emit/snapshots/unit_returning_call_in_tuple.snap
@@ -13,10 +13,10 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func do_nothing() {}
+func doNothing() {}
 
 func main() {
-	do_nothing()
+	doNothing()
 	t := lisette.MakeTuple2(42, struct{}{})
 	_ = t.First
 }

--- a/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
+++ b/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
@@ -14,7 +14,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func maybe_pair(n int) (lisette.Tuple2[int, int], bool) {
+func maybePair(n int) (lisette.Tuple2[int, int], bool) {
 	if n > 0 {
 		return lisette.MakeTuple2(n, n+1), true
 	}
@@ -22,7 +22,7 @@ func maybe_pair(n int) (lisette.Tuple2[int, int], bool) {
 }
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybe_pair(5))
+	option_1 := lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybePair(5))
 	r := option_1
 	_ = r
 }

--- a/tests/spec/emit/snapshots/void_fn_in_tuple_return_type.snap
+++ b/tests/spec/emit/snapshots/void_fn_in_tuple_return_type.snap
@@ -10,7 +10,7 @@ description: |
 ---
 package main
 
-func make_pair() (func() int, func()) {
+func makePair() (func() int, func()) {
 	get := func() int {
 		return 42
 	}

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -23,7 +23,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func next_item(counter int) (int, bool) {
+func nextItem(counter int) (int, bool) {
 	if counter < 5 {
 		return counter, true
 	}
@@ -33,7 +33,7 @@ func next_item(counter int) (int, bool) {
 func test() {
 	i := 0
 	for {
-		option_2 := lisette.OptionFromCommaOk[int](next_item(i))
+		option_2 := lisette.OptionFromCommaOk[int](nextItem(i))
 		subject_1 := option_2
 		if subject_1.Tag == lisette.OptionSome {
 			x := subject_1.SomeVal

--- a/tests/spec/emit/snapshots/while_let_result_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_result_function_call.snap
@@ -23,7 +23,7 @@ import (
 	lisette "github.com/ivov/lisette/prelude"
 )
 
-func next_result(counter int) lisette.Result[int, string] {
+func nextResult(counter int) lisette.Result[int, string] {
 	if counter < 5 {
 		return lisette.MakeResultOk[int, string](counter)
 	}
@@ -33,7 +33,7 @@ func next_result(counter int) lisette.Result[int, string] {
 func test() {
 	i := 0
 	for {
-		subject_1 := next_result(i)
+		subject_1 := nextResult(i)
 		if subject_1.Tag == lisette.ResultOk {
 			x := subject_1.OkVal
 			fmt.Printf("Got: %d\n", x)


### PR DESCRIPTION
Generated Go now uses idiomatic casing. Constants emit as PascalCase and private functions, methods, and fields as camelCase.

```rs
pub const MAX_SIZE = 100

struct Counter {
  retry_count: int,
}

fn build_counter() -> Counter { ... }
```

now emits

```go
const MaxSize int = 100

type Counter struct {
	retryCount int
}

func buildCounter() Counter { ... }
```